### PR TITLE
PR for #2316: remove test code from leoImport.py

### DIFF
--- a/leo/commands/testCommands.py
+++ b/leo/commands/testCommands.py
@@ -191,7 +191,7 @@ def test_checker_commands(event=None):
 @g.command('test-colorizer')
 def test_colorizer(event=None):
     """Run all unit tests for leoColorizer.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoColorizer.TestColorizer')
+    g.run_unit_tests('leo.unittests.core.test_leoColorizer')
 #@+node:ekr.20211013080906.1: *3* test-convert
 @g.command('test-convert')
 def test_convert(event=None):
@@ -207,7 +207,7 @@ def test_commands(event=None):
 @g.command('test-config')
 def test_config(event=None):
     """Run all unit tests for leoConfig.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoConfig.TestConfig')
+    g.run_unit_tests('leo.unittests.core.test_leoConfig')
 #@+node:ekr.20210926051147.1: *3* test-doctests
 @g.command('test-doctests')
 def test_doctests(event=None):
@@ -217,7 +217,7 @@ def test_doctests(event=None):
 @g.command('test-edit-commands')
 def test_edit_commands(event=None):
     """Run all unit tests for leo.commands.editCommands."""
-    g.run_unit_tests('leo.unittests.commands.test_editCommands.TestEditCommands')
+    g.run_unit_tests('leo.unittests.commands.test_editCommands')
 #@+node:ekr.20210907103024.20: *3* test-external-files
 @g.command('test-external-files')
 def test_external_files(event=None):
@@ -227,27 +227,27 @@ def test_external_files(event=None):
 @g.command('test-file-commands')
 def test_file_commands(event=None):
     """Run all unit tests for leoFileCommands.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoFileCommands.TestFileCommands')
+    g.run_unit_tests('leo.unittests.core.test_leoFileCommands')
 #@+node:ekr.20210907103024.21: *3* test-find
 @g.command('test-find')
 def test_find(event=None):
     """Run all unit tests for leoFind.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoFind.TestFind')
+    g.run_unit_tests('leo.unittests.core.test_leoFind.')
 #@+node:ekr.20210907103024.22: *3* test-frame
 @g.command('test-frame')
 def test_frame(event=None):
     """Run all unit tests for leoFrame.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoFrame.TestFrame')
+    g.run_unit_tests('leo.unittests.core.test_leoFrame')
 #@+node:ekr.20210907103024.23: *3* test-globals
 @g.command('test-globals')
 def test_globals(event=None):
     """Run all unit tests for leoGlobals.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoGlobals.TestGlobals')
+    g.run_unit_tests('leo.unittests.core.test_leoGlobals')
 #@+node:ekr.20210907103024.24: *3* test-import
 @g.command('test-import')
 def test_import(event=None):
     """Run all unit tests for leoImport.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoImport.TestImporter')
+    g.run_unit_tests('leo.unittests.core.test_leoImport')
 #@+node:ekr.20210907103024.25: *3* test-keys
 @g.command('test-keys')
 def test_keys(event=None):
@@ -257,7 +257,7 @@ def test_keys(event=None):
 @g.command('test-leoserver')
 def test_leoserver(event=None):
     """Run all unittests for leoserver.py"""
-    g.run_unit_tests('leo.unittests.core.test_leoserver.TestLeoServer')
+    g.run_unit_tests('leo.unittests.core.test_leoserver')
 #@+node:ekr.20210907103024.10: *3* test-leoserver-with-leoclient
 @g.command('test-leoserver-with-leoclient')
 def test_leo_client_and_server(event=None):
@@ -278,42 +278,42 @@ def test_leo_client_and_server(event=None):
 @g.command('test-nodes')
 def test_nodes(event=None):
     """Run all unit tests for leoNodes.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoNodes.TestNodes')
+    g.run_unit_tests('leo.unittests.core.test_leoNodes')
 #@+node:ekr.20210909091424.1: *3* test-persistence
 @g.command('test-persistence')
 def test_persistence(event=None):
     """Run all unit tests for leoPersistence.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoPersistence.TestPersistence')
+    g.run_unit_tests('leo.unittests.core.test_leoPersistence')
 #@+node:ekr.20210907103024.27: *3* test-plugins
 @g.command('test-plugins')
 def test_plugins(event=None):
     """Run all unit tests relating to plugins."""
-    g.run_unit_tests('leo.unittests.test_plugins.TestPlugins')
+    g.run_unit_tests('leo.unittests.test_plugins')
 #@+node:ekr.20210907103024.28: *3* test-rst
 @g.command('test-rst')
 def test_rst3(event=None):
     """Run all unit tests for leoRst.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoRst.TestRst')
+    g.run_unit_tests('leo.unittests.core.test_leoRst')
 #@+node:ekr.20210907103024.30: *3* test-shadow
 @g.command('test-shadow')
 def test_shadow(event=None):
     """Run all unit tests for leoShadow.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoShadow.TestAtShadow')
+    g.run_unit_tests('leo.unittests.core.test_leoShadow')
 #@+node:ekr.20210907103024.31: *3* test-syntax
 @g.command('test-syntax')
 def test_syntax(event=None):
     """Run all testss in test_syntax.py."""
-    g.run_unit_tests('leo.unittests.test_syntax.TestSyntax')
+    g.run_unit_tests('leo.unittests.test_syntax')
 #@+node:ekr.20210907103024.32: *3* test-undo
 @g.command('test-undo')
 def test_undo(event=None):
     """Run all unit tests for leoUndo.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoUndo.TestUndo')
+    g.run_unit_tests('leo.unittests.core.test_leoUndo')
 #@+node:ekr.20210910073036.1: *3* test-vim
 @g.command('test-vim')
 def test_vim(event=None):
     """Run all unit tests for leoVim.py."""
-    g.run_unit_tests('leo.unittests.core.test_leoVim.TestVim')
+    g.run_unit_tests('leo.unittests.core.test_leoVim')
 #@+node:ekr.20210910085337.1: *3* test_gui
 @g.command('test-gui')
 def test_gui(event=None):

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1197,36 +1197,6 @@ class LeoImportCommands:
             return obj.run(s, parent, parse_body=True)
 
         return body_parser_for_class if aClass else None
-    #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def textUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.txt')
-
-    def typeScriptUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.ts')
-    #@+node:ekr.20070713082220: *4* ic.scannerUnitTest (uses GeneralTestCase)
-    def scannerUnitTest(self, p, s, ext):
-        """
-        Run a unit test of an import scanner,
-        i.e., create a tree from string s at location p.
-        """
-        assert ext, g.callers()
-        self.treeType = '@file'  # Fix #352.
-        fileName = 'test'
-        # Run the test.
-        parent = p.insertAsLastChild()
-        kind = self.compute_unit_test_kind(ext)
-        parent.h = f"{kind} {fileName}"
-        self.createOutline(parent=parent.copy(), ext=ext, s=s)
-    #@+node:ekr.20170405201254.1: *5* ic.compute_unit_test_kind
-    def compute_unit_test_kind(self, ext):
-        """Return kind from the given extention."""
-        aClass = g.app.classDispatchDict.get(ext)
-        if aClass:
-            d2 = g.app.atAutoDict
-            for z in d2:
-                if d2.get(z) == aClass:
-                    return z
-        return '@file'
     #@+node:ekr.20031218072017.3305: *3* ic.Utilities
     #@+node:ekr.20090122201952.4: *4* ic.appendStringToBody & setBodyString (leoImport)
     def appendStringToBody(self, p, s):

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def cythonUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.pyx')
-
     def ctextUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.txt')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1201,9 +1201,6 @@ class LeoImportCommands:
     def ctextUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.txt')
 
-    def dartUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.dart')
-
     def elispUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.el')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def pythonUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.py')
-
     def textUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.txt')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1237,9 +1237,6 @@ class LeoImportCommands:
     def javaScriptUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.js')
 
-    def markdownUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.md')
-
     def orgUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.org')
 
@@ -1257,9 +1254,6 @@ class LeoImportCommands:
 
     def pythonUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.py')
-
-    def rstUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.rst')
 
     def textUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.txt')

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def otlUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.otl')
-
     def pascalUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.pas')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def orgUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.org')
-
     def otlUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.otl')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def javaUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.java')
-
     def javaScriptUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.js')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def cSharpUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.c#')
-
     def cythonUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.pyx')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,12 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def perlUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.pl')
-
-    def phpUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.php')
-
     def pythonUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.py')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1225,9 +1225,6 @@ class LeoImportCommands:
         c.config.set(p, 'data', 'import-html-tags', tags_list, warn=True)
         self.scannerUnitTest(p, s, ext='.htm')
 
-    def iniUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.ini')
-
     def javaUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.java')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,20 +1198,8 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def ctextUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.txt')
-
     def elispUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.el')
-
-    def htmlUnitTest(self, p, s):
-        c = self.c
-        # Simulate @data import-html-tags, with *only* standard tags.
-        tags_list = ['html', 'body', 'head', 'div', 'table']
-        settingsDict, junk = g.app.loadManager.createDefaultSettingsDicts()
-        c.config.settingsDict = settingsDict
-        c.config.set(p, 'data', 'import-html-tags', tags_list, warn=True)
-        self.scannerUnitTest(p, s, ext='.htm')
 
     def javaUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.java')
@@ -1242,18 +1230,6 @@ class LeoImportCommands:
 
     def typeScriptUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.ts')
-
-    def xmlUnitTest(self, p, s):
-        c = self.c
-        # Simulate @data import-xml-tags with *only* standard tags.
-        tags_list = ['html', 'body', 'head', 'div', 'table']
-        settingsDict, junk = g.app.loadManager.createDefaultSettingsDicts()
-        c.config.settingsDict = settingsDict
-        c.config.set(p, 'data', 'import-xml-tags', tags_list, warn=True)
-        self.scannerUnitTest(p, s, ext='.xml')
-
-    def defaultImporterUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.xxx')
     #@+node:ekr.20070713082220: *4* ic.scannerUnitTest (uses GeneralTestCase)
     def scannerUnitTest(self, p, s, ext):
         """

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def elispUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.el')
-
     def javaUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.java')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1201,9 +1201,6 @@ class LeoImportCommands:
     def cythonUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.pyx')
 
-    def coffeeScriptUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.coffee')
-
     def ctextUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.txt')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def cUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.c')
-
     def cSharpUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.c#')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def pascalUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.pas')
-
     def perlUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.pl')
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1198,9 +1198,6 @@ class LeoImportCommands:
 
         return body_parser_for_class if aClass else None
     #@+node:ekr.20070713075450: *3* ic.Unit tests
-    def javaScriptUnitTest(self, p, s):
-        self.scannerUnitTest(p, s, ext='.js')
-
     def orgUnitTest(self, p, s):
         self.scannerUnitTest(p, s, ext='.org')
 

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -6897,7 +6897,7 @@ def convert_node(self, c, p, target):
     result.append(f"{indent}self.runTest(before, after, i, j, func)\n")
     # Set the body text!
     test_node.b = ''.join(result)
-#@+node:ekr.20070713082220: *3* ic.scannerUnitTest (uses GeneralTestCase)
+#@+node:ekr.20070713082220: *3* ic.scannerUnitTest
 def scannerUnitTest(self, p, s, ext):
     """
     Run a unit test of an import scanner,

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -6897,6 +6897,30 @@ def convert_node(self, c, p, target):
     result.append(f"{indent}self.runTest(before, after, i, j, func)\n")
     # Set the body text!
     test_node.b = ''.join(result)
