### PR TITLE
Add docstrings for 5 commands. Retire at-file-to-at-auto command

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -643,6 +643,7 @@ class Commands:
     #@+node:vitalije.20190924191405.1: *3* @cmd execute-pytest
     @cmd('execute-pytest')
     def execute_pytest(self, event=None):
+        """Using pytest, execute all @test nodes for p, p's parents and p's subtree."""
         c = self
 
         def it(p):
@@ -1009,6 +1010,7 @@ class Commands:
     #@+node:ekr.20190506060937.1: *5* c.dumpExpanded
     @cmd('dump-expanded')
     def dump_expanded(self, event):
+        """Print all non-empty v.expandedPositions lists."""
         c = event.get('c')
         if not c:
             return

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -34,6 +34,7 @@ def cmd(name):
 #@+node:ekr.20180708114847.1: *3* dump-clone-parents
 @g.command('dump-clone-parents')
 def dump_clone_parents(event):
+    """Print the parent vnodes of all cloned vnodes."""
     c = event.get('c')
     if not c:
         return
@@ -47,6 +48,7 @@ def dump_clone_parents(event):
 #@+node:ekr.20210309114903.1: *3* dump-gnx-dict
 @g.command('dump-gnx-dict')
 def dump_gnx_dict(event):
+    """Dump c.fileCommands.gnxDict."""
     c = event.get('c')
     if not c:
         return

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -755,6 +755,7 @@ class LeoFind:
     @cmd('replace')
     @cmd('change')
     def change(self, event=None):  # pragma: no cover (cmd)
+        """Replace the selected text with the replacement text."""
         p = self.c.p
         if self.check_args('replace'):
             self.init_in_headline()

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -8,14 +8,10 @@ import pickle
 from leo.core import leoGlobals as g
 #@+others
 #@+node:ekr.20140711111623.17886: ** Commands (leoPersistence.py)
-@g.command('at-file-to-at-auto')
-def at_file_to_at_auto_command(event):
-    c = event.get('c')
-    if c and c.persistenceController:
-        c.persistenceController.convert_at_file_to_at_auto(c.p)
 
 @g.command('clean-persistence')
 def view_pack_command(event):
+    """Remove all @data nodes that do not correspond to an existing foreign file."""
     c = event.get('c')
     if c and c.persistenceController:
         c.persistenceController.clean()

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -10176,6 +10176,12 @@ def insertTree(self, p):
         self.write(f"\n\n::\n\n{''.join(tree)}\n\n")
     else:
         g.es_print(f"gnx not found: {gnx!r} in {p.h}")
+#@+node:ekr.20210712134630.1: ** From leoPersistence.py
+@g.command('at-file-to-at-auto')
+def at_file_to_at_auto_command(event):
+    c = event.get('c')
+    if c and c.persistenceController:
+        c.persistenceController.convert_at_file_to_at_auto(c.p)
 #@+node:ekr.20210312150753.1: ** leoTangle.py
 '''
 Support for @root and Leo's tangle and untangle commands.


### PR DESCRIPTION
New docstrings for dump-clone-parents, dump-expanded, dump-gnx-dict, execute-pytest and replace.

Only the "replace" command is important. leoInteg need not support the other commands.