### PR TITLE
PR for #2362: remove tnodeList and related code

### DIFF
--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -27,13 +27,10 @@ class BufferCommandsClass(BaseEditCommandsClass):
         """Ctor for the BufferCommandsClass class."""
         # pylint: disable=super-init-not-called
         self.c = c
-        self.fromName = ''
-            # Saved name from getBufferName.
-        self.nameList = []
-            # [n: <headline>]
+        self.fromName = ''  # Saved name from getBufferName.
+        self.nameList = []  # [n: <headline>]
         self.names = {}
-        self.tnodes = {}
-            # Keys are n: <headline>, values are tnodes.
+        self.vnodes = {}  # Keys are n: <headline>, values are vnodes.
     #@+node:ekr.20150514045829.5: *3* buffer.Entry points
     #@+node:ekr.20150514045829.6: *4* appendToBuffer
     @cmd('buffer-append-to')
@@ -205,7 +202,7 @@ class BufferCommandsClass(BaseEditCommandsClass):
     def computeData(self):
         self.nameList = []
         self.names = {}
-        self.tnodes = {}
+        self.vnodes = {}
         for p in self.c.all_unique_positions():
             h = p.h.strip()
             v = p.v
@@ -218,12 +215,12 @@ class BufferCommandsClass(BaseEditCommandsClass):
             else:
                 key = h
             self.nameList.append(key)
-            self.tnodes[key] = v
+            self.vnodes[key] = v
             nameList.append(key)
             self.names[h] = nameList
     #@+node:ekr.20150514045829.16: *4* findBuffer
     def findBuffer(self, name):
-        v = self.tnodes.get(name)
+        v = self.vnodes.get(name)
         for p in self.c.all_unique_positions():
             if p.v == v:
                 return p

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -226,7 +226,7 @@ def pasteAsTemplate(self, event=None):
         # the first node is inserted at the given index
         # and the rest are just appended at parents children
         # to achieve this we first create a generator object
-        rows = viter(vpargnx, xvnodes[0])
+        rows = viter(vpargnx, xvelements[0])
 
         # then we just take first tuple
         pgnx, gnx, h, b = next(rows)
@@ -273,12 +273,12 @@ def pasteAsTemplate(self, event=None):
         c.redraw(newp)
     #@-others
     xroot = ElementTree.fromstring(g.app.gui.getTextFromClipboard())
-    xvnodes = xroot.find('vnodes')
-    xtnodes = xroot.find('tnodes')
+    xvelements = xroot.find('vnodes')  # <v> elements.
+    xtelements = xroot.find('tnodes')  # <t> elements.
 
-    bodies, uas = leoFileCommands.FastRead(c, {}).scanTnodes(xtnodes)
+    bodies, uas = leoFileCommands.FastRead(c, {}).scanTnodes(xtelements)
 
-    root_gnx = xvnodes[0].attrib.get('t')  # the gnx of copied node
+    root_gnx = xvelements[0].attrib.get('t')  # the gnx of copied node
     outside = {x.gnx for x in skip_root(c.hiddenRootNode)}
         # outside will contain gnxes of nodes that are outside the copied tree
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -122,7 +122,6 @@ class AtFile:
         at.root = root
         at.rootSeen = False
         at.targetFileName = fileName  # For at.writeError only.
-        at.tnodeListIndex = 0
         at.v = None
         at.vStack = []  # Stack of at.v values.
         at.thinChildIndexStack = []  # number of siblings at this level.
@@ -363,16 +362,16 @@ class AtFile:
 
         c = self.c
         p = root.copy()
-        scanned_tnodes = set()
+        scanned_nodes = set()
         files = []
         after = p.nodeAfterTree() if force else None
         while p and p != after:
             data = (p.gnx, g.fullPath(c, p))
             # skip clones referring to exactly the same paths.
-            if data in scanned_tnodes:
+            if data in scanned_nodes:
                 p.moveToNodeAfterTree()
                 continue
-            scanned_tnodes.add(data)
+            scanned_nodes.add(data)
             if not p.h.startswith('@'):
                 p.moveToThreadNext()
             elif p.isAtIgnoreNode():
@@ -2024,7 +2023,7 @@ class AtFile:
             return
         s = at.nodeSentinelText(p)
         at.putSentinel("@+node:" + s)
