### PR TITLE
Revise setup.py, w/o importing leo and with new tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,6 +19,8 @@ include pyproject.toml
 # same as scrub_datafiles in setup.py, prior to Github commit 9982d17e2470ac8313050b8a0288cd39d7ad4f5b
 prune leo/test
 prune leo/doc/html
+prune leo/core/.mypy_cache
+prune leo/core/mypy_stubs
 
 # Issue #603, https://github.com/leo-editor/leo-editor/issues/603
 include leo/doc/html/conf.py

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -151,6 +151,13 @@
 <v t="ekr.20150425135153.2"><vh>brew install formula</vh></v>
 </v>
 <v t="mhw-nc.20190126223741.1"><vh>Pip</vh>
+<v t="ekr.20210813103123.1"><vh>--- no longer used, from setup.py</vh>
+<v t="maphew.20181010203342.385"><vh>get_version (not used)</vh></v>
+<v t="maphew.20181010203342.386"><vh>git_version (not used)</vh>
+<v t="maphew.20180224170257.1"><vh>clean_git_tag</vh></v>
+</v>
+<v t="maphew.20180224170149.1"><vh>get_semantic_version (not used)</vh></v>
+</v>
 <v t="maphew.20180224170853.1"><vh>@file ../../setup.py</vh></v>
 <v t="maphew.20190208135916.1"><vh>@clean ../../setup.cfg</vh></v>
 <v t="maphew.20190206032329.1"><vh>@clean ../../pyproject.toml</vh></v>
@@ -187,6 +194,7 @@
 <v t="ekr.20150416081546.7"></v>
 </v>
 </v>
+<v t="maphew.20180224170853.1"></v>
 </vnodes>
 <tnodes>
 <t tx="EKR.20040519090846">@language rest
@@ -2203,6 +2211,8 @@ Public announcements, after Matt creates a package:
 <t tx="ekr.20200313063940.1">git checkout -b 6.3
 git push origin 6.3
 </t>
+<t tx="ekr.20210813103123.1">@language python
+</t>
 <t tx="maphew.20180128212042.1">@language md
 @wrap
 
