### PR TITLE
Fix check-settings complaints in leoSettings.leo. Fix misspelling in VR3

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1946,6 +1946,10 @@
 <v t="ekr.20060807103220.10"><vh>@bool datenodes-year-node-omit-saturdays = True</vh></v>
 <v t="ekr.20060807103220.11"><vh>@bool datenodes-year-node-omit-sundays = True</vh></v>
 </v>
+<v t="ekr.20210823172721.1"><vh>freewin plugin</vh>
+<v t="ekr.20210823172729.1"><vh>@bool fw-copy-html = False</vh></v>
+<v t="ekr.20210823173032.1"><vh>@string fw-render-pane = ''</vh></v>
+</v>
 <v t="ekr.20181018105433.1"><vh>graphcanvas plugin</vh>
 <v t="ekr.20181018105440.1"><vh>@bool graph-manual-layout = False</vh></v>
 </v>
@@ -2055,9 +2059,11 @@
 <v t="ekr.20201021105654.2"><vh>@bool vr3-math-output = False</vh></v>
 <v t="ekr.20201021110420.1"><vh>@bool vr3-md-math-output = False</vh></v>
 <v t="ekr.20201021110503.1"><vh>@bool vr3-prefer-asciidoc3 = False</vh></v>
+<v t="ekr.20210823172944.1"><vh>@bool vr3-rst-use-dark-theme = False</vh></v>
 <v t="ekr.20201021110638.1"><vh>@int qweb-view-font-size = 16</vh></v>
 <v t="ekr.20201021105651.1"><vh>@string vr3-asciidoc-path = None</vh></v>
 <v t="ekr.20201021105654.1"><vh>@string vr3-default-kind = None</vh></v>
+<v t="ekr.20210823173736.1"><vh>@string vr3-ext-editor = NOne</vh></v>
 <v t="ekr.20201021105654.3"><vh>@string vr3-mathjax-url = None</vh></v>
 <v t="ekr.20201021110716.1"><vh>@string vr3-md-stylesheet = None</vh></v>
 <v t="ekr.20201021110839.1"><vh>@string vr3-prefer-external = None</vh></v>
@@ -2310,7 +2316,6 @@
 </v>
 </v>
 <v t="ekr.20140915194122.23428"></v>
-<v t="ekr.20210728045642.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11651,6 +11656,11 @@ rust: ^\s*--&gt; (.+):([0-9]+):([0-9]+)\s*$</t>
 <t tx="ekr.20210802064734.1">Path to .mypy.ini file.
 
 Relative paths are resolved starting from the location of the file being checked.</t>
+<t tx="ekr.20210823172721.1"></t>
+<t tx="ekr.20210823172729.1"></t>
+<t tx="ekr.20210823172944.1"></t>
+<t tx="ekr.20210823173032.1">Valid values:  '', 'browser_view', 'nav-view'</t>
+<t tx="ekr.20210823173736.1">Path to external editor.</t>
 <t tx="jlunz.20150821113251.1">def html_tag():
     """expand &lt;tag&gt; to 
        &lt;tag&gt;\n&lt;/tag&gt; with proper indendation"""

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -1694,58 +1694,10 @@
 </v>
 <v t="ekr.20180125034510.1"><vh>Release Notes</vh>
 <v t="ekr.20210405104422.1"><vh>Leo 6.4 release notes</vh>
+<v t="ekr.20210822062604.1"><vh>6.4: Pull Requests</vh></v>
 <v t="ekr.20210405104614.1"><vh>6.4: Bugs</vh>
-<v t="ekr.20210405100137.555"><vh>#1591: no todo icons</vh></v>
-<v t="ekr.20210514065835.1"><vh>#1722: slow new command</vh></v>
-<v t="ekr.20210405100137.626"><vh>#1726: crasher in leoflexx.py</vh></v>
 <v t="ekr.20210405100137.627"><vh>#1731: Handle Tab keys properly</vh></v>