-        # Leo 4.7 b2: we never write tnodeLists.
+        # Leo 4.7: we never write tnodeLists.
     #@+node:ekr.20041005105605.194: *5* at.putSentinel (applies cweb hack) 4.x
     def putSentinel(self, s):
         """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -122,7 +122,6 @@ class AtFile:
         at.root = root
         at.rootSeen = False
         at.targetFileName = fileName  # For at.writeError only.
-        ### at.tnodeList = []  # Needed until old-style @file nodes are no longer supported.
         at.tnodeListIndex = 0
         at.v = None
         at.vStack = []  # Stack of at.v values.
@@ -176,9 +175,6 @@ class AtFile:
         #
         # Clean root.v.
         if not at.errors and at.root:
-            ###
-                # if hasattr(at.root.v, 'tnodeList'):
-                    # delattr(at.root.v, 'tnodeList')  # pragma: no cover
             at.root.v._p_changed = True
         #
         # #1907: Compute the file name and create directories as needed.
@@ -1348,9 +1344,6 @@ class AtFile:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
         except Exception:
-            ###
-                # if hasattr(self.root.v, 'tnodeList'):
-                    # delattr(self.root.v, 'tnodeList')
             at.writeException(fileName, root)
     #@+node:ekr.20090225080846.5: *6* at.writeOneAtEditNode
     def writeOneAtEditNode(self, p):  # pragma: no cover
@@ -1402,9 +1395,6 @@ class AtFile:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
         except Exception:
-            ###
-                # if hasattr(self.root.v, 'tnodeList'):
-                    # delattr(self.root.v, 'tnodeList')
             at.writeException(fileName, root)
     #@+node:ekr.20210501065352.1: *6* at.writeOneAtNosentNode
     def writeOneAtNosentNode(self, root):  # pragma: no cover
@@ -1429,9 +1419,6 @@ class AtFile:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
         except Exception:
-            ###
-                # if hasattr(self.root.v, 'tnodeList'):
-                    # delattr(self.root.v, 'tnodeList')
             at.writeException(fileName, root)
     #@+node:ekr.20080711093251.5: *6* at.writeOneAtShadowNode & helper
     def writeOneAtShadowNode(self, p, testing=False):  # pragma: no cover
@@ -1586,17 +1573,8 @@ class AtFile:
             at.putFile(root, sentinels=sentinels)
             assert root == at.root, 'write'
             contents = '' if at.errors else ''.join(at.outputList)
-            ###
-                # # Major bug: failure to clear this wipes out headlines!
-                # #            Sometimes this causes slight problems...
-                # if hasattr(self.root.v, 'tnodeList'):
-                    # delattr(self.root.v, 'tnodeList')
-                    # root.v._p_changed = True
             return contents
         except Exception:
-            ###
-                # if hasattr(self.root.v, 'tnodeList'):
-                    # delattr(self.root.v, 'tnodeList')
             at.exception("exception preprocessing script")
             root.v._p_changed = True
             return ''
@@ -1622,9 +1600,6 @@ class AtFile:
             # Major bug: failure to clear this wipes out headlines!
             #            Sometimes this causes slight problems...
             if root:
-                ###
-                    # if hasattr(self.root.v, 'tnodeList'):
-                        # delattr(self.root.v, 'tnodeList')
                 root.v._p_changed = True
             return contents
         except Exception:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -122,7 +122,7 @@ class AtFile:
         at.root = root
         at.rootSeen = False
         at.targetFileName = fileName  # For at.writeError only.
-        at.tnodeList = []  # Needed until old-style @file nodes are no longer supported.
+        ### at.tnodeList = []  # Needed until old-style @file nodes are no longer supported.
         at.tnodeListIndex = 0
         at.v = None
         at.vStack = []  # Stack of at.v values.
@@ -176,8 +176,9 @@ class AtFile:
         #
         # Clean root.v.
         if not at.errors and at.root:
-            if hasattr(at.root.v, 'tnodeList'):
-                delattr(at.root.v, 'tnodeList')  # pragma: no cover
+            ###
+                # if hasattr(at.root.v, 'tnodeList'):
+                    # delattr(at.root.v, 'tnodeList')  # pragma: no cover
             at.root.v._p_changed = True
         #
         # #1907: Compute the file name and create directories as needed.
@@ -324,15 +325,6 @@ class AtFile:
         FastAtRead(c, gnx2vnode).read_into_root(contents, fileName, root)
         root.clearDirty()
         return True
-    #@+node:ekr.20100122130101.6174: *6* at.deleteTnodeList
-    def deleteTnodeList(self, p):  # pragma: no cover
-        """Remove p's tnodeList."""
-        v = p.v
-        if hasattr(v, "tnodeList"):
-            # Not an error, but a useful trace.
-                # g.blue("deleting tnodeList for " + repr(v))
-            delattr(v, "tnodeList")
-            v._p_changed = True
     #@+node:ekr.20071105164407: *6* at.deleteUnvisitedNodes
     def deleteUnvisitedNodes(self, root, redraw=True):  # pragma: no cover
         """
@@ -1356,8 +1348,9 @@ class AtFile:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
         except Exception:
-            if hasattr(self.root.v, 'tnodeList'):
-                delattr(self.root.v, 'tnodeList')
+            ###
+                # if hasattr(self.root.v, 'tnodeList'):
+                    # delattr(self.root.v, 'tnodeList')
             at.writeException(fileName, root)
     #@+node:ekr.20090225080846.5: *6* at.writeOneAtEditNode
     def writeOneAtEditNode(self, p):  # pragma: no cover
@@ -1409,8 +1402,9 @@ class AtFile:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
         except Exception:
-            if hasattr(self.root.v, 'tnodeList'):
-                delattr(self.root.v, 'tnodeList')
+            ###
+                # if hasattr(self.root.v, 'tnodeList'):
+                    # delattr(self.root.v, 'tnodeList')
             at.writeException(fileName, root)
     #@+node:ekr.20210501065352.1: *6* at.writeOneAtNosentNode
     def writeOneAtNosentNode(self, root):  # pragma: no cover
@@ -1435,8 +1429,9 @@ class AtFile:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
         except Exception:
-            if hasattr(self.root.v, 'tnodeList'):
-                delattr(self.root.v, 'tnodeList')
+            ###
+                # if hasattr(self.root.v, 'tnodeList'):
+                    # delattr(self.root.v, 'tnodeList')
             at.writeException(fileName, root)
     #@+node:ekr.20080711093251.5: *6* at.writeOneAtShadowNode & helper
     def writeOneAtShadowNode(self, p, testing=False):  # pragma: no cover
@@ -1591,15 +1586,17 @@ class AtFile:
             at.putFile(root, sentinels=sentinels)
             assert root == at.root, 'write'
             contents = '' if at.errors else ''.join(at.outputList)
-            # Major bug: failure to clear this wipes out headlines!
-            #            Sometimes this causes slight problems...
-            if hasattr(self.root.v, 'tnodeList'):
-                delattr(self.root.v, 'tnodeList')
-                root.v._p_changed = True
+            ###
+                # # Major bug: failure to clear this wipes out headlines!
+                # #            Sometimes this causes slight problems...
+                # if hasattr(self.root.v, 'tnodeList'):
+                    # delattr(self.root.v, 'tnodeList')
+                    # root.v._p_changed = True
             return contents
         except Exception:
-            if hasattr(self.root.v, 'tnodeList'):
-                delattr(self.root.v, 'tnodeList')
+            ###
+                # if hasattr(self.root.v, 'tnodeList'):
+                    # delattr(self.root.v, 'tnodeList')
             at.exception("exception preprocessing script")
             root.v._p_changed = True
             return ''
@@ -1625,8 +1622,9 @@ class AtFile:
             # Major bug: failure to clear this wipes out headlines!
             #            Sometimes this causes slight problems...
             if root:
-                if hasattr(self.root.v, 'tnodeList'):
-                    delattr(self.root.v, 'tnodeList')
+                ###
+                    # if hasattr(self.root.v, 'tnodeList'):
+                        # delattr(self.root.v, 'tnodeList')
                 root.v._p_changed = True
             return contents
         except Exception:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1461,10 +1461,6 @@ class Commands:
         for p in c.safe_all_positions(copy=False):
             count += 1
             v = p.v
-            ###
-                # if hasattr(v, "tnodeList"):
-                    # delattr(v, "tnodeList")
-                    # v._p_changed = True
             gnx = v.fileIndex
             if gnx:  # gnx must be a string.
                 aSet: Set["leoNodes.VNode"] = d.get(gnx, set())

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1461,9 +1461,10 @@ class Commands:
         for p in c.safe_all_positions(copy=False):
             count += 1
             v = p.v
-            if hasattr(v, "tnodeList"):
-                delattr(v, "tnodeList")
-                v._p_changed = True
+            ###
+                # if hasattr(v, "tnodeList"):
+                    # delattr(v, "tnodeList")
+                    # v._p_changed = True
             gnx = v.fileIndex
             if gnx:  # gnx must be a string.
                 aSet: Set["leoNodes.VNode"] = d.get(gnx, set())

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -827,9 +827,7 @@ class Commands:
 
     # Compatibility with old code...
 
-    all_tnodes_iter = all_nodes
     all_vnodes_iter = all_nodes
-    all_unique_tnodes_iter = all_unique_nodes
     all_unique_vnodes_iter = all_unique_nodes
     #@+node:ekr.20091001141621.6044: *5* c.all_positions
     def all_positions(self, copy=True):
@@ -924,7 +922,6 @@ class Commands:
 
     # Compatibility with old code...
 
-    all_positions_with_unique_tnodes_iter = all_unique_positions
     all_positions_with_unique_vnodes_iter = all_unique_positions
     #@+node:ekr.20161120125322.1: *5* c.all_unique_roots
     def all_unique_roots(self, copy=True, predicate=None):
@@ -1444,12 +1441,13 @@ class Commands:
     #@+node:ekr.20141024211256.22: *4* c.checkGnxs
     def checkGnxs(self):
         """
