### PR TITLE
PR: Clean plugins

### DIFF
--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -38,27 +38,9 @@ actions, Leo does not do anything with or to such files.
 #@-<< docstring >>
 
 # Written by Konrad Hinsen <konrad.hinsen@laposte.net>
+# Edited by TL and EKR.
 # Distributed under the same licence as Leo.
 
-__version__ = "0.4"
-#@+<< version history >>
-#@+node:ekr.20040915110738: ** << version history >>
-#@@nocolor
-#@+at
-#
-# 0.2 EKR:
-# - Convert to a typical outline.
-# 0.3 EKR:
-# - Removed all calls to g.top()
-# - Simplified definition of shellScriptInWindow.
-# - Added c arg to shellScriptInWindow.
-#   This may change existing scripts.
-# - Added c arg to g.findNodeAnywhere.
-# - Execute scripts with 'c' and 'g' predefined.
-# 0.4 TL: Double-click does nothing for non @file/@thin etc. nodes.
-# 0.5 TL: Replaced logic for obtaining filename to fix problems with spaces
-#         Fixed problem with @file-ref feature created by 0.4 release
-#@-<< version history >>
 #@+<< imports >>
 #@+node:ekr.20090317093747.1: ** << imports >>
 import fnmatch

--- a/leo/plugins/anki.py
+++ b/leo/plugins/anki.py
@@ -25,10 +25,7 @@ Create headline like this:
 Select any of these nodes (@anki, @anki front, @anki back), do `alt-x act-on-node`. This pushes the card to AnkiConnect. If any errors happen, a child to `@anki` called `@anki error` is populated with the relevant error details.
 '''
 
-__version__ = '0.1'
-
 import leo.core.leoGlobals as g
-
 from leo.core import leoPlugins
 
 try:
@@ -161,3 +158,4 @@ def anki_act_on_node(c, p, event):
             },
             'tags' : tag.split(",")
         })
+        

--- a/leo/plugins/at_folder.py
+++ b/leo/plugins/at_folder.py
@@ -16,7 +16,7 @@ while keep every files in a flat/single directory on your computer.
 
 import os
 from leo.core import leoGlobals as g
-__version__ = "1.4"
+
 #@+others
 #@+node:ekr.20140920173002.17961: ** init
 def init():
@@ -65,5 +65,4 @@ def sync_node_to_folder(c,parent,d):
 #@-others
 #@@language python
 #@@tabwidth -4
-
 #@-leo

--- a/leo/plugins/at_view.py
+++ b/leo/plugins/at_view.py
@@ -17,7 +17,7 @@ r''' Adds support for \@clip, \@view and \@strip nodes.
 This plugin also accumulates the effect of all \@path nodes.
 '''
 #@-<< docstring >>
-__version__ = "0.9"
+
 from leo.core import leoGlobals as g
 path           = g.import_module('path')
 win32clipboard = g.import_module('win32clipboard')

--- a/leo/plugins/chapter_hoist.py
+++ b/leo/plugins/chapter_hoist.py
@@ -13,20 +13,12 @@ Requires at least version 0.19 of mod_scripting.
 
 """
 #@-<< docstring >>
+
+# By btheado. Edited by EKR.
+
 from leo.core import leoGlobals as g
 from leo.plugins.mod_scripting import scriptingController
-__version__ = "0.5"
-#@+<< version history >>
-#@+node:ekr.20060328125925.3: ** << version history >>
-#@+at
-#
-# 0.1 btheado: initial creation.
-# 0.2 EKR: changed to @thin.
-# 0.3 EKR: init now succeeds for unit tests.
-# 0.4 EKR: use new calling sequences for sc.createIconButton.
-#          Among other things, this creates the save-hoist commnand.
-# 0.5 EKR: Made gui-independent.
-#@-<< version history >>
+
 #@+others
 #@+node:ekr.20060328125925.4: ** init
 def init ():

--- a/leo/plugins/datenodes.py
+++ b/leo/plugins/datenodes.py
@@ -2,7 +2,8 @@
 #@+node:ekr.20060807103814.1: * @file ../plugins/datenodes.py
 #@+<< docstring >>
 #@+node:bobjack.20080615065747.4: ** << docstring >>
-""" Allows users to insert headlines containing dates.
+"""
+Allows users to insert headlines containing dates.
 
 'Date nodes' are nodes that have dates in their headlines. They may be added to
 the outline one at a time, a month's-worth at a time, or a year's-worth at a
@@ -26,31 +27,6 @@ The following commands are available for use via the minibuffer or in
 """
 #@-<< docstring >>
 
-#@@language python
-#@@tabwidth -4
-
-__version__ = "0.7"
-#@+<< version history >>
-#@+node:gfunch.20041207100416.2: ** << version history >>
-#@@nocolor
-#@+at
-#
-# 0.1: Initial version.
-# 0.2: Improved menu structure. Added ini file.
-# 0.3: Changed docstring slightly.
-# 0.4: Added event=None to insert_xxx_node.
-# 0.5: Added options to omit saturdays and sundays. Use leoSettings.leo instead of datenodes.ini for storing options.
-# 0.6: Removed @c from most nodes: this is not needed.  Also removed .ini file from cvs.
-# 0.7 bobjack:
-#     - added plugin init method
-#     - exposed the pluginController as c.theDateNodesController
-#     - added support for settings:
-#         - @bool suppress-datenodes-menus
-#     - added minibuffer commands
-#         - datenodes-today
-#         - datenodes-this-month
-#         - datenodes-this-year
-#@-<< version history >>
 #@+<< todo >>
 #@+node:bobjack.20080615065747.5: ** << todo >>
 #@@nocolor
@@ -262,5 +238,7 @@ def on_create(tag, keywords):
     #@-<< Create the plug-in menu. >>
 
 #@-others
+#@@language python
+#@@tabwidth -4
 
 #@-leo

--- a/leo/plugins/dragdropgoodies.py
+++ b/leo/plugins/dragdropgoodies.py
@@ -12,16 +12,6 @@ will be available. The buttons use the icon specified in the active Qt style
 
 '''
 #@-<< docstring >>
-
-__version__ = '0.2'
-#@+<< version history >>
-#@+node:ville.20110115234843.8744: ** << version history >>
-#@@killcolor
-#@+at
-#
-# 0.1 Functionally complete version
-#@-<< version history >>
-
 #@+<< imports >>
 #@+node:ville.20110115234843.8745: ** << imports >>
 from leo.core import leoGlobals as g
@@ -85,4 +75,6 @@ class pluginController:
 
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/dtest.py
+++ b/leo/plugins/dtest.py
@@ -34,16 +34,6 @@ import os
 from leo.core import leoGlobals as g
 from leo.core.leoPlugins import BaseLeoPlugin
 #@-<< imports >>
-#@+<< version history >>
-#@+node:ekr.20070119094733.3: ** << version history >>
-#@@nocolor
-
-#@+at
-# v 0.1 EKR: modified slightly from original by ktenney.
-# v 0.2 EKR: modified from mod_dtest by ktenney:
-# - Converted to @thin
-# - Use section references for code that must be in a particular place.
-#@-<< version history >>
 
 #@+others
 #@+node:ekr.20070119094733.5: ** init
@@ -140,6 +130,6 @@ class DT(BaseLeoPlugin):
     #@-others
 
 #@-others
-
-
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/dump_globals.py
+++ b/leo/plugins/dump_globals.py
@@ -1,10 +1,7 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.730: * @file ../plugins/dump_globals.py
 """Dumps Python globals at startup."""
-#@@language python
-#@@tabwidth -4
 from leo.core import leoGlobals as g
-__version__ = "1.2"
 #@+others
 #@+node:ekr.20100128091412.5380: ** init
 def init():
@@ -25,4 +22,6 @@ def onStart(tag, keywords):
         if s not in __builtins__:
             g.pr(s)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/empty_leo_file.py
+++ b/leo/plugins/empty_leo_file.py
@@ -8,8 +8,6 @@
 import os
 from leo.core import leoGlobals as g
 
-__version__ = "1.2"
-
 #@+<< define minimal .leo file >>
 #@+node:EKR.20040517080049.2: ** << define minimal .leo file >>
 empty_leo_file = """<?xml version="1.0" encoding="UTF-8"?>

--- a/leo/plugins/enable_gc.py
+++ b/leo/plugins/enable_gc.py
@@ -1,10 +1,9 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.732: * @file ../plugins/enable_gc.py
 """Enables debugging and tracing for Python's garbage collector."""
-#@@language python
-#@@tabwidth -4
+
 from leo.core import leoGlobals as g
