### PR TITLE
PR: Clean unit tests. Other tweaks

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -46,7 +46,7 @@ from leo.core import leoGlobals as g
 @g.command('find-long-lines')
 def find_long_lines(event):
     """Report long lines in the log, with clickable links."""
-    c = event.get('c')
+    c = event and event.get('c')
     if not c:
         return
     #@+others # helper functions
@@ -98,7 +98,7 @@ def find_long_lines(event):
 @g.command('find-missing-docstrings')
 def find_missing_docstrings(event):
     """Report missing docstrings in the log, with clickable links."""
-    c = event.get('c')
+    c = event and event.get('c')
     if not c:
         return
     #@+others # Define functions
@@ -167,7 +167,7 @@ def flake8_command(event):
     if not flake8:
         g.es_print(f"{tag} can not import flake8")
         return
-    c = event.get('c')
+    c = event and event.get('c')
     if not c or not c.p:
         return
     python = sys.executable
@@ -209,7 +209,7 @@ def mypy_command(event):
 
     See leoSettings.leo for details.
     """
-    c = event.get('c')
+    c = event and event.get('c')
     if not c:
         return
     if c.isChanged():
@@ -225,7 +225,7 @@ def pyflakes_command(event):
     Run pyflakes on all nodes of the selected tree,
     or the first @<file> node in an ancestor.
     """
-    c = event.get('c')
+    c = event and event.get('c')
     if c:
         if c.isChanged():
             c.save()
@@ -244,7 +244,7 @@ def pylint_command(event):
     or the last checked @<file> node.
     """
     global last_pylint_path
-    c = event.get('c')
+    c = event and event.get('c')
     if c:
         if c.isChanged():
             c.save()

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3073,15 +3073,15 @@ class FastAtRead:
     This is Vitalije's code, edited by EKR.
     """
 
-    def __init__(self, c, gnx2vnode, test=False, TestVNode=None):
+    def __init__(self, c, gnx2vnode): ### , test=False, TestVNode=None):
         self.c = c
         assert gnx2vnode is not None
+        # The global fc.gnxDict. Keys are gnx's, values are vnodes.
         self.gnx2vnode = gnx2vnode
-            # The global fc.gnxDict. Keys are gnx's, values are vnodes.
         self.path = None
         self.root = None
-        self.VNode = TestVNode if test else leoNodes.VNode
-        self.test = test
+        ### self.VNode = TestVNode if test else leoNodes.VNode
+        ### self.test = test
     #@+others
     #@+node:ekr.20180602103135.3: *3* fast_at.get_patterns
     #@@nobeautify
@@ -3116,7 +3116,7 @@ class FastAtRead:
     def post_pass(self, gnx2body, gnx2vnode, root_v):
         """Set all body text."""
         # Set the body text.
-        if self.test:
+        if False: ### self.test:
             # Check the keys.
             bkeys = sorted(gnx2body.keys())
             vkeys = sorted(gnx2vnode.keys())
@@ -3124,8 +3124,8 @@ class FastAtRead:
                 g.trace('KEYS MISMATCH')
                 g.printObj(bkeys)
                 g.printObj(vkeys)
-                if self.test:
-                    sys.exit(1)
+                ### if self.test:
+                ###    sys.exit(1)
             # Set the body text.
             for key in vkeys:
                 v = gnx2vnode.get(key)
@@ -3196,7 +3196,7 @@ class FastAtRead:
         #
         # Init the parent vnode for testing.
         #
-        if self.test:
+        if False: ### self.test:
             # Start with the gnx for the @file node.
             root_gnx = gnx = 'root-gnx'  # The node that we are reading.
             gnx_head = '<hidden top vnode>'  # The headline of the root node.
@@ -3380,7 +3380,8 @@ class FastAtRead:
                     v.children = []
                 else:
                     # Make a new vnode.
-                    v = self.VNode(context=context, gnx=gnx)
+                    ### v = self.VNode(context=context, gnx=gnx)
+                    v = leoNodes.VNode(context=context, gnx=gnx)
                 #
                 # The last version of the body and headline wins.
                 gnx2vnode[gnx] = v

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -9,12 +9,11 @@ import textwrap
 from leo.core import leoGlobals as g
 from leo.core import leoBridge
 from leo.core.leoTest2 import LeoUnitTest
-import leo.core.leoFileCommands as leoFileCommands
 
 #@+others
 #@+node:ekr.20210901172446.1: ** class TestAtFile(LeoUnitTest)
 class TestAtFile(LeoUnitTest):
-    """Test cases for leoApp.py"""
+    """Test cases for leoAtFile.py"""
     #@+others
     #@+node:ekr.20200204095726.1: *3*  TestAtFile.bridge
     def bridge(self):
@@ -316,15 +315,16 @@ class TestAtFile(LeoUnitTest):
             child.b = '@language python\n# test #1889'
             path = g.fullPath(c, child)
             assert '~' not in path, repr(path)
