### PR TITLE
try and make leoQt more informative when import fails

### DIFF
--- a/leo/core/commit_timestamp.json
+++ b/leo/core/commit_timestamp.json
@@ -1,1 +1,4 @@
-{"hash": "after 71ac282359b5cb2b7c5b47103a3b551b13c9e809", "date": "Tue Nov 22 06:41:35 2016"}
+{
+    "asctime": "Tue Nov 22 21:03:45 CST 2016",
+    "timestamp": "20161122210345"
+}

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -17,6 +17,7 @@ Callers are expected to use the *PyQt5* spellings of modules:
     # QtDeclarative, Qsci, QString, QtSvg, QtWebKit, QtWebKitWidgets
     # printsupport
 import leo.core.leoGlobals as g
+import traceback
 strict = False
 trace = False
 fail = g.in_bridge
@@ -38,43 +39,50 @@ else:
             else:
                 fail = True
 # Complete the imports.
+
+QString = g.u
+QtConst = QtCore = QtGui = QtWidgets = QUrl = None
+QtDeclarative = Qsci = QtSvg = QtWebKit = QtWebKitWidgets = None
+phonon = uic = None
+qt_version = '<no version>'
+printsupport = None
+
 if fail:
     isQt5 = False
-    QString = g.u
-    Qt = QtConst = QtCore = QtGui = QtWidgets = QUrl = None
-    QtDeclarative = Qsci = QtSvg = QtWebKit = QtWebKitWidgets = None
-    phonon = uic = None
-    qt_version = '<no version>'
-    printsupport = None
+    Qt = None
 elif isQt5:
     try:
         from PyQt5 import QtCore
         from PyQt5 import QtGui
         from PyQt5 import QtWidgets
         from PyQt5.QtCore import QUrl
-        QtConst = QtCore.Qt
         printsupport = Qt
     except ImportError:
         print('leoQt.py: can not fully import PyQt5.')
+        print(traceback.format_exc())
+        print("")
 else:
     try:
         from PyQt4 import QtCore
         from PyQt4 import QtGui
         from PyQt4.QtCore import QUrl
         assert QUrl # for pyflakes.
-        QtConst = QtCore.Qt
         QtWidgets = QtGui
         printsupport = QtWidgets
     except ImportError:
         print('leoQt.py: can not fully import PyQt4.')
+        print(traceback.format_exc())
+        print("")
+
+if QtCore:
+    QtConst = QtCore.Qt
+
 # Define qt_version
 if fail:
     pass
 else:
-    qt_version = QtCore.QT_VERSION_STR
-    if 0:
-        import leo.core.leoGlobals as g
-        isNewQt = g.CheckVersion(qt_version, '4.5.0')
+    if QtCore:
+        qt_version = QtCore.QT_VERSION_STR
 if trace:
     print('leoQt.py: isQt5: %s' % isQt5)
 # Define phonon,Qsci,QtSvg,QtWebKit,QtWebKitWidgets,uic.


### PR DESCRIPTION
Wanted to run this by you before pushing to master - Chris George reported a failure that ended in:

```
leoQt.py: can not fully import PyQt5.
[snip]
  File "/home/chris/leo-editor/leo/core/leoQt.py", line 74, in <module>
    qt_version = QtCore.QT_VERSION_STR
NameError: name 'QtCore' is not defined
```

Which is a program flow error, although I think it only happens when PyQt import is already failing in an unrecoverable way, but anyway, see what you think, trying to make leoQt more helpful when everything is falling apart.
