### PR TITLE
--trace=startup prints timing stats

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2307,11 +2307,12 @@ class LoadManager:
             print(d)
     #@+node:ekr.20120219154958.10452: *3* LM.load & helpers
     def load(self, fileName=None, pymacs=None):
-        """Load the indicated file"""
+        """This is Leo's main startup method."""
         lm = self
-        t1 = time.process_time()
+        #
         # Phase 1: before loading plugins.
         # Scan options, set directories and read settings.
+        t1 = time.process_time()
         print('')  # Give some separation for the coming traces.
         if not lm.isValidPython():
             return
@@ -2327,12 +2328,15 @@ class LoadManager:
             # Disable redraw until all files are loaded.
         #
         # Phase 2: load plugins: the gui has already been set.
+        t2 = time.process_time()
         g.doHook("start1")
+        t3 = time.process_time()
         if g.app.killed:
             return
         g.app.idleTimeManager.start()
         #
         # Phase 3: after loading plugins. Create one or more frames.
+        t3 = time.process_time()
         if lm.options.get('script') and not self.files:
             ok = True
         else:
@@ -2347,8 +2351,13 @@ class LoadManager:
         if g.app.listen_to_log_flag:
             g.app.listenToLog()
         if 'startup' in g.app.debug:
-            t2 = time.process_time()
-            g.es_print(f"startup time: {t2 - t1:5.2f} sec")
+            t4 = time.process_time()
+            print('')
+            g.es_print(f"settings:{t2 - t1:5.2f} sec")
+            g.es_print(f" plugins:{t3 - t2:5.2f} sec")
+            g.es_print(f"   files:{t4 - t3:5.2f} sec")
+            g.es_print(f"   total:{t4 - t1:5.2f} sec")
+            print('')
         g.app.gui.runMainLoop()
         # For scripts, the gui is a nullGui.
         # and the gui.setScript has already been called.

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -77,10 +77,10 @@ class SessionManager:
             exists = fn and g.os_path_exists(fn)
             if not exists:
                 if 'startup' in g.app.debug:
-                    g.trace('file not found:', fn)
+                    g.trace('session file not found:', fn)
                 continue
             if 'startup' in g.app.debug:
-                g.trace('loading:', fn)
+                g.trace('loading session file:', fn)
             g.app.loadManager.loadLocalFile(fn, gui=g.app.gui, old_c=c)
                 # This selects the proper position.
     #@+node:ekr.20120420054855.14248: *3* SessionManager.load_snapshot

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -121,8 +121,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
         """Ctor for the DynamicWindow class.  The main window is c.frame.top"""
             # Called from LeoQtFrame.finishCreate.
             # parent is a LeoTabbedTopLevel.
-        if 'startup' in g.app.debug:
-            print('DynamicWindow.__init__', c.shortFileName())
         super().__init__(parent)
         self.leo_c = c
         self.leo_master = None  # Set in construct.


### PR DESCRIPTION
Useful for overall comparisons of Leo's load times.

Will be used to compare "devel" and "speed" branches.