### PR TITLE
Fixes on some plugins

### DIFF
--- a/leo/plugins/active_path.py
+++ b/leo/plugins/active_path.py
@@ -392,11 +392,14 @@ def openFile(c,parent,d, autoload=False):
             c.config.getData('active_path_bin_open') or '')
 
         if not binary_open:
-            start = open(path).read(100)
-            for i in start:
-                if ord(i) == 0:
-                    binary_open = True
-                    break
+            try:
+                start = open(path).read(100)
+                for i in start:
+                    if ord(i) == 0:
+                        binary_open = True
+                        break
+            except:
+                binary_open = True
 
         if binary_open:
             g.es('Treating file as binary')

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -236,11 +236,11 @@ def universal_line_numbers(root, target_p, delim_st, delim_en):
             return (0, n-st) if delim_st else (0, n-st)
         #@+node:vitalije.20170726193933.1: *4* doc part
         if doc_pattern.match(line):
-            if delim_en: return 0, 2
-            return 1,1
+            if delim_st: return 0, 1
+            return 0, 0
         #@+node:vitalije.20170726193941.1: *4* code part
         if code_pattern.match(line):
-            if delim_en: return 1, 2
+            # if delim_en: return 1, 2
             if delim_st: return 0, 1
             return 0, 0
         #@-others

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -240,7 +240,6 @@ def universal_line_numbers(root, target_p, delim_st, delim_en):
             return 0, 0
         #@+node:vitalije.20170726193941.1: *4* code part
         if code_pattern.match(line):
-            # if delim_en: return 1, 2
             if delim_st: return 0, 1
             return 0, 0
         #@-others

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -10,7 +10,7 @@
    
    Author: vitalije(at)kviziracija.net
 """
-__version__ = "0.1"
+__version__ = "0.2"
 #@+node:vitalije.20170727201931.1: ** imports
 import re
 import leo.core.leoGlobals as g

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,9 @@ def git_version(file, version=None):
 def clean_git_tag(tag):
     """Return only version number from tag name. Ignore unknown formats.
        Is specific to tags in Leo's repository.
-            5.7b1          -->	5.7b1
-            Leo-4-4-8-b1   -->	4-4-8-b1
-            v5.3           -->	5.3
+            5.7b1          -->  5.7b1
+            Leo-4-4-8-b1   -->  4-4-8-b1
+            v5.3           -->  5.3
             Fixed-bug-149  -->  Fixed-bug-149
     """
     if tag.lower().startswith('leo-'): tag = tag[4:]
@@ -107,8 +107,8 @@ setup_requires = []
     # setup_requires no longer needed with PEP-518 and pip >v10
 #@+node:maphew.20171120133429.1: ** User requirements
 user_requires = [
-    # ~'PyQt5 >= 5.12',  # v5.12+ to close #1217
-    # ~'PyQtWebEngine',  # #1202 QtWebKit needs to be installed separately starting Qt 5.6
+    'PyQt5 >= 5.12',  # v5.12+ to close #1217
+    'PyQtWebEngine',  # #1202 QtWebKit needs to be installed separately starting Qt 5.6
     'asttokens',  # abstract syntax tree text parsing
     'docutils',  # used by Sphinx, rST plugin
     'flexx',  # for LeoWapp browser gui

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,9 @@ def git_version(file, version=None):
 def clean_git_tag(tag):
     """Return only version number from tag name. Ignore unknown formats.
        Is specific to tags in Leo's repository.
-            5.7b1          -->  5.7b1
-            Leo-4-4-8-b1   -->  4-4-8-b1
-            v5.3           -->  5.3
+            5.7b1          -->	5.7b1
+            Leo-4-4-8-b1   -->	4-4-8-b1
+            v5.3           -->	5.3
             Fixed-bug-149  -->  Fixed-bug-149
     """
     if tag.lower().startswith('leo-'): tag = tag[4:]

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,8 @@ setup_requires = []
     # setup_requires no longer needed with PEP-518 and pip >v10
 #@+node:maphew.20171120133429.1: ** User requirements
 user_requires = [
-    'PyQt5 >= 5.12',  # v5.12+ to close #1217
-    'PyQtWebEngine',  # #1202 QtWebKit needs to be installed separately starting Qt 5.6
+    # ~'PyQt5 >= 5.12',  # v5.12+ to close #1217
+    # ~'PyQtWebEngine',  # #1202 QtWebKit needs to be installed separately starting Qt 5.6
     'asttokens',  # abstract syntax tree text parsing
     'docutils',  # used by Sphinx, rST plugin
     'flexx',  # for LeoWapp browser gui


### PR DESCRIPTION
active_path.py: Opening a binary file caused an exception because the plugin tried to read the filestream directly.
line_numbering.py: The plugin incorrectly numbered the lines when it found a Leo directive.
nodeActions.py: The plugin was registering its double-click handler in an obsolete event. I added a command and fixed the file node recognition.