-        Check the consistency of all gnx's and remove any tnodeLists.
+        Check the consistency of all gnx's.
         Reallocate gnx's for duplicates or empty gnx's.
         Return the number of structure_errors found.
         """
         c = self
-        d: Dict[str, Set["leoNodes.VNode"]] = {}  # Keys are gnx's; values are sets of vnodes with that gnx.
+        # Keys are gnx's; values are sets of vnodes with that gnx.
+        d: Dict[str, Set["leoNodes.VNode"]] = {}
         ni = g.app.nodeIndices
         t1 = time.time()
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1271,11 +1271,9 @@ class FileCommands:
         expanded, marks = {}, {}
         for gnx in self.descendentExpandedList:
             v = self.gnxDict.get(gnx)
-            # g.trace('expanded', gnx)
             if v:
                 expanded[v] = v
         for gnx in self.descendentMarksList:
-            # g.trace('   marks', gnx)
             v = self.gnxDict.get(gnx)
             if v:
                 marks[v] = v

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -420,11 +420,9 @@ class FileCommands:
         self.currentPosition = None
         # New in 3.12...
         self.copiedTree = None
-        # Keys are gnx strings. Values are vnodes.
-        # 2011/12/10: This dict is never re-inited.
-        self.gnxDict = {}
-        self.vnodesDict = {}
-            # keys are gnx strings; values are ignored
+        # fc.gnxDict is never re-inited.
+        self.gnxDict = {}  # Keys are gnx strings. Values are vnodes.
+        self.vnodesDict = {}  # keys are gnx strings; values are ignored
     #@+node:ekr.20210316042224.1: *3* fc: Commands
     #@+node:ekr.20031218072017.2012: *4* fc.writeAtFileNodes
     @cmd('write-at-file-nodes')

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1271,11 +1271,11 @@ class FileCommands:
         expanded, marks = {}, {}
         for gnx in self.descendentExpandedList:
             v = self.gnxDict.get(gnx)
-            g.trace('expanded', gnx)
+            # g.trace('expanded', gnx)
             if v:
                 expanded[v] = v
         for gnx in self.descendentMarksList:
-            g.trace('   marks', gnx)
+            # g.trace('   marks', gnx)
             v = self.gnxDict.get(gnx)
             if v:
                 marks[v] = v

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -336,10 +336,7 @@ class FastRead:
                     #@-<< Make a new vnode, linked to the parent >>
                     #@+<< handle all other v attributes >>
                     #@+node:ekr.20180605075113.1: *6* << handle all other v attributes >>
-                    # Like fc.handleVnodeSaxAttrutes.
-                    #
-                    # The native attributes of <v> elements are:
-                    # a, t, vtag, marks, expanded, VnodeUnknownAttributes.
+                    # FastRead.nativeVnodeAttributes defines the native attributes of <v> elements.
                     d = e.attrib
                     s = d.get('descendentTnodeUnknownAttributes')
                     if s:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -708,14 +708,8 @@ class FileCommands:
                 if v:
                     c.hiddenRootNode = v
             if v:
-                ###
-                    # fc.resolveTnodeLists()  # Do this before reading external files.
                 c.setFileTimeStamp(fileName)
                 if readAtFileNodesFlag:
-                    # c.redraw()
-                        # Does not work.
-                        # Redraw before reading the @file nodes so the screen isn't blank.
-                        # This is important for big files like LeoPy.leo.
                     recoveryNode = fc.readExternalFiles(fileName)
         finally:
             p = recoveryNode or c.p or c.lastTopLevel()

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -2080,8 +2080,7 @@ class NullTree(LeoTree):
         super().__init__(frame)
         assert self.frame
         self.c = frame.c
-        self.editWidgetsDict = {}
-            # Keys are tnodes, values are StringTextWidgets.
+        self.editWidgetsDict = {}  # Keys are vnodes, values are StringTextWidgets.
         self.font = None
         self.fontName = None
         self.canvas = None

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -510,7 +510,6 @@ class Position:
 
     # Compatibility with old code.
 
-    tnodes_iter = nodes
     vnodes_iter = nodes
     #@+node:ekr.20091001141621.6058: *4* p.parents
     def parents(self, copy=True):
@@ -589,7 +588,6 @@ class Position:
 
     # Compatibility with old code.
 
-    unique_tnodes_iter = unique_nodes
     unique_vnodes_iter = unique_nodes
     #@+node:ekr.20091002083910.6103: *4* p.unique_subtree
     def unique_subtree(self):
@@ -604,7 +602,6 @@ class Position:
 
     # Compatibility with old code...
 
-    subtree_with_unique_tnodes_iter = unique_subtree
     subtree_with_unique_vnodes_iter = unique_subtree
     #@+node:ekr.20040306212636: *3* p.Getters
     #@+node:ekr.20040306210951: *4* p.VNode proxies

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -111,14 +111,14 @@ class NodeIndices:
         else:
             v.fileIndex = ni.getNewIndex(v)
     #@+node:ekr.20031218072017.1997: *3* ni.scanGnx
-    def scanGnx(self, s, i=0):
+    def scanGnx(self, s):
         """Create a gnx from its string representation."""
         if not isinstance(s, str):
             g.error("scanGnx: unexpected index type:", type(s), '', s)
             return None, None, None
         s = s.strip()
         theId, t, n = None, None, None
-        i, theId = g.skip_to_char(s, i, '.')
+        i, theId = g.skip_to_char(s, 0, '.')
         if g.match(s, i, '.'):
             i, t = g.skip_to_char(s, i + 1, '.')
             if g.match(s, i, '.'):

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -354,7 +354,7 @@ class Undoer:
         if topLevel:
             treeInfo = []
         # Add info for p.v.  Duplicate info is harmless.
-        data = (p.v, u.createVnodeUndoInfo(p.v)) ###, u.createTnodeUndoInfo(p.v))
+        data = (p.v, u.createVnodeUndoInfo(p.v))
         treeInfo.append(data)
         # Recursively add info for the subtree.
         child = p.firstChild()

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -303,9 +303,8 @@ class Undoer:
         including all links."""
         u = self
         # This effectively relinks all vnodes.
