### PR TITLE
Leo babel drop call to remove extra lws - This was a mistake.  It should be a pull request for branch devel.

### DIFF
--- a/leo/plugins/leo_babel/babel_lib.py
+++ b/leo/plugins/leo_babel/babel_lib.py
@@ -515,8 +515,6 @@ def babelExec(event):
                 s = w.getSelectedText()
             else:
                 s = p.b
-            # Remove extra leading whitespace so the user may execute indented code.
-            s = leoG.removeExtraLws(s, c.tab_width)
             s = extractExecutableString(c, p, s, language)
             script = composeScript(c, p, s,
                         forcePythonSentinels=forcePythonSentinels,


### PR DESCRIPTION
Drop the only call to removeExtraLws() because it is no longer needed and it no longer exists in Leo-Editor core.