### PR TITLE
Keep cursor on blank last line after end-of-line command

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2028,7 +2028,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 self.moveToHelper(event, i, extend=extend)
             elif spot == 'end-line':
                 # Bug fix: 2011/11/13: Significant in external tests.
-                if g.match(s, j - 1, '\n'): j -= 1
+                if g.match(s, j - 1, '\n') and i != j: j -= 1
                 self.moveToHelper(event, j, extend=extend)
             elif spot == 'finish-line':
                 if not line.isspace():

--- a/leo/test/activeUnitTests.txt
+++ b/leo/test/activeUnitTests.txt
@@ -7841,6 +7841,81 @@ line 1
         line b
 line c
 last line
+#@+node:btheado.20190926223006.1: *5* @test end-of-line (internal blank line)
+c.testManager.runEditCommandTest(p)
+#@+node:btheado.20190926223006.2: *6* work
+first line
+
+line 1
+    line a
+        line b
+line c
+last line
+#@+node:btheado.20190926223006.3: *6* before sel=2.0,2.0
+first line
+
+line 1
+    line a
+        line b
+line c
+last line
+#@+node:btheado.20190926223006.4: *6* after sel=2.0,2.0
+first line
+
+line 1
+    line a
+        line b
+line c
+last line
+#@+node:btheado.20190926182937.1: *5* @test end-of-line (blank last line)
+c.testManager.runEditCommandTest(p)
+#@+node:btheado.20190926182937.2: *6* work
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+#@+node:btheado.20190926182937.3: *6* before sel=7.0,7.0
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+#@+node:btheado.20190926182937.4: *6* after sel=7.0,7.0
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+#@+node:btheado.20190926224744.1: *5* @test end-of-line (single char last line)
+c.testManager.runEditCommandTest(p)
+#@+node:btheado.20190926224744.2: *6* work
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+ 
+#@+node:btheado.20190926224744.3: *6* before sel=7.0,7.0
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+ 
+#@+node:btheado.20190926224744.4: *6* after sel=7.1,7.1
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+ 
 #@+node:ekr.20061101121602.194: *5* @test end-of-line-extend-selection
 c.testManager.runEditCommandTest(p)
 #@+node:ekr.20061101121602.195: *6* work
@@ -7864,6 +7939,29 @@ line 1
         line b
 line c
 last line
+#@+node:btheado.20190927201634.1: *5* @test end-of-line-extend-selection (blank last line)
+c.testManager.runEditCommandTest(p)
+#@+node:btheado.20190927201634.2: *6* work
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+#@+node:btheado.20190927201634.3: *6* before sel=7.0,7.0
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
+#@+node:btheado.20190927201634.4: *6* after sel=7.0,7.0
+first line
+line 1
+    line a
+        line b
+line c
+last non-blank line
 #@+node:ekr.20061101121602.198: *5* @test exchange-point-mark
 c.testManager.runEditCommandTest(p)
 #@+node:ekr.20061101121602.199: *6* work


### PR DESCRIPTION
Fixes #1354. I'm not 100% sure this is the right fix. It isn't obvious to me whether or not g.getLine has the correct behavior in this case. I chose to fix it in a less obtrusive place which only affects the `end-of-line` command.

I added two unit tests which fail before the fix and pass after. I also added a few other tests to help me feel better about the change.