### PR TITLE
Failure to close git files

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4246,7 +4246,9 @@ def gitInfo(path=None):
         # Try to get a better commit number.
         path = g.os_path_finalize_join(git_dir, pointer)
         try:
-            s = open(path, 'r').read()
+            gfid = open(path, 'r')
+            s = gfid.read()
+            gfid.close()
             commit = s.strip()[0: 12]
             # shorten the hash to a unique shortname
         except IOError:


### PR DESCRIPTION
# Symptoms:
When I try to use Leo-Editor with the Python 3 debug version, the following warnings are printed:

> 2017-05-27 15:16:00 /sec/tmp
> $ leomy xxx.leo
> setting leoID from os.getenv('USER'): 'bob'
> reading settings in /pri/git/leo-editor/leo/config/leoSettings.leo
> /pri/git/leo-editor/leo/core/leoGlobals.py:4249: ResourceWarning: unclosed file <_io.TextIOWrapper name='/pri/git/leo-editor/.git/refs/heads/master' mode='r' encoding='UTF-8'>
>   s = open(path, 'r').read()
> /pri/git/leo-editor/leo/core/leoGlobals.py:4249: ResourceWarning: unclosed file <_io.TextIOWrapper name='/pri/git/leo-editor/.git/refs/heads/master' mode='r' encoding='UTF-8'>
>   s = open(path, 'r').read()
> reading settings in /home/bob/.leo/myLeoSettings.leo
> /pri/git/leo-editor/leo/core/leoGlobals.py:4249: ResourceWarning: unclosed file <_io.TextIOWrapper name='/pri/git/leo-editor/.git/refs/heads/master' mode='r' encoding='UTF-8'>
>   s = open(path, 'r').read()
> /pri/git/leo-editor/leo/core/leoGlobals.py:4249: ResourceWarning: unclosed file <_io.TextIOWrapper name='/pri/git/leo-editor/.git/refs/heads/master' mode='r' encoding='UTF-8'>
>   s = open(path, 'r').read()
> Found /help
> /pri/git/leo-editor/leo/core/leoApp.py:3294: ResourceWarning: unclosed file <_io.TextIOWrapper name='/sec/.leo/.leoRecentFiles.txt' mode='r' encoding='utf-8'>
>   ok = rf.readRecentFilesFile(path)
> 

The file open identifier is not saved.  The warnings are obviously correct.  The file(s) are closed only when Leo-Editor terminates.

# Test System

> Xubuntu 16.04 with window manager i3
> Leo Log Window
> Leo 5.5, build 20170526124207, Fri May 26 12:42:07 CDT 2017
> Git repo info: branch = close-git-files, commit = 0cd611d4d468
> Python 3.5.2, PyQt version 5.5.1
> linux

After the close-git-files fix:

2017-05-27 15:41:36 /sec/tmp
$ leomy xxx.leo
setting leoID from os.getenv('USER'): 'bob'
reading settings in /pri/git/leo-editor/leo/config/leoSettings.leo
reading settings in /home/bob/.leo/myLeoSettings.leo
Found /help
/pri/git/leo-editor/leo/core/leoApp.py:3294: ResourceWarning: unclosed file <_io.TextIOWrapper name='/sec/.leo/.leoRecentFiles.txt' mode='r' encoding='utf-8'>
  ok = rf.readRecentFilesFile(path)

# Possible Additional Bug
I don't know if file /sec/.leo/.leoRecentFiles.txt should remain open as long as Leo-Editor runs?  Is this a bug also?