### PR TITLE
Fix broken link to screen shots

### DIFF
--- a/leo/doc/html/index.html
+++ b/leo/doc/html/index.html
@@ -250,7 +250,7 @@
             <a class="reference external" href="leo_toc.html">
               Documentation</a><br>
               
-            <a class="reference external" href="http:screen-shots.html">
+            <a class="reference external" href="screen-shots.html">
               Screen shots</a><br>
               
             <a class="reference external" href="screencasts.html">


### PR DESCRIPTION
```html
<a class="reference external" href="http:screen-shots.html">
```

There is no site at http screen-shots dot html. 😄 