### PR TITLE
fix: initial fix to graphcanvas PyQt5 zoom problem, second try

### DIFF
--- a/leo/plugins/graphcanvas.py
+++ b/leo/plugins/graphcanvas.py
@@ -48,7 +48,7 @@ except Exception:
 
 # Fail gracefully if the gui is not qt.
 g.assertUi('qt')
-from leo.core.leoQt import QtConst, QtCore, QtGui, QtWidgets, uic
+from leo.core.leoQt import QtConst, QtCore, QtGui, QtWidgets, uic, isQt5
 
 pygraphviz = None
 if not pydot:
@@ -204,15 +204,17 @@ class GraphicsView(QtWidgets.QGraphicsView):
     #@+node:tbrown.20110122085529.15399: *3* wheelEvent
     def wheelEvent(self, event):
 
+        distance = event.angleDelta().y() if isQt5 else event.delta()
+
         if int(event.modifiers() & QtConst.ControlModifier):
 
-            scale = 1.+0.1*(event.delta() / 120)
+            scale = 1.+0.1*(distance / 120)
 
             self.scale(scale, scale)
 
         elif int(event.modifiers() & QtConst.AltModifier):
 
-            self.glue.scale_centers(event.delta() / 120)
+            self.glue.scale_centers(distance / 120)
 
         else:
 


### PR DESCRIPTION
Leo crashed after holding Ctrl and scrolling up (zooming) in the Graph pane with the following exception:

```
Traceback (most recent call last):
  File "/home/nodex/Software/Leo/leo/plugins/graphcanvas.py", line 209, in wheelEvent
    scale = 1.+0.1*(event.delta() / 120)
AttributeError: 'QWheelEvent' object has no attribute 'delta'
```

It is line 209 in the `graphcanvas.py` file. After some debugging and googling I have found out, that I am using PyQt 5 and in Qt 5 `delta()` method of `QWheelEvent` class is depracated and replaced by `angleDelta()` method.

PyQt4.8: http://doc.qt.io/qt-4.8/qwheelevent.html#delta
PyQt5: http://doc.qt.io/qt-5/qwheelevent.html#angleDelta

So I have created a new variable, `direction`, and, depending on whether PyQt4 or PyQt5 is used, assigned return value of either `event.delta()` or `event.angleDelta().y()` to it. Then I used it in 2 places, where the crash can happen.

Finally I have tested it with my setup:

* Leo 5.4, build 20170312075431, Sun Mar 12 07:54:31 CDT 2017
* Python 3.6.0
* PyQt 5.6.2

and it worked and Leo did not crash.