-__version__ = "1.2"
+
 #@+others
 #@+node:ekr.20100128091412.5385: ** init
 def init():
@@ -22,4 +21,6 @@ def onStart(tag, keywords):
     except Exception:
         pass
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/examples/chinese_menu.py
+++ b/leo/plugins/examples/chinese_menu.py
@@ -2,8 +2,7 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20040828105233: * @file ../plugins/examples/chinese_menu.py
 #@@first
-#@@language python
-#@@tabwidth -4
+
 """
 Translate a few menu items into Simplified Chinese
 本插件将部分Leo菜单翻译成简体中文
@@ -20,7 +19,7 @@ Translate a few menu items into Simplified Chinese
 # Note 2 (EKR):  The menu names themselves did not translate on my XP machine.
 # All the headlines appear as "??".
 from leo.core import leoGlobals as g
-__version__ = "1.1" # Set version for the plugin handler.
+
 #@+others
 #@+node:ekr.20111104210837.9689: ** init
 def init():
@@ -214,4 +213,6 @@ def onMenu (tag,keywords):
     # Call the convenience routine to do the work.
     c.frame.menu.setRealMenuNamesFromTable(table)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/examples/french_fm.py
+++ b/leo/plugins/examples/french_fm.py
@@ -3,11 +3,11 @@
 #@+node:EKR.20040517080202.3: * @file ../plugins/examples/french_fm.py
 #@@first
 """traduit les menus en Français"""
-#@@language python
-#@@tabwidth -4
+
 # French translation completed by Frédéric Momméja, Spring 2003
+
 from leo.core import leoGlobals as g
-__version__ = "1.4" # Set version for the plugin handler.
+
 #@+others
 #@+node:ekr.20111104210837.9688: ** init
 def init():
@@ -173,4 +173,6 @@ def onMenu(tag, keywords):
     # Call the convenience routine to do the work.
     c.frame.menu.setRealMenuNamesFromTable(table)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/examples/override_classes.py
+++ b/leo/plugins/examples/override_classes.py
@@ -1,12 +1,11 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.916: * @file ../plugins/examples/override_classes.py
 """A plugin showing how to override Leo's core classes."""
-#@@language python
-#@@tabwidth -4
+
 from leo.core import leoGlobals as g
 from leo.core import leoApp
 from leo.core import leoFrame
-__version__ = "1.2"
+
 #@+others
 #@+node:ekr.20111104210837.9692: ** init
 def init():
@@ -37,4 +36,6 @@ def init():
         g.plugin_signon(__name__)
     return ok
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/examples/override_commands.py
+++ b/leo/plugins/examples/override_commands.py
@@ -1,10 +1,9 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.919: * @file ../plugins/examples/override_commands.py
 """Override the Equal Sized Pane command"""
-#@@language python
-#@@tabwidth -4
+
 from leo.core import leoGlobals as g
-__version__ = "1.2"
+
 #@+others
 #@+node:ekr.20111104210837.9691: ** init
 def init():
@@ -24,4 +23,6 @@ def onCommand(tag, keywords):
         return "override" # Anything other than None overrides.
     return None
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/examples/redefine_put.py
+++ b/leo/plugins/examples/redefine_put.py
@@ -1,10 +1,9 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.921: * @file ../plugins/examples/redefine_put.py
 """Redefine the "put" and "put_nl" methods"""
-#@@language python
-#@@tabwidth -4
+
 from leo.core import leoGlobals as g
-__version__ = "1.4"
+
 #@+others
 #@+node:ekr.20111104210837.9690: ** init
 def init():
@@ -54,4 +53,6 @@ def newPutNl(self):
     else:
         g.pr('')
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/expfolder.py
+++ b/leo/plugins/expfolder.py
@@ -24,16 +24,11 @@ Manager's Plugin Load Order pane.
 '''
 #@-<< docstring >>
 
-#@@language python
-#@@tabwidth -4
-
 import os
 import os.path
 import configparser as ConfigParser
 from leo.core import leoGlobals as g
 from leo.plugins.textnode import savetextnode
-
-__version__ = "1.0"
 
 textexts = []
 
@@ -106,4 +101,6 @@ def on_icondclick(tag, keywords):
             c.setHeadString(pn, "@expfolder "+d)
         c.expandSubtree(p)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/geotag.py
+++ b/leo/plugins/geotag.py
@@ -2,9 +2,6 @@
 #@+node:tbrown.20091214233510.5347: * @file ../plugins/geotag.py
 ''' Tags nodes with latitude and longitude. '''
 
-#@@language python
-#@@tabwidth -4
-
 #@+<< imports >>
 #@+node:tbrown.20091214233510.5349: ** << imports >>
 import socket
@@ -12,7 +9,6 @@ from leo.core import leoGlobals as g
 from leo.plugins.pygeotag import pygeotag
 
 #@-<< imports >>
-__version__ = "0.1"
 
 #@+others
 #@+node:tbrown.20091214233510.5351: ** init
@@ -103,4 +99,6 @@ def cmd_ShowNode(event):
         data = {'description':c.p.h}
     g.pygeotag.show_position(data)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/history_tracer.py
+++ b/leo/plugins/history_tracer.py
@@ -41,8 +41,9 @@ from leo.core.leoQt import QtCore
 #@-<< imports >>
 #@afterref
  # history_tracer.py
-__version__ = "0.1"
+
 idle_checker = None
+
 #@+others
 #@+node:vitalije.20190928154420.4: ** init
 def init():

--- a/leo/plugins/initinclass.py
+++ b/leo/plugins/initinclass.py
@@ -15,7 +15,6 @@ the order of declarations if other methods are declared before __init__.
 """
 #@-<< docstring >>
 
-__version__ = "0.1"
 __plugin_name__ = "__init__ in class"
 
 from leo.core import leoGlobals as g

--- a/leo/plugins/jinjarender.py
+++ b/leo/plugins/jinjarender.py
@@ -20,17 +20,7 @@ Requires "valuespace" plugin. Fetches vars from valuespace.
 '''
 #@-<< docstring >>
 
-__version__ = '0.1'
-#@+<< version history >>
-#@+node:ville.20110409151021.5701: ** << version history >>
-#@@killcolor
-#@+at
-#
-# 0.1 Ville M. Vainio:
-#
-#     * First version
-#
-#@-<< version history >>
+# By Ville M. Vainio.
 
 #@+<< imports >>
 #@+node:ville.20110409151021.5702: ** << imports >>
@@ -106,4 +96,6 @@ class JinjaCl:
 
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/leoPluginNotes.txt
+++ b/leo/plugins/leoPluginNotes.txt
@@ -2,12 +2,12 @@
 #@+node:ekr.20090430075506.3: * @file ../plugins/leoPluginNotes.txt
 #@+all
 #@+node:ekr.20071113084440.1: ** @@file test/syntax_error_plugin.py
-# pylint: disable=syntax-error
-
-'''
+"""
 This plugin intentially has a syntax error.
 It is used for testing Leo's plugin loading logic.
-'''
+"""
+
+# pylint: disable=syntax-error
 
 a = # This is the syntax error
 

--- a/leo/plugins/leo_pdf.py
+++ b/leo/plugins/leo_pdf.py
@@ -5,14 +5,15 @@
 #@@first
 #@@first
 
-''' This NOT a Leo plugin: this is a docutils writer for .pdf files.
+"""
+This NOT a Leo plugin: this is a docutils writer for .pdf files.
 
 That file uses the reportlab module to convert html markup to pdf.
 
 The original code written by Engelbert Gruber.
 
 Rewritten by Edward K. Ream for the Leo rst3 plugin.
