### PR TITLE
Fix crash in backlink plugin when using Qt6

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -3784,13 +3784,13 @@ free_layout.py      # loaded automatically. Puts free_layout in Plugins menu.
 contextmenu.py      # Required by the vim.py and xemacs.py plugins.
 leo_to_html.py
 mod_scripting.py
-nav_qt.py
+nav_qt.py           # Forward/back buttons &amp; goto-next/prev-history-node
 nodetags.py
-quicksearch.py
+quicksearch.py      # Nav pane.
 screen_capture.py
 stickynotes.py
-todo.py
-viewrendered.py
+todo.py             # Task pane.
+viewrendered.py     # (Or viewrendered3.py) Plugins menu support.
 </t>
 <t tx="ekr.20070318065601">True:  Chapter commands are functional.
 False: Chapter commands do not exists.

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -73,10 +73,9 @@ where the extra information is the name of the linked node's parent.
 #     - linkClicked(n) (zero based)
 #@-<< notes >>
 # By TNB
-# **Important**: this plugin is gui-independent.
 from leo.core import leoGlobals as g
+from leo.core.leoQt import isQt6, Qt, QtGui, QtWidgets, uic
 Tk = None
-Qt = None
 #@+others
 #@+node:ekr.20090616105756.3942: ** class backlinkController
 class backlinkController:
@@ -732,8 +731,6 @@ class backlinkController:
 #@+node:ekr.20090616105756.3939: ** class backlinkQtUI
 if g.app.gui.guiName() == "qt":
 
-    from leo.core.leoQt import Qt,QtGui,QtWidgets,uic
-
     class backlinkQtUI(QtWidgets.QWidget):
         #@+others
         #@+node:ekr.20140920145803.17987: *3* __init__
@@ -936,14 +933,21 @@ if g.app.gui.guiName() == "tkinter":
         #@-others
 #@+node:ekr.20140920145803.17995: ** top-level
 #@+node:ekr.20090616105756.3940: *3* init
+warning_given = False
+
 def init ():
     '''Return True if the plugin has loaded successfully.'''
-    ok = g.app.gui.guiName() != 'nullGui'
-    if ok:
-        g.registerHandler('after-create-leo-frame',onCreate)
-        # can't use before-create-leo-frame because Qt dock's not ready
-        g.plugin_signon(__name__)
-    return ok
+    global warning_given
+    if g.app.gui.guiName() == 'nullGui':
+        return False
+    if isQt6:
+        if not warning_given:
+            warning_given = True
+            print('backlink.py: Qt6 support not ready yet.')
+        return False
+    g.registerHandler('after-create-leo-frame',onCreate)
+    g.plugin_signon(__name__)
+    return True
 #@+node:ekr.20090616105756.3941: *3* onCreate
 def onCreate (tag, keys):
 


### PR DESCRIPTION
- [x] Fix crash in backlink.py when using PyQt6.
- [x] Add comments to `@enabled-plugins` node.