### PR TITLE
PR: Fix buglet reported by Félix

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3736,11 +3736,11 @@ class Commands:
             if p.isDirty():
                 return True
         return False
-    #@+node:ekr.20031218072017.2969: *7* c.canMarkChangedRoots (slow)
+    #@+node:ekr.20031218072017.2969: *7* c.canMarkChangedRoots
     def canMarkChangedRoots(self):
         c = self
         for p in c.all_unique_positions():
-            if p.isDirty and p.isAnyAtFileNode():
+            if p.isDirty() and p.isAnyAtFileNode():
                 return True
         return False
     #@+node:ekr.20031218072017.2990: *4* c.Selecting


### PR DESCRIPTION
Previously, c.canMarkChangedRoots would return True if c's outline contained any `@<file>` node.