-'''
+"""
 
 # Note: you must copy this file to the Python/Lib/site-packages/docutils/writers folder.
 
@@ -118,124 +119,13 @@ Rewritten by Edward K. Ream for the Leo rst3 plugin.
 #
 #####################################################################################
 #@-<< copyright >>
-#@+<< version history >>
-#@+node:ekr.20090704103932.5165: ** << version history >>
-#@@nocolor
-#@+others
-#@+node:ekr.20090704103932.5166: *3* Early versions
-#@+node:ekr.20090704103932.5167: *4* Initial conversion
-#@+at
-#
-# - Added 'c:\reportlab_1_20' to sys.path.
-#
-# - Obtained this file and stylesheet.py from
-#   http://docutils.sourceforge.net/sandbox/dreamcatcher/rlpdf/
-#
-# - Put stylesheet.py in docutils/writers directory.
-#   This is a stylesheet class used by the file.
-#
-# - Made minor mods to stop crashes.
-#     - Added support for the '--stylesheet' option.
-#         - This may be doing more harm than good.
-#     - Changed the following methods of the PDFTranslator class:
-#         - createParagraph
-#         - depart_title
-#@+node:ekr.20090704103932.5168: *4* 0.0.1
-#@+at
-#
-# - Removed '\r' characters in Writer.translate.
-# - Created self.push and self.pop.
-# - Rewrote visit/depart_title.  The code now is clear and works properly.
-#
-# To do:
-#     The code in several places uses x in self.context.
-#     This won't work when g.Bunches are on the context stack,
-#     so we shall need a method that searches the bunches on the stack.
-#@+node:ekr.20090704103932.5169: *4* 0.0.2
-#@+at
-#
-# - Fixed bug in visit_reference: added self.push(b).
-# - Added putHead, putTail utilities.
-# - Simplified most of the code.
-# - Reorganized node handlers so that it is clear what the important methods are.
-# - Almost all the grunt work is done.
-#@+node:ekr.20090704103932.5170: *4* 0.0.3
-#@+at
-#
-# All grunt work completed:
-#
-# - Moved Bunch class into this file (so no dependencies on leoGlobals.py).
-#
-# - Simplified calls to self.push
-#
-# - Finish all simple methods.
-#
-# - Better dumps in createParagraph.
-#@+node:ekr.20090704103932.5171: *4* 0.0.4
-#@+at
-#
-# - Added dummyPDFTranslator class.
-#
-# - Added support for this dummy class to Writer.translate.
-#@+node:ekr.20090704103932.5172: *4* 0.0.5
-#@+at
-#
-# - First working version.
-#
-#@+node:ekr.20090704103932.5173: *3* 0.1
-#@+at
-#
-# - Completed the conversion to using Bunches on the context stack.
-#     - Added peek method.
-#     - In context now searches from top of context stack and returns a Bunch.
-#     - Rewrote the footnote logic to use bunches:
-#         - footnote_backrefs sets b.setLink and b.links.  Much clearer code.
-#         - visit/depart_label uses b.setLink and b.links to generate code.
-# - The code now passes a minimal test of footnote code.
-#
-# - WARNING: auto-footnote numbering does not work.  I doubt it ever did.  I feel under no obligation to make it work.
-#@+node:ekr.20090704103932.5174: *3* 0.2
-#@+at
-#
-# - Added 'about this code' section.
-#@+node:ekr.20090704103932.5175: *3* 0.3
-#@+at Minor improvements to documentation.
-#@+node:ekr.20090704103932.5176: *3* 0.4
-#@+at
-#
-# - Added warning to docstring that this is not a valid Leo plugin.
-#
-# - Added init function that always returns False.  This helps Leo's unit tests.
-#@-others
 
-#@+at
-# 0.5 EKR:
-# - Define subclasses of docutils classes only if docutils can be imported.
-# - This supresses errors during unit tests.
-#
-# 1.0 EKR 2011/11/03:
-# - Various changes to come accomodate docutils changes.
-#     - Added dummy Reporter class for use by get_language.
-#     - I suspect this should be logger class, but I don't much care.
-# - Incorporate getStyleSheet from stylesheet.py, obtained from:
-#     http://docutils.sourceforge.net/sandbox/dreamcatcher/rlpdf/
-#
-# Note: passing writer_name = leo.plugins.leo_pdf to docutils does not work,
-# presumably because __import__('leo.plugins.leo_pdf') returns the *leo* module,
-# and docutils seems not to be aware of it. Thus, the new rst3 code passes writer
-# = Writer() (an instance) instead.
-#@-<< version history >>
-#@+<< to do >>
-#@+node:ekr.20090704103932.5177: ** << to do >>
-#@@nocolor
-#@+at
-#
+# To do:
 # - Bullets show up as a black 2 ball.
 # - More flexible handling of style sheets.
 # - Auto-footnote numbering does not work.
 # - Test rST raw: pdf feature.
-#@-<< to do >>
-__version__ = '1.0'
+
 __docformat__ = 'reStructuredText'
 
 #@+<< imports >>

--- a/leo/plugins/leo_to_html.py
+++ b/leo/plugins/leo_to_html.py
@@ -1,11 +1,9 @@
 #@+leo-ver=5-thin
 #@+node:danr7.20060902215215.1: * @file ../plugins/leo_to_html.py
-#@@language python
-#@@tabwidth -4
-
 #@+<< docstring >>
 #@+node:danr7.20060902215215.2: ** << docstring >>
-r''' Converts a leo outline to an html web page.
+r"""
+Converts a leo outline to an html web page.
 
 This plugin takes an outline stored in Leo and converts it to html which is then
 either saved in a file or shown in a browser. It is based on the original
@@ -119,49 +117,11 @@ At present, the file leo/plugins/leo_to_html.ini contains configuration
 settings. In particular, the default export path, "c:\" must be changed for \*nix
 systems.
 
-'''
+"""
 #@-<< docstring >>
-#@+<< version history >>
-#@+node:danr7.20060902215215.3: ** << version history >>
-#@@killcolor
-#@+at
-#
-# 1.00 - Finished testing with 4 different options & outlines
-# 0.91 - Got initial headline export code working. Resolved bug in INI file checking
-# 0.90 - Created initial plug-in framework
-# 1.1 ekr: Added init method.
-# 2.0 plumloco:
-#     - made gui independent
-#     - made output xhtml compliant
-#     - added ini options
-#         - use_xhtml: 'Yes' to included xhtml headers in output.
-#         - bullet_type: 'number', 'bullet', or 'head'.
-#         - browser_command: the command needed to launch a browser.
-#     - removed bullet/headlines dialog in favour of bullet_type ini option.
-#     - added option to show output in a browser instead of saving to a file
-#     - added extra menu items to save/show current node only
-#     - added export-html-*-* commands
-#     - added show-html-*-* commands
-#     - added Leo_to_HTML object so all the plugins functionality can be scripted.
-# 2.1 plumloco:
-#     - fixed bug in export of single nodes
-#     - fixed to use tempdir to get a temp dir
-#     - improved (and spellchecked :) docstring.
-#     - added abspath module level method
-# 2.2 bobjack:
-#     - fixed tempdir bug
-#     - converted docstring to rst
-#     - removed trace
-# 2.3 bobjack:
-#     - adopt 'every method must have a docstring' ( however inane :) ) rule
-#     - added support for @string leo_to_html_no_menus setting.
-#     - changed browser_command property default to empty string
-#     - use webbrowser module if browser_command property is empty or does not work.
-#
-#
-#
-#
-#@-<< version history >>
+
+# Edited by plumloco, bobjack, and EKR.
+
 #@+<< imports >>
 #@+node:danr7.20060902215215.4: ** << imports >>
 import configparser as ConfigParser
@@ -171,8 +131,6 @@ import tempfile
 import webbrowser
 from leo.core import leoGlobals as g
 #@-<< imports >>
-
-__version__ = '2.3'
 
 #@+others
 #@+node:bob.20080107154936: ** module level functions
@@ -754,4 +712,6 @@ class Leo_to_HTML:
     """
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -2,7 +2,8 @@
 #@+node:vitalije.20170727201534.1: * @file ../plugins/line_numbering.py
 #@+others
 #@+node:vitalije.20170727201830.1: ** About line_numbering plugin
-"""This plugin makes line numbers in gutter (if used), to represent
+"""
+This plugin makes line numbers in gutter (if used), to represent
    real line numbers in generated file. Root of file is either a
    first of ancestor nodes with heading at-(file,clean,...), or first
    of ancestor nodes which was marked as root for line numbering  using
@@ -10,7 +11,7 @@
    
    Author: vitalije(at)kviziracija.net
 """
-__version__ = "0.2"
+
 #@+node:vitalije.20170727201931.1: ** imports
 from contextlib import contextmanager
 import re