-<v t="ekr.20210405100137.690"><vh>#1739: allow tab to be inserted</vh></v>
-<v t="ekr.20210405100137.757"><vh>#1748: replace-all regex</vh></v>
-<v t="ekr.20210405100137.758"><vh>#1749: external files not marked dirty</vh></v>
-<v t="ekr.20210405100137.785"><vh>#1751: crash in quicksearch</vh></v>
-<v t="ekr.20210405100137.792"><vh>#1757: vim emulation</vh></v>
-<v t="ekr.20210405100137.907"><vh>#1763: delete in headline</vh></v>
-<v t="ekr.20210405100137.918"><vh>#1777: git-diff-pr</vh></v>
-<v t="ekr.20210405100137.945"><vh>#1790: Undo crash, word granularity</vh></v>
-<v t="ekr.20210405100137.982"><vh>#1801: crash when editing headlines</vh></v>
-<v t="ekr.20210405100137.1331"><vh>#1815: createDirectoryForFile</vh></v>
-<v t="ekr.20210405100137.1333"><vh>#1817: gnxDict</vh></v>
-<v t="ekr.20210405100137.1338"><vh>#1824: curses gui</vh></v>
-<v t="ekr.20210405100137.1358"><vh>#1839: crash in leoflexx.py</vh></v>
-<v t="ekr.20210405100137.1400"><vh>#1851: leoAst bugs</vh></v>
-<v t="ekr.20210405100137.1411"><vh>#1858: bugs in leoAst.py</vh></v>
-<v t="ekr.20210429042049.1771"><vh>#1880: plugins outside of leo/plugins</vh></v>
-<v t="ekr.20210429042049.1816"><vh>#1884: rst buglet</vh></v>
-<v t="ekr.20210429044504.1"><vh>#1888: No To All doesn't work</vh></v>
-<v t="ekr.20210429042049.1943"><vh>#1900: ~ in paths</vh></v>
-<v t="ekr.20210528082736.8"><vh>#1907: backslash not handled properly in @path</vh></v>
-<v t="ekr.20210429061759.1"><vh>#1910: checkDerivedFiles</vh></v>
-<v t="ekr.20210429064509.1"><vh>#1912: ignoring command: already</vh></v>
-<v t="ekr.20210505081910.1"><vh>#1919: width of hard tabs</vh></v>
-<v t="ekr.20210511103242.190"><vh>#1926: fix bugs in @button write-leoPyRef</vh></v>
-<v t="ekr.20210511103020.1"><vh>#1930: crash in refresh-from-disk</vh></v>
-<v t="ekr.20210528082736.2"><vh>#1959: crash in on_idle</vh></v>
-<v t="ekr.20210528125316.1"><vh>#1961: multiple popups</vh></v>
-<v t="ekr.20210607023121.1"><vh>#1965: LM.createAllImporterData</vh></v>
-<v t="ekr.20210617091939.1"><vh>#1968: leo-editor path</vh></v>
-<v t="ekr.20210718082823.41"><vh>#1972: show-bindings does not show F-Keys</vh></v>
-<v t="ekr.20210617164840.1"><vh>#1974: spaces in path</vh></v>
-<v t="ekr.20210717092635.1363"><vh>#1995: menu styles</vh></v>
-<v t="ekr.20210717092635.785"><vh>#2000: copy from log pane (from context menu)</vh></v>
-<v t="ekr.20210710040014.54"><vh>#2011: buttons </vh></v>
-<v t="ekr.20210710040014.55"><vh>#2020: leoflexx crash</vh></v>
-<v t="ekr.20210710040014.57"><vh>#2022: quicksearch crash</vh></v>
-<v t="ekr.20210717092635.919"><vh>#2024: Button background</vh></v>
-<v t="ekr.20210710040014.73"><vh>#2030: NO PARENT message</vh></v>
-<v t="ekr.20210710040014.133"><vh>#2036: move-right</vh></v>
-<v t="ekr.20210717092635.921"><vh>#2040: auto-indent</vh></v>
-<v t="ekr.20210802163908.2"><vh>#2041 &amp; #2094: Alt-x in find panel</vh></v>
-<v t="ekr.20210710163244.4"><vh>#2041: Alt-x in find panel</vh></v>
-<v t="ekr.20210717092635.1337"><vh>#2076: find-all</vh></v>
-<v t="ekr.20210718082823.28"><vh>#2080: Context Menu</vh></v>
-<v t="ekr.20210810072331.1"><vh>#2127: Hard crash when showing tips</vh></v>
-<v t="ekr.20210405100137.1784"><vh>PR #1822: fix recursive import for @edit</vh></v>
-<v t="ekr.20210405100137.1801"><vh>PR #1865: Ctrl-click must not search @nosearch trees</vh></v>
+<v t="ekr.20210822062836.1"><vh>Bugs in leoAst.py</vh></v>
 </v>
 <v t="ekr.20210405104619.1"><vh>6.4: Code</vh>
 <v t="ekr.20210405100137.468"><vh>#1413: New undo pattern</vh></v>