-        for v, vInfo, tInfo in treeInfo:
+        for v, vInfo in treeInfo:
             u.restoreVnodeUndoInfo(vInfo)
-            u.restoreTnodeUndoInfo(tInfo)
     #@+node:ekr.20050415170737.2: *5* u.restoreVnodeUndoInfo
     def restoreVnodeUndoInfo(self, bunch):
         """Restore all ivars saved in the bunch."""
@@ -341,15 +340,11 @@ class Undoer:
         # "undo" tree and some were not. Moreover, it required complex
         # adjustments to t.vnodeLists.
         #
-        # Instead of creating new nodes, the new code creates all information
-        # needed to properly restore the vnodes and tnodes. It creates a list of
-        # tuples, on tuple for each VNode in the tree. Each tuple has the form,
-        #
-        # (vnodeInfo, tnodeInfo)
-        #
-        # where vnodeInfo and tnodeInfo are dicts contain all info needed to
-        # recreate the nodes. The v.createUndoInfoDict and t.createUndoInfoDict
-        # methods correspond to the old v.copy and t.copy methods.
+        # Instead of creating new nodes, the new code creates all information needed
+        # to properly restore the vnodes. It creates a list of tuples, on tuple for
+        # each VNode in the tree. Each tuple has the form (v, vnodeInfo), where
+        # vnodeInfo is a dict containing all info needed to recreate the nodes. The
+        # v.createUndoInfoDict method corresponds to the old v.copy method.
         #
         # Aside: Prior to 4.2 Leo used a scheme that was equivalent to the
         # createUndoInfoDict info, but quite a bit uglier.