--- a/leo/plugins/macros.py
+++ b/leo/plugins/macros.py
@@ -63,26 +63,7 @@ It's a lot easier to use than to explain!
 
 '''
 #@-<< docstring >>
-__version__ = "2.0" # BobS & EKR.
-#@+<< version history >>
-#@+node:ekr.20040916091520: ** << version history >>
-#@+at
-#
-# 1.2 EKR:
-# - Converted to outline.
-# - Use g.angleBrackets to enclose lines with < < and > >.
-# - Use new instead of start2 hook.
-# - onCreate creates a new class for each commander.
-# - Removed all globals.
-# 1.3 EKR: Changed 'new_c' logic to 'c' logic.
-# 1.4 EKR: Replaced tree.begin/endUpdate by c.beginEndUpdate.
-# 1.5 EKR: Added event param to parameterize.
-# 1.6 EKR: imported leoNodes.
-# 1.7 Rich Ries: improved the docstring.
-# 1.8 EKR: Add the menu only for the tkinter gui.
-# 1.9 BobS: Revised self.pattern & added traces.
-# 2.0 EKR: Many code cleanups & fixed several crashers.
-#@-<< version history >>
+# BobS & EKR.
 import re
 from leo.core import leoGlobals as g
 #@+others

--- a/leo/plugins/maximizeNewWindows.py
+++ b/leo/plugins/maximizeNewWindows.py
@@ -2,28 +2,9 @@
 #@+node:ekr.20040915073259.1: * @file ../plugins/maximizeNewWindows.py
 """Maximizes all new windows."""
 
-#@@language python
-#@@tabwidth -4
-
-__version__ = "1.4"
-#@+<< version history >>
-#@+node:Dmitry.20101128013501.1257: ** << version history >>
-#@+at
-#
 # Original written by Jaakko Kourula.
-#
-# 1.0 EKR:
-#     - Enabled only for windows platform.
-#     - Minor style changes.
-# 1.1 EKR: Make sure c exists in maximize_window.
-# 1.2 EKR:
-#     - The proper guard is:
-#         if c and c.exists and c.frame and not c.frame.isNullFrame:
-#     - Added init function.
-# 1.3 EKR: Now works on Linux.
-# 1.4 Ivanov Dmitriy, Ville M. Vainio:
-#     Added the support for Qt UI, removed Tk check in init function
-#@-<< version history >>
+# Edited by EKR.
+
 #@+<< imports >>
 #@+node:Dmitry.20101128013501.1258: ** << imports >>
 from leo.core import leoGlobals as g
@@ -51,4 +32,6 @@ def maximize_window(tag, keywords):
         # elif gui == 'tkinter':
             # c.frame.resizeToScreen()
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/mnplugins.py
+++ b/leo/plugins/mnplugins.py
@@ -27,8 +27,6 @@ from leo.core import leoCommands
 #@-<< imports >>
 
 OKFLAG='OK '  # Space required.
-__version__ = "0.2"
-    # 0.2: EKR: added c arg to setOK: fixes bug reported by pylint.
 
 #@+others
 #@+node:ekr.20100128091412.5381: ** init (mnplugins.py)
@@ -126,4 +124,6 @@ def create_UserMenu (tag,keywords):
     ]
     c.frame.menu.createMenuEntries(c.pluginMenu, table)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/mod_leo2ascd.py
+++ b/leo/plugins/mod_leo2ascd.py
@@ -1,97 +1,12 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20101110093449.5822: * @file ../plugins/mod_leo2ascd.py
-__version__ = ".7" # Set version for the plugin handler.
-
 import re
 import os
 from leo.core import leoGlobals as g
 from leo.core import leoPlugins
-#@+<< define classes >>
-#@+node:ekr.20141110071911.17: ** << define classes >>
-#@+others
-#@+node:ekr.20101110094152.5824: *3* class _AssignUniqueConstantValue
-class   _AssignUniqueConstantValue:
-    """ Provide unique value to be used as a constant """
 
-    #@+others
-    #@+node:ekr.20101110094152.5825: *4* __init__
-    def __init__(self):
-        self.UniqueInternalValue = 0
-        self.Assign_at_start()
-
-    #@+node:ekr.20101110094152.5826: *4* class ConstError
-    class ConstError(TypeError):
-        pass
-    #@+node:ekr.20101110094152.5827: *4* __setattr__
-    def __setattr__(self,name,value):
-
-        if name in self.__dict__:
-            if name != "UniqueInternalValue":
-                raise self.ConstError("Can't rebind const(%s)"%name)
-        self.__dict__[name]=value
-    #@+node:ekr.20101110094152.5828: *4* Assign_at_start
-    def Assign_at_start(self):
-        self.END_PROGRAM = self.Next()   # signal abort
-        self.LINE_WAS_NONE = self.Next() # describe last line printed
-        self.LINE_WAS_CODE = self.Next()
-        self.LINE_WAS_DOC  = self.Next()
-        self.LINE_WAS_HEAD = self.Next()
-        self.LINE_PENDING_NONE  = self.Next() # describe next line to be printed
-        self.LINE_PENDING_CODE  = self.Next()
-        self.LINE_PENDING_DOC   = self.Next()
-    #@+node:ekr.20101110094152.5829: *4* Next
-    def Next(self):
-        self.UniqueInternalValue += 1
-        return(self.UniqueInternalValue)
-    #@-others
-#@+node:ekr.20101110094152.5830: *3* class _ConfigOptions
-class _ConfigOptions:
-    """Hold current configuration options."""
-    #@+others
-    #@+node:ekr.20101110094152.5831: *4* __init__
-    def __init__(self):
-        self.current = {}
-        self.default = {}
-        self.default["maxCodeLineLength"] = '76'
-        self.default["delimiterForCodeStart"] = '~-~--- code starts --------'
-        self.default["delimiterForCodeEnd"]   = '~-~--- code ends ----------'
-        self.default["delimiterForCodeSectionDefinition"] = '*example*'
-        self.default["headingUnderlines"] = '=-~^+'
-        self.default["asciiDocSectionLevels"] = '5'
-        self.default["PrintHeadings"] = "on"
-
-    #@+node:ekr.20101110094152.5832: *4* __GetNodeOptions
-    def __GetNodeOptions(self, vnode):
-        bodyString = vnode.bodyString()
-        lines = bodyString.splitlines()
-        for line in lines:
-            containsAscConfigDirective = patternAscDirectiveConfig.match(line)
-            if containsAscConfigDirective:
-                # Leo uses unicode, convert to plain ascii
-                name = str(containsAscConfigDirective.group(1))
-                value = str(containsAscConfigDirective.group(2))
-                if name in self.current:
-                    self.current[name] = value
-                else:
-                    g.es(vnode.headString())
-                    g.es("  No such config option: %s" % name)
-
-    #@+node:ekr.20101110094152.5833: *4* GetCurrentOptions
-    def GetCurrentOptions(self,c,p):
-        self.current.clear()
-        self.current = self.default.copy()
-        self.__GetNodeOptions(c.rootPosition())
-        self.__GetNodeOptions(p)
-
-    #@-others
-#@-others
-#@-<< define classes >>
-#@+<< constants >>
-#@+node:ekr.20101110094152.5834: ** << constants >> (mod_leo2ascd.py)
-CV = _AssignUniqueConstantValue()
-CV.NODE_IGNORE = CV.Next()      # demo of adding in code
-Conf = _ConfigOptions()
-
+#@+<< patterns >>
+#@+node:ekr.20101110094152.5834: ** << patterns >> (mod_leo2ascd.py)
 # compile the patterns we'll be searching for frequently
 patternSectionName = re.compile(r"\<\< *(.+?) *\>\>")
 patternSectionDefinition = re.compile(r"(\<\< *)(.+?)( *\>\>)(=)")
@@ -108,7 +23,8 @@ patternAscDirectiveExit = re.compile(r"^@ascexit")
 patternAscDirectiveIgnore = re.compile(r"^@ascignore")
 patternAscDirectiveSkip = re.compile(r"^@ascskip")
 patternAscDirectiveSkipToggle = re.compile(r"^@ascskip\s*(\w+)+.*")
-#@-<< constants >>
+#@-<< patterns >>
+
 #@+others
 #@+node:ekr.20140920145803.17999: ** init
 def init():
@@ -394,6 +310,86 @@ def WriteTreeOfCurrentNode(c):
         g.es("Sorry, there was no @ascfile directive in this outline tree.")
     else:
         WriteTreeAsAsc(p,ascFileN)
+#@+node:ekr.20101110094152.5824: ** class _AssignUniqueConstantValue
+class   _AssignUniqueConstantValue:
+    """ Provide unique value to be used as a constant """
+
+    #@+others
+    #@+node:ekr.20101110094152.5825: *3* __init__
+    def __init__(self):
+        self.UniqueInternalValue = 0
+        self.Assign_at_start()
+
+    #@+node:ekr.20101110094152.5826: *3* class ConstError
+    class ConstError(TypeError):
+        pass
+    #@+node:ekr.20101110094152.5827: *3* __setattr__
+    def __setattr__(self,name,value):
+
+        if name in self.__dict__:
+            if name != "UniqueInternalValue":
+                raise self.ConstError("Can't rebind const(%s)"%name)
+        self.__dict__[name]=value
+    #@+node:ekr.20101110094152.5828: *3* Assign_at_start
+    def Assign_at_start(self):
+        self.END_PROGRAM = self.Next()   # signal abort
+        self.LINE_WAS_NONE = self.Next() # describe last line printed
+        self.LINE_WAS_CODE = self.Next()
+        self.LINE_WAS_DOC  = self.Next()
+        self.LINE_WAS_HEAD = self.Next()
+        self.LINE_PENDING_NONE  = self.Next() # describe next line to be printed
+        self.LINE_PENDING_CODE  = self.Next()
+        self.LINE_PENDING_DOC   = self.Next()
+    #@+node:ekr.20101110094152.5829: *3* Next
+    def Next(self):
+        self.UniqueInternalValue += 1
+        return(self.UniqueInternalValue)
+    #@-others
+
+CV = _AssignUniqueConstantValue()
+CV.NODE_IGNORE = CV.Next()      # demo of adding in code
+#@+node:ekr.20101110094152.5830: ** class _ConfigOptions
+class _ConfigOptions:
+    """Hold current configuration options."""
+    #@+others
+    #@+node:ekr.20101110094152.5831: *3* __init__
+    def __init__(self):
+        self.current = {}
+        self.default = {}
+        self.default["maxCodeLineLength"] = '76'
+        self.default["delimiterForCodeStart"] = '~-~--- code starts --------'
+        self.default["delimiterForCodeEnd"]   = '~-~--- code ends ----------'
+        self.default["delimiterForCodeSectionDefinition"] = '*example*'
+        self.default["headingUnderlines"] = '=-~^+'
+        self.default["asciiDocSectionLevels"] = '5'
+        self.default["PrintHeadings"] = "on"
+
+    #@+node:ekr.20101110094152.5832: *3* __GetNodeOptions
+    def __GetNodeOptions(self, vnode):
+        bodyString = vnode.bodyString()
+        lines = bodyString.splitlines()
+        for line in lines:
+            containsAscConfigDirective = patternAscDirectiveConfig.match(line)
+            if containsAscConfigDirective:
+                # Leo uses unicode, convert to plain ascii
+                name = str(containsAscConfigDirective.group(1))
+                value = str(containsAscConfigDirective.group(2))
+                if name in self.current:
+                    self.current[name] = value
+                else:
+                    g.es(vnode.headString())
+                    g.es("  No such config option: %s" % name)
+
+    #@+node:ekr.20101110094152.5833: *3* GetCurrentOptions
+    def GetCurrentOptions(self,c,p):
+        self.current.clear()
+        self.current = self.default.copy()
+        self.__GetNodeOptions(c.rootPosition())
+        self.__GetNodeOptions(p)
+
+    #@-others
+
+Conf = _ConfigOptions()
 #@-others
 #@@language python
 #@@tabwidth -4

--- a/leo/plugins/mod_leo2ascd.txt
+++ b/leo/plugins/mod_leo2ascd.txt
@@ -2286,8 +2286,6 @@ Here is where we insert the < Call XEmacs > code fragment defined above:
         g.app.hasOpenWithMenu = True
         g.registerHandler("idle", on_idle)
         g.registerHandler(("start2","menu2","command2"), create_open_with_menu)
-
-        __version__ = "1.4" # Set version for the plugin handler.
         g.plugin_signon(__name__)
 
 #@+node:ekr.20040331071919.32: *4* << Open_Tree Plugin >>
@@ -2358,8 +2356,6 @@ def CreateOpenTreeMenu (tag,keywords):
 
 if 1:
     g.registerHandler(("start2","menu2","command2"),CreateOpenTreeMenu)
-
-    __version__ = ".4" # Set version for the plugin handler.
     g.plugin_signon(__name__)
 #@+node:ekr.20040331071919.33: *4* << Filename modification >>
 @language python
@@ -2431,8 +2427,6 @@ def openWithTempFilePath (self,v,ext):
 
 # Register the handlers...
 g.registerHandler("start2", onStart)
-
-__version__ = "1.3"
 g.plugin_signon(__name__)
 #@+node:ekr.20040331071919.34: *4* << Kill Temporary Buffers >>
 @language plain

--- a/leo/plugins/mod_read_dir_outline.py
+++ b/leo/plugins/mod_read_dir_outline.py
@@ -5,7 +5,8 @@
 
 #@+<< docstring >>
 #@+node:ekr.20050301084207: ** << docstring >>
-''' Allows Leo to read a complete directory tree into a Leo outline. Converts
+'''
+Allows Leo to read a complete directory tree into a Leo outline. Converts
 directories into headlines and puts the list of file names into bodies.
 
 Ce plug-in permet de traduire l'arborescence d'un répertoire en une arborescence
@@ -26,31 +27,6 @@ Feedback on this plugin can be sent to::
 
 import os
 from leo.core import leoGlobals as g
-
-__version__ = '2.0'
-#@+<< version history >>
-#@+node:ekr.20050301083306.3: ** << version history >>
-#@@killcolor
-
-#@+at
-#
-# 1.3 Original version by Frédéric Momméja
-#
-# 1.4 EKR:  Changes for 4.3 code base and new plugins style.
-#
-#     - Created typical init and onCreate functions.
-#     - Created language global.
-#     - Changed true/false to True/False.
-#     - Used g.os_path functions to support Unicode properly.
-#     - Added '@first # -*- coding: utf-8 -*-' to suppress deprecation warning.
-# 1.5 EKR:
-#     - use g.importExtension to import tkFileDialog.
-#     - Redraw the screen only once (in readDir instead of importDir).
-# 1.6 EKR:
-#     - Changed 'new_c' logic to 'c' logic.
-#     - Added init function.
-# 2.0 EKR: now gui independent.
-#@-<< version history >>
 
 language = 'english' # Anything except 'french' uses english.
 

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -229,7 +229,6 @@ from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoGui
 #@-<< imports >>
-__version__ = '3.0' # Added EvalController class.
 
 #@+others
 #@+node:ekr.20210228135810.1: ** cmd decorator
@@ -1554,4 +1553,6 @@ class EvalController:
         return s
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/mod_timestamp.py
+++ b/leo/plugins/mod_timestamp.py
@@ -9,8 +9,6 @@
 import time
 from leo.core import leoGlobals as g
 
-__version__ = "0.1"
-
 #@+others
 #@+node:ekr.20100128073941.5374: ** init
 def init():

--- a/leo/plugins/nodeActions.py
+++ b/leo/plugins/nodeActions.py
@@ -199,16 +199,6 @@ execute a command in the first line of the body of a double-clicked node::
 # Derived from the fileActions plugin.
 # Distributed under the same licence as Leo.
 
-__version__ = "0.5"
-#@+<< version history >>
-#@+node:TL.20080507213950.4: ** << version history >>
-#@@nocolor
-#@+at
-# 0.5 : 02-Ago-20 : XC : Added a command annotation, fixed handler registering and @files pattern recognition, removed functionality of doubtful utility
-# 0.3 : 02-Apr-10 : TL : Support search all sub-nodes for pattern match
-# 0.2 : 02-Mar-09 : TL : Support for 'X', 'V', and  '>' directives added
-# 0.1 : 27-Feb-09 : TL : Initial code (modified from FileActions plugin)
-#@-<< version history >>
 #@+<< imports >>
 #@+node:ekr.20040915110738.1: ** << imports >>
 import fnmatch

--- a/leo/plugins/nodediff.py
+++ b/leo/plugins/nodediff.py
@@ -1,8 +1,5 @@
 #@+leo-ver=5-thin
 #@+node:peckj.20140113150237.7083: * @file ../plugins/nodediff.py
-#@@language python
-#@@tabwidth -4
-
 #@+<< docstring >>
 #@+node:peckj.20140113131037.5792: ** << docstring >>
 '''Provides commands to run text diffs on node bodies within Leo.
