### PR TITLE
PR for #2143

### DIFF
--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -724,13 +724,12 @@ class GitDiffController:
             self.file_node.b = (
                 f"{self.file_node.b.rstrip()}\n"
                 f"@language {c2.target_language}\n")
-    #@+node:ekr.20201208115447.1: *4* gdc.diff_pull_request (test)
+    #@+node:ekr.20201208115447.1: *4* gdc.diff_pull_request
     def diff_pull_request(self, base_branch_name='devel', directory=None):
         """
         Create a Leonine version of the diffs that would be
         produced by a pull request between two branches.
         """
-        g.trace(base_branch_name)  ###
         directory = self.get_directory(directory=directory, filename=None)
         if not directory:
             return
@@ -745,7 +744,7 @@ class GitDiffController:
             )
         else:
             g.es_print('FAIL: git rev-parse devel')
-    #@+node:ekr.20180506064102.10: *4* gdc.diff_two_branches (test)
+    #@+node:ekr.20180506064102.10: *4* gdc.diff_two_branches
     def diff_two_branches(self, branch1, branch2, fn, directory=None):
         """Create an outline describing the git diffs for fn."""
         c = self.c
@@ -780,12 +779,13 @@ class GitDiffController:
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
         """
-        g.trace(rev1, rev2)  ###
         c = self.c
+        g.trace(rev1, rev2)  ###
         if not self.get_directory(directory):
             return
         # Get list of changed files.
         files = self.get_files(rev1, rev2)
+        g.printObj(files)
         n = len(files)
         message = f"diffing {n} file{g.plural(n)}"
         if n > 5:
@@ -974,11 +974,10 @@ class GitDiffController:
         directory = g.os_path_finalize_join(base_directory, '..', '..')
         return directory
         
-    #@+node:ekr.20180506064102.11: *4* gdc.get_file_from_branch (test)
+    #@+node:ekr.20180506064102.11: *4* gdc.get_file_from_branch
     def get_file_from_branch(self, branch, fn):
         """Get the file from the head of the given branch."""
         # #2143
-        g.trace(branch)  ###
         directory = self.get_directory(fn)
         if not directory:
             return ''

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -959,6 +959,7 @@ class GitDiffController:
             directory = os.path.dirname(directory)
         if not directory:
             print(f"git-diff: outline has no directory. filename: {filename!r}")
+            return None
         # Does path/../ref exist?
         base_directory = g.gitHeadPath(directory)
         if not base_directory:

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1106,12 +1106,23 @@ class GitDiffController:
         Handle directory inits.
         Return self.repo_dir if the .git directory has been found.
         """
-        if not directory:
-            if self.repo_dir:
-                # Use previously-computed result.
-                # g.trace('EXISTS', self.repo_dir)
-                return self.repo_dir
-            directory = g.os_path_abspath(os.curdir)
+        if 1:  # #2143. Code similar to path logic in g.gitInfo.
+            if not directory:
+                # Default to leo/core.
+                directory = os.path.dirname(__file__)
+            if not os.path.isdir(directory):
+                directory = os.path.dirname(directory)
+            # Does path/../ref exist?
+            if not g.gitHeadPath(directory):
+                g.trace('NO DIRECTORY')
+                return None
+        else:  ### Legacy code.
+            if not directory:
+                if self.repo_dir:
+                    # Use previously-computed result.
+                    # g.trace('EXISTS', self.repo_dir)
+                    return self.repo_dir
+                directory = g.os_path_abspath(os.curdir)
         #
         # Change to the new directory.
         self.repo_dir = self.find_git_working_directory(directory)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -675,7 +675,7 @@ class GitDiffController:
         self.root = None
     #@+others
     #@+node:ekr.20180510095544.1: *3* gdc.Entries...
-    #@+node:ekr.20170806094320.6: *4* gdc.diff_file (test)
+    #@+node:ekr.20170806094320.6: *4* gdc.diff_file
     def diff_file(self, fn, directory=None, rev1='HEAD', rev2=''):
         """
         Create an outline describing the git diffs for fn.
@@ -730,6 +730,7 @@ class GitDiffController:
         Create a Leonine version of the diffs that would be
         produced by a pull request between two branches.
         """
