### PR TITLE
PR: leoserver.py: put leo-editor on sys.path

### DIFF
--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -37,7 +37,7 @@ leoVersion.version:     Leo's version number.
 # 6.3:    November 6, 2020.
 # 6.4-b1  July 18, 2021.
 #@-<< version dates >>
-version = '6.4-b1'
+version = '6.4-devel2'
 static_date = 'July 18, 2021'
 #@@language python
 #@@tabwidth -4

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -20,7 +20,14 @@ import time
 import unittest
 # Third-party.
 import websockets
+# Make sure leo-editor folder is on sys.path.
+core_dir = os.path.dirname(__file__)
+leo_path = os.path.normpath(os.path.join(core_dir, '..', '..'))
+assert os.path.exists(leo_path), repr(leo_path)
+if leo_path not in sys.path:
+    sys.path.append(leo_path)
 # Leo
+# pylint: disable=wrong-import-position
 from leo.core.leoNodes import Position
 from leo.core.leoGui import StringFindTabManager
 from leo.core.leoExternalFiles import ExternalFilesController


### PR DESCRIPTION
This PR will help ensure that vs-code's command to start the server will work even if the path to the leo-editor folder **isn't** on sys.path.

On my machine, the command is: `python39 c:\leo.repo\leo-editor/leo/core/leoserver.py -p 32125`