@@ -83,13 +80,7 @@ positions as input::
 '''
 #@-<< docstring >>
 
-__version__ = '0.1'
-#@+<< version history >>
-#@+node:peckj.20140113131037.5793: ** << version history >>
-#@+at
-#
-# JMP 0.1 - initial version
-#@-<< version history >>
+# By JMP.
 
 #@+<< imports >>
 #@+node:peckj.20140113131037.5794: ** << imports >>
@@ -336,4 +327,6 @@ class NodeDiffController:
 
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/outline_export.py
+++ b/leo/plugins/outline_export.py
@@ -7,8 +7,6 @@
 
 from leo.core import leoGlobals as g
 
-__version__ = "1.2" # Set version for the plugin handler.
-
 #@+others
 #@+node:ekr.20100128073941.5375: ** init
 def init():

--- a/leo/plugins/paste_as_headlines.py
+++ b/leo/plugins/paste_as_headlines.py
@@ -2,7 +2,6 @@
 #@+leo-ver=5-thin
 #@+node:danr7.20060912105041.1: * @file ../plugins/paste_as_headlines.py
 #@@first
-
 #@+<< docstring >>
 #@+node:danr7.20060912105041.2: ** << docstring >>
 ''' Creates new headlines from clipboard text.
@@ -14,28 +13,12 @@ under the existing Paste option.
 
 '''
 #@-<< docstring >>
-
-#@@language python
-#@@tabwidth -4
-
-#@+<< version history >>
-#@+node:danr7.20060912105041.3: ** << version history >>
-#@+at
-# 0.91 - Added headline truncate code
-# 0.90 - Created initial plug-in framework
-# 1.0: Dan Rahmel
-# 1.1 EKR:
-# - Converted code to use c.setHead/BodyString rather than the old position setters.
-# - Added call to currentNode.expand in paste_as_headlines, enclosed in c.begin/endUpate.
-#@-<< version history >>
+# By Dan Rahmel.
 #@+<< imports >>
 #@+node:danr7.20060912105041.4: ** << imports >>
 from leo.core import leoGlobals as g
 
 #@-<< imports >>
-
-__version__ = "1.1"
-
 #@+others
 #@+node:ekr.20100128073941.5377: ** init
 def init():
@@ -97,4 +80,6 @@ def paste_as_headlines(c):
     currentPos.expand()
     c.redraw()
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -61,10 +61,11 @@ import configparser as ConfigParser
 import os
 from leo.core import leoGlobals as g
 #@-<< imports >>
-__version__ = "2.3"
+
 __plugin_name__ = "Plugins Menu"
 __plugin_priority__ = -100
 __plugin_group__ = "Core"
+
 #@+others
 #@+node:ekr.20060107091318: ** Functions
 #@+node:EKR.20040517080555.24: *3* addPluginMenuItem

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -128,23 +128,9 @@ Tags
 
 """
 #@-<< docstring >>
-__version__ = '0.7'
-#@+<< version history >>
-#@+node:tbrown.20070117104409.6: ** << version history >>
-#@+at
-# 0.1 by Terry Brown, 2007-01-12
-# 0.2 EKR:
-# - Revised docstring.
-# - Use positions and position methods rather than vnodes.
-# - Use checkMoveWithParentWithWarning.
-# - Support undo.
-# - Clearer command names.
-# 0.3 EKR: Various small mods suggested by Terry.
-# 0.4 EKR: Added checkMove method.
-# 0.5 EKR: Added c arg to p.visNext & p.visBack.
-# 0.6 TNB: Store vnodes rather than positions, vnodes are more durable
-# 0.7 TNB: Added "clone to" as well as "move to"
-#@-<< version history >>
+
+# By Terry Brown, 2007-01-12
+
 #@+<< imports >>
 #@+node:tbrown.20070117104409.2: ** << imports >>
 from copy import deepcopy

--- a/leo/plugins/rss.py
+++ b/leo/plugins/rss.py
@@ -1,8 +1,5 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20131004162848.11444: * @file ../plugins/rss.py
-#@@language python
-#@@tabwidth -4
-
 #@+<< docstring >>
 #@+node:peckj.20131002201824.5539: ** << docstring >>
 '''Adds primitive RSS reader functionality to Leo.
