### PR TITLE
PR: Use generators to full effect in two important methods

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3381,6 +3381,8 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
     v0 = p.v
     
     # The same generator as in v.setAllAncestorAtFileNodesDirty.
+    # Original idea by Виталије Милошевић (Vitalije Milosevic).
+    # Modified by EKR.
 
     def v_and_parents(v):
         if v not in seen:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3380,10 +3380,12 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
     """
     v0 = p.v
     
+    # The same generator as in v.setAllAncestorAtFileNodesDirty.
+
     def v_and_parents(v):
         if v not in seen:
-            yield v
             seen.add(v)
+            yield v
         for parent_v in v.parents:
             yield from v_and_parents(parent_v)
 
@@ -3412,9 +3414,9 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
     language = g.findFirstValidAtLanguageDirective(p.b)
     if language:
         return language
+    #
     # Phase 1: search only @<file> nodes: #2308.
     # Phase 2: search all nodes.
-    
     for phase in (1, 2):
         # Search direct parents.
         for p2 in p.self_and_parents(copy=False):
@@ -3422,24 +3424,11 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
             if language:
                 return language
         # Search all extended parents.
-        if 1: # Use a generator.
-            seen = set([v0.context.hiddenRootNode])
-            for v in v_and_parents(v0):
-                language = find_language(v, phase)
-                if language:
-                    return language
-        else: # Use a list.
-            seen = []
-            parents = v0.parents[:]  # vnodes whose extended parents are to be searched.
-            while parents:
-                parent_v = parents.pop()
-                if parent_v in seen:
-                    continue
-                seen.append(parent_v)
-                language = find_language(parent_v, phase)
-                if language:
-                    return language
-                parents.extend(list(z for z in parent_v.parents if z not in seen))
+        seen = set([v0.context.hiddenRootNode])
+        for v in v_and_parents(v0):
+            language = find_language(v, phase)
+            if language:
+                return language
     return None
 #@+node:ekr.20150325075144.1: *3* g.getLanguageFromPosition
 def getLanguageAtPosition(c: Cmdr, p: Pos):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3387,7 +3387,8 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
             seen.add(v)
             yield v
         for parent_v in v.parents:
-            yield from v_and_parents(parent_v)
+            if parent_v not in seen:
+                yield from v_and_parents(parent_v)
 
     def find_language(v, phase):
         """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3385,9 +3385,10 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
     # Modified by EKR.
 
     def v_and_parents(v):
-        if v not in seen:
-            seen.add(v)
-            yield v
+        if v in seen:
+            return
+        seen.add(v)
+        yield v
         for parent_v in v.parents:
             if parent_v not in seen:
                 yield from v_and_parents(parent_v)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2505,13 +2505,12 @@ class VNode:
         Modified by EKR.
         """
         v = self
-        ### hiddenRootVnode = v.context.hiddenRootNode
         seen = set([v.context.hiddenRootNode])
 
         def v_and_parents(v):
             if v not in seen:
-                yield v
                 seen.add(v)
+                yield v
             for parent_v in v.parents:
                 yield from v_and_parents(parent_v)
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2508,16 +2508,17 @@ class VNode:
         seen = set([v.context.hiddenRootNode])
 
         def v_and_parents(v):
-            if v not in seen:
-                seen.add(v)
-                yield v
+            if v in seen:
+                return
+            seen.add(v)
+            yield v
             for parent_v in v.parents:
                 if parent_v not in seen:
                     yield from v_and_parents(parent_v)
 
         for v2 in v_and_parents(v):
             if v2.isAnyAtFileNode():
-                v2.setDirty()
+                v2.setDirty()  # Faster than testing v2.isDirty()
     #@+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s):
         v = self

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2505,15 +2505,15 @@ class VNode:
         Modified by EKR.
         """
         v = self
-        hiddenRootVnode = v.context.hiddenRootNode
+        ### hiddenRootVnode = v.context.hiddenRootNode
+        seen = set([v.context.hiddenRootNode])
 
         def v_and_parents(v):
-            if v != hiddenRootVnode:
+            if v not in seen:
                 yield v
-                for parent_v in v.parents:
-                    yield from v_and_parents(parent_v)
-
-        # There is no harm in calling v2.setDirty redundantly.
+                seen.add(v)
+            for parent_v in v.parents:
+                yield from v_and_parents(parent_v)
 
         for v2 in v_and_parents(v):
             if v2.isAnyAtFileNode():

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2512,7 +2512,8 @@ class VNode:
                 seen.add(v)
                 yield v
             for parent_v in v.parents:
-                yield from v_and_parents(parent_v)
+                if parent_v not in seen:
+                    yield from v_and_parents(parent_v)
 
         for v2 in v_and_parents(v):
             if v2.isAnyAtFileNode():


### PR DESCRIPTION
I thought the recent code g.getLanguageFromAncestorAtFileNode could be applied to v.setAllAncestorAtFileNodesDirty. However, Vitalije had already done better by using a generator. However, it was also possible to improve  v.setAllAncestorAtFileNodesDirty a bit:

- Use the v_and_parents generator in g.getLanguageFromAncestorAtFileNode.
- Avoid redundancy in v.setAllAncestorAtFileNodesDirty by using a 'seen' set.
  Also: make *sure* that all parents are indeed visited exactly once.