### PR TITLE
Fix crash in 'show-stats'. Remove all references to iteritems

### DIFF
--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1792,7 +1792,7 @@ class TokenOrderGenerator:
     #@+node:ekr.20191113063144.36: *6* tog.DictComp
     # DictComp(expr key, expr value, comprehension* generators)
 
-    # d2 = {val: key for key, val in d.iteritems()}
+    # d2 = {val: key for key, val in d}
 
     def do_DictComp(self, node):
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3159,13 +3159,13 @@ def printStats(event=None, name=None):
         if not isinstance(name, str):
             name = repr(name)
     else:
-        name = g._callerName(n=2)  # Get caller name 2 levels back.
-    #
+        # Get caller name 2 levels back.
+        name = g._callerName(n=2)
     # Print the stats, organized by number of calls.
     d = g.app.statsDict
-    d2 = {val: key for key, val in d.iteritems()}
-    for key in reversed(sorted(d2.keys())):
-        print(f"{key:7} {d2.get(key)}")
+    print('g.app.statsDict...')
+    for key in reversed(sorted(d)):
+        print(f"{key:7} {d.get(key)}")
 #@+node:ekr.20031218072017.3136: *4* g.stat
 def stat(name=None):
     """Increments the statistic for name in g.app.statsDict

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1798,7 +1798,7 @@ class TestTOG(BaseTest):
     def test_DictComp(self):
         # leoGlobals.py, line 3028.
         contents = r"""\
-    d2 = {val: key for key, val in d.iteritems()}
+    d2 = {val: key for key, val in d}
     """
         self.make_data(contents)
     #@+node:ekr.20200112042410.1: *5* test_ExtSlice


### PR DESCRIPTION
```
Traceback (most recent call last):

  File "c:\leo.repo\leo-editor\leo\core\leoKeys.py", line 2474, in callAltXFunction
    func(event)

  File "c:\leo.repo\leo-editor\leo\core\leoGlobals.py", line 3166, in printStats
    d2 = {val: key for key, val in d.iteritems()}

AttributeError: 'dict' object has no attribute 'iteritems'
```