### PR TITLE
Auto-strip the path in absolute UNLs for easy feed to find_absolute_unl_node

### DIFF
--- a/leo/core/leoViews.py
+++ b/leo/core/leoViews.py
@@ -2105,6 +2105,8 @@ class ViewController:
         vc = self
         aList = unl.split('-->')
         if aList:
+            if len(aList[0].split("#"))>1:
+                aList[0]="".join(aList[0].split("#")[1:])
             first,rest = aList[0],'-->'.join(aList[1:])
             for parent in vc.c.rootPosition().self_and_siblings():
                 if parent.h.strip() == first.strip():


### PR DESCRIPTION
c.p.get_UNL() returns a node UNL preceeded by its file path.
But when feeding that string to c.viewController.find_absolute_unl_node, it fails, because the file path must be stripped.

This change safely strips the path if found, although still will fail in case the file path / name contains this charcter "#". (very few cases, as opposed as always, as currently is now)

The stripping is done inside the find_absolute_unl_node function.

This makes the resulting string from c.p.get_UNL() directly compatible with c.viewController.find_absolute_unl_node, without the user needing to work on it in most of the cases.
