### PR TITLE
Fixed bug in the todo.py plugin

### DIFF
--- a/leo/plugins/leoGuiPluginsRef.leo
+++ b/leo/plugins/leoGuiPluginsRef.leo
@@ -1,11 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Created by Leo: http://leoeditor.com/leo_toc.html -->
 <leo_file xmlns:leo="http://leoeditor.com/namespaces/leo-python-editor/1.1" >
-<leo_header file_format="2" tnodes="0" max_tnode_index="0" clone_windows="0"/>
-<globals body_outline_ratio="0.5" body_secondary_ratio="0.5">
-	<global_window_position top="50" left="50" height="500" width="700"/>
-	<global_log_window_position top="0" left="0" height="0" width="0"/>
-</globals>
+<leo_header file_format="2"/>
+<globals/>
 <preferences/>
 <find_panel_settings/>
 <vnodes>

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1,5 +1,5 @@
 #@+leo-ver=5-thin
-#@+node:tbrown.20090119215428.2: * @file ../plugins/todo.py
+#@+node:tbrown.20090119215428.2: * @file todo.py
 #@+<< docstring >>
 #@+node:tbrown.20090119215428.3: ** << docstring >> (todo.py)
 ''' Provides to-do list and simple task management.
@@ -782,7 +782,7 @@ class todoController:
             p = self.c.currentPosition()
 
         for nd in p.self_and_subtree():
-            p.h = re.sub(' <[^>]*>$', '', nd.headString())
+            nd.h = re.sub(' <[^>]*>$', '', nd.headString())
             tr = self.getat(nd.v, 'time_req')
             pr = self.getat(nd.v, 'progress')
             try: pr = float(pr)


### PR DESCRIPTION
It was corrupting the headline of the above node when the project aggregate time recalculation command was executed