@@ -358,8 +353,8 @@ class Undoer:
         topLevel = (treeInfo is None)
         if topLevel:
             treeInfo = []
-        # Add info for p.v.  Duplicate tnode info is harmless.
-        data = (p.v, u.createVnodeUndoInfo(p.v), u.createTnodeUndoInfo(p.v))
+        # Add info for p.v.  Duplicate info is harmless.
+        data = (p.v, u.createVnodeUndoInfo(p.v)) ###, u.createTnodeUndoInfo(p.v))
         treeInfo.append(data)
         # Recursively add info for the subtree.
         child = p.firstChild()
@@ -376,13 +371,6 @@ class Undoer:
             parents=v.parents[:],
             children=v.children[:],
         )
-        if hasattr(v, 'unknownAttributes'):
-            bunch.unknownAttributes = v.unknownAttributes
-        return bunch
-    #@+node:ekr.20050415170812.1: *5* u.createTnodeUndoInfo
-    def createTnodeUndoInfo(self, v):
-        """Create a bunch containing all info needed to recreate a VNode."""
-        bunch = g.Bunch(v=v, headString=v.h, bodyString=v.b, statusBits=v.statusBits,)
         if hasattr(v, 'unknownAttributes'):
             bunch.unknownAttributes = v.unknownAttributes
         return bunch