@@ -2328,6 +2338,69 @@ That said, here's my recipe for packaging a new release for Test PyPi:
 Remove broken releases (still can't re-use identical version numbers and file names though):
 https://testpypi.python.org/pypi?%3Aaction=pkg_edit&amp;name=leo
 </t>
+<t tx="maphew.20180224170149.1">def get_semantic_version(tag):
+    """Return 'Semantic Version' from tag string"""
+    try:
+        import semantic_version
+    except Exception:
+        print(f"Can not import semantic_version. Using {tag!r}")
+        return tag
+    try:
+        # tuple of major, minor, build, pre-release, patch.
+        # Example: 5.6b2 --&gt; 5.6-b2
+        return str(semantic_version.Version.coerce(tag, partial=True))
+    except Exception:
+        ### g.es_exception()
+        print_exception()
+        print(f"Bad version: {tag!r}")
+        return tag
+        ###
+        # print(
+            # f"*** Failed to parse Semantic Version from git tag '{tag}'.\n"
+            # "Expecting tag name like '5.7b2', 'leo-4.9.12', 'v4.3' for releases.\n"
+            # "This version can't be uploaded to PyPi.org.")
+        # version = tag
+    # return version
+</t>
+<t tx="maphew.20180224170257.1">def clean_git_tag(tag):
+    """Return only version number from tag name. Ignore unknown formats.
+       Is specific to tags in Leo's repository.
+            5.7b1          --&gt;	5.7b1
+            Leo-4-4-8-b1   --&gt;	4-4-8-b1
+            v5.3           --&gt;	5.3
+            Fixed-bug-149  --&gt;  Fixed-bug-149
+    """
+    if tag.lower().startswith('leo-'): tag = tag[4:]
+    if tag.lower().startswith('v'): tag = tag[1:]
+    return tag
+</t>
+<t tx="maphew.20181010203342.385">def get_version(file, version=None):
+    """Determine current Leo version. Use git if in checkout, else internal Leo"""
+    root = os.path.dirname(os.path.realpath(file))
+    if os.path.exists(os.path.join(root, '.git')):
+        version = git_version(file)
+    if not version:
+        version = get_semantic_version(leoVersion.version)
+    return version</t>
+<t tx="maphew.20181010203342.386">def git_version(file, version=None):
+    """
+    Fetch from Git: {tag} {distance-from-tag} {current commit hash}
+    Return as semantic version string compliant with PEP440
+    """
+    root = os.path.dirname(os.path.realpath(file))
+    try:
+        tag, distance, commit = g.gitDescribe(root)  # 5.6b2, 55, e1129da
+        ctag = clean_git_tag(tag)
+        #version = get_semver(ctag)
+        version = ctag
+        if int(distance) &gt; 0:
+            version = '{}-dev{}'.format(version, distance)
+    except IndexError:
+        print('Attempt to `git describe` failed with IndexError')
+    except FileNotFoundError:
+        print('Attempt to `git describe` failed with FileNotFoundError')
+    return version
+</t>
 <t tx="maphew.20181010205346.1">**Pushed a commit but nothing is happening in the dashboard?**
 Check the _requests_ log: https://travis-ci.org/leo-editor/leo-editor/requests
 The link is hidden under [more options] at right.
@@ -2366,9 +2439,8 @@ requires = ["setuptools&gt;=38.6.0",
 build-backend = 'setuptools.build_meta'
 </t>
 <t tx="maphew.20190208135916.1">[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
+
+# Leo 6.4: Leo only supports Python 3, so universal should be zero.
 universal=0
 </t>
 <t tx="maphew.20190208142757.1">@language python

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -140,6 +140,7 @@
 <v t="EKR.20040519090846.1"><vh>@clean ../../LICENSE</vh></v>
 <v t="EKR.20040519090846.8"><vh>@clean ../../PKG-INFO.TXT</vh></v>
 <v t="EKR.20040519090846.9"><vh>@clean ../../README.md</vh></v>
+<v t="ekr.20210814054641.1"><vh>@clean ../../MANIFEST.in</vh></v>
 <v t="maphew.20200605112459.1"><vh>Continual Integration</vh>
 <v t="matt.20190205105334.1"><vh>@clean ../../.travis.yml</vh></v>
 <v t="maphew.20200605112532.1"><vh>@clean ../../.github/workflows/build-leo-exe.yml</vh></v>
@@ -2212,6 +2213,35 @@ Public announcements, after Matt creates a package:
 git push origin 6.3
 </t>
 <t tx="ekr.20210813103123.1">@language python
+</t>
+<t tx="ekr.20210814054641.1">@language unknown_language
+# Processed in order listed
+# Global
+#recursive-include leo *.*     # not needed when using `graft`
+graft leo
+global-exclude *.py[cod] __pycache__ *.so
+
+# Root folder
+include *.TXT
+include launchLeo.py
+include profileLeo.py
+include pylint-leo.bat
+include pylint-leo.py
+include *.nsi
+include LICENSE
+# obscure pip bugfix https://github.com/pypa/setuptools/issues/1694
+include pyproject.toml
+
+# Exclusions
+# same as scrub_datafiles in setup.py, prior to Github commit 9982d17e2470ac8313050b8a0288cd39d7ad4f5b
+prune leo/test
+prune leo/doc/html
+prune leo/core/.mypy_cache
+prune leo/core/mypy_stubs
+
+# Issue #603, https://github.com/leo-editor/leo-editor/issues/603
+include leo/doc/html/conf.py
+include leo/doc/html/index.html
 </t>
 <t tx="maphew.20180128212042.1">@language md
 @wrap

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -2462,6 +2462,7 @@ needed to leverage PEP-518. Fix: upgrade pip in `.travis.yml`
 </t>
 <t tx="maphew.20190206032329.1">[build-system]
 requires = ["setuptools&gt;=38.6.0",
+    "build&gt;=0.6.0",
     "setupext-janitor&gt;=1.1",
     "wheel&gt;=0.31.0",
     "twine&gt;=1.11.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=38.6.0",
+    "build>=0.6.0",
     "setupext-janitor>=1.1",
     "wheel>=0.31.0",
     "twine>=1.11.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
+
+# Leo 6.4: Leo only supports Python 3, so universal should be zero.
 universal=0

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     'PyQt5 >= 5.12',  # v5.12+ to close #1217
     'PyQtWebEngine',  # #1202 QtWebKit needs to be installed separately starting Qt 5.6
     'asttokens',  # abstract syntax tree text parsing
+    'build >= 0.6.0',  # simple PEP 517 package builder
     'docutils',  # used by Sphinx, rST plugin
     'flexx',  # for LeoWapp browser gui
     'meta',  # for livecode.py plugin, which is enabled by default

--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,10 @@ def is_valid_version(version):
     
     See PEP 440: https://www.python.org/dev/peps/pep-0440/
     
-    For Leo, we shall limit the valid versions with: N1.N2(.N3)?(bN|rcN)?
-    where N is any integer. Alpha releases aren't valid.
+    For Leo, valid versions shall have the form: N1.N2(.N3)?(bN|rcN)?
+    where N is any integer.
+    
+    Note: Neither alternative spellings nor alpha releases are valid.
     """
     m = pattern.match(version)
     return bool(m and len(m.group(0)) == len(version))
@@ -114,15 +116,13 @@ def test_is_valid_version():
         ok = is_valid_version(s)
         print(f"{ok!s:5} {s}")
 #@-others
+version = '6.4b2'  # Should match version in leoVersion.py.
 entry_points = define_entry_points()
 long_description = get_readme_contents()
-# version = get_semantic_version('6.4b2') # leoVersion.version)
-version = '6.4b2'
 assert is_valid_version(version), version
-if 0:
-    print('setup.py: Version', version)
+if 0:  # Testing.
     dump_entry_points()
-if 0:
+if 0:  # Testing.
     test_is_valid_version()
 if 1:  # For testing, don't execute setup.
     setuptools.setup(


### PR DESCRIPTION
**Important**: The crucial define_entry_points function is unchanged, except for formatting.

**Summary of changes**

- Always use a **static** version number, defined in setup.py itself.
  Use neither the git version nor leo.core.leoVersion.version.
- Check the version with a regex matching only a limited number of valid version numbers:
  `pattern = re.compile(r'[0-9]+\.[0-9]+(\.[0-9]+)?((b|rc)[0-9]+)?')`
   That is: `N1.N2(.N3)?(bN|rcN)?`
- Besides the standard library, import only setuptools.
  - Don't use semvar library.
  - Import neither leoGlobals.py nor leoVersion.py.
- Add print_exception function and get_readme_contents functions.
- Add is_valid_version, test_is_valid_version, and dump_entry_point functions.
- Set `universal=0` in setup.cfg.  setup.py itself must be run with python 3.
- Use open, not codecs.open. The encoding of README.md is known!

Acknowledgement: I could not have begun this work without Matt's previous work.
