### PR TITLE
Fix typo in spellCommands.py

### DIFF
--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -77,7 +77,7 @@ class BaseSpellWrapper:
             if g.os_path_exists(path):
                 return path
         #
-        g.es_print('Do spellpyx.txt file found')
+        g.es_print('No spellpyx.txt file found')
         return None
     #@+node:ekr.20150514063305.515: *3* spell.ignore
     def ignore(self, word):


### PR DESCRIPTION
First introduced in 2d17e29a26b7cab8454db1f8be6634d700d8c718.

Note: I came across this because it showed up when I first launched leo after installing it with `pip3 install leo` and starting it from the command line with `leo`:

```
Leo Log Window
Leo 6.1-final
Python 3.7.7, PyQt version 5.12.7
darwin
created directory: /Users/waldyrious/.leo
setting leoID from os.getenv('USER'): 'waldyrious'
current dir: /Users/waldyrious
load dir: /usr/local/lib/python3.7/site-packages/leo/core
global config dir: /usr/local/lib/python3.7/site-packages/leo/config
home dir: /Users/waldyrious
reading settings in /usr/local/lib/python3.7/site-packages/leo/config/leoSettings.leo
Do spellpyx.txt file found
unexpected error creating: None
Traceback (most recent call last):

  File "/usr/local/lib/python3.7/site-packages/leo/commands/spellCommands.py", line 56, in create
    f = open(fn, mode='wb')

TypeError: expected str, bytes or os.PathLike object, not NoneType

reading settings in /usr/local/lib/python3.7/site-packages/leo/doc/CheatSheet.leo
```