+        g.trace(base_branch_name)  ###
         directory = self.get_directory(directory=directory, filename=None)
         if not directory:
             return
@@ -779,6 +780,7 @@ class GitDiffController:
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
         """
+        g.trace(rev1, rev2)  ###
         c = self.c
         if not self.get_directory(directory):
             return
@@ -819,7 +821,7 @@ class GitDiffController:
             n1, n2 = n1 + 1, n2 + 1
         if not ok:
             g.es_print('no changed readable files from HEAD@{1}..HEAD@{5}')
-    #@+node:ekr.20170820082125.1: *5* gdc.diff_revs (test)
+    #@+node:ekr.20170820082125.1: *5* gdc.diff_revs
     def diff_revs(self, rev1, rev2):
         """Diff all files given by rev1 and rev2."""
         files = self.get_files(rev1, rev2)
@@ -974,8 +976,9 @@ class GitDiffController:
         
     #@+node:ekr.20180506064102.11: *4* gdc.get_file_from_branch (test)
     def get_file_from_branch(self, branch, fn):
-        """Get the file from the hed of the given branch."""
+        """Get the file from the head of the given branch."""
         # #2143
+        g.trace(branch)  ###
         directory = self.get_directory(fn)
         if not directory:
             return ''
@@ -1008,7 +1011,7 @@ class GitDiffController:
             g.es_print('Can not read', path)
             g.es_exception()
             return ''
-    #@+node:ekr.20170806094320.9: *4* gdc.get_files (test)
+    #@+node:ekr.20170806094320.9: *4* gdc.get_files
     def get_files(self, rev1, rev2):
         """Return a list of changed files."""
         # #2143

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -730,7 +730,7 @@ class GitDiffController:
         Create a Leonine version of the diffs that would be
         produced by a pull request between two branches.
         """
-        directory = self.get_directory(directory=directory, filename=None)
+        directory = self.get_directory(directory)
         if not directory:
             return
         aList = g.execGitCommand("git rev-parse devel", directory)
@@ -773,19 +773,17 @@ class GitDiffController:
             self.make_diff_outlines(c1, c2, fn)
             self.file_node.b = f"{self.file_node.b.rstrip()}\n@language {c2.target_language}\n"
         self.finish()
-    #@+node:ekr.20180507212821.1: *4* gdc.diff_two_revs (test)
+    #@+node:ekr.20180507212821.1: *4* gdc.diff_two_revs
     def diff_two_revs(self, directory=None, rev1='HEAD', rev2=''):
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
         """
         c = self.c
-        g.trace(rev1, rev2)  ###
         if not self.get_directory(directory):
             return
         # Get list of changed files.
         files = self.get_files(rev1, rev2)
-        g.printObj(files)
         n = len(files)
         message = f"diffing {n} file{g.plural(n)}"
         if n > 5:
@@ -978,7 +976,7 @@ class GitDiffController:
     def get_file_from_branch(self, branch, fn):
         """Get the file from the head of the given branch."""
         # #2143
-        directory = self.get_directory(fn)
+        directory = self.get_directory(filename=fn)
         if not directory:
             return ''
         command = f"git show {branch}:{fn}"
@@ -989,7 +987,7 @@ class GitDiffController:
     def get_file_from_rev(self, rev, fn):
         """Get the file from the given rev, or the working directory if None."""
         # #2143
-        directory = self.get_directory(fn)
+        directory = self.get_directory(filename=fn)
         if not directory:
             return ''
         path = g.os_path_finalize_join(directory, fn)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -683,10 +683,9 @@ class GitDiffController:
         # Common code.
         c = self.c
         # #1781, #2143
-        directory = self.get_directory(fn)
+        directory = self.get_directory()
         if not directory:
             return
-        path = g.os_path_finalize_join(directory, fn)  # #1781: bug fix.
         s1 = self.get_file_from_rev(rev1, fn)
         s2 = self.get_file_from_rev(rev2, fn)
         lines1 = g.splitLines(s1)
@@ -707,6 +706,7 @@ class GitDiffController:
             self.file_node.h = f"Deleted: {self.file_node.h}"
             return
         # Finish.
+        path = g.os_path_finalize_join(directory, fn)  # #1781: bug fix.
         c1 = c2 = None
         if fn.endswith('.leo'):
             c1 = self.make_leo_outline(fn, path, s1, rev1)
@@ -944,13 +944,13 @@ class GitDiffController:
         c.redraw()
         c.treeWantsFocusNow()
     #@+node:ekr.20210819080657.1: *4* gdc.get_directory
-    def get_directory(self, filename=None):  #2143.
+    def get_directory(self):  
         """
