### PR TITLE
Remove most g.app ivars relating to unit tests

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -359,18 +359,7 @@ class LeoApp:
         #@-<< LeoApp: scripting ivars >>
         #@+<< LeoApp: unit testing ivars >>
         #@+node:ekr.20161028040330.1: *5* << LeoApp: unit testing ivars >>
-        self.isExternalUnitTest = False
-            # True: we are running a unit test externally.
-        self.runningAllUnitTests = False
-            # True: we are running all unit tests (Only for local tests).
-        self.suppressImportChecks = False
-            # Used only in basescanner.py
-            # True: suppress importCommands.check
-        self.unitTestGui = None
-            # A way to override the gui in external unit tests.
-        self.unitTestMenusDict = {}
-            # Created in LeoMenu.createMenuEntries for a unit test.
-            # keys are command names. values are sets of strokes.
+        self.suppressImportChecks = False  # True: suppress importCommands.check
         #@-<< LeoApp: unit testing ivars >>
         # Define all global data.
         self.init_at_auto_names()

--- a/leo/core/leoDynamicTest.py
+++ b/leo/core/leoDynamicTest.py
@@ -57,7 +57,6 @@ def main():
     if bridge.isOpen():
         g = bridge.globals()
         g.app.silentMode = options.silent
-        g.app.isExternalUnitTest = True
         path = g.os_path_finalize_join(g.app.loadDir, '..', 'test', options.path)
         c = bridge.openLeoFile(path)
         if g_trace:

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -17922,6 +17922,58 @@ def test_minibuffer_find_commands(self):
         # This is not a full test.  We must use keyboardQuit here!
         c.k.simulateCommand(command)
         c.k.keyboardQuit(None)
+#@+node:ekr.20210923171931.1: *3* OLD: TestCommands.test_all_menus_execute_the_proper_command
+def test_all_menus_execute_the_proper_command(self):
+    """
+    Check that when masterMenuHandler does:
+
+        event = g.app.gui.create_key_event(c,binding=stroke,w=w)
+        return k.masterKeyHandler(event)
+
+    that the effect will be to call commandName, where commandName
+    is the arg passed to masterMenuHandler.
+
+    createMenuEntries creates the association of stroke to commandName.
+    """
+    
+    trace = False  # False: the unit test can fail.
+    c, p = self.c, self.c.p
+    k = c.k
+    d = g.app.unitTestMenusDict
+    assert not d
+    self.fail('test')
+    ### g.printObj(d, tag=g.app.unitTestMenusDict)
+    d2 = k.bindingsDict
+    d2name = 'k.bindingsDict'
+    commandNames = list(d.keys())
+    commandNames.sort()
+    exclude_strokes = ('Alt+F4', 'Ctrl+q', 'Ctrl+Shift+Tab',)
+    for name in commandNames:
+        assert name in c.commandsDict, 'unexpected command name: %s' % (
+            repr(name))
+        aSet = d.get(name)
+        aList = list(aSet)
+        aList.sort()
+        for z in exclude_strokes:
+            if z in aList:
+                aList.remove(z)
+        for stroke in aList:
+            aList2 = d2.get(stroke)
+            assert aList2, 'stroke %s not in %s' % (
+                repr(stroke), d2name)
+            for b in aList2:
+                if b.commandName == name:
+                    break
+            else:
+                if trace:
+                    inverseBindingDict = k.computeInverseBindingDict()
+                    print('%s: stroke %s not bound to %s in %s' % (
+                        p.h, repr(stroke), repr(name), d2name))
+                    print('%s: inverseBindingDict.get(%s): %s' % (
+                        p.h, name, inverseBindingDict.get(name)))
+                else:
+                    assert False, 'stroke %s not bound to %s in %s' % (
+                        repr(stroke), repr(name), d2name)
 #@+node:ekr.20031218072017.3632: ** go (leoCompare.py) no longer used
 def go():
     compare = LeoCompare(

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -103,54 +103,6 @@ class TestCommands(LeoUnitTest):
             expected = ('event',)
             message = f"no event arg for command {key}, func: {name}, args: {args}"
             assert arg0 in expected or arg1 in expected, message
-    #@+node:ekr.20210901140645.3: *3* TestCommands.test_all_menus_execute_the_proper_command
-    def test_all_menus_execute_the_proper_command(self):
-        """
-        We want to ensure that when masterMenuHandler does:
-
-            event = g.app.gui.create_key_event(c,binding=stroke,w=w)
-            return k.masterKeyHandler(event)
-
-        that the effect will be to call commandName, where commandName
-        is the arg passed to masterMenuHandler.
-
-        createMenuEntries creates the association of stroke to commandName.
-        """
-        trace = False  # False: the unit test can fail.
-        c, p = self.c, self.c.p
-        k = c.k
-        d = g.app.unitTestMenusDict
-        d2 = k.bindingsDict
-        d2name = 'k.bindingsDict'
-        commandNames = list(d.keys())
-        commandNames.sort()
-        exclude_strokes = ('Alt+F4', 'Ctrl+q', 'Ctrl+Shift+Tab',)
-        for name in commandNames:
-            assert name in c.commandsDict, 'unexpected command name: %s' % (
-                repr(name))
-            aSet = d.get(name)
-            aList = list(aSet)
-            aList.sort()
-            for z in exclude_strokes:
-                if z in aList:
-                    aList.remove(z)
-            for stroke in aList:
-                aList2 = d2.get(stroke)
-                assert aList2, 'stroke %s not in %s' % (
-                    repr(stroke), d2name)
-                for b in aList2:
-                    if b.commandName == name:
-                        break
-                else:
-                    if trace:
-                        inverseBindingDict = k.computeInverseBindingDict()
-                        print('%s: stroke %s not bound to %s in %s' % (
-                            p.h, repr(stroke), repr(name), d2name))
-                        print('%s: inverseBindingDict.get(%s): %s' % (
-                            p.h, name, inverseBindingDict.get(name)))
-                    else:
-                        assert False, 'stroke %s not bound to %s in %s' % (
-                            repr(stroke), repr(name), d2name)
     #@+node:ekr.20210906075242.2: *3* TestCommands.test_c_alert
     def test_c_alert(self):
         c = self.c


### PR DESCRIPTION
- [x] Delete 3 g.app.isExternalUnitTest, g.app.runningAllUnitTests, g.app.unitTestMenusDict, and g.app.unitTestGui.
- [x] Move test_all_menus_execute_the_proper_command to the attic.
    This test does nothing because unitTestMenusDict is empty!