### PR TITLE
Felix server4

### DIFF
--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -33,77 +33,109 @@ def _dump_outline(c):  # pragma: no cover
 #@+node:ekr.20210206075253.1: ** function: _get_action_list
 def _get_action_list():
     """
-    Return all callable public methods of the server.
-    In effect, these are unit tests.
+    Return a list of command entries: (name, params)
+    
+    - Names starting with "!" are names of server *methods*.
+    - All other names are names of Leo *commands*.
     """
-    import inspect
     import os
     server = leoserver.LeoServer()
-    # file_name = "xyzzy.leo"
+    assert server ###
+    log = True
     file_name = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
     assert os.path.exists(file_name), repr(file_name)
-    log = False
-    exclude_names = [
-        # Find methods...
-        'replace_all', 'replace_then_find',
-        'clone_find_all', 'clone_find_all_flattened', 'clone_find_tag',
-        'find_all', 'find_def', 'find_next', 'find_previous', 'find_var',
-        'tag_children',
-        # Other methods
-        'set_body',
-        'error',
-        'replace',
-        'delete_node', 'cut_node',  # dangerous.
-        'click_button', 'get_buttons', 'remove_button',  # Require plugins.
-        'save_file',  # way too dangerous!
-        # 'set_selection',  ### Not ready yet.
-        'open_file', 'close_file',  # Done by hand.
-        'import_any_file',
-        'insert_child_named_node',
-        'insert_named_node',
-        'set_ask_result',
-        'set_opened_file',
-        'set_search_settings',
-        'set_selection',
-        'shut_down',  # Don't shut down the server.
-    ]
-    head = [
-        # ("apply_config", {"config": {"whatever": True}}),
+    return [
+        # HEAD
         ("!error", {}),
         # ("bad_server_command", {}),
         ("!open_file", {"filename": file_name, "log": log}),
-    ]
-    head_names = [name for (name, package) in head]
-    tail = [
-        # ("get_body_length", {}),  # All responses now contain len(p.b).
+        # MIDDLE
         ("!find_all", {"find_text": "def"}),
         ("!get_ua", {"log": log}),
         ("!get_parent",  {"log": log}),
-        ("!get_children",  {"log": log}),
-        ("!set_body", {"body": "new body"}),
-        ("!set_headline", {"name": "new headline", 'gnx': "ekr.20061008140603"}),
-        ("contractAllHeadlines", {}), # normal leo command
-        ("!insert_node", {}),
-        ("!contract_node", {}),
+        # Tail
+        ("contract-all", {}), # normal leo command
+        # ("!insert_node", {}),
+        # ("!contract_node", {}),
         ("!close_file", {"forced": True}), # forced flag set to true because it was modified
         ("!get_all_leo_commands", {}),
         ("!get_all_server_commands", {}),
         ("!shut_down", {}),
     ]
-    tail_names = [name for (name, package) in tail]
-    
-    # Add all remaining methods to the middle.
-    tests = inspect.getmembers(server, inspect.ismethod)
-    test_names = sorted([name for (name, value) in tests if not name.startswith('_')])
-    middle = [("!"+z, {}) for z in test_names
-        if z not in head_names + tail_names + exclude_names]
-    middle_names = [name for (name, package) in middle]
-    all_tests = head + middle + tail
-    if 0:
-        g.printObj(middle_names, tag='middle_names')
-        all_names = sorted([name for (name, package) in all_tests])
-        g.printObj(all_names, tag='all_names')
-    return all_tests
+    ###
+        # """
+        # Return all callable public methods of the server.
+        # In effect, these are unit tests.
+        # """
+        # import inspect
+        # import os
+        # server = leoserver.LeoServer()
+        # # file_name = "xyzzy.leo"
+        # file_name = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
+        # assert os.path.exists(file_name), repr(file_name)
+        # log = False
+        # exclude_names = [
+            # # Find methods...
+            # 'replace_all', 'replace_then_find',
+            # 'clone_find_all', 'clone_find_all_flattened', 'clone_find_tag',
+            # 'find_all', 'find_def', 'find_next', 'find_previous', 'find_var',
+            # 'tag_children',
+            # # Other methods
+            # 'set_body',
+            # 'error',
+            # 'replace',
+            # 'delete_node', 'cut_node',  # dangerous.
+            # 'click_button', 'get_buttons', 'remove_button',  # Require plugins.
+            # 'save_file',  # way too dangerous!
+            # # 'set_selection',  ### Not ready yet.
+            # 'open_file', 'close_file',  # Done by hand.
+            # 'import_any_file',
+            # 'insert_child_named_node',
+            # 'insert_named_node',
+            # 'set_ask_result',
+            # 'set_opened_file',
+            # 'set_search_settings',
+            # 'set_selection',
+            # 'shut_down',  # Don't shut down the server.
+        # ]
+        # head = [
+            # # ("apply_config", {"config": {"whatever": True}}),
+            # ("!error", {}),
+            # # ("bad_server_command", {}),
+            # ("!open_file", {"filename": file_name, "log": log}),
+        # ]
+        # head_names = [name for (name, package) in head]
+        # tail = [
+            # # ("get_body_length", {}),  # All responses now contain len(p.b).
+            # ("!find_all", {"find_text": "def"}),
+            # ("!get_ua", {"log": log}),
+            # ("!get_parent",  {"log": log}),
+            # ("!get_children",  {"log": log}),
+            # ("!set_body", {"body": "new body"}),
+            # ("!set_headline", {"name": "new headline", 'gnx': "ekr.20061008140603"}),
+            # ("contractAllHeadlines", {}), # normal leo command
+            # ("!insert_node", {}),
+            # ("!contract_node", {}),
+            # ("!close_file", {"forced": True}), # forced flag set to true because it was modified
+            # ("!get_all_leo_commands", {}),
+            # ("!get_all_server_commands", {}),
+            # ("!shut_down", {}),
+        # ]
+        # tail_names = [name for (name, package) in tail]
+        
+        # # Add all remaining methods to the middle.
+        # tests = inspect.getmembers(server, inspect.ismethod)
+        # test_names = sorted([name for (name, value) in tests if not name.startswith('_')])
+        # middle = [("!"+z, {}) for z in test_names
+            # if z not in head_names + tail_names + exclude_names]
+        # middle_names = [name for (name, package) in middle]
+        # ### all_tests = head + middle + tail
+        # all_tests = head + tail
+        # if 0:
+            # g.printObj(middle_names, tag='middle_names')
+            # all_names = sorted([name for (name, package) in all_tests])
+            # g.printObj(all_names, tag='all_names')
+        # return all_tests
     
 #@+node:ekr.20210206093130.1: ** function: _show_response
 def _show_response(n, d, trace, verbose):

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -33,109 +33,77 @@ def _dump_outline(c):  # pragma: no cover
 #@+node:ekr.20210206075253.1: ** function: _get_action_list
 def _get_action_list():
     """
-    Return a list of command entries: (name, params)
-    
-    - Names starting with "!" are names of server *methods*.
-    - All other names are names of Leo *commands*.
+    Return all callable public methods of the server.
+    In effect, these are unit tests.
     """
+    import inspect
     import os
     server = leoserver.LeoServer()
-    assert server ###
-    log = True
+    # file_name = "xyzzy.leo"
     file_name = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
     assert os.path.exists(file_name), repr(file_name)
-    return [
-        # HEAD
+    log = False
+    exclude_names = [
+        # Find methods...
+        'replace_all', 'replace_then_find',
+        'clone_find_all', 'clone_find_all_flattened', 'clone_find_tag',
+        'find_all', 'find_def', 'find_next', 'find_previous', 'find_var',
+        'tag_children',
+        # Other methods
+        'set_body',
+        'error',
+        'replace',
+        'delete_node', 'cut_node',  # dangerous.
+        'click_button', 'get_buttons', 'remove_button',  # Require plugins.
+        'save_file',  # way too dangerous!
+        # 'set_selection',  ### Not ready yet.
+        'open_file', 'close_file',  # Done by hand.
+        'import_any_file',
+        'insert_child_named_node',
+        'insert_named_node',
+        'set_ask_result',
+        'set_opened_file',
+        'set_search_settings',
+        'set_selection',
+        'shut_down',  # Don't shut down the server.
+    ]
+    head = [
+        # ("apply_config", {"config": {"whatever": True}}),
         ("!error", {}),
         # ("bad_server_command", {}),
         ("!open_file", {"filename": file_name, "log": log}),
-        # MIDDLE
+    ]
+    head_names = [name for (name, package) in head]
+    tail = [
+        # ("get_body_length", {}),  # All responses now contain len(p.b).
         ("!find_all", {"find_text": "def"}),
         ("!get_ua", {"log": log}),
         ("!get_parent",  {"log": log}),
-        # Tail
-        ("contract-all", {}), # normal leo command
-        # ("!insert_node", {}),
-        # ("!contract_node", {}),
+        ("!get_children",  {"log": log}),
+        ("!set_body", {"body": "new body"}),
+        ("!set_headline", {"name": "new headline", 'gnx': "ekr.20061008140603"}),
+        ("contractAllHeadlines", {}), # normal leo command
+        ("!insert_node", {}),
+        ("!contract_node", {}),
         ("!close_file", {"forced": True}), # forced flag set to true because it was modified
         ("!get_all_leo_commands", {}),
         ("!get_all_server_commands", {}),
         ("!shut_down", {}),
     ]
-    ###
-        # """
-        # Return all callable public methods of the server.
-        # In effect, these are unit tests.
-        # """
-        # import inspect
-        # import os
-        # server = leoserver.LeoServer()
-        # # file_name = "xyzzy.leo"
-        # file_name = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
-        # assert os.path.exists(file_name), repr(file_name)
-        # log = False
-        # exclude_names = [
-            # # Find methods...
-            # 'replace_all', 'replace_then_find',
-            # 'clone_find_all', 'clone_find_all_flattened', 'clone_find_tag',
-            # 'find_all', 'find_def', 'find_next', 'find_previous', 'find_var',
-            # 'tag_children',
-            # # Other methods
-            # 'set_body',
-            # 'error',
-            # 'replace',
-            # 'delete_node', 'cut_node',  # dangerous.
-            # 'click_button', 'get_buttons', 'remove_button',  # Require plugins.
-            # 'save_file',  # way too dangerous!
-            # # 'set_selection',  ### Not ready yet.
-            # 'open_file', 'close_file',  # Done by hand.
-            # 'import_any_file',
-            # 'insert_child_named_node',
-            # 'insert_named_node',
-            # 'set_ask_result',
-            # 'set_opened_file',
-            # 'set_search_settings',
-            # 'set_selection',
-            # 'shut_down',  # Don't shut down the server.
-        # ]
-        # head = [
-            # # ("apply_config", {"config": {"whatever": True}}),
-            # ("!error", {}),
-            # # ("bad_server_command", {}),
-            # ("!open_file", {"filename": file_name, "log": log}),
-        # ]
-        # head_names = [name for (name, package) in head]
-        # tail = [
-            # # ("get_body_length", {}),  # All responses now contain len(p.b).
-            # ("!find_all", {"find_text": "def"}),
-            # ("!get_ua", {"log": log}),
-            # ("!get_parent",  {"log": log}),
-            # ("!get_children",  {"log": log}),
-            # ("!set_body", {"body": "new body"}),
-            # ("!set_headline", {"name": "new headline", 'gnx': "ekr.20061008140603"}),
-            # ("contractAllHeadlines", {}), # normal leo command
-            # ("!insert_node", {}),
-            # ("!contract_node", {}),
-            # ("!close_file", {"forced": True}), # forced flag set to true because it was modified
-            # ("!get_all_leo_commands", {}),
-            # ("!get_all_server_commands", {}),
-            # ("!shut_down", {}),
-        # ]
-        # tail_names = [name for (name, package) in tail]
-        
-        # # Add all remaining methods to the middle.
-        # tests = inspect.getmembers(server, inspect.ismethod)
-        # test_names = sorted([name for (name, value) in tests if not name.startswith('_')])
-        # middle = [("!"+z, {}) for z in test_names
-            # if z not in head_names + tail_names + exclude_names]
-        # middle_names = [name for (name, package) in middle]
-        # ### all_tests = head + middle + tail
-        # all_tests = head + tail
-        # if 0:
-            # g.printObj(middle_names, tag='middle_names')
-            # all_names = sorted([name for (name, package) in all_tests])
-            # g.printObj(all_names, tag='all_names')
-        # return all_tests
+    tail_names = [name for (name, package) in tail]
+    
+    # Add all remaining methods to the middle.
+    tests = inspect.getmembers(server, inspect.ismethod)
+    test_names = sorted([name for (name, value) in tests if not name.startswith('_')])
+    middle = [("!"+z, {}) for z in test_names
+        if z not in head_names + tail_names + exclude_names]
+    middle_names = [name for (name, package) in middle]
+    all_tests = head + middle + tail
+    if 0:
+        g.printObj(middle_names, tag='middle_names')
+        all_names = sorted([name for (name, package) in all_tests])
+        g.printObj(all_names, tag='all_names')
+    return all_tests
     
 #@+node:ekr.20210206093130.1: ** function: _show_response
 def _show_response(n, d, trace, verbose):

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -3033,8 +3033,9 @@ class LeoServer:
         "id": A positive integer.
 
         "action": A string, which is either:
-            - The name of public method of this class, prefixed with a '!'.
-            - The name of a leo command, without prefix, to be run by _do_leo_command
+            - The name of public method of this class, prefixed with '!'.
+            - The name of a Leo command, prefixed with '-'
+            - The name of a method of a Leo class, without prefix.
 
         "param": A dict to be passed to the called "action" method.
             (Passed to the public method, or the _do_leo_command. Often contains ap, text & keep)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1633,8 +1633,9 @@ class LeoServer:
     def get_all_leo_commands(self, param):
         """Return a list of all commands that make sense for connected clients."""
         tag = 'get_all_leo_commands'
-        c = self.dummy_c  # Use the dummy commander.
-        d = c.commandsDict  # keys are command names, values are functions.
+        # #173: Use the present commander to get commands created by @button and @command.
+        c = self.c
+        d = c.commandsDict if c else {}  # keys are command names, values are functions.
         bad_names = self._bad_commands(c)  # #92.
         good_names = self._good_commands()
         duplicates = set(bad_names).intersection(set(good_names))
@@ -1651,14 +1652,14 @@ class LeoServer:
             if command_name in bad_names:  # #92.
                 continue
             # Prefer func.__func_name__ to func.__name__: Leo's decorators change func.__name__!
-            func_name = getattr(func, '__func_name__', func.__name__)
-            if not func_name:  # pragma: no cover
-                print(f"{tag}: no name {command_name!r}")
-                continue
+                # func_name = getattr(func, '__func_name__', func.__name__)
+                # if not func_name:  # pragma: no cover
+                    # print(f"{tag}: no name {command_name!r}")
+                    # continue
             doc = func.__doc__ or ''
             result.append({
                 "label": command_name,
-                "func":  func_name,
+                ### "func":  func_name,
                 "detail": doc,
             })
         if self.log_flag:  # pragma: no cover
@@ -1668,19 +1669,17 @@ class LeoServer:
     #@+node:felix.20210621233316.73: *6* server._bad_commands
     def _bad_commands(self, c):
         """Return the list of command names that connected clients should ignore."""
-        d = c.commandsDict  # keys are command names, values are functions.
+        d = c.commandsDict if c else {}  # keys are command names, values are functions.
         bad = []
         #
-        # First, remove @button, @command and vim commands.
+        # leoInteg #173: Remove only vim commands.
         for command_name in sorted(d):
-            if command_name.startswith((':', '@')):
-                # print('ignore', command_name)
+            if command_name.startswith(':'):
                 bad.append(command_name)
-        # Second, remove other commands.
+        #
+        # Remove other commands.
         # This is a hand-curated list.
         bad_list = [
-
-            # Originally in good list
             'demangle-recent-files',
             'clean-main-spell-dict',
             'clean-persistence',
@@ -2900,27 +2899,6 @@ class LeoServer:
                     f"{tag}: stack: {stack!r}")
             return False # fallback to c.p
         return p
-    #@+node:felix.20210622232409.1: *4* server._send_async_output & helper
-    def _send_async_output(self, package):
-        """
-        Send data asynchronously to the client
-        """
-        tag = "send async output"
-        jsonPackage = json.dumps(package, separators=(',', ':'), cls=SetEncoder)
-        if "async" not in package:
-            InternalServerError(f"\n{tag}: async member missing in package {jsonPackage} \n")
-        if self.loop:
-            self.loop.create_task(self._async_output(jsonPackage))
-        else:
-            InternalServerError(f"\n{tag}: loop not ready {jsonPackage} \n")
-    #@+node:felix.20210621233316.89: *5* server._async_output
-    async def _async_output(self, json):  # pragma: no cover (tested in server)
-        """Output json string to the web_socket"""
-        tag = '_async_output'
-        if self.web_socket:
-            await self.web_socket.send(bytes(json, 'utf-8'))
-        else:
-            g.trace(f"{tag}: no web socket. json: {json!r}")
     #@+node:felix.20210621233316.80: *4* server._check_c
     def _check_c(self):
         """Return self.c or raise ServerError if self.c is None."""
@@ -2946,8 +2924,8 @@ class LeoServer:
                 print(message)
                 self._dump_position(p)
                 raise ServerError(message)
-    #@+node:felix.20210621233316.84: *4* server._do_leo_command
-    def _do_leo_command(self, command, param):
+    #@+node:felix.20210621233316.84: *4* server._do_leo_command_by_name
+    def _do_leo_command_by_name(self, command_name, param):
         """
         Generic call to a method in Leo's Commands class or any subcommander class.
 
@@ -2957,7 +2935,7 @@ class LeoServer:
 
         TODO: The whole of those operations is to be undoable as one undo step.
 
-        command: a method name (a string).
+        command_name: the name of a Leo command (a string).
         param["ap"]: an archived position.
         param["keep"]: preserve the current selection, if possible.
 
@@ -2965,21 +2943,19 @@ class LeoServer:
         tag = '_do_leo_command'
         c = self._check_c()
 
-        if command in self.bad_commands_list:  # pragma: no cover
-            raise ServerError(f"{tag}: disallowed command: {command!r}")
+        if command_name in self.bad_commands_list:  # pragma: no cover
+            raise ServerError(f"{tag}: disallowed command: {command_name!r}")
 
         keepSelection = False  # Set default, optional component of param
         if "keep" in param:
             keepSelection = param["keep"]
 
-        func = self._get_commander_method(command) # GET FUNC
-        # func = c.commandsDict.get(command) # Does not work, e.g.: 'executeScript'
-
+        ### func = self._get_commander_method(command) # GET FUNC
+        func = c.commandsDict.get(command_name) # Does not work, e.g.: 'executeScript'
         if not func:  # pragma: no cover
-            raise ServerError(f"{tag}: Leo command not found: {command!r}")
+            raise ServerError(f"{tag}: Leo command not found: {command_name!r}")
 
         p = self._get_p(param)
-
         try:
             if p == c.p:
                 value = func(event={"c":c})  # no need for re-selection
@@ -2998,48 +2974,56 @@ class LeoServer:
         if self._is_jsonable(value):
             return self._make_response({"return-value": value})
         return self._make_response()
-    #@+node:felix.20210625230236.1: *4* server._get_commander_method
-    def _get_commander_method(self, command):
-        """ Return the given method (p_command) in the Commands class or subcommanders."""
-        # First, try the commands class.
+    #@+node:ekr.20210722184932.1: *4* server._do_leo_function_by_name
+    def _do_leo_function_by_name(self, command, param):
+        """
+        Generic call to a method in Leo's Commands class or any subcommander class.
+
+        The param["ap"] position is to be selected before having the command run,
+        while the param["keep"] parameter specifies wether the original position
+        should be re-selected afterward.
+
+        TODO: The whole of those operations is to be undoable as one undo step.
+
+        command_name: the name of a Leo command (a string).
+        param["ap"]: an archived position.
+        param["keep"]: preserve the current selection, if possible.
+
+        """
+        tag = '_do_leo_command'
         c = self._check_c()
-        func = getattr(c, command, None)
-        if func:
-            return func
-        # Otherwise, search all subcommanders for the method.
-        table = (  # This table comes from c.initObjectIvars.
-            'abbrevCommands',
-            'bufferCommands',
-            'chapterCommands',
-            'controlCommands',
-            'convertCommands',
-            'debugCommands',
-            'editCommands',
-            'editFileCommands',
-            'evalController',
-            'gotoCommands',
-            'helpCommands',
-            'keyHandler',
-            'keyHandlerCommands',
-            'killBufferCommands',
-            'leoCommands',
-            'leoTestManager',
-            'macroCommands',
-            'miniBufferWidget',
-            'printingController',
-            'queryReplaceCommands',
-            'rectangleCommands',
-            'searchCommands',
-            'spellCommands',
-            'vimCommands',  # Not likely to be useful.
-        )
-        for ivar in table:
-            subcommander = getattr(c, ivar, None)
-            if subcommander:
-                func = getattr(subcommander, command, None)
-                if func:
-                    return func
-        return None
+
+        ### #173
+            # if command in self.bad_commands_list:  # pragma: no cover
+                # raise ServerError(f"{tag}: disallowed command: {command!r}")
+
+        keepSelection = False  # Set default, optional component of param
+        if "keep" in param:
+            keepSelection = param["keep"]
+
+        func = self._get_commander_method(command) # GET FUNC
+        if not func:  # pragma: no cover
+            raise ServerError(f"{tag}: Leo command not found: {command!r}")
+
+        p = self._get_p(param)
+        try:
+            if p == c.p:
+                value = func(event={"c":c})  # no need for re-selection
+            else:
+                old_p = c.p  # preserve old position
+                c.selectPosition(p)  # set position upon which to perform the command
+                value = func(event={"c":c})
+                if keepSelection and c.positionExists(old_p):
+                    # Only if 'keep' old position was set, and old_p still exists
+                    c.selectPosition(old_p)
+        except Exception as e:
+            print("_do_leo_command Recovered from Error "+ str(e))
+            return self._make_response() # Return empty on error
+        #
+        # Tag along a possible return value with info sent back by _make_response
+        if self._is_jsonable(value):
+            return self._make_response({"return-value": value})
+        return self._make_response()
     #@+node:felix.20210621233316.85: *4* server._do_message
     def _do_message(self, d):
         """
@@ -3086,9 +3070,10 @@ class LeoServer:
         if action[0] == "!":
             action = action[1:] # Remove exclamation point "!"
             func = self._do_server_command  # Server has this method.
+        elif action[0] == '-':  
+            func = self._do_leo_command_by_name  # It's a command name.
         else:
-            func = self._do_leo_command  # No prefix, so it's a Leo command.
-
+            func = self._do_leo_function_by_name  # It's the name of a method in some commander.
         result = func(action, param)
         if result is None:  # pragma: no cover
             raise ServerError(f"{tag}: no response: {action!r}")
@@ -3118,6 +3103,71 @@ class LeoServer:
     def _dump_position(self, p):  # pragma: no cover
         level_s = ' ' * 2 * p.level()
         print(f"{level_s}{p.childIndex():2} {p.v.gnx} {p.h}")
+    #@+node:felix.20210624160812.1: *4* server._emit_signon
+    def _emit_signon(self):
+        '''Simulate the Initial Leo Log Entry'''
+        tag = 'emit_signon'
+        if self.loop:
+            g.app.computeSignon()
+            signon = []
+            for z in (g.app.signon, g.app.signon1):
+                for z2 in z.split('\n'):
+                    signon.append(z2.strip())
+            g.es("\n".join(signon))
+        else:
+            raise ServerError(f"{tag}: no loop ready for emit_signon")
+    #@+node:felix.20210625230236.1: *4* server._get_commander_method
+    def _get_commander_method(self, command):
+        """ Return the given method (p_command) in the Commands class or subcommanders."""
+        # First, try the commands class.
+        c = self._check_c()
+        func = getattr(c, command, None)
+        if func:
+            return func
+        # Otherwise, search all subcommanders for the method.
+        table = (  # This table comes from c.initObjectIvars.
+            'abbrevCommands',
+            'bufferCommands',
+            'chapterCommands',
+            'controlCommands',
+            'convertCommands',
+            'debugCommands',
+            'editCommands',
+            'editFileCommands',
+            'evalController',
+            'gotoCommands',
+            'helpCommands',
+            'keyHandler',
+            'keyHandlerCommands',
+            'killBufferCommands',
+            'leoCommands',
+            'leoTestManager',
+            'macroCommands',
+            'miniBufferWidget',
+            'printingController',
+            'queryReplaceCommands',
+            'rectangleCommands',
+            'searchCommands',
+            'spellCommands',
+            'vimCommands',  # Not likely to be useful.
+        )
+        for ivar in table:
+            subcommander = getattr(c, ivar, None)
+            if subcommander:
+                func = getattr(subcommander, command, None)
+                if func:
+                    return func
+        return None
+    #@+node:felix.20210621233316.91: *4* server._get_focus
+    def _get_focus(self):
+        """Server helper method to get the focused panel name string"""
+        tag = '_get_focus'
+        try:
+            w = g.app.gui.get_focus()
+            focus = g.app.gui.widget_name(w)
+        except Exception as e:
+            raise ServerError(f"{tag}: exception trying to get the focused widget: {e}")
+        return focus
     #@+node:felix.20210621233316.90: *4* server._get_p
     def _get_p(self, param, strict = False):
         """
@@ -3143,16 +3193,6 @@ class LeoServer:
             raise ServerError(f"{tag}: no c.p")
 
         return c.p
-    #@+node:felix.20210621233316.91: *4* server._get_focus
-    def _get_focus(self):
-        """Server helper method to get the focused panel name string"""
-        tag = '_get_focus'
-        try:
-            w = g.app.gui.get_focus()
-            focus = g.app.gui.widget_name(w)
-        except Exception as e:
-            raise ServerError(f"{tag}: exception trying to get the focused widget: {e}")
-        return focus
     #@+node:felix.20210621233316.92: *4* server._get_position_d
     def _get_position_d(self, p):
         """
@@ -3192,6 +3232,31 @@ class LeoServer:
             return True
         except (TypeError, OverflowError):
             return False
+    #@+node:felix.20210621233316.94: *4* server._make_minimal_response
+    def _make_minimal_response(self, package=None):
+        """
+        Return a json string representing a response dict.
+
+        The 'package' kwarg, if present, must be a python dict describing a
+        response. package may be an empty dict or None.
+
+        The 'p' kwarg, if present, must be a position.
+
+        First, this method creates a response (a python dict) containing all
+        the keys in the 'package' dict.
+
+        Then it adds 'id' to the package.
+
+        Finally, this method returns the json string corresponding to the
+        response.
+        """
+        if package is None:
+            package = {}
+
+        # Always add id.
+        package ["id"] = self.current_id
+
+        return json.dumps(package, separators=(',', ':'), cls=SetEncoder)
     #@+node:felix.20210621233316.93: *4* server._make_response
     def _make_response(self, package=None):
         """
@@ -3250,31 +3315,6 @@ class LeoServer:
         if self.log_flag:  # pragma: no cover
             g.printObj(package, tag=f"{tag} returns")
         return json.dumps(package, separators=(',', ':'), cls=SetEncoder)
-    #@+node:felix.20210621233316.94: *4* server._make_minimal_response
-    def _make_minimal_response(self, package=None):
-        """
-        Return a json string representing a response dict.
-
-        The 'package' kwarg, if present, must be a python dict describing a
-        response. package may be an empty dict or None.
-
-        The 'p' kwarg, if present, must be a position.
-
-        First, this method creates a response (a python dict) containing all
-        the keys in the 'package' dict.
-
-        Then it adds 'id' to the package.
-
-        Finally, this method returns the json string corresponding to the
-        response.
-        """
-        if package is None:
-            package = {}
-
-        # Always add id.
-        package ["id"] = self.current_id
-
-        return json.dumps(package, separators=(',', ':'), cls=SetEncoder)
     #@+node:felix.20210621233316.95: *4* server._p_to_ap
     def _p_to_ap(self, p):
         """
@@ -3301,6 +3341,27 @@ class LeoServer:
             if p.v.gnx == gnx:
                 return p
         return False
+    #@+node:felix.20210622232409.1: *4* server._send_async_output & helper
+    def _send_async_output(self, package):
+        """
+        Send data asynchronously to the client
+        """
+        tag = "send async output"
+        jsonPackage = json.dumps(package, separators=(',', ':'), cls=SetEncoder)
+        if "async" not in package:
+            InternalServerError(f"\n{tag}: async member missing in package {jsonPackage} \n")
+        if self.loop:
+            self.loop.create_task(self._async_output(jsonPackage))
+        else:
+            InternalServerError(f"\n{tag}: loop not ready {jsonPackage} \n")
+    #@+node:felix.20210621233316.89: *5* server._async_output
+    async def _async_output(self, json):  # pragma: no cover (tested in server)
+        """Output json string to the web_socket"""
+        tag = '_async_output'
+        if self.web_socket:
+            await self.web_socket.send(bytes(json, 'utf-8'))
+        else:
+            g.trace(f"{tag}: no web socket. json: {json!r}")
     #@+node:felix.20210621233316.97: *4* server._test_round_trip_positions
     def _test_round_trip_positions(self, c):  # pragma: no cover (tested in client).
         """Test the round tripping of p_to_ap and ap_to_p."""
@@ -3320,19 +3381,6 @@ class LeoServer:
             yield p
             p.moveToNext()
 
-    #@+node:felix.20210624160812.1: *4* server._emit_signon
-    def _emit_signon(self):
-        '''Simulate the Initial Leo Log Entry'''
-        tag = 'emit_signon'
-        if self.loop:
-            g.app.computeSignon()
-            signon = []
-            for z in (g.app.signon, g.app.signon1):
-                for z2 in z.split('\n'):
-                    signon.append(z2.strip())
-            g.es("\n".join(signon))
-        else:
-            raise ServerError(f"{tag}: no loop ready for emit_signon")
     #@-others
 #@+node:felix.20210621233316.98: ** class TestLeoServer (unittest.TestCase)
 class TestLeoServer (unittest.TestCase):  # pragma: no cover


### PR DESCRIPTION
I started by pulling the ekr-server-protocol which had your changes on leoserver and leoclient.

**I Fixed leoserver to work alongside leointeg's dev branch** which now also supports this new protocol for the minibuffer commands.

**But I have not touched at the modifications in leoclient.** (I'll let you assign me a new issue if the client/tests need fixing as so the unit tests run fine for the next release 6.4, ...if needed)

**EKR**: I reverted leoclient.py. The changes in that file were obsolete. I'll work on this later.