### PR TITLE
Allow for hexadecimal encoding of delimiters where literal definition causes problems

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -128,6 +128,8 @@ if isPython3:
 else:
     import urlparse
 
+import binascii
+
 # import zipfile
 
 # These do not exist in IronPython.
@@ -2468,11 +2470,26 @@ def set_delims_from_string(s):
         delims[1] = delims[0]
         delims[0] = ''
 
-    # 7/8/02: The "REM hack": replace underscores by blanks.
-    # 9/25/02: The "perlpod hack": replace double underscores by newlines.
     for i in range(0,3):
         if delims[i]:
-            delims[i] = delims[i].replace("__",'\n').replace('_',' ')
+            if delims[i].startswith("@0x"):
+                # Allow delimiter definition as @0x + hexadecimal encoded delimiter
+                # to avoid problems with duplicate delimiters on the @comment line. 
+                # If used, whole delimiter must be encoded.
+                if len(delims[i]) == 3:
+                    g.warning("'%s' delimiter is invalid" % delims[i])
+                    return None, None, None
+                    
+                try:
+                    delims[i] = binascii.unhexlify(delims[i][3:])
+                except Exception as e:
+                    g.warning("'%s' delimiter is invalid: %s" % (delims[i], e))
+                    return None, None, None
+            else:    
+                # 7/8/02: The "REM hack": replace underscores by blanks.
+                # 9/25/02: The "perlpod hack": replace double underscores by newlines.
+                delims[i] = delims[i].replace("__",'\n').replace('_',' ')
+    
 
     return delims[0], delims[1], delims[2]
 #@+node:ekr.20031218072017.1384: *3* g.set_language

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -10366,7 +10366,26 @@ Nevertheless, these sentinels can be useful in special situations.
 
     The \@comment directive must precede the first section name or \@c
     directive.
-
+    
+    There are situations where using \@delims or \@comment is not avoidable or impractical to
+    add new language definition, and including it causes the resulting file to be invalid.
+    In place of delimiter definition, use @0x + delimiter encoded in hexadecimal.
+    The hexadecimal part must be acceptable input to binascii.unhexlify(), otherwise whole 
+    directive will be ignored. Use binascii.hexlify('my-delimiter') to generate it.
+    Decoded delimiters are not checked for validity (such as, UTF-8) and whether they 
+    do not clash with Leo format (like newline or NUL characters)!
+    
+    Example::
+    
+        @comment @0x3c212d2d2120 @0x202d2d3e
+    
+    for GenshiXML is the same definition as 
+        
+        @comment &lt;!--!_ _--&gt;
+    
+    to create comments that will be removed from the output by Genshi. But the latter would 
+    cause XML parsing error on the @comment line.
+    
 .. index::
     pair: @delims; Reference
 


### PR DESCRIPTION
I am often working with "mongrel files" that have some template markup, but content is in unrelated format. I want to have the templates as @file nodes with syntax highlighting, but with sentinels to be removed from generated file by templating engine. It is not practical to add language definition for every template+content combination, and @comment or @delim definitions cause syntax errors in their literal form, especially in XML formats.
