### PR TITLE
Normalize path names in the cache

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1459,12 +1459,13 @@ class LeoApp:
         ):
             return
         # #1519: check os.path.exists.
-        aList = g.app.db.get(tag) or []
-        if [x for x in aList if os.path.exists(x) and os.path.samefile(x, fn)]:
+        aList = g.app.db.get(tag) or []  # A list of normalized file names.
+        if any(os.path.exists(z) and os.path.samefile(z, fn) for z in aList):
             # The file may be open in another copy of Leo, or not:
             # another Leo may have been killed prematurely.
             # Put the file on the global list.
             # A dialog will warn the user such files later.
+            fn = os.path.normpath(fn)
             if fn not in g.app.already_open_files:
                 g.es('may be open in another Leo:', color='red')
                 g.es(fn)
@@ -1483,6 +1484,7 @@ class LeoApp:
             d is None or g.app.unitTesting or g.app.batchMode or g.app.reverting):
             return
         aList = d.get(tag) or []
+        fn = os.path.normpath(fn)
         if fn in aList:
             aList.remove(fn)
             if trace:
@@ -1502,7 +1504,7 @@ class LeoApp:
         else:
             aList = d.get(tag) or []
             # It's proper to add duplicates to this list.
-            aList.append(fn)
+            aList.append(os.path.normpath(fn))
             d[tag] = aList
     #@+node:ekr.20150621062355.1: *4* app.runAlreadyOpenDialog
     def runAlreadyOpenDialog(self, c):


### PR DESCRIPTION
This prevents a recent problem, and looks ahead to eliminating g.os_path*.