### PR TITLE
PR for #2094

### DIFF
--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -422,21 +422,23 @@ class HelpCommandsClass(BaseEditCommandsClass):
     #@+node:ekr.20150514063305.385: *4* replaceBindingPatterns
     def replaceBindingPatterns(self, s):
         """
-        For each instance of the pattern !<command-name>! is s,
+        For each instance of the pattern !<command-name>! in s,
         replace the pattern by the key binding for command-name.
         """
         c = self.c
         pattern = re.compile(r'!<(.*)>!')
         while True:
             m = pattern.search(s, 0)
-            if m is None: break
+            if m is None:
+                break
             name = m.group(1)
             junk, aList = c.config.getShortcut(name)
             for bi in aList:
                 if bi.pane == 'all':
                     key = c.k.prettyPrintKey(bi.stroke.s)
                     break
-            else: key = f"<Alt-X>{name}<Return>"
+            else:
+                key = f"<Alt-X>{name}<Return>"
             s = s[: m.start()] + key + s[m.end() :]
         return s
     #@+node:ekr.20150514063305.386: *3* helpForCreatingExternalFiles

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -2089,7 +2089,7 @@ class LocalConfigManager:
             key = c.frame.menu.canonicalizeMenuName(commandName)
             key = key.replace('&', '')  # Allow '&' in names.
             aList = d.get(commandName, [])
-            if aList:  # A list of g.BindingIndo objects.
+            if aList:  # A list of g.BindingInfo objects.
                 # It's important to filter empty strokes here.
                 aList = [z for z in aList
                     if z.stroke and z.stroke.lower() != 'none']

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3872,7 +3872,7 @@ class KeyHandlerClass:
                         shortcutList.append(data)
                 d[bi.commandName] = shortcutList
         return d
-    #@+node:ekr.20061031131434.179: *4* k.getShortcutForCommand/Name
+    #@+node:ekr.20061031131434.179: *4* k.getShortcutForCommandName
     def getStrokeForCommandName(self, commandName):
         k = self; c = k.c
         command = c.commandsDict.get(commandName)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -915,7 +915,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 self.oldEvent = w.event
                 w.event = self.wrapper
             #@+others
-            #@+node:ekr.20131120054058.16281: *8* create_d
+            #@+node:ekr.20131120054058.16281: *8* EventWrapper.create_d
             def create_d(self):
                 """Create self.d dictionary."""
                 c = self.c
@@ -940,13 +940,17 @@ class DynamicWindow(QtWidgets.QMainWindow):
                     'set-find-everywhere',
                     'set-find-node-only',
                     'set-find-suboutline-only',
+                    # #2041 & # 2094 (Leo 6.4): Support Alt-x.
+                    'full-command',
                 )
                 for cmd_name in table:
                     stroke = c.k.getStrokeForCommandName(cmd_name)
+                    if cmd_name == 'full-command':
+                        g.trace(cmd_name, stroke)
                     if stroke:
                         d[stroke.s] = cmd_name
                 return d
-            #@+node:ekr.20131118172620.16893: *8* wrapper
+            #@+node:ekr.20131118172620.16893: *8* EventWrapper.wrapper
             def wrapper(self, event):
 
                 type_ = event.type()
@@ -956,7 +960,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 if type_ == Type.KeyRelease:
                     return self.keyRelease(event)
                 return self.oldEvent(event)
-            #@+node:ekr.20131118172620.16894: *8* keyPress (EventWrapper)
+            #@+node:ekr.20131118172620.16894: *8* EventWrapper.keyPress
             def keyPress(self, event):
 
                 s = event.text()
@@ -974,14 +978,16 @@ class DynamicWindow(QtWidgets.QMainWindow):
                     return True
                 # Stay in the present widget.
                 binding, ch, lossage = self.eventFilter.toBinding(event)
+                g.trace(repr(ch), repr(binding))
                 if binding:
                     cmd_name = self.d.get(binding)
+                    g.trace(repr(cmd_name))
                     if cmd_name:
                         self.c.k.simulateCommand(cmd_name)
                         return True
                 # Do the normal processing.
                 return self.oldEvent(event)
-            #@+node:ekr.20131118172620.16895: *8* keyRelease
+            #@+node:ekr.20131118172620.16895: *8* EventWrapper.keyRelease
             def keyRelease(self, event):
                 return self.oldEvent(event)
             #@-others

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -15,6 +15,7 @@ from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoColorizer
 from leo.core import leoFrame
+from leo.core import leoGui
 from leo.core import leoMenu
 from leo.commands import gotoCommands
 from leo.core.leoQt import isQt5, isQt6, QtCore, QtGui, QtWidgets
@@ -945,8 +946,6 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 )
                 for cmd_name in table:
                     stroke = c.k.getStrokeForCommandName(cmd_name)
-                    if cmd_name == 'full-command':
-                        g.trace(cmd_name, stroke)
                     if stroke:
                         d[stroke.s] = cmd_name
                 return d
@@ -976,12 +975,14 @@ class DynamicWindow(QtWidgets.QMainWindow):
                     elif self.func:
                         self.func()
                     return True
-                # Stay in the present widget.
                 binding, ch, lossage = self.eventFilter.toBinding(event)
-                g.trace(repr(ch), repr(binding))
-                if binding:
-                    cmd_name = self.d.get(binding)
-                    g.trace(repr(cmd_name))
+                # #2094: Use code similar to the end of LeoQtEventFilter.eventFilter.
+                #        The ctor converts <Alt-X> to <Atl-x> !!
+                #        That is, we must use the stroke, not the binding.
+                key_event = leoGui.LeoKeyEvent(
+                    c=self.c, char=ch, event=event, binding=binding, w=self.w)
+                if key_event.stroke:
+                    cmd_name = self.d.get(key_event.stroke)
                     if cmd_name:
                         self.c.k.simulateCommand(cmd_name)
                         return True

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -943,6 +943,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
                     'set-find-suboutline-only',
                     # #2041 & # 2094 (Leo 6.4): Support Alt-x.
                     'full-command',
+                    'keyboard-quit', # Might as well :-)
                 )
                 for cmd_name in table:
                     stroke = c.k.getStrokeForCommandName(cmd_name)


### PR DESCRIPTION
- [x] Add 'full-command' to list of commands in EventWrapper.create_d.
- [x] Fix EventWrapper.keyPress so it uses the proper stroke.

[This comment in #2094](https://github.com/leo-editor/leo-editor/issues/2094#issuecomment-887294414) explains how I found and fixed the bug.

And, what-the-heck, Ctrl-g now works in the find/change widgets :-)