### PR TITLE
Fix/suppress pylint 3.9 complaints

### DIFF
--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -110,7 +110,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         except Exception:
             g.es_exception()
         return None
-    #@+node:ekr.20150514063305.416: *3* iterateKillBuffer
+    #@+node:ekr.20150514063305.416: *3* class iterateKillBuffer
     class KillBufferIterClass:
         """Returns a list of positions in a subtree, possibly including the root of the subtree."""
         #@+others
@@ -122,8 +122,8 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
 
         def __iter__(self):
             return self
-        #@+node:ekr.20150514063305.418: *4* next
-        def next(self):
+        #@+node:ekr.20150514063305.418: *4* __next__
+        def __next__(self):
             commands = self.c.killBufferCommands
             aList = g.app.globalKillBuffer  # commands.killBuffer
             if not aList:
@@ -139,8 +139,8 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
             self.index = i + 1
             return val
 
-        __next__ = next
         #@-others
+
     def iterateKillBuffer(self):
         return self.KillBufferIterClass(self.c)
     #@+node:ekr.20150514063305.419: *3* kill (helper)
@@ -294,7 +294,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         try:
             if not pop or self.lastYankP and self.lastYankP != current:
                 self.reset = 0
-            s = self.kbiterator.next()
+            s = self.kbiterator.__next__()
             if s is None: s = clip_text or ''
             if i != j: w.deleteTextSelection()
             if s != s.lstrip():  # s contains leading whitespace.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -999,8 +999,8 @@ class LeoApp:
             import curses
             assert curses
         except Exception:
-            g.es_exception()
-            print('can not import _curses.')
+            # g.es_exception()
+            print('can not import curses.')
             if g.isWindows:
                 print('Windows: pip install windows-curses')
             sys.exit()

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2342,6 +2342,7 @@ class AtFile:
             return True  # Suppress error if pyflakes can not be imported.
         except Exception:
             g.es_exception()
+            return False
     #@+node:ekr.20090514111518.5665: *6* at.tabNannyNode
     def tabNannyNode(self, p, body, suppress=False):
         import parser

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -706,17 +706,14 @@ class AutoCompleterClass:
         if jedi_line is not None:
             import jedi
             try:
