### PR TITLE
Added support for bash files with unused shellscript.py mode and add placeholders to param_doc()

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -10023,7 +10023,7 @@ def param_doc(k=None):
         indent = '        '
     if k in _values and _values[k]:
         return "\n\n%s:Parameters:\n%s" % (indent, '\n'.join(
-            ["%s- `%s`: describe %s" % (
+            ["%s- `%s`: &lt;|describe %s|&gt;" % (
                 indent, i.split('=',1)[0].strip(), i.split('=',1)[0].strip()
              ) for i in _values[k].split(',')]))
     return ""

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1235,7 +1235,7 @@ class LeoApp:
             "scheme"        : "scm",
             "sgml"          : "sgml",
             "shell"         : "sh", # DS 4/1/04
-            "shellscript"   : "sh",
+            "shellscript"   : "bash",
             "shtml"         : "ssi", # Only one extension is valid: .shtml
             "smalltalk"     : "sm",
             "splus"         : "splus",
@@ -1293,6 +1293,7 @@ class LeoApp:
             "awk":      "awk",
             "b":        "b",
             "bas":      "rapidq", # fil 2004-march-11
+            "bash":     "shellscript",
             "bat":      "batch",
             "bbj":      "bbj",
             "bcel":     "bcel",
@@ -1389,7 +1390,6 @@ class LeoApp:
             "scpt":     "applescript",
             "sgml":     "sgml",
             "sh":       "shell", # DS 4/1/04. modes/shell.py exists.
-            # "sh":     "shellscript",
             "shtml":    "shtml",
             "sm":       "smalltalk",
             "splus":    "splus",


### PR DESCRIPTION
I am not certain that shellscript.py addresses all bash syntax but it's better than none at all.

This addresses @edit nodes of .bash files loading with @nocolor. Now they should automatically load to @language shellscript.

I figured this was the easiest way of doing this since shellscript.py was not being used. But if you think this is misleading we can find another approach.