### PR TITLE
Comment out rules that use match_mark_previous

### DIFF
--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -5569,10 +5569,13 @@ If successful, match_eol_span highlights from i to the end of the line with the 
         at_whitespace_end = False,
         at_word_start = False,
         exclude_match = False):
+        
+At present match_mark_previous does nothing (always returns 0).
+Its use is deprectated.
 
-match_mark_previous succeeds if s[i:].startswith(pattern),and the at_line_start, at_whitespace_end and at_word_start conditions are all satisfied.
+..  match_mark_previous succeeds if s[i:].startswith(pattern),and the at_line_start, at_whitespace_end and at_word_start conditions are all satisfied.
 
-If successful, match_mark_previous colors from the end of the previous token to i with the color specified by kind. If the exclude_match argument is True, only the text before the matched text will be colored.
+..  If successful, match_mark_previous colors from the end of the previous token to i with the color specified by kind. If the exclude_match argument is True, only the text before the matched text will be colored.
 </t>
 <t tx="ekr.20060503064515">.. _`Ruleset name`: `Ruleset names`_
 

--- a/leo/modes/forth.py
+++ b/leo/modes/forth.py
@@ -115,9 +115,11 @@ if 0:
         return colorer.match_seq(s, i, kind="operator", seq="~",
             at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
 
+    # #1821.
     def forth_rule20(colorer, s, i):
-        return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-            at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+        return 0
+        # return colorer.match_mark_previous(s, i, kind="function", pattern="(",
+            # at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
 
     def forth_rule21(colorer, s, i):
         return colorer.match_keywords(s, i)

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -386,9 +386,10 @@ def python_rule19(colorer, s, i):
     return colorer.match_seq(s, i, kind="operator", seq="~",
         at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
 
-def python_rule20(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+# #1821.
+# def python_rule20(colorer, s, i):
+    # return colorer.match_mark_previous(s, i, kind="function", pattern="(",
+        # at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
 
 def python_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -422,7 +423,7 @@ rulesDict1 = {
     "%": [python_rule15,],
     "&": [python_rule16,],
     "'": [python_rule2, python_rule4,],
-    "(": [python_rule20,],
+    # "(": [python_rule20,],
     "*": [python_rule12,],
     "+": [python_rule9,],
     "-": [python_rule10,],


### PR DESCRIPTION
See #1821.  The match_mark_previous rule appears in many files.

For now, I plan only to change modes/python.py and modes/forth.py.