### PR TITLE
Allow native menu bar at least on mac.

### DIFF
--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -270,7 +270,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         '''Create Leo's menu bar.'''
         dw = self
         w = QtWidgets.QMenuBar(dw)
-        w.setNativeMenuBar(False)
+        w.setNativeMenuBar(platform.system() == 'Darwin')
         w.setGeometry(QtCore.QRect(0, 0, 957, 22))
         w.setObjectName("menubar")
         dw.setMenuBar(w)


### PR DESCRIPTION
Menu bar in-window is disorienting on mac.
I saw from commit history (bcc0dea4f22cf7c51d152ce1d1f9c074e8a9aaeb) that native menus are buggy on Xubuntu.
Maybe should be enabled on windows as well?