### PR TITLE
PR: Add picture_viewer plugin

### DIFF
--- a/leo/plugins/picture_viewer.py
+++ b/leo/plugins/picture_viewer.py
@@ -5,9 +5,7 @@
 """
 A plugin for displaying slides from a folder and its subfolders.
 
-**Script**
-
-Designed to be called from a script as follows:
+Designed to be called from a script (or @command nodes) as follows:
     
     from leo.plugins.picture_viewer import Slides
     Slides().run()  # See below for defaults.


### PR DESCRIPTION
The plugin's docstring:

```rst

A plugin for displaying slides from a folder and its subfolders.

Designed to be called from a script as follows:
    
    from leo.plugins.picture_viewer import Slides
    Slides().run()  # See below for defaults.

**Key bindings**
    
Plain keys control the display of slides:
    
      space: show the next slide.
  backspace: show the previous slide.
     escape: end the slideshow
          =: zoom in
          -: zoom out
arrows keys: pan the slide
          d: prompt to move the slide to the trash
          h: show the help message
          m: move the file.

**Defaults**

The following keyword arguments may be supplied to the run method:
    
    background_color = "black",  # Default background color.
    delay = 100,  # Delay between slides, in seconds.
    extensions = ['.jpeg', '.jpg', '.png'],  # List of file extensions.
    full_screen = True,  # True: start in full-screen mode.
    height = 900,  # Window height (pixels) when not in full screen mode.
    path = None,  # If none, display a dialog.
    sort_kind = 'random',  # 'date', 'name', 'none', 'random', or 'size'
    width = 1500,  # Window width (pixels) when not un full screen mode.
```