### PR TITLE
fix hex delimiters for python 3

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2477,6 +2477,7 @@ def set_delims_from_string(s):
                     
                 try:
                     delims[i] = binascii.unhexlify(delims[i][3:])
+                    delims[i] = delims[i].decode('utf-8')
                 except Exception as e:
                     g.warning("'%s' delimiter is invalid: %s" % (delims[i], e))
                     return None, None, None


### PR DESCRIPTION
Unhexlify produces bytes under python 3, must decode it.