### PR TITLE
use python -m to invoke black

### DIFF
--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -101,7 +101,7 @@ def blacken_files(event):
         path = g.fullPath(c, root)
         if path and os.path.exists(path):
             g.es_print(f"{tag}: {path}")
-            g.execute_shell_commands(f"&black --skip-string-normalization {path}")
+            g.execute_shell_commands(f"&python -m black --skip-string-normalization {path}")
         else:
             print(f"{tag}: file not found:{path}")
             g.es(f"{tag}: file not found:\n{path}")
@@ -123,7 +123,7 @@ def blacken_files_diff(event):
         path = g.fullPath(c, root)
         if path and os.path.exists(path):
             g.es_print(f"{tag}: {path}")
-            g.execute_shell_commands(f"&black --skip-string-normalization --diff {path}")
+            g.execute_shell_commands(f"&python -m black --skip-string-normalization --diff {path}")
         else:
             print(f"{tag}: file not found:{path}")
             g.es(f"{tag}: file not found:\n{path}")


### PR DESCRIPTION
`python -m` is more flexible than specifying a path or relying on app-specific .cmd or .sh files.