### PR TITLE
felix-server4

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -233,13 +233,11 @@ class ServerExternalFilesController(ExternalFilesController):
             g.trace('changed', has_changed, p.h)
         if has_changed:
             self.lastPNode = p  # can be set here because its the same process for ask/warn
-
-            old_p = c.p # To restore selection if refresh option set to yes-all & is descendant of at-file
-
             if p.isAtAsisFileNode() or p.isAtNoSentFileNode():
                 # Fix #1081: issue a warning.
                 self.warn(c, path, p=p)
             elif self.ask(c, path, p=p):
+                old_p = c.p # To restore selection if refresh option set to yes-all & is descendant of at-file
                 c.selectPosition(self.lastPNode)
                 c.refreshFromDisk() # Ends with selection on new c.p which is the at-file node
                 # check with leoServer's config first, and if new c.p is ancestor of old_p


### PR DESCRIPTION
Added new feature for server, set by client, for when automatically refreshing external files that changed: 
 If the current selected node was part of that at-file, and the node still exists and is still part of that at-file after file refreshed, then selection is kept on the original node instead of being changed to the at-file node which creates the file.
This helps a lot when having side-by side windows of body pane and external file and editing randomly one and the other! :) And is only for special case set by the client voluntarily.