@@ -30920,48 +30872,21 @@ The example filters shown above simulate the often-requested "half clone" featur
 <t tx="ekr.20210405100137.1061">https://github.com/leo-editor/leo-editor/issues/1808</t>
 <t tx="ekr.20210405100137.1062">https://github.com/leo-editor/leo-editor/issues/1813
 </t>
-<t tx="ekr.20210405100137.1331">https://github.com/leo-editor/leo-editor/issues/1815</t>
-<t tx="ekr.20210405100137.1333">https://github.com/leo-editor/leo-editor/issues/1817</t>
 <t tx="ekr.20210405100137.1336">https://github.com/leo-editor/leo-editor/issues/1821
 </t>
-<t tx="ekr.20210405100137.1338">https://github.com/leo-editor/leo-editor/issues/1824</t>
 <t tx="ekr.20210405100137.1340">https://github.com/leo-editor/leo-editor/issues/1831
 
 https://github.com/leo-editor/leo-editor/issues/2049
 </t>
 <t tx="ekr.20210405100137.1345">https://github.com/leo-editor/leo-editor/issues/1832</t>
-<t tx="ekr.20210405100137.1358">https://github.com/leo-editor/leo-editor/issues/1839
-</t>
 <t tx="ekr.20210405100137.1384">https://github.com/leo-editor/leo-editor/issues/1840</t>
 <t tx="ekr.20210405100137.1396">https://github.com/leo-editor/leo-editor/issues/1841</t>
-<t tx="ekr.20210405100137.1400">https://github.com/leo-editor/leo-editor/issues/1851
-
-PR: https://github.com/leo-editor/leo-editor/pull/1852
-</t>
-<t tx="ekr.20210405100137.1411">https://github.com/leo-editor/leo-editor/issues/1857
-
-PR #1859.
-
-python -m unittest leo.core.leoAst.TestTOG
-python39 -m unittest leo.core.leoAst.TestTOG
-python39 -m unittest leo.core.leoAst.TestTOG.test_bug_1851
-
-Python 3.8
-- Pep 572: Walrus Operator.
-- Pep 570: Positional-only parameters. 
-- f"{x=}"
-- AST nodes now have end_lineno and end_col_offset attributes
-  (This only applies to nodes that have lineno and col_offset attributes.)
-</t>
 <t tx="ekr.20210405100137.1743">https://github.com/leo-editor/leo-editor/issues/1867</t>
 <t tx="ekr.20210405100137.1772">https://github.com/leo-editor/leo-editor/issues/1804</t>
 <t tx="ekr.20210405100137.1773">https://github.com/leo-editor/leo-editor/pull/1818
 </t>
-<t tx="ekr.20210405100137.1784">https://github.com/leo-editor/leo-editor/pull/1822
-</t>
 <t tx="ekr.20210405100137.1798">https://github.com/leo-editor/leo-editor/issues/1849
 </t>
-<t tx="ekr.20210405100137.1801">https://github.com/leo-editor/leo-editor/issues/1865</t>
 <t tx="ekr.20210405100137.2">https://github.com/leo-editor/leo-editor/issues/442</t>
 <t tx="ekr.20210405100137.456">https://github.com/leo-editor/leo-editor/issues/1240</t>
 <t tx="ekr.20210405100137.468">https://github.com/leo-editor/leo-editor/issues/1413
@@ -30972,11 +30897,8 @@ PR: https://github.com/leo-editor/leo-editor/issues/1759</t>
 PR: https://github.com/leo-editor/leo-editor/pull/1830
 
 Config file: http://mypy.readthedocs.io/en/latest/config_file.html</t>
-<t tx="ekr.20210405100137.555">https://github.com/leo-editor/leo-editor/issues/1591</t>
 <t tx="ekr.20210405100137.563">https://github.com/leo-editor/leo-editor/issues/1721</t>
