### PR TITLE
Adds command line scripts for starting in console mode and with shell messages (#637)

### DIFF
--- a/launchLeo-console.py
+++ b/launchLeo-console.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+""" Leo launcher script
+A minimal script to launch leo.
+"""
+
+import leo.core.runLeo
+leo.core.runLeo.run_console()

--- a/leo/core/commit_timestamp.json
+++ b/leo/core/commit_timestamp.json
@@ -1,4 +1,4 @@
 {
-    "asctime": "Sat Jan  6 23:02:24 PST 2018",
-    "timestamp": "20180106230224"
+    "asctime": "Sat Jan  6 23:26:25 PST 2018",
+    "timestamp": "20180106232625"
 }

--- a/leo/core/commit_timestamp.json
+++ b/leo/core/commit_timestamp.json
@@ -1,4 +1,4 @@
 {
-    "asctime": "Fri Jan  5 17:33:08 CST 2018",
-    "timestamp": "20180105173308"
+    "asctime": "Sat Jan  6 23:02:24 PST 2018",
+    "timestamp": "20180106230224"
 }

--- a/leo/core/commit_timestamp.json
+++ b/leo/core/commit_timestamp.json
@@ -1,4 +1,4 @@
 {
-    "asctime": "Sat Jan  6 23:26:25 PST 2018",
-    "timestamp": "20180106232625"
+    "asctime": "Wed Jan 10 22:09:05 PST 2018",
+    "timestamp": "20180110220905"
 }

--- a/leo/core/commit_timestamp.json
+++ b/leo/core/commit_timestamp.json
@@ -1,4 +1,4 @@
 {
-    "asctime": "Wed Jan 10 22:09:05 PST 2018",
-    "timestamp": "20180110220905"
+    "asctime": "Wed Jan 10 22:17:01 PST 2018",
+    "timestamp": "20180110221701"
 }

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -73,14 +73,17 @@ def run(fileName=None, pymacs=None, *args, **keywords):
     g.app.loadManager = leoApp.LoadManager()
     g.app.loadManager.load(fileName, pymacs)
 
-def run_console(fileName=None, pymacs=None, *args, **keywords):
-    """Initialize and run Leo"""
-    run(fileName=None, pymacs=None, gui=console, *args, **keywords)
+def run_console(fileName=None, pymacs=None, gui='console', *args, **keywords):
+    """Initialize and run Leo in console mode"""
+    assert g.app
+    # g.trace('runLeo.py', fileName, args, keywords)
+    g.app.loadManager = leoApp.LoadManager()
+    g.app.loadManager.load(fileName, pymacs)
 
 #@-others
 #@@language python
 #@@tabwidth -4
 #@@pagewidth 70
 if __name__ == "__main__":
-    run()
+    run_console()
 #@-leo

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -72,7 +72,7 @@ def run(fileName=None, pymacs=None, *args, **keywords):
     # g.trace('runLeo.py', fileName, args, keywords)
     g.app.loadManager = leoApp.LoadManager()
     g.app.loadManager.load(fileName, pymacs)
-
+#@+node:maphew.20180110221247.1: ** run console (runLeo.py)
 def run_console(*args, **keywords):
     """Initialize and run Leo in console mode gui"""
     import sys

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -73,17 +73,15 @@ def run(fileName=None, pymacs=None, *args, **keywords):
     g.app.loadManager = leoApp.LoadManager()
     g.app.loadManager.load(fileName, pymacs)
 
-def run_console(fileName=None, pymacs=None, gui='console', *args, **keywords):
-    """Initialize and run Leo in console mode"""
-    assert g.app
-    # g.trace('runLeo.py', fileName, args, keywords)
-    g.app.loadManager = leoApp.LoadManager()
-    g.app.loadManager.load(fileName, pymacs)
-
+def run_console(*args, **keywords):
+    """Initialize and run Leo in console mode gui"""
+    import sys
+    sys.argv.append('--gui=console')
+    run(*args, *keywords)
 #@-others
 #@@language python
 #@@tabwidth -4
 #@@pagewidth 70
 if __name__ == "__main__":
-    run_console()
+    run()
 #@-leo

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -72,6 +72,11 @@ def run(fileName=None, pymacs=None, *args, **keywords):
     # g.trace('runLeo.py', fileName, args, keywords)
     g.app.loadManager = leoApp.LoadManager()
     g.app.loadManager.load(fileName, pymacs)
+
+def run_console(fileName=None, pymacs=None, *args, **keywords):
+    """Initialize and run Leo"""
+    run(fileName=None, pymacs=None, gui=console, *args, **keywords)
+
 #@-others
 #@@language python
 #@@tabwidth -4

--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,11 @@ setup(
     include_package_data=True, # also include MANIFEST files in wheels
     install_requires=user_requires,
     entry_points={
-       'console_scripts': ['leoc = leo.core.runLeo:run'],
-       'gui_scripts': ['leo = leo.core.runLeo:run']
+       'console_scripts': ['leo-c = leo.core.runLeo:run',
+            'leo-console = leo.core.runLeo:run_console',
+            'leo-m = leo.core.runLeo:run',
+            'leo-messages = leo.core.runLeo:run'],
+            'gui_scripts': ['leo = leo.core.runLeo:run']
        }
 )
 

--- a/setup.py
+++ b/setup.py
@@ -112,10 +112,10 @@ setup(
     include_package_data=True, # also include MANIFEST files in wheels
     install_requires=user_requires,
     entry_points={
-       'console_scripts': ['leo-c = leo.core.runLeo:run',
-            'leo-console = leo.core.runLeo:run_console',
-            'leo-m = leo.core.runLeo:run',
-            'leo-messages = leo.core.runLeo:run'],
+       'console_scripts': ['leo-c = leo.core.runLeo:run_console',
+                'leo-console = leo.core.runLeo:run_console',
+                'leo-m = leo.core.runLeo:run',
+                'leo-messages = leo.core.runLeo:run'],
             'gui_scripts': ['leo = leo.core.runLeo:run']
        }
 )


### PR DESCRIPTION
When using `pip install` this setup.py installs the following scripts in `PYTHONHOME\Scripts`:

* `leo` - start Leo in normal graphical mode (qt)
* `leo-c`, `leo-console` - start Leo in console (curses) mode
* `leo-m`, `leo-messages` - start Leo in normal (qt) mode, and echo log messages to the starting shell

**leo-m** is new name for an old thing. **leo-c** is a new thing, re-using an old name. There might be some confusion over this, but I don't think it will be serious or long lasting because `leo-c` hasn't been talked about or promoted very much. In short, I think it's worth the pain, if any.

I'm little unsure about the new `run_console()` function in `runLeo.py`. The result works, but I don't know if it should also pass `fileName=None, pymacs=None` along with `*args` and `**keywords. `