-                script = jedi.Script(
-                    source=source,
+                # https://jedi.readthedocs.io/en/latest/docs/api.html#script
+                script = jedi.Script(source, path=g.shortFileName(fileName))
+                completions = script.complete(
                     line=1 + n0 + jedi_line,
                     column=column,
-                    path=g.shortFileName(fileName),
-                    # encoding='utf-8',
-                    # sys_path=None):
                 )
-                completions = script.completions()
                 t3 = time.process_time()
-            except ValueError:
+            except Exception:
                 t3 = time.process_time()
                 completions = None
                 g.printObj(source_lines[n0 - 1 : n0 + 30])

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -1786,8 +1786,9 @@ class LinkAnchorParserClass(HTMLParser.HTMLParser):
     #@+node:ekr.20120219194520.10446: *4* __init__
     def __init__(self, rst, p):
         """Ctor for the LinkAnchorParserClass class."""
-        super().__init__(p)
+        super().__init__()
         self.rst = rst
+        self.p = p.copy()
         # Set ivars from options.
         # This works only if we don't change nodes!
         self.node_begin_marker = rst.getOption(p, 'node_begin_marker')
@@ -1973,8 +1974,7 @@ class LinkHtmlparserClass(LinkAnchorParserClass):
     #@+node:ekr.20120219194520.10460: *4* __init__
     def __init__(self, rst, p):
         """Ctor for the LinkHtmlParserClass class."""
-        super().__init__(rst)
-        self.p = p.copy()
+        super().__init__(rst, p)
         self.anchor_map = rst.anchor_map
         self.replacements = []
     #@+node:ekr.20120219194520.10461: *4* handle_starttag

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -23,6 +23,7 @@ import websockets
 from leo.core.leoNodes import Position
 from leo.core.leoGui import StringFindTabManager
 #@-<< imports >>
+# pylint: disable=raise-missing-from
 g = None  # The bridge's leoGlobals module. Unit tests use self.g.
 # For unit tests.
 g_leoserver = None

--- a/leo/external/npyscreen/wgmultiline.py
+++ b/leo/external/npyscreen/wgmultiline.py
@@ -503,7 +503,7 @@ class MultiLine(widget.Widget):
         searchingfor = chr(input).upper()
         for counter in range(len(self.values)):
             try:
-                if self.values[counter].find(searchingfor) is not -1:
+                if self.values[counter].find(searchingfor) != -1:
                     self.cursor_line = counter
                     break
             except AttributeError:

--- a/leo/plugins/active_path.py
+++ b/leo/plugins/active_path.py
@@ -266,25 +266,6 @@ def getPath(c, p):
         else:
             path = os.path.join(path, p.h.strip())
     return path
-#@+node:tbrown.20090219133655.230: ** getPathOld
-def getPathOld(p):
-    # NOT USED, my version which does its own @path scanning
-    p = p.copy()
-    path = []
-    while p:
-        h = p.h
-        if g.match_word(h,0,"@path"):  # top of the tree
-            path.insert(0,os.path.expanduser(h[6:].strip()))
-            d = os.path.join(*path)
-            return d
-        if h.startswith('@'):  # some other directive, run away
-            break
-        elif isDirNode(p):  # a directory
-            path.insert(0,h.strip('/*'))
-        elif not p.hasChildren():  # a leaf node, assume a file
-            path.insert(0,h.strip('*'))
-        p = p.parent()
-    return None
 #@+node:tbrown.20080613095157.5: ** flattenOrganizers
 def flattenOrganizers(p):
     """Children of p, some of which may be in organizer nodes

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -485,14 +485,13 @@ class FlowLayout(QtWidgets.QLayout):
     #@+node:ekr.20140917180536.17897: *3* __init__
     def __init__(self, parent=None, margin=0, spacing=-1):
         '''Ctor for FlowLayout class.'''
-        super(FlowLayout, self).__init__(parent)
+        super().__init__(parent)
         if parent is not None:
             self.setMargin(margin)
         else:
             self.setMargin(0)
         self.setSpacing(spacing)
         self.itemList = []
-
     #@+node:ekr.20140917180536.17898: *3* __del__
     def __del__(self):
         item = self.takeAt(0)
@@ -540,7 +539,7 @@ class FlowLayout(QtWidgets.QLayout):
 
     #@+node:ekr.20140917180536.17907: *3* setGeometry
     def setGeometry(self, rect):
-        super(FlowLayout, self).setGeometry(rect)
+        super().setGeometry(rect)
         self.doLayout(rect, False)
 
     #@+node:ekr.20140917180536.17908: *3* sizeHint

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -483,7 +483,7 @@ class LeoTreeLine(npyscreen.TreeLine):
     def __init__(self, *args, **kwargs):
 
         self.leo_c = None  # Injected later.
-        super(LeoTreeLine, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # Done in TreeLine.init:
             # self._tree_real_value   = None
                 # A weakproxy to LeoTreeData.
@@ -773,9 +773,7 @@ def es(*args, **keys):
 def has_logger():
 
     logger = logging.getLogger()
-    return any([
-        isinstance(z, logging.handlers.SocketHandler) for z in logger.handlers or []
-    ])
+    return any(isinstance(z, logging.handlers.SocketHandler) for z in logger.handlers or [])
 #@+node:ekr.20170501043411.1: *4* curses2: pr
 def pr(*args, **keys):
     """Monkey-patch for g.pr."""
@@ -2344,7 +2342,7 @@ class CoreFrame (leoFrame.LeoFrame):
         s = g.app.gui.getTextFromClipboard()
         s = g.toUnicode(s)
         if trace: g.trace('wname', wname, 'len(s)', len(s))
-        single_line = any([wname.startswith(z) for z in ('head', 'minibuffer')])
+        single_line = any(wname.startswith(z) for z in ('head', 'minibuffer'))
         if single_line:
             # Strip trailing newlines so the truncation doesn't cause confusion.
             while s and s[-1] in ('\n', '\r'):
@@ -2732,7 +2730,7 @@ class LeoBody (npyscreen.MultiLineEditable):
     _contained_widgets = LeoBodyTextfield
 
     def __init__ (self, *args, **kwargs):
-        super(LeoBody, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.leo_box = None
         self.leo_c = None
         self.leo_wrapper = None
@@ -2960,7 +2958,7 @@ class LeoLog (npyscreen.MultiLineEditable):
     _contained_widgets = LeoLogTextfield
 
     def __init__ (self, *args, **kwargs):
-        super(LeoLog, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.set_handlers()
         self.leo_box = None
         self.leo_c = None
@@ -3109,18 +3107,18 @@ class LeoForm (npyscreen.Form):
     how_exited = None
 
     def display(self, *args, **kwargs):
-        changed = any([z.c.isChanged() for z in g.app.windowList])
+        changed = any(z.c.isChanged() for z in g.app.windowList)
         c = g.app.log.c
         self.name = 'Welcome to Leo: %s%s' % (
             '(changed) ' if changed else '',
             c.fileName() if c else '')
-        super(LeoForm, self).display(*args, **kwargs)
+        super().display(*args, **kwargs)
 #@+node:ekr.20170510092721.1: *3* class LeoMiniBuffer (npyscreen.Textfield)
 class LeoMiniBuffer(npyscreen.Textfield):
     '''An npyscreen class representing Leo's minibuffer, with binding.'''
 
     def __init__(self, *args, **kwargs):
-        super(LeoMiniBuffer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.leo_c = None # Set later
         self.leo_wrapper = None # Set later.
         self.leo_completion_index = 0
@@ -3274,7 +3272,7 @@ class LeoStatusLine(npyscreen.Textfield):
     '''An npyscreen class representing Leo's status line'''
 
     def __init__(self, *args, **kwargs):
-        super(LeoStatusLine, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         # These are injected later.
         self.leo_c = None
         self.leo_wrapper = None
@@ -3732,7 +3730,7 @@ class LeoMLTree(npyscreen.MLTree):
         self.handlers = d
     #@+node:ekr.20170516100256.1: *5* LeoMLTree.set_up_handlers
     def set_up_handlers(self):
-        super(LeoMLTree, self).set_up_handlers()
+        super().set_up_handlers()
         assert not hasattr(self, 'hidden_root_node'), repr(self)
         self.leo_c = None # Set later.
         self.currentItem = None
@@ -3952,7 +3950,7 @@ class LeoValues(npyscreen.TreeData):
     #@+node:ekr.20170619070717.1: *4* values.__init__
     def __init__(self, c, tree):
         '''Ctor for LeoValues class.'''
-        super(LeoValues, self).__init__()
+        super().__init__()
             # Init the base class.
         self.c = c
             # The commander of this outline.

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -17,6 +17,7 @@ from leo.core import leoGlobals as g
 from leo.plugins import qt_events
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 #@-<< demo.py imports >>
+# pylint: disable=no-member,not-callable
 #@@language python
 #@@tabwidth -4
 #@+others

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -89,7 +89,7 @@ class LeoEditPane(QtWidgets.QWidget):
         :param dict **kwargs: pass through
         """
         DBG("__init__ LEP")
-        super(LeoEditPane, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.setAttribute(QtConst.WA_DeleteOnClose)
 
         lep_type = lep_type or ['EDITOR', 'TEXT']

--- a/leo/plugins/editpane/leotextedit.py
+++ b/leo/plugins/editpane/leotextedit.py
@@ -31,7 +31,7 @@ class LEP_LeoTextEdit(QtWidgets.QTextEdit):
     #@+node:tbrown.20171028115508.4: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_LeoTextEdit, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.c = c
         self.lep = lep
         self.textChanged.connect(self.text_changed)

--- a/leo/plugins/editpane/markdownview.py
+++ b/leo/plugins/editpane/markdownview.py
@@ -45,7 +45,7 @@ class LEP_MarkdownView(HtmlView):
     #@+node:tbrown.20171028115507.4: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_MarkdownView, self).__init__(c=c, lep=lep, *args, **kwargs)
+        super().__init__(c=c, lep=lep, *args, **kwargs)
         self.c = c
         self.lep = lep
     #@+node:tbrown.20171028115507.5: *3* new_text
@@ -79,7 +79,7 @@ class LEP_MarkdownHtmlView(TextView):
     #@+node:tbrown.20171028115507.8: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_MarkdownHtmlView, self).__init__(c=c, lep=lep, *args, **kwargs)
+        super().__init__(c=c, lep=lep, *args, **kwargs)
         self.c = c
         self.lep = lep
     #@+node:tbrown.20171028115507.9: *3* new_text

--- a/leo/plugins/editpane/pandownview.py
+++ b/leo/plugins/editpane/pandownview.py
@@ -46,7 +46,7 @@ def to_html(text, from_='markdown'):
 
 try:
     to_html("test")
-except:
+except:  # pylint: disable=raise-missing-from
     raise ImportError
 #@+node:tbrown.20171028115505.3: ** class LEP_PanDownView
 class LEP_PanDownView(HtmlView):
@@ -59,7 +59,7 @@ class LEP_PanDownView(HtmlView):
     #@+node:tbrown.20171028115505.4: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_PanDownView, self).__init__(c=c, lep=lep, *args, **kwargs)
+        super().__init__(c=c, lep=lep, *args, **kwargs)
         self.c = c
         self.lep = lep
     #@+node:tbrown.20171028115505.5: *3* new_text
@@ -94,7 +94,7 @@ class LEP_PanDownHtmlView(TextView):
     #@+node:tbrown.20171028115505.8: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_PanDownHtmlView, self).__init__(c=c, lep=lep, *args, **kwargs)
+        super().__init__(c=c, lep=lep, *args, **kwargs)
         self.c = c
         self.lep = lep
     #@+node:tbrown.20171028115505.9: *3* new_text

--- a/leo/plugins/editpane/plaintextedit.py
+++ b/leo/plugins/editpane/plaintextedit.py
@@ -28,7 +28,7 @@ class LEP_PlainTextEdit(QtWidgets.QTextEdit):
     #@+node:tbrown.20171028115504.4: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_PlainTextEdit, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.c = c
         self.lep = lep
         self.textChanged.connect(self.text_changed)
@@ -97,7 +97,7 @@ class LEP_PlainTextEditB(LEP_PlainTextEdit):
     #@+node:tbrown.20171028115504.13: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_PlainTextEditB, self).__init__(c=c, lep=lep, *args, **kwargs)
+        super().__init__(c=c, lep=lep, *args, **kwargs)
         self.setStyleSheet("* {background: #989; color: #222; }")
         self.highlighter = self.BHighlighter(self.document())
     #@-others

--- a/leo/plugins/editpane/plaintextview.py
+++ b/leo/plugins/editpane/plaintextview.py
@@ -17,7 +17,7 @@ class LEP_PlainTextView(QtWidgets.QTextBrowser):
     #@+node:tbrown.20171028115502.3: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_PlainTextView, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.c = c
         self.lep = lep
         self.setStyleSheet("* {background: #998; color: #222; }")
@@ -52,7 +52,7 @@ class LEP_PlainTextViewB(LEP_PlainTextView):
     #@+node:tbrown.20171028115502.7: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_PlainTextViewB, self).__init__(c=c, lep=lep, *args, **kwargs)
+        super().__init__(c=c, lep=lep, *args, **kwargs)
         self.setStyleSheet("* {background: #899; color: #222; }")
     #@-others
 #@-others

--- a/leo/plugins/editpane/vanillascintilla.py
+++ b/leo/plugins/editpane/vanillascintilla.py
@@ -32,7 +32,7 @@ class LEP_VanillaScintilla(Qsci.QsciScintilla):
     #@+node:tbrown.20171028115501.4: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_VanillaScintilla, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.c = c
         self.lep = lep
         self.textChanged.connect(self.text_changed)

--- a/leo/plugins/editpane/webengineview.py
+++ b/leo/plugins/editpane/webengineview.py
@@ -20,7 +20,7 @@ class LEP_WebEngineView(QtWebEngineWidgets.QWebEngineView):
     #@+node:tbrown.20171028115459.3: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_WebEngineView, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.c = c
         self.lep = lep
     #@+node:tbrown.20171028115459.4: *3* new_text

--- a/leo/plugins/editpane/webkitview.py
+++ b/leo/plugins/editpane/webkitview.py
@@ -57,7 +57,7 @@ class LEP_WebKitView(QtWebKitWidgets.QWebView):
     #@+node:tbrown.20171028115457.4: *3* __init__
     def __init__(self, c=None, lep=None, *args, **kwargs):
         """set up"""
-        super(LEP_WebKitView, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.c = c
         self.lep = lep
 

--- a/leo/plugins/examples/override_classes.py
+++ b/leo/plugins/examples/override_classes.py
@@ -19,9 +19,9 @@ def init():
 
             class myLeoFrame(leoFrame.LeoFrame):
 
-                def __init__(self, title=None):
+                def __init__(self, c, title=None):
                     g.pr("myLeoFrame ctor", title)
-                    super().__init__(title)
+                    super().__init__(c, gui=None)
 
             leoFrame.LeoFrame = myLeoFrame
         if 0:

--- a/leo/plugins/importers/javascript.py
+++ b/leo/plugins/importers/javascript.py
@@ -517,7 +517,8 @@ class JsLexer(Lexer):
     #@+others
     #@+node:ekr.20200131110322.11: *4* JsLexer.__init__
     def __init__(self):
-        super(JsLexer, self).__init__(self.states, 'reg')
+        ### super(JsLexer, self).__init__(self.states, 'reg')
+        super().__init__(self.states, 'reg')
 
 
     #@-others

--- a/leo/plugins/importers/javascript.py
+++ b/leo/plugins/importers/javascript.py
@@ -76,7 +76,6 @@ class JS_Importer(Importer):
     def remove_organizer_nodes(self, parent):
         '''Removed all organizer nodes created by i.delete_all_empty_nodes.'''
         # Careful: Restart this loop whenever we find an organizer.
-        ### g.trace(parent.h)
         found = True
         while found:
             found = False
@@ -209,7 +208,6 @@ class JS_Importer(Importer):
         '''True if line ends the block.'''
         # Comparing new_state against prev_state does not work for python.
         top = stack[-1]
-        ### g.trace(f"{new_state.level() < top.state.level():1}") # , {line!r}")
         return new_state.level() < top.state.level()
     #@+node:ekr.20161101183354.1: *3* js_i.clean_headline
     clean_regex_list1 = [
@@ -517,10 +515,7 @@ class JsLexer(Lexer):
     #@+others
     #@+node:ekr.20200131110322.11: *4* JsLexer.__init__
     def __init__(self):
-        ### super(JsLexer, self).__init__(self.states, 'reg')
         super().__init__(self.states, 'reg')
-
-
     #@-others
 #@+node:ekr.20200131070055.1: ** class TestJSImporter (importers/javascript.py)
 class TestJSImporter(unittest.TestCase):

--- a/leo/plugins/leofeeds.py
+++ b/leo/plugins/leofeeds.py
@@ -19,11 +19,12 @@ Do alt-x act-on-node on that node to populate the subtree from the feed data. Re
 #@+<< imports >>
 #@+node:ville.20110206142055.10643: ** << imports >>
 import html.parser as HTMLParser
+# Third-party imports
+import feedparser
+# Leo imports.
 from leo.core import leoGlobals as g
 from leo.core import leoPlugins
     # Uses leoPlugins.TryNext
-# Third-party imports
-import feedparser
 #@-<< imports >>
 
 #@+others

--- a/leo/plugins/python_terminal.py
+++ b/leo/plugins/python_terminal.py
@@ -72,7 +72,7 @@ if QtWidgets:
     class MyInterpreter(QtWidgets.QWidget):
     
         def __init__(self, parent, c):
-            super(MyInterpreter, self).__init__(parent)
+            super().__init__(parent)
             hBox = QtWidgets.QHBoxLayout()
             self.setLayout(hBox)
             self.textEdit = PyInterp(self, c)
@@ -290,7 +290,7 @@ if QtWidgets:
                     self.doEnter(event)
                     return
                 # allow all other key events
-                super(PyInterp, self).keyPressEvent(event)
+                super().keyPressEvent(event)
             except Exception:
                 g.es_exception()
 

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -243,7 +243,7 @@ class OrderedDefaultDict(OrderedDict):
                 raise TypeError('first argument must be callable or None')
             self.default_factory = args[0]
             args = args[1:]
-        super(OrderedDefaultDict, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __missing__ (self, key):
         if self.default_factory is None:

--- a/leo/plugins/read_only_nodes.py
+++ b/leo/plugins/read_only_nodes.py
@@ -53,7 +53,7 @@ Davide Salomoni
 
 # EKR: This plugin does not appear to be ready for Python 3.
 
-# pylint: disable=not-callable
+# pylint: disable=not-callable,raise-missing-from
 
 #@+<< imports >>
 #@+node:ekr.20050311091110.1: ** << imports >>

--- a/leo/plugins/screencast.py
+++ b/leo/plugins/screencast.py
@@ -221,6 +221,7 @@ from leo.core import leoGlobals as g
 from leo.core import leoGui # for LeoKeyEvents.
 from leo.core.leoQt import QtCore, QtGui, QtWidgets
 #@-<< imports >>
+# pylint: disable=not-callable
 #@+at
 # To do:
 # - Document this plugin in the docstring and with a screencast.

--- a/leo/plugins/stickynotes_plus.py
+++ b/leo/plugins/stickynotes_plus.py
@@ -180,8 +180,7 @@ class notetextedit(QTextEdit):
     #@+others
     #@+node:ekr.20100103100944.5397: *3* __init__
     def __init__(self, get_markdown, save, parent=None):
-        super(notetextedit, self).__init__(parent)
-
+        super().__init__(parent)
         self.save = save
         self.setLineWrapMode(QTextEdit.WidgetWidth)
         self.setTabChangesFocus(True)

--- a/leo/plugins/tomboy_import.py
+++ b/leo/plugins/tomboy_import.py
@@ -59,7 +59,9 @@ def parsenote(cont):
     tree = ET.parse(cont)
     #ET.dump(tree)
     title = tree.findtext('{http://beatniksoftware.com/tomboy}title')
-    body  = tree.getiterator('{http://beatniksoftware.com/tomboy}note-content')[0]
+    ### EKR: I'm not sure that finditer is correct, but geiterator no longer exists.
+    ### body  = tree.getiterator('{http://beatniksoftware.com/tomboy}note-content')[0]
+    body  = tree.iterfind('{http://beatniksoftware.com/tomboy}note-content')[0]
     #b = "".join(el.text for el in body.getiterator())
     b = ET.tostring(body)
     b = strip_tags(b)

--- a/leo/plugins/viewrendered2.py
+++ b/leo/plugins/viewrendered2.py
@@ -471,7 +471,7 @@ class WebViewPlus(QtWidgets.QWidget):
     #@+others
     #@+node:ekr.20140226075611.16793: *3* vr2.ctor (WebViewPlus) & helpers
     def __init__(self, pc):
-        super(WebViewPlus, self).__init__()
+        super().__init__()
         self.app = QtCore.QCoreApplication.instance()
         self.c = c = pc.c
         self.docutils_settings = None # Set below.

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1781,6 +1781,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         """
 
         global AsciiDocError
+        h = None
         if self.prefer_external:
             h =  self.convert_to_asciidoc_external(s)
             self.rst_html = h
@@ -1839,9 +1840,11 @@ class ViewRenderedController3(QtWidgets.QWidget):
                     return h
                 except Exception:
                     g.es_exception()
+                    return None
             finally:
                 infile.close()
                 outfile.close()
+        return h
 
     #@+node:TomP.20191215195433.56: *5* vr3.convert_to_asciidoc_external
     def convert_to_asciidoc_external(self, s):


### PR DESCRIPTION
Pylint 3.9 found many possible improvements, including removing Python-2-style calls to super.