--- a/leo/plugins/importers/leo_json.py
+++ b/leo/plugins/importers/leo_json.py
@@ -67,7 +67,7 @@ class JSON_Scanner:
                 # else:
                     # c.clearChanged()
         else:
-            parent.setDirty()  # setDescendentsDirty=False)
+            parent.setDirty()
             c.setChanged()
         return ok
     #@+node:ekr.20160504092347.2: *4* json.escapeFalseSectionReferences

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -44,8 +44,7 @@ Leo writes body text to the OPML file only if this is True.
 If True, Leo writes the native attributes of Leo's <v> elements as attributes of
 the opml <outline> elements.
 
-The native attributes of <v> elements are a, t, vtag (new), tnodeList,
-marks, expanded and descendentTnodeUnknownAttributes.
+FastRead.nativeVnodeAttributes defines the native attributes of <v> elements.
 
 - @bool opml_write_leo_globals_attributes = True
 

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -316,19 +316,6 @@ class OpmlController:
             if p.v == v:
                 c.selectPosition(p)
                 break
-    #@+node:ekr.20060918132045: *4* oc.resolveTnodeLists
-    def resolveTnodeLists(self, c):
-        for p in c.allNodes_iter():
-            if hasattr(p.v, 'tempTnodeList'):
-                result = []
-                for gnx in p.v.tempTnodeList:
-                    v = self.generated_gnxs.get(gnx)
-                    if v:
-                        result.append(v)
-                    else:
-                        g.trace('No tnode for %s' % gnx)
-                p.v.tnodeList = result
-                delattr(p.v, 'tempTnodeList')
     #@+node:ekr.20060919201810: *3* oc.readOpmlCommand
     def readOpmlCommand(self, event=None):
         """Open a Leo window containing the contents of an .opml file."""

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -261,7 +261,7 @@ class OpmlController:
         """
         Write the c.p as OPML, using the owner's put method."""
         PutToOPML(owner)
-    #@+node:ekr.20060904103721: *3* oc.readFile & helpers
+    #@+node:ekr.20060904103721: *3* oc.readFile & helper
     def readFile(self, fileName):
         """Read the opml file."""
         dumpTree = False
@@ -286,26 +286,9 @@ class OpmlController:
             c.dumpOutline()
             g.trace('%s errors!' % errors)
             return None
