### PR TITLE
! Fixed a typo and a wrong directive

### DIFF
--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -19925,7 +19925,7 @@ refresh-from-disk command to populate the node. Do this *before* saving the
 .leo file. If you try to save an empty @auto-org-mode node Leo will warn
 you that you are about to overwrite the file.
 
-The refresh-from-disck command creates an @auto-otl node whose **children**
+The ``refresh-from-disk`` command creates an @auto-org-mode node whose **children**
 represent the contents of the external .org file. Leo does *not* write the
 \@auto-org-mode node itself. This allows you to put Leo directives in the
 node.


### PR DESCRIPTION
Fixed a typo and a wrong directive. Also I made `refresh-from-disk` a code sample - I think it should make it more readable but please remove the backquotes if it is not the convention in the leo documentation.