+        #2143.
         Resolve filename to the nearest directory containing a .git directory.
         """
         c = self.c
-        if not filename:
-            filename = c.fileName()
+        filename = c.fileName()
         if not filename:
             print('git-diff: outline has no name')
             return None
@@ -966,12 +966,13 @@ class GitDiffController:
             return None
         # This should guarantee that the directory contains a .git directory.
         directory = g.os_path_finalize_join(base_directory, '..', '..')
+        g.trace(filename, '-->', directory) ###
         return directory
     #@+node:ekr.20180506064102.11: *4* gdc.get_file_from_branch
     def get_file_from_branch(self, branch, fn):
         """Get the file from the head of the given branch."""
         # #2143
-        directory = self.get_directory(fn)
+        directory = self.get_directory()
         if not directory:
             return ''
         command = f"git show {branch}:{fn}"
@@ -982,7 +983,7 @@ class GitDiffController:
     def get_file_from_rev(self, rev, fn):
         """Get the file from the given rev, or the working directory if None."""
         # #2143
-        directory = self.get_directory(fn)
+        directory = self.get_directory()
         if not directory:
             return ''
         path = g.os_path_finalize_join(directory, fn)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -966,7 +966,7 @@ class GitDiffController:
             return None
         # This should guarantee that the directory contains a .git directory.
         directory = g.os_path_finalize_join(base_directory, '..', '..')
-        g.trace(filename, '-->', directory) ###
+        ### g.trace(filename, '-->', directory) ###
         return directory
     #@+node:ekr.20180506064102.11: *4* gdc.get_file_from_branch
     def get_file_from_branch(self, branch, fn):

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2855,14 +2855,14 @@ class Commands:
         c.fileCommands.gnxDict = d
     #@+node:ekr.20180508111544.1: *3* c.Git
     #@+node:ekr.20180510104805.1: *4* c.diff_file
-    def diff_file(self, fn, rev1='HEAD', rev2='', directory=None):
+    def diff_file(self, fn, rev1='HEAD', rev2=''):
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
         """
         from leo.commands import editFileCommands as efc
         x = efc.GitDiffController(c=self)
-        x.diff_file(directory=directory, fn=fn, rev1=rev1, rev2=rev2)
+        x.diff_file(fn=fn, rev1=rev1, rev2=rev2)
     #@+node:ekr.20180508110755.1: *4* c.diff_two_revs
     def diff_two_revs(self, directory=None, rev1='', rev2=''):
         """
@@ -2876,27 +2876,19 @@ class Commands:
             rev2=rev2,
         )
     #@+node:ekr.20180510103923.1: *4* c.diff_two_branches
-    def diff_two_branches(self, branch1, branch2, fn, directory=None):
+    def diff_two_branches(self, branch1, branch2, fn):
         """
         Create an outline describing the git diffs for all files changed
         between rev1 and rev2.
         """
         from leo.commands import editFileCommands as efc
         efc.GitDiffController(c=self).diff_two_branches(
-            branch1=branch1,
-            branch2=branch2,
-            directory=directory,
-            fn=fn,
-        )
+            branch1=branch1, branch2=branch2, fn=fn)
     #@+node:ekr.20180510105125.1: *4* c.git_diff
-    def git_diff(self, rev1='HEAD', rev2='', directory=None):
+    def git_diff(self, rev1='HEAD', rev2=''):
 
         from leo.commands import editFileCommands as efc
-        efc.GitDiffController(c=self).git_diff(
-            directory=directory,
-            rev1=rev1,
-            rev2=rev2,
-        )
+        efc.GitDiffController(c=self).git_diff(rev1, rev2)
     #@+node:ekr.20171124100534.1: *3* c.Gui
     #@+node:ekr.20111217154130.10286: *4* c.Dialogs & messages
     #@+node:ekr.20110510052422.14618: *5* c.alert

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4900,18 +4900,20 @@ def backupGitIssues(c: Cmdr, base_url=None):
     c.selectPosition(root)
     c.redraw()
     g.trace('done')
-#@+node:ekr.20170616102324.1: *3* g.execGitCommand
-def execGitCommand(command, directory=None):
+#@+node:ekr.20170616102324.1: *3* g.execGitCommand (changed)
+def execGitCommand(command, directory):
     """Execute the given git command in the given directory."""
-    git_dir = g.os_path_finalize_join(directory, '.git')
-    if not g.os_path_exists(git_dir):
-        g.trace('not found:', git_dir, g.callers())
-        return []
+    ###
+        # git_dir = g.os_path_finalize_join(directory, '.git')
+        # if not g.os_path_exists(git_dir):
+            # g.trace('not found:', git_dir, g.callers())
+            # return []
     if '\n' in command:
         g.trace('removing newline from', command)
         command = command.replace('\n', '')
     # #1777: Save/restore os.curdir
-    old_dir = os.path.normpath(os.path.abspath(os.curdir))
+    ### old_dir = os.path.normpath(os.path.abspath(os.curdir))
+    old_dir = os.getcwd()
     if directory:
         os.chdir(directory)
     try:
@@ -5152,7 +5154,7 @@ def gitInfoForOutline(c: Cmdr):
     Return the git (branch, commit) info associated for commander c.
     """
     return g.gitInfoForFile(c.fileName())