@@ -129,17 +126,6 @@ Clears the viewed stories history of every `@feed` node in the current outline.
 
 '''
 #@-<< docstring >>
-
-__version__ = '0.3'
-#@+<< version history >>
-#@+node:peckj.20131002201824.5540: ** << version history >>
-#@+at
-#
-# Version 0.1 - initial functionality.  NO UNDO.
-# Version 0.2 - bugfix for bug reported by Viktor Ransmayr regarding not having dates in the feed.
-# Version 0.3 - configurable with a few @settings in myLeoSettings.leo
-#@-<< version history >>
-
 #@+<< imports >>
 #@+node:peckj.20131002201824.5541: ** << imports >>
 try:
@@ -356,4 +342,6 @@ class RSSController:
             self.clear_history(self.c.vnode2position(feed))
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -36,33 +36,8 @@ By Alexis Gendron Paquette. Please send comments to the Leo forums.
 '''
 #@-<< docstring >>
 
-# At present, this plugin is experimental, that is, broken.
+# At present, this plugin is *broken*.
 
-#@+<< version history >>
-#@+node:ekr.20040910070811.3: ** << version history >>
-#@@nocolor
-#@+at
-#
-# 0.13 EKR:
-# - use import leo.core.leoGlobals as leoGlobals and import leoPlugins rather from x import *
-# - Made positions explicit and use position iterators.
-# - Support @arg nodes.
-# - Support @run # comment (or #comment)
-# - Support @run command args # comment (or #comment)
-# - Allow @input as well as @in.
-# - Simpler log messages.
-# 0.14 EKR:
-# - Removed call to g.top()
-# - Added init function.
-# 0.15 EKR: Corrected the call to os.popen3 in OpenProcess per
-# http://sourceforge.net/forum/message.php?msg_id=3761385
-# 0.16 EKR:
-# - replaced os.popen3 by calls to subprocess.Popen.
-#   This probably altered the intension of this plugin.
-# - Fixed several other crashers.
-#
-# Important: at present, this plugin must be considered broken.
-#@-<< version history >>
 #@+<< imports >>
 #@+node:ekr.20040910070811.4: ** << imports >>
 import os

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -312,8 +312,6 @@ the @slideshow tree whose sanitized name is
 """
 #@@pagewidth 50
 #@-<< docstring >>
-# To do: create _static folder.
-__version__ = '1.0.3'
 #@+<< imports >>
 #@+node:ekr.20100908110845.5604: ** << imports >>
 import copy
@@ -338,6 +336,9 @@ except ImportError:
 # Alias.
 got_qt = QtGui is not None
 #@-<< imports >>
+
+# To do: create _static folder.
+
 #@+others
 #@+node:ekr.20100914090933.5771: ** Top level
 #@+node:ekr.20100908110845.5581: *3* g.command(apropos-slides)
@@ -1952,4 +1953,6 @@ class ScreenShotController:
         return False
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/script_io_to_body.py
+++ b/leo/plugins/script_io_to_body.py
@@ -2,23 +2,10 @@
 #@+node:edream.110203113231.925: * @file ../plugins/script_io_to_body.py
 """Sends output from the Execute Script command to the end of the body pane."""
 
-#@@language python
-#@@tabwidth -4
-
-__version__ = "1.5"
-
 #@+<< imports >>
 #@+node:ekr.20050101090207.4: ** << imports >>
 from leo.core import leoGlobals as g
 #@-<< imports >>
-#@+<< version history >>
-#@+node:ekr.20071212114235: ** << version history >>
-#@@nocolor
-#@+at
-#
-# 1.5 EKR: A complete rewrite. Now works with Leo 4.4.5 code base.
-# 2.0 EKR: Gui independent.
-#@-<< version history >>
 
 #@+others
 #@+node:ekr.20071025195133: ** init
@@ -93,4 +80,7 @@ def undirect (c):
     g.funcToMethod(c.script_io_to_body_oldput,log,"put")
     g.funcToMethod(c.script_io_to_body_oldputnl,log,"putnl")
 #@-others
+#@@language python
+#@@tabwidth -4
+
 #@-leo

--- a/leo/plugins/sftp.py
+++ b/leo/plugins/sftp.py
@@ -1,8 +1,5 @@
 #@+leo-ver=5-thin
 #@+node:peckj.20140811080604.9496: * @file ../plugins/sftp.py
-#@@language python
-#@@tabwidth -4
-
 #@+<< docstring >>
 #@+node:peckj.20140218144401.6036: ** << docstring >>
 '''@edit-like functionality for remote files over SFTP
@@ -96,16 +93,6 @@ sftp-cache-credentials = True`.
 
 '''
 #@-<< docstring >>
-
-__version__ = '0.2'
-#@+<< version history >>
-#@+node:peckj.20140218144401.6037: ** << version history >>
-#@+at
-#
-# Version 0.1 - initial functionality
-# Version 0.2 - use leoQt instead of PyQt4
-#@-<< version history >>
-
 #@+<< imports >>
 #@+node:peckj.20140218144401.6038: ** << imports >>
 try:
@@ -342,4 +329,6 @@ class SFTPController:
         g.user_dict['sftp'] = {}
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/slideshow.py
+++ b/leo/plugins/slideshow.py
@@ -20,33 +20,15 @@ All these commands ignore @ignore trees.
 
 '''
 #@-<< docstring >>
-__version__ = '0.4'
-#@+at
-# To do:
-# - Add sound/script support for slides.
-# - Save/restore changes to slides when entering/leaving a slide.
-#@@c
-#@+<< version history >>
-#@+node:ekr.20060831165845.2: ** << version history >>
-#@@killcolor
-#@+at
-#
-# 0.01 EKR: Initial version.
-# 0.02 EKR: Improved docstring and added todo notes.
-# 0.03 EKR: Simplified createCommands.
-# 0.1  EKR: A big step forward.
-# The next/prev-slide-show commands allow easy management of multiple slideshows.
-# 0.2  EKR: next/pref-slide-show commands work properly when
-# a) c.currentPosition changes and
-# b) @slideshow nodes inserted or deleted.
-# 0.3 EKR:
-# - next-slide and prev-slide now work more intuitively when current position changes.
-# 0.4 EKR: Support @ignore nodes in all commands.
-#@-<< version history >>
 #@+<< imports >>
 #@+node:ekr.20060831165845.3: ** << imports >>
 from leo.core import leoGlobals as g
 #@-<< imports >>
+
+# To do:
+# - Add sound/script support for slides.
+# - Save/restore changes to slides when entering/leaving a slide.
+
 #@+others
 #@+node:ekr.20060831165845.4: ** init
 def init():

--- a/leo/plugins/systray.py
+++ b/leo/plugins/systray.py
@@ -1,10 +1,12 @@
 #@+leo-ver=5-thin
 #@+node:ville.20110304230157.6513: * @file ../plugins/systray.py
-''' systray'''
+"""systray"""
+
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtGui, QtWidgets
-__version__ = '0.2'
+
 g.assertUi('qt')
+
 #@+others
 #@+node:ville.20110219221839.6553: ** init
 def init ():

--- a/leo/plugins/test/failed_to_load_plugin.py
+++ b/leo/plugins/test/failed_to_load_plugin.py
@@ -1,9 +1,9 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20071113085315: * @file ../plugins/test/failed_to_load_plugin.py
-'''This plugin intentially reports that it fails to load.
-It is used for testing Leo's plugin loading logic.'''
-
-__version__ = '1.0'
+"""
+This plugin intentially reports that it fails to load.
+It is used for testing Leo's plugin loading logic.
+"""
 
 def init ():
     '''Return True if the plugin has loaded successfully.'''

--- a/leo/plugins/textnode.py
+++ b/leo/plugins/textnode.py
@@ -17,14 +17,10 @@ node.
 '''
 #@-<< docstring >>
 
-#@@language python
-#@@tabwidth -4
+# Terry Brown: support for @path ancestors and uses universal newline mode for opening.
 
 import os.path
 from leo.core import leoGlobals as g
-
-__version__ = "1.1"
-    # Terry Brown: support for @path ancestors and uses universal newline mode for opening.
 
 #@+others
 #@+node:ajones.20070122160142.2: ** init (textnode.py)
@@ -102,4 +98,6 @@ def savetextnode(c, p):
         p.setDirty()
         p.setMarked()
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/trace_gc_plugin.py
+++ b/leo/plugins/trace_gc_plugin.py
@@ -1,12 +1,12 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.735: * @file ../plugins/trace_gc_plugin.py
 """ Traces changes to Leo's objects at idle time."""
