### PR TITLE
felix-server4

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -296,7 +296,10 @@ def new_cmd_decorator(name, ivars):
     def _decorator(func):
 
         def new_cmd_wrapper(event):
-            c = event.get('c')
+            if isinstance(event, dict):
+                c = event.get('c')
+            else:
+                c = event.c
             self = g.ivars2instance(c, g, ivars)
             try:
                 func(self, event=event)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -296,7 +296,7 @@ def new_cmd_decorator(name, ivars):
     def _decorator(func):
 
         def new_cmd_wrapper(event):
-            c = event.c
+            c = event.get('c')
             self = g.ivars2instance(c, g, ivars)
             try:
                 func(self, event=event)


### PR DESCRIPTION
MAJOR FIX in leoGlobals.py PLEASE REVISE THIS PULL REQUEST
(Using the minibuffer in leointeg worked with commands such as 'mark' but not with rst3 and ecexute-script among others. This small fix using .get('c') instead of .c makes everything work!)
*BUT NOT SURE IF I DIDNT BREAK ANYTHING IMPORTANT*