### PR TITLE
Correct --reset-zoom, --verbose, --full-screen options to give desired effect.

### DIFF
--- a/leo/plugins/picture_viewer.py
+++ b/leo/plugins/picture_viewer.py
@@ -115,7 +115,7 @@ def get_args():
 
     # Parse the options, and remove them from sys.argv.
     args = parser.parse_args()
-    print(args.fullscreen)
+
     # Check and return the args.
     return {
          'background_color': args.background or "black",


### PR DESCRIPTION
argparse automatically supplies False for _store_true_ if its arg is missing, and vice-versa.  _--reset-zoom_ is intended to be True by default, so if it is included on the command line we want False returned, and if it is missing, we want True (the intended default) to be returned.  This PR corrects this condition, and also removes several `default=` parameters which are not needed and may even be in conflict with how argparse treats _store_true_ and _store_false_ parameters, thus preventing the intended function (such as full-screen).

From the Python docs:

`'store_true' and 'store_false' - These are special cases of 'store_const' used for storing the values True and False respectively. In addition, they create default values of False and True respectively`

See [argparse docs](https://docs.python.org/3.9/library/argparse.html).