### PR TITLE
Remove oldRoot kwarg

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1257,7 +1257,7 @@ def moveMarked(self, event=None):
 def createMoveMarkedNode(c):
     oldRoot = c.rootPosition()
     p = oldRoot.insertAfter()
-    p.moveToRoot(oldRoot)
+    p.moveToRoot()
     c.setHeadString(p, 'Moved marked nodes')
     return p
 #@+node:ekr.20031218072017.2923: *3* c_oc.markChangedHeadlines
@@ -1539,7 +1539,7 @@ def moveOutlineUp(self, event=None):
         else:
             # p will be the new root node
             p.setDirty()
-            p.moveToRoot(oldRoot=c.rootPosition())
+            p.moveToRoot()
             moved = True
     elif back2.hasChildren() and back2.isExpanded():
         if c.checkMoveWithParentWithWarning(p, back2, True):

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -1032,8 +1032,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
             p.moveToFirstChildOf(parent,n)
             p.moveToLastChildOf(parent,n)
             p.moveToNthChildOf(parent,n)
-            p.moveToRoot(oldRoot=None)
-                # oldRoot **must** be the old root position if it exists.
+            p.moveToRoot()
 
         The following position methods move positions *themselves*: they change the
         node to which a position refers. They do *not* change outline structure in

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -720,13 +720,16 @@ class LeoFrame:
         self.tab_width = 0  # The tab width in effect in this pane.
     #@+node:ekr.20051009045404: *4* frame.createFirstTreeNode
     def createFirstTreeNode(self):
-        f = self; c = f.c
+        c= self.c
         v = leoNodes.VNode(context=c)
         p = leoNodes.Position(v)
         v.initHeadString("NewHeadline")
+        #
+        # #1631: Initialize here, not in p._linkAsRoot.
+        c.hiddenRootNode.children = []
+        #
         # New in Leo 4.5: p.moveToRoot would be wrong: the node hasn't been linked yet.
-        p._linkAsRoot(oldRoot=None)
-        # c.setRootPosition() # New in 4.4.2.
+        p._linkAsRoot()
     #@+node:ekr.20150509194519.1: *3* LeoFrame.cmd (decorator)
     def cmd(name):
         """Command decorator for the LeoFrame class."""

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1024,21 +1024,20 @@ class Position:
         p._childIndex = n
         child = p.v
         child._addCopiedLink(n, parent_v)
-    #@+node:ekr.20080416161551.216: *4* p._linkAsRoot
-    def _linkAsRoot(self, oldRoot):
+    #@+node:ekr.20080416161551.216: *4* p._linkAsRoot (changed)
+    def _linkAsRoot(self):
         """Link self as the root node."""
         p = self
         assert(p.v)
-        hiddenRootNode = p.v.context.hiddenRootNode
-        # if oldRoot: oldRootNode = oldRoot.v
-        # else:       oldRootNode = None
-        # Init the ivars.
+        parent_v = p.v.context.hiddenRootNode
+        assert parent_v, g.callers()
+        #
+        # Make p the root position.
         p.stack = []
         p._childIndex = 0
-        parent_v = hiddenRootNode
-        child = p.v
-        if not oldRoot: parent_v.children = []
-        child._addLink(0, parent_v)
+        #
+        # Make p.v the first child of parent_v.
+        p.v._addLink(0, parent_v)
         return p
     #@+node:ekr.20080416161551.212: *4* p._parentVnode
     def _parentVnode(self):
@@ -1527,18 +1526,14 @@ class Position:
         p._unlink()
         p._linkAsNthChild(parent, n)
         return p
-    #@+node:ekr.20040303175026.6: *4* p.moveToRoot
-    def moveToRoot(self, oldRoot=None):
-        """
-        Moves a position to the root position.
-
-        Important: oldRoot must the previous root position if it exists.
-        """
+    #@+node:ekr.20040303175026.6: *4* p.moveToRoot (changed)
+    def moveToRoot(self):
+        """Move self to the root position."""
         p = self  # Do NOT copy the position!
-        if oldRoot:
-            oldRoot._adjustPositionBeforeUnlink(p)
+        #
+        # #1631. The old root can not possibly be affected by unlinking p.
         p._unlink()
-        p._linkAsRoot(oldRoot)
+        p._linkAsRoot()
         return p
     #@+node:ekr.20180123062833.1: *4* p.promote
     def promote(self):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1487,7 +1487,7 @@ class Position:
             p = parent.insertAsNthChild(0)
         else:
             p = p.insertAfter()
-            p.moveToRoot(oldRoot=p)
+            p.moveToRoot()
         return p
     #@+node:ekr.20040310062332.1: *4* p.invalidOutline
     def invalidOutline(self, message):

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -1144,8 +1144,7 @@ class Undoer:
         elif u.newParent:
             u.newP._linkAsNthChild(u.newParent, 0)
         else:
-            oldRoot = c.rootPosition()
-            u.newP._linkAsRoot(oldRoot)
+            u.newP._linkAsRoot()
         c.selectPosition(u.newP)
         u.newP.setDirty()
     #@+node:ekr.20111005152227.15559: *4* u.redoDeleteMarkedNodes
@@ -1226,8 +1225,7 @@ class Undoer:
         elif u.newParent:
             u.newP._linkAsNthChild(u.newParent, 0)
         else:
-            oldRoot = c.rootPosition()
-            u.newP._linkAsRoot(oldRoot)
+            u.newP._linkAsRoot()
         if u.pasteAsClone:
             for bunch in u.afterTree:
                 v = bunch.v
@@ -1445,8 +1443,7 @@ class Undoer:
         elif u.oldParent:
             u.p._linkAsNthChild(u.oldParent, 0)
         else:
-            oldRoot = c.rootPosition()
-            u.p._linkAsRoot(oldRoot)
+            u.p._linkAsRoot()
         u.p.setDirty()
         c.selectPosition(u.p)
     #@+node:ekr.20080425060424.10: *4* u.undoDemote

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -176,7 +176,7 @@ class TextFrame(leoFrame.LeoFrame):
         v.initHeadString("NewHeadline")
         # New in Leo 4.5: p.moveToRoot would be wrong:
         # the node hasn't been linked yet.
-        p._linkAsRoot(oldRoot=None)
+        p._linkAsRoot()
         # c.setRootPosition(p) # New in 4.4.2.
 
     #@+node:ekr.20150107090324.24: *3* deiconify

--- a/leo/test/activeUnitTests.txt
+++ b/leo/test/activeUnitTests.txt
@@ -21642,8 +21642,7 @@ try:
     assert not child.isCloned(), 'fail 1-c'
     c.undoer.redo()
     assert child.isCloned(),    'fail 1-d'
-    oldRoot = c.rootPosition()
-    clone.moveToRoot(oldRoot=oldRoot) # Does not change child position.
+    clone.moveToRoot()  # Does not change child position.
     assert child.isCloned(),    'fail 3-2'
     assert clone.isCloned(),    'fail 4-2'
     assert not clone.parent(),  'fail 5'
@@ -21716,8 +21715,7 @@ else:
     child.setHeadString('child')
     
     try:
-        oldRoot = c.rootPosition()
-        child.moveToRoot(oldRoot=oldRoot) # Does not change child position.
+        child.moveToRoot()  # Does not change child position.
         c.setRootPosition(child)
         assert c.positionExists(child)
         assert c.rootPosition().h == 'child', 'fail 1'


### PR DESCRIPTION
This is a subset of #1631. It removes the oldRoot kwarg from p._linkAsRoot and p.moveToRoot.