### PR TITLE
Fix two potential ReDoS issues

### DIFF
--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -191,7 +191,7 @@ class Xml_Importer(Importer):
         return new_state.tag_level > prev_state.tag_level
     #@+node:ekr.20161121212858.1: *3* xml_i.is_ws_line
     # Warning: base Importer class defines ws_pattern.
-    xml_ws_pattern = re.compile(r'\s*(<!--.*-->\s*)*$')
+    xml_ws_pattern = re.compile(r'\s*(<!--([^-]|-[^-])*-->\s*)*$')
 
     def is_ws_line(self, s):
         """True if s is nothing but whitespace or single-line comments."""

--- a/leo/plugins/leocursor.py
+++ b/leo/plugins/leocursor.py
@@ -59,7 +59,7 @@ class AM_Colon(AttribManager):
 
     """
 
-    pattern = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)(:)(\s+(\S.*))*$")
+    pattern = re.compile(r"^([A-Za-z][A-Za-z0-9_]*)(:)(\s+(\S+))*$")
 
     def filterBody(self, b):
         return '\n'.join(


### PR DESCRIPTION
These two potential ReDoS issues were found by a [CodeQL query](https://lgtm.com/query/6017926600791434440/), written by my colleague @RasmusWL. We do not believe that these issues have any security impact in leo-editor, so I am posting these suggested fixes as a public pull request.

My fix for `xml_ws_pattern` is based on [this answer on stackoverflow](https://stackoverflow.com/a/1324838), which says that XML comments are not permitted to contain the string `--`.

In `leocursor.py`, I have modified the regex in a way which I believe fixes the potential ReDoS issue without changing its behavior.