-<t tx="ekr.20210405100137.626">https://github.com/leo-editor/leo-editor/issues/1726</t>
-<t tx="ekr.20210405100137.627">Issue: https://github.com/leo-editor/leo-editor/issues/1731
-
+<t tx="ekr.20210405100137.627">https://github.com/leo-editor/leo-editor/issues/1731
 PR: https://github.com/leo-editor/leo-editor/pull/1732
 
 Summary of tab binding in EKR bindings:
@@ -30987,42 +30909,27 @@ focus-to-body       !tree = Tab
 unindent-region     = ctrl-less # Ctrl-Shift-&lt;
 unindent-region     = Shift-tab
 </t>
-<t tx="ekr.20210405100137.690">https://github.com/leo-editor/leo-editor/issues/1739
-
-PR: https://github.com/leo-editor/leo-editor/issues/1740
-</t>
 <t tx="ekr.20210405100137.705">https://github.com/leo-editor/leo-editor/issues/1742
 </t>
 <t tx="ekr.20210405100137.755">https://github.com/leo-editor/leo-editor/issues/1743</t>
-<t tx="ekr.20210405100137.757">https://github.com/leo-editor/leo-editor/issues/1748</t>
-<t tx="ekr.20210405100137.758">https://github.com/leo-editor/leo-editor/issues/1749
-</t>
-<t tx="ekr.20210405100137.785">https://github.com/leo-editor/leo-editor/issues/1751</t>
 <t tx="ekr.20210405100137.787">https://github.com/leo-editor/leo-editor/issues/1754
 
 w.see works for the first time ever!</t>
-<t tx="ekr.20210405100137.792">https://github.com/leo-editor/leo-editor/issues/1757</t>
 <t tx="ekr.20210405100137.887">https://github.com/leo-editor/leo-editor/issues/1759
 </t>
-<t tx="ekr.20210405100137.907">https://github.com/leo-editor/leo-editor/issues/1763</t>
 <t tx="ekr.20210405100137.912">https://github.com/leo-editor/leo-editor/issues/1768</t>
 <t tx="ekr.20210405100137.915">https://github.com/leo-editor/leo-editor/issues/1772
 
 Added gdc.diff_pull_request.</t>
 <t tx="ekr.20210405100137.917">https://github.com/leo-editor/leo-editor/issues/1775</t>
-<t tx="ekr.20210405100137.918">https://github.com/leo-editor/leo-editor/issues/1777</t>
 <t tx="ekr.20210405100137.923">https://github.com/leo-editor/leo-editor/issues/1780</t>
 <t tx="ekr.20210405100137.931">https://github.com/leo-editor/leo-editor/issues/1781</t>
 <t tx="ekr.20210405100137.943">https://github.com/leo-editor/leo-editor/issues/1788</t>
 <t tx="ekr.20210405100137.944">https://github.com/leo-editor/leo-editor/issues/1789</t>
-<t tx="ekr.20210405100137.945">https://github.com/leo-editor/leo-editor/issues/1790
-
-</t>
 <t tx="ekr.20210405100137.946">https://github.com/leo-editor/leo-editor/issues/1792</t>
 <t tx="ekr.20210405100137.955">https://github.com/leo-editor/leo-editor/issues/1798
 
 Note: Leo can not recognize @path directives in the body text of @file nodes!</t>
-<t tx="ekr.20210405100137.982">https://github.com/leo-editor/leo-editor/issues/1801</t>
 <t tx="ekr.20210405104357.1">- Add support for leoInteg: "Leo in vs-code".
 - Add leoserver.py, stand-alone server for Leo.
 - Add support for .leojs, a json outline format.