-    #@+node:ekr.20210905052021.32: *3* TestAtFile.test_fast_readWithElementTree
-    def test_fast_readWithElementTree(self):
-        # Test the translation table and associated logic.
-        c = self.c
-        table = leoFileCommands.FastRead(c, {}).translate_table
-        s = chr(0) + "a" + chr(0) + "b"
-        self.assertEqual(len(s), 4)
-        s = s.translate(table)
-        self.assertEqual(len(s), 2)
+    #@-others
+#@+node:ekr.20211031085414.1: ** class TestFastAtRead(LeoUnitTest)
+class TestFastAtRead(LeoUnitTest):
+    """Test the FastAtRead class."""
+    #@+others
+    #@+node:ekr.20211031085620.1: *3*  FastAtRead.setUp
+    ###
+        # def setUp(self):
+            # super().setup()
+
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import textwrap
 from leo.core import leoGlobals as g
+from leo.core import leoAtFile
 from leo.core import leoBridge
 from leo.core.leoTest2 import LeoUnitTest
 
@@ -321,10 +322,58 @@ class TestFastAtRead(LeoUnitTest):
     """Test the FastAtRead class."""
     #@+others
     #@+node:ekr.20211031085620.1: *3*  FastAtRead.setUp
-    ###
-        # def setUp(self):
-            # super().setup()
+    def setUp(self):
+        super().setUp()
+        self.x = leoAtFile.FastAtRead(
+            self.c,
+            gnx2vnode={},
+            ### test=False,  ### Should this be true?
+            ### TestVNode=None,
+        )
 
+    #@+node:ekr.20211031093209.1: *3* FastAtRead.test_round_trip_of_sentinels_delim
+    def test_round_trip_of_sentinels_delim(self):
+
+        c, x = self.c, self.x
+        #@+<< define contents >>
+        #@+node:ekr.20211101050923.1: *4* << define contents >>
+        contents = textwrap.dedent('''\
+        # -*- coding: utf-8 -*-
+        #AT+leo-ver=5-thin
+        #AT+node:ekr.20211029054120.1: * @file c:\test\section_delims_test.py
+        #AT@first
+
+        """Classes to read and write @file nodes."""
+
+        #AT@section-delims <!< >!>
+
+        #AT+<!< test >!>
+        #AT+node:ekr.20211029054238.1: ** <!< test >!>
+        print('in test section')
+        print('done')
+        #AT-<!< test >!>
+
+        #AT+others
+        #AT+node:ekr.20211030052810.1: ** spam
+        def spam():
+        pass
+        #AT+node:ekr.20211030053502.1: ** eggs
+        def eggs():
+        pass
+        #AT-others
+
+        #AT@language python
+        #AT-leo
+        ''').replace('#AT', '#@')
+        #@-<< define contents >>
+        if '@section-delims' not in g.globalDirectiveList:
+            self.skipTest('@section-delims not supported')
+        root = c.rootPosition()
+        x.read_into_root(contents, path='test', root=root)
+        if 0: ### Not ready yet.
+            self.dump_tree()
+            s = c.atFileCommands.atFileToString(root, sentinels=True)
+            self.assertEqual(contents, s)
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoFileCommands.py
+++ b/leo/unittests/core/test_leoFileCommands.py
@@ -2,25 +2,19 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20210910065135.1: * @file ../unittests/core/test_leoFileCommands.py
 #@@first
-"""Tests of leoFileCommands.py"""
+"""
+Tests of leoFileCommands.py.
 
-from leo.core import leoGlobals as g
-import leo.core.leoApp as leoApp
+test-file-commands runs these tests.
+"""
+
+import leo.core.leoFileCommands as leoFileCommands
 from leo.core.leoTest2 import LeoUnitTest
-import leo.core.leoExternalFiles as leoExternalFiles
 
 #@+others
 #@+node:ekr.20210910065135.2: ** class TestFileCommands (LeoUnitTest)
 class TestFileCommands(LeoUnitTest):
     #@+others
-    #@+node:ekr.20210910065135.3: *3* TestFileCommands.setUp
-    def setUp(self):
-        """setUp for TestFind class"""
-        super().setUp()
-        c = self.c
-        g.app.idleTimeManager = leoApp.IdleTimeManager()
-        g.app.idleTimeManager.start()
-        g.app.externalFilesController = leoExternalFiles.ExternalFilesController(c=c)
     #@+node:ekr.20210909194336.24: *3* TestFileCommands.test_fc_resolveArchivedPosition
     def test_fc_resolveArchivedPosition(self):
         c, root = self.c, self.root_p
@@ -100,6 +94,15 @@ class TestFileCommands(LeoUnitTest):
         s = fc.putUnknownAttributes(p.v)
         expected = ' unit_test="58040000006162636471002e"'
         self.assertEqual(s, expected)
+    #@+node:ekr.20210905052021.32: *3* TestFileCommands.test_fast_readWithElementTree
+    def test_fast_readWithElementTree(self):
+        # Test the translation table and associated logic.
+        c = self.c
+        table = leoFileCommands.FastRead(c, {}).translate_table
+        s = chr(0) + "a" + chr(0) + "b"
+        self.assertEqual(len(s), 4)
+        s = s.translate(table)
+        self.assertEqual(len(s), 2)
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
A bit of a catch-all. Preliminary to an upcoming PR to cover the FastAtRead class.

- [x] Move test_fast_readWithElementTree to TestFileCommands class.
- [x] Delete TestFileCommands.setUp.
- [x] Disable test code in FastAtRead class.
- [x] Add guards for conversion methods.