### PR TITLE
Fix bad recent bug: don't search @noseach trees for definitions

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -422,7 +422,7 @@ class LeoFind:
         while True:
             p, pos, newpos = self.find_next_match(p)
             found = pos is not None
-            if not found or not g.inAtNosearch(c.p):
+            if not found or not g.inAtNosearch(p):  # 2021/03/25: do *not* use c.p.
                 break
         if not found and def_flag and not strict:
             # Leo 5.7.3: Look for an alternative defintion of function/methods.


### PR DESCRIPTION
The recent refactoring of leoFind.py introduced this serious blunder.

The bug fix ensures that Leo does not search `@nosearch` trees when looking for definitions of classes or defs.