### PR TITLE
Backlink undirected

### DIFF
--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -245,22 +245,24 @@ class backlinkController:
 
         if dir_ == 'url':
             self.linkUrl()
+        
         elif not self.linkMark or not self.c.positionExists(self.linkMark):
             self.showMessage('Link mark not specified or no longer valid', color='red')
             return
 
-        if dir_ == "from":
+        else: # dir_ in ['from', 'to', 'undirected']
             p = self.linkMark
+            
             if newChild:
                 p = self.linkMark.insertAsLastChild()
                 p.h = self.c.p.h
-            self.link(self.c.p, p)
-        elif dir_ == 'to':
-            p = self.linkMark
-            if newChild:
-                p = self.linkMark.insertAsLastChild()
-                p.h = self.c.p.h
-            self.link(p, self.c.p)
+
+            if dir_ == 'from':
+                self.link(self.c.p, p)
+            elif dir_ == 'to':
+                self.link(p, self.c.p)
+            else:
+                self.link(p, self.c.p, 'undirected')
 
         self.updateTabInt()
         self.c.redraw()

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -689,7 +689,10 @@ class backlinkController:
                 self.showMessage('Click a link to follow it', optional=True)
                 # pylint: disable=cell-var-from-loop
                 for i in dests:
-                    
+
+                    if i[1] is None: # destination node is deleted
+                        continue
+
                     def goThere(where = i[1]):
                         c.selectPosition(where)
 


### PR DESCRIPTION
It is a little fix of the Backlink plugin which does not let creating 'undirected' links between nodes and displays an AttributeError message in the Log pane on deleting a node with links

Repro steps:

1. Create a new Leo-outline
2. Enable the Backlink plugin (backlink.py) in the body of the node "@settings -> @enabled-plugins"
3. Create two top-level nodes "foo" and "boo"
4. Select node "foo"
5. In the "Link" pane click button "Place"
6. Select node "boo"
7. In the Link tab select the link direction "mark, undirected" and click button "Link"
8. See that no link has appeared
9. In the Link tab select the link direction "mark" and click button "Link"
10. Note that the link is created
11. Delete node "boo"
12. See a message "AttributeError: 'NoneType' object has no attribute 'h'" in the log pane

A link is not created at step#8 because only link direction strings "to" and "from" are handled in backling.py (method backlinkController.linkAction). The error appears because there is omitted check that a linked position exists in the outline.

Could you please review the suggested fix?