+#@+node:ekr.20070713082220: *3* ic.scannerUnitTest (uses GeneralTestCase)
+def scannerUnitTest(self, p, s, ext):
+    """
+    Run a unit test of an import scanner,
+    i.e., create a tree from string s at location p.
+    """
+    assert ext, g.callers()
+    self.treeType = '@file'  # Fix #352.
+    fileName = 'test'
+    # Run the test.
+    parent = p.insertAsLastChild()
+    kind = self.compute_unit_test_kind(ext)
+    parent.h = f"{kind} {fileName}"
+    self.createOutline(parent=parent.copy(), ext=ext, s=s)
+#@+node:ekr.20170405201254.1: *4* ic.compute_unit_test_kind
+def compute_unit_test_kind(self, ext):
+    """Return kind from the given extention."""
+    aClass = g.app.classDispatchDict.get(ext)
+    if aClass:
+        d2 = g.app.atAutoDict
+        for z in d2:
+            if d2.get(z) == aClass:
+                return z
+    return '@file'
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,137 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122909.1: *3* Perl tests
-    #@+node:ekr.20210904065459.51: *4* TestImport.test_perl_1
-    def test_perl_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            #!/usr/bin/perl
-
-            # Function definition
-            sub Hello{
-               print "Hello, World!\n";
-            }
-
-            sub Test{
-               print "Test!\n";
-            }
-            "\N{LATIN SMALL LIGATURE FI}" =~ /fi/i;
-
-            $bar = "foo";
-            if ($bar =~ /foo/){
-               print "Second time is matching\n";
-            }else{
-               print "Second time is not matching\n";
-            }
-
-            # Function call
-            Hello();
-        """)
-        c.importCommands.perlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.52: *4* TestImport.test_perlpod_comment
-    def test_perlpod_comment(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            #!/usr/bin/perl
-
-            sub Test{
-               print "Test!\n";
-            }
-
-            =begin comment
-            sub World {
-                print "This is not a funtion!"
-            }
-            =cut
-
-            # Function definition
-            sub Hello{
-               print "Hello, World!\n";
-            }
-        """)
-        c.importCommands.perlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.53: *4* TestImport.test_perl_multi_line_string
-    def test_perl_multi_line_string(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            #!/usr/bin/perl
-
-            # This would print with a line break in the middle
-            print "Hello
-
-            sub World {
-                print "This is not a funtion!"
-            }
-
-            world\n";
-        """)
-        c.importCommands.perlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.54: *4* TestImport.test_perl_regex_1
-    def test_perl_regex_1(self):
-        c = self.c
-        # ('len',   'tr///', '/',       context,  0,       0,       0),
-        # ('len',   's///',  '/',       context,  0,       0,       0),
-        # ('len',   'm//',   '/',       context,  0,       0,       0),
-        # ('len',   '/',     '/',       '',       0,       0,       0),
-        s = textwrap.dedent("""\
-            #!/usr/bin/perl
-
-            sub test1 {
-                s = /{/g;
-            }
-
-            sub test2 {
-                s = m//{/;
-            }
-
-            sub test3 {
-                s = s///{/;
-            }
-
-            sub test4 {
-                s = tr///{/;
-            }
-        """)
-        c.importCommands.perlUnitTest(c.p, s=s)
-
-    #@+node:ekr.20210904065459.55: *4* TestImport.test_perl_regex_2
-    def test_perl_regex_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            #!/usr/bin/perl
-
-            sub test1 {
-                s = /}/g;
-            }
-
-            sub test2 {
-                s = m//}/;
-            }
-
-            sub test3 {
-                s = s///}/;
-            }
-
-            sub test4 {
-                s = tr///}/;
-            }
-        """)
-        table = (
-            'sub test1',
-            'sub test2',
-            'sub test3',
-            'sub test4'
-        )
-        c.importCommands.perlUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-
     #@+node:ekr.20210904122920.1: *3* PHP tests
     #@+node:ekr.20210904065459.56: *4* TestImport.test_php_import_class
     def test_php_import_class(self):
@@ -4115,6 +3984,143 @@ class TestPascal (BaseTestImporter):
         self.assertEqual(root.h, '@file test')
         p2 = root.firstChild()
         for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+
+    #@-others
+#@+node:ekr.20211108081950.1: ** class TestPerl (BaseTestImporter)
+class TestPerl (BaseTestImporter):
+    
+    ext = '.pl'
+    
+    #@+others
+    #@+node:ekr.20210904065459.51: *3* TestPerl.test_1
+    def test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            #!/usr/bin/perl
+
+            # Function definition
+            sub Hello{
+               print "Hello, World!\n";
+            }
+
+            sub Test{
+               print "Test!\n";
+            }
+            "\N{LATIN SMALL LIGATURE FI}" =~ /fi/i;
+
+            $bar = "foo";
+            if ($bar =~ /foo/){
+               print "Second time is matching\n";
+            }else{
+               print "Second time is not matching\n";
+            }
+
+            # Function call
+            Hello();
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.53: *3* TestPerl.test_multi_line_string
+    def test_multi_line_string(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            #!/usr/bin/perl
+
+            # This would print with a line break in the middle
+            print "Hello
+
+            sub World {
+                print "This is not a funtion!"
+            }
+
+            world\n";
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.52: *3* TestPerl.test_perlpod_comment
+    def test_perlpod_comment(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            #!/usr/bin/perl
+
+            sub Test{
+               print "Test!\n";
+            }
+
+            =begin comment
+            sub World {
+                print "This is not a funtion!"
+            }
+            =cut
+
+            # Function definition
+            sub Hello{
+               print "Hello, World!\n";
+            }
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.54: *3* TestPerl.test_regex_1
+    def test_regex_1(self):
+        c = self.c
+        # ('len',   'tr///', '/',       context,  0,       0,       0),
+        # ('len',   's///',  '/',       context,  0,       0,       0),
+        # ('len',   'm//',   '/',       context,  0,       0,       0),
+        # ('len',   '/',     '/',       '',       0,       0,       0),
+        s = textwrap.dedent("""\
+            #!/usr/bin/perl
+
+            sub test1 {
+                s = /{/g;
+            }
+
+            sub test2 {
+                s = m//{/;
+            }
+
+            sub test3 {
+                s = s///{/;
+            }
+
+            sub test4 {
+                s = tr///{/;
+            }
+        """)
+        self.run_test(c.p, s)
+
+    #@+node:ekr.20210904065459.55: *3* TestPerl.test_regex_2
+    def test_regex_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            #!/usr/bin/perl
+
+            sub test1 {
+                s = /}/g;
+            }
+
+            sub test2 {
+                s = m//}/;
+            }
+
+            sub test3 {
+                s = s///}/;
+            }
+
+            sub test4 {
+                s = tr///}/;
+            }
+        """)
+        table = (
+            'sub test1',
+            'sub test2',
+            'sub test3',
+            'sub test4'
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -20,9 +20,9 @@ import leo.plugins.importers.pascal as pascal
 import leo.plugins.importers.python as python
 import leo.plugins.importers.xml as xml
 #@+others
-#@+node:ekr.20210904064440.3: **  class TestImporter(LeoUnitTest)
-class TestImporter(LeoUnitTest):
-    """Test cases for leoImport.py"""
+#@+node:ekr.20210904064440.3: ** class BaseTestImporter(LeoUnitTest)
+class BaseTestImporter(LeoUnitTest):
+    """The base class for tests of leoImport.py"""
     
     def setUp(self):
         super().setUp()
@@ -44,7 +44,7 @@ class TestImporter(LeoUnitTest):
         c.importCommands.createOutline(parent=parent.copy(), ext=ext, s=s)
 
     #@+others
-    #@+node:ekr.20211108044605.1: *3*  TestImporter.compute_unit_test_kind
+    #@+node:ekr.20211108044605.1: *3*  BaseTestImporter.compute_unit_test_kind
     def compute_unit_test_kind(self, ext):
         """Return kind from the given extention."""
         aClass = g.app.classDispatchDict.get(ext)
@@ -55,8 +55,8 @@ class TestImporter(LeoUnitTest):
                     return z
         return '@file'
     #@-others
-#@+node:ekr.20211108052633.1: ** class TempImporterTest (TestImporter)
-class TempImporterTest (TestImporter):
+#@+node:ekr.20211108052633.1: ** class TempImporterTest (BaseTestImporter)
+class TempImporterTest (BaseTestImporter):
     
     #@+others  ### To be moved to other classes.
     #@+node:ekr.20210904065613.1: *3* Tests of @auto
@@ -383,11 +383,10 @@ class TempImporterTest (TestImporter):
             'buildCoffee = (str) ->',
         )
         c.importCommands.coffeeScriptUnitTest(c.p, s=s)
-        if 1:
-          p2 = c.p.firstChild().firstChild()
-          for h in table:
-              self.assertEqual(p2.h, h)
-              p2.moveToThreadNext()
+        p2 = c.p.firstChild().firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
     #@+node:ekr.20210904065459.16: *5* TestImport.test_coffeescript_3
     #@@tabwidth -2 # Required
 
@@ -432,11 +431,10 @@ class TempImporterTest (TestImporter):
           'body: (node, opts={}) ->',
         )
         c.importCommands.coffeeScriptUnitTest(c.p, s=s)
-        if 1:
-          p2 = c.p.firstChild().firstChild()
-          for h in table:
-              self.assertEqual(p2.h, h)
-              p2.moveToThreadNext()
+        p2 = c.p.firstChild().firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
     #@+node:ekr.20210904084324.1: *4* Cython tests
     #@+node:ekr.20210904065459.11: *5* TestImport.test_cython_importer
     def test_cython_importer(self):
@@ -3899,9 +3897,10 @@ class TempImporterTest (TestImporter):
         importer = python.Py_Importer(c.importCommands, atAuto=True)
         importer.test_scan_state(tests, State)
     #@-others
-#@+node:ekr.20211108043230.1: ** class TestMarkdown(TestImporter)
-class TestMarkdown(TestImporter):
-    
+#@+node:ekr.20211108043230.1: ** class TestMarkdown(BaseTestImporter)
+class TestMarkdown(BaseTestImporter):
+
+    # pylint: disable=arguments-differ
     def run_test(self, p, s):
         super().run_test(p, s, ext='.md')
     
@@ -4114,9 +4113,10 @@ class TestMarkdown(TestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
-#@+node:ekr.20211108050827.1: ** class TestRst(TestImporter)
-class TestRst(TestImporter):
+#@+node:ekr.20211108050827.1: ** class TestRst(BaseTestImporter)
+class TestRst(BaseTestImporter):
     
+    # pylint: disable=arguments-differ
     def run_test(self, p, s):
         super().run_test(p, s, ext='.rst')
     

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,1858 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122944.1: *3* Python tests
-    #@+node:ekr.20210904065459.60: *4* TestImport.test_i_scan_state_for_python_
-    def test_i_scan_state_for_python_(self):
-        c = self.c
-        # A list of dictionaries.
-        tests = (
-            g.Bunch(line='\n'),
-            g.Bunch(line='\\\n'),
-            g.Bunch(line='s = "\\""', ctx=('', '')),  # empty string.
-            g.Bunch(line="s = '\\''", ctx=('', '')),  # empty string.
-            g.Bunch(line='# comment'),
-            g.Bunch(line='  # comment'),
-            g.Bunch(line='    # comment'),
-            g.Bunch(line='a = "string"'),
-            g.Bunch(line='a = "Continued string', ctx=('', '"')),
-            g.Bunch(line='end of continued string"', ctx=('"', '')),
-            g.Bunch(line='a = """Continued docstring', ctx=('', '"""')),
-            g.Bunch(line='a = """#', ctx=('', '"""')),
-            g.Bunch(line='end of continued string"""', ctx=('"""', '')),
-            g.Bunch(line="a = '''Continued docstring", ctx=('', "'''")),
-            g.Bunch(line="end of continued string'''", ctx=("'''", '')),
-            g.Bunch(line='a = {[(')
-        )
-        importer = python.Py_Importer(c.importCommands)
-        importer.test_scan_state(tests, State=python.Python_ScanState)
-    #@+node:ekr.20210904065459.61: *4* TestImport.test_leoApp_fail
-    def test_leoApp_fail(self):
-        c = self.c
-        s = textwrap.dedent('''
-            def isValidPython(self):
-                if sys.platform == 'cli':
-                    return True
-                minimum_python_version = '2.6'
-                message = """\
-            Leo requires Python %s or higher.
-            You may download Python from
-            http://python.org/download/
-            """ % minimum_python_version
-                try:
-                    version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
-                    ok = g.CheckVersion(version, minimum_python_version)
-                    if not ok:
-                        print(message)
-                        try:
-                            # g.app.gui does not exist yet.
-                            import Tkinter as Tk
-                            class EmergencyDialog(object):
-                                def run(self):
-                                    """Run the modal emergency dialog."""
-                                    self.top.geometry("%dx%d%+d%+d" % (300, 200, 50, 50))
-                                    self.top.lift()
-                                    self.top.grab_set() # Make the dialog a modal dialog.
-                                    self.root.wait_window(self.top)
-                            d = EmergencyDialog(
-                                title='Python Version Error',
-                                message=message)
-                            d.run()
-                        except Exception:
-                            pass
-                    return ok
-                except Exception:
-                    print("isValidPython: unexpected exception: g.CheckVersion")
-                    traceback.print_exc()
-                    return 0
-            def loadLocalFile(self, fn, gui, old_c):
-                trace = (False or g.trace_startup) and not g.unitTesting
-        ''')
-        table = (
-            (1, 'isValidPython'),
-            # (2, 'class EmergencyDialog'),
-            # (3, 'run'),
-            (1, 'loadLocalFile'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-
-    #@+node:ekr.20210904065459.62: *4* TestImport.test_python_bad_class_test
-    def test_python_bad_class_test(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class testClass1 # no colon
-                pass
-
-            def spam():
-                pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.63: *4* TestImport.test_python_basic_nesting_test
-    def test_python_basic_nesting_test(self):
-        c = self.c
-        # Was unittest/at_auto-unit-test.py
-        s = textwrap.dedent("""\
-            class class1:
-                def class1_method1():
-                    pass
-                def class1_method2():
-                    pass
-                # After @others in child1.
-            class class2:
-                def class2_method1():
-                    pass
-                def class2_method2():
-                    pass
-            # last line
-        """)
-        table = (
-            (1, 'class class1'),
-            (2, 'class1_method1'),
-            (2, 'class1_method2'),
-            (1, 'class class2'),
-            (2, 'class2_method1'),
-            (2, 'class2_method2'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-
-    #@+node:ekr.20210904065459.64: *4* TestImport.test_python_bug_346
-    def test_python_bug_346(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            import sys
-
-            if sys.version_info[0] >= 3:
-                exec_ = eval('exec')
-            else:
-                def exec_(_code_, _globs_=None, _locs_=None):
-                    """Execute code in a namespace."""
-                    if _globs_ is None:
-                        frame = sys._getframe(1)
-                        _globs_ = frame.f_globals
-                        if _locs_ is None:
-                            _locs_ = frame.f_locals
-                        del frame
-                    elif _locs_ is None:
-                        _locs_ = _globs_
-                    exec("""exec _code_ in _globs_, _locs_""")
-
-            def make_parser():
-
-                parser = argparse.ArgumentParser(
-                    description="""Raster calcs. with GDAL.
-                    The first --grid defines the projection, extent, cell size, and origin
-                    for all calculations, all other grids are transformed and resampled
-                    as needed to match.""",
-                    formatter_class=argparse.ArgumentDefaultsHelpFormatter
-            )
-        ''')
-        table = (
-            (1, 'Declarations'),
-            (1, 'make_parser'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.65: *4* TestImport.test_python_bug_354
-    def test_python_bug_354(self):
-        c = self.c
-        s = """
-        if isPython3:
-            def u(s):
-                '''Return s, converted to unicode from Qt widgets.'''
-                return s
-
-            def ue(s, encoding):
-                return s if g.isUnicode(s) else str(s, encoding)
-        else:
-            def u(s):
-                '''Return s, converted to unicode from Qt widgets.'''
-                return builtins.unicode(s) # Suppress pyflakes complaint.
-
-            def ue(s, encoding):
-                return builtins.unicode(s, encoding)
-        """
-        table = (
-            (1, 'Declarations'),
-            # (1, 'u'),
-            # (1, 'ue'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.66: *4* TestImport.test_python_bug_357
-    def test_python_bug_357(self):
-        c = self.c
-        s = textwrap.dedent('''
-            """
-            sheet_stats.py - report column stats for spreadsheets
-
-            requires openpyxl and numpy
-
-            Terry N. Brown, terrynbrown@gmail.com, Fri Dec 16 13:20:47 2016
-            2016-12-26 Henry Helgen added average, variance, standard deviation,
-                                    coefficient of variation to output
-            2016-12-23 Henry Helgen updated to Python 3.5 syntax including print() and
-                                    writer = csv.writer(open(opt.output, 'w', newline=''))
-            """
-
-            import csv
-            import argparse
-            import glob
-            import multiprocessing
-            import os
-            import sys
-            from collections import namedtuple
-            from math import sqrt, isnan
-            NAN = float('NAN')
-
-            from openpyxl import load_workbook
-
-            PYTHON_2 = sys.version_info[0] < 3
-            if not PYTHON_2:
-                unicode = str
-
-            class AttrDict(dict):
-                """allow d.attr instead of d['attr']
-                http://stackoverflow.com/a/14620633
-                """
-                def __init__(self, *args, **kwargs):
-                    super(AttrDict, self).__init__(*args, **kwargs)
-                    self.__dict__ = self
-
-            FIELDS = [  # fields in outout table
-                'file', 'field', 'n', 'blank', 'bad', 'min', 'max', 'mean', 'std',
-                'sum', 'sumsq', 'variance', 'coefvar'
-            ]
-            def make_parser():
-                """build an argparse.ArgumentParser, don't call this directly,
-                   call get_options() instead.
-                """
-                parser = argparse.ArgumentParser(
-                    description="""Report column stats for spreadsheets""",
-                    formatter_class=argparse.ArgumentDefaultsHelpFormatter
-                )
-
-                parser.add_argument('files', type=str, nargs='+',
-                    help="Files to process, '*' patterns expanded."
-                )
-
-                required_named = parser.add_argument_group('required named arguments')
-
-                required_named.add_argument("--output",
-                    help="Path to .csv file for output, will be overwritten",
-                    metavar='FILE'
-                )
-
-                return parser
-
-            def get_options(args=None):
-                """
-                get_options - use argparse to parse args, and return a
-                argparse.Namespace, possibly with some changes / expansions /
-                validatations.
-
-                Client code should call this method with args as per sys.argv[1:],
-                rather than calling make_parser() directly.
-
-                :param [str] args: arguments to parse
-                :return: options with modifications / validations
-                :rtype: argparse.Namespace
-                """
-                opt = make_parser().parse_args(args)
-
-                # modifications / validations go here
-
-                if not opt.output:
-                    print("No --output supplied")
-                    exit(10)
-
-                return opt
-
-            def get_aggregate(psumsqn, psumn, pcountn):
-                """
-                get_aggregate - compute mean, variance, standard deviation,
-                coefficient of variation This function is used instead of
-                numpy.mean, numpy.var, numpy.std since the sum, sumsq, and count are
-                available when the function is called. It avoids an extra pass
-                through the list.
-
-                # note pcountn means the full list n,  not a sample n - 1
-
-                :param sum of squares, sum, count
-                :return: a tuple of floats mean, variance, standard deviation, coefficient of variation
-                """
-
-                Agg = namedtuple("Agg", "mean variance std coefvar")
-
-                # validate inputs check for count == 0
-                if pcountn == 0:
-                    result = Agg(NAN, NAN, NAN, NAN)
-                else:
-
-                    mean = psumn / pcountn # mean
-
-                    # compute variance from sum squared without knowing mean while summing
-                    variance = (psumsqn - (psumn * psumn) / pcountn ) / pcountn
-
-                    #compute standard deviation
-                    if variance < 0:
-                        std = NAN
-                    else:
-                        std = sqrt(variance)
-
-                    # compute coefficient of variation
-                    if mean == 0:
-                        coefvar = NAN
-                    else:
-                        coefvar = std / mean
-
-                    result = Agg(mean, variance, std, coefvar)
-
-                return result
-
-
-            def proc_file(filepath):
-                """
-                proc_file - process one .xlsx file
-
-                :param str filepath: path to file
-                :return: list of lists, rows of info. as expected in main()
-                """
-
-                print(filepath)
-
-                # get the first sheet
-                book = load_workbook(filename=filepath, read_only=True)
-                sheets = book.get_sheet_names()
-                sheet = book[sheets[0]]
-                row_source = sheet.rows
-                row0 = next(row_source)
-                # get field names from the first row
-                fields = [i.value for i in row0]
-
-                data = {
-                    'filepath': filepath,
-                    'fields': {field:AttrDict({f:0 for f in FIELDS}) for field in fields}
-                }
-
-                for field in fields:
-                    # init. mins/maxs with invalid value for later calc.
-                    data['fields'][field].update(dict(
-                        min=NAN,
-                        max=NAN,
-                        field=field,
-                        file=filepath,
-                    ))
-
-                rows = 0
-                for row in row_source:
-
-                    if rows % 1000 == 0:  # feedback every 1000 rows
-                        print(rows)
-                        # Much cleaner to exit by creating a file called "STOP" in the
-                        # local directory than to try and use Ctrl-C, when using
-                        # multiprocessing.  Save time by checking only every 1000 rows.
-                        if os.path.exists("STOP"):
-                            return
-
-                    rows += 1
-
-                    for cell_n, cell in enumerate(row):
-                        d = data['fields'][fields[cell_n]]
-                        if cell.value is None or unicode(cell.value).strip() == '':
-                            d.blank += 1
-                        else:
-                            try:
-                                x = float(cell.value)
-                                d.sum += x
-                                d.sumsq += x*x
-                                d.n += 1
-                                # min is x if no value seen yet, else min(prev-min, x)
-                                if isnan(d.min):
-                                    d.min = x
-                                else:
-                                    d.min = min(d.min, x)
-                                # as for min
-                                if isnan(d.max):
-                                    d.max = x
-                                else:
-                                    d.max = max(d.max, x)
-                            except ValueError:
-                                d.bad += 1
-
-                assert sum(d.n+d.blank+d.bad for d in data['fields'].values()) == rows * len(fields)
-
-                # compute the derived values
-                for field in data['fields']:
-                    d = data['fields'][field]
-                    d.update(get_aggregate(d.sumsq, d.sum, d.n)._asdict().items())
-
-                return data
-            def get_answers(opt=None, **kwargs):
-                """get_answers - process files
-
-                :param argparse.Namespace opt: options
-                :return: list of answers from proc_file
-                """
-
-                if opt is None:  # API call rather than command line
-                    opt = type("opt", (), kwargs)
-
-                # pass filenames through glob() to expand "2017_*.xlsx" etc.
-                files = []
-                for filepath in opt.files:
-                    files.extend(glob.glob(filepath))
-
-                # create a pool of processors
-                pool = multiprocessing.Pool(multiprocessing.cpu_count()-1)
-
-                # process file list with processor pool
-                return pool.map(proc_file, files)
-            def get_table_rows(answers):
-                """get_table_rows - generator - convert get_answers() output to table format
-
-                :param list answers: output from get_answers()
-                :return: list of rows suitable for csv.writer
-                """
-                yield FIELDS
-                for answer in answers:
-                    for field in answer['fields']:
-                        row = [answer['fields'][field][k] for k in FIELDS]
-                        if PYTHON_2:
-                            yield [unicode(col).encode('utf-8') for col in row]
-                        else:
-                            yield row
-
-            def main():
-                """main() - when invoked directly"""
-                opt = get_options()
-
-                # csv.writer does its own EOL handling,
-                # see https://docs.python.org/3/library/csv.html#csv.reader
-                if PYTHON_2:
-                    output = open(opt.output, 'wb')
-                else:
-                    output = open(opt.output, 'w', newline='')
-
-                with output as out:
-                    writer = csv.writer(out)
-                    for row in get_table_rows(get_answers(opt)):
-                        writer.writerow(row)
-
-            if __name__ == '__main__':
-                main()
-        ''')
-        table = (
-            (1, "Declarations"),
-            (1, "class AttrDict(dict)"),
-            (2, "__init__"),
-            (1, "make_parser"),
-            (1, "get_options"),
-            (1, "get_aggregate"),
-            (1, "proc_file"),
-            (1, "get_answers"),
-            (1, "get_table_rows"),
-            (1, "main"),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        assert root
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            assert p, h
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.67: *4* TestImport.test_python_bug_360
-    def test_python_bug_360(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            @base_task(
-                targets=['img/who_map.png', 'img/who_map.pdf'],
-                file_dep=[data_path('phyto')],
-                task_dep=['load_data'],
-            )
-            def make_map():
-                '''make_map - plot the Thompson / Bartsh / WHO map'''
-        """)
-        table = (
-            (1, '@base_task make_map'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.68: *4* TestImport.test_python_bug_390
-    def test_python_bug_390(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            import sys
-
-            class Foo():
-                pass
-
-            a = 2
-
-            def main(self):
-                pass
-
-            if __name__ == '__main__':
-                main()
-        """)
-        table = (
-            (1, 'Declarations'),
-            (1, 'class Foo'),
-            (1, 'main'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-        assert "if __name__ == '__main__':" in root.b
-    #@+node:ekr.20210904065459.70: *4* TestImport.test_python_bug_603720
-    def test_python_bug_603720(self):
-        c = self.c
-        # Leo bug 603720
-        # Within the docstring we must change '\' to '\\'
-        s = textwrap.dedent('''\
-            def foo():
-                s = \\
-            """#!/bin/bash
-            cd /tmp
-            ls"""
-                file('/tmp/script', 'w').write(s)
-
-            class bar:
-                pass
-
-            foo()
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.69: *4* TestImport.test_python_bug_978
-    def test_python_bug_978(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            import foo
-            import bar
-
-            class A(object):
-                pass
-            class B(foo):
-                pass
-            class C(bar.Bar):
-                pass
-        """)
-        table = (
-            (1, 'Declarations'),
-            (1, 'class A(object)'),
-            (1, 'class B(foo)'),
-            (1, 'class C(bar.Bar)'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        assert root
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.72: *4* TestImport.test_python_class_test_2
-    def test_python_class_test_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class testClass2:
-                pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.73: *4* TestImport.test_python_class_tests_1
-    def test_python_class_tests_1(self):
-        c = self.c
-        s = textwrap.dedent('''\
-        class testClass1:
-            """A docstring"""
-            def __init__ (self):
-                pass
-            def f1(self):
-                pass
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.74: *4* TestImport.test_python_comment_after_dict_assign
-    def test_python_comment_after_dict_assign(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            NS = { 'i': 'http://www.inkscape.org/namespaces/inkscape',
-                  's': 'http://www.w3.org/2000/svg',
-                  'xlink' : 'http://www.w3.org/1999/xlink'}
-
-            tabLevels = 4  # number of defined tablevels, FIXME, could derive from template?
-        """)
-        table = (
-            (1, 'Declarations'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.75: *4* TestImport.test_python_decls_test_1
-    def test_python_decls_test_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            import leo.core.leoGlobals as g
-
-            a = 3
-        """)
-        table = (
-            (1, 'Declarations'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.76: *4* TestImport.test_python_decorator
-    def test_python_decorator(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            class Index:
-                """docstring"""
-                @cherrypy.nocolor
-                @cherrypy.expose
-                def index(self):
-                    return "Hello world!"
-
-                @cmd('abc')
-                def abc(self):
-                    return "abc"
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)  # Must be true.
-        index = g.findNodeInTree(c, c.p, '@cherrypy.nocolor index')
-        assert index
-        lines = g.splitLines(index.b)
-        self.assertEqual(lines[0], '@cherrypy.nocolor\n')
-        self.assertEqual(lines[1], '@cherrypy.expose\n')
-        abc = g.findNodeInTree(c, c.p, "@cmd('abc') abc")
-        lines = g.splitLines(abc.b)
-        self.assertEqual(lines[0], "@cmd('abc')\n")
-    #@+node:ekr.20210904065459.77: *4* TestImport.test_python_decorator_2
-    def test_python_decorator_2(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            """
-            A PyQt "task launcher" for quick access to python scripts.
-
-            Buttons to click to make working in Windows less unproductive.
-
-            e.g. a button to move the current window to top or bottom half
-            of screen, because Windows-Up / Windows-Down doesn't do that.
-            Or quote the text on the clipboard properly, because Outlook
-            can't do that.
-
-            terrynbrown@gmail.com, 2016-12-23
-            """
-
-            import sys
-            import time
-            from PyQt4 import QtGui, QtCore, Qt
-            from PyQt4.QtCore import Qt as QtConst
-
-            COMMANDS = []
-
-            class Draggable(QtGui.QWidget):
-                def __init__(self, *args, **kwargs):
-                    """__init__
-                    """
-
-                    QtGui.QWidget.__init__(self, *args, **kwargs)
-                    # self.setMouseTracking(True)
-                    self.offset = None
-                    layout = QtGui.QHBoxLayout()
-                    self.setLayout(layout)
-                    layout.addItem(QtGui.QSpacerItem(15, 5))
-                    layout.setSpacing(0)
-                    layout.setContentsMargins(0, 0, 0, 0)
-
-                def mousePressEvent(self, event):
-                    self.offset = event.pos()
-
-                def mouseMoveEvent(self, event):
-                    x=event.globalX()
-                    y=event.globalY()
-                    x_w = self.offset.x()
-                    y_w = self.offset.y()
-                    self.parent().move(x-x_w, y-y_w)
-
-            def command(name):
-                def makebutton(function):
-                    COMMANDS.append((name, function))
-                    return function
-                return makebutton
-
-            @command("Exit")
-            def exit_():
-                exit()
-
-            def main():
-
-                app = Qt.QApplication(sys.argv)
-
-                main = QtGui.QMainWindow(None,
-                   # QtConst.CustomizeWindowHint  |
-                   QtConst.FramelessWindowHint #  |
-                   # QtConst.WindowCloseButtonHint
-                )
-
-                main.resize(800,16)
-                main.move(40,40)
-                mainwidj = Draggable()
-
-                for name, function in COMMANDS:
-                    button = QtGui.QPushButton(name)
-                    button.clicked.connect(function)
-                    mainwidj.layout().addWidget(button)
-
-                main.setCentralWidget(mainwidj)
-                main.show()
-                app.exec_()
-
-            if __name__ == '__main__':
-                main()
-        ''')
-        table = (
-            (1, "Declarations"),
-            (1, "class Draggable(QtGui.QWidget)"),
-            (2, "__init__"),
-            (2, "mousePressEvent"),
-            (2, "mouseMoveEvent"),
-            (1, "command"),
-            (1, '@command("Exit") exit_'),
-            (1, "main"),
-        )
-        c.importCommands.pythonUnitTest(c.p, s=s)
-        after = c.p.nodeAfterTree()
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-        target = g.findNodeInTree(c, root, '@command("Exit") exit_')
-        assert target
-        lines = g.splitLines(target.b)
-        self.assertEqual(lines[0], '@command("Exit")\n')
-
-    #@+node:ekr.20210904065459.78: *4* TestImport.test_python_def_inside_def
-    def test_python_def_inside_def(self):
-        c = self.c
-        s = textwrap.dedent('''\
-        class aClass:
-            def outerDef(self):
-                """docstring.
-                line two."""
-
-                def pr(*args,**keys):
-                    g.es_print(color='blue',*args,**keys)
-
-                a = 3
-        ''')
-        table = (
-            (1, 'class aClass'),
-            (2, 'outerDef'),
-            # (3, 'pr'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-
-    #@+node:ekr.20210904065459.79: *4* TestImport.test_python_def_test_1
-    def test_python_def_test_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class test:
-
-                def importFilesCommand (self,files=None,treeType=None,
-                    perfectImport=True,testing=False,verbose=False):
-                        # Not a command.  It must *not* have an event arg.
-
-                    c = self.c
-                    if c == None: return
-                    p = c.currentPosition()
-
-                # Used by paste logic.
-
-                def convertMoreStringToOutlineAfter (self,s,firstVnode):
-                    s = string.replace(s,"\\r","")
-                    strings = string.split(s,"\\n")
-                    return self.convertMoreStringsToOutlineAfter(strings,firstVnode)
-        """)
-        table = (
-            (1, 'class test'),
-            (2, 'importFilesCommand'),
-            (2, 'convertMoreStringToOutlineAfter'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-
-    #@+node:ekr.20210904065459.80: *4* TestImport.test_python_def_test_2
-    def test_python_def_test_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class test:
-                def spam(b):
-                    pass
-
-                # Used by paste logic.
-
-                def foo(a):
-                    pass
-        """)
-        table = (
-            (1, 'class test'),
-            (2, 'spam'),
-            (2, 'foo'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-
-    #@+node:ekr.20210904065459.81: *4* TestImport.test_python_docstring_only
-    def test_python_docstring_only(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            """A file consisting only of a docstring.
-            """
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.82: *4* TestImport.test_python_empty_decls
-    def test_python_empty_decls(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            import leo.core.leoGlobals as g
-
-            a = 3
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.71: *4* TestImport.test_python_enhancement_481
-    def test_python_enhancement_481(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            @g.cmd('my-command')
-            def myCommand(event=None):
-                pass
-        """)
-        table = (
-            # (1, '@g.cmd myCommand'),
-            (1, "@g.cmd('my-command') myCommand"),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.83: *4* TestImport.test_python_extra_leading_ws_test
-    def test_python_extra_leading_ws_test(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class cls:
-                 def fun(): # one extra space.
-                    pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.84: *4* TestImport.test_python_indent_decls
-    def test_python_indent_decls(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            class mammalProviderBase(object):
-                """Root class for content providers used by DWEtree.py"""
-                def __init__(self, params):
-                    """store reference to parameters"""
-                    self.params = params
-                def provide(self, what):
-                    """default <BASE> value"""
-                    if what == 'doctitle':
-                        return ELE('base', href=self.params['/BASE/'])
-                    return None
-
-                def imagePath(self, sppdat):
-                    """return path to images and list of images for *species*"""
-                    path = 'MNMammals/imglib/Mammalia'
-                    for i in 'Order', 'Family', 'Genus', 'Species':
-                        path = os.path.join(path, sppdat['%sName' % (i,)])
-                    imglib = os.path.join('/var/www',path)
-                    imglib = os.path.join(imglib, '*.[Jj][Pp][Gg]')
-                    path = os.path.join('/',path)
-                    lst = [os.path.split(i)[1] for i in glob.glob(imglib)]
-                    lst.sort()
-                    return path, lst
-
-            class mainPages(mammalProviderBase):
-                """provide content for pages in 'main' folder"""
-                __parent = mammalProviderBase
-                def provide(self, what):
-                    """add one layer to <BASE>"""
-                    ans = self.__parent.provide(self, what)
-                    if what == 'doctitle':
-                        return ELE('base', href=self.params['/BASE/']+'main/')
-                    return ans
-        ''')
-        table = (
-            (1, 'class mammalProviderBase(object)'),
-            (2, '__init__'),
-            (2, 'provide'),
-            (2, 'imagePath'),
-            (1, 'class mainPages(mammalProviderBase)'),
-            (2, 'provide'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.85: *4* TestImport.test_python_leoImport_py_small_
-    def test_python_leoImport_py_small_(self):
-        c = self.c
-
-        s = textwrap.dedent("""\
-            # -*- coding: utf-8 -*-
-            import leo.core.leoGlobals as g
-            class LeoImportCommands(object):
-                '''A class implementing all of Leo's import/export code.'''
-                def createOutline(self, fileName, parent, s=None, ext=None):
-                    '''Create an outline by importing a file or string.'''
-
-                def dispatch(self, ext, p):
-                    '''Return the correct scanner function for p, an @auto node.'''
-                    # Match the @auto type first, then the file extension.
-                    return self.scanner_for_at_auto(p) or self.scanner_for_ext(ext)
-                def scanner_for_at_auto(self, p):
-                    '''A factory returning a scanner function for p, an @auto node.'''
-                    d = self.atAutoDict
-                    for key in d.keys():
-                        aClass = d.get(key)
-                        if aClass and g.match_word(p.h, 0, key):
-                            if trace: g.trace('found', aClass.__name__)
-
-                            def scanner_for_at_auto_cb(parent, s, prepass=False):
-                                try:
-                                    scanner = aClass(importCommands=self)
-                                    return scanner.run(s, parent, prepass=prepass)
-                                except Exception:
-                                    g.es_print('Exception running', aClass.__name__)
-                                    g.es_exception()
-                                    return None
-
-                            if trace: g.trace('found', p.h)
-                            return scanner_for_at_auto_cb
-                    if trace: g.trace('not found', p.h, sorted(d.keys()))
-                    return None
-                def scanner_for_ext(self, ext):
-                    '''A factory returning a scanner function for the given file extension.'''
-                    aClass = self.classDispatchDict.get(ext)
-                    if aClass:
-
-                        def scanner_for_ext_cb(parent, s, prepass=False):
-                            try:
-                                scanner = aClass(importCommands=self)
-                                return scanner.run(s, parent, prepass=prepass)
-                            except Exception:
-                                g.es_print('Exception running', aClass.__name__)
-                                g.es_exception()
-                                return None
-
-                        return scanner_for_ext_cb
-                    else:
-                        return None
-                def get_import_filename(self, fileName, parent):
-                    '''Return the absolute path of the file and set .default_directory.'''
-
-                def init_import(self, ext, fileName, s):
-                    '''Init ivars & vars for imports.'''
-        """)
-        table = (
-            (1, 'Declarations'),
-            (1, "class LeoImportCommands(object)"),
-            (2, "createOutline"),
-            (2, "dispatch"),
-            (2, "scanner_for_at_auto"),
-            (2, "scanner_for_ext"),
-            (2, "get_import_filename"),
-            (2, "init_import"),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.86: *4* TestImport.test_python_looks_like_section_ref
-    def test_python_looks_like_section_ref(self):
-        c = self.c
-        # ~/at-auto-test.py
-
-        # Careful: don't put a section reference in the string.
-        s = textwrap.dedent("""\
-            # This is valid Python, but it looks like a section reference.
-            a = b < < c > > d
-        """).replace('> >', '>>').replace('< <', '<<')
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.87: *4* TestImport.test_python_minimal_class_1
-    def test_python_minimal_class_1(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            class ItasException(Exception):
-
-                pass
-
-            def gpRun(gp, cmd, args, log = None):
-
-                """Wrapper for making calls to the geoprocessor and reporting errors"""
-
-                if log:
-
-                    log('gp: %s: %s\\n' % (cmd, str(args)))
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.88: *4* TestImport.test_python_minimal_class_2
-    def test_python_minimal_class_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class emptyClass: pass
-
-            def followingDef():
-                pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.89: *4* TestImport.test_python_minimal_class_3
-    def test_python_minimal_class_3(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class emptyClass: pass # comment
-
-            def followingDef(): # comment
-                pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.90: *4* TestImport.test_python_overindent_def_no_following_def
-    def test_python_overindent_def_no_following_def(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class aClass:
-                def def1(self):
-                    pass
-
-                if False or g.unitTesting:
-
-                    def pr(*args,**keys): # reportMismatch test
-                        g.es_print(color='blue',*args,**keys)
-
-                    pr('input...')
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.91: *4* TestImport.test_python_overindent_def_one_following_def
-    def test_python_overindent_def_one_following_def(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class aClass:
-                def def1(self):
-                    pass
-
-                if False or g.unitTesting:
-
-                    def pr(*args,**keys): # reportMismatch test
-                        g.es_print(color='blue',*args,**keys)
-
-                    pr('input...')
-
-                def def2(self):
-                    pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.92: *4* TestImport.test_python_overindented_def_3
-    def test_python_overindented_def_3(self):
-        # This caused PyParse.py not to be imported properly.
-        c = self.c
-        s = textwrap.dedent(r'''
-            import re
-            if 0: # Causes the 'overindent'
-               if 0:   # for throwaway debugging output
-                  def dump(*stuff):
-                    sys.__stdout__.write(" ".join(map(str, stuff)) + "\n")
-            for ch in "({[":
-               _tran[ord(ch)] = '('
-            class testClass1:
-                pass
-        ''')
-        table = (
-            (1, 'Declarations'),
-            (1, 'class testClass1'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(c.p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.93: *4* TestImport.test_python_string_test_extra_indent
-    def test_python_string_test_extra_indent(self):
-        c = self.c
-        s = textwrap.dedent('''\
-        class BaseScanner:
-
-                """The base class for all import scanner classes."""
-
-                def __init__ (self,importCommands,language):
-
-                    self.c = ic.c
-
-                def createHeadline (self,parent,body,headline):
-                    # g.trace("parent,headline:",parent,headline)
-                    return p
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.94: *4* TestImport.test_python_string_underindent_lines
-    def test_python_string_underindent_lines(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class BaseScanner:
-                def containsUnderindentedComment(self):
-                    a = 2
-                # A true underindented comment.
-                    b = 3
-                # This underindented comment should be placed with next function.
-                def empty(self):
-                    pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.95: *4* TestImport.test_python_string_underindent_lines_2
-    def test_python_string_underindent_lines_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class BaseScanner:
-                def containsUnderindentedComment(self):
-                    a = 2
-                #
-                    b = 3
-                    # This comment is part of the present function.
-
-                def empty(self):
-                    pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.96: *4* TestImport.test_python_top_level_later_decl
-    def test_python_top_level_later_decl(self):
-        # From xo.py.
-        c = self.c
-        # The first line *must* be blank.
-        s = textwrap.dedent(r'''
-
-            #!/usr/bin/env python3
-
-            import os
-            import re
-
-            def merge_value(v1, v2):
-                return v
-
-            class MainDisplay(object):
-
-                def save_file(self):
-                    """Write the file out to disk."""
-                    with open(self.save_name, "w") as f:
-                        for newline in newlines:
-                            f.write(newline)
-
-            # The next line should be included at the end of the class node.
-
-            ensure_endswith_newline = lambda x: x if x.endswith('\n') else x + '\n'
-
-            def retab(s, tabsize):
-                return ''.join(pieces)
-
-            if __name__=="__main__":
-                main()
-
-        ''')
-        table = (
-            (1, 'Declarations'),
-            (1, 'merge_value'),
-            (1, 'class MainDisplay(object)'),
-            (2, 'save_file'),
-            (1, 'retab'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        root = p.lastChild()
-        assert root
-        self.assertEqual(root.h, '@file test')
-        after = p.nodeAfterTree()
-        p = root.firstChild()
-        for n, h in table:
-            assert p, h
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.97: *4* TestImport.test_python_trailing_comment
-    def test_python_trailing_comment(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class aClass: # trailing comment
-
-
-                def def1(self):             # trailing comment
-                    pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.98: *4* TestImport.test_python_trailing_comment_outer_levels
-    def test_python_trailing_comment_outer_levels(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            xyz = 6 # trailing comment
-            pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.99: *4* TestImport.test_python_two_functions
-    def test_python_two_functions(self):
-        # For comparison with unindent does not end function.
-        c = self.c
-        s = textwrap.dedent("""\
-            def foo():
-                pass
-
-            def bar():
-                pass
-        """)
-        c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.100: *4* TestImport.test_python_underindent_method
-    def test_python_underindent_method(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            class emptyClass:
-
-                def spam():
-                    """docstring line 1
-            under-indented docstring line"""
-                    pass
-
-            def followingDef(): # comment
-                pass
-        ''')
-        table = (
-            (1, 'class emptyClass'),
-            (2, 'spam'),
-            (1, 'followingDef'),
-        )
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.101: *4* TestImport.test_python_unindent_in_triple_string_does_not_end_function
-    def test_python_unindent_in_triple_string_does_not_end_function(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            def foo():
-
-                error("""line1
-            line2.
-            """)
-
-                a = 5
-
-            def bar():
-                pass
-        ''')
-        p = c.p
-        c.importCommands.pythonUnitTest(p, s=s)
-        child = p.firstChild()
-        n = child.numberOfChildren()
-        self.assertEqual(n, 2)
-    #@+node:ekr.20210904065459.102: *4* TestImport.test_python_unittest_perfectImport_formatter_py
-    def test_python_unittest_perfectImport_formatter_py(self):
-        c = self.c
-
-        s = textwrap.dedent('''\
-
-            """Generic output formatting.
-            """
-
-            import sys
-
-
-            AS_IS = None
-
-
-            class NullFormatter:
-                """A formatter which does nothing.
-
-                If the writer parameter is omitted, a NullWriter instance is created.
-                No methods of the writer are called by NullFormatter instances.
-
-                Implementations should inherit from this class if implementing a writer
-                interface but don't need to inherit any implementation.
-
-                """
-
-                def __init__(self, writer=None):
-                    if writer is None:
-                        writer = NullWriter()
-                    self.writer = writer
-                def end_paragraph(self, blankline): pass
-                def add_line_break(self): pass
-                def add_hor_rule(self, *args, **kw): pass
-                def add_label_data(self, format, counter, blankline=None): pass
-                def add_flowing_data(self, data): pass
-                def add_literal_data(self, data): pass
-                def flush_softspace(self): pass
-                def push_alignment(self, align): pass
-                def pop_alignment(self): pass
-                def push_font(self, x): pass
-                def pop_font(self): pass
-                def push_margin(self, margin): pass
-                def pop_margin(self): pass
-                def set_spacing(self, spacing): pass
-                def push_style(self, *styles): pass
-                def pop_style(self, n=1): pass
-                def assert_line_data(self, flag=1): pass
-
-
-            class AbstractFormatter:
-                """The standard formatter.
-
-                This implementation has demonstrated wide applicability to many writers,
-                and may be used directly in most circumstances.  It has been used to
-                implement a full-featured World Wide Web browser.
-
-                """
-
-                #  Space handling policy:  blank spaces at the boundary between elements
-                #  are handled by the outermost context.  "Literal" data is not checked
-                #  to determine context, so spaces in literal data are handled directly
-                #  in all circumstances.
-
-                def __init__(self, writer):
-                    self.writer = writer            # Output device
-                    self.align = None               # Current alignment
-                    self.align_stack = []           # Alignment stack
-                    self.font_stack = []            # Font state
-                    self.margin_stack = []          # Margin state
-                    self.spacing = None             # Vertical spacing state
-                    self.style_stack = []           # Other state, e.g. color
-                    self.nospace = 1                # Should leading space be suppressed
-                    self.softspace = 0              # Should a space be inserted
-                    self.para_end = 1               # Just ended a paragraph
-                    self.parskip = 0                # Skipped space between paragraphs?
-                    self.hard_break = 1             # Have a hard break
-                    self.have_label = 0
-
-                def end_paragraph(self, blankline):
-                    if not self.hard_break:
-                        self.writer.send_line_break()
-                        self.have_label = 0
-                    if self.parskip < blankline and not self.have_label:
-                        self.writer.send_paragraph(blankline - self.parskip)
-                        self.parskip = blankline
-                        self.have_label = 0
-                    self.hard_break = self.nospace = self.para_end = 1
-                    self.softspace = 0
-
-                def add_line_break(self):
-                    if not (self.hard_break or self.para_end):
-                        self.writer.send_line_break()
-                        self.have_label = self.parskip = 0
-                    self.hard_break = self.nospace = 1
-                    self.softspace = 0
-
-                def add_hor_rule(self, *args, **kw):
-                    if not self.hard_break:
-                        self.writer.send_line_break()
-                    self.writer.send_hor_rule(*args, **kw)
-                    self.hard_break = self.nospace = 1
-                    self.have_label = self.para_end = self.softspace = self.parskip = 0
-
-                def add_label_data(self, format, counter, blankline = None):
-                    if self.have_label or not self.hard_break:
-                        self.writer.send_line_break()
-                    if not self.para_end:
-                        self.writer.send_paragraph((blankline and 1) or 0)
-                    if isinstance(format, str):
-                        self.writer.send_label_data(self.format_counter(format, counter))
-                    else:
-                        self.writer.send_label_data(format)
-                    self.nospace = self.have_label = self.hard_break = self.para_end = 1
-                    self.softspace = self.parskip = 0
-
-                def format_counter(self, format, counter):
-                    label = ''
-                    for c in format:
-                        if c == '1':
-                            label = label + ('%d' % counter)
-                        elif c in 'aA':
-                            if counter > 0:
-                                label = label + self.format_letter(c, counter)
-                        elif c in 'iI':
-                            if counter > 0:
-                                label = label + self.format_roman(c, counter)
-                        else:
-                            label = label + c
-                    return label
-
-                def format_letter(self, case, counter):
-                    label = ''
-                    while counter > 0:
-                        counter, x = divmod(counter-1, 26)
-                        # This makes a strong assumption that lowercase letters
-                        # and uppercase letters form two contiguous blocks, with
-                        # letters in order!
-                        s = chr(ord(case) + x)
-                        label = s + label
-                    return label
-
-                def format_roman(self, case, counter):
-                    ones = ['i', 'x', 'c', 'm']
-                    fives = ['v', 'l', 'd']
-                    label, index = '', 0
-                    # This will die of IndexError when counter is too big
-                    while counter > 0:
-                        counter, x = divmod(counter, 10)
-                        if x == 9:
-                            label = ones[index] + ones[index+1] + label
-                        elif x == 4:
-                            label = ones[index] + fives[index] + label
-                        else:
-                            if x >= 5:
-                                s = fives[index]
-                                x = x-5
-                            else:
-                                s = ''
-                            s = s + ones[index]*x
-                            label = s + label
-                        index = index + 1
-                    if case == 'I':
-                        return label.upper()
-                    return label
-
-                def add_flowing_data(self, data):
-                    if not data: return
-                    # The following looks a bit convoluted but is a great improvement over
-                    # data = regsub.gsub('[' + string.whitespace + ']+', ' ', data)
-                    prespace = data[:1].isspace()
-                    postspace = data[-1:].isspace()
-                    data = " ".join(data.split())
-                    if self.nospace and not data:
-                        return
-                    elif prespace or self.softspace:
-                        if not data:
-                            if not self.nospace:
-                                self.softspace = 1
-                                self.parskip = 0
-                            return
-                        if not self.nospace:
-                            data = ' ' + data
-                    self.hard_break = self.nospace = self.para_end = \
-                                      self.parskip = self.have_label = 0
-                    self.softspace = postspace
-                    self.writer.send_flowing_data(data)
-
-                def add_literal_data(self, data):
-                    if not data: return
-                    if self.softspace:
-                        self.writer.send_flowing_data(" ")
-                    self.hard_break = data[-1:] == '\n'
-                    self.nospace = self.para_end = self.softspace = \
-                                   self.parskip = self.have_label = 0
-                    self.writer.send_literal_data(data)
-
-                def flush_softspace(self):
-                    if self.softspace:
-                        self.hard_break = self.para_end = self.parskip = \
-                                          self.have_label = self.softspace = 0
-                        self.nospace = 1
-                        self.writer.send_flowing_data(' ')
-
-                def push_alignment(self, align):
-                    if align and align != self.align:
-                        self.writer.new_alignment(align)
-                        self.align = align
-                        self.align_stack.append(align)
-                    else:
-                        self.align_stack.append(self.align)
-
-                def pop_alignment(self):
-                    if self.align_stack:
-                        del self.align_stack[-1]
-                    if self.align_stack:
-                        self.align = align = self.align_stack[-1]
-                        self.writer.new_alignment(align)
-                    else:
-                        self.align = None
-                        self.writer.new_alignment(None)
-
-                def push_font(self, (size, i, b, tt)):
-                    if self.softspace:
-                        self.hard_break = self.para_end = self.softspace = 0
-                        self.nospace = 1
-                        self.writer.send_flowing_data(' ')
-                    if self.font_stack:
-                        csize, ci, cb, ctt = self.font_stack[-1]
-                        if size is AS_IS: size = csize
-                        if i is AS_IS: i = ci
-                        if b is AS_IS: b = cb
-                        if tt is AS_IS: tt = ctt
-                    font = (size, i, b, tt)
-                    self.font_stack.append(font)
-                    self.writer.new_font(font)
-
-                def pop_font(self):
-                    if self.font_stack:
-                        del self.font_stack[-1]
-                    if self.font_stack:
-                        font = self.font_stack[-1]
-                    else:
-                        font = None
-                    self.writer.new_font(font)
-
-                def push_margin(self, margin):
-                    self.margin_stack.append(margin)
-                    fstack = filter(None, self.margin_stack)
-                    if not margin and fstack:
-                        margin = fstack[-1]
-                    self.writer.new_margin(margin, len(fstack))
-
-                def pop_margin(self):
-                    if self.margin_stack:
-                        del self.margin_stack[-1]
-                    fstack = filter(None, self.margin_stack)
-                    if fstack:
-                        margin = fstack[-1]
-                    else:
-                        margin = None
-                    self.writer.new_margin(margin, len(fstack))
-
-                def set_spacing(self, spacing):
-                    self.spacing = spacing
-                    self.writer.new_spacing(spacing)
-
-                def push_style(self, *styles):
-                    if self.softspace:
-                        self.hard_break = self.para_end = self.softspace = 0
-                        self.nospace = 1
-                        self.writer.send_flowing_data(' ')
-                    for style in styles:
-                        self.style_stack.append(style)
-                    self.writer.new_styles(tuple(self.style_stack))
-
-                def pop_style(self, n=1):
-                    del self.style_stack[-n:]
-                    self.writer.new_styles(tuple(self.style_stack))
-
-                def assert_line_data(self, flag=1):
-                    self.nospace = self.hard_break = not flag
-                    self.para_end = self.parskip = self.have_label = 0
-
-
-            class NullWriter:
-                """Minimal writer interface to use in testing & inheritance.
-
-                A writer which only provides the interface definition; no actions are
-                taken on any methods.  This should be the base class for all writers
-                which do not need to inherit any implementation methods.
-
-                """
-                def __init__(self): pass
-                def flush(self): pass
-                def new_alignment(self, align): pass
-                def new_font(self, font): pass
-                def new_margin(self, margin, level): pass
-                def new_spacing(self, spacing): pass
-                def new_styles(self, styles): pass
-                def send_paragraph(self, blankline): pass
-                def send_line_break(self): pass
-                def send_hor_rule(self, *args, **kw): pass
-                def send_label_data(self, data): pass
-                def send_flowing_data(self, data): pass
-                def send_literal_data(self, data): pass
-
-
-            class AbstractWriter(NullWriter):
-                """A writer which can be used in debugging formatters, but not much else.
-
-                Each method simply announces itself by printing its name and
-                arguments on standard output.
-
-                """
-
-                def new_alignment(self, align):
-                    print "new_alignment(%s)" % `align`
-
-                def new_font(self, font):
-                    print "new_font(%s)" % `font`
-
-                def new_margin(self, margin, level):
-                    print "new_margin(%s, %d)" % (`margin`, level)
-
-                def new_spacing(self, spacing):
-                    print "new_spacing(%s)" % `spacing`
-
-                def new_styles(self, styles):
-                    print "new_styles(%s)" % `styles`
-
-                def send_paragraph(self, blankline):
-                    print "send_paragraph(%s)" % `blankline`
-
-                def send_line_break(self):
-                    print "send_line_break()"
-
-                def send_hor_rule(self, *args, **kw):
-                    print "send_hor_rule()"
-
-                def send_label_data(self, data):
-                    print "send_label_data(%s)" % `data`
-
-                def send_flowing_data(self, data):
-                    print "send_flowing_data(%s)" % `data`
-
-                def send_literal_data(self, data):
-                    print "send_literal_data(%s)" % `data`
-
-
-            class DumbWriter(NullWriter):
-                """Simple writer class which writes output on the file object passed in
-                as the file parameter or, if file is omitted, on standard output.  The
-                output is simply word-wrapped to the number of columns specified by
-                the maxcol parameter.  This class is suitable for reflowing a sequence
-                of paragraphs.
-
-                """
-
-                def __init__(self, file=None, maxcol=72):
-                    self.file = file or sys.stdout
-                    self.maxcol = maxcol
-                    NullWriter.__init__(self)
-                    self.reset()
-
-                def reset(self):
-                    self.col = 0
-                    self.atbreak = 0
-
-                def send_paragraph(self, blankline):
-                    self.file.write('\n'*blankline)
-                    self.col = 0
-                    self.atbreak = 0
-
-                def send_line_break(self):
-                    self.file.write('\n')
-                    self.col = 0
-                    self.atbreak = 0
-
-                def send_hor_rule(self, *args, **kw):
-                    self.file.write('\n')
-                    self.file.write('-'*self.maxcol)
-                    self.file.write('\n')
-                    self.col = 0
-                    self.atbreak = 0
-
-                def send_literal_data(self, data):
-                    self.file.write(data)
-                    i = data.rfind('\n')
-                    if i >= 0:
-                        self.col = 0
-                        data = data[i+1:]
-                    data = data.expandtabs()
-                    self.col = self.col + len(data)
-                    self.atbreak = 0
-
-                def send_flowing_data(self, data):
-                    if not data: return
-                    atbreak = self.atbreak or data[0].isspace()
-                    col = self.col
-                    maxcol = self.maxcol
-                    write = self.file.write
-                    for word in data.split():
-                        if atbreak:
-                            if col + len(word) >= maxcol:
-                                write('\n')
-                                col = 0
-                            else:
-                                write(' ')
-                                col = col + 1
-                        write(word)
-                        col = col + len(word)
-                        atbreak = 1
-                    self.col = col
-                    self.atbreak = data[-1].isspace()
-
-
-            def test(file = None):
-                w = DumbWriter()
-                f = AbstractFormatter(w)
-                if file is not None:
-                    fp = open(file)
-                elif sys.argv[1:]:
-                    fp = open(sys.argv[1])
-                else:
-                    fp = sys.stdin
-                while 1:
-                    line = fp.readline()
-                    if not line:
-                        break
-                    if line == '\n':
-                        f.end_paragraph(1)
-                    else:
-                        f.add_flowing_data(line)
-                f.end_paragraph(0)
-
-
-            if __name__ == '__main__':
-                test()
-        ''')
-        c.importCommands.pythonUnitTest(c.p, s=s)
     #@+node:ekr.20210904123047.1: *3* Typescript tests
     #@+node:ekr.20210904065459.103: *4* TestImport.test_TypeScript_class
     def test_TypeScript_class(self):
@@ -4131,6 +2279,1864 @@ class TestPhp (BaseTestImporter):
             ?>
         """)
         self.run_test(c.p, s)
+    #@-others
+#@+node:ekr.20211108082509.1: ** class TestPython (BaseTestImporter)
+class TestPython (BaseTestImporter):
+    
+    ext = '.py'
+    
+    #@+others
+    #@+node:ekr.20210904065459.60: *3* TestPython.test_i_scan_state
+    def test_i_scan_state(self):
+        c = self.c
+        # A list of dictionaries.
+        tests = (
+            g.Bunch(line='\n'),
+            g.Bunch(line='\\\n'),
+            g.Bunch(line='s = "\\""', ctx=('', '')),  # empty string.
+            g.Bunch(line="s = '\\''", ctx=('', '')),  # empty string.
+            g.Bunch(line='# comment'),
+            g.Bunch(line='  # comment'),
+            g.Bunch(line='    # comment'),
+            g.Bunch(line='a = "string"'),
+            g.Bunch(line='a = "Continued string', ctx=('', '"')),
+            g.Bunch(line='end of continued string"', ctx=('"', '')),
+            g.Bunch(line='a = """Continued docstring', ctx=('', '"""')),
+            g.Bunch(line='a = """#', ctx=('', '"""')),
+            g.Bunch(line='end of continued string"""', ctx=('"""', '')),
+            g.Bunch(line="a = '''Continued docstring", ctx=('', "'''")),
+            g.Bunch(line="end of continued string'''", ctx=("'''", '')),
+            g.Bunch(line='a = {[(')
+        )
+        importer = python.Py_Importer(c.importCommands)
+        importer.test_scan_state(tests, State=python.Python_ScanState)
+    #@+node:ekr.20210904065459.61: *3* TestPython.test_leoApp_fail
+    def test_leoApp_fail(self):
+        c = self.c
+        s = textwrap.dedent('''
+            def isValidPython(self):
+                if sys.platform == 'cli':
+                    return True
+                minimum_python_version = '2.6'
+                message = """\
+            Leo requires Python %s or higher.
+            You may download Python from
+            http://python.org/download/
+            """ % minimum_python_version
+                try:
+                    version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
+                    ok = g.CheckVersion(version, minimum_python_version)
+                    if not ok:
+                        print(message)
+                        try:
+                            # g.app.gui does not exist yet.
+                            import Tkinter as Tk
+                            class EmergencyDialog(object):
+                                def run(self):
+                                    """Run the modal emergency dialog."""
+                                    self.top.geometry("%dx%d%+d%+d" % (300, 200, 50, 50))
+                                    self.top.lift()
+                                    self.top.grab_set() # Make the dialog a modal dialog.
+                                    self.root.wait_window(self.top)
+                            d = EmergencyDialog(
+                                title='Python Version Error',
+                                message=message)
+                            d.run()
+                        except Exception:
+                            pass
+                    return ok
+                except Exception:
+                    print("isValidPython: unexpected exception: g.CheckVersion")
+                    traceback.print_exc()
+                    return 0
+            def loadLocalFile(self, fn, gui, old_c):
+                trace = (False or g.trace_startup) and not g.unitTesting
+        ''')
+        table = (
+            (1, 'isValidPython'),
+            # (2, 'class EmergencyDialog'),
+            # (3, 'run'),
+            (1, 'loadLocalFile'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+
+    #@+node:ekr.20210904065459.62: *3* TestPython.test_bad_class_test
+    def test_bad_class_test(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class testClass1 # no colon
+                pass
+
+            def spam():
+                pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.63: *3* TestPython.test_basic_nesting_test
+    def test_basic_nesting_test(self):
+        c = self.c
+        # Was unittest/at_auto-unit-test.py
+        s = textwrap.dedent("""\
+            class class1:
+                def class1_method1():
+                    pass
+                def class1_method2():
+                    pass
+                # After @others in child1.
+            class class2:
+                def class2_method1():
+                    pass
+                def class2_method2():
+                    pass
+            # last line
+        """)
+        table = (
+            (1, 'class class1'),
+            (2, 'class1_method1'),
+            (2, 'class1_method2'),
+            (1, 'class class2'),
+            (2, 'class2_method1'),
+            (2, 'class2_method2'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+
+    #@+node:ekr.20210904065459.64: *3* TestPython.test_bug_346
+    def test_bug_346(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            import sys
+
+            if sys.version_info[0] >= 3:
+                exec_ = eval('exec')
+            else:
+                def exec_(_code_, _globs_=None, _locs_=None):
+                    """Execute code in a namespace."""
+                    if _globs_ is None:
+                        frame = sys._getframe(1)
+                        _globs_ = frame.f_globals
+                        if _locs_ is None:
+                            _locs_ = frame.f_locals
+                        del frame
+                    elif _locs_ is None:
+                        _locs_ = _globs_
+                    exec("""exec _code_ in _globs_, _locs_""")
+
+            def make_parser():
+
+                parser = argparse.ArgumentParser(
+                    description="""Raster calcs. with GDAL.
+                    The first --grid defines the projection, extent, cell size, and origin
+                    for all calculations, all other grids are transformed and resampled
+                    as needed to match.""",
+                    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+            )
+        ''')
+        table = (
+            (1, 'Declarations'),
+            (1, 'make_parser'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.65: *3* TestPython.test_bug_354
+    def test_bug_354(self):
+        c = self.c
+        s = """
+        if isPython3:
+            def u(s):
+                '''Return s, converted to unicode from Qt widgets.'''
+                return s
+
+            def ue(s, encoding):
+                return s if g.isUnicode(s) else str(s, encoding)
+        else:
+            def u(s):
+                '''Return s, converted to unicode from Qt widgets.'''
+                return builtins.unicode(s) # Suppress pyflakes complaint.
+
+            def ue(s, encoding):
+                return builtins.unicode(s, encoding)
+        """
+        table = (
+            (1, 'Declarations'),
+            # (1, 'u'),
+            # (1, 'ue'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.66: *3* TestPython.test_bug_357
+    def test_bug_357(self):
+        c = self.c
+        s = textwrap.dedent('''
+            """
+            sheet_stats.py - report column stats for spreadsheets
+
+            requires openpyxl and numpy
+
+            Terry N. Brown, terrynbrown@gmail.com, Fri Dec 16 13:20:47 2016
+            2016-12-26 Henry Helgen added average, variance, standard deviation,
+                                    coefficient of variation to output
+            2016-12-23 Henry Helgen updated to Python 3.5 syntax including print() and
+                                    writer = csv.writer(open(opt.output, 'w', newline=''))
+            """
+
+            import csv
+            import argparse
+            import glob
+            import multiprocessing
+            import os
+            import sys
+            from collections import namedtuple
+            from math import sqrt, isnan
+            NAN = float('NAN')
+
+            from openpyxl import load_workbook
+
+            PYTHON_2 = sys.version_info[0] < 3
+            if not PYTHON_2:
+                unicode = str
+
+            class AttrDict(dict):
+                """allow d.attr instead of d['attr']
+                http://stackoverflow.com/a/14620633
+                """
+                def __init__(self, *args, **kwargs):
+                    super(AttrDict, self).__init__(*args, **kwargs)
+                    self.__dict__ = self
+
+            FIELDS = [  # fields in outout table
+                'file', 'field', 'n', 'blank', 'bad', 'min', 'max', 'mean', 'std',
+                'sum', 'sumsq', 'variance', 'coefvar'
+            ]
+            def make_parser():
+                """build an argparse.ArgumentParser, don't call this directly,
+                   call get_options() instead.
+                """
+                parser = argparse.ArgumentParser(
+                    description="""Report column stats for spreadsheets""",
+                    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+                )
+
+                parser.add_argument('files', type=str, nargs='+',
+                    help="Files to process, '*' patterns expanded."
+                )
+
+                required_named = parser.add_argument_group('required named arguments')
+
+                required_named.add_argument("--output",
+                    help="Path to .csv file for output, will be overwritten",
+                    metavar='FILE'
+                )
+
+                return parser
+
+            def get_options(args=None):
+                """
+                get_options - use argparse to parse args, and return a
+                argparse.Namespace, possibly with some changes / expansions /
+                validatations.
+
+                Client code should call this method with args as per sys.argv[1:],
+                rather than calling make_parser() directly.
+
+                :param [str] args: arguments to parse
+                :return: options with modifications / validations
+                :rtype: argparse.Namespace
+                """
+                opt = make_parser().parse_args(args)
+
+                # modifications / validations go here
+
+                if not opt.output:
+                    print("No --output supplied")
+                    exit(10)
+
+                return opt
+
+            def get_aggregate(psumsqn, psumn, pcountn):
+                """
+                get_aggregate - compute mean, variance, standard deviation,
+                coefficient of variation This function is used instead of
+                numpy.mean, numpy.var, numpy.std since the sum, sumsq, and count are
+                available when the function is called. It avoids an extra pass
+                through the list.
+
+                # note pcountn means the full list n,  not a sample n - 1
+
+                :param sum of squares, sum, count
+                :return: a tuple of floats mean, variance, standard deviation, coefficient of variation
+                """
+
+                Agg = namedtuple("Agg", "mean variance std coefvar")
+
+                # validate inputs check for count == 0
+                if pcountn == 0:
+                    result = Agg(NAN, NAN, NAN, NAN)
+                else:
+
+                    mean = psumn / pcountn # mean
+
+                    # compute variance from sum squared without knowing mean while summing
+                    variance = (psumsqn - (psumn * psumn) / pcountn ) / pcountn
+
+                    #compute standard deviation
+                    if variance < 0:
+                        std = NAN
+                    else:
+                        std = sqrt(variance)
+
+                    # compute coefficient of variation
+                    if mean == 0:
+                        coefvar = NAN
+                    else:
+                        coefvar = std / mean
+
+                    result = Agg(mean, variance, std, coefvar)
+
+                return result
+
+
+            def proc_file(filepath):
+                """
+                proc_file - process one .xlsx file
+
+                :param str filepath: path to file
+                :return: list of lists, rows of info. as expected in main()
+                """
+
+                print(filepath)
+
+                # get the first sheet
+                book = load_workbook(filename=filepath, read_only=True)
+                sheets = book.get_sheet_names()
+                sheet = book[sheets[0]]
+                row_source = sheet.rows
+                row0 = next(row_source)
+                # get field names from the first row
+                fields = [i.value for i in row0]
+
+                data = {
+                    'filepath': filepath,
+                    'fields': {field:AttrDict({f:0 for f in FIELDS}) for field in fields}
+                }
+
+                for field in fields:
+                    # init. mins/maxs with invalid value for later calc.
+                    data['fields'][field].update(dict(
+                        min=NAN,
+                        max=NAN,
+                        field=field,
+                        file=filepath,
+                    ))
+
+                rows = 0
+                for row in row_source:
+
+                    if rows % 1000 == 0:  # feedback every 1000 rows
+                        print(rows)
+                        # Much cleaner to exit by creating a file called "STOP" in the
+                        # local directory than to try and use Ctrl-C, when using
+                        # multiprocessing.  Save time by checking only every 1000 rows.
+                        if os.path.exists("STOP"):
+                            return
+
+                    rows += 1
+
+                    for cell_n, cell in enumerate(row):
+                        d = data['fields'][fields[cell_n]]
+                        if cell.value is None or unicode(cell.value).strip() == '':
+                            d.blank += 1
+                        else:
+                            try:
+                                x = float(cell.value)
+                                d.sum += x
+                                d.sumsq += x*x
+                                d.n += 1
+                                # min is x if no value seen yet, else min(prev-min, x)
+                                if isnan(d.min):
+                                    d.min = x
+                                else:
+                                    d.min = min(d.min, x)
+                                # as for min
+                                if isnan(d.max):
+                                    d.max = x
+                                else:
+                                    d.max = max(d.max, x)
+                            except ValueError:
+                                d.bad += 1
+
+                assert sum(d.n+d.blank+d.bad for d in data['fields'].values()) == rows * len(fields)
+
+                # compute the derived values
+                for field in data['fields']:
+                    d = data['fields'][field]
+                    d.update(get_aggregate(d.sumsq, d.sum, d.n)._asdict().items())
+
+                return data
+            def get_answers(opt=None, **kwargs):
+                """get_answers - process files
+
+                :param argparse.Namespace opt: options
+                :return: list of answers from proc_file
+                """
+
+                if opt is None:  # API call rather than command line
+                    opt = type("opt", (), kwargs)
+
+                # pass filenames through glob() to expand "2017_*.xlsx" etc.
+                files = []
+                for filepath in opt.files:
+                    files.extend(glob.glob(filepath))
+
+                # create a pool of processors
+                pool = multiprocessing.Pool(multiprocessing.cpu_count()-1)
+
+                # process file list with processor pool
+                return pool.map(proc_file, files)
+            def get_table_rows(answers):
+                """get_table_rows - generator - convert get_answers() output to table format
+
+                :param list answers: output from get_answers()
+                :return: list of rows suitable for csv.writer
+                """
+                yield FIELDS
+                for answer in answers:
+                    for field in answer['fields']:
+                        row = [answer['fields'][field][k] for k in FIELDS]
+                        if PYTHON_2:
+                            yield [unicode(col).encode('utf-8') for col in row]
+                        else:
+                            yield row
+
+            def main():
+                """main() - when invoked directly"""
+                opt = get_options()
+
+                # csv.writer does its own EOL handling,
+                # see https://docs.python.org/3/library/csv.html#csv.reader
+                if PYTHON_2:
+                    output = open(opt.output, 'wb')
+                else:
+                    output = open(opt.output, 'w', newline='')
+
+                with output as out:
+                    writer = csv.writer(out)
+                    for row in get_table_rows(get_answers(opt)):
+                        writer.writerow(row)
+
+            if __name__ == '__main__':
+                main()
+        ''')
+        table = (
+            (1, "Declarations"),
+            (1, "class AttrDict(dict)"),
+            (2, "__init__"),
+            (1, "make_parser"),
+            (1, "get_options"),
+            (1, "get_aggregate"),
+            (1, "proc_file"),
+            (1, "get_answers"),
+            (1, "get_table_rows"),
+            (1, "main"),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        assert root
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            assert p, h
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.67: *3* TestPython.test_bug_360
+    def test_bug_360(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            @base_task(
+                targets=['img/who_map.png', 'img/who_map.pdf'],
+                file_dep=[data_path('phyto')],
+                task_dep=['load_data'],
+            )
+            def make_map():
+                '''make_map - plot the Thompson / Bartsh / WHO map'''
+        """)
+        table = (
+            (1, '@base_task make_map'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.68: *3* TestPython.test_bug_390
+    def test_bug_390(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            import sys
+
+            class Foo():
+                pass
+
+            a = 2
+
+            def main(self):
+                pass
+
+            if __name__ == '__main__':
+                main()
+        """)
+        table = (
+            (1, 'Declarations'),
+            (1, 'class Foo'),
+            (1, 'main'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+        assert "if __name__ == '__main__':" in root.b
+    #@+node:ekr.20210904065459.70: *3* TestPython.test_bug_603720
+    def test_bug_603720(self):
+        c = self.c
+        # Leo bug 603720
+        # Within the docstring we must change '\' to '\\'
+        s = textwrap.dedent('''\
+            def foo():
+                s = \\
+            """#!/bin/bash
+            cd /tmp
+            ls"""
+                file('/tmp/script', 'w').write(s)
+
+            class bar:
+                pass
+
+            foo()
+        ''')
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.69: *3* TestPython.test_bug_978
+    def test_bug_978(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            import foo
+            import bar
+
+            class A(object):
+                pass
+            class B(foo):
+                pass
+            class C(bar.Bar):
+                pass
+        """)
+        table = (
+            (1, 'Declarations'),
+            (1, 'class A(object)'),
+            (1, 'class B(foo)'),
+            (1, 'class C(bar.Bar)'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        assert root
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.72: *3* TestPython.test_class_test_2
+    def test_class_test_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class testClass2:
+                pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.73: *3* TestPython.test_class_tests_1
+    def test_class_tests_1(self):
+        c = self.c
+        s = textwrap.dedent('''\
+        class testClass1:
+            """A docstring"""
+            def __init__ (self):
+                pass
+            def f1(self):
+                pass
+        ''')
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.74: *3* TestPython.test_comment_after_dict_assign
+    def test_comment_after_dict_assign(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            NS = { 'i': 'http://www.inkscape.org/namespaces/inkscape',
+                  's': 'http://www.w3.org/2000/svg',
+                  'xlink' : 'http://www.w3.org/1999/xlink'}
+
+            tabLevels = 4  # number of defined tablevels, FIXME, could derive from template?
+        """)
+        table = (
+            (1, 'Declarations'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.75: *3* TestPython.test_decls_test_1
+    def test_decls_test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            import leo.core.leoGlobals as g
+
+            a = 3
+        """)
+        table = (
+            (1, 'Declarations'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.76: *3* TestPython.test_decorator
+    def test_decorator(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            class Index:
+                """docstring"""
+                @cherrypy.nocolor
+                @cherrypy.expose
+                def index(self):
+                    return "Hello world!"
+
+                @cmd('abc')
+                def abc(self):
+                    return "abc"
+        ''')
+        self.run_test(c.p, s=s)  # Must be true.
+        index = g.findNodeInTree(c, c.p, '@cherrypy.nocolor index')
+        assert index
+        lines = g.splitLines(index.b)
+        self.assertEqual(lines[0], '@cherrypy.nocolor\n')
+        self.assertEqual(lines[1], '@cherrypy.expose\n')
+        abc = g.findNodeInTree(c, c.p, "@cmd('abc') abc")
+        lines = g.splitLines(abc.b)
+        self.assertEqual(lines[0], "@cmd('abc')\n")
+    #@+node:ekr.20210904065459.77: *3* TestPython.test_decorator_2
+    def test_decorator_2(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            """
+            A PyQt "task launcher" for quick access to python scripts.
+
+            Buttons to click to make working in Windows less unproductive.
+
+            e.g. a button to move the current window to top or bottom half
+            of screen, because Windows-Up / Windows-Down doesn't do that.
+            Or quote the text on the clipboard properly, because Outlook
+            can't do that.
+
+            terrynbrown@gmail.com, 2016-12-23
+            """
+
+            import sys
+            import time
+            from PyQt4 import QtGui, QtCore, Qt
+            from PyQt4.QtCore import Qt as QtConst
+
+            COMMANDS = []
+
+            class Draggable(QtGui.QWidget):
+                def __init__(self, *args, **kwargs):
+                    """__init__
+                    """
+
+                    QtGui.QWidget.__init__(self, *args, **kwargs)
+                    # self.setMouseTracking(True)
+                    self.offset = None
+                    layout = QtGui.QHBoxLayout()
+                    self.setLayout(layout)
+                    layout.addItem(QtGui.QSpacerItem(15, 5))
+                    layout.setSpacing(0)
+                    layout.setContentsMargins(0, 0, 0, 0)
+
+                def mousePressEvent(self, event):
+                    self.offset = event.pos()
+
+                def mouseMoveEvent(self, event):
+                    x=event.globalX()
+                    y=event.globalY()
+                    x_w = self.offset.x()
+                    y_w = self.offset.y()
+                    self.parent().move(x-x_w, y-y_w)
+
+            def command(name):
+                def makebutton(function):
+                    COMMANDS.append((name, function))
+                    return function
+                return makebutton
+
+            @command("Exit")
+            def exit_():
+                exit()
+
+            def main():
+
+                app = Qt.QApplication(sys.argv)
+
+                main = QtGui.QMainWindow(None,
+                   # QtConst.CustomizeWindowHint  |
+                   QtConst.FramelessWindowHint #  |
+                   # QtConst.WindowCloseButtonHint
+                )
+
+                main.resize(800,16)
+                main.move(40,40)
+                mainwidj = Draggable()
+
+                for name, function in COMMANDS:
+                    button = QtGui.QPushButton(name)
+                    button.clicked.connect(function)
+                    mainwidj.layout().addWidget(button)
+
+                main.setCentralWidget(mainwidj)
+                main.show()
+                app.exec_()
+
+            if __name__ == '__main__':
+                main()
+        ''')
+        table = (
+            (1, "Declarations"),
+            (1, "class Draggable(QtGui.QWidget)"),
+            (2, "__init__"),
+            (2, "mousePressEvent"),
+            (2, "mouseMoveEvent"),
+            (1, "command"),
+            (1, '@command("Exit") exit_'),
+            (1, "main"),
+        )
+        self.run_test(c.p, s=s)
+        after = c.p.nodeAfterTree()
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+        target = g.findNodeInTree(c, root, '@command("Exit") exit_')
+        assert target
+        lines = g.splitLines(target.b)
+        self.assertEqual(lines[0], '@command("Exit")\n')
+
+    #@+node:ekr.20210904065459.78: *3* TestPython.test_def_inside_def
+    def test_def_inside_def(self):
+        c = self.c
+        s = textwrap.dedent('''\
+        class aClass:
+            def outerDef(self):
+                """docstring.
+                line two."""
+
+                def pr(*args,**keys):
+                    g.es_print(color='blue',*args,**keys)
+
+                a = 3
+        ''')
+        table = (
+            (1, 'class aClass'),
+            (2, 'outerDef'),
+            # (3, 'pr'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+
+    #@+node:ekr.20210904065459.79: *3* TestPython.test_def_test_1
+    def test_def_test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class test:
+
+                def importFilesCommand (self,files=None,treeType=None,
+                    perfectImport=True,testing=False,verbose=False):
+                        # Not a command.  It must *not* have an event arg.
+
+                    c = self.c
+                    if c == None: return
+                    p = c.currentPosition()
+
+                # Used by paste logic.
+
+                def convertMoreStringToOutlineAfter (self,s,firstVnode):
+                    s = string.replace(s,"\\r","")
+                    strings = string.split(s,"\\n")
+                    return self.convertMoreStringsToOutlineAfter(strings,firstVnode)
+        """)
+        table = (
+            (1, 'class test'),
+            (2, 'importFilesCommand'),
+            (2, 'convertMoreStringToOutlineAfter'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+
+    #@+node:ekr.20210904065459.80: *3* TestPython.test_def_test_2
+    def test_def_test_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class test:
+                def spam(b):
+                    pass
+
+                # Used by paste logic.
+
+                def foo(a):
+                    pass
+        """)
+        table = (
+            (1, 'class test'),
+            (2, 'spam'),
+            (2, 'foo'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+
+    #@+node:ekr.20210904065459.81: *3* TestPython.test_docstring_only
+    def test_docstring_only(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            """A file consisting only of a docstring.
+            """
+        ''')
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.82: *3* TestPython.test_empty_decls
+    def test_empty_decls(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            import leo.core.leoGlobals as g
+
+            a = 3
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.71: *3* TestPython.test_enhancement_481
+    def test_enhancement_481(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            @g.cmd('my-command')
+            def myCommand(event=None):
+                pass
+        """)
+        table = (
+            # (1, '@g.cmd myCommand'),
+            (1, "@g.cmd('my-command') myCommand"),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.83: *3* TestPython.test_extra_leading_ws_test
+    def test_extra_leading_ws_test(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class cls:
+                 def fun(): # one extra space.
+                    pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.84: *3* TestPython.test_indent_decls
+    def test_indent_decls(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            class mammalProviderBase(object):
+                """Root class for content providers used by DWEtree.py"""
+                def __init__(self, params):
+                    """store reference to parameters"""
+                    self.params = params
+                def provide(self, what):
+                    """default <BASE> value"""
+                    if what == 'doctitle':
+                        return ELE('base', href=self.params['/BASE/'])
+                    return None
+
+                def imagePath(self, sppdat):
+                    """return path to images and list of images for *species*"""
+                    path = 'MNMammals/imglib/Mammalia'
+                    for i in 'Order', 'Family', 'Genus', 'Species':
+                        path = os.path.join(path, sppdat['%sName' % (i,)])
+                    imglib = os.path.join('/var/www',path)
+                    imglib = os.path.join(imglib, '*.[Jj][Pp][Gg]')
+                    path = os.path.join('/',path)
+                    lst = [os.path.split(i)[1] for i in glob.glob(imglib)]
+                    lst.sort()
+                    return path, lst
+
+            class mainPages(mammalProviderBase):
+                """provide content for pages in 'main' folder"""
+                __parent = mammalProviderBase
+                def provide(self, what):
+                    """add one layer to <BASE>"""
+                    ans = self.__parent.provide(self, what)
+                    if what == 'doctitle':
+                        return ELE('base', href=self.params['/BASE/']+'main/')
+                    return ans
+        ''')
+        table = (
+            (1, 'class mammalProviderBase(object)'),
+            (2, '__init__'),
+            (2, 'provide'),
+            (2, 'imagePath'),
+            (1, 'class mainPages(mammalProviderBase)'),
+            (2, 'provide'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.85: *3* TestPython.test_leoImport_py_small_
+    def test_leoImport_py_small_(self):
+        c = self.c
+
+        s = textwrap.dedent("""\
+            # -*- coding: utf-8 -*-
+            import leo.core.leoGlobals as g
+            class LeoImportCommands(object):
+                '''A class implementing all of Leo's import/export code.'''
+                def createOutline(self, fileName, parent, s=None, ext=None):
+                    '''Create an outline by importing a file or string.'''
+
+                def dispatch(self, ext, p):
+                    '''Return the correct scanner function for p, an @auto node.'''
+                    # Match the @auto type first, then the file extension.
+                    return self.scanner_for_at_auto(p) or self.scanner_for_ext(ext)
+                def scanner_for_at_auto(self, p):
+                    '''A factory returning a scanner function for p, an @auto node.'''
+                    d = self.atAutoDict
+                    for key in d.keys():
+                        aClass = d.get(key)
+                        if aClass and g.match_word(p.h, 0, key):
+                            if trace: g.trace('found', aClass.__name__)
+
+                            def scanner_for_at_auto_cb(parent, s, prepass=False):
+                                try:
+                                    scanner = aClass(importCommands=self)
+                                    return scanner.run(s, parent, prepass=prepass)
+                                except Exception:
+                                    g.es_print('Exception running', aClass.__name__)
+                                    g.es_exception()
+                                    return None
+
+                            if trace: g.trace('found', p.h)
+                            return scanner_for_at_auto_cb
+                    if trace: g.trace('not found', p.h, sorted(d.keys()))
+                    return None
+                def scanner_for_ext(self, ext):
+                    '''A factory returning a scanner function for the given file extension.'''
+                    aClass = self.classDispatchDict.get(ext)
+                    if aClass:
+
+                        def scanner_for_ext_cb(parent, s, prepass=False):
+                            try:
+                                scanner = aClass(importCommands=self)
+                                return scanner.run(s, parent, prepass=prepass)
+                            except Exception:
+                                g.es_print('Exception running', aClass.__name__)
+                                g.es_exception()
+                                return None
+
+                        return scanner_for_ext_cb
+                    else:
+                        return None
+                def get_import_filename(self, fileName, parent):
+                    '''Return the absolute path of the file and set .default_directory.'''
+
+                def init_import(self, ext, fileName, s):
+                    '''Init ivars & vars for imports.'''
+        """)
+        table = (
+            (1, 'Declarations'),
+            (1, "class LeoImportCommands(object)"),
+            (2, "createOutline"),
+            (2, "dispatch"),
+            (2, "scanner_for_at_auto"),
+            (2, "scanner_for_ext"),
+            (2, "get_import_filename"),
+            (2, "init_import"),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.86: *3* TestPython.test_looks_like_section_ref
+    def test_looks_like_section_ref(self):
+        c = self.c
+        # ~/at-auto-test.py
+
+        # Careful: don't put a section reference in the string.
+        s = textwrap.dedent("""\
+            # This is valid Python, but it looks like a section reference.
+            a = b < < c > > d
+        """).replace('> >', '>>').replace('< <', '<<')
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.87: *3* TestPython.test_minimal_class_1
+    def test_minimal_class_1(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            class ItasException(Exception):
+
+                pass
+
+            def gpRun(gp, cmd, args, log = None):
+
+                """Wrapper for making calls to the geoprocessor and reporting errors"""
+
+                if log:
+
+                    log('gp: %s: %s\\n' % (cmd, str(args)))
+        ''')
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.88: *3* TestPython.test_minimal_class_2
+    def test_minimal_class_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class emptyClass: pass
+
+            def followingDef():
+                pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.89: *3* TestPython.test_minimal_class_3
+    def test_minimal_class_3(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class emptyClass: pass # comment
+
+            def followingDef(): # comment
+                pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.90: *3* TestPython.test_overindent_def_no_following_def
+    def test_overindent_def_no_following_def(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class aClass:
+                def def1(self):
+                    pass
+
+                if False or g.unitTesting:
+
+                    def pr(*args,**keys): # reportMismatch test
+                        g.es_print(color='blue',*args,**keys)
+
+                    pr('input...')
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.91: *3* TestPython.test_overindent_def_one_following_def
+    def test_overindent_def_one_following_def(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class aClass:
+                def def1(self):
+                    pass
+
+                if False or g.unitTesting:
+
+                    def pr(*args,**keys): # reportMismatch test
+                        g.es_print(color='blue',*args,**keys)
+
+                    pr('input...')
+
+                def def2(self):
+                    pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.92: *3* TestPython.test_overindented_def_3
+    def test_overindented_def_3(self):
+        # This caused PyParse.py not to be imported properly.
+        c = self.c
+        s = textwrap.dedent(r'''
+            import re
+            if 0: # Causes the 'overindent'
+               if 0:   # for throwaway debugging output
+                  def dump(*stuff):
+                    sys.__stdout__.write(" ".join(map(str, stuff)) + "\n")
+            for ch in "({[":
+               _tran[ord(ch)] = '('
+            class testClass1:
+                pass
+        ''')
+        table = (
+            (1, 'Declarations'),
+            (1, 'class testClass1'),
+        )
+        p = c.p
+        self.run_test(c.p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.93: *3* TestPython.test_string_test_extra_indent
+    def test_string_test_extra_indent(self):
+        c = self.c
+        s = textwrap.dedent('''\
+        class BaseScanner:
+
+                """The base class for all import scanner classes."""
+
+                def __init__ (self,importCommands,language):
+
+                    self.c = ic.c
+
+                def createHeadline (self,parent,body,headline):
+                    # g.trace("parent,headline:",parent,headline)
+                    return p
+        ''')
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.94: *3* TestPython.test_string_underindent_lines
+    def test_string_underindent_lines(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class BaseScanner:
+                def containsUnderindentedComment(self):
+                    a = 2
+                # A true underindented comment.
+                    b = 3
+                # This underindented comment should be placed with next function.
+                def empty(self):
+                    pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.95: *3* TestPython.test_string_underindent_lines_2
+    def test_string_underindent_lines_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class BaseScanner:
+                def containsUnderindentedComment(self):
+                    a = 2
+                #
+                    b = 3
+                    # This comment is part of the present function.
+
+                def empty(self):
+                    pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.96: *3* TestPython.test_top_level_later_decl
+    def test_top_level_later_decl(self):
+        # From xo.py.
+        c = self.c
+        # The first line *must* be blank.
+        s = textwrap.dedent(r'''
+
+            #!/usr/bin/env python3
+
+            import os
+            import re
+
+            def merge_value(v1, v2):
+                return v
+
+            class MainDisplay(object):
+
+                def save_file(self):
+                    """Write the file out to disk."""
+                    with open(self.save_name, "w") as f:
+                        for newline in newlines:
+                            f.write(newline)
+
+            # The next line should be included at the end of the class node.
+
+            ensure_endswith_newline = lambda x: x if x.endswith('\n') else x + '\n'
+
+            def retab(s, tabsize):
+                return ''.join(pieces)
+
+            if __name__=="__main__":
+                main()
+
+        ''')
+        table = (
+            (1, 'Declarations'),
+            (1, 'merge_value'),
+            (1, 'class MainDisplay(object)'),
+            (2, 'save_file'),
+            (1, 'retab'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        root = p.lastChild()
+        assert root
+        self.assertEqual(root.h, '@file test')
+        after = p.nodeAfterTree()
+        p = root.firstChild()
+        for n, h in table:
+            assert p, h
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.97: *3* TestPython.test_trailing_comment
+    def test_trailing_comment(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class aClass: # trailing comment
+
+
+                def def1(self):             # trailing comment
+                    pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.98: *3* TestPython.test_trailing_comment_outer_levels
+    def test_trailing_comment_outer_levels(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            xyz = 6 # trailing comment
+            pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.99: *3* TestPython.test_two_functions
+    def test_two_functions(self):
+        # For comparison with unindent does not end function.
+        c = self.c
+        s = textwrap.dedent("""\
+            def foo():
+                pass
+
+            def bar():
+                pass
+        """)
+        self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.100: *3* TestPython.test_underindent_method
+    def test_underindent_method(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            class emptyClass:
+
+                def spam():
+                    """docstring line 1
+            under-indented docstring line"""
+                    pass
+
+            def followingDef(): # comment
+                pass
+        ''')
+        table = (
+            (1, 'class emptyClass'),
+            (2, 'spam'),
+            (1, 'followingDef'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.101: *3* TestPython.test_unindent_in_triple_string_does_not_end_function
+    def test_unindent_in_triple_string_does_not_end_function(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            def foo():
+
+                error("""line1
+            line2.
+            """)
+
+                a = 5
+
+            def bar():
+                pass
+        ''')
+        p = c.p
+        self.run_test(p, s=s)
+        child = p.firstChild()
+        n = child.numberOfChildren()
+        self.assertEqual(n, 2)
+    #@+node:ekr.20210904065459.102: *3* TestPython.test_unittest_perfectImport_formatter_py
+    def test_unittest_perfectImport_formatter_py(self):
+        c = self.c
+
+        s = textwrap.dedent('''\
+
+            """Generic output formatting.
+            """
+
+            import sys
+
+
+            AS_IS = None
+
+
+            class NullFormatter:
+                """A formatter which does nothing.
+
+                If the writer parameter is omitted, a NullWriter instance is created.
+                No methods of the writer are called by NullFormatter instances.
+
+                Implementations should inherit from this class if implementing a writer
+                interface but don't need to inherit any implementation.
+
+                """
+
+                def __init__(self, writer=None):
+                    if writer is None:
+                        writer = NullWriter()
+                    self.writer = writer
+                def end_paragraph(self, blankline): pass
+                def add_line_break(self): pass
+                def add_hor_rule(self, *args, **kw): pass
+                def add_label_data(self, format, counter, blankline=None): pass
+                def add_flowing_data(self, data): pass
+                def add_literal_data(self, data): pass
+                def flush_softspace(self): pass
+                def push_alignment(self, align): pass
+                def pop_alignment(self): pass
+                def push_font(self, x): pass
+                def pop_font(self): pass
+                def push_margin(self, margin): pass
+                def pop_margin(self): pass
+                def set_spacing(self, spacing): pass
+                def push_style(self, *styles): pass
+                def pop_style(self, n=1): pass
+                def assert_line_data(self, flag=1): pass
+
+
+            class AbstractFormatter:
+                """The standard formatter.
+
+                This implementation has demonstrated wide applicability to many writers,
+                and may be used directly in most circumstances.  It has been used to
+                implement a full-featured World Wide Web browser.
+
+                """
+
+                #  Space handling policy:  blank spaces at the boundary between elements
+                #  are handled by the outermost context.  "Literal" data is not checked
+                #  to determine context, so spaces in literal data are handled directly
+                #  in all circumstances.
+
+                def __init__(self, writer):
+                    self.writer = writer            # Output device
+                    self.align = None               # Current alignment
+                    self.align_stack = []           # Alignment stack
+                    self.font_stack = []            # Font state
+                    self.margin_stack = []          # Margin state
+                    self.spacing = None             # Vertical spacing state
+                    self.style_stack = []           # Other state, e.g. color
+                    self.nospace = 1                # Should leading space be suppressed
+                    self.softspace = 0              # Should a space be inserted
+                    self.para_end = 1               # Just ended a paragraph
+                    self.parskip = 0                # Skipped space between paragraphs?
+                    self.hard_break = 1             # Have a hard break
+                    self.have_label = 0
+
+                def end_paragraph(self, blankline):
+                    if not self.hard_break:
+                        self.writer.send_line_break()
+                        self.have_label = 0
+                    if self.parskip < blankline and not self.have_label:
+                        self.writer.send_paragraph(blankline - self.parskip)
+                        self.parskip = blankline
+                        self.have_label = 0
+                    self.hard_break = self.nospace = self.para_end = 1
+                    self.softspace = 0
+
+                def add_line_break(self):
+                    if not (self.hard_break or self.para_end):
+                        self.writer.send_line_break()
+                        self.have_label = self.parskip = 0
+                    self.hard_break = self.nospace = 1
+                    self.softspace = 0
+
+                def add_hor_rule(self, *args, **kw):
+                    if not self.hard_break:
+                        self.writer.send_line_break()
+                    self.writer.send_hor_rule(*args, **kw)
+                    self.hard_break = self.nospace = 1
+                    self.have_label = self.para_end = self.softspace = self.parskip = 0
+
+                def add_label_data(self, format, counter, blankline = None):
+                    if self.have_label or not self.hard_break:
+                        self.writer.send_line_break()
+                    if not self.para_end:
+                        self.writer.send_paragraph((blankline and 1) or 0)
+                    if isinstance(format, str):
+                        self.writer.send_label_data(self.format_counter(format, counter))
+                    else:
+                        self.writer.send_label_data(format)
+                    self.nospace = self.have_label = self.hard_break = self.para_end = 1
+                    self.softspace = self.parskip = 0
+
+                def format_counter(self, format, counter):
+                    label = ''
+                    for c in format:
+                        if c == '1':
+                            label = label + ('%d' % counter)
+                        elif c in 'aA':
+                            if counter > 0:
+                                label = label + self.format_letter(c, counter)
+                        elif c in 'iI':
+                            if counter > 0:
+                                label = label + self.format_roman(c, counter)
+                        else:
+                            label = label + c
+                    return label
+
+                def format_letter(self, case, counter):
+                    label = ''
+                    while counter > 0:
+                        counter, x = divmod(counter-1, 26)
+                        # This makes a strong assumption that lowercase letters
+                        # and uppercase letters form two contiguous blocks, with
+                        # letters in order!
+                        s = chr(ord(case) + x)
+                        label = s + label
+                    return label
+
+                def format_roman(self, case, counter):
+                    ones = ['i', 'x', 'c', 'm']
+                    fives = ['v', 'l', 'd']
+                    label, index = '', 0
+                    # This will die of IndexError when counter is too big
+                    while counter > 0:
+                        counter, x = divmod(counter, 10)
+                        if x == 9:
+                            label = ones[index] + ones[index+1] + label
+                        elif x == 4:
+                            label = ones[index] + fives[index] + label
+                        else:
+                            if x >= 5:
+                                s = fives[index]
+                                x = x-5
+                            else:
+                                s = ''
+                            s = s + ones[index]*x
+                            label = s + label
+                        index = index + 1
+                    if case == 'I':
+                        return label.upper()
+                    return label
+
+                def add_flowing_data(self, data):
+                    if not data: return
+                    # The following looks a bit convoluted but is a great improvement over
+                    # data = regsub.gsub('[' + string.whitespace + ']+', ' ', data)
+                    prespace = data[:1].isspace()
+                    postspace = data[-1:].isspace()
+                    data = " ".join(data.split())
+                    if self.nospace and not data:
+                        return
+                    elif prespace or self.softspace:
+                        if not data:
+                            if not self.nospace:
+                                self.softspace = 1
+                                self.parskip = 0
+                            return
+                        if not self.nospace:
+                            data = ' ' + data
+                    self.hard_break = self.nospace = self.para_end = \
+                                      self.parskip = self.have_label = 0
+                    self.softspace = postspace
+                    self.writer.send_flowing_data(data)
+
+                def add_literal_data(self, data):
+                    if not data: return
+                    if self.softspace:
+                        self.writer.send_flowing_data(" ")
+                    self.hard_break = data[-1:] == '\n'
+                    self.nospace = self.para_end = self.softspace = \
+                                   self.parskip = self.have_label = 0
+                    self.writer.send_literal_data(data)
+
+                def flush_softspace(self):
+                    if self.softspace:
+                        self.hard_break = self.para_end = self.parskip = \
+                                          self.have_label = self.softspace = 0
+                        self.nospace = 1
+                        self.writer.send_flowing_data(' ')
+
+                def push_alignment(self, align):
+                    if align and align != self.align:
+                        self.writer.new_alignment(align)
+                        self.align = align
+                        self.align_stack.append(align)
+                    else:
+                        self.align_stack.append(self.align)
+
+                def pop_alignment(self):
+                    if self.align_stack:
+                        del self.align_stack[-1]
+                    if self.align_stack:
+                        self.align = align = self.align_stack[-1]
+                        self.writer.new_alignment(align)
+                    else:
+                        self.align = None
+                        self.writer.new_alignment(None)
+
+                def push_font(self, (size, i, b, tt)):
+                    if self.softspace:
+                        self.hard_break = self.para_end = self.softspace = 0
+                        self.nospace = 1
+                        self.writer.send_flowing_data(' ')
+                    if self.font_stack:
+                        csize, ci, cb, ctt = self.font_stack[-1]
+                        if size is AS_IS: size = csize
+                        if i is AS_IS: i = ci
+                        if b is AS_IS: b = cb
+                        if tt is AS_IS: tt = ctt
+                    font = (size, i, b, tt)
+                    self.font_stack.append(font)
+                    self.writer.new_font(font)
+
+                def pop_font(self):
+                    if self.font_stack:
+                        del self.font_stack[-1]
+                    if self.font_stack:
+                        font = self.font_stack[-1]
+                    else:
+                        font = None
+                    self.writer.new_font(font)
+
+                def push_margin(self, margin):
+                    self.margin_stack.append(margin)
+                    fstack = filter(None, self.margin_stack)
+                    if not margin and fstack:
+                        margin = fstack[-1]
+                    self.writer.new_margin(margin, len(fstack))
+
+                def pop_margin(self):
+                    if self.margin_stack:
+                        del self.margin_stack[-1]
+                    fstack = filter(None, self.margin_stack)
+                    if fstack:
+                        margin = fstack[-1]
+                    else:
+                        margin = None
+                    self.writer.new_margin(margin, len(fstack))
+
+                def set_spacing(self, spacing):
+                    self.spacing = spacing
+                    self.writer.new_spacing(spacing)
+
+                def push_style(self, *styles):
+                    if self.softspace:
+                        self.hard_break = self.para_end = self.softspace = 0
+                        self.nospace = 1
+                        self.writer.send_flowing_data(' ')
+                    for style in styles:
+                        self.style_stack.append(style)
+                    self.writer.new_styles(tuple(self.style_stack))
+
+                def pop_style(self, n=1):
+                    del self.style_stack[-n:]
+                    self.writer.new_styles(tuple(self.style_stack))
+
+                def assert_line_data(self, flag=1):
+                    self.nospace = self.hard_break = not flag
+                    self.para_end = self.parskip = self.have_label = 0
+
+
+            class NullWriter:
+                """Minimal writer interface to use in testing & inheritance.
+
+                A writer which only provides the interface definition; no actions are
+                taken on any methods.  This should be the base class for all writers
+                which do not need to inherit any implementation methods.
+
+                """
+                def __init__(self): pass
+                def flush(self): pass
+                def new_alignment(self, align): pass
+                def new_font(self, font): pass
+                def new_margin(self, margin, level): pass
+                def new_spacing(self, spacing): pass
+                def new_styles(self, styles): pass
+                def send_paragraph(self, blankline): pass
+                def send_line_break(self): pass
+                def send_hor_rule(self, *args, **kw): pass
+                def send_label_data(self, data): pass
+                def send_flowing_data(self, data): pass
+                def send_literal_data(self, data): pass
+
+
+            class AbstractWriter(NullWriter):
+                """A writer which can be used in debugging formatters, but not much else.
+
+                Each method simply announces itself by printing its name and
+                arguments on standard output.
+
+                """
+
+                def new_alignment(self, align):
+                    print "new_alignment(%s)" % `align`
+
+                def new_font(self, font):
+                    print "new_font(%s)" % `font`
+
+                def new_margin(self, margin, level):
+                    print "new_margin(%s, %d)" % (`margin`, level)
+
+                def new_spacing(self, spacing):
+                    print "new_spacing(%s)" % `spacing`
+
+                def new_styles(self, styles):
+                    print "new_styles(%s)" % `styles`
+
+                def send_paragraph(self, blankline):
+                    print "send_paragraph(%s)" % `blankline`
+
+                def send_line_break(self):
+                    print "send_line_break()"
+
+                def send_hor_rule(self, *args, **kw):
+                    print "send_hor_rule()"
+
+                def send_label_data(self, data):
+                    print "send_label_data(%s)" % `data`
+
+                def send_flowing_data(self, data):
+                    print "send_flowing_data(%s)" % `data`
+
+                def send_literal_data(self, data):
+                    print "send_literal_data(%s)" % `data`
+
+
+            class DumbWriter(NullWriter):
+                """Simple writer class which writes output on the file object passed in
+                as the file parameter or, if file is omitted, on standard output.  The
+                output is simply word-wrapped to the number of columns specified by
+                the maxcol parameter.  This class is suitable for reflowing a sequence
+                of paragraphs.
+
+                """
+
+                def __init__(self, file=None, maxcol=72):
+                    self.file = file or sys.stdout
+                    self.maxcol = maxcol
+                    NullWriter.__init__(self)
+                    self.reset()
+
+                def reset(self):
+                    self.col = 0
+                    self.atbreak = 0
+
+                def send_paragraph(self, blankline):
+                    self.file.write('\n'*blankline)
+                    self.col = 0
+                    self.atbreak = 0
+
+                def send_line_break(self):
+                    self.file.write('\n')
+                    self.col = 0
+                    self.atbreak = 0
+
+                def send_hor_rule(self, *args, **kw):
+                    self.file.write('\n')
+                    self.file.write('-'*self.maxcol)
+                    self.file.write('\n')
+                    self.col = 0
+                    self.atbreak = 0
+
+                def send_literal_data(self, data):
+                    self.file.write(data)
+                    i = data.rfind('\n')
+                    if i >= 0:
+                        self.col = 0
+                        data = data[i+1:]
+                    data = data.expandtabs()
+                    self.col = self.col + len(data)
+                    self.atbreak = 0
+
+                def send_flowing_data(self, data):
+                    if not data: return
+                    atbreak = self.atbreak or data[0].isspace()
+                    col = self.col
+                    maxcol = self.maxcol
+                    write = self.file.write
+                    for word in data.split():
+                        if atbreak:
+                            if col + len(word) >= maxcol:
+                                write('\n')
+                                col = 0
+                            else:
+                                write(' ')
+                                col = col + 1
+                        write(word)
+                        col = col + len(word)
+                        atbreak = 1
+                    self.col = col
+                    self.atbreak = data[-1].isspace()
+
+
+            def test(file = None):
+                w = DumbWriter()
+                f = AbstractFormatter(w)
+                if file is not None:
+                    fp = open(file)
+                elif sys.argv[1:]:
+                    fp = open(sys.argv[1])
+                else:
+                    fp = sys.stdin
+                while 1:
+                    line = fp.readline()
+                    if not line:
+                        break
+                    if line == '\n':
+                        f.end_paragraph(1)
+                    else:
+                        f.add_flowing_data(line)
+                f.end_paragraph(0)
+
+
+            if __name__ == '__main__':
+                test()
+        ''')
+        self.run_test(c.p, s=s)
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,61 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904143328.1: *3* Pascal tests
-    #@+node:ekr.20210904065459.50: *4* TestImport.test_pascal_to_delphi_interface
-    def test_pascal_to_delphi_interface(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            unit Unit1;
-
-            interface
-
-            uses
-            Windows, Messages, SysUtils, Variants, Classes, Graphics, Controls,
-            Forms,
-            Dialogs;
-
-            type
-            TForm1 = class(TForm)
-            procedure FormCreate(Sender: TObject);
-            private
-            { Private declarations }
-            public
-            { Public declarations }
-            end;
-
-            var
-            Form1: TForm1;
-
-            implementation
-
-            {$R *.dfm}
-
-            procedure TForm1.FormCreate(Sender: TObject);
-            var
-            x,y: double;
-            begin
-            x:= 4;
-            Y := x/2;
-            end;
-
-            end. // interface
-        """)
-        table = (
-            'interface',
-            'procedure FormCreate',
-            'procedure TForm1.FormCreate',
-        )
-        c.importCommands.pascalUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        assert root
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-
     #@+node:ekr.20210904122909.1: *3* Perl tests
     #@+node:ekr.20210904065459.51: *4* TestImport.test_perl_1
     def test_perl_1(self):
@@ -4113,6 +4058,67 @@ class TestOtl (BaseTestImporter):
         for line in table:
             m = pattern.match(line)
             self.assertTrue(m, msg=repr(line))
+    #@-others
+#@+node:ekr.20211108081719.1: ** class TestPascal (BaseTestImporter)
+class TestPascal (BaseTestImporter):
+    
+    ext = '.pas'
+    
+    #@+others
+    #@+node:ekr.20210904065459.50: *3* TestPascal.test_delphi_interface
+    def test_delphi_interface(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            unit Unit1;
+
+            interface
+
+            uses
+            Windows, Messages, SysUtils, Variants, Classes, Graphics, Controls,
+            Forms,
+            Dialogs;
+
+            type
+            TForm1 = class(TForm)
+            procedure FormCreate(Sender: TObject);
+            private
+            { Private declarations }
+            public
+            { Public declarations }
+            end;
+
+            var
+            Form1: TForm1;
+
+            implementation
+
+            {$R *.dfm}
+
+            procedure TForm1.FormCreate(Sender: TObject);
+            var
+            x,y: double;
+            begin
+            x:= 4;
+            Y := x/2;
+            end;
+
+            end. // interface
+        """)
+        table = (
+            'interface',
+            'procedure FormCreate',
+            'procedure TForm1.FormCreate',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        assert root
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -61,50 +61,6 @@ class BaseTestImporter(LeoUnitTest):
 class TempImporterTest (BaseTestImporter):
     
     #@+others  ### To be moved to other classes.
-    #@+node:ekr.20210904144251.1: *3* C# tests
-    #@+node:ekr.20210904065459.12: *4* TestImport.test_c_sharp_namespace_indent
-    def test_c_sharp_namespace_indent(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            namespace {
-                class cTestClass1 {
-                    ;
-                }
-            }
-        """)
-        table = (
-            'namespace',
-            'class cTestClass1',
-        )
-        c.importCommands.cSharpUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.13: *4* TestImport.test_c_sharp_namespace_no_indent
-    def test_c_sharp_namespace_no_indent(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            namespace {
-            class cTestClass1 {
-                ;
-            }
-            }
-        """)
-        c.importCommands.cSharpUnitTest(c.p, s=s)
-        table = (
-            'namespace',
-            'class cTestClass1',
-        )
-        root = c.p.firstChild()
-        # assert root.h.endswith('c# namespace no indent'), root.h
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
     #@+node:ekr.20210904122726.1: *3* Coffeescript tests
     #@+node:ekr.20210904065459.15: *4* TestImport.test_coffeescript_2
     def test_coffeescript_2(self):
@@ -4432,6 +4388,56 @@ class TestIni(BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
+#@+node:ekr.20211108062958.1: ** class TestCSharp(BaseTestImporter)
+class TestCSharp(BaseTestImporter):
+    
+    ext = '.c#'
+    
+    #@+others
+    #@+node:ekr.20210904065459.12: *3* TestCSharp.test_namespace_indent
+    def test_namespace_indent(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            namespace {
+                class cTestClass1 {
+                    ;
+                }
+            }
+        """)
+        table = (
+            'namespace',
+            'class cTestClass1',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+    #@+node:ekr.20210904065459.13: *3* TestImport.test_namespace_no_indent
+    def test_namespace_no_indent(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            namespace {
+            class cTestClass1 {
+                ;
+            }
+            }
+        """)
+        self.run_test(c.p, s)
+        table = (
+            'namespace',
+            'class cTestClass1',
+        )
+        root = c.p.firstChild()
+        # assert root.h.endswith('c# namespace no indent'), root.h
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
     #@-others
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -424,6 +424,83 @@ class TestCSharp(BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
     #@-others
+#@+node:ekr.20211108063908.1: ** class TestCython (BaseTestImporter)
+class TestCython (BaseTestImporter):
+    
+    ext = '.pyx'
+#@+node:ekr.20210904065459.11: *3* TestCython.test_importer
+def test_importer(self):
+    c = self.c
+    s = textwrap.dedent('''\
+        from libc.math cimport pow
+
+        cdef double square_and_add (double x):
+            """Compute x^2 + x as double.
+
+            This is a cdef function that can be called from within
+            a Cython program, but not from Python.
+            """
+            return pow(x, 2.0) + x
+
+        cpdef print_result (double x):
+            """This is a cpdef function that can be called from Python."""
+            print("({} ^ 2) + {} = {}".format(x, x, square_and_add(x)))
+
+    ''')
+    table = (
+        'Declarations',
+        'double',
+        'print_result',
+    )
+    self.run_test(c.p, s)
+    root = c.p.lastChild()
+    self.assertEqual(root.h, '@file test')
+    p2 = root.firstChild()
+    for h in table:
+        self.assertEqual(p2.h, h)
+        p2.moveToThreadNext()
+    assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+#@+node:ekr.20211108064115.1: ** class TestDart (BaseTestImporter)
+class TestDart (BaseTestImporter):
+    
+    ext = '.dart'
+    
+    #@+others
+    #@+node:ekr.20210904065459.17: *3* TestDart.test_hello_world
+    def test_hello_world(self):
+        c = self.c
+        s = r'''
+        var name = 'Bob';
+
+        hello() {
+          print('Hello, World!');
+        }
+
+        // Define a function.
+        printNumber(num aNumber) {
+          print('The number is $aNumber.'); // Print to console.
+        }
+
+        // This is where the app starts executing.
+        void main() {
+          var number = 42; // Declare and initialize a variable.
+          printNumber(number); // Call a function.
+        }
+        '''
+        table = (
+            'hello',
+            'printNumber',
+            'void main',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+
+    #@-others
 #@+node:ekr.20211108062617.1: ** class TestIni (BaseTestImporter)
 class TestIni(BaseTestImporter):
     
@@ -674,41 +751,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904144021.1: *3* Dart tests
-    #@+node:ekr.20210904065459.17: *4* TestImport.test_dart_hello_world
-    def test_dart_hello_world(self):
-        c = self.c
-        s = r'''
-        var name = 'Bob';
-
-        hello() {
-          print('Hello, World!');
-        }
-
-        // Define a function.
-        printNumber(num aNumber) {
-          print('The number is $aNumber.'); // Print to console.
-        }
-
-        // This is where the app starts executing.
-        void main() {
-          var number = 42; // Declare and initialize a variable.
-          printNumber(number); // Call a function.
-        }
-        '''
-        table = (
-            'hello',
-            'printNumber',
-            'void main',
-        )
-        c.importCommands.dartUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-
     #@+node:ekr.20210904143920.1: *3* Elisp tests
     #@+node:ekr.20210904065459.18: *4* TestImport.test_elisp
     def test_elisp(self):
@@ -4412,42 +4454,6 @@ class TestRst(BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
-#@+node:ekr.20211108063908.1: ** class TestCython (BaseTestImporter)
-class TestCython (BaseTestImporter):
-    
-    ext = '.pyx'
-#@+node:ekr.20210904065459.11: *3* TestCython.test_importer
-def test_importer(self):
-    c = self.c
-    s = textwrap.dedent('''\
-        from libc.math cimport pow
-
-        cdef double square_and_add (double x):
-            """Compute x^2 + x as double.
-
-            This is a cdef function that can be called from within
-            a Cython program, but not from Python.
-            """
-            return pow(x, 2.0) + x
-
-        cpdef print_result (double x):
-            """This is a cpdef function that can be called from Python."""
-            print("({} ^ 2) + {} = {}".format(x, x, square_and_add(x)))
-
-    ''')
-    table = (
-        'Declarations',
-        'double',
-        'print_result',
-    )
-    self.run_test(c.p, s)
-    root = c.p.lastChild()
-    self.assertEqual(root.h, '@file test')
-    p2 = root.firstChild()
-    for h in table:
-        self.assertEqual(p2.h, h)
-        p2.moveToThreadNext()
-    assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 #@-others
 
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -57,6 +57,20 @@ class BaseTestImporter(LeoUnitTest):
                     return z
         return '@file'
     #@-others
+#@+node:ekr.20211108052633.1: ** class TestAtAuto (BaseTestImporter)
+class TestAtAuto (BaseTestImporter):
+    
+    #@+others
+    #@+node:ekr.20210904065459.122: *3* TestAtAuto.test_importers_can_be_imported
+    def test_importers_can_be_imported(self):
+        path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'importers')
+        assert g.os_path_exists(path), repr(path)
+        pattern = g.os_path_finalize_join(path, '*.py')
+        for fn in glob.glob(pattern):
+            sfn = g.shortFileName(fn)
+            m = importlib.import_module('leo.plugins.importers.%s' % sfn[:-3])
+            assert m
+    #@-others
 #@+node:ekr.20211108062025.1: ** class TestC (BaseTestImporter)
 class TestC(BaseTestImporter):
     
@@ -376,7 +390,7 @@ class TestCoffeescript (BaseTestImporter):
     #@+node:ekr.20211108085023.1: *3* TestCoffeescript.test_get_leading_indent
     def test_get_leading_indent(self):
         c = self.c
-        importer = linescanner.Importer(c.importCommands, language='coffeescrip')
+        importer = linescanner.Importer(c.importCommands, language='coffeescript')
         self.assertEqual(importer.single_comment, '#')
     #@+node:ekr.20210904065459.126: *3* TestCoffeescript.test_scan_line
     def test_scan_line(self):
@@ -1567,20 +1581,6 @@ class TestMarkdown(BaseTestImporter):
         for line in ('-\n', '--\n', '---\n', '==\n', '===\n', '===\n', '==-==\n', 'abc\n'):
             got = x.is_underline(line)
             assert not got, repr(line)
-    #@-others
-#@+node:ekr.20211108052633.1: ** class TestMisc (BaseTestImporter) ===========
-class TestMisc (BaseTestImporter):
-    
-    #@+others
-    #@+node:ekr.20210904065459.122: *3* TestImport.test_at_auto_importers
-    def test_at_auto_importers(self):
-        path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'importers')
-        assert g.os_path_exists(path), repr(path)
-        pattern = g.os_path_finalize_join(path, '*.py')
-        for fn in glob.glob(pattern):
-            sfn = g.shortFileName(fn)
-            m = importlib.import_module('leo.plugins.importers.%s' % sfn[:-3])
-            assert m
     #@-others
 #@+node:ekr.20211108080955.1: ** class TestOrg (BaseTestImporter)
 class TestOrg (BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -20,7 +20,7 @@ import leo.plugins.importers.pascal as pascal
 import leo.plugins.importers.python as python
 import leo.plugins.importers.xml as xml
 #@+others
-#@+node:ekr.20210904064440.3: ** class TestImporter(LeoUnitTest):
+#@+node:ekr.20210904064440.3: **  class TestImporter(LeoUnitTest)
 class TestImporter(LeoUnitTest):
     """Test cases for leoImport.py"""
     
@@ -3705,309 +3705,6 @@ class TestImporter(LeoUnitTest):
             <_.ÌÑ>
         """)
         c.importCommands.xmlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904071345.1: *3* Tests of @auto-rst
-    #@+node:ekr.20210904065459.115: *4* TestImport.test_rST_import_test
-    def test_rST_import_test(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        s = textwrap.dedent("""\
-            .. toc
-
-            ====
-            top
-            ====
-
-            The top section
-
-            section 1
-            ---------
-
-            section 1, line 1
-            --
-            section 1, line 2
-
-            section 2
-            ---------
-
-            section 2, line 1
-
-            section 2.1
-            ~~~~~~~~~~~
-
-            section 2.1, line 1
-
-            section 2.1.1
-            .............
-
-            section 2.2.1 line 1
-
-            section 3
-            ---------
-
-            section 3, line 1
-
-            section 3.1.1
-            .............
-
-            section 3.1.1, line 1
-        """)
-        table = (
-            '!Dummy chapter',
-            'top',
-            'section 1',
-            'section 2',
-            'section 2.1',
-            'section 2.1.1',
-            'section 3',
-            'placeholder',
-            'section 3.1.1',
-        )
-        c.importCommands.rstUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.116: *4* TestImport.test_rST_import_test_simple
-    def test_rST_import_test_simple(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        s = textwrap.dedent("""\
-            .. toc
-
-            .. The section name contains trailing whitespace.
-
-            =======
-            Chapter
-            =======
-
-            The top chapter.
-        """)
-        table = (
-            "!Dummy chapter",
-            "Chapter",
-        )
-        c.importCommands.rstUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.117: *4* TestImport.test_rST_import_test_no_double_underlines
-    def test_rST_import_test_no_double_underlines(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        s = textwrap.dedent("""\
-            .. toc
-
-            top
-            ====
-
-            The top section
-
-            section 1
-            ---------
-
-            section 1, line 1
-            --
-            section 1, line 2
-
-            section 2
-            ---------
-
-            section 2, line 1
-
-            section 2.1
-            ~~~~~~~~~~~
-
-            section 2.1, line 1
-
-            section 2.1.1
-            .............
-
-            section 2.2.1 line 1
-
-            section 3
-            ---------
-
-            section 3, line 1
-
-            section 3.1.1
-            .............
-
-            section 3.1.1, line 1
-        """)
-        table = (
-            '!Dummy chapter',
-            'top',
-            'section 1',
-            'section 2',
-            'section 2.1',
-            'section 2.1.1',
-            'section 3',
-            'placeholder',
-            'section 3.1.1',
-        )
-        c.importCommands.rstUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.118: *4* TestImport.test_rST_import_test_long_underlines
-    def test_rST_import_test_long_underlines(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        s = textwrap.dedent("""\
-            .. toc
-
-            top
-            -------------
-
-            The top section
-        """)
-        table = (
-            '!Dummy chapter',
-            'top',
-        )
-        c.importCommands.rstUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.119: *4* TestImport.test_rST_import_test_long_overlines
-    def test_rST_import_test_long_overlines(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        s = textwrap.dedent("""\
-            .. toc
-
-            ======
-            top
-            ======
-
-            The top section
-        """)
-        table = (
-            "!Dummy chapter",
-            "top",
-        )
-        c.importCommands.rstUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.120: *4* TestImport.test_rST_import_test_trailing_whitespace
-    def test_rST_import_test_trailing_whitespace(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        s = textwrap.dedent("""\
-            .. toc
-
-            .. The section name contains trailing whitespace.
-
-            ======
-            top
-            ======
-
-            The top section.
-        """)
-        table = (
-            "!Dummy chapter",
-            "top",
-        )
-        p = c.p
-        c.importCommands.rstUnitTest(p, s=s)
-        root = p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.121: *4* TestImport.test_leo_rst
-    def test_leo_rst(self):
-        c = self.c
-        try:
-            import docutils
-            assert docutils
-        except Exception:
-            self.skipTest('no docutils')
-
-        # All heading must be followed by an empty line.
-        s = textwrap.dedent("""\
-            #########
-            Chapter 1
-            #########
-
-            It was a dark and stormy night.
-
-            section 1
-            +++++++++
-
-            Sec 1.
-
-            section 2
-            +++++++++
-
-            Sec 2.
-        """)
-        table = (
-            'Chapter 1',
-            'section 1',
-            'section 2',
-        )
-        c.importCommands.rstUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-rst test')
-        p2 = root.firstChild()
-        assert p2, g.tree_to_string(c)
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904071422.1: *3* All other tests
     #@+node:ekr.20210904065459.122: *4* TestImport.test_at_auto_importers
     def test_at_auto_importers(self):
@@ -4197,14 +3894,14 @@ class TestImporter(LeoUnitTest):
         importer = python.Py_Importer(c.importCommands, atAuto=True)
         importer.test_scan_state(tests, State)
     #@-others
-#@+node:ekr.20211108043230.1: ** class TestMarkdownImporter(TestImporter):
-class TestMarkdownImporter(TestImporter):
+#@+node:ekr.20211108043230.1: ** class TestMarkdown(TestImporter)
+class TestMarkdown(TestImporter):
     
     def run_test(self, p, s):
         super().run_test(p, s, ext='.md')
     
     #@+others
-    #@+node:ekr.20210904065459.109: *3* TestImport.test_md_import_test
+    #@+node:ekr.20210904065459.109: *3* TestMarkdown.test_md_import_test
     def test_md_import_test(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -4250,7 +3947,7 @@ class TestMarkdownImporter(TestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.110: *3* TestImport.test_md_import_test_rst_style
+    #@+node:ekr.20210904065459.110: *3* TestMarkdown.test_md_import_test_rst_style
     def test_md_import_test_rst_style(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -4308,7 +4005,7 @@ class TestMarkdownImporter(TestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.111: *3* TestImport.test_markdown_importer_basic
+    #@+node:ekr.20210904065459.111: *3* TestMarkdown.test_markdown_importer_basic
     def test_markdown_importer_basic(self):
         c = self.c
         # insert test for markdown here.
@@ -4342,7 +4039,7 @@ class TestMarkdownImporter(TestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.112: *3* TestImport.test_markdown_importer_implicit_section
+    #@+node:ekr.20210904065459.112: *3* TestMarkdown.test_markdown_importer_implicit_section
     def test_markdown_importer_implicit_section(self):
         c = self.c
         # insert test for markdown here.
@@ -4382,7 +4079,7 @@ class TestMarkdownImporter(TestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.114: *3* TestImport.test_markdown_github_syntax
+    #@+node:ekr.20210904065459.114: *3* TestMarkdown.test_markdown_github_syntax
     def test_markdown_github_syntax(self):
         c = self.c
         # insert test for markdown here.
@@ -4407,6 +4104,323 @@ class TestMarkdownImporter(TestImporter):
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-md test')
         p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
+#@+node:ekr.20211108050827.1: ** class TestRst(TestImporter)
+class TestRst(TestImporter):
+    
+    def run_test(self, p, s):
+        super().run_test(p, s, ext='.rst')
+    
+    #@+others
+    #@+node:ekr.20210904065459.115: *3* TestRst.test_test1
+    def test_test1(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        s = textwrap.dedent("""\
+            .. toc
+
+            ====
+            top
+            ====
+
+            The top section
+
+            section 1
+            ---------
+
+            section 1, line 1
+            --
+            section 1, line 2
+
+            section 2
+            ---------
+
+            section 2, line 1
+
+            section 2.1
+            ~~~~~~~~~~~
+
+            section 2.1, line 1
+
+            section 2.1.1
+            .............
+
+            section 2.2.1 line 1
+
+            section 3
+            ---------
+
+            section 3, line 1
+
+            section 3.1.1
+            .............
+
+            section 3.1.1, line 1
+        """)
+        table = (
+            '!Dummy chapter',
+            'top',
+            'section 1',
+            'section 2',
+            'section 2.1',
+            'section 2.1.1',
+            'section 3',
+            'placeholder',
+            'section 3.1.1',
+        )
+        # c.importCommands.rstUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.116: *3* TestRst.test_simple
+    def test_simple(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        s = textwrap.dedent("""\
+            .. toc
+
+            .. The section name contains trailing whitespace.
+
+            =======
+            Chapter
+            =======
+
+            The top chapter.
+        """)
+        table = (
+            "!Dummy chapter",
+            "Chapter",
+        )
+        ### c.importCommands.rstUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.117: *3* TestRst.test_no_double_underlines
+    def test_no_double_underlines(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        s = textwrap.dedent("""\
+            .. toc
+
+            top
+            ====
+
+            The top section
+
+            section 1
+            ---------
+
+            section 1, line 1
+            --
+            section 1, line 2
+
+            section 2
+            ---------
+
+            section 2, line 1
+
+            section 2.1
+            ~~~~~~~~~~~
+
+            section 2.1, line 1
+
+            section 2.1.1
+            .............
+
+            section 2.2.1 line 1
+
+            section 3
+            ---------
+
+            section 3, line 1
+
+            section 3.1.1
+            .............
+
+            section 3.1.1, line 1
+        """)
+        table = (
+            '!Dummy chapter',
+            'top',
+            'section 1',
+            'section 2',
+            'section 2.1',
+            'section 2.1.1',
+            'section 3',
+            'placeholder',
+            'section 3.1.1',
+        )
+        ### c.importCommands.rstUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.118: *3* TestRst.test_long_underlines
+    def test_long_underlines(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        s = textwrap.dedent("""\
+            .. toc
+
+            top
+            -------------
+
+            The top section
+        """)
+        table = (
+            '!Dummy chapter',
+            'top',
+        )
+        ### c.importCommands.rstUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.119: *3* TestRst.test_test_long_overlines
+    def test_test_long_overlines(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        s = textwrap.dedent("""\
+            .. toc
+
+            ======
+            top
+            ======
+
+            The top section
+        """)
+        table = (
+            "!Dummy chapter",
+            "top",
+        )
+        ### c.importCommands.rstUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.120: *3* TestRst.test_trailing_whitespace
+    def test_trailing_whitespace(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        s = textwrap.dedent("""\
+            .. toc
+
+            .. The section name contains trailing whitespace.
+
+            ======
+            top
+            ======
+
+            The top section.
+        """)
+        table = (
+            "!Dummy chapter",
+            "top",
+        )
+        p = c.p
+        ### c.importCommands.rstUnitTest(p, s=s)
+        self.run_test(c.p, s)
+        root = p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.121: *3* TestRst.test_leo_rst
+    def test_leo_rst(self):
+        c = self.c
+        try:
+            import docutils
+            assert docutils
+        except Exception:
+            self.skipTest('no docutils')
+
+        # All heading must be followed by an empty line.
+        s = textwrap.dedent("""\
+            #########
+            Chapter 1
+            #########
+
+            It was a dark and stormy night.
+
+            section 1
+            +++++++++
+
+            Sec 1.
+
+            section 2
+            +++++++++
+
+            Sec 2.
+        """)
+        table = (
+            'Chapter 1',
+            'section 1',
+            'section 2',
+        )
+        ### c.importCommands.rstUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-rst test')
+        p2 = root.firstChild()
+        assert p2, g.tree_to_string(c)
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,165 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122840.1: *3* Org mode tests
-    #@+node:ekr.20210904065459.41: *4* TestImport.test_org_pattern
-    def test_org_pattern(self):
-        c = self.c
-        x = org.Org_Importer(c.importCommands, atAuto=False)
-        pattern = x.org_pattern
-        table = (
-            # 'body * line',
-            '* line 1',
-            '** level 2',
-        )
-        for line in table:
-            m = pattern.match(line)
-            # print('%20s ==> (%r)(%r)' % (line, m and m.group(1), m and m.group(2)))
-            assert m, repr(line)
-    #@+node:ekr.20210904065459.42: *4* TestImport.test_org_1
-    def test_org_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            * Section 1
-            Sec 1.
-            * Section 2
-            Sec 2.
-            ** Section 2-1
-            Sec 2.1
-            *** Section 2-1-1
-            Sec 2.1.1
-            * Section 3
-            ** Section 3.1
-            Sec 3.1
-        """)
-        table = (
-            'Section 1',
-            'Section 2', 'Section 2-1', 'Section 2-1-1',
-            'Section 3', 'Section 3.1',
-        )
-        c.importCommands.orgUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.43: *4* TestImport.test_org_tags
-    def test_org_tags(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            * Section 1 :tag1:
-            * Section 2 :tag2:
-            * Section 3 :tag3:tag4:
-        """)
-        table = (
-            'Section 1 :tag1:',
-            'Section 2 :tag2:',
-            'Section 3 :tag3:tag4:',
-        )
-        c.importCommands.orgUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.44: *4* TestImport.test_org_intro
-    def test_org_intro(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            Intro line.
-            * Section 1
-            Sec 1.
-            * Section 2
-            Sec 2.
-        """)
-        table = (
-            'Section 1',
-            'Section 2',
-        )
-        c.importCommands.orgUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.45: *4* TestImport.test_org_552
-    def test_org_552(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            * Events
-              :PROPERTIES:
-              :CATEGORY: events
-              :END:
-            ** 整理个人生活
-            *** 每周惯例
-        """)
-        table = (
-            'Events',
-            '整理个人生活',
-            '每周惯例',
-        )
-        c.importCommands.orgUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, g.toUnicode(h))
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.46: *4* TestImport.test_org_1074
-    def test_org_1074(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            *  Test
-            First line.
-        """)
-        table = (
-            ' Test',
-        )
-        c.importCommands.orgUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, g.toUnicode(h))
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.47: *4* TestImport.test_org_placeholder
-    def test_org_placeholder(self):
-        c = self.c
-        # insert test for org here.
-        s = textwrap.dedent("""\
-            * Section 1
-            Sec 1.
-            * Section 2
-            Sec 2.
-            ** Section 2-1
-            Sec 2.1
-            *** Section 2-1-1
-            Sec 2.1.1
-            * Section 3
-            ****** Section 3-1-1-1-1-1
-            : Sec 3-1-1-1-1-1
-            ** Section 3.1
-            Sec 3.1
-        """)
-        table = (
-            'Section 1',
-            'Section 2', 'Section 2-1', 'Section 2-1-1',
-            'Section 3',
-            'placeholder', 'placeholder', 'placeholder', 'placeholder',
-            'Section 3-1-1-1-1-1',
-            'Section 3.1',
-        )
-        g.app.suppressImportChecks = True
-        c.importCommands.orgUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904122853.1: *3* Otl tests
     #@+node:ekr.20210904065459.48: *4* TestImport.test_otl_vim_outline_mode
     def test_otl_vim_outline_mode(self):
@@ -4103,6 +3944,171 @@ class TestMisc (BaseTestImporter):
             ]
         importer = python.Py_Importer(c.importCommands, atAuto=True)
         importer.test_scan_state(tests, State)
+    #@-others
+#@+node:ekr.20211108080955.1: ** class TestOrg (BaseTestImporter)
+class TestOrg (BaseTestImporter):
+    
+    ext = '.org'
+    
+    #@+others
+    #@+node:ekr.20210904065459.42: *3* TestOrg.test_1
+    def test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            * Section 1
+            Sec 1.
+            * Section 2
+            Sec 2.
+            ** Section 2-1
+            Sec 2.1
+            *** Section 2-1-1
+            Sec 2.1.1
+            * Section 3
+            ** Section 3.1
+            Sec 3.1
+        """)
+        table = (
+            'Section 1',
+            'Section 2', 'Section 2-1', 'Section 2-1-1',
+            'Section 3', 'Section 3.1',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.46: *3* TestOrg.test_1074
+    def test_1074(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            *  Test
+            First line.
+        """)
+        table = (
+            ' Test',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, g.toUnicode(h))
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.45: *3* TestOrg.test_552
+    def test_552(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            * Events
+              :PROPERTIES:
+              :CATEGORY: events
+              :END:
+            ** 整理个人生活
+            *** 每周惯例
+        """)
+        table = (
+            'Events',
+            '整理个人生活',
+            '每周惯例',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, g.toUnicode(h))
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.44: *3* TestOrg.test_intro
+    def test_intro(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            Intro line.
+            * Section 1
+            Sec 1.
+            * Section 2
+            Sec 2.
+        """)
+        table = (
+            'Section 1',
+            'Section 2',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.41: *3* TestOrg.test_pattern
+    def test_pattern(self):
+        c = self.c
+        x = org.Org_Importer(c.importCommands, atAuto=False)
+        pattern = x.org_pattern
+        table = (
+            # 'body * line',
+            '* line 1',
+            '** level 2',
+        )
+        for line in table:
+            m = pattern.match(line)
+            # print('%20s ==> (%r)(%r)' % (line, m and m.group(1), m and m.group(2)))
+            assert m, repr(line)
+    #@+node:ekr.20210904065459.47: *3* TestOrg.test_placeholder
+    def test_placeholder(self):
+        c = self.c
+        # insert test for org here.
+        s = textwrap.dedent("""\
+            * Section 1
+            Sec 1.
+            * Section 2
+            Sec 2.
+            ** Section 2-1
+            Sec 2.1
+            *** Section 2-1-1
+            Sec 2.1.1
+            * Section 3
+            ****** Section 3-1-1-1-1-1
+            : Sec 3-1-1-1-1-1
+            ** Section 3.1
+            Sec 3.1
+        """)
+        table = (
+            'Section 1',
+            'Section 2', 'Section 2-1', 'Section 2-1-1',
+            'Section 3',
+            'placeholder', 'placeholder', 'placeholder', 'placeholder',
+            'Section 3-1-1-1-1-1',
+            'Section 3.1',
+        )
+        g.app.suppressImportChecks = True
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.43: *3* TestOrg.test_tags
+    def test_tags(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            * Section 1 :tag1:
+            * Section 2 :tag2:
+            * Section 3 :tag3:tag4:
+        """)
+        table = (
+            'Section 1 :tag1:',
+            'Section 2 :tag2:',
+            'Section 3 :tag3:tag4:',
+        )
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1129,6 +1129,179 @@ class TestJava (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
+#@+node:ekr.20211108070310.1: ** class TestJavascript (BaseTestImporter)
+class TestJavascript (BaseTestImporter):
+    
+    ext = '.js'
+    
+    #@+others
+    #@+node:ekr.20210904065459.34: *3* TestJavascript.test_regex_1
+    def test_regex_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            String.prototype.toJSONString = function()
+            {
+                if(/["\\\\\\x00-\\x1f]/.test(this))
+                    return '"' + this.replace(/([\\x00-\\x1f\\"])/g,replaceFn) + '"';
+
+                return '"' + this + '"';
+            };
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.35: *3* TestJavascript.test_3
+    def test_3(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            // Restarting
+            function restart()
+            {
+                invokeParamifier(params,"onstart");
+                if(story.isEmpty()) {
+                    var tiddlers = store.filterTiddlers(store.getTiddlerText("DefaultTiddlers"));
+                    for(var t=0; t<tiddlers.length; t++) {
+                        story.displayTiddler("bottom",tiddlers[t].title);
+                    }
+                }
+                window.scrollTo(0,0);
+            }
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.36: *3* TestJavascript.test_4
+    def test_4(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            var c3 = (function () {
+                "use strict";
+
+                // Globals
+                var c3 = { version: "0.0.1"   };
+
+                c3.someFunction = function () {
+                    console.log("Just a demo...");
+                };
+
+                return c3;
+            }());
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.37: *3* TestJavascript.test_5
+    def test_5(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            var express = require('express');
+
+            var app = express.createServer(express.logger());
+
+            app.get('/', function(request, response) {
+            response.send('Hello World!');
+            });
+
+            var port = process.env.PORT || 5000;
+            app.listen(port, function() {
+            console.log("Listening on " + port);
+            });
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.38: *3* TestJavascript.test_639_many_top_level_nodes
+    def test_639_many_top_level_nodes(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            // Easy test for #639: https://github.com/leo-editor/leo-editor/issues/639
+
+            //=============================================================================
+            // rpg_core.js v1.3.0
+            //=============================================================================
+
+            //-----------------------------------------------------------------------------
+            /**
+             * This is not a class, but contains some methods that will be added to the
+             * standard Javascript objects.
+             *
+             * @class JsExtensions
+             */
+            function JsExtensions() {
+                throw new Error('This is not a class');
+            }
+
+            /**
+             * Returns a number whose value is limited to the given range.
+             *
+             * @method Number.prototype.clamp
+             * @param {Number} min The lower boundary
+             * @param {Number} max The upper boundary
+             * @return {Number} A number in the range (min, max)
+             */
+            Number.prototype.clamp = function(min, max) {
+                return Math.min(Math.max(this, min), max);
+            };
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.39: *3* TestJavascript.test_639_acid_test_1
+    def test_639_acid_test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            // Acid test for #639: https://github.com/leo-editor/leo-editor/issues/639
+            require([
+                'jquery',
+            ], function(
+                    $,
+                    termjs,
+            ){
+                var header = $("#header")[0];
+                function calculate_size() {
+                    var height = $(window).height() - header.offsetHeight;
+                }
+                page.show_header();
+                window.onresize = function() {
+                  terminal.socket.send(JSON.stringify([
+                        "set_size", geom.rows, geom.cols,
+                        $(window).height(), $(window).width()])
+                    );
+                };
+                window.terminal = terminal;
+            });
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.40: *3* TestJavascript.test_639_acid_test_2
+    def test_639_acid_test_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            // Acid test for #639: https://github.com/leo-editor/leo-editor/issues/639
+            require([
+                'jquery',
+            ], function(
+                    $,
+                    termjs,
+            ){
+                var head = "head"
+                function f1() {
+                    var head1 = "head1"
+                    function f11 () {
+                        var v11 ="v1.1"
+                    }
+                    var middle1 = "middle1"
+                    function f12 () {
+                        var v12 ="v1.2"
+                    }
+                    var tail1 = "tail1"
+                }
+                var middle = "middle"
+                function f2() {
+                    var head2 = "head2"
+                    function f21 () {
+                        var v21 ="2.1"
+                    }
+                    var middle2 = "middle2"
+                    function f22 () {
+                        var v22 = "2.2.1"
+                    }
+                    var tail2 = "tail2"
+                }
+                var tail = "tail"
+            });
+        """)
+        self.run_test(c.p, s)
+    #@-others
 #@+node:ekr.20211108043230.1: ** class TestMarkdown (BaseTestImporter)
 class TestMarkdown(BaseTestImporter):
     
@@ -1347,173 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122826.1: *3* Javascript tests
-    #@+node:ekr.20210904065459.34: *4* TestImport.test_Javascript_regex_1
-    def test_Javascript_regex_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            String.prototype.toJSONString = function()
-            {
-                if(/["\\\\\\x00-\\x1f]/.test(this))
-                    return '"' + this.replace(/([\\x00-\\x1f\\"])/g,replaceFn) + '"';
-
-                return '"' + this + '"';
-            };
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.35: *4* TestImport.test_Javascript_3
-    def test_Javascript_3(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            // Restarting
-            function restart()
-            {
-                invokeParamifier(params,"onstart");
-                if(story.isEmpty()) {
-                    var tiddlers = store.filterTiddlers(store.getTiddlerText("DefaultTiddlers"));
-                    for(var t=0; t<tiddlers.length; t++) {
-                        story.displayTiddler("bottom",tiddlers[t].title);
-                    }
-                }
-                window.scrollTo(0,0);
-            }
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.36: *4* TestImport.test_Javascript_4
-    def test_Javascript_4(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            var c3 = (function () {
-                "use strict";
-
-                // Globals
-                var c3 = { version: "0.0.1"   };
-
-                c3.someFunction = function () {
-                    console.log("Just a demo...");
-                };
-
-                return c3;
-            }());
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.37: *4* TestImport.test_Javascript_5
-    def test_Javascript_5(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            var express = require('express');
-
-            var app = express.createServer(express.logger());
-
-            app.get('/', function(request, response) {
-            response.send('Hello World!');
-            });
-
-            var port = process.env.PORT || 5000;
-            app.listen(port, function() {
-            console.log("Listening on " + port);
-            });
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.38: *4* TestImport.test_Javascript_639_many_top_level_nodes
-    def test_Javascript_639_many_top_level_nodes(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            // Easy test for #639: https://github.com/leo-editor/leo-editor/issues/639
-
-            //=============================================================================
-            // rpg_core.js v1.3.0
-            //=============================================================================
-
-            //-----------------------------------------------------------------------------
-            /**
-             * This is not a class, but contains some methods that will be added to the
-             * standard Javascript objects.
-             *
-             * @class JsExtensions
-             */
-            function JsExtensions() {
-                throw new Error('This is not a class');
-            }
-
-            /**
-             * Returns a number whose value is limited to the given range.
-             *
-             * @method Number.prototype.clamp
-             * @param {Number} min The lower boundary
-             * @param {Number} max The upper boundary
-             * @return {Number} A number in the range (min, max)
-             */
-            Number.prototype.clamp = function(min, max) {
-                return Math.min(Math.max(this, min), max);
-            };
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.39: *4* TestImport.test_Javascript_639_acid_test_1
-    def test_Javascript_639_acid_test_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            // Acid test for #639: https://github.com/leo-editor/leo-editor/issues/639
-            require([
-                'jquery',
-            ], function(
-                    $,
-                    termjs,
-            ){
-                var header = $("#header")[0];
-                function calculate_size() {
-                    var height = $(window).height() - header.offsetHeight;
-                }
-                page.show_header();
-                window.onresize = function() {
-                  terminal.socket.send(JSON.stringify([
-                        "set_size", geom.rows, geom.cols,
-                        $(window).height(), $(window).width()])
-                    );
-                };
-                window.terminal = terminal;
-            });
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.40: *4* TestImport.test_Javascript_639_acid_test_2
-    def test_Javascript_639_acid_test_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            // Acid test for #639: https://github.com/leo-editor/leo-editor/issues/639
-            require([
-                'jquery',
-            ], function(
-                    $,
-                    termjs,
-            ){
-                var head = "head"
-                function f1() {
-                    var head1 = "head1"
-                    function f11 () {
-                        var v11 ="v1.1"
-                    }
-                    var middle1 = "middle1"
-                    function f12 () {
-                        var v12 ="v1.2"
-                    }
-                    var tail1 = "tail1"
-                }
-                var middle = "middle"
-                function f2() {
-                    var head2 = "head2"
-                    function f21 () {
-                        var v21 ="2.1"
-                    }
-                    var middle2 = "middle2"
-                    function f22 () {
-                        var v22 = "2.2.1"
-                    }
-                    var tail2 = "tail2"
-                }
-                var tail = "tail"
-            });
-        """)
-        c.importCommands.javaScriptUnitTest(c.p, s=s)
     #@+node:ekr.20210904122840.1: *3* Org mode tests
     #@+node:ekr.20210904065459.41: *4* TestImport.test_org_pattern
     def test_org_pattern(self):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,62 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904123047.1: *3* Typescript tests
-    #@+node:ekr.20210904065459.103: *4* TestImport.test_TypeScript_class
-    def test_TypeScript_class(self):
-        c = self.c
-        s = '''
-
-        class Greeter {
-            greeting: string;
-            constructor (message: string) {
-                this.greeting = message;
-            }
-            greet() {
-                return "Hello, " + this.greeting;
-            }
-        }
-
-        var greeter = new Greeter("world");
-
-        var button = document.createElement('button')
-        button.innerText = "Say Hello"
-        button.onclick = function() {
-            alert(greeter.greet())
-        }
-
-        document.body.appendChild(button)
-
-        '''
-
-        c.importCommands.typeScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.104: *4* TestImport.test_TypeScript_module
-    def test_TypeScript_module(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            module Sayings {
-                export class Greeter {
-                    greeting: string;
-                    constructor (message: string) {
-                        this.greeting = message;
-                    }
-                    greet() {
-                        return "Hello, " + this.greeting;
-                    }
-                }
-            }
-            var greeter = new Sayings.Greeter("world");
-
-            var button = document.createElement('button')
-            button.innerText = "Say Hello"
-            button.onclick = function() {
-                alert(greeter.greet())
-            }
-
-            document.body.appendChild(button)
-        ''')
-
-        c.importCommands.typeScriptUnitTest(c.p, s=s)
     #@+node:ekr.20210904071422.1: *3* All other tests
     #@+node:ekr.20210904065459.122: *4* TestImport.test_at_auto_importers
     def test_at_auto_importers(self):
@@ -4446,6 +4390,68 @@ class TestRst(BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
+#@+node:ekr.20211108083038.1: ** class TestTypescript (BaseTestImporter)
+class TestTypescript (BaseTestImporter):
+    
+    ext = '.ts'
+    
+    #@+others
+    #@+node:ekr.20210904065459.103: *3* TestTypescript.test_class
+    def test_class(self):
+        c = self.c
+        s = '''
+
+        class Greeter {
+            greeting: string;
+            constructor (message: string) {
+                this.greeting = message;
+            }
+            greet() {
+                return "Hello, " + this.greeting;
+            }
+        }
+
+        var greeter = new Greeter("world");
+
+        var button = document.createElement('button')
+        button.innerText = "Say Hello"
+        button.onclick = function() {
+            alert(greeter.greet())
+        }
+
+        document.body.appendChild(button)
+
+        '''
+
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.104: *3* TestTypescript.test_module
+    def test_module(self):
+        c = self.c
+        s = textwrap.dedent('''\
+            module Sayings {
+                export class Greeter {
+                    greeting: string;
+                    constructor (message: string) {
+                        this.greeting = message;
+                    }
+                    greet() {
+                        return "Hello, " + this.greeting;
+                    }
+                }
+            }
+            var greeter = new Sayings.Greeter("world");
+
+            var button = document.createElement('button')
+            button.innerText = "Say Hello"
+            button.onclick = function() {
+                alert(greeter.greet())
+            }
+
+            document.body.appendChild(button)
+        ''')
+
+        self.run_test(c.p, s)
     #@-others
 #@+node:ekr.20211108065014.1: ** class TestXML (BaseTestImporter)
 class TestXML (BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -27,8 +27,33 @@ class TestImporter(LeoUnitTest):
     def setUp(self):
         super().setUp()
         g.app.loadManager.createAllImporterData()
+        
+    def run_test(self, p, s, ext):  # #2316: was ic.scannerUnitTest.
+        """
+        Run a unit test of an import scanner,
+        i.e., create a tree from string s at location p.
+        """
+        c = self.c
+        self.assertTrue(ext)
+        self.treeType = '@file'  # Fix #352.
+        fileName = 'test'
+        # Run the test.
+        parent = p.insertAsLastChild()
+        kind = self.compute_unit_test_kind(ext)
+        parent.h = f"{kind} {fileName}"
+        c.importCommands.createOutline(parent=parent.copy(), ext=ext, s=s)
 
     #@+others
+    #@+node:ekr.20211108044605.1: *3*  TestImporter.compute_unit_test_kind
+    def compute_unit_test_kind(self, ext):
+        """Return kind from the given extention."""
+        aClass = g.app.classDispatchDict.get(ext)
+        if aClass:
+            d2 = g.app.atAutoDict
+            for z in d2:
+                if d2.get(z) == aClass:
+                    return z
+        return '@file'
     #@+node:ekr.20210904065613.1: *3* Tests of @auto
     #@+node:ekr.20210904143515.1: *4* .ini tests
     #@+node:ekr.20210904065459.29: *5* TestImport.test_ini_test_1
@@ -4175,6 +4200,9 @@ class TestImporter(LeoUnitTest):
 #@+node:ekr.20211108043230.1: ** class TestMarkdownImporter(TestImporter):
 class TestMarkdownImporter(TestImporter):
     
+    def run_test(self, p, s):
+        super().run_test(p, s, ext='.md')
+    
     #@+others
     #@+node:ekr.20210904065459.109: *3* TestImport.test_md_import_test
     def test_md_import_test(self):
@@ -4211,7 +4239,7 @@ class TestMarkdownImporter(TestImporter):
             (3, 'Section 2.2'),
             (2, 'Section 3'),
         )
-        c.importCommands.markdownUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
         after = c.p.nodeAfterTree()
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-md test')
@@ -4259,7 +4287,7 @@ class TestMarkdownImporter(TestImporter):
 
             section 3, line 1
     """)
-        c.importCommands.markdownUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
         table = (
             (1, 'Top'),
             (2, 'Section 1'),
@@ -4306,7 +4334,7 @@ class TestMarkdownImporter(TestImporter):
                 'Subheader',
                 'Last header: no text',
         )
-        c.importCommands.markdownUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-md test')
         p2 = root.firstChild()
@@ -4344,10 +4372,9 @@ class TestMarkdownImporter(TestImporter):
                     'This *should* be a section',
                 'Last header: no text',
         )
+        # Implicit underlining *must* cause the perfect-import test to fail!
         g.app.suppressImportChecks = True
-            # Required, because the implicit underlining *must*
-            # cause the perfect-import test to fail!
-        c.importCommands.markdownUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-md test')
         p2 = root.firstChild()
@@ -4376,7 +4403,7 @@ class TestMarkdownImporter(TestImporter):
             'Header',
             'Last header',
         )
-        c.importCommands.markdownUnitTest(c.p, s=s)
+        self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-md test')
         p2 = root.firstChild()

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -24,16 +24,18 @@ import leo.plugins.importers.xml as xml
 class BaseTestImporter(LeoUnitTest):
     """The base class for tests of leoImport.py"""
     
+    ext = None  # Subclasses must set this to the language's extension.
+    
     def setUp(self):
         super().setUp()
         g.app.loadManager.createAllImporterData()
         
-    def run_test(self, p, s, ext):  # #2316: was ic.scannerUnitTest.
+    def run_test(self, p, s):  # #2316: was ic.scannerUnitTest.
         """
         Run a unit test of an import scanner,
         i.e., create a tree from string s at location p.
         """
-        c = self.c
+        c, ext = self.c, self.ext
         self.assertTrue(ext)
         self.treeType = '@file'  # Fix #352.
         fileName = 'test'
@@ -3899,10 +3901,8 @@ class TempImporterTest (BaseTestImporter):
     #@-others
 #@+node:ekr.20211108043230.1: ** class TestMarkdown(BaseTestImporter)
 class TestMarkdown(BaseTestImporter):
-
-    # pylint: disable=arguments-differ
-    def run_test(self, p, s):
-        super().run_test(p, s, ext='.md')
+    
+    ext = '.md'
     
     #@+others
     #@+node:ekr.20210904065459.109: *3* TestMarkdown.test_md_import_test
@@ -4116,9 +4116,7 @@ class TestMarkdown(BaseTestImporter):
 #@+node:ekr.20211108050827.1: ** class TestRst(BaseTestImporter)
 class TestRst(BaseTestImporter):
     
-    # pylint: disable=arguments-differ
-    def run_test(self, p, s):
-        super().run_test(p, s, ext='.rst')
+    ext = '.rst'
     
     #@+others
     #@+node:ekr.20210904065459.115: *3* TestRst.test_test1

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,54 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122853.1: *3* Otl tests
-    #@+node:ekr.20210904065459.48: *4* TestImport.test_otl_vim_outline_mode
-    def test_otl_vim_outline_mode(self):
-        c = self.c
-        x = otl.Otl_Importer(c.importCommands, atAuto=False)
-        pattern = x.otl_pattern
-        table = (
-            'body line',
-            '\tline 1',
-            '  \tlevel 2',
-        )
-        for line in table:
-            m = pattern.match(line)
-            # print('%20r ==> (%r)(%r)' % (
-                # line, m and m.group(1), m and m.group(2)))
-            assert m
-    #@+node:ekr.20210904065459.49: *4* TestImport.test_otl_1
-    def test_otl_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            preamble.
-            Section 1
-            : Sec 1.
-            Section 2
-            : Sec 2.
-            \tSection 2-1
-            : Sec 2-1
-            \t\tSection 2-1-1
-            : Sect 2-1-1
-            Section 3
-            : Sec 3
-            \tSection 3.1
-            : Sec 3.1
-        """)
-        table = (
-            'Section 1',
-            'Section 2', 'Section 2-1', 'Section 2-1-1',
-            'Section 3', 'Section 3.1',
-        )
-        c.importCommands.otlUnitTest(c.p, s=s)
-        if 0:
-            root = c.p.firstChild()
-            p2 = root.firstChild()
-            for h in table:
-                self.assertEqual(p2.h, h)
-                p2.moveToThreadNext()
-            assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-
     #@+node:ekr.20210904143328.1: *3* Pascal tests
     #@+node:ekr.20210904065459.50: *4* TestImport.test_pascal_to_delphi_interface
     def test_pascal_to_delphi_interface(self):
@@ -4109,6 +4061,58 @@ class TestOrg (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
+#@+node:ekr.20211108081327.1: ** class TestOtl (BaseTestImporter)
+class TestOtl (BaseTestImporter):
+    
+    ext = '.otl'
+    
+    #@+others
+    #@+node:ekr.20210904065459.49: *3* TestOtl.test_1
+    def test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            preamble.
+            Section 1
+            : Sec 1.
+            Section 2
+            : Sec 2.
+            \tSection 2-1
+            : Sec 2-1
+            \t\tSection 2-1-1
+            : Sect 2-1-1
+            Section 3
+            : Sec 3
+            \tSection 3.1
+            : Sec 3.1
+        """)
+        table = (
+            'Section 1',
+            'Section 2', 'Section 2-1', 'Section 2-1-1',
+            'Section 3', 'Section 3.1',
+        )
+        self.run_test(c.p, s)
+        if 0:
+            root = c.p.firstChild()
+            p2 = root.firstChild()
+            for h in table:
+                self.assertEqual(p2.h, h)
+                p2.moveToThreadNext()
+            assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+
+    #@+node:ekr.20210904065459.48: *3* TestOtl.test_vim_outline_mode
+    def test_vim_outline_mode(self):
+        c = self.c
+        x = otl.Otl_Importer(c.importCommands, atAuto=False)
+        pattern = x.otl_pattern
+        table = (
+            'body line',
+            '\tline 1',
+            '  \tlevel 2',
+        )
+        for line in table:
+            m = pattern.match(line)
+            self.assertTrue(m, msg=repr(line))
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -4177,7 +4177,6 @@ class TestRst(TestImporter):
             'placeholder',
             'section 3.1.1',
         )
-        # c.importCommands.rstUnitTest(c.p, s=s)
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')
@@ -4210,7 +4209,6 @@ class TestRst(TestImporter):
             "!Dummy chapter",
             "Chapter",
         )
-        ### c.importCommands.rstUnitTest(c.p, s=s)
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')
@@ -4279,7 +4277,6 @@ class TestRst(TestImporter):
             'placeholder',
             'section 3.1.1',
         )
-        ### c.importCommands.rstUnitTest(c.p, s=s)
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')
@@ -4309,7 +4306,6 @@ class TestRst(TestImporter):
             '!Dummy chapter',
             'top',
         )
-        ### c.importCommands.rstUnitTest(c.p, s=s)
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')
@@ -4340,7 +4336,6 @@ class TestRst(TestImporter):
             "!Dummy chapter",
             "top",
         )
-        ### c.importCommands.rstUnitTest(c.p, s=s)
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')
@@ -4374,7 +4369,6 @@ class TestRst(TestImporter):
             "top",
         )
         p = c.p
-        ### c.importCommands.rstUnitTest(p, s=s)
         self.run_test(c.p, s)
         root = p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')
@@ -4415,7 +4409,6 @@ class TestRst(TestImporter):
             'section 1',
             'section 2',
         )
-        ### c.importCommands.rstUnitTest(c.p, s=s)
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@auto-rst test')

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -23,11 +23,12 @@ import leo.plugins.importers.xml as xml
 #@+node:ekr.20210904064440.3: ** class TestImporter(LeoUnitTest):
 class TestImporter(LeoUnitTest):
     """Test cases for leoImport.py"""
-    #@+others
-    #@+node:ekr.20210904064548.1: *3* TestImporter.setUp
+    
     def setUp(self):
         super().setUp()
         g.app.loadManager.createAllImporterData()
+
+    #@+others
     #@+node:ekr.20210904065613.1: *3* Tests of @auto
     #@+node:ekr.20210904143515.1: *4* .ini tests
     #@+node:ekr.20210904065459.29: *5* TestImport.test_ini_test_1
@@ -3679,215 +3680,6 @@ class TestImporter(LeoUnitTest):
             <_.ÌÑ>
         """)
         c.importCommands.xmlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904071301.1: *3* Tests of @auto-md
-    #@+node:ekr.20210904065459.109: *4* TestImport.test_md_import_test
-    def test_md_import_test(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            #Top
-            The top section
-
-            ##Section 1
-            section 1, line 1
-            section 1, line 2
-
-            ##Section 2
-            section 2, line 1
-
-            ###Section 2.1
-            section 2.1, line 1
-
-            ####Section 2.1.1
-            section 2.2.1 line 1
-            The next section is empty. It must not be deleted.
-
-            ###Section 2.2
-
-            ##Section 3
-            Section 3, line 1
-    """)
-        table = (
-            (1, 'Top'),
-            (2, 'Section 1'),
-            (2, 'Section 2'),
-            (3, 'Section 2.1'),
-            (4, 'Section 2.1.1'),
-            (3, 'Section 2.2'),
-            (2, 'Section 3'),
-        )
-        c.importCommands.markdownUnitTest(c.p, s=s)
-        after = c.p.nodeAfterTree()
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-md test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.110: *4* TestImport.test_md_import_test_rst_style
-    def test_md_import_test_rst_style(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            Top
-            ====
-
-            The top section
-
-            Section 1
-            ---------
-
-            section 1, line 1
-            -- Not an underline
-            secttion 1, line 2
-
-            Section 2
-            ---------
-
-            section 2, line 1
-
-            ###Section 2.1
-
-            section 2.1, line 1
-
-            ####Section 2.1.1
-
-            section 2.2.1 line 1
-
-            ###Section 2.2
-            section 2.2, line 1.
-
-            Section 3
-            ---------
-
-            section 3, line 1
-    """)
-        c.importCommands.markdownUnitTest(c.p, s=s)
-        table = (
-            (1, 'Top'),
-            (2, 'Section 1'),
-            (2, 'Section 2'),
-            (3, 'Section 2.1'),
-            (4, 'Section 2.1.1'),
-            (3, 'Section 2.2'),
-            (2, 'Section 3'),
-        )
-        p = c.p
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@auto-md test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.111: *4* TestImport.test_markdown_importer_basic
-    def test_markdown_importer_basic(self):
-        c = self.c
-        # insert test for markdown here.
-        s = textwrap.dedent("""\
-            Decl line.
-            #Header
-
-            After header text
-
-            ##Subheader
-
-            Not an underline
-
-            ----------------
-
-            After subheader text
-
-            #Last header: no text
-        """)
-        table = (
-            '!Declarations',
-            'Header',
-                'Subheader',
-                'Last header: no text',
-        )
-        c.importCommands.markdownUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-md test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.112: *4* TestImport.test_markdown_importer_implicit_section
-    def test_markdown_importer_implicit_section(self):
-        c = self.c
-        # insert test for markdown here.
-        s = textwrap.dedent("""\
-            Decl line.
-            #Header
-
-            After header text
-
-            ##Subheader
-
-            Not an underline
-
-            ----------------
-
-            This *should* be a section
-            ==========================
-
-            After subheader text
-
-            #Last header: no text
-        """)
-        table = (
-            '!Declarations',
-            'Header',
-                'Subheader',
-                    'This *should* be a section',
-                'Last header: no text',
-        )
-        g.app.suppressImportChecks = True
-            # Required, because the implicit underlining *must*
-            # cause the perfect-import test to fail!
-        c.importCommands.markdownUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-md test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.114: *4* TestImport.test_markdown_github_syntax
-    def test_markdown_github_syntax(self):
-        c = self.c
-        # insert test for markdown here.
-        s = textwrap.dedent("""\
-            Decl line.
-            #Header
-
-            `​``python
-            loads.init = {
-                Chloride: 11.5,
-                TotalP: 0.002,
-            }
-            `​``
-            #Last header
-        """)
-        table = (
-            '!Declarations',
-            'Header',
-            'Last header',
-        )
-        c.importCommands.markdownUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@auto-md test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904071345.1: *3* Tests of @auto-rst
     #@+node:ekr.20210904065459.115: *4* TestImport.test_rST_import_test
     def test_rST_import_test(self):
@@ -4379,6 +4171,219 @@ class TestImporter(LeoUnitTest):
             ]
         importer = python.Py_Importer(c.importCommands, atAuto=True)
         importer.test_scan_state(tests, State)
+    #@-others
+#@+node:ekr.20211108043230.1: ** class TestMarkdownImporter(TestImporter):
+class TestMarkdownImporter(TestImporter):
+    
+    #@+others
+    #@+node:ekr.20210904065459.109: *3* TestImport.test_md_import_test
+    def test_md_import_test(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            #Top
+            The top section
+
+            ##Section 1
+            section 1, line 1
+            section 1, line 2
+
+            ##Section 2
+            section 2, line 1
+
+            ###Section 2.1
+            section 2.1, line 1
+
+            ####Section 2.1.1
+            section 2.2.1 line 1
+            The next section is empty. It must not be deleted.
+
+            ###Section 2.2
+
+            ##Section 3
+            Section 3, line 1
+    """)
+        table = (
+            (1, 'Top'),
+            (2, 'Section 1'),
+            (2, 'Section 2'),
+            (3, 'Section 2.1'),
+            (4, 'Section 2.1.1'),
+            (3, 'Section 2.2'),
+            (2, 'Section 3'),
+        )
+        c.importCommands.markdownUnitTest(c.p, s=s)
+        after = c.p.nodeAfterTree()
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-md test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.110: *3* TestImport.test_md_import_test_rst_style
+    def test_md_import_test_rst_style(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            Top
+            ====
+
+            The top section
+
+            Section 1
+            ---------
+
+            section 1, line 1
+            -- Not an underline
+            secttion 1, line 2
+
+            Section 2
+            ---------
+
+            section 2, line 1
+
+            ###Section 2.1
+
+            section 2.1, line 1
+
+            ####Section 2.1.1
+
+            section 2.2.1 line 1
+
+            ###Section 2.2
+            section 2.2, line 1.
+
+            Section 3
+            ---------
+
+            section 3, line 1
+    """)
+        c.importCommands.markdownUnitTest(c.p, s=s)
+        table = (
+            (1, 'Top'),
+            (2, 'Section 1'),
+            (2, 'Section 2'),
+            (3, 'Section 2.1'),
+            (4, 'Section 2.1.1'),
+            (3, 'Section 2.2'),
+            (2, 'Section 3'),
+        )
+        p = c.p
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@auto-md test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.111: *3* TestImport.test_markdown_importer_basic
+    def test_markdown_importer_basic(self):
+        c = self.c
+        # insert test for markdown here.
+        s = textwrap.dedent("""\
+            Decl line.
+            #Header
+
+            After header text
+
+            ##Subheader
+
+            Not an underline
+
+            ----------------
+
+            After subheader text
+
+            #Last header: no text
+        """)
+        table = (
+            '!Declarations',
+            'Header',
+                'Subheader',
+                'Last header: no text',
+        )
+        c.importCommands.markdownUnitTest(c.p, s=s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-md test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.112: *3* TestImport.test_markdown_importer_implicit_section
+    def test_markdown_importer_implicit_section(self):
+        c = self.c
+        # insert test for markdown here.
+        s = textwrap.dedent("""\
+            Decl line.
+            #Header
+
+            After header text
+
+            ##Subheader
+
+            Not an underline
+
+            ----------------
+
+            This *should* be a section
+            ==========================
+
+            After subheader text
+
+            #Last header: no text
+        """)
+        table = (
+            '!Declarations',
+            'Header',
+                'Subheader',
+                    'This *should* be a section',
+                'Last header: no text',
+        )
+        g.app.suppressImportChecks = True
+            # Required, because the implicit underlining *must*
+            # cause the perfect-import test to fail!
+        c.importCommands.markdownUnitTest(c.p, s=s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-md test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.114: *3* TestImport.test_markdown_github_syntax
+    def test_markdown_github_syntax(self):
+        c = self.c
+        # insert test for markdown here.
+        s = textwrap.dedent("""\
+            Decl line.
+            #Header
+
+            `​``python
+            loads.init = {
+                Chloride: 11.5,
+                TotalP: 0.002,
+            }
+            `​``
+            #Last header
+        """)
+        table = (
+            '!Declarations',
+            'Header',
+            'Last header',
+        )
+        c.importCommands.markdownUnitTest(c.p, s=s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@auto-md test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1170,34 +1170,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904143920.1: *3* Elisp tests
-    #@+node:ekr.20210904065459.18: *4* TestImport.test_elisp
-    def test_elisp(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            ;;; comment
-            ;;; continue
-            ;;;
-
-            (defun abc (a b)
-               (+ 1 2 3))
-
-            ; comm
-            (defun cde (a b)
-               (+ 1 2 3))
-        """)
-        table = (
-            'defun abc',
-            'defun cde',
-        )
-        c.importCommands.elispUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904122815.1: *3* Java tests
     #@+node:ekr.20210904065459.30: *4* TestImport.test_from_AdminPermission_java
     def test_from_AdminPermission_java(self):
@@ -4483,6 +4455,40 @@ class TestXML (BaseTestImporter):
             <_.ÌÑ>
         """)
         self.run_test(c.p, s)
+    #@-others
+#@+node:ekr.20211108065659.1: ** class TestElisp (BaseTestImporter)
+class TestElisp (BaseTestImporter):
+    
+    ext = '.el'
+    
+    #@+others
+    #@+node:ekr.20210904065459.18: *3* TestElisp.test_1
+    def test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            ;;; comment
+            ;;; continue
+            ;;;
+
+            (defun abc (a b)
+               (+ 1 2 3))
+
+            ; comm
+            (defun cde (a b)
+               (+ 1 2 3))
+        """)
+        table = (
+            'defun abc',
+            'defun cde',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -373,6 +373,11 @@ class TestCoffeescript (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
+    #@+node:ekr.20211108085023.1: *3* TestCoffeescript.test_get_leading_indent
+    def test_get_leading_indent(self):
+        c = self.c
+        importer = linescanner.Importer(c.importCommands, language='coffeescrip')
+        self.assertEqual(importer.single_comment, '#')
     #@+node:ekr.20210904065459.126: *3* TestCoffeescript.test_scan_line
     def test_scan_line(self):
         c = self.c
@@ -1576,77 +1581,6 @@ class TestMisc (BaseTestImporter):
             sfn = g.shortFileName(fn)
             m = importlib.import_module('leo.plugins.importers.%s' % sfn[:-3])
             assert m
-    #@+node:ekr.20210904065459.123: *3* TestImport.test_get_leading_indent
-    def test_get_leading_indent(self):
-        c = self.c
-        lines_table = [
-            'abc',
-            '    xyz',
-            '    ',
-            '  # comment',
-        ]
-        for language in ('python', 'coffeescript'):
-            importer = linescanner.Importer(
-                c.importCommands,
-                language=language,
-            )
-            self.assertEqual(importer.single_comment, '#')
-            if 0:
-                for line in lines_table:
-                    lines = [line]
-                    n = importer.get_leading_indent(lines, 0)
-                    print('%s %r' % (n, line))
-    #@+node:ekr.20210904065459.133: *3* TestImport.test_importers_xml_scan_line
-    def test_importers_xml_scan_line(self):
-        c = self.c
-        x = xml.Xml_Importer(importCommands=c.importCommands, atAuto=False)
-        x.start_tags.append('html')  # Don't rely on settings.
-        table = (
-            (0, '<tag>'),
-            (0, '<tag></tag'),
-            (1, '<html'),
-            (1, '<html attrib="<">'),
-            (0, '<html attrib="<" />'),
-            (0, '<html>x</html>'),
-            (0, '</br>'),  # Tag underflow
-            (0, '<br />'),
-            (0, '<br/>'),
-        )
-        for level, line in table:
-            prev_state = x.state_class()  # Start in level 0
-            self.assertEqual(prev_state.tag_level, 0, msg=line)
-            new_state = x.scan_line(line, prev_state)
-            self.assertEqual(new_state.tag_level, level, msg=line)
-    #@+node:ekr.20210904065459.131: *3* TestImport.test_importers_python_test_scan_state
-    def test_importers_python_test_scan_state(self):
-        c = self.c
-        State = python.Python_ScanState
-        # A list of dictionaries.
-        if 0:
-            tests = [
-                g.Bunch(line='s = "\\""', ctx=('', '')),
-            ]
-        else:
-            tests = [
-                g.Bunch(line='\n'),
-                g.Bunch(line='\\\n'),
-                g.Bunch(line='s = "\\""', ctx=('', '')),
-                g.Bunch(line="s = '\\''", ctx=('', '')),
-                g.Bunch(line='# comment'),
-                g.Bunch(line='  # comment'),
-                g.Bunch(line='    # comment'),
-                g.Bunch(line='a = "string"'),
-                g.Bunch(line='a = "Continued string', ctx=('', '"')),
-                g.Bunch(line='end of continued string"', ctx=('"', '')),
-                g.Bunch(line='a = """Continued docstring', ctx=('', '"""')),
-                g.Bunch(line='a = """#', ctx=('', '"""')),
-                g.Bunch(line='end of continued string"""', ctx=('"""', '')),
-                g.Bunch(line="a = '''Continued docstring", ctx=('', "'''")),
-                g.Bunch(line="end of continued string'''", ctx=("'''", '')),
-                g.Bunch(line='a = {[(')
-            ]
-        importer = python.Py_Importer(c.importCommands, atAuto=True)
-        importer.test_scan_state(tests, State)
     #@-others
 #@+node:ekr.20211108080955.1: ** class TestOrg (BaseTestImporter)
 class TestOrg (BaseTestImporter):
@@ -3070,6 +3004,12 @@ class TestPython (BaseTestImporter):
                     pass
         """)
         self.run_test(c.p, s=s)
+    #@+node:ekr.20211108084817.1: *3* TestPython.test_get_leading_indent
+    def test_get_leading_indent(self):
+        c = self.c
+        importer = linescanner.Importer(c.importCommands, language='python')
+        self.assertEqual(importer.single_comment, '#')
+           
     #@+node:ekr.20210904065459.124: *3* TestPython.test_get_str_lws
     def test_get_str_lws(self):
         c = self.c
@@ -3433,6 +3373,36 @@ class TestPython (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.131: *3* TestPython.test_scan_state
+    def test_scan_state(self):
+        c = self.c
+        State = python.Python_ScanState
+        # A list of dictionaries.
+        if 0:
+            tests = [
+                g.Bunch(line='s = "\\""', ctx=('', '')),
+            ]
+        else:
+            tests = [
+                g.Bunch(line='\n'),
+                g.Bunch(line='\\\n'),
+                g.Bunch(line='s = "\\""', ctx=('', '')),
+                g.Bunch(line="s = '\\''", ctx=('', '')),
+                g.Bunch(line='# comment'),
+                g.Bunch(line='  # comment'),
+                g.Bunch(line='    # comment'),
+                g.Bunch(line='a = "string"'),
+                g.Bunch(line='a = "Continued string', ctx=('', '"')),
+                g.Bunch(line='end of continued string"', ctx=('"', '')),
+                g.Bunch(line='a = """Continued docstring', ctx=('', '"""')),
+                g.Bunch(line='a = """#', ctx=('', '"""')),
+                g.Bunch(line='end of continued string"""', ctx=('"""', '')),
+                g.Bunch(line="a = '''Continued docstring", ctx=('', "'''")),
+                g.Bunch(line="end of continued string'''", ctx=("'''", '')),
+                g.Bunch(line='a = {[(')
+            ]
+        importer = python.Py_Importer(c.importCommands, atAuto=True)
+        importer.test_scan_state(tests, State)
     #@+node:ekr.20210904065459.93: *3* TestPython.test_string_test_extra_indent
     def test_string_test_extra_indent(self):
         c = self.c
@@ -4532,6 +4502,27 @@ class TestXML (BaseTestImporter):
         for expected, line in table:
             got = x.is_ws_line(line)
             self.assertEqual(expected, got, msg=repr(line))
+    #@+node:ekr.20210904065459.133: *3* TestXml.test_scan_line
+    def test_scan_line(self):
+        c = self.c
+        x = xml.Xml_Importer(importCommands=c.importCommands, atAuto=False)
+        x.start_tags.append('html')  # Don't rely on settings.
+        table = (
+            (0, '<tag>'),
+            (0, '<tag></tag'),
+            (1, '<html'),
+            (1, '<html attrib="<">'),
+            (0, '<html attrib="<" />'),
+            (0, '<html>x</html>'),
+            (0, '</br>'),  # Tag underflow
+            (0, '<br />'),
+            (0, '<br/>'),
+        )
+        for level, line in table:
+            prev_state = x.state_class()  # Start in level 0
+            self.assertEqual(prev_state.tag_level, 0, msg=line)
+            new_state = x.scan_line(line, prev_state)
+            self.assertEqual(new_state.tag_level, level, msg=line)
     #@-others
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -61,35 +61,8 @@ class BaseTestImporter(LeoUnitTest):
 class TempImporterTest (BaseTestImporter):
     
     #@+others  ### To be moved to other classes.
-    #@+node:ekr.20210904065613.1: *3* Tests of @auto
-    #@+node:ekr.20210904143515.1: *4* .ini tests
-    #@+node:ekr.20210904065459.29: *5* TestImport.test_ini_test_1
-    def test_ini_test_1(self):
-        c = self.c
-        s = textwrap.dedent(r'''\
-            ; last modified 1 April 2001 by John Doe
-            [owner]
-            name=John Doe
-            organization=Acme Widgets Inc.
-
-            ; [ not a section ]
-
-            [database]
-            server=192.0.2.62
-                ; use IP address
-            port=143
-            file = "payroll.dat"
-        ''')
-        table = ('[owner]', '[database]')
-        c.importCommands.iniUnitTest(c.p, s=s)
-        root = c.p.firstChild()
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904144251.1: *4* C# tests
-    #@+node:ekr.20210904065459.12: *5* TestImport.test_c_sharp_namespace_indent
+    #@+node:ekr.20210904144251.1: *3* C# tests
+    #@+node:ekr.20210904065459.12: *4* TestImport.test_c_sharp_namespace_indent
     def test_c_sharp_namespace_indent(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -110,7 +83,7 @@ class TempImporterTest (BaseTestImporter):
         for i, h in enumerate(table):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.13: *5* TestImport.test_c_sharp_namespace_no_indent
+    #@+node:ekr.20210904065459.13: *4* TestImport.test_c_sharp_namespace_no_indent
     def test_c_sharp_namespace_no_indent(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -132,8 +105,8 @@ class TempImporterTest (BaseTestImporter):
         for i, h in enumerate(table):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904122726.1: *4* Coffeescript tests
-    #@+node:ekr.20210904065459.15: *5* TestImport.test_coffeescript_2
+    #@+node:ekr.20210904122726.1: *3* Coffeescript tests
+    #@+node:ekr.20210904065459.15: *4* TestImport.test_coffeescript_2
     def test_coffeescript_2(self):
         c = self.c
         s = r'''
@@ -159,7 +132,7 @@ class TempImporterTest (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.16: *5* TestImport.test_coffeescript_3
+    #@+node:ekr.20210904065459.16: *4* TestImport.test_coffeescript_3
     #@@tabwidth -2 # Required
 
     def test_coffeescript_3(self):
@@ -207,8 +180,8 @@ class TempImporterTest (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904084324.1: *4* Cython tests
-    #@+node:ekr.20210904065459.11: *5* TestImport.test_cython_importer
+    #@+node:ekr.20210904084324.1: *3* Cython tests
+    #@+node:ekr.20210904065459.11: *4* TestImport.test_cython_importer
     def test_cython_importer(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -240,8 +213,8 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904144021.1: *4* Dart tests
-    #@+node:ekr.20210904065459.17: *5* TestImport.test_dart_hello_world
+    #@+node:ekr.20210904144021.1: *3* Dart tests
+    #@+node:ekr.20210904065459.17: *4* TestImport.test_dart_hello_world
     def test_dart_hello_world(self):
         c = self.c
         s = r'''
@@ -275,8 +248,8 @@ class TempImporterTest (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
-    #@+node:ekr.20210904143920.1: *4* Elisp tests
-    #@+node:ekr.20210904065459.18: *5* TestImport.test_elisp
+    #@+node:ekr.20210904143920.1: *3* Elisp tests
+    #@+node:ekr.20210904065459.18: *4* TestImport.test_elisp
     def test_elisp(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -303,8 +276,8 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904122741.1: *4* HTML tests
-    #@+node:ekr.20210904065459.19: *5* TestImport.test_html_lowercase_tags
+    #@+node:ekr.20210904122741.1: *3* HTML tests
+    #@+node:ekr.20210904065459.19: *4* TestImport.test_html_lowercase_tags
     def test_html_lowercase_tags(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -329,7 +302,7 @@ class TempImporterTest (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.20: *5* TestImport.test_html_multiple_tags_on_a_line
+    #@+node:ekr.20210904065459.20: *4* TestImport.test_html_multiple_tags_on_a_line
     def test_html_multiple_tags_on_a_line(self):
         c = self.c
         # tags that cause nodes: html, head, body, div, table, nodeA, nodeB
@@ -389,7 +362,7 @@ class TempImporterTest (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.21: *5* TestImport.test_html_multple_node_completed_on_a_line
+    #@+node:ekr.20210904065459.21: *4* TestImport.test_html_multple_node_completed_on_a_line
     def test_html_multple_node_completed_on_a_line(self):
         c = self.c
 
@@ -407,7 +380,7 @@ class TempImporterTest (BaseTestImporter):
             assert p2
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.22: *5* TestImport.test_html_multple_node_starts_on_a_line
+    #@+node:ekr.20210904065459.22: *4* TestImport.test_html_multple_node_starts_on_a_line
     def test_html_multple_node_starts_on_a_line(self):
         c = self.c
         s = '''
@@ -426,7 +399,7 @@ class TempImporterTest (BaseTestImporter):
             assert p2
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.23: *5* TestImport.test_html_underindented_comment
+    #@+node:ekr.20210904065459.23: *4* TestImport.test_html_underindented_comment
     def test_html_underindented_comment(self):
         c = self.c
         s = r'''
@@ -461,7 +434,7 @@ class TempImporterTest (BaseTestImporter):
             p2.moveToThreadNext()
 
 
-    #@+node:ekr.20210904065459.24: *5* TestImport.test_html_uppercase_tags
+    #@+node:ekr.20210904065459.24: *4* TestImport.test_html_uppercase_tags
     def test_html_uppercase_tags(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -475,7 +448,7 @@ class TempImporterTest (BaseTestImporter):
             </HTML>
         """)
         c.importCommands.htmlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.25: *5* TestImport.test_html_improperly_nested_tags
+    #@+node:ekr.20210904065459.25: *4* TestImport.test_html_improperly_nested_tags
     def test_html_improperly_nested_tags(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -505,7 +478,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
 
-    #@+node:ekr.20210904065459.26: *5* TestImport.test_html_improperly_terminated_tags
+    #@+node:ekr.20210904065459.26: *4* TestImport.test_html_improperly_terminated_tags
     def test_html_improperly_terminated_tags(self):
         c = self.c
         s = r'''
@@ -531,7 +504,7 @@ class TempImporterTest (BaseTestImporter):
         for i, h in enumerate(table):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.27: *5* TestImport.test_html_improperly_terminated_tags2
+    #@+node:ekr.20210904065459.27: *4* TestImport.test_html_improperly_terminated_tags2
     def test_html_improperly_terminated_tags2(self):
         c = self.c
         s = '''
@@ -554,7 +527,7 @@ class TempImporterTest (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.28: *5* TestImport.test_html_brython
+    #@+node:ekr.20210904065459.28: *4* TestImport.test_html_brython
     def test_html_brython(self):
         c = self.c
         # https://github.com/leo-editor/leo-editor/issues/479
@@ -707,8 +680,8 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
 
-    #@+node:ekr.20210904122815.1: *4* Java tests
-    #@+node:ekr.20210904065459.30: *5* TestImport.test_from_AdminPermission_java
+    #@+node:ekr.20210904122815.1: *3* Java tests
+    #@+node:ekr.20210904065459.30: *4* TestImport.test_from_AdminPermission_java
     def test_from_AdminPermission_java(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -740,7 +713,7 @@ class TempImporterTest (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
-    #@+node:ekr.20210904065459.31: *5* TestImport.test_from_BundleException_java
+    #@+node:ekr.20210904065459.31: *4* TestImport.test_from_BundleException_java
     def test_from_BundleException_java(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -804,7 +777,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.32: *5* TestImport.test_java_interface_test1
+    #@+node:ekr.20210904065459.32: *4* TestImport.test_java_interface_test1
     def test_java_interface_test1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -824,7 +797,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.33: *5* TestImport.test_java_interface_test2
+    #@+node:ekr.20210904065459.33: *4* TestImport.test_java_interface_test2
     def test_java_interface_test2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -844,8 +817,8 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904122826.1: *4* Javascript tests
-    #@+node:ekr.20210904065459.34: *5* TestImport.test_Javascript_regex_1
+    #@+node:ekr.20210904122826.1: *3* Javascript tests
+    #@+node:ekr.20210904065459.34: *4* TestImport.test_Javascript_regex_1
     def test_Javascript_regex_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -858,7 +831,7 @@ class TempImporterTest (BaseTestImporter):
             };
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.35: *5* TestImport.test_Javascript_3
+    #@+node:ekr.20210904065459.35: *4* TestImport.test_Javascript_3
     def test_Javascript_3(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -876,7 +849,7 @@ class TempImporterTest (BaseTestImporter):
             }
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.36: *5* TestImport.test_Javascript_4
+    #@+node:ekr.20210904065459.36: *4* TestImport.test_Javascript_4
     def test_Javascript_4(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -894,7 +867,7 @@ class TempImporterTest (BaseTestImporter):
             }());
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.37: *5* TestImport.test_Javascript_5
+    #@+node:ekr.20210904065459.37: *4* TestImport.test_Javascript_5
     def test_Javascript_5(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -912,7 +885,7 @@ class TempImporterTest (BaseTestImporter):
             });
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.38: *5* TestImport.test_Javascript_639_many_top_level_nodes
+    #@+node:ekr.20210904065459.38: *4* TestImport.test_Javascript_639_many_top_level_nodes
     def test_Javascript_639_many_top_level_nodes(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -946,7 +919,7 @@ class TempImporterTest (BaseTestImporter):
             };
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.39: *5* TestImport.test_Javascript_639_acid_test_1
+    #@+node:ekr.20210904065459.39: *4* TestImport.test_Javascript_639_acid_test_1
     def test_Javascript_639_acid_test_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -972,7 +945,7 @@ class TempImporterTest (BaseTestImporter):
             });
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.40: *5* TestImport.test_Javascript_639_acid_test_2
+    #@+node:ekr.20210904065459.40: *4* TestImport.test_Javascript_639_acid_test_2
     def test_Javascript_639_acid_test_2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1011,8 +984,8 @@ class TempImporterTest (BaseTestImporter):
             });
         """)
         c.importCommands.javaScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904122840.1: *4* Org mode tests
-    #@+node:ekr.20210904065459.41: *5* TestImport.test_org_pattern
+    #@+node:ekr.20210904122840.1: *3* Org mode tests
+    #@+node:ekr.20210904065459.41: *4* TestImport.test_org_pattern
     def test_org_pattern(self):
         c = self.c
         x = org.Org_Importer(c.importCommands, atAuto=False)
@@ -1026,7 +999,7 @@ class TempImporterTest (BaseTestImporter):
             m = pattern.match(line)
             # print('%20s ==> (%r)(%r)' % (line, m and m.group(1), m and m.group(2)))
             assert m, repr(line)
-    #@+node:ekr.20210904065459.42: *5* TestImport.test_org_1
+    #@+node:ekr.20210904065459.42: *4* TestImport.test_org_1
     def test_org_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1054,7 +1027,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.43: *5* TestImport.test_org_tags
+    #@+node:ekr.20210904065459.43: *4* TestImport.test_org_tags
     def test_org_tags(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1074,7 +1047,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.44: *5* TestImport.test_org_intro
+    #@+node:ekr.20210904065459.44: *4* TestImport.test_org_intro
     def test_org_intro(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1095,7 +1068,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.45: *5* TestImport.test_org_552
+    #@+node:ekr.20210904065459.45: *4* TestImport.test_org_552
     def test_org_552(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1118,7 +1091,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, g.toUnicode(h))
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.46: *5* TestImport.test_org_1074
+    #@+node:ekr.20210904065459.46: *4* TestImport.test_org_1074
     def test_org_1074(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1135,7 +1108,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, g.toUnicode(h))
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.47: *5* TestImport.test_org_placeholder
+    #@+node:ekr.20210904065459.47: *4* TestImport.test_org_placeholder
     def test_org_placeholder(self):
         c = self.c
         # insert test for org here.
@@ -1170,8 +1143,8 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904122853.1: *4* Otl tests
-    #@+node:ekr.20210904065459.48: *5* TestImport.test_otl_vim_outline_mode
+    #@+node:ekr.20210904122853.1: *3* Otl tests
+    #@+node:ekr.20210904065459.48: *4* TestImport.test_otl_vim_outline_mode
     def test_otl_vim_outline_mode(self):
         c = self.c
         x = otl.Otl_Importer(c.importCommands, atAuto=False)
@@ -1186,7 +1159,7 @@ class TempImporterTest (BaseTestImporter):
             # print('%20r ==> (%r)(%r)' % (
                 # line, m and m.group(1), m and m.group(2)))
             assert m
-    #@+node:ekr.20210904065459.49: *5* TestImport.test_otl_1
+    #@+node:ekr.20210904065459.49: *4* TestImport.test_otl_1
     def test_otl_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1218,8 +1191,8 @@ class TempImporterTest (BaseTestImporter):
                 p2.moveToThreadNext()
             assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
-    #@+node:ekr.20210904143328.1: *4* Pascal tests
-    #@+node:ekr.20210904065459.50: *5* TestImport.test_pascal_to_delphi_interface
+    #@+node:ekr.20210904143328.1: *3* Pascal tests
+    #@+node:ekr.20210904065459.50: *4* TestImport.test_pascal_to_delphi_interface
     def test_pascal_to_delphi_interface(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1273,8 +1246,8 @@ class TempImporterTest (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
-    #@+node:ekr.20210904122909.1: *4* Perl tests
-    #@+node:ekr.20210904065459.51: *5* TestImport.test_perl_1
+    #@+node:ekr.20210904122909.1: *3* Perl tests
+    #@+node:ekr.20210904065459.51: *4* TestImport.test_perl_1
     def test_perl_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1301,7 +1274,7 @@ class TempImporterTest (BaseTestImporter):
             Hello();
         """)
         c.importCommands.perlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.52: *5* TestImport.test_perlpod_comment
+    #@+node:ekr.20210904065459.52: *4* TestImport.test_perlpod_comment
     def test_perlpod_comment(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1323,7 +1296,7 @@ class TempImporterTest (BaseTestImporter):
             }
         """)
         c.importCommands.perlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.53: *5* TestImport.test_perl_multi_line_string
+    #@+node:ekr.20210904065459.53: *4* TestImport.test_perl_multi_line_string
     def test_perl_multi_line_string(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1339,7 +1312,7 @@ class TempImporterTest (BaseTestImporter):
             world\n";
         """)
         c.importCommands.perlUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.54: *5* TestImport.test_perl_regex_1
+    #@+node:ekr.20210904065459.54: *4* TestImport.test_perl_regex_1
     def test_perl_regex_1(self):
         c = self.c
         # ('len',   'tr///', '/',       context,  0,       0,       0),
@@ -1367,7 +1340,7 @@ class TempImporterTest (BaseTestImporter):
         """)
         c.importCommands.perlUnitTest(c.p, s=s)
 
-    #@+node:ekr.20210904065459.55: *5* TestImport.test_perl_regex_2
+    #@+node:ekr.20210904065459.55: *4* TestImport.test_perl_regex_2
     def test_perl_regex_2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1404,8 +1377,8 @@ class TempImporterTest (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
-    #@+node:ekr.20210904122920.1: *4* PHP tests
-    #@+node:ekr.20210904065459.56: *5* TestImport.test_php_import_class
+    #@+node:ekr.20210904122920.1: *3* PHP tests
+    #@+node:ekr.20210904065459.56: *4* TestImport.test_php_import_class
     def test_php_import_class(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1423,7 +1396,7 @@ class TempImporterTest (BaseTestImporter):
             ?>
         """)
         c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.57: *5* TestImport.test_php_import_conditional_class
+    #@+node:ekr.20210904065459.57: *4* TestImport.test_php_import_conditional_class
     def test_php_import_conditional_class(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1442,7 +1415,7 @@ class TempImporterTest (BaseTestImporter):
             ?>
         """)
         c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.58: *5* TestImport.test_php_import_classes__functions
+    #@+node:ekr.20210904065459.58: *4* TestImport.test_php_import_classes__functions
     def test_php_import_classes__functions(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1484,7 +1457,7 @@ class TempImporterTest (BaseTestImporter):
             ?>
         """)
         c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.59: *5* TestImport.test_php_here_doc
+    #@+node:ekr.20210904065459.59: *4* TestImport.test_php_here_doc
     def test_php_here_doc(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1498,8 +1471,8 @@ class TempImporterTest (BaseTestImporter):
             ?>
         """)
         c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904122944.1: *4* Python tests
-    #@+node:ekr.20210904065459.60: *5* TestImport.test_i_scan_state_for_python_
+    #@+node:ekr.20210904122944.1: *3* Python tests
+    #@+node:ekr.20210904065459.60: *4* TestImport.test_i_scan_state_for_python_
     def test_i_scan_state_for_python_(self):
         c = self.c
         # A list of dictionaries.
@@ -1523,7 +1496,7 @@ class TempImporterTest (BaseTestImporter):
         )
         importer = python.Py_Importer(c.importCommands)
         importer.test_scan_state(tests, State=python.Python_ScanState)
-    #@+node:ekr.20210904065459.61: *5* TestImport.test_leoApp_fail
+    #@+node:ekr.20210904065459.61: *4* TestImport.test_leoApp_fail
     def test_leoApp_fail(self):
         c = self.c
         s = textwrap.dedent('''
@@ -1584,7 +1557,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
 
-    #@+node:ekr.20210904065459.62: *5* TestImport.test_python_bad_class_test
+    #@+node:ekr.20210904065459.62: *4* TestImport.test_python_bad_class_test
     def test_python_bad_class_test(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -1595,7 +1568,7 @@ class TempImporterTest (BaseTestImporter):
                 pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.63: *5* TestImport.test_python_basic_nesting_test
+    #@+node:ekr.20210904065459.63: *4* TestImport.test_python_basic_nesting_test
     def test_python_basic_nesting_test(self):
         c = self.c
         # Was unittest/at_auto-unit-test.py
@@ -1634,7 +1607,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
 
-    #@+node:ekr.20210904065459.64: *5* TestImport.test_python_bug_346
+    #@+node:ekr.20210904065459.64: *4* TestImport.test_python_bug_346
     def test_python_bug_346(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -1681,7 +1654,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.65: *5* TestImport.test_python_bug_354
+    #@+node:ekr.20210904065459.65: *4* TestImport.test_python_bug_354
     def test_python_bug_354(self):
         c = self.c
         s = """
@@ -1717,7 +1690,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.66: *5* TestImport.test_python_bug_357
+    #@+node:ekr.20210904065459.66: *4* TestImport.test_python_bug_357
     def test_python_bug_357(self):
         c = self.c
         s = textwrap.dedent('''
@@ -2006,7 +1979,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.67: *5* TestImport.test_python_bug_360
+    #@+node:ekr.20210904065459.67: *4* TestImport.test_python_bug_360
     def test_python_bug_360(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2033,7 +2006,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.68: *5* TestImport.test_python_bug_390
+    #@+node:ekr.20210904065459.68: *4* TestImport.test_python_bug_390
     def test_python_bug_390(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2068,7 +2041,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
         assert "if __name__ == '__main__':" in root.b
-    #@+node:ekr.20210904065459.70: *5* TestImport.test_python_bug_603720
+    #@+node:ekr.20210904065459.70: *4* TestImport.test_python_bug_603720
     def test_python_bug_603720(self):
         c = self.c
         # Leo bug 603720
@@ -2087,7 +2060,7 @@ class TempImporterTest (BaseTestImporter):
             foo()
         ''')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.69: *5* TestImport.test_python_bug_978
+    #@+node:ekr.20210904065459.69: *4* TestImport.test_python_bug_978
     def test_python_bug_978(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2120,7 +2093,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.72: *5* TestImport.test_python_class_test_2
+    #@+node:ekr.20210904065459.72: *4* TestImport.test_python_class_test_2
     def test_python_class_test_2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2128,7 +2101,7 @@ class TempImporterTest (BaseTestImporter):
                 pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.73: *5* TestImport.test_python_class_tests_1
+    #@+node:ekr.20210904065459.73: *4* TestImport.test_python_class_tests_1
     def test_python_class_tests_1(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2140,7 +2113,7 @@ class TempImporterTest (BaseTestImporter):
                 pass
         ''')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.74: *5* TestImport.test_python_comment_after_dict_assign
+    #@+node:ekr.20210904065459.74: *4* TestImport.test_python_comment_after_dict_assign
     def test_python_comment_after_dict_assign(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2165,7 +2138,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.75: *5* TestImport.test_python_decls_test_1
+    #@+node:ekr.20210904065459.75: *4* TestImport.test_python_decls_test_1
     def test_python_decls_test_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2188,7 +2161,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.76: *5* TestImport.test_python_decorator
+    #@+node:ekr.20210904065459.76: *4* TestImport.test_python_decorator
     def test_python_decorator(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2212,7 +2185,7 @@ class TempImporterTest (BaseTestImporter):
         abc = g.findNodeInTree(c, c.p, "@cmd('abc') abc")
         lines = g.splitLines(abc.b)
         self.assertEqual(lines[0], "@cmd('abc')\n")
-    #@+node:ekr.20210904065459.77: *5* TestImport.test_python_decorator_2
+    #@+node:ekr.20210904065459.77: *4* TestImport.test_python_decorator_2
     def test_python_decorator_2(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2322,7 +2295,7 @@ class TempImporterTest (BaseTestImporter):
         lines = g.splitLines(target.b)
         self.assertEqual(lines[0], '@command("Exit")\n')
 
-    #@+node:ekr.20210904065459.78: *5* TestImport.test_python_def_inside_def
+    #@+node:ekr.20210904065459.78: *4* TestImport.test_python_def_inside_def
     def test_python_def_inside_def(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2354,7 +2327,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
 
-    #@+node:ekr.20210904065459.79: *5* TestImport.test_python_def_test_1
+    #@+node:ekr.20210904065459.79: *4* TestImport.test_python_def_test_1
     def test_python_def_test_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2393,7 +2366,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
 
-    #@+node:ekr.20210904065459.80: *5* TestImport.test_python_def_test_2
+    #@+node:ekr.20210904065459.80: *4* TestImport.test_python_def_test_2
     def test_python_def_test_2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2424,7 +2397,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
 
-    #@+node:ekr.20210904065459.81: *5* TestImport.test_python_docstring_only
+    #@+node:ekr.20210904065459.81: *4* TestImport.test_python_docstring_only
     def test_python_docstring_only(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2432,7 +2405,7 @@ class TempImporterTest (BaseTestImporter):
             """
         ''')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.82: *5* TestImport.test_python_empty_decls
+    #@+node:ekr.20210904065459.82: *4* TestImport.test_python_empty_decls
     def test_python_empty_decls(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2441,7 +2414,7 @@ class TempImporterTest (BaseTestImporter):
             a = 3
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.71: *5* TestImport.test_python_enhancement_481
+    #@+node:ekr.20210904065459.71: *4* TestImport.test_python_enhancement_481
     def test_python_enhancement_481(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2465,7 +2438,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.83: *5* TestImport.test_python_extra_leading_ws_test
+    #@+node:ekr.20210904065459.83: *4* TestImport.test_python_extra_leading_ws_test
     def test_python_extra_leading_ws_test(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2474,7 +2447,7 @@ class TempImporterTest (BaseTestImporter):
                     pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.84: *5* TestImport.test_python_indent_decls
+    #@+node:ekr.20210904065459.84: *4* TestImport.test_python_indent_decls
     def test_python_indent_decls(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2531,7 +2504,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.85: *5* TestImport.test_python_leoImport_py_small_
+    #@+node:ekr.20210904065459.85: *4* TestImport.test_python_leoImport_py_small_
     def test_python_leoImport_py_small_(self):
         c = self.c
 
@@ -2613,7 +2586,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.86: *5* TestImport.test_python_looks_like_section_ref
+    #@+node:ekr.20210904065459.86: *4* TestImport.test_python_looks_like_section_ref
     def test_python_looks_like_section_ref(self):
         c = self.c
         # ~/at-auto-test.py
@@ -2624,7 +2597,7 @@ class TempImporterTest (BaseTestImporter):
             a = b < < c > > d
         """).replace('> >', '>>').replace('< <', '<<')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.87: *5* TestImport.test_python_minimal_class_1
+    #@+node:ekr.20210904065459.87: *4* TestImport.test_python_minimal_class_1
     def test_python_minimal_class_1(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2641,7 +2614,7 @@ class TempImporterTest (BaseTestImporter):
                     log('gp: %s: %s\\n' % (cmd, str(args)))
         ''')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.88: *5* TestImport.test_python_minimal_class_2
+    #@+node:ekr.20210904065459.88: *4* TestImport.test_python_minimal_class_2
     def test_python_minimal_class_2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2651,7 +2624,7 @@ class TempImporterTest (BaseTestImporter):
                 pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.89: *5* TestImport.test_python_minimal_class_3
+    #@+node:ekr.20210904065459.89: *4* TestImport.test_python_minimal_class_3
     def test_python_minimal_class_3(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2661,7 +2634,7 @@ class TempImporterTest (BaseTestImporter):
                 pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.90: *5* TestImport.test_python_overindent_def_no_following_def
+    #@+node:ekr.20210904065459.90: *4* TestImport.test_python_overindent_def_no_following_def
     def test_python_overindent_def_no_following_def(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2677,7 +2650,7 @@ class TempImporterTest (BaseTestImporter):
                     pr('input...')
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.91: *5* TestImport.test_python_overindent_def_one_following_def
+    #@+node:ekr.20210904065459.91: *4* TestImport.test_python_overindent_def_one_following_def
     def test_python_overindent_def_one_following_def(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2696,7 +2669,7 @@ class TempImporterTest (BaseTestImporter):
                     pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.92: *5* TestImport.test_python_overindented_def_3
+    #@+node:ekr.20210904065459.92: *4* TestImport.test_python_overindented_def_3
     def test_python_overindented_def_3(self):
         # This caused PyParse.py not to be imported properly.
         c = self.c
@@ -2727,7 +2700,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.93: *5* TestImport.test_python_string_test_extra_indent
+    #@+node:ekr.20210904065459.93: *4* TestImport.test_python_string_test_extra_indent
     def test_python_string_test_extra_indent(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2744,7 +2717,7 @@ class TempImporterTest (BaseTestImporter):
                     return p
         ''')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.94: *5* TestImport.test_python_string_underindent_lines
+    #@+node:ekr.20210904065459.94: *4* TestImport.test_python_string_underindent_lines
     def test_python_string_underindent_lines(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2758,7 +2731,7 @@ class TempImporterTest (BaseTestImporter):
                     pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.95: *5* TestImport.test_python_string_underindent_lines_2
+    #@+node:ekr.20210904065459.95: *4* TestImport.test_python_string_underindent_lines_2
     def test_python_string_underindent_lines_2(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2773,7 +2746,7 @@ class TempImporterTest (BaseTestImporter):
                     pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.96: *5* TestImport.test_python_top_level_later_decl
+    #@+node:ekr.20210904065459.96: *4* TestImport.test_python_top_level_later_decl
     def test_python_top_level_later_decl(self):
         # From xo.py.
         c = self.c
@@ -2828,7 +2801,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.97: *5* TestImport.test_python_trailing_comment
+    #@+node:ekr.20210904065459.97: *4* TestImport.test_python_trailing_comment
     def test_python_trailing_comment(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2839,7 +2812,7 @@ class TempImporterTest (BaseTestImporter):
                     pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.98: *5* TestImport.test_python_trailing_comment_outer_levels
+    #@+node:ekr.20210904065459.98: *4* TestImport.test_python_trailing_comment_outer_levels
     def test_python_trailing_comment_outer_levels(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -2847,7 +2820,7 @@ class TempImporterTest (BaseTestImporter):
             pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.99: *5* TestImport.test_python_two_functions
+    #@+node:ekr.20210904065459.99: *4* TestImport.test_python_two_functions
     def test_python_two_functions(self):
         # For comparison with unindent does not end function.
         c = self.c
@@ -2859,7 +2832,7 @@ class TempImporterTest (BaseTestImporter):
                 pass
         """)
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.100: *5* TestImport.test_python_underindent_method
+    #@+node:ekr.20210904065459.100: *4* TestImport.test_python_underindent_method
     def test_python_underindent_method(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2890,7 +2863,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.101: *5* TestImport.test_python_unindent_in_triple_string_does_not_end_function
+    #@+node:ekr.20210904065459.101: *4* TestImport.test_python_unindent_in_triple_string_does_not_end_function
     def test_python_unindent_in_triple_string_does_not_end_function(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -2910,7 +2883,7 @@ class TempImporterTest (BaseTestImporter):
         child = p.firstChild()
         n = child.numberOfChildren()
         self.assertEqual(n, 2)
-    #@+node:ekr.20210904065459.102: *5* TestImport.test_python_unittest_perfectImport_formatter_py
+    #@+node:ekr.20210904065459.102: *4* TestImport.test_python_unittest_perfectImport_formatter_py
     def test_python_unittest_perfectImport_formatter_py(self):
         c = self.c
 
@@ -3350,8 +3323,8 @@ class TempImporterTest (BaseTestImporter):
                 test()
         ''')
         c.importCommands.pythonUnitTest(c.p, s=s)
-    #@+node:ekr.20210904123047.1: *4* Typescript tests
-    #@+node:ekr.20210904065459.103: *5* TestImport.test_TypeScript_class
+    #@+node:ekr.20210904123047.1: *3* Typescript tests
+    #@+node:ekr.20210904065459.103: *4* TestImport.test_TypeScript_class
     def test_TypeScript_class(self):
         c = self.c
         s = '''
@@ -3379,7 +3352,7 @@ class TempImporterTest (BaseTestImporter):
         '''
 
         c.importCommands.typeScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.104: *5* TestImport.test_TypeScript_module
+    #@+node:ekr.20210904065459.104: *4* TestImport.test_TypeScript_module
     def test_TypeScript_module(self):
         c = self.c
         s = textwrap.dedent('''\
@@ -3406,8 +3379,8 @@ class TempImporterTest (BaseTestImporter):
         ''')
 
         c.importCommands.typeScriptUnitTest(c.p, s=s)
-    #@+node:ekr.20210904123056.1: *4* XML tests
-    #@+node:ekr.20210904065459.105: *5* TestImport.test_xml_with_standard_opening_elements
+    #@+node:ekr.20210904123056.1: *3* XML tests
+    #@+node:ekr.20210904065459.105: *4* TestImport.test_xml_with_standard_opening_elements
     def test_xml_with_standard_opening_elements(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -3439,7 +3412,7 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
-    #@+node:ekr.20210904065459.106: *5* TestImport.test_xml_1
+    #@+node:ekr.20210904065459.106: *4* TestImport.test_xml_1
     def test_xml_1(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -3471,7 +3444,7 @@ class TempImporterTest (BaseTestImporter):
             p.moveToThreadNext()
         self.assertEqual(p, after)
 
-    #@+node:ekr.20210904065459.108: *5* TestImport.test_xml_non_ascii_tags
+    #@+node:ekr.20210904065459.108: *4* TestImport.test_xml_non_ascii_tags
     def test_xml_non_ascii_tags(self):
         c = self.c
         s = textwrap.dedent("""\
@@ -4422,6 +4395,38 @@ class TestC(BaseTestImporter):
         self.run_test(c.p, s)
         root = c.p.lastChild()
         self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
+#@+node:ekr.20211108062617.1: ** class TestIni(BaseTestImporter)
+class TestIni(BaseTestImporter):
+    
+    ext = '.ini'
+    
+    #@+others
+    #@+node:ekr.20210904065459.29: *3* TestIni.test_1
+    def test_1(self):
+        c = self.c
+        s = textwrap.dedent(r'''\
+            ; last modified 1 April 2001 by John Doe
+            [owner]
+            name=John Doe
+            organization=Acme Widgets Inc.
+
+            ; [ not a section ]
+
+            [database]
+            server=192.0.2.62
+                ; use IP address
+            port=143
+            file = "payroll.dat"
+        ''')
+        table = ('[owner]', '[database]')
+        self.run_test(c.p, s)
+        root = c.p.firstChild()
         p2 = root.firstChild()
         for h in table:
             self.assertEqual(p2.h, h)

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -54,6 +54,11 @@ class TestImporter(LeoUnitTest):
                 if d2.get(z) == aClass:
                     return z
         return '@file'
+    #@-others
+#@+node:ekr.20211108052633.1: ** class TempImporterTest (TestImporter)
+class TempImporterTest (TestImporter):
+    
+    #@+others  ### To be moved to other classes.
     #@+node:ekr.20210904065613.1: *3* Tests of @auto
     #@+node:ekr.20210904143515.1: *4* .ini tests
     #@+node:ekr.20210904065459.29: *5* TestImport.test_ini_test_1

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -293,6 +293,87 @@ class TestC(BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
+#@+node:ekr.20211108063520.1: ** class TestCoffeescript (BaseTextImporter)
+class TestCoffeescript (BaseTestImporter):
+    
+    ext = '.coffee'
+    
+    #@+others
+    #@+node:ekr.20210904065459.15: *3* TestCoffeescript.test_1
+    def test_1(self):
+        c = self.c
+        s = r'''
+
+        # Js2coffee relies on Narcissus's parser.
+
+        {parser} = @Narcissus or require('./narcissus_packed')
+
+        # Main entry point
+
+        buildCoffee = (str) ->
+          str  = str.replace /\r/g, ''
+          str += "\n"
+
+          builder    = new Builder
+          scriptNode = parser.parse str
+        '''
+        table = (
+            'buildCoffee = (str) ->',
+        )
+        self.run_test(c.p, s)
+        p2 = c.p.firstChild().firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+    #@+node:ekr.20210904065459.16: *3* TestCoffeescript.test_2
+    #@@tabwidth -2 # Required
+
+    def test_2(self):
+        c = self.c
+
+        s = textwrap.dedent("""\
+        class Builder
+          constructor: ->
+            @transformer = new Transformer
+          # `build()`
+
+          build: (args...) ->
+            node = args[0]
+            @transform node
+
+            name = 'other'
+            name = node.typeName()  if node != undefined and node.typeName
+
+            fn  = (@[name] or @other)
+            out = fn.apply(this, args)
+
+            if node.parenthesized then paren(out) else out
+          # `transform()`
+
+          transform: (args...) ->
+            @transformer.transform.apply(@transformer, args)
+
+          # `body()`
+
+          body: (node, opts={}) ->
+            str = @build(node, opts)
+            str = blockTrim(str)
+            str = unshift(str)
+            if str.length > 0 then str else ""
+        """)
+        table = (
+          'class Builder',
+          'constructor: ->',
+          'build: (args...) ->',
+          'transform: (args...) ->',
+          'body: (node, opts={}) ->',
+        )
+        self.run_test(c.p, s)
+        p2 = c.p.firstChild().firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+    #@-others
 #@+node:ekr.20211108062958.1: ** class TestCSharp (BaseTestImporter)
 class TestCSharp(BaseTestImporter):
     
@@ -593,39 +674,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904084324.1: *3* Cython tests
-    #@+node:ekr.20210904065459.11: *4* TestImport.test_cython_importer
-    def test_cython_importer(self):
-        c = self.c
-        s = textwrap.dedent('''\
-            from libc.math cimport pow
-
-            cdef double square_and_add (double x):
-                """Compute x^2 + x as double.
-
-                This is a cdef function that can be called from within
-                a Cython program, but not from Python.
-                """
-                return pow(x, 2.0) + x
-
-            cpdef print_result (double x):
-                """This is a cpdef function that can be called from Python."""
-                print("({} ^ 2) + {} = {}".format(x, x, square_and_add(x)))
-
-        ''')
-        table = (
-            'Declarations',
-            'double',
-            'print_result',
-        )
-        c.importCommands.cythonUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904144021.1: *3* Dart tests
     #@+node:ekr.20210904065459.17: *4* TestImport.test_dart_hello_world
     def test_dart_hello_world(self):
@@ -4364,87 +4412,42 @@ class TestRst(BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
-#@+node:ekr.20211108063520.1: ** class TestCoffeescript (BaseTextImporter)
-class TestCoffeescript (BaseTestImporter):
+#@+node:ekr.20211108063908.1: ** class TestCython (BaseTestImporter)
+class TestCython (BaseTestImporter):
     
-    ext = '.coffee'
-    
-    #@+others
-    #@+node:ekr.20210904065459.15: *3* TestCoffeescript.test_1
-    def test_1(self):
-        c = self.c
-        s = r'''
+    ext = '.pyx'
+#@+node:ekr.20210904065459.11: *3* TestCython.test_importer
+def test_importer(self):
+    c = self.c
+    s = textwrap.dedent('''\
+        from libc.math cimport pow
 
-        # Js2coffee relies on Narcissus's parser.
+        cdef double square_and_add (double x):
+            """Compute x^2 + x as double.
 
-        {parser} = @Narcissus or require('./narcissus_packed')
+            This is a cdef function that can be called from within
+            a Cython program, but not from Python.
+            """
+            return pow(x, 2.0) + x
 
-        # Main entry point
+        cpdef print_result (double x):
+            """This is a cpdef function that can be called from Python."""
+            print("({} ^ 2) + {} = {}".format(x, x, square_and_add(x)))
 
-        buildCoffee = (str) ->
-          str  = str.replace /\r/g, ''
-          str += "\n"
-
-          builder    = new Builder
-          scriptNode = parser.parse str
-        '''
-        table = (
-            'buildCoffee = (str) ->',
-        )
-        self.run_test(c.p, s)
-        p2 = c.p.firstChild().firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-    #@+node:ekr.20210904065459.16: *3* TestCoffeescript.test_2
-    #@@tabwidth -2 # Required
-
-    def test_2(self):
-        c = self.c
-
-        s = textwrap.dedent("""\
-        class Builder
-          constructor: ->
-            @transformer = new Transformer
-          # `build()`
-
-          build: (args...) ->
-            node = args[0]
-            @transform node
-
-            name = 'other'
-            name = node.typeName()  if node != undefined and node.typeName
-
-            fn  = (@[name] or @other)
-            out = fn.apply(this, args)
-
-            if node.parenthesized then paren(out) else out
-          # `transform()`
-
-          transform: (args...) ->
-            @transformer.transform.apply(@transformer, args)
-
-          # `body()`
-
-          body: (node, opts={}) ->
-            str = @build(node, opts)
-            str = blockTrim(str)
-            str = unshift(str)
-            if str.length > 0 then str else ""
-        """)
-        table = (
-          'class Builder',
-          'constructor: ->',
-          'build: (args...) ->',
-          'transform: (args...) ->',
-          'body: (node, opts={}) ->',
-        )
-        self.run_test(c.p, s)
-        p2 = c.p.firstChild().firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-    #@-others
+    ''')
+    table = (
+        'Declarations',
+        'double',
+        'print_result',
+    )
+    self.run_test(c.p, s)
+    root = c.p.lastChild()
+    self.assertEqual(root.h, '@file test')
+    p2 = root.firstChild()
+    for h in table:
+        self.assertEqual(p2.h, h)
+        p2.moveToThreadNext()
+    assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 #@-others
 
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -373,6 +373,11 @@ class TestCoffeescript (BaseTestImporter):
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
+    #@+node:ekr.20210904065459.126: *3* TestCoffeescript.test_scan_line
+    def test_scan_line(self):
+        c = self.c
+        x = cs.CS_Importer(c.importCommands, atAuto=True)
+        self.assertEqual(x.single_comment, '#')
     #@-others
 #@+node:ekr.20211108062958.1: ** class TestCSharp (BaseTestImporter)
 class TestCSharp(BaseTestImporter):
@@ -500,6 +505,17 @@ class TestDart (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
+    #@+node:ekr.20210904065459.127: *3* TestDart.test_clean_headline
+    def test_clean_headline(self):
+        c = self.c
+        x = dart.Dart_Importer(c.importCommands, atAuto=False)
+        table = (
+            ('func(abc) {', 'func'),
+            ('void foo() {', 'void foo'),
+        )
+        for s, expected in table:
+            got = x.clean_headline(s)
+            self.assertEqual(got, expected)
     #@-others
 #@+node:ekr.20211108065659.1: ** class TestElisp (BaseTestImporter)
 class TestElisp (BaseTestImporter):
@@ -1515,92 +1531,8 @@ class TestMarkdown(BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@-others
-#@+node:ekr.20211108052633.1: ** class TestMisc (BaseTestImporter) ===========
-class TestMisc (BaseTestImporter):
-    
-    #@+others
-    #@+node:ekr.20210904071422.1: *3* All other tests
-    #@+node:ekr.20210904065459.122: *4* TestImport.test_at_auto_importers
-    def test_at_auto_importers(self):
-        path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'importers')
-        assert g.os_path_exists(path), repr(path)
-        pattern = g.os_path_finalize_join(path, '*.py')
-        for fn in glob.glob(pattern):
-            sfn = g.shortFileName(fn)
-            m = importlib.import_module('leo.plugins.importers.%s' % sfn[:-3])
-            assert m
-    #@+node:ekr.20210904065459.123: *4* TestImport.test_Importer_get_leading_indent
-    def test_Importer_get_leading_indent(self):
-        c = self.c
-        lines_table = [
-            'abc',
-            '    xyz',
-            '    ',
-            '  # comment',
-        ]
-        for language in ('python', 'coffeescript'):
-            importer = linescanner.Importer(
-                c.importCommands,
-                language=language,
-            )
-            self.assertEqual(importer.single_comment, '#')
-            if 0:
-                for line in lines_table:
-                    lines = [line]
-                    n = importer.get_leading_indent(lines, 0)
-                    print('%s %r' % (n, line))
-    #@+node:ekr.20210904065459.124: *4* TestImport.test_Importer_get_str_lws
-    def test_Importer_get_str_lws(self):
-        c = self.c
-        table = [
-            ('', 'abc\n'),
-            ('    ', '    xyz\n'),
-            ('    ', '    \n'),
-            ('  ', '  # comment\n'),
-            ('', '\n'),
-        ]
-        importer = linescanner.Importer(c.importCommands, language='python')
-        for val, s in table:
-            self.assertEqual(val, importer.get_str_lws(s), msg=repr(s))
-    #@+node:ekr.20210904065459.125: *4* TestImport.test_Importer_is_ws_line
-    def test_Importer_is_ws_line(self):
-        c = self.c
-        table = [
-            (False, 'abc'),
-            (False, '    xyz'),
-            (True, '    '),
-            (True, '  # comment'),
-        ]
-        importer = linescanner.Importer(c.importCommands, language='python')
-        for val, s in table:
-            self.assertEqual(val, importer.is_ws_line(s), msg=repr(s))
-    #@+node:ekr.20210904065459.126: *4* TestImport.test_importers_coffee_scan_line
-    def test_importers_coffee_scan_line(self):
-        c = self.c
-        table = []  # State after line, line
-        x = cs.CS_Importer(c.importCommands, atAuto=True)
-        self.assertEqual(x.single_comment, '#')
-        for new_state, line in table:
-            print('%5s %r' % (new_state, line))
-        if 0:
-            for line in table:
-                lines = [line]
-                n = x.get_leading_indent(lines, 0)
-                print('%s %r' % (n, line))
-    #@+node:ekr.20210904065459.127: *4* TestImport.test_importers_dart_clean_headline
-    def test_importers_dart_clean_headline(self):
-        c = self.c
-        x = dart.Dart_Importer(c.importCommands, atAuto=False)
-        table = (
-            ('func(abc) {', 'func'),
-            ('void foo() {', 'void foo'),
-        )
-        for s, expected in table:
-            got = x.clean_headline(s)
-            self.assertEqual(got, expected)
-    #@+node:ekr.20210904065459.128: *4* TestImport.test_importers_markdown_is_hash
-    def test_importers_markdown_is_hash(self):
+    #@+node:ekr.20210904065459.128: *3* TestMarkdown.test_is_hash
+    def test_is_hash(self):
         c = self.c
         ic = c.importCommands
         x = markdown.Markdown_Importer(ic, atAuto=False)
@@ -1619,8 +1551,8 @@ class TestMisc (BaseTestImporter):
         level3, name = x.is_hash('Not a hash')
         assert level3 is None
         assert name is None
-    #@+node:ekr.20210904065459.129: *4* TestImport.test_importers_markdown_is_underline
-    def test_importers_markdown_is_underline(self):
+    #@+node:ekr.20210904065459.129: *3* TestMarkdown.test_is_underline
+    def test_is_underline(self):
         c = self.c
         ic = c.importCommands
         x = markdown.Markdown_Importer(ic, atAuto=False)
@@ -1630,34 +1562,41 @@ class TestMisc (BaseTestImporter):
         for line in ('-\n', '--\n', '---\n', '==\n', '===\n', '===\n', '==-==\n', 'abc\n'):
             got = x.is_underline(line)
             assert not got, repr(line)
-    #@+node:ekr.20210904065459.130: *4* TestImport.test_importers_pascal_methods
-    def test_importers_pascal_methods(self):
+    #@-others
+#@+node:ekr.20211108052633.1: ** class TestMisc (BaseTestImporter) ===========
+class TestMisc (BaseTestImporter):
+    
+    #@+others
+    #@+node:ekr.20210904065459.122: *3* TestImport.test_at_auto_importers
+    def test_at_auto_importers(self):
+        path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'importers')
+        assert g.os_path_exists(path), repr(path)
+        pattern = g.os_path_finalize_join(path, '*.py')
+        for fn in glob.glob(pattern):
+            sfn = g.shortFileName(fn)
+            m = importlib.import_module('leo.plugins.importers.%s' % sfn[:-3])
+            assert m
+    #@+node:ekr.20210904065459.123: *3* TestImport.test_get_leading_indent
+    def test_get_leading_indent(self):
         c = self.c
-        x = pascal.Pascal_Importer(c.importCommands, atAuto=False)
-        table = (
-            ('procedure TForm1.FormCreate(Sender: TObject);\n', 'procedure TForm1.FormCreate'),
-        )
-        state = g.Bunch(context='')
-        for line, cleaned in table:
-            assert x.starts_block(0, [line], state, state)
-            self.assertEqual(x.clean_headline(line), cleaned)
-    #@+node:ekr.20210904065459.132: *4* TestImport.test_importers_xml_is_ws_line
-    def test_importers_xml_is_ws_line(self):
-        c = self.c
-        x = xml.Xml_Importer(importCommands=c.importCommands, atAuto=False)
-        table = (
-           (1, ' \n'),
-           (1, '\n'),
-           (1, ' '),
-           (1, '<!-- comment -->'),
-           (0, '  <!-- comment --> Help'),
-           (0, 'x <!-- comment -->'),
-           (0, 'Help'),
-        )
-        for expected, line in table:
-            got = x.is_ws_line(line)
-            self.assertEqual(expected, got, msg=repr(line))
-    #@+node:ekr.20210904065459.133: *4* TestImport.test_importers_xml_scan_line
+        lines_table = [
+            'abc',
+            '    xyz',
+            '    ',
+            '  # comment',
+        ]
+        for language in ('python', 'coffeescript'):
+            importer = linescanner.Importer(
+                c.importCommands,
+                language=language,
+            )
+            self.assertEqual(importer.single_comment, '#')
+            if 0:
+                for line in lines_table:
+                    lines = [line]
+                    n = importer.get_leading_indent(lines, 0)
+                    print('%s %r' % (n, line))
+    #@+node:ekr.20210904065459.133: *3* TestImport.test_importers_xml_scan_line
     def test_importers_xml_scan_line(self):
         c = self.c
         x = xml.Xml_Importer(importCommands=c.importCommands, atAuto=False)
@@ -1678,7 +1617,7 @@ class TestMisc (BaseTestImporter):
             self.assertEqual(prev_state.tag_level, 0, msg=line)
             new_state = x.scan_line(line, prev_state)
             self.assertEqual(new_state.tag_level, level, msg=line)
-    #@+node:ekr.20210904065459.131: *4* TestImport.test_importers_python_test_scan_state
+    #@+node:ekr.20210904065459.131: *3* TestImport.test_importers_python_test_scan_state
     def test_importers_python_test_scan_state(self):
         c = self.c
         State = python.Python_ScanState
@@ -1986,6 +1925,17 @@ class TestPascal (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
+    #@+node:ekr.20210904065459.130: *3* TestPascal.test_methods
+    def test_methods(self):
+        c = self.c
+        x = pascal.Pascal_Importer(c.importCommands, atAuto=False)
+        table = (
+            ('procedure TForm1.FormCreate(Sender: TObject);\n', 'procedure TForm1.FormCreate'),
+        )
+        state = g.Bunch(context='')
+        for line, cleaned in table:
+            assert x.starts_block(0, [line], state, state)
+            self.assertEqual(x.clean_headline(line), cleaned)
     #@-others
 #@+node:ekr.20211108081950.1: ** class TestPerl (BaseTestImporter)
 class TestPerl (BaseTestImporter):
@@ -2230,91 +2180,6 @@ class TestPython (BaseTestImporter):
     ext = '.py'
     
     #@+others
-    #@+node:ekr.20210904065459.60: *3* TestPython.test_i_scan_state
-    def test_i_scan_state(self):
-        c = self.c
-        # A list of dictionaries.
-        tests = (
-            g.Bunch(line='\n'),
-            g.Bunch(line='\\\n'),
-            g.Bunch(line='s = "\\""', ctx=('', '')),  # empty string.
-            g.Bunch(line="s = '\\''", ctx=('', '')),  # empty string.
-            g.Bunch(line='# comment'),
-            g.Bunch(line='  # comment'),
-            g.Bunch(line='    # comment'),
-            g.Bunch(line='a = "string"'),
-            g.Bunch(line='a = "Continued string', ctx=('', '"')),
-            g.Bunch(line='end of continued string"', ctx=('"', '')),
-            g.Bunch(line='a = """Continued docstring', ctx=('', '"""')),
-            g.Bunch(line='a = """#', ctx=('', '"""')),
-            g.Bunch(line='end of continued string"""', ctx=('"""', '')),
-            g.Bunch(line="a = '''Continued docstring", ctx=('', "'''")),
-            g.Bunch(line="end of continued string'''", ctx=("'''", '')),
-            g.Bunch(line='a = {[(')
-        )
-        importer = python.Py_Importer(c.importCommands)
-        importer.test_scan_state(tests, State=python.Python_ScanState)
-    #@+node:ekr.20210904065459.61: *3* TestPython.test_leoApp_fail
-    def test_leoApp_fail(self):
-        c = self.c
-        s = textwrap.dedent('''
-            def isValidPython(self):
-                if sys.platform == 'cli':
-                    return True
-                minimum_python_version = '2.6'
-                message = """\
-            Leo requires Python %s or higher.
-            You may download Python from
-            http://python.org/download/
-            """ % minimum_python_version
-                try:
-                    version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
-                    ok = g.CheckVersion(version, minimum_python_version)
-                    if not ok:
-                        print(message)
-                        try:
-                            # g.app.gui does not exist yet.
-                            import Tkinter as Tk
-                            class EmergencyDialog(object):
-                                def run(self):
-                                    """Run the modal emergency dialog."""
-                                    self.top.geometry("%dx%d%+d%+d" % (300, 200, 50, 50))
-                                    self.top.lift()
-                                    self.top.grab_set() # Make the dialog a modal dialog.
-                                    self.root.wait_window(self.top)
-                            d = EmergencyDialog(
-                                title='Python Version Error',
-                                message=message)
-                            d.run()
-                        except Exception:
-                            pass
-                    return ok
-                except Exception:
-                    print("isValidPython: unexpected exception: g.CheckVersion")
-                    traceback.print_exc()
-                    return 0
-            def loadLocalFile(self, fn, gui, old_c):
-                trace = (False or g.trace_startup) and not g.unitTesting
-        ''')
-        table = (
-            (1, 'isValidPython'),
-            # (2, 'class EmergencyDialog'),
-            # (3, 'run'),
-            (1, 'loadLocalFile'),
-        )
-        p = c.p
-        self.run_test(p, s=s)
-        after = p.nodeAfterTree()
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p = root.firstChild()
-        for n, h in table:
-            n2 = p.level() - root.level()
-            self.assertEqual(h, p.h)
-            self.assertEqual(n, n2)
-            p.moveToThreadNext()
-        self.assertEqual(p, after)
-
     #@+node:ekr.20210904065459.62: *3* TestPython.test_bad_class_test
     def test_bad_class_test(self):
         c = self.c
@@ -3205,6 +3070,43 @@ class TestPython (BaseTestImporter):
                     pass
         """)
         self.run_test(c.p, s=s)
+    #@+node:ekr.20210904065459.124: *3* TestPython.test_get_str_lws
+    def test_get_str_lws(self):
+        c = self.c
+        table = [
+            ('', 'abc\n'),
+            ('    ', '    xyz\n'),
+            ('    ', '    \n'),
+            ('  ', '  # comment\n'),
+            ('', '\n'),
+        ]
+        importer = linescanner.Importer(c.importCommands, language='python')
+        for val, s in table:
+            self.assertEqual(val, importer.get_str_lws(s), msg=repr(s))
+    #@+node:ekr.20210904065459.60: *3* TestPython.test_i_scan_state
+    def test_i_scan_state(self):
+        c = self.c
+        # A list of dictionaries.
+        tests = (
+            g.Bunch(line='\n'),
+            g.Bunch(line='\\\n'),
+            g.Bunch(line='s = "\\""', ctx=('', '')),  # empty string.
+            g.Bunch(line="s = '\\''", ctx=('', '')),  # empty string.
+            g.Bunch(line='# comment'),
+            g.Bunch(line='  # comment'),
+            g.Bunch(line='    # comment'),
+            g.Bunch(line='a = "string"'),
+            g.Bunch(line='a = "Continued string', ctx=('', '"')),
+            g.Bunch(line='end of continued string"', ctx=('"', '')),
+            g.Bunch(line='a = """Continued docstring', ctx=('', '"""')),
+            g.Bunch(line='a = """#', ctx=('', '"""')),
+            g.Bunch(line='end of continued string"""', ctx=('"""', '')),
+            g.Bunch(line="a = '''Continued docstring", ctx=('', "'''")),
+            g.Bunch(line="end of continued string'''", ctx=("'''", '')),
+            g.Bunch(line='a = {[(')
+        )
+        importer = python.Py_Importer(c.importCommands)
+        importer.test_scan_state(tests, State=python.Python_ScanState)
     #@+node:ekr.20210904065459.84: *3* TestPython.test_indent_decls
     def test_indent_decls(self):
         c = self.c
@@ -3262,6 +3164,79 @@ class TestPython (BaseTestImporter):
             self.assertEqual(n, n2)
             p.moveToThreadNext()
         self.assertEqual(p, after)
+    #@+node:ekr.20210904065459.125: *3* TestPython.test_is_ws_line
+    def test_is_ws_line(self):
+        c = self.c
+        table = [
+            (False, 'abc'),
+            (False, '    xyz'),
+            (True, '    '),
+            (True, '  # comment'),
+        ]
+        importer = linescanner.Importer(c.importCommands, language='python')
+        for val, s in table:
+            self.assertEqual(val, importer.is_ws_line(s), msg=repr(s))
+    #@+node:ekr.20210904065459.61: *3* TestPython.test_leoApp_fail
+    def test_leoApp_fail(self):
+        c = self.c
+        s = textwrap.dedent('''
+            def isValidPython(self):
+                if sys.platform == 'cli':
+                    return True
+                minimum_python_version = '2.6'
+                message = """\
+            Leo requires Python %s or higher.
+            You may download Python from
+            http://python.org/download/
+            """ % minimum_python_version
+                try:
+                    version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
+                    ok = g.CheckVersion(version, minimum_python_version)
+                    if not ok:
+                        print(message)
+                        try:
+                            # g.app.gui does not exist yet.
+                            import Tkinter as Tk
+                            class EmergencyDialog(object):
+                                def run(self):
+                                    """Run the modal emergency dialog."""
+                                    self.top.geometry("%dx%d%+d%+d" % (300, 200, 50, 50))
+                                    self.top.lift()
+                                    self.top.grab_set() # Make the dialog a modal dialog.
+                                    self.root.wait_window(self.top)
+                            d = EmergencyDialog(
+                                title='Python Version Error',
+                                message=message)
+                            d.run()
+                        except Exception:
+                            pass
+                    return ok
+                except Exception:
+                    print("isValidPython: unexpected exception: g.CheckVersion")
+                    traceback.print_exc()
+                    return 0
+            def loadLocalFile(self, fn, gui, old_c):
+                trace = (False or g.trace_startup) and not g.unitTesting
+        ''')
+        table = (
+            (1, 'isValidPython'),
+            # (2, 'class EmergencyDialog'),
+            # (3, 'run'),
+            (1, 'loadLocalFile'),
+        )
+        p = c.p
+        self.run_test(p, s=s)
+        after = p.nodeAfterTree()
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p = root.firstChild()
+        for n, h in table:
+            n2 = p.level() - root.level()
+            self.assertEqual(h, p.h)
+            self.assertEqual(n, n2)
+            p.moveToThreadNext()
+        self.assertEqual(p, after)
+
     #@+node:ekr.20210904065459.85: *3* TestPython.test_leoImport_py_small_
     def test_leoImport_py_small_(self):
         c = self.c
@@ -4541,6 +4516,22 @@ class TestXML (BaseTestImporter):
             <_.ÌÑ>
         """)
         self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.132: *3* TestXml.test_is_ws_line
+    def test_is_ws_line(self):
+        c = self.c
+        x = xml.Xml_Importer(importCommands=c.importCommands, atAuto=False)
+        table = (
+           (1, ' \n'),
+           (1, '\n'),
+           (1, ' '),
+           (1, '<!-- comment -->'),
+           (0, '  <!-- comment --> Help'),
+           (0, 'x <!-- comment -->'),
+           (0, 'Help'),
+        )
+        for expected, line in table:
+            got = x.is_ws_line(line)
+            self.assertEqual(expected, got, msg=repr(line))
     #@-others
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1520,100 +1520,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122920.1: *3* PHP tests
-    #@+node:ekr.20210904065459.56: *4* TestImport.test_php_import_class
-    def test_php_import_class(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            <?php
-
-            $type = 'cc';
-            $obj = new $type; // outputs "hi!"
-
-            class cc {
-                function __construct() {
-                    echo 'hi!';
-                }
-            }
-
-            ?>
-        """)
-        c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.57: *4* TestImport.test_php_import_conditional_class
-    def test_php_import_conditional_class(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            <?php
-
-            if (expr) {
-                class cc {
-                    // version 1
-                }
-            } else {
-                class cc {
-                    // version 2
-                }
-            }
-
-            ?>
-        """)
-        c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.58: *4* TestImport.test_php_import_classes__functions
-    def test_php_import_classes__functions(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            <?php
-            class Enum {
-                protected $self = array();
-                public function __construct( /*...*/ ) {
-                    $args = func_get_args();
-                    for( $i=0, $n=count($args); $i<$n; $i++ )
-                        $this->add($args[$i]);
-                }
-
-                public function __get( /*string*/ $name = null ) {
-                    return $this->self[$name];
-                }
-
-                public function add( /*string*/ $name = null, /*int*/ $enum = null ) {
-                    if( isset($enum) )
-                        $this->self[$name] = $enum;
-                    else
-                        $this->self[$name] = end($this->self) + 1;
-                }
-            }
-
-            class DefinedEnum extends Enum {
-                public function __construct( /*array*/ $itms ) {
-                    foreach( $itms as $name => $enum )
-                        $this->add($name, $enum);
-                }
-            }
-
-            class FlagsEnum extends Enum {
-                public function __construct( /*...*/ ) {
-                    $args = func_get_args();
-                    for( $i=0, $n=count($args), $f=0x1; $i<$n; $i++, $f *= 0x2 )
-                        $this->add($args[$i], $f);
-                }
-            }
-            ?>
-        """)
-        c.importCommands.phpUnitTest(c.p, s=s)
-    #@+node:ekr.20210904065459.59: *4* TestImport.test_php_here_doc
-    def test_php_here_doc(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            <?php
-            class foo {
-                public $bar = <<<EOT
-            a test.
-            bar
-            EOT;
-            }
-            ?>
-        """)
-        c.importCommands.phpUnitTest(c.p, s=s)
     #@+node:ekr.20210904122944.1: *3* Python tests
     #@+node:ekr.20210904065459.60: *4* TestImport.test_i_scan_state_for_python_
     def test_i_scan_state_for_python_(self):
@@ -4125,6 +4031,106 @@ class TestPerl (BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
+    #@-others
+#@+node:ekr.20211108082208.1: ** class TestPhp (BaseTestImporter)
+class TestPhp (BaseTestImporter):
+    
+    ext = '.php'
+    
+    #@+others
+    #@+node:ekr.20210904065459.56: *3* TestPhp.test_import_class
+    def test_import_class(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            <?php
+
+            $type = 'cc';
+            $obj = new $type; // outputs "hi!"
+
+            class cc {
+                function __construct() {
+                    echo 'hi!';
+                }
+            }
+
+            ?>
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.57: *3* TestPhp.test_import_conditional_class
+    def test_import_conditional_class(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            <?php
+
+            if (expr) {
+                class cc {
+                    // version 1
+                }
+            } else {
+                class cc {
+                    // version 2
+                }
+            }
+
+            ?>
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.58: *3* TestPhp.test_import_classes__functions
+    def test_import_classes__functions(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            <?php
+            class Enum {
+                protected $self = array();
+                public function __construct( /*...*/ ) {
+                    $args = func_get_args();
+                    for( $i=0, $n=count($args); $i<$n; $i++ )
+                        $this->add($args[$i]);
+                }
+
+                public function __get( /*string*/ $name = null ) {
+                    return $this->self[$name];
+                }
+
+                public function add( /*string*/ $name = null, /*int*/ $enum = null ) {
+                    if( isset($enum) )
+                        $this->self[$name] = $enum;
+                    else
+                        $this->self[$name] = end($this->self) + 1;
+                }
+            }
+
+            class DefinedEnum extends Enum {
+                public function __construct( /*array*/ $itms ) {
+                    foreach( $itms as $name => $enum )
+                        $this->add($name, $enum);
+                }
+            }
+
+            class FlagsEnum extends Enum {
+                public function __construct( /*...*/ ) {
+                    $args = func_get_args();
+                    for( $i=0, $n=count($args), $f=0x1; $i<$n; $i++, $f *= 0x2 )
+                        $this->add($args[$i], $f);
+                }
+            }
+            ?>
+        """)
+        self.run_test(c.p, s)
+    #@+node:ekr.20210904065459.59: *3* TestPhp.test_here_doc
+    def test_here_doc(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            <?php
+            class foo {
+                public $bar = <<<EOT
+            a test.
+            bar
+            EOT;
+            }
+            ?>
+        """)
+        self.run_test(c.p, s)
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -501,6 +501,40 @@ class TestDart (BaseTestImporter):
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
 
     #@-others
+#@+node:ekr.20211108065659.1: ** class TestElisp (BaseTestImporter)
+class TestElisp (BaseTestImporter):
+    
+    ext = '.el'
+    
+    #@+others
+    #@+node:ekr.20210904065459.18: *3* TestElisp.test_1
+    def test_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            ;;; comment
+            ;;; continue
+            ;;;
+
+            (defun abc (a b)
+               (+ 1 2 3))
+
+            ; comm
+            (defun cde (a b)
+               (+ 1 2 3))
+        """)
+        table = (
+            'defun abc',
+            'defun cde',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
 #@+node:ekr.20211108064432.1: ** class TestHtml (BaseTestImporter)
 class TestHtml (BaseTestImporter):
     
@@ -952,6 +986,149 @@ class TestIni(BaseTestImporter):
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
+#@+node:ekr.20211108065916.1: ** class TestJava (BaseTestImporter)
+class TestJava (BaseTestImporter):
+    
+    ext = '.java'
+    
+    #@+others
+    #@+node:ekr.20210904065459.30: *3* TestJava.test_from_AdminPermission_java
+    def test_from_AdminPermission_java(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            /**
+             * Indicates the caller's authority to perform lifecycle operations on
+             */
+
+            public final class AdminPermission extends BasicPermission
+            {
+                /**
+                 * Creates a new <tt>AdminPermission</tt> object.
+                 */
+                public AdminPermission()
+                {
+                    super("AdminPermission");
+                }
+            }
+        """)
+        table = (
+            'public final class AdminPermission extends BasicPermission',
+            'public AdminPermission',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+
+    #@+node:ekr.20210904065459.31: *3* TestJava.test_from_BundleException_java
+    def test_from_BundleException_java(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            /*
+             * $Header: /cvs/leo/test/unitTest.leo,v 1.247 2008/02/14 14:59:04 edream Exp $
+             *
+             * Copyright (c) OSGi Alliance (2000, 2005). All Rights Reserved.
+             *
+             * This program and the accompanying materials are made available under the
+             * terms of the Eclipse Public License v1.0 which accompanies this
+             * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
+             */
+
+            package org.osgi.framework;
+
+            /**
+             * A Framework exception used to indicate that a bundle lifecycle problem
+             * occurred.
+             *
+             * <p>
+             * <code>BundleException</code> object is created by the Framework to denote
+             * an exception condition in the lifecycle of a bundle.
+             * <code>BundleException</code>s should not be created by bundle developers.
+             *
+             * <p>
+             * This exception is updated to conform to the general purpose exception
+             * chaining mechanism.
+             *
+             * @version $Revision: 1.247 $
+             */
+
+            public class BundleException extends Exception {
+                static final long	serialVersionUID	= 3571095144220455665L;
+                /**
+                 * Nested exception.
+                 */
+                private Throwable	cause;
+
+                /**
+                 * Creates a <code>BundleException</code> that wraps another exception.
+                 *
+                 * @param msg The associated message.
+                 * @param cause The cause of this exception.
+                 */
+                public BundleException(String msg, Throwable cause) {
+                    super(msg);
+                    this.cause = cause;
+                }
+            }
+
+        """)
+        table = (
+            'public class BundleException extends Exception',
+            'public BundleException',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.32: *3* TestJava.test_interface_test1
+    def test_interface_test1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            interface Bicycle {
+                void changeCadence(int newValue);
+                void changeGear(int newValue);
+            }
+        """)
+        table = (
+            'interface Bicycle',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.33: *3* TestJava.test_interface_test2
+    def test_interface_test2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            interface Bicycle {
+            void changeCadence(int newValue);
+            void changeGear(int newValue);
+            }
+        """)
+        table = (
+            'interface Bicycle',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for i, h in enumerate(table):
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
 #@+node:ekr.20211108043230.1: ** class TestMarkdown (BaseTestImporter)
 class TestMarkdown(BaseTestImporter):
     
@@ -1170,143 +1347,6 @@ class TestMarkdown(BaseTestImporter):
 class TestMisc (BaseTestImporter):
     
     #@+others
-    #@+node:ekr.20210904122815.1: *3* Java tests
-    #@+node:ekr.20210904065459.30: *4* TestImport.test_from_AdminPermission_java
-    def test_from_AdminPermission_java(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            /**
-             * Indicates the caller's authority to perform lifecycle operations on
-             */
-
-            public final class AdminPermission extends BasicPermission
-            {
-                /**
-                 * Creates a new <tt>AdminPermission</tt> object.
-                 */
-                public AdminPermission()
-                {
-                    super("AdminPermission");
-                }
-            }
-        """)
-        table = (
-            'public final class AdminPermission extends BasicPermission',
-            'public AdminPermission',
-        )
-        c.importCommands.javaUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-
-    #@+node:ekr.20210904065459.31: *4* TestImport.test_from_BundleException_java
-    def test_from_BundleException_java(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            /*
-             * $Header: /cvs/leo/test/unitTest.leo,v 1.247 2008/02/14 14:59:04 edream Exp $
-             *
-             * Copyright (c) OSGi Alliance (2000, 2005). All Rights Reserved.
-             *
-             * This program and the accompanying materials are made available under the
-             * terms of the Eclipse Public License v1.0 which accompanies this
-             * distribution, and is available at http://www.eclipse.org/legal/epl-v10.html.
-             */
-
-            package org.osgi.framework;
-
-            /**
-             * A Framework exception used to indicate that a bundle lifecycle problem
-             * occurred.
-             *
-             * <p>
-             * <code>BundleException</code> object is created by the Framework to denote
-             * an exception condition in the lifecycle of a bundle.
-             * <code>BundleException</code>s should not be created by bundle developers.
-             *
-             * <p>
-             * This exception is updated to conform to the general purpose exception
-             * chaining mechanism.
-             *
-             * @version $Revision: 1.247 $
-             */
-
-            public class BundleException extends Exception {
-                static final long	serialVersionUID	= 3571095144220455665L;
-                /**
-                 * Nested exception.
-                 */
-                private Throwable	cause;
-
-                /**
-                 * Creates a <code>BundleException</code> that wraps another exception.
-                 *
-                 * @param msg The associated message.
-                 * @param cause The cause of this exception.
-                 */
-                public BundleException(String msg, Throwable cause) {
-                    super(msg);
-                    this.cause = cause;
-                }
-            }
-
-        """)
-        table = (
-            'public class BundleException extends Exception',
-            'public BundleException',
-        )
-        c.importCommands.javaUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.32: *4* TestImport.test_java_interface_test1
-    def test_java_interface_test1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            interface Bicycle {
-                void changeCadence(int newValue);
-                void changeGear(int newValue);
-            }
-        """)
-        table = (
-            'interface Bicycle',
-        )
-        c.importCommands.javaUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.33: *4* TestImport.test_java_interface_test2
-    def test_java_interface_test2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            interface Bicycle {
-            void changeCadence(int newValue);
-            void changeGear(int newValue);
-            }
-        """)
-        table = (
-            'interface Bicycle',
-        )
-        c.importCommands.javaUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for i, h in enumerate(table):
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904122826.1: *3* Javascript tests
     #@+node:ekr.20210904065459.34: *4* TestImport.test_Javascript_regex_1
     def test_Javascript_regex_1(self):
@@ -4455,40 +4495,6 @@ class TestXML (BaseTestImporter):
             <_.ÌÑ>
         """)
         self.run_test(c.p, s)
-    #@-others
-#@+node:ekr.20211108065659.1: ** class TestElisp (BaseTestImporter)
-class TestElisp (BaseTestImporter):
-    
-    ext = '.el'
-    
-    #@+others
-    #@+node:ekr.20210904065459.18: *3* TestElisp.test_1
-    def test_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            ;;; comment
-            ;;; continue
-            ;;;
-
-            (defun abc (a b)
-               (+ 1 2 3))
-
-            ; comm
-            (defun cde (a b)
-               (+ 1 2 3))
-        """)
-        table = (
-            'defun abc',
-            'defun cde',
-        )
-        self.run_test(c.p, s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@-others
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -88,236 +88,6 @@ class TempImporterTest (BaseTestImporter):
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()
         assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065632.1: *4* C tests
-    #@+node:ekr.20210904065459.3: *5* TestImport.test_c_class_1
-    def test_c_class_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class cTestClass1 {
-
-                int foo (int a) {
-                    a = 2 ;
-                }
-
-                char bar (float c) {
-                    ;
-                }
-            }
-        """)
-        table = (
-            'class cTestClass1',
-            'int foo',
-            'char bar',
-        )
-        c.importCommands.cUnitTest(c.p, s=s)
-        # Check structure
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.4: *5* TestImport.test_c_class_underindented_line
-    def test_c_class_underindented_line(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            class cTestClass1 {
-
-                int foo (int a) {
-            // an underindented line.
-                    a = 2 ;
-                }
-
-                // This should go with the next function.
-
-                char bar (float c) {
-                    ;
-                }
-            }
-        """)
-        table = (
-            'class cTestClass1',
-            'int foo',
-            'char bar',
-        )
-        c.importCommands.cUnitTest(c.p, s=s)
-        # Check structure
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.5: *5* TestImport.test_c_comment_follows_arg_list
-    def test_c_comment_follows_arg_list(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            void
-            aaa::bbb::doit
-                (
-                awk* b
-                )
-            {
-                assert(false);
-            }
-
-            bool
-            aaa::bbb::dothat
-                (
-                xyz *b
-                ) //  <---------------------problem
-            {
-                return true;
-            }
-        """)
-        table = (
-            'void aaa::bbb::doit',
-            'bool aaa::bbb::dothat',
-        )
-        c.importCommands.cUnitTest(c.p, s=s)
-        # Check structure
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.6: *5* TestImport.test_c_comment_follows_block_delim
-    def test_c_comment_follows_block_delim(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            void
-            aaa::bbb::doit
-                (
-                awk* b
-                )
-            {
-                assert(false);
-            }
-
-            bool
-            aaa::bbb::dothat
-                (
-                xyz *b
-                )
-            {
-                return true;
-            } //  <---------------------problem
-        """)
-        table = (
-            'void aaa::bbb::doit',
-            'bool aaa::bbb::dothat',
-        )
-        c.importCommands.cUnitTest(c.p, s=s)
-        # Check structure
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        assert p2, g.tree_to_string(c)
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.10: *5* TestImport.test_c_extern
-    def test_c_extern(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            extern "C"
-            {
-            #include "stuff.h"
-            void    init(void);
-            #include "that.h"
-            }
-        """)
-        table = (
-            'extern "C"',
-        )
-        p = c.p
-        c.importCommands.cUnitTest(p, s=s)
-        root = p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.7: *5* TestImport.test_c_intermixed_blanks_and_tabs
-    def test_c_intermixed_blanks_and_tabs(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            void
-            aaa::bbb::doit
-                (
-                awk* b  // leading blank
-                )
-            {
-                assert(false); // leading tab
-            }
-        """)
-        table = (
-            'void aaa::bbb::doit',
-        )
-
-        c.importCommands.cUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-
-    #@+node:ekr.20210904065459.8: *5* TestImport.test_c_old_style_decl_1
-    def test_c_old_style_decl_1(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            static void
-            ReleaseCharSet(cset)
-                CharSet *cset;
-            {
-                ckfree((char *)cset->chars);
-                if (cset->ranges) {
-                ckfree((char *)cset->ranges);
-                }
-            }
-        """)
-        table = (
-            'static void ReleaseCharSet',
-        )
-        c.importCommands.cUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test', root.h)
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
-    #@+node:ekr.20210904065459.9: *5* TestImport.test_c_old_style_decl_2
-    def test_c_old_style_decl_2(self):
-        c = self.c
-        s = textwrap.dedent("""\
-            Tcl_Obj *
-            Tcl_NewLongObj(longValue)
-                register long longValue;	/* Long integer used to initialize the
-                     * new object. */
-            {
-                return Tcl_DbNewLongObj(longValue, "unknown", 0);
-            }
-        """)
-        table = (
-            'Tcl_Obj * Tcl_NewLongObj',
-        )
-        c.importCommands.cUnitTest(c.p, s=s)
-        root = c.p.lastChild()
-        self.assertEqual(root.h, '@file test')
-        p2 = root.firstChild()
-        for h in table:
-            self.assertEqual(p2.h, h)
-            p2.moveToThreadNext()
-        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
     #@+node:ekr.20210904144251.1: *4* C# tests
     #@+node:ekr.20210904065459.12: *5* TestImport.test_c_sharp_namespace_indent
     def test_c_sharp_namespace_indent(self):
@@ -4417,6 +4187,242 @@ class TestRst(BaseTestImporter):
         self.assertEqual(root.h, '@auto-rst test')
         p2 = root.firstChild()
         assert p2, g.tree_to_string(c)
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@-others
+#@+node:ekr.20211108062025.1: ** class TestC(BaseTestImporter)
+class TestC(BaseTestImporter):
+    
+    ext = '.c'
+    
+    #@+others
+    #@+node:ekr.20210904065459.3: *3* TestC.test_class_1
+    def test_class_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class cTestClass1 {
+
+                int foo (int a) {
+                    a = 2 ;
+                }
+
+                char bar (float c) {
+                    ;
+                }
+            }
+        """)
+        table = (
+            'class cTestClass1',
+            'int foo',
+            'char bar',
+        )
+        self.run_test(c.p, s)
+        # Check structure
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.4: *3* TestC.test_class_underindented_line
+    def test_class_underindented_line(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            class cTestClass1 {
+
+                int foo (int a) {
+            // an underindented line.
+                    a = 2 ;
+                }
+
+                // This should go with the next function.
+
+                char bar (float c) {
+                    ;
+                }
+            }
+        """)
+        table = (
+            'class cTestClass1',
+            'int foo',
+            'char bar',
+        )
+        self.run_test(c.p, s)
+        # Check structure
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.5: *3* TestC.test_comment_follows_arg_list
+    def test_comment_follows_arg_list(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            void
+            aaa::bbb::doit
+                (
+                awk* b
+                )
+            {
+                assert(false);
+            }
+
+            bool
+            aaa::bbb::dothat
+                (
+                xyz *b
+                ) //  <---------------------problem
+            {
+                return true;
+            }
+        """)
+        table = (
+            'void aaa::bbb::doit',
+            'bool aaa::bbb::dothat',
+        )
+        self.run_test(c.p, s)
+        # Check structure
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.6: *3* TestC.test_comment_follows_block_delim
+    def test_comment_follows_block_delim(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            void
+            aaa::bbb::doit
+                (
+                awk* b
+                )
+            {
+                assert(false);
+            }
+
+            bool
+            aaa::bbb::dothat
+                (
+                xyz *b
+                )
+            {
+                return true;
+            } //  <---------------------problem
+        """)
+        table = (
+            'void aaa::bbb::doit',
+            'bool aaa::bbb::dothat',
+        )
+        self.run_test(c.p, s)
+        # Check structure
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        assert p2, g.tree_to_string(c)
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.10: *3* TestC.test_extern
+    def test_extern(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            extern "C"
+            {
+            #include "stuff.h"
+            void    init(void);
+            #include "that.h"
+            }
+        """)
+        table = (
+            'extern "C"',
+        )
+        p = c.p
+        self.run_test(c.p, s)
+        root = p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.7: *3* TestC.test_intermixed_blanks_and_tabs
+    def test_intermixed_blanks_and_tabs(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            void
+            aaa::bbb::doit
+                (
+                awk* b  // leading blank
+                )
+            {
+                assert(false); // leading tab
+            }
+        """)
+        table = (
+            'void aaa::bbb::doit',
+        )
+
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+
+    #@+node:ekr.20210904065459.8: *3* TestC.test_old_style_decl_1
+    def test_old_style_decl_1(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            static void
+            ReleaseCharSet(cset)
+                CharSet *cset;
+            {
+                ckfree((char *)cset->chars);
+                if (cset->ranges) {
+                ckfree((char *)cset->ranges);
+                }
+            }
+        """)
+        table = (
+            'static void ReleaseCharSet',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test', root.h)
+        p2 = root.firstChild()
+        for h in table:
+            self.assertEqual(p2.h, h)
+            p2.moveToThreadNext()
+        assert not root.isAncestorOf(p2), p2.h  # Extra nodes
+    #@+node:ekr.20210904065459.9: *3* TestC.test_old_style_decl_2
+    def test_old_style_decl_2(self):
+        c = self.c
+        s = textwrap.dedent("""\
+            Tcl_Obj *
+            Tcl_NewLongObj(longValue)
+                register long longValue;	/* Long integer used to initialize the
+                     * new object. */
+            {
+                return Tcl_DbNewLongObj(longValue, "unknown", 0);
+            }
+        """)
+        table = (
+            'Tcl_Obj * Tcl_NewLongObj',
+        )
+        self.run_test(c.p, s)
+        root = c.p.lastChild()
+        self.assertEqual(root.h, '@file test')
+        p2 = root.firstChild()
         for h in table:
             self.assertEqual(p2.h, h)
             p2.moveToThreadNext()


### PR DESCRIPTION
See #2316.

- Don't specify classes in the 'edit-*' commands. Execute *all* test code.
- Don't put tests in the BaseTestImporter class. Those tests would be executed in all subclasses!
- Remove test wrappers from leoImport.py.