### PR TITLE
PR for #1749

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1694,7 +1694,6 @@ class EditCommandsClass(BaseEditCommandsClass):
             newText = w.getAllText()  # Converts to unicode.
             u.setUndoTypingParams(p, undoType, oldText, newText,
                 oldSel=oldSel, oldYview=oldYview, newInsert=newInsert, newSel=newSel)
-
         g.doHook("bodykey2", c=c, p=p, ch=ch, oldSel=oldSel, undoType=undoType)
     #@+node:ekr.20160924135613.1: *5* ec.doPlainChar
     def doPlainChar(self, action, ch, event, inBrackets, oldSel, stroke, w):

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1684,6 +1684,7 @@ class NullFrame(LeoFrame):
         assert self.c
         self.wrapper = None
         self.iconBar = NullIconBarClass(self.c, self)
+        self.initComplete = True
         self.isNullFrame = True
         self.outerFrame = None
         self.ratio = self.secondary_ratio = 0.5

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2262,7 +2262,12 @@ class VNode:
         v.statusBits &= ~v.dirtyBit
     #@+node:ekr.20080429053831.12: *5* v.setDirty
     def setDirty(self):
-        """Set the vnode dirty bit."""
+        """
+        Set the vnode dirty bit.
+        
+        This method is fast, but dangerous. Unlike p.setDirty, this method does
+        not call v.setAllAncestorAtFileNodesDirty.
+        """
         self.statusBits |= self.dirtyBit
     #@+node:ekr.20031218072017.3386: *4*  v.Status bits
     #@+node:ekr.20031218072017.3389: *5* v.clearClonedBit

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -421,6 +421,11 @@ class Undoer:
             bunch.newSel = 0, 0
         bunch.newYScroll = w.getYScrollPosition() if w else 0
         u.pushBead(bunch)
+        # #1749.
+        if not p.isDirty():
+            p.setDirty()  # Do not call p.v.setDirty!
+        if not c.isChanged():
+            c.setChanged()
         # Do *not* recolor or redraw here!
         w.setFocus()
         
@@ -1158,10 +1163,18 @@ class Undoer:
                 i, j = j, i
             p.v.selectionStart, p.v.selectionLength = (i, j - i)
         c.recolor()
-        if not c.changed and c.frame.initComplete:
-            c.setChanged()
+        # #1749.
+        redraw_flag = False
+        if c.frame.initComplete:
+            if not p.isDirty():
+                p.setDirty()  # Do not call p.v.setDirty!
+                redraw_flag = True
+            if not c.isChanged():
+                c.setChanged()
         c.frame.body.updateEditors()
         c.frame.tree.updateIcon(p)
+        if redraw_flag:
+            c.redraw()
     #@+node:ekr.20050126081529: *5* u.recognizeStartOfTypingWord
     def recognizeStartOfTypingWord(self,
         old_lines, old_row, old_col, old_ch,


### PR DESCRIPTION
See #1749.

- [x] Add initComplete ivar to NullFrame class.
  This prevents a crash during unit testing.
- [x] The docstring for v.setDirty now warns that v.setDirty does not set ancestor `@file` nodes dirty.
- [x] u.afterChangeBody now calls p.setDirty, c.setChanged and c.redraw as needed.
- [x] u.setUndoTypingParams now calls p.setDirty and c.setChanged as needed.
  It never recolors or redraws.
