### PR TITLE
PR for #2080

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -646,7 +646,7 @@
 <v t="tbnorth.20170111153412.1"><vh>Editing</vh>
 <v t="tbnorth.20170111153417.1"><vh>@int autojustify = 78</vh></v>
 <v t="tbnorth.20170111153430.1"><vh>@bool autojustify-on-at-start = False</vh></v>
-<v t="ekr.20181018113730.1"><vh>@string external-editor</vh></v>
+<v t="ekr.20181018113730.1"><vh>@string external-editor = None</vh></v>
 </v>
 <v t="ekr.20061003173413"><vh>Files &amp; directories</vh>
 <v t="ekr.20061210091932"><vh>@bool chdir-to-relative-path = False</vh></v>
@@ -2306,6 +2306,7 @@
 </v>
 <v t="ekr.20140915194122.23428"></v>
 <v t="ville.20091008201813.3911"></v>
+<v t="ekr.20181018113730.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11243,7 +11244,7 @@ See https://jedi.readthedocs.io/en/latest/index.html
 <t tx="ekr.20181018113502.1"></t>
 <t tx="ekr.20181018113612.1"></t>
 <t tx="ekr.20181018113656.1"></t>
-<t tx="ekr.20181018113730.1"></t>
+<t tx="ekr.20181018113730.1"># Name of external editor.</t>
 <t tx="ekr.20181018113812.1">
 </t>
 <t tx="ekr.20181018113813.1"></t>

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -65,7 +65,7 @@ def cm_external_editor(event):
     Set LEO_EDITOR/EDITOR environment variable to get the editor you want.
     """
     c = event['c']
-    editor = g.guessExternalEditor()
+    editor = g.guessExternalEditor(c)
     d = {'kind':'subprocess.Popen','args':[editor],'ext':None}
     c.openWith(d=d)
 #@+node:tbrown.20121123075838.19937: *3* 'context_menu_open'
@@ -193,7 +193,7 @@ def deletenodes_rclick(c,p,menu):
 def editnode_rclick(c,p,menu):
     """ Provide "edit in EDITOR" context menu item """
 
-    editor = g.guessExternalEditor()
+    editor = g.guessExternalEditor(c)
     if editor:
 
         def editnode_rclick_cb():
@@ -246,8 +246,8 @@ def openurl_rclick(c,p,menu):
 
         action = menu.addAction("Open URL")
         action.triggered.connect(openurl_rclick_cb)
-#@+node:ville.20090630210947.5465: *3* openwith_rclick
-def openwith_rclick(c,p,menu):
+#@+node:ville.20090630210947.5465: *3* openwith_rclick & callbacks
+def openwith_rclick(c, p, menu):
     """
     Show "Edit with" in context menu for external file root nodes (@thin, @auto...)
 
@@ -256,14 +256,14 @@ def openwith_rclick(c,p,menu):
     """
     # define callbacks
     #@+others
-    #@+node:ekr.20140613141207.17666: *4* openwith_rclick_cb
+    #@+node:ekr.20140613141207.17666: *4* function: openwith_rclick_cb
     def openwith_rclick_cb():
 
         if editor:
             cmd = '%s "%s"' % (editor, absp)
             g.es('Edit: %s' % cmd)
             subprocess.Popen(cmd, shell=True)
-    #@+node:ekr.20140613141207.17667: *4* openfolder_rclick_cb
+    #@+node:ekr.20140613141207.17667: *4* function: openfolder_rclick_cb
     def openfolder_rclick_cb():
         
         if g.os_path_exists(path):
@@ -271,12 +271,12 @@ def openwith_rclick(c,p,menu):
         else:
             # #1257:
             g.es_print('file not found:', repr(path))
-    #@+node:ekr.20140613141207.17668: *4* create_rclick_cb
+    #@+node:ekr.20140613141207.17668: *4* function: create_rclick_cb
     def create_rclick_cb():
 
         os.makedirs(absp)
         g.es("Created " + absp)
-    #@+node:ekr.20140613141207.17669: *4* importfiles_rclick_cb
+    #@+node:ekr.20140613141207.17669: *4* function: importfiles_rclick_cb
     def importfiles_rclick_cb():
 
         def shorten(pth, prefix):
@@ -310,8 +310,9 @@ def openwith_rclick(c,p,menu):
     fname = p.anyAtFileNodeName()
     if not fname and head != "@path":
         return
-    path = g.scanAllAtPathDirectives(c,p)
-    editor = g.guessExternalEditor()
+    path = g.scanAllAtPathDirectives(c, p)
+    editor = g.guessExternalEditor(c)
+    g.trace('editor', editor)
     absp = g.os_path_finalize_join(path, fname)
     exists = os.path.exists(absp)
     if not exists and head == "@path":


### PR DESCRIPTION
See #2080.

- [x] Pass c to g.guessExternalEditor()

**Won't do**
- Launching the external editor fails when the editor path contains spaces.
- There are two separate entries in the context menu for opening a file with an external editor.