### PR TITLE
Tiny changes to auto-rst and auto-md headline defaults

### DIFF
--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -9,7 +9,8 @@ import leo.core.leoGlobals as g
 import leo.plugins.importers.linescanner as linescanner
 Importer = linescanner.Importer
 # Used by writers.leo_rst as well as in this file.
-underlines = "!\"$%&'()*+,-./:;<=>?@[\\]^_`{|}~#"
+underlines_old = "!\"$%&'()*+,-./:;<=>?@[\\]^_`{|}~#"
+underlines = '*=-^~"+!\$%&(),./:;<>?@[\\]_`{|}#'
     # All valid rst underlines, with '#' *last*, so it is effectively reserved.
 #@+others
 #@+node:ekr.20161127192007.2: ** class Rst_Importer

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -33,7 +33,7 @@ class MarkdownWriter(basewriter.BaseWriter):
     def write_headline(self, p):
         '''
         Write or skip the headline.
-        
+
         New in Leo 5.5: Always write '#' sections.
         This will cause perfect import to fail.
         The alternatives are much worse.
@@ -47,7 +47,7 @@ class MarkdownWriter(basewriter.BaseWriter):
             # self.put(p.h)
             # self.put(kind*max(4,len(p.h)))
         else:
-            self.put('%s%s' % ('#'*level, p.h))
+            self.put('%s %s' % ('#'*level, p.h))
     #@-others
 #@-others
 writer_dict = {


### PR DESCRIPTION
Two non-controversial small changes to rst and md writer defaults: 

1. The sequence of rst underline characters are now more consistent with sphinx defaults (http://www.sphinx-doc.org/en/stable/rest.html)

2.  Added a space between the # the title text in markdown writer so `#Header 1` becomes `# Header 1`