### PR TITLE
Freshen download links and pip install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 - [Tutorials](https://leoeditor.com/tutorial.html)
 - [Video tutorials](https://leoeditor.com/screencasts.html)
 - [Forum](https://groups.google.com/group/leo-editor)
-- [Download](https://leoeditor.com/download)
+- [Download](https://github.com/leo-editor/leo-editor/releases)
 - [Leo on GitHub](https://github.com/leo-editor/leo-editor)
 - [LeoVue](https://github.com/kaleguy/leovue#leo-vue)
 - [What people are saying about Leo](https://leoeditor.com/testimonials.html)

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 
 **Links**
 
-- Leo's home page: http://leoeditor.com
-- [Documentation](http://leoeditor.com/leo_toc.html)
-- [Tutorials](http://leoeditor.com/tutorial.html)
-- [Video tutorials](http://leoeditor.com/screencasts.html)
-- [Forum](http://groups.google.com/group/leo-editor)
-- [Download](http://sourceforge.net/projects/leo/files/)
+- Leo's home page: https://leoeditor.com
+- [Documentation](https://leoeditor.com/leo_toc.html)
+- [Tutorials](https://leoeditor.com/tutorial.html)
+- [Video tutorials](https://leoeditor.com/screencasts.html)
+- [Forum](https://groups.google.com/group/leo-editor)
+- [Download](https://leoeditor.com/download)
 - [Leo on GitHub](https://github.com/leo-editor/leo-editor)
 - [LeoVue](https://github.com/kaleguy/leovue#leo-vue)
-- [What people are saying about Leo](http://leoeditor.com/testimonials.html)
-- [A web page that displays .leo files](http://leoeditor.com/load-leo.html)
-- [More links](http://leoeditor.com/leoLinks.html)
+- [What people are saying about Leo](https://leoeditor.com/testimonials.html)
+- [A web page that displays .leo files](https://leoeditor.com/load-leo.html)
+- [More links](https://leoeditor.com/leoLinks.html)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 - Fixed several "fit and finish" issues.
 - Removed unused settings from leoSettings.leo.
 
+**Quick Install**
+
+- Install python3
+- if not using git:
+    `pip install leo`
+- If using git:
+    `git clone https://github.com/leo-editor/leo-editor.git`
+    `pip install --editable leo-editor`
+
+See [Getting Started](http://leoeditor.com/getting-started.html) for more. 
+
 **Links**
 
 - Leo's home page: https://leoeditor.com

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -273,7 +273,7 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 - [Tutorials](https://leoeditor.com/tutorial.html)
 - [Video tutorials](https://leoeditor.com/screencasts.html)
 - [Forum](https://groups.google.com/group/leo-editor)
-- [Download](https://leoeditor.com/download)
+- [Download](https://github.com/leo-editor/leo-editor/releases)
 - [Leo on GitHub](https://github.com/leo-editor/leo-editor)
 - [LeoVue](https://github.com/kaleguy/leovue#leo-vue)
 - [What people are saying about Leo](https://leoeditor.com/testimonials.html)

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -268,17 +268,17 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 
 **Links**
 
-- Leo's home page: http://leoeditor.com
-- [Documentation](http://leoeditor.com/leo_toc.html)
-- [Tutorials](http://leoeditor.com/tutorial.html)
-- [Video tutorials](http://leoeditor.com/screencasts.html)
-- [Forum](http://groups.google.com/group/leo-editor)
-- [Download](http://sourceforge.net/projects/leo/files/)
+- Leo's home page: https://leoeditor.com
+- [Documentation](https://leoeditor.com/leo_toc.html)
+- [Tutorials](https://leoeditor.com/tutorial.html)
+- [Video tutorials](https://leoeditor.com/screencasts.html)
+- [Forum](https://groups.google.com/group/leo-editor)
+- [Download](https://leoeditor.com/download)
 - [Leo on GitHub](https://github.com/leo-editor/leo-editor)
 - [LeoVue](https://github.com/kaleguy/leovue#leo-vue)
-- [What people are saying about Leo](http://leoeditor.com/testimonials.html)
-- [A web page that displays .leo files](http://leoeditor.com/load-leo.html)
-- [More links](http://leoeditor.com/leoLinks.html)
+- [What people are saying about Leo](https://leoeditor.com/testimonials.html)
+- [A web page that displays .leo files](https://leoeditor.com/load-leo.html)
+- [More links](https://leoeditor.com/leoLinks.html)
 </t>
 <t tx="EKR.20040519091259.1">5.1:        setup: 1,114    zip: 2,912
 5.0:        setup: 552      zip: 1,617
@@ -2426,6 +2426,7 @@ git:
     ## Clone depth, must be big enough to include a tag
     depth: 500
 install:
+    - python -m pip install --upgrade pip
     - pip --version
     - pip install setupext-janitor asttokens
 script:

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -266,6 +266,17 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 - Fixed several "fit and finish" issues.
 - Removed unused settings from leoSettings.leo.
 
+**Quick Install**
+
+- Install python3
+- if not using git:
+    `pip install leo`
+- If using git:
+    `git clone https://github.com/leo-editor/leo-editor.git`
+    `pip install --editable leo-editor`
+
+See [Getting Started](http://leoeditor.com/getting-started.html) for more. 
+
 **Links**
 
 - Leo's home page: https://leoeditor.com

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -31708,11 +31708,13 @@ Time passes, upgrade desired::
 dramatically speed up download time as it only grabs the latest
 development branch and skips all but the last couple weeks or months of
 history.</t>
-<t tx="matt.20200331213038.1">When Leo has been installed in non-editable mode* (the above) there will be messages in the log pane window when opening certain .leo files distributed with Leo, such as LeoDocs.leo. (_File &gt;&gt; Open Leo File &gt;&gt; ..._). The warnings are not serious and may be ignored.
+<t tx="matt.20200331213038.1">.._`Missing files when installing Leo from PyPI using "pip install leo"`:    https://github.com/leo-editor/leo-editor/issues/603
+
+When Leo has been installed in non-editable mode* (the above) there will be messages in the log pane window when opening certain .leo files distributed with Leo, such as LeoDocs.leo. (_File &gt;&gt; Open Leo File &gt;&gt; ..._). The warnings are not serious and may be ignored.
 
 This is a known issue with no practical solution. Files in the root folder of the leo-editor code repository is not installed when using pip. This is because they need to be relative to ``./leo-editor/leo`` folder, which make them at the top of ``PYTHONHOME/lib/site-packages``, and thus in the global namespace and not part of leo as far as python is concerned.
 
-Details at https://github.com/leo-editor/leo-editor/issues/603
+Details at `Missing files when installing Leo from PyPI using "pip install leo`_
 
 * An editable install is from source code, either a git clone or downloaded archive. See: 
 - Installing Leo with git

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -12529,13 +12529,13 @@ write_intermediate_file = True
 Downloading Leo
 ###############
 
-There are four ways to download Leo:
+There are three ways to download Leo:
 
-- **New**: Leo 5.7 final will have a `Python wheel`_, so ``pip install leo`` will automatically download *and* install Leo, including all Leo's dependencies. See `Installing Leo with pip`_.
+- ``pip install leo`` will automatically download *and* install Leo, including all Leo's dependencies, less a couple of non-essential things. See `Installing Leo with pip`_.
 
-- We recommend installing Leo using `git`_, see `Installing Leo with git`_. Git gives you the latest, thoroughly tested code. All of Leo's developers use git.
+- Recommended: install Leo using `git`_, see `Installing Leo with git`_. Git gives you the latest, thoroughly tested code with nothing missing.
 
-- If you prefer a new development version, or a version from from 1, 2, 5, 10, 30 or 90 days ago, download a `Nightly snapshot`_.
+- If you prefer a new development version and don't want to use git download a `Nightly snapshot`_.
 </t>
 <t tx="ekr.20120130101219.10182">def computeBindingLetter(self, kind):
     # lm = self
@@ -26143,9 +26143,17 @@ Python's `pip`_ tool will download *and* install Leo and all of Leo's dependenci
 
     pip --version
 
+In some circumstances using pip as a module works better:
+
+    python -m pip --version
+
 3. Install Leo and all required packages:
 
     pip install leo
+
+or 
+
+    python -m pip install leo
 </t>
 <t tx="ekr.20180130055320.1">https://github.com/leo-editor/leo-editor/issues/562</t>
 <t tx="ekr.20180130092843.1">.. https://groups.google.com/forum/#!topic/leo-editor/yAtfcG6AL70

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -553,7 +553,9 @@
 </v>
 <v t="ekr.20131008041326.16094"><vh>@rst html/installing.html</vh>
 <v t="ekr.20141105052052.4"><vh>Dependencies</vh></v>
-<v t="ekr.20180130033527.1"><vh>Installing Leo with pip</vh></v>
+<v t="ekr.20180130033527.1"><vh>Installing Leo with pip</vh>
+<v t="matt.20200331213038.1"><vh>PyPi install caveat</vh></v>
+</v>
 <v t="ekr.20101125062332.5090"><vh>Installing packages</vh></v>
 <v t="ekr.20170206073848.1"><vh>Installing Leo itself</vh>
 <v t="ekr.20170206073747.2"><vh>Installing Leo on Windows</vh>
@@ -2381,6 +2383,7 @@
 </v>
 <v t="ekr.20200313060126.1"></v>
 <v t="ekr.20200225075435.1"></v>
+<v t="ekr.20180130033527.1"></v>
 </vnodes>
 <tnodes>
 <t tx="EKR.20040524104904.140">Leo stores options in **@settings trees**, outlines whose headline is @settings. When opening a .leo file, Leo looks for @settings trees not only in the outline being opened but also in various leoSettings.leo files. This scheme allows for the following kinds of settings:
@@ -26133,7 +26136,8 @@ the headline of any node.
 </t>
 <t tx="ekr.20180130033527.1">.. _`Install pip`:      https://pip.pypa.io/en/stable/installing/               
 .. _`Install Python`:   http://python.org.
-.. _`pip`:              https://pypi.python.org/pypi/pip
+.. _`pip`:              https://pypi.org/pypi/pip
+.. _`PyPi`:              https://pypi.org/
 
 Python's `pip`_ tool will download *and* install Leo and all of Leo's dependencies automatically.
 
@@ -26147,14 +26151,14 @@ In some circumstances using pip as a module works better:
 
     python -m pip --version
 
-3. Install Leo and all required packages:
+3. Download and install Leo and all required packages from `PyPi`_::
 
     pip install leo
 
 or 
 
     python -m pip install leo
-</t>
+    </t>
 <t tx="ekr.20180130055320.1">https://github.com/leo-editor/leo-editor/issues/562</t>
 <t tx="ekr.20180130092843.1">.. https://groups.google.com/forum/#!topic/leo-editor/yAtfcG6AL70
 
@@ -31704,6 +31708,15 @@ Time passes, upgrade desired::
 dramatically speed up download time as it only grabs the latest
 development branch and skips all but the last couple weeks or months of
 history.</t>
+<t tx="matt.20200331213038.1">When Leo has been installed in non-editable mode* (the above) there will be messages in the log pane window when opening certain .leo files distributed with Leo, such as LeoDocs.leo. (_File &gt;&gt; Open Leo File &gt;&gt; ..._). The warnings are not serious and may be ignored.
+
+This is a known issue with no practical solution. Files in the root folder of the leo-editor code repository is not installed when using pip. This is because they need to be relative to ``./leo-editor/leo`` folder, which make them at the top of ``PYTHONHOME/lib/site-packages``, and thus in the global namespace and not part of leo as far as python is concerned.
+
+Details at https://github.com/leo-editor/leo-editor/issues/603
+
+* An editable install is from source code, either a git clone or downloaded archive. See: 
+- Installing Leo with git
+- Installing from sources (Windows)</t>
 <t tx="mhw.20191008134016.1"></t>
 <t tx="mhw.20191008134029.1">##########################
 Leo and Asciidoctor


### PR DESCRIPTION
As per #1550. I'm doing this as a PR instead of a straight merge because I'm not that good with rst formatting. One thing missing is the link from _Caveats_ section to _Install from Git_, and _from Source_. I don't know how to link across chapters in the same document but in different nodes. There might some other mistakes too ;-)