@@ -31066,8 +30973,11 @@ Leo is an [IDE, outliner and PIM](http://leoeditor.com/preface.html).
 - [A web page that displays .leo files](http://leoeditor.com/load-leo.html)
 - [More links](http://leoeditor.com/leoLinks.html)
 </t>
-<t tx="ekr.20210405104614.1">For a list of all bugs fixed in Leo 6.4 see:
-https://github.com/leo-editor/leo-editor/issues?q=is%3Aissue+milestone%3A6.4+label%3Abug</t>
+<t tx="ekr.20210405104614.1">The following is a list of only the most important bugs.
+
+For a list of all bugs fixed in Leo 6.4 see:
+https://github.com/leo-editor/leo-editor/issues?q=is%3Aissue+milestone%3A6.4+label%3Abug
+</t>
 <t tx="ekr.20210405104619.1"></t>
 <t tx="ekr.20210405104753.1">Add commands:
 - convert-at-root: #1832.
@@ -31093,22 +31003,13 @@ https://github.com/leo-editor/leo-editor/issues/2049
 @string mypy-config-file</t>
 <t tx="ekr.20210405110053.1"></t>
 <t tx="ekr.20210405110145.1"></t>
-<t tx="ekr.20210429042049.1771">https://github.com/leo-editor/leo-editor/issues/1880</t>
-<t tx="ekr.20210429042049.1816">https://github.com/leo-editor/leo-editor/issues/1884
-</t>
 <t tx="ekr.20210429042049.1902">https://github.com/leo-editor/leo-editor/issues/1889
 
 - atFile.read calls g.fullPath instead of at.initFileName.
 - Delete at.initFileName.
 - c.scanAtPathDirectives expands ~ in all paths.</t>
 <t tx="ekr.20210429042049.1914">https://github.com/leo-editor/leo-editor/issues/1895</t>
-<t tx="ekr.20210429042049.1943">https://github.com/leo-editor/leo-editor/issues/1900</t>
 <t tx="ekr.20210429042049.1947">https://github.com/leo-editor/leo-editor/issues/1903</t>
-<t tx="ekr.20210429044504.1">https://github.com/leo-editor/leo-editor/issues/1888</t>
-<t tx="ekr.20210429061759.1">https://github.com/leo-editor/leo-editor/issues/1910</t>
-<t tx="ekr.20210429064509.1">https://github.com/leo-editor/leo-editor/issues/1912</t>
-<t tx="ekr.20210505081910.1">https://github.com/leo-editor/leo-editor/issues/1919
-</t>
 <t tx="ekr.20210509173514.1"></t>
 <t tx="ekr.20210509173536.1">###################
 Using leoserver.py
@@ -31128,8 +31029,6 @@ and receive JSON responses from the server.
 .. contents:: Contents
     :depth: 2
     :local:</t>
-<t tx="ekr.20210511103020.1">https://github.com/leo-editor/leo-editor/issues/1930</t>
-<t tx="ekr.20210511103242.190">https://github.com/leo-editor/leo-editor/issues/1926</t>
 <t tx="ekr.20210511103242.2">https://github.com/leo-editor/leo-editor/issues/1914</t>
 <t tx="ekr.20210513053406.1">https://github.com/leo-editor/leo-editor/issues/1933
 </t>
@@ -31173,7 +31072,6 @@ first draft of the all-important ws_handler function.
 Edward K. Ream made the code more pythonic and provided Leo-specific
 advice.
 </t>
-<t tx="ekr.20210514065835.1">https://github.com/leo-editor/leo-editor/issues/1722</t>
 <t tx="ekr.20210514075844.1">The **_make_response** and **_make_minimal_response** methods return python
 dicts. The server's main loop converts those dicts to JSON. All responses
 contain an 'id' key that matches the corresponding requests.
@@ -31183,23 +31081,16 @@ contain an 'id' key that matches the corresponding requests.
 <t tx="ekr.20210515095924.1"></t>
 <t tx="ekr.20210520081100.1">https://github.com/leo-editor/leo-editor/issues/1946</t>
 <t tx="ekr.20210528082736.11">https://github.com/leo-editor/leo-editor/issues/1955</t>
-<t tx="ekr.20210528082736.2">https://github.com/leo-editor/leo-editor/issues/1959
-
-File "...leoExternalFiles.py", line 150, in on_idle
-    assert len(self.unchecked_files) &lt; n</t>
 <t tx="ekr.20210528082736.20">https://github.com/leo-editor/leo-editor/issues/1953</t>
-<t tx="ekr.20210528082736.8">https://github.com/leo-editor/leo-editor/issues/1907</t>
 <t tx="ekr.20210528083337.1">https://github.com/leo-editor/leo-editor/issues/1846
 </t>
 <t tx="ekr.20210528083510.1">https://github.com/leo-editor/leo-editor/issues/1672
 
 Leo's Qt docks caused great confusion. Leo is better off without them.
 </t>
-<t tx="ekr.20210528125316.1">https://github.com/leo-editor/leo-editor/issues/1961</t>
 <t tx="ekr.20210606081234.1">https://github.com/leo-editor/leo-editor/issues/1715
 
 Add c.general_script_helper.</t>
-<t tx="ekr.20210607023121.1">https://github.com/leo-editor/leo-editor/issues/1965</t>
 <t tx="ekr.20210607135729.1">The execute-general-script command invokes an external language processor on an **script file** as follows:
 
 - If c.p is any kind of @&lt;file&gt; node, the script file is the corresponding external file.
@@ -31214,20 +31105,13 @@ Add c.general_script_helper.</t>
 - This command is a thin wrapper around the c.general_script_helper method.
   Scripts can call this method directly if desired.
 </t>
-<t tx="ekr.20210617091939.1">https://github.com/leo-editor/leo-editor/issues/1968</t>
 <t tx="ekr.20210617092021.1">https://github.com/leo-editor/leo-editor/issues/1979</t>
-<t tx="ekr.20210617164840.1">https://github.com/leo-editor/leo-editor/issues/1974</t>
 <t tx="ekr.20210710040014.128">https://github.com/leo-editor/leo-editor/issues/2031
 
 Part of support for "Leo in vs-code"</t>
-<t tx="ekr.20210710040014.133">https://github.com/leo-editor/leo-editor/issues/2036</t>
 <t tx="ekr.20210710040014.2">https://github.com/leo-editor/leo-editor/issues/1944
 
 PR: https://github.com/leo-editor/leo-editor/pull/1948</t>
-<t tx="ekr.20210710040014.54">https://github.com/leo-editor/leo-editor/issues/2011</t>
-<t tx="ekr.20210710040014.55">https://github.com/leo-editor/leo-editor/issues/2020</t>
-<t tx="ekr.20210710040014.57">https://github.com/leo-editor/leo-editor/issues/2022</t>
-<t tx="ekr.20210710040014.73">https://github.com/leo-editor/leo-editor/issues/2030</t>
 <t tx="ekr.20210710040931.1">This script creates stub (.pyi) files from def lines containing annotations,
 then removes the annotations.
 
@@ -31236,31 +31120,12 @@ files, and then move most of the clutter to stub files.
 
 Imo, the wax_off script makes my make_stub_files project obsolete.</t>
 <t tx="ekr.20210710163244.2">https://github.com/leo-editor/leo-editor/issues/2023</t>
-<t tx="ekr.20210710163244.4">https://github.com/leo-editor/leo-editor/issues/2041
-
-PR: https://github.com/leo-editor/leo-editor/pull/2044</t>
-<t tx="ekr.20210717092635.1337">https://github.com/leo-editor/leo-editor/issues/2076</t>
 <t tx="ekr.20210717092635.1339">https://github.com/leo-editor/leo-editor/issues/2068</t>
-<t tx="ekr.20210717092635.1363">https://github.com/leo-editor/leo-editor/issues/1995</t>
 <t tx="ekr.20210717092635.2">https://github.com/leo-editor/leo-editor/issues/1973</t>
-<t tx="ekr.20210717092635.785">https://github.com/leo-editor/leo-editor/issues/2000</t>
 <t tx="ekr.20210717092635.918">https://github.com/leo-editor/leo-editor/issues/2005</t>
-<t tx="ekr.20210717092635.919">https://github.com/leo-editor/leo-editor/issues/2024</t>
-<t tx="ekr.20210717092635.921">https://github.com/leo-editor/leo-editor/issues/2040</t>
 <t tx="ekr.20210717092635.938">https://github.com/leo-editor/leo-editor/issues/2069</t>
 <t tx="ekr.20210718082823.2">https://github.com/leo-editor/leo-editor/issues/2081</t>
-<t tx="ekr.20210718082823.28">Context Menu Does Not Use External Editor Setting
-https://github.com/leo-editor/leo-editor/issues/2080
-
-See Also PR #2083 (Tom Passin)
-https://github.com/leo-editor/leo-editor/pull/2083</t>
 <t tx="ekr.20210718082823.40">https://github.com/leo-editor/leo-editor/issues/1995</t>
-<t tx="ekr.20210718082823.41">show-settings does not show F-keys
-https://github.com/leo-editor/leo-editor/issues/1972</t>
-<t tx="ekr.20210802163908.2">https://github.com/leo-editor/leo-editor/issues/2041
-PR: https://github.com/leo-editor/leo-editor/pull/2044
-
-https://github.com/leo-editor/leo-editor/issues/2094</t>
 <t tx="ekr.20210802163908.24">https://github.com/leo-editor/leo-editor/issues/2098</t>
 <t tx="ekr.20210802163908.29">https://github.com/leo-editor/leo-editor/issues/2102
 
@@ -31268,8 +31133,6 @@ Cover keyword-only arguments.
 pep 570: https://www.python.org/dev/peps/pep-0570/#keyword-only-arguments</t>
 <t tx="ekr.20210802163908.31">https://github.com/leo-editor/leo-editor/issues/2103</t>
 <t tx="ekr.20210802163908.50">https://github.com/leo-editor/leo-editor/issues/2112</t>
-<t tx="ekr.20210810072331.1">https://github.com/leo-editor/leo-editor/issues/2127
-</t>
 <t tx="ekr.20210822061928.1">gnx: ekr.20191216061356.4
 unl: Leo's demo.py plugin
 gnx: ekr.20191216061356.5
@@ -31320,6 +31183,25 @@ gnx: ekr.20191216061356.27
 unl: Summary
 gnx: ekr.20191216061356.28
 unl: History and change log
+</t>
+<t tx="ekr.20210822062604.1">For a list of all Pull Requests in Leo 6.4 see:
+https://github.com/leo-editor/leo-editor/pulls?q=is%3Apr+is%3Aopen+milestone%3A6.4</t>
+<t tx="ekr.20210822062836.1">https://github.com/leo-editor/leo-editor/issues/1851
+PR: https://github.com/leo-editor/leo-editor/pull/1852
+
+https://github.com/leo-editor/leo-editor/issues/1857
+PR: https://github.com/leo-editor/leo-editor/pull/1859
+
+python -m unittest leo.core.leoAst.TestTOG
+python39 -m unittest leo.core.leoAst.TestTOG
+python39 -m unittest leo.core.leoAst.TestTOG.test_bug_1851
+
+Python 3.8
+- Pep 572: Walrus Operator.
+- Pep 570: Positional-only parameters. 
+- f"{x=}"
+- AST nodes now have end_lineno and end_col_offset attributes
+  (This only applies to nodes that have lineno and col_offset attributes.)
 </t>
 <t tx="maphew.20200616225715.1">Getting to the archive in order to download is a bit of work as there isn't a stable url.
 

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -140,7 +140,7 @@ All settings are of type @string unless shown as ``@bool``
    :widths: 18, 5, 5, 30
 
    "vr3-default-kind", "rst", "rst, md, asciidoc", "Default for rendering type"
-   "vr3-external-editor", "", "Path to external editor", "Specify
+   "vr3-ext-editor", "", "Path to external editor", "Specify
    desired external editor to receive generated markup"
    "vr3-math-output", "False", "bool (True, False)", "RsT MathJax math rendering"
    "vr3-md-math-output", "False", "bool (True, False)", "MD MathJax math rendering"
@@ -294,13 +294,11 @@ rarely a reason to invoke any of them, except two:
     1. ``vr3-toggle``, which shows or hides the VR3 pane. 
     This is best bound to a hot key (see `Hot Key`_).
 
-    2.``vr3-open-markup-in-editor`` exports the generated markup
-    to temporary file and opens it in a text editor. The editor
-    is one specified by the setting ``@string vr3-external-editor``,
-    the setting ``@string external-editor``, by the environmental
-    variable ``EDITOR`` or ``LEO-EDITOR``, or is the default 
+    2.``vr3-open-markup-in-editor`` exports the generated markup to
+    temporary file and opens it in a text editor. The editor is one
+    specified by the setting ``@string vr3-ext-editor``, by the
+    environmental variable ``EDITOR`` or ``LEO-EDITOR``, or is the default
     editor chosen by Leo.
-
 
 #@+node:TomP.20200902222012.1: *3* Structured Text
 Structured Text


### PR DESCRIPTION
Fix problems reported by `@button check-settings' in leoSettings.leo.

Also removed top-level clone in leoDocs.leo.

@tbpassin There was an apparent misspelling in VR3.