-        # if self.opml_read_derived_files:
-            # at = c.atFileCommands
-            # c.fileCommands.tnodesDict = self.createTnodesDict()
-            # self.resolveTnodeLists(c)
-            # if self.opml_read_derived_files:
-                # c.atFileCommands.readAll(c.rootPosition())
         c.selectPosition(p)
         c.redraw()
         return c  # for testing.
-    #@+node:ekr.20060921153603: *4* oc.createTnodesDict
-    def createTnodesDict(self):
-        """
-        Create c.tnodesDict by from self.generated_gnxs
-        by converting VNode entries to tnodes.
-        """
-        d = {}
-        for key in list(self.generated_gnxs.keys()):
-            v = self.generated_gnxs.get(key)
-            d[key] = v
-        return d
     #@+node:ekr.20060917214140: *4* oc.setCurrentPosition
     def setCurrentPosition(self, c):
         v = self.currentVnode
@@ -537,24 +520,6 @@ class PutToOPML:
         if c.isCurrentPosition(p):
             attr.append('V')
         return ''.join(attr)
-    #@+node:ekr.20060919172012.9: *4* tnodeListAttributes (Not used)
-    # Based on fileCommands.putTnodeList.
-
-    def tnodeListAttributes(self, p):
-        """Put the tnodeList attribute of p.v"""
-        # Remember: entries in the tnodeList correspond to @+node sentinels, _not_ to tnodes!
-        if not hasattr(p.v, 'tnodeList') or not p.v.tnodeList:
-            return None
-        # Assign fileIndices.
-        for v in p.v.tnodeList:
-            try:  # Will fail for None or any pre 4.1 file index.
-                theId, time, n = p.v.fileIndex
-            except Exception:
-                g.trace("assigning gnx for ", p.v)
-                gnx = g.app.nodeIndices.getNewIndex(p.v)
-                p.v.setFileIndex(gnx)  # Don't convert to string until the actual write.
-        s = ','.join([g.app.nodeIndices.tupleToString(v.fileIndex) for v in p.v.tnodeList])
-        return s
     #@+node:tbrown.20061004094757: *4* uAAttributes
     def uAAttributes(self, p):
         """write unknownAttributes with various levels of expansion"""

