### PR TITLE
Ekr bug 2220 base 6.4

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2035,7 +2035,11 @@ class LeoFind:
             p.setMarked()
             p.setDirty()
         if self.in_headline:  # pragma: no cover
-            p.h = self.work_s  # #2172
+            pass
+            g.trace('   p.h:', repr(p.h))
+            g.trace('work_s:', repr(self.work_s))
+            ### WRONG
+            ### p.h = self.work_s  # #2172
         else:
             c.frame.body.onBodyChanged('Change', oldSel=oldSel)
         c.frame.tree.updateIcon(p)  # redraw only the icon.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2038,6 +2038,7 @@ class LeoFind:
             pass
             g.trace('   p.h:', repr(p.h))
             g.trace('work_s:', repr(self.work_s))
+            g.trace(' gui_s:', repr(gui_w.getAllText()))
             ### WRONG
             ### p.h = self.work_s  # #2172
         else:


### PR DESCRIPTION
See #2220.

Devel, but *not* 6.4, contains a new unit test: test_change_then_find_in_headline. This test failed initially and now passes.

test-all passes in devel.  Running all unit tests in ekr-bug-2220-base-6.4 also passes.