### PR TITLE
Rendering @image nodes with text in the body

### DIFF
--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -640,7 +640,7 @@ class ViewRenderedController(QtGui.QWidget):
             pc.length = len(p.b) # not s
         
             # Remove Leo directives.
-            s = keywords.get('s') if 's' in keywords else p.b
+            s = keywords.get('s') if 's' in keywords else p.b.splitlines()[0] if p.b.splitlines() else ""
             s = pc.remove_directives(s)
             # Dispatch based on the computed kind.
             kind = keywords.get('flags') if 'flags' in keywords else pc.get_kind(p)


### PR DESCRIPTION
This little fix makes Leo able to render @image nodes even when there is text inside the node.
The full history of this fix is here:
https://groups.google.com/forum/#!topic/leo-editor/xyMMQ-avUWE