-#@@language python
-#@@tabwidth -4
+
 from leo.core import leoGlobals as g
-__version__ = "1.3"
+
 g.debugGC = True # Force debugging on.
 gcCount = 0
+
 #@+others
 #@+node:ekr.20100128091412.5386: ** init (trace_gc_plugin)
 def init():
@@ -36,4 +36,6 @@ def printIdleGC(tag, keywords):
     else:
         g.printGc()
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/trace_keys.py
+++ b/leo/plugins/trace_keys.py
@@ -1,10 +1,9 @@
 #@+leo-ver=5-thin
 #@+node:edream.110203113231.736: * @file ../plugins/trace_keys.py
 """ Traces keystrokes in the outline and body panes."""
-#@@language python
-#@@tabwidth -4
+
 from leo.core import leoGlobals as g
-__version__ = "1.2"
+
 #@+others
 #@+node:ekr.20100128091412.5387: ** init
 def init():
@@ -20,4 +19,6 @@ def onKey(tag, keywords):
     if ch:
         g.es("key", repr(ch))
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/viewrendered2.py
+++ b/leo/plugins/viewrendered2.py
@@ -1,6 +1,6 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20140225222704.16748: * @file ../plugins/viewrendered2.py
-#@@language python
+
 #@+<< docstring >>
 #@+node:ekr.20140226074510.4187: ** << docstring >> (VR2)
 '''
@@ -202,11 +202,11 @@ See the viewrendered.py plugin for additional acknowledgments.
 
 '''
 #@-<< docstring >>
+
 # 2018/03/05:
 # - New code by Tom Passin, per #756.
 # - EKR added previous fix for #734.
 # Porting to PyQt5: https://wiki.qt.io/Porting_from_QtWebKit_to_QtWebEngine
-__version__ = '1.2' # tbp: added "Code Only" option to emit only code.
 
 #@+<< imports >>
 #@+node:ekr.20140226074510.4188: ** << imports >> (VR2)
@@ -1890,4 +1890,6 @@ class ViewRenderedController(QtWidgets.QWidget):
     #@-others
 #@-others
 # print('vr2 imported correctly')
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/vim.py
+++ b/leo/plugins/vim.py
@@ -41,51 +41,10 @@ Settings
 
 '''
 #@-<< docstring >>
-#@+<< version history >>
-#@+node:ekr.20050226184411.1: ** << version history >>
-#@@killcolor
-#@+at
-#
+
 # Contributed by Andrea Galimberti.
-# Edited by Felix Breuer.
-#
-# 1.5 EKR:
-#     - Added new sections.
-#     - Move most comments into docstring.
-#     - Added useDoubleClick variable.
-#     - Added init function.
-#     - Init _vim_cmd depending on sys.platform.
-# 1.6 EKR:
-#     - Use keywords to get c, not g.top().
-#     - Don't use during unit testing: prefer xemacs instead.
-#     - Added _vim_exe
-#     - Use "os.spawnv" instead of os.system.
-#     - Simplified the search of g.app.openWithFiles.
-#     - Fixed bug in open_in_vim: hanged v.bodyString to v.bodyString()
-# 1.7 EKR: Excellent new code by Jim Sizelove solves weird message on first open of vim.
-# 1.8 EKR: Set subprocess = None if import fails.
-# 1.9 EKR:
-#     - Document how install subproces, and use g.importExtension to import subprocess.
-#     - Import subprocess with g.importExtension.
-# 1.10 EKR:
-#     - Support 'vim_cmd' and 'vim_exe' settings.
-#     - These override the default _vim_cmd and _vim_exe settings.
-# 1.11 EKR: Emergency default for window is now the default location: c:\Program Files\vim\vim63
-# 1.12 EKR:
-#     - Added emergency default for 'darwin'.
-#     - Corrected the call to openWith.  It must now use data=data due to a new event param.
-# 1.13 EKR: The docstring now states that the open_with plugin must be enabled for this to work.
-# 1.14 EKR: Emphasized that the open_with plugin must be enabled.
-# 1.15 EKR: Don't open @url nodes in vim if @bool vim_plugin_opens_url_nodes setting is False.
-# 1.16 TL: open_in_vim modifications
-#     - support file open in gVim at same line number as Leo cursor location
-#     - support file open in a gVim tab
-# 1.17 EKR: Give a location message to help with settings.
-# 1.18 VMV:
-#     - Use gvim on Linux too, emergency default on Windows doesn't have explicit path
-#     - Works when subprocess.Popen(shell=True)
-# 2.0 EKR: Use *only* the vim-open-node command.  Do not pollute click handlers.
-#@-<< version history >>
+# Edited by Felix Breuer, TL, VMV and EKR.
+
 #@+<< documentation from Jim Sizelove >>
 #@+node:ekr.20050909102921: ** << documentation from Jim Sizelove >>
 #@+at
@@ -163,6 +122,7 @@ import subprocess
 import sys
 from leo.core import leoGlobals as g
 #@-<< imports >>
+
 # This command is used to communicate with the vim server. If you use gvim
 # you can leave the command as is, you do not need to change it to "gvim ..."
 # New in version 1.10 of this plugin: these are emergency defaults only.

--- a/leo/plugins/wikiview.py
+++ b/leo/plugins/wikiview.py
@@ -39,18 +39,12 @@ Settings
     The pattern will be applied only for strings starting with the leadin character.
 """
 #@-<< docstring >>
-
-#@@language python
-#@@tabwidth -4
-
-__version__ = "0.1"
 #@+<< imports >>
 #@+node:tbrown.20141101114322.3: ** << imports >>
 import re
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtGui
 #@-<< imports >>
-
 #@+others
 #@+node:tbrown.20141101114322.4: ** init
 def init():
@@ -204,4 +198,6 @@ class WikiView:
                 # Triggers a recolor.
     #@-others
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/word_count.py
+++ b/leo/plugins/word_count.py
@@ -1,36 +1,23 @@
 #@+leo-ver=5-thin
 #@+node:danr7.20061010105952.1: * @file ../plugins/word_count.py
-#@@language python
-#@@tabwidth -4
-
 #@+<< docstring >>
 #@+node:danr7.20061010105952.2: ** << docstring >>
-''' Counts characters, words, lines, and paragraphs in the body pane.
+''' 
+
+Word Count plugin by Dan Rahmel
+
+
+Counts characters, words, lines, and paragraphs in the body pane.
 
 It adds a "Word Count..." option to the bottom of the Edit menu that will
 activate the command.
 
 '''
 #@-<< docstring >>
