### PR TITLE
Suggesting a fix, relative paths do not work in image nodes.

### DIFF
--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -757,9 +757,9 @@ if QtWidgets:
             w = pc.ensure_text_widget()
             ok,path = pc.get_fn(fn,'@image')
             if not ok:
-                w.setPlainText('@image: file not found: %s' % (fn))
+                w.setPlainText('@image: file not found: %s' % (path))
                 return
-            path = fn.replace('\\','/')
+            path = path.replace('\\','/')
             template = '''\
         <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
          "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">


### PR DESCRIPTION
To repro, create a directory "d" and directory "subdir".
Create "d/image.png" using any valid png file.
Create "d/test.leo"
In d/test.leo, create a node with name "@image" and body "image.png"
Create "d/subdir/test2.leo"
In d/subdir/test2.leo, create a node with name "@image" and body "../image.png"
Open both d/test.leo and d/subdir/test2.leo in Leo and use Alt-0 to show the viewrendered pane, only one of the nodes shows the image correctly in the pane and the other shows a broken placeholder. Reading the code, it looks like supporting relative paths was intended but broken by a typo.
Issue is resolved with this patch which was likely the intended functionality.