--- a/leo/plugins/leo_interface.py
+++ b/leo/plugins/leo_interface.py
@@ -186,7 +186,7 @@ class leo_node(LeoNode, node_with_parent):
     """
     Leo specific class representing a node.
 
-    These nodes correspond to tnodes in LEO.
+    These nodes correspond to vnodes in Leo.
     They have a headline and a body.
 
     They also represent the (only) vnode in an outline without clones.
@@ -205,18 +205,18 @@ class leo_node(LeoNode, node_with_parent):
     #@+node:ekr.20101110092416.5753: *3* bodyString
     def bodyString(self, body):
         return self.body
-    #@+node:ekr.20101110092416.5755: *3* gen_tnodes
-    def gen_tnodes(self, file):
+    #@+node:ekr.20101110092416.5755: *3* gen_t_elements
+    def gen_t_elements(self, file):
         self.mark_with_attributes(file, "t", (
             ("tx", "T" + repr(self.nr)),
-            ), self.gen_tnodes1, newline=False)
+            ), self.gen_t_elements1, newline=False)
         for child in self.children:
-            child.gen_tnodes(file)
-    #@+node:ekr.20101110092416.5757: *3* gen_tnodes1
-    def gen_tnodes1(self, file):
+            child.gen_t_elements(file)
+    #@+node:ekr.20101110092416.5757: *3* gen_t_elements1
+    def gen_t_elements1(self, file):
         self.write_body_escaped(file)
-    #@+node:ekr.20101110092416.5759: *3* gen_vnodes
-    def gen_vnodes(self, file):
+    #@+node:ekr.20101110092416.5759: *3* gen_v_elements
+    def gen_v_elements(self, file):
         attributes = [("t", "T" + repr(self.nr))]
         if debug:
             # For debugging, make sure that we are not getting
@@ -224,7 +224,7 @@ class leo_node(LeoNode, node_with_parent):
             # Also number all nodes for easier error hunting.
             vnode_stack.append(self)
             if self in allvnodes:
-                print("Fix this; This is an endless recursive call in leo_interface.leo_node.gen_vnodes")
+                print("Fix this; This is an endless recursive call in leo_interface.leo_node.gen_v_elements")
                 x = vnode_stack[:]
                 x.reverse()
                 for i in x:
@@ -235,15 +235,15 @@ class leo_node(LeoNode, node_with_parent):
             attributes.append(('model_node_number', repr(vnode_count)))
             vnode_count += 1
             allvnodes[self] = None
-        self.mark_with_attributes(file, "v", attributes, self.gen_vnodes1)
+        self.mark_with_attributes(file, "v", attributes, self.gen_v_elements1)
         if debug:
             del allvnodes[self]
             vnode_stack.pop()
-    #@+node:ekr.20101110092416.5761: *3* gen_vnodes1
-    def gen_vnodes1(self, file):
+    #@+node:ekr.20101110092416.5761: *3* gen_v_elements1
+    def gen_v_elements1(self, file):
         self.mark(file, "vh", self.write_headline_escaped, newline=False)
         for child in self.children:
-            child.gen_vnodes(file)
+            child.gen_v_elements(file)
     #@+node:ekr.20101110092416.5763: *3* headString
     def headString(self):
         return self.headline

--- a/leo/plugins/xsltWithNodes.py
+++ b/leo/plugins/xsltWithNodes.py
@@ -141,7 +141,7 @@ def processDocumentNode(c):
         xmlsource = InputSource.DefaultFactory.fromString(xIO, uri=xhead)
         result = proc.run(xmlsource)
         nhline = "xsl:transform of " + str(xmlnode.headString)
-        p2 = pos.insertAfter()  # tnode )
+        p2 = pos.insertAfter()
         p2.setBodyString(result)
         p2.setHeadString(nhline)
         c.redraw()
@@ -154,15 +154,11 @@ def addXSLTNode(c):
     """creates a node and inserts some xslt boilerplate"""
     pos = c.p
 
-    #body = '''<?xml version="1.0"?>'''
-    # body = '''<?xml version="1.0"?>
-    #<xsl:transform xmlns:xsl="http:///www.w3.org/1999/XSL/Transform" version="1.0">'''
-
     body = '''<?xml version="1.0"?>
 <xsl:transform xmlns:xsl="http:///www.w3.org/1999/XSL/Transform" version="1.0">
 </xsl:transform>'''
 
-    p2 = pos.insertAfter()  # tnode)
+    p2 = pos.insertAfter()
     p2.setBodyString(body)
     p2.setHeadString("xslt stylesheet")
     c.redraw()

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -1102,7 +1102,7 @@ class TestColorizer(LeoUnitTest):
 
         text = textwrap.dedent('''\
             """This creates a free-floating copy of v's tree for undo.
-            The copied trees must use different tnodes than the original."""
+            The copied trees must use different vnodes than the original."""
 
             def copyTree(self,root):
                 c = self
@@ -1111,7 +1111,7 @@ class TestColorizer(LeoUnitTest):
                 # Copy the headline and icon values v.copyNode(root,v)
                 # Copy the rest of tree.
                 v.copyTree(root,v)
-                # Replace all tnodes in v by copies.
+                # Replace all vnodes in v by copies.
                 assert(v.nodeAfterTree() == None)
                 while v:
                     v = leoNodes.VNode(c)


### PR DESCRIPTION
See #2362. Work is in the ekr-bug-2362 branch.

tnodes were removed a long time ago, so it's important to use t_element terminology when reading (and especially writing) outlines.

**Core**

- [x] Remove at.tnodeList. v.tnodeList and related logic.
- [x] Remove AtFile.deleteTnodeList.
- [x] Remove 'tnodeList' from FastRead.nativeVnodeAttributes.
- [x] Remove fc.canonicalTnodeIndex and related logic.
    This strange code was the original motivation for this issue.
- [x] Remove fc.resolveTnodeLists.
- [x] Remove the "i" kwarg from ni.scanGnx.
- [x] Replace putTnodes/putVnodes by put_t_elements/put_v_elements.
- [x] Replace/remove obsolete references to tnodes.
- [x] Remove ancient aliases that reference tnodes.
- [x] Remove tInfo dict from undo data.
- [x] Remove u.createTnodeUndoInfo.

**Plugins**

- [x] leoOPML.py:  replace tnode terminology with t element terminology.
- [x] leo_interface.py: replace tnode terminology with t element terminology.