-#@+<< version history >>
-#@+node:danr7.20061010105952.3: ** << version history >>
-#@@killcolor
-#@+at
-# 1.00 - Finalized 1st version of plug-in & added return focus line
-# 0.95 - Tested counting routines
-# 0.94 - Added shortcut key to menu
-# 0.93 - Created para count routine & added char count
-# 0.92 - Created line count routine
-# 0.91 - Created word count routine
-# 0.90 - Created initial plug-in framework
-# 1.2: The plugin now is gui independent.
-#@-<< version history >>
 
-# Word Count plugin by Dan Rahmel
+# 
 
 from leo.core import leoGlobals as g
-
-__version__ = "1.2"
 
 #@+others
 #@+node:ekr.20070301062245: ** init
@@ -74,4 +61,6 @@ def word_count(c):
     g.es("Words: %s, Chars: %s\nParagraphs: %s, Lines: %s" % (
         wordNum,charNum,paraNum,lineNum))
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/word_export.py
+++ b/leo/plugins/word_export.py
@@ -1,31 +1,12 @@
 #@+leo-ver=5-thin
 #@+node:EKR.20040517075715.14: * @file ../plugins/word_export.py
-r'''
+r"""
 Adds the Plugins\:Word Export\:Export menu item to format and export
 the selected outline to a Word document, starting Word if necessary.
-'''
+"""
 
 __plugin_name__ = "Word Export"
-__version__ = "0.8"
 
-#@+<< version history >>
-#@+node:ekr.20040909110753: ** << version history >>
-#@@killcolor
-#@+at
-#
-# 0.3 EKR:
-#     - Changed os.path.x to g.os_path_x for better handling of unicode filenames.
-#     - Better error messages.
-# 0.4 EKR:
-#     - Added autostart code per http://sourceforge.net/forum/message.php?msg_id=2842589
-# 0.5 EKR:
-#     - Added init function so that a proper message is given if win32com can not be imported.
-# 0.6 EKR: (eliminated g.top)
-#     - Add c arg to writeNodeAndTree.
-#     - Set encoding to sys.getdefaultencoding() if there is no @encoding directive in effect.
-# 0.7 EKR: cmd_ functions now get c arg.
-# 0.8 EKR: set __plugin_name__ rather than __name__
-#@-<< version history >>
 #@+<< imports >>
 #@+node:ekr.20040909105522: ** << imports >>
 import configparser as ConfigParser

--- a/leo/plugins/xemacs.py
+++ b/leo/plugins/xemacs.py
@@ -12,44 +12,17 @@ appear in Leo.
 
 '''
 #@-<< docstring >>
-#@@language python
-#@@tabwidth -4
+
+# Initial version: http://www.cs.mu.oz.au/~markn/leo/external_editors.leo
+# Edited by EKR.
+
 #@+<< imports >>
 #@+node:ekr.20050218024153: ** << imports >> (xemacs.py)
 import os
 import sys
 from leo.core import leoGlobals as g
 #@-<< imports >>
-__version__ = "2.0"
-#@+<< version history >>
-#@+node:ekr.20050218024153.1: ** << version history >> (xemacs.py)
-#@@killcolor
-#@+at
-#
-# Initial version: http://www.cs.mu.oz.au/~markn/leo/external_editors.leo
-#
-# 1.5 EKR:
-# - Added commander-specific callback in onCreate.
-# - Added init method.
-# 1.6 MCM
-# - Added sections from Vim mode and some clean-up.
-# 1.7 EKR:
-# - Select _emacs_cmd using sys.platform.
-# 1.8 EKR:
-# - Get c from keywords, not g.top().
-# - Simplified the search of g.app.openWithFiles.
-# - Fixed bug in open_in_emacs: hanged v.bodyString to v.bodyString()
-# 1.9 EKR:
-# - Installed patch from mackal to find client on Linux.
-#   See http://sourceforge.net/forum/message.php?msg_id=3219471
-# 1.10 EKR:
-# - Corrected the call to openWith.  It must now use data=data due to a new event param.
-# 1.11 EKR:
-# - The docstring now states that the open_with plugin must be enabled for this to work.
-# 2.0 EKR:
-# - Use only the emacs-open-node command.  Don't pollute clicks.
-#@-<< version history >>
-# useDoubleClick = True
+
 # Full path of emacsclient executable. We need the full path as spawnlp
 # is not yet implemented in leoCommands.py
 if sys.platform == "win32":
@@ -68,6 +41,7 @@ elif sys.platform.startswith("linux"):
         print("Unable to locate a usable version of *Emacs")
 else:
     _emacs_cmd = "/Applications/Emacs.app/Contents/MacOS/bin/emacsclient"
+
 #@+others
 #@+node:ekr.20050218023308: ** xemacs.init
 def init():
@@ -133,4 +107,6 @@ def open_in_emacs_command(event):
     if c:
         open_in_emacs_helper(c, c.p)
 #@-others
+#@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/plugins/xsltWithNodes.py
+++ b/leo/plugins/xsltWithNodes.py
@@ -18,10 +18,6 @@ Requires 4Suite 1.0a3 or better, downloadable from http://4Suite.org.
 
 """
 #@-<< docstring >>
-
-#@@language python
-#@@tabwidth -4
-
 #@+<< imports >>
 #@+node:mork.20041025113509: ** << imports >>
 import io
@@ -57,34 +53,6 @@ StringIO = io.StringIO
 #
 #     I dont know at this point if its just illegal xml, or its a problem in the parser. ??
 #@-<<parser problems>>
-#@+<<future directions>>
-#@+node:mork.20041025101943: ** <<future directions>>
-#@+at
-# 1. Add more XSLT boilerplate insertions.( done in .3 )
-# 2. Maybe add a well-formedness check. (done in .3, test with minidom )
-#@-<<future directions>>
-__version__ = '0.6'
-#@+<< version history >>
-#@+node:mork.20041025113211: ** << version history >>
-#@@killcolor
-
-#@+at
-#
-# 0.1: Original code.
-#
-# 0.2 EKR: Converted to outline.
-#
-# 0.3: Added more XSLT boilerplate. Added Test with Minidom Discovered parser problem(?).
-#
-# 0.4 EKR:
-#     - Added init function.
-# 0.5 EKR:
-#     - Remove 'start2' hook & haveseen dict.
-#     - Use keywords.get('c') instead of g.top().
-# 0.6 EKR:
-#     - Removed g.top from example code.
-#@-<< version history >>
-
 #@+others
 #@+node:ekr.20050226120104.1: ** init
 def init():
@@ -538,7 +506,6 @@ class CSVVisualizer:
     if 1:
 
         registerHandler( ('start2' , 'open2', "new") , addMenu )
-        __version__ = ".125"
         g.plugin_signon( __name__ )
 
     #@-others
@@ -591,4 +558,7 @@ class CSVVisualizer:
 #@-others
 '''
 #@-others
+#@@language python
+#@@tabwidth -4
+
 #@-leo


### PR DESCRIPTION
Remove `__version__` and `<< version history >>` sections, etc. from all plugins.

These "features" are unnecessary (and potentially misleading) now that git tracks everything.

Do *not* try to replace `'''` by `"""` automatically. Not all `'''` delimit docstrings!

In the unlikely event that someone wants the now-deleted contents of a `<< version history >>` for some plugin x.py, `gitk x.py` will retrieve those contents.