### PR TITLE
PR for #2069 (abandoned)

### DIFF
--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -10182,6 +10182,52 @@ def at_file_to_at_auto_command(event):
     c = event.get('c')
     if c and c.persistenceController:
         c.persistenceController.convert_at_file_to_at_auto(c.p)
+#@+node:ekr.20210716174757.1: ** From qt_tree.py
+#@+node:ekr.20110605121601.17900: *3* qtree.OnPopup & allies (not used)
+def OnPopup(self, p, event):
+    """Handle right-clicks in the outline.
+
+    This is *not* an event handler: it is called from other event handlers."""
+    # Note: "headrclick" hooks handled by VNode callback routine.
+    if event:
+        c = self.c
+        c.setLog()
+        if not g.doHook("create-popup-menu", c=c, p=p, event=event):
+            self.createPopupMenu(event)
+        if not g.doHook("enable-popup-menu-items", c=c, p=p, event=event):
+            self.enablePopupMenuItems(p, event)
+        if not g.doHook("show-popup-menu", c=c, p=p, event=event):
+            self.showPopupMenu(event)
+    return "break"
+#@+node:ekr.20110605121601.17901: *4* qtree.OnPopupFocusLost
+@language rest
+@
+On Linux we must do something special to make the popup menu "unpost" if the
+mouse is clicked elsewhere. So we have to catch the <FocusOut> event and
+explicitly unpost. In order to process the <FocusOut> event, we need to be able
+to find the reference to the popup window again, so this needs to be an
+attribute of the tree object; hence, "self.popupMenu".
+
+Aside: though Qt tries to be muli-platform, the interaction with different
+window managers does cause small differences that will need to be compensated by
+system specific application code. :-(
+@c
+@language python
+
+# 20-SEP-2002 DTHEIN: This event handler is only needed for Linux.
+
+def OnPopupFocusLost(self, event=None):
+    # self.popupMenu.unpost()
+    pass
+#@+node:ekr.20110605121601.17902: *4* qtree.createPopupMenu
+def createPopupMenu(self, event):
+    """This might be a placeholder for plugins.  Or not :-)"""
+#@+node:ekr.20110605121601.17903: *4* qtree.enablePopupMenuItems
+def enablePopupMenuItems(self, p, event):
+    """Enable and disable items in the popup menu."""
+#@+node:ekr.20110605121601.17904: *4* qtree.showPopupMenu
+def showPopupMenu(self, event):
+    """Show a popup menu."""
 #@+node:ekr.20210312150753.1: ** leoTangle.py
 '''
 Support for @root and Leo's tangle and untangle commands.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1879,42 +1879,45 @@ class LeoQtBody(leoFrame.LeoBody):
     #@+node:ekr.20110930174206.15472: *4* LeoQtBody.onFocusIn
     def onFocusIn(self, obj):
         """Handle a focus-in event in the body pane."""
-        trace = 'select' in g.app.debug and not g.unitTesting
-        tag = 'qt_body.onFocusIn'
-        if obj.objectName() == 'richTextEdit':
-            wrapper = getattr(obj, 'leo_wrapper', None)
-            if trace:
-                print(f"{tag:>30}: {wrapper}")
-            if wrapper and wrapper != self.wrapper:
-                self.selectEditor(wrapper)
-            self.onFocusColorHelper('focus-in', obj)
-            if hasattr(obj, 'leo_copy_button') and obj.leo_copy_button:
-                obj.setReadOnly(True)
-            else:
-                obj.setReadOnly(False)
-            obj.setFocus()  # Weird, but apparently necessary.
+        try:  # #2069
+            trace = 'select' in g.app.debug and not g.unitTesting
+            tag = 'qt_body.onFocusIn'
+            if obj.objectName() == 'richTextEdit':
+                wrapper = getattr(obj, 'leo_wrapper', None)
+                if trace:
+                    print(f"{tag:>30}: {wrapper}")
+                if wrapper and wrapper != self.wrapper:
+                    self.selectEditor(wrapper)
+                self.onFocusColorHelper('focus-in', obj)
+                if hasattr(obj, 'leo_copy_button') and obj.leo_copy_button:
+                    obj.setReadOnly(True)
+                else:
+                    obj.setReadOnly(False)
+                obj.setFocus()  # Weird, but apparently necessary.
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110930174206.15473: *4* LeoQtBody.onFocusOut
     def onFocusOut(self, obj):
         """Handle a focus-out event in the body pane."""
-        # Apparently benign.
-        if obj.objectName() == 'richTextEdit':
-            self.onFocusColorHelper('focus-out', obj)
-            if hasattr(obj, 'setReadOnly'):
-                obj.setReadOnly(True)
-    #@+node:ekr.20110605121601.18224: *4* LeoQtBody.qtBody.onFocusColorHelper (revised)
-    # badFocusColors = []
-
+        try:  # #2069
+            # Apparently benign.
+            if obj.objectName() == 'richTextEdit':
+                self.onFocusColorHelper('focus-out', obj)
+                if hasattr(obj, 'setReadOnly'):
+                    obj.setReadOnly(True)
+        except Exception:
+            g.es_exception()
+    #@+node:ekr.20110605121601.18224: *4* LeoQtBody.qtBody.onFocusColorHelper
     def onFocusColorHelper(self, kind, obj):
         """Handle changes of style when focus changes."""
-        c, vc = self.c, self.c.vimCommands
-        if vc and c.vim_mode:
-            try:
+        try:  # #2069
+            c, vc = self.c, self.c.vimCommands
+            if vc and c.vim_mode:
                 assert kind in ('focus-in', 'focus-out')
                 w = c.frame.body.wrapper.widget
                 vc.set_border(w=w, activeFlag=kind == 'focus-in')
-            except Exception:
-                # g.es_exception()
-                pass
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.18217: *3* LeoQtBody.Renderer panes
     #@+node:ekr.20110605121601.18218: *4* LeoQtBody.hideCanvasRenderer
     def hideCanvasRenderer(self, event=None):
@@ -3689,26 +3692,29 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
     #@+node:ekr.20110605121601.18364: *4* LeoQTreeWidget.dragEnterEvent & helper
     def dragEnterEvent(self, ev):
         """Export c.p's tree as a Leo mime-data."""
-        c = self.c
-        if not ev:
-            g.trace('no event!')
-            return
-        md = ev.mimeData()
-        if not md:
-            g.trace('No mimeData!')
-            return
-        c.endEditing()
-        # Fix bug 135: cross-file drag and drop is broken.
-        # This handler may be called several times for the same drag.
-        # Only the first should should set g.app.drag_source.
-        if g.app.dragging:
-            pass
-        else:
-            g.app.dragging = True
-            g.app.drag_source = c, c.p
-            self.setText(md)
-        # Always accept the drag, even if we are already dragging.
-        ev.accept()
+        try:  # #2069
+            c = self.c
+            if not ev:
+                g.trace('no event!')
+                return
+            md = ev.mimeData()
+            if not md:
+                g.trace('No mimeData!')
+                return
+            c.endEditing()
+            # #135: cross-file drag and drop is broken.
+            # This handler may be called several times for the same drag.
+            # Only the first should should set g.app.drag_source.
+            if g.app.dragging:
+                pass
+            else:
+                g.app.dragging = True
+                g.app.drag_source = c, c.p
+                self.setText(md)
+            # Always accept the drag, even if we are already dragging.
+            ev.accept()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.18384: *5* LeoQTreeWidget.setText
     def setText(self, md):
         c = self.c
@@ -3718,51 +3724,55 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
     #@+node:ekr.20110605121601.18365: *4* LeoQTreeWidget.dropEvent & helpers
     def dropEvent(self, ev):
         """Handle a drop event in the QTreeWidget."""
-        if not ev:
-            return
-        md = ev.mimeData()
-        if not md:
-            g.trace('no mimeData!')
-            return
-        try:
-            ### These probably can be unified.
-            if isQt6:
-                mods = ev.modifiers()
-                self.was_alt_drag = bool(mods & KeyboardModifier.AltModifier)
-                self.was_control_drag = bool(mods & KeyboardModifier.AltModifier)
+        try:  # #2069
+            if not ev:
+                return
+            md = ev.mimeData()
+            if not md:
+                g.trace('no mimeData!')
+                return
+            try:
+                ### These probably can be unified.
+                if isQt6:
+                    mods = ev.modifiers()
+                    self.was_alt_drag = bool(mods & KeyboardModifier.AltModifier)
+                    self.was_control_drag = bool(mods & KeyboardModifier.AltModifier)
+                else:
+                    mods = int(ev.keyboardModifiers())
+                    self.was_alt_drag = (mods & Modifier.AltModifier) != 0
+                    self.was_control_drag = (mods & Modifier.AltModifier) != 0
+            except Exception:  # Defensive.
+                g.es_exception()
+                g.app.dragging = False
+                return
+            c, tree = self.c, self.c.frame.tree
+            p = None
+            point = ev.position().toPoint() if isQt6 else ev.pos()
+            item = self.itemAt(point)
+            if item:
+                itemHash = tree.itemHash(item)
+                p = tree.item2positionDict.get(itemHash)
+            if not p:
+                # #59: Drop at last node.
+                p = c.rootPosition()
+                while p.hasNext():
+                    p.moveToNext()
+            formats = set(str(f) for f in md.formats())
+            ev.setDropAction(DropAction.IgnoreAction)
+            ev.accept()
+            hookres = g.doHook("outlinedrop", c=c, p=p, dropevent=ev, formats=formats)
+            if hookres:
+                # A plugin handled the drop.
+                pass
             else:
-                mods = int(ev.keyboardModifiers())
-                self.was_alt_drag = (mods & Modifier.AltModifier) != 0
-                self.was_control_drag = (mods & Modifier.AltModifier) != 0
-        except Exception:  # Defensive.
+                if md.hasUrls():
+                    self.urlDrop(md, p)
+                else:
+                    self.nodeDrop(md, p)
+            g.app.dragging = False
+        except Exception:
             g.es_exception()
             g.app.dragging = False
-            return
-        c, tree = self.c, self.c.frame.tree
-        p = None
-        point = ev.position().toPoint() if isQt6 else ev.pos()
-        item = self.itemAt(point)
-        if item:
-            itemHash = tree.itemHash(item)
-            p = tree.item2positionDict.get(itemHash)
-        if not p:
-            # #59: Drop at last node.
-            p = c.rootPosition()
-            while p.hasNext():
-                p.moveToNext()
-        formats = set(str(f) for f in md.formats())
-        ev.setDropAction(DropAction.IgnoreAction)
-        ev.accept()
-        hookres = g.doHook("outlinedrop", c=c, p=p, dropevent=ev, formats=formats)
-        if hookres:
-            # A plugin handled the drop.
-            pass
-        else:
-            if md.hasUrls():
-                self.urlDrop(md, p)
-            else:
-                self.nodeDrop(md, p)
-        g.app.dragging = False
     #@+node:ekr.20110605121601.18366: *5* LeoQTreeWidget.nodeDrop & helpers
     def nodeDrop(self, md, p):
         """
@@ -4167,7 +4177,7 @@ class LeoQtSpellTab:
             self.fillbox([])
         else:
             self.handler.loaded = False
-    #@+node:ekr.20110605121601.18389: *3* Event handlers
+    #@+node:ekr.20110605121601.18389: *3* LeoQtSpellTab.Event handlers
     #@+node:ekr.20110605121601.18390: *4* onAddButton
     def onAddButton(self):
         """Handle a click in the Add button in the Check Spelling dialog."""

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -104,15 +104,17 @@ class QTextMixin:
     # These are independent of the kind of Qt widget.
     #@+node:ekr.20140901062324.18716: *4* qtm.onCursorPositionChanged
     def onCursorPositionChanged(self, event=None):
-
-        c = self.c
-        name = c.widget_name(self)
-        # Apparently, this does not cause problems
-        # because it generates no events in the body pane.
-        if not name.startswith('body'):
-            return
-        if hasattr(c.frame, 'statusLine'):
-            c.frame.statusLine.update()
+        try:  # #2069
+            c = self.c
+            name = c.widget_name(self)
+            # Apparently, this does not cause problems
+            # because it generates no events in the body pane.
+            if not name.startswith('body'):
+                return
+            if hasattr(c.frame, 'statusLine'):
+                c.frame.statusLine.update()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20140901062324.18714: *4* qtm.onTextChanged
     def onTextChanged(self):
         """
@@ -122,29 +124,32 @@ class QTextMixin:
         """
         # Important: usually w.changingText is True.
         # This method very seldom does anything.
-        w = self
-        c = self.c; p = c.p
-        tree = c.frame.tree
-        if w.changingText:
-            return
-        if tree.tree_select_lockout:
-            g.trace('*** LOCKOUT', g.callers())
-            return
-        if not p:
-            return
-        newInsert = w.getInsertPoint()
-        newSel = w.getSelectionRange()
-        newText = w.getAllText()  # Converts to unicode.
-        # Get the previous values from the VNode.
-        oldText = p.b
-        if oldText == newText:
-            # This can happen as the result of undo.
-            # g.error('*** unexpected non-change')
-            return
-        i, j = p.v.selectionStart, p.v.selectionLength
-        oldSel = (i, i + j)
-        c.undoer.doTyping(p, 'Typing', oldText, newText,
-            oldSel=oldSel, oldYview=None, newInsert=newInsert, newSel=newSel)
+        try:  # #2069
+            w = self
+            c = self.c; p = c.p
+            tree = c.frame.tree
+            if w.changingText:
+                return
+            if tree.tree_select_lockout:
+                g.trace('*** LOCKOUT', g.callers())
+                return
+            if not p:
+                return
+            newInsert = w.getInsertPoint()
+            newSel = w.getSelectionRange()
+            newText = w.getAllText()  # Converts to unicode.
+            # Get the previous values from the VNode.
+            oldText = p.b
+            if oldText == newText:
+                # This can happen as the result of undo.
+                # g.error('*** unexpected non-change')
+                return
+            i, j = p.v.selectionStart, p.v.selectionLength
+            oldSel = (i, i + j)
+            c.undoer.doTyping(p, 'Typing', oldText, newText,
+                oldSel=oldSel, oldYview=None, newInsert=newInsert, newSel=newSel)
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20140901122110.18734: *3* qtm.Generic high-level interface
     # These call only wrapper methods.
     #@+node:ekr.20140902181058.18645: *4* qtm.Enable/disable

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -678,71 +678,91 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.17887: *4*  qtree.Click Box
     #@+node:ekr.20110605121601.17888: *5* qtree.onClickBoxClick
     def onClickBoxClick(self, event, p=None):
-        if self.busy:
-            return
-        c = self.c
-        g.doHook("boxclick1", c=c, p=p, event=event)
-        g.doHook("boxclick2", c=c, p=p, event=event)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            g.doHook("boxclick1", c=c, p=p, event=event)
+            g.doHook("boxclick2", c=c, p=p, event=event)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17889: *5* qtree.onClickBoxRightClick
     def onClickBoxRightClick(self, event, p=None):
-        if self.busy:
-            return
-        c = self.c
-        g.doHook("boxrclick1", c=c, p=p, event=event)
-        g.doHook("boxrclick2", c=c, p=p, event=event)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            g.doHook("boxrclick1", c=c, p=p, event=event)
+            g.doHook("boxrclick2", c=c, p=p, event=event)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17890: *5* qtree.onPlusBoxRightClick
     def onPlusBoxRightClick(self, event, p=None):
-        if self.busy:
-            return
-        c = self.c
-        g.doHook('rclick-popup', c=c, p=p, event=event, context_menu='plusbox')
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            g.doHook('rclick-popup', c=c, p=p, event=event, context_menu='plusbox')
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17891: *4*  qtree.Icon Box
     # For Qt, there seems to be no way to trigger these events.
     #@+node:ekr.20110605121601.17892: *5* qtree.onIconBoxClick
     def onIconBoxClick(self, event, p=None):
-        if self.busy:
-            return
-        c = self.c
-        g.doHook("iconclick1", c=c, p=p, event=event)
-        g.doHook("iconclick2", c=c, p=p, event=event)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            g.doHook("iconclick1", c=c, p=p, event=event)
+            g.doHook("iconclick2", c=c, p=p, event=event)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17893: *5* qtree.onIconBoxRightClick
     def onIconBoxRightClick(self, event, p=None):
         """Handle a right click in any outline widget."""
-        if self.busy:
-            return
-        c = self.c
-        g.doHook("iconrclick1", c=c, p=p, event=event)
-        g.doHook("iconrclick2", c=c, p=p, event=event)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            g.doHook("iconrclick1", c=c, p=p, event=event)
+            g.doHook("iconrclick2", c=c, p=p, event=event)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17894: *5* qtree.onIconBoxDoubleClick
     def onIconBoxDoubleClick(self, event, p=None):
-        if self.busy:
-            return
-        c = self.c
-        if not p: p = c.p
-        if not g.doHook("icondclick1", c=c, p=p, event=event):
-            self.endEditLabel()
-            self.OnIconDoubleClick(p)  # Call the method in the base class.
-        g.doHook("icondclick2", c=c, p=p, event=event)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            if not p: p = c.p
+            if not g.doHook("icondclick1", c=c, p=p, event=event):
+                self.endEditLabel()
+                self.OnIconDoubleClick(p)  # Call the method in the base class.
+            g.doHook("icondclick2", c=c, p=p, event=event)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.18437: *4* qtree.onContextMenu
     def onContextMenu(self, point):
         """LeoQtTree: Callback for customContextMenuRequested events."""
-        # #1286.
-        c, w = self.c, self.treeWidget
-        g.app.gui.onContextMenu(c, w, point)
+        try:  # #2069
+            c, w = self.c, self.treeWidget  # #1286.
+            g.app.gui.onContextMenu(c, w, point)
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17896: *4* qtree.onItemClicked
     def onItemClicked(self, item, col):
         """Handle a click in a BaseNativeTree widget item."""
         # This is called after an item is selected.
-        if self.busy:
-            return
-        c = self.c
         try:
+            if self.busy:
+                return
+            c = self.c
             self.busy = True
             p = self.item2position(item)
             if p:
@@ -777,126 +797,95 @@ class LeoQtTree(leoFrame.LeoTree):
             # enters editing state.
             if auto_edit and self.auto_edit:
                 e, wrapper = self.createTreeEditorForItem(item)
+        except Exception:  # #2069
+            g.es_exception()
         finally:
             self.busy = False
     #@+node:ekr.20110605121601.17895: *4* qtree.onItemCollapsed
     def onItemCollapsed(self, item):
 
-        if self.busy:
-            return
-        c = self.c
-        p = self.item2position(item)
-        if not p:
-            self.error('no p')
-            return
-        # Do **not** set lockouts here.
-        # Only methods that actually generate events should set lockouts.
-        if p.isExpanded():
-            p.contract()
-            c.redraw_after_contract(p)
-        self.select(p)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:
+                return
+            c = self.c
+            p = self.item2position(item)
+            if not p:
+                self.error('no p')
+                return
+            # Do **not** set lockouts here.
+            # Only methods that actually generate events should set lockouts.
+            if p.isExpanded():
+                p.contract()
+                c.redraw_after_contract(p)
+            self.select(p)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17897: *4* qtree.onItemDoubleClicked
     def onItemDoubleClicked(self, item, col):
         """Handle a double click in a BaseNativeTree widget item."""
-        if self.busy:  # Required.
-            return
-        c = self.c
-        try:
-            self.busy = True
-            e, wrapper = self.createTreeEditorForItem(item)
-            if not e:
-                g.trace('*** no e')
-            p = self.item2position(item)
-        # 2011/07/28: End the lockout here, not at the end.
-        finally:
-            self.busy = False
-        if not p:
-            self.error('no p')
-            return
-        # 2014/02/21: generate headddlick1/2 instead of icondclick1/2.
-        if g.doHook("headdclick1", c=c, p=p, event=None) is None:
-            c.frame.tree.OnIconDoubleClick(p)  # Call the base class method.
-        g.doHook("headclick2", c=c, p=p, event=None)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:  # Required.
+                return
+            c = self.c
+            try:
+                self.busy = True
+                e, wrapper = self.createTreeEditorForItem(item)
+                if not e:
+                    g.trace('*** no e')
+                p = self.item2position(item)
+            # 2011/07/28: End the lockout here, not at the end.
+            finally:
+                self.busy = False
+            if not p:
+                self.error('no p')
+                return
+            # 2014/02/21: generate headddlick1/2 instead of icondclick1/2.
+            if g.doHook("headdclick1", c=c, p=p, event=None) is None:
+                c.frame.tree.OnIconDoubleClick(p)  # Call the base class method.
+            g.doHook("headclick2", c=c, p=p, event=None)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17898: *4* qtree.onItemExpanded
     def onItemExpanded(self, item):
         """Handle and tree-expansion event."""
-        if self.busy:  # Required
-            return
-        c = self.c
-        p = self.item2position(item)
-        if not p:
-            self.error('no p')
-            return
-        # Do **not** set lockouts here.
-        # Only methods that actually generate events should set lockouts.
-        if not p.isExpanded():
-            p.expand()
-            c.redraw_after_expand(p)
-        self.select(p)
-        c.outerUpdate()
+        try:  # #2069
+            if self.busy:  # Required
+                return
+            c = self.c
+            p = self.item2position(item)
+            if not p:
+                self.error('no p')
+                return
+            # Do **not** set lockouts here.
+            # Only methods that actually generate events should set lockouts.
+            if not p.isExpanded():
+                p.expand()
+                c.redraw_after_expand(p)
+            self.select(p)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17899: *4* qtree.onTreeSelect
     def onTreeSelect(self):
         """Select the proper position when a tree node is selected."""
-        if self.busy:  # Required
-            return
-        c = self.c
-        item = self.getCurrentItem()
-        p = self.item2position(item)
-        if not p:
-            self.error(f"no p for item: {item}")
-            return
-        # Do **not** set lockouts here.
-        # Only methods that actually generate events should set lockouts.
-        self.select(p)
-            # This is a call to LeoTree.select(!!)
-        c.outerUpdate()
-    #@+node:ekr.20110605121601.17900: *4* qtree.OnPopup & allies
-    def OnPopup(self, p, event):
-        """Handle right-clicks in the outline.
-
-        This is *not* an event handler: it is called from other event handlers."""
-        # Note: "headrclick" hooks handled by VNode callback routine.
-        if event:
+        try:  # #2069
+            if self.busy:  # Required
+                return
             c = self.c
-            c.setLog()
-            if not g.doHook("create-popup-menu", c=c, p=p, event=event):
-                self.createPopupMenu(event)
-            if not g.doHook("enable-popup-menu-items", c=c, p=p, event=event):
-                self.enablePopupMenuItems(p, event)
-            if not g.doHook("show-popup-menu", c=c, p=p, event=event):
-                self.showPopupMenu(event)
-        return "break"
-    #@+node:ekr.20110605121601.17901: *5* qtree.OnPopupFocusLost
-    #@@language rest
-    #@+at
-    # On Linux we must do something special to make the popup menu "unpost" if the
-    # mouse is clicked elsewhere. So we have to catch the <FocusOut> event and
-    # explicitly unpost. In order to process the <FocusOut> event, we need to be able
-    # to find the reference to the popup window again, so this needs to be an
-    # attribute of the tree object; hence, "self.popupMenu".
-    #
-    # Aside: though Qt tries to be muli-platform, the interaction with different
-    # window managers does cause small differences that will need to be compensated by
-    # system specific application code. :-(
-    #@@c
-    #@@language python
-
-    # 20-SEP-2002 DTHEIN: This event handler is only needed for Linux.
-
-    def OnPopupFocusLost(self, event=None):
-        # self.popupMenu.unpost()
-        pass
-    #@+node:ekr.20110605121601.17902: *5* qtree.createPopupMenu
-    def createPopupMenu(self, event):
-        """This might be a placeholder for plugins.  Or not :-)"""
-    #@+node:ekr.20110605121601.17903: *5* qtree.enablePopupMenuItems
-    def enablePopupMenuItems(self, p, event):
-        """Enable and disable items in the popup menu."""
-    #@+node:ekr.20110605121601.17904: *5* qtree.showPopupMenu
-    def showPopupMenu(self, event):
-        """Show a popup menu."""
+            item = self.getCurrentItem()
+            p = self.item2position(item)
+            if not p:
+                self.error(f"no p for item: {item}")
+                return
+            # Do **not** set lockouts here.
+            # Only methods that actually generate events should set lockouts.
+            self.select(p)
+                # This is a call to LeoTree.select(!!)
+            c.outerUpdate()
+        except Exception:
+            g.es_exception()
     #@+node:ekr.20110605121601.17944: *3* qtree.Focus
     def getFocus(self):
         return g.app.gui.get_focus(self.c)  # Bug fix: 2009/6/30

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -697,7 +697,7 @@ class QuickSearchController:
             if p.isMarked():
                 pl.append(p.copy())
         self.addHeadlineMatches(pl)
-    #@+node:ekr.20111015194452.15700: *3* Event handlers
+    #@+node:ekr.20111015194452.15700: *3* Event handlers (quicksearch.py)
     #@+node:ekr.20111015194452.15686: *4* onSelectItem (quicksearch.py)
     def onSelectItem(self, it, it_prev=None):
 


### PR DESCRIPTION
See #2069.  I am going to abandon the ekr-2069 branch. The ekr-2069-2 branch will use a new g.event_handler decorator.

Protecting all event handlers in plugins would be a massive job. It might do more harm than good.

- [x] Move `qtree.OnPopup & allies` to the attic.