### PR TITLE
Correct imports in tests

### DIFF
--- a/leoclient.py
+++ b/leoclient.py
@@ -37,7 +37,7 @@ def _get_action_list():
     """
     import inspect
     import os
-    import leo.core.leoserver as leoserver
+    import leoserver
     server = leoserver.LeoServer()
     # file_name = "xyzzy.leo"
     file_name = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')

--- a/leoserver.py
+++ b/leoserver.py
@@ -2223,7 +2223,7 @@ class TestLeoServer (unittest.TestCase):  # pragma: no cover
     def setUpClass(cls):
         # Assume we are running in the leo-editor directory.
         # pylint: disable=import-self
-        import leo.core.leoserver as leoserver
+        import leoserver
         global g, g_leoserver, g_server
         g_leoserver = leoserver
         g_server = leoserver.LeoServer(testing=True)


### PR DESCRIPTION
Changed imports to correspond to new locations for leoclient.py and leoserver.py.

Discovered while running this test script on Windows:
```python
g.cls()
import os
import time
if c.changed:
    c.save()
leo_dir = os.path.abspath(os.path.join(g.app.loadDir, '..', '..'))
assert os.path.exists(leo_dir), repr(leo_dir)
os.chdir(leo_dir)
g.execute_shell_commands('start cmd /k "python leoserver.py"')
time.sleep(0.5)
g.execute_shell_commands('start cmd /k "python leoclient.py"')
```