-#@+node:maphew.20171112205129.1: *3* g.gitDescribe
+#@+node:maphew.20171112205129.1: *3* g.gitDescribe (unchanged)
 def gitDescribe(path: str=None):
     """
     Return the Git tag, distance-from-tag, and commit hash for the
@@ -5164,8 +5166,9 @@ def gitDescribe(path: str=None):
     describe = g.execGitCommand('git describe --tags --long', path)
     tag, distance, commit = describe[0].rsplit('-', 2)
         # rsplit not split, as '-' might be in tag name
-    if 'g' in commit[0:]: commit = commit[1:]
+    if 'g' in commit[0:]:
         # leading 'g' isn't part of the commit hash
+        commit = commit[1:]
     commit = commit.rstrip()
     return tag, distance, commit
 #@+node:ekr.20170414034616.6: *3* g.gitHeadPath

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4900,19 +4900,17 @@ def backupGitIssues(c: Cmdr, base_url=None):
     c.selectPosition(root)
     c.redraw()
     g.trace('done')
-#@+node:ekr.20170616102324.1: *3* g.execGitCommand (changed)
+#@+node:ekr.20170616102324.1: *3* g.execGitCommand
 def execGitCommand(command, directory):
     """Execute the given git command in the given directory."""
-    ###
-        # git_dir = g.os_path_finalize_join(directory, '.git')
-        # if not g.os_path_exists(git_dir):
-            # g.trace('not found:', git_dir, g.callers())
-            # return []
+    git_dir = g.os_path_finalize_join(directory, '.git')
+    if not g.os_path_exists(git_dir):
+        g.trace('not found:', git_dir, g.callers())
+        return []
     if '\n' in command:
         g.trace('removing newline from', command)
         command = command.replace('\n', '')
     # #1777: Save/restore os.curdir
-    ### old_dir = os.path.normpath(os.path.abspath(os.curdir))
     old_dir = os.getcwd()
     if directory:
         os.chdir(directory)
@@ -5094,8 +5092,6 @@ def getGitVersion(directory=None):
             stderr=subprocess.DEVNULL,
             shell=True,
         )
-        if trace:
-            g.trace(s)
     # #1209.
     except subprocess.CalledProcessError as e:
         s = e.output
@@ -5154,7 +5150,7 @@ def gitInfoForOutline(c: Cmdr):
     Return the git (branch, commit) info associated for commander c.
     """
     return g.gitInfoForFile(c.fileName())
-#@+node:maphew.20171112205129.1: *3* g.gitDescribe (unchanged)
+#@+node:maphew.20171112205129.1: *3* g.gitDescribe
 def gitDescribe(path: str=None):
     """
     Return the Git tag, distance-from-tag, and commit hash for the


### PR DESCRIPTION
See #2143.
- [x] Remove "directory" kwarg from all relevant methods & functions.
- [x] get_directory *only* uses c.fileName() to compute a base directory.