### PR TITLE
PR for #2365: mypy coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 profile.txt
 __pycache__/
 .mypy_cache/
+.dmypy.json
 .cache/
 *.py[cod]
 *.history

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -5,15 +5,17 @@
 [mypy]
 python_version = 3.9
 ignore_missing_imports  = True
-incremental = True
+incremental = False
 # cache_dir=nul
 cache_dir = mypy_stubs
 show_error_codes = True
 check_untyped_defs = True
 strict_optional = False
-### --disable-error-code=attr-defined
 disable_error_code=attr-defined
 # follow_imports = skip
+
+# exclude =
+# ^leo/core/leoQt*\.py$
 
 # Suppression for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -12,7 +12,6 @@ show_error_codes = True
 check_untyped_defs = True
 strict_optional = False
 disable_error_code=attr-defined
-# follow_imports = skip
 
 exclude =
     ^leo/dist/$
@@ -29,34 +28,14 @@ exclude =
 
 # Suppression for particular files...
 
-[mypy-leo.core.leoGlobals]
-
-[mypy-leo.core.leoNodes]
-# Mypy doesn't know about attributes defined outside the ctor.
-# However, it appears that this must be done on the command line.
-# disable_error_code = attr-defined
+[mypy-leo.core.leoGlobals,leo.core.leoNodes]
+disallow_untyped_defs = True
 
 # mypy generates lots of useless errors for leoQt.py
-[mypy-leo.core.leoQt]
+[mypy-leo.core.leoQt,leo.core.leoQt5,leo.core.leoQt6]
 follow_imports = skip
 ignore_missing_imports  = True
 
-[mypy-leo.core.leoQt4]
+[mypy-leo.core.leoRope,leo.external.npyscreen]
 follow_imports = skip
 ignore_missing_imports  = True
-
-[mypy-leo.core.leoQt5]
-follow_imports = skip
-ignore_missing_imports  = True
-
-[mypy-leo.core.leoQt6]
-follow_imports = skip
-ignore_missing_imports  = True
-
-[mypy-leo.core.leoRope]
-follow_imports = skip
-ignore_missing_imports  = True
-
-# Don't bother checking npyscreen.
-[mypy-leo.external.npyscreen]
-follow_imports = skip

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -17,12 +17,12 @@ exclude =
     ^leo/dist/$
     ^leo/doc/$
     ^leo/core/leoQt6.py$
-    ^leo/core/format-code.py$
+    ^leo/core/format-code\.py$
     ^leo/extensions/$
     ^leo/external/$
     ^leo/modes/$
     ^leo/plugins/(?!qt_).*\.py$
-    ^leo/plugins/qt_main.py$
+    ^leo/plugins/qt_main\.py$
     ^leo/scripts/$
     ^leo/test/$
     ^leo/unittests/$

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -14,8 +14,18 @@ strict_optional = False
 disable_error_code=attr-defined
 # follow_imports = skip
 
-# exclude =
-# ^leo/core/leoQt*\.py$
+exclude =
+    ^leo/dist/$
+    ^leo/doc/$
+    ^leo/core/leoQt6.py$
+    ^leo/core/format-code.py$
+    ^leo/external/$
+    ^leo/modes/$
+    ^leo/plugins/$
+    ^leo/extensions/$
+    ^leo/scripts/$
+    ^leo/test/$
+    ^leo/unittests/$
 
 # Suppression for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -5,7 +5,7 @@
 [mypy]
 python_version = 3.9
 ignore_missing_imports  = True
-incremental = False
+incremental = True
 # cache_dir=nul
 cache_dir = mypy_stubs
 show_error_codes = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -31,6 +31,7 @@ exclude =
 
 [mypy-leo.core.leoGlobals,leo.core.leoNodes]
 disallow_untyped_defs = True
+disallow_incomplete_defs = False
 
 # mypy generates lots of useless errors for leoQt.py
 [mypy-leo.core.leoQt,leo.core.leoQt5,leo.core.leoQt6]

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -18,15 +18,16 @@ exclude =
     ^leo/doc/$
     ^leo/core/leoQt6.py$
     ^leo/core/format-code.py$
+    ^leo/extensions/$
     ^leo/external/$
     ^leo/modes/$
-    ^leo/plugins/$
-    ^leo/extensions/$
+    ^leo/plugins/(?!qt_).*\.py$
+    ^leo/plugins/qt_main.py$
     ^leo/scripts/$
     ^leo/test/$
     ^leo/unittests/$
 
-# Suppression for particular files...
+# Settings for particular files...
 
 [mypy-leo.core.leoGlobals,leo.core.leoNodes]
 disallow_untyped_defs = True

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -215,6 +215,7 @@ def mypy_command(event):
     if c.isChanged():
         c.save()
     if mypy_api:
+        g.cls()
         MypyCommand(c).run(c.p)
     else:
         g.es_print('can not import mypy')
@@ -257,7 +258,7 @@ class MypyCommand:
     """A class to run mypy on all Python @<file> nodes in c.p's tree."""
 
     def __init__(self, c):
-        """ctor for PyflakesCommand class."""
+        """ctor for MypyCommand class."""
         self.c = c
         self.link_limit = None  # Set in check_file.
         self.unknown_path_names = []
@@ -284,15 +285,22 @@ class MypyCommand:
         c.frame.log.clearLog()
         link_pattern = re.compile(r'^(.+):([0-9]+): (error|note): (.*)\s*$')
         # Change working directory.
-        directory = os.path.dirname(fn)
+        if 1: ###
+            directory = os.path.abspath(os.path.join(g.app.loadDir, '..', '..'))
+            config_file = os.path.abspath(os.path.join(directory, '.mypy.ini'))
+            args = [f"--config-file={config_file}"] + self.args
+        else:
+            directory = os.path.dirname(fn)
+        g.trace('directory', directory)
         os.chdir(directory)
         # Check the config file.
-        if self.config_file:
-            config_file = g.os_path_finalize_join(directory, self.config_file)
-            if not os.path.exists(config_file):
-                print(f"config file not found: {config_file!r}")
-                return
-            args = [f"--config-file={config_file}"] + self.args
+        ###
+            # if self.config_file:
+                # config_file = g.os_path_finalize_join(directory, self.config_file)
+                # if not os.path.exists(config_file):
+                    # print(f"config file not found: {config_file}")
+                    # return
+            # args = [f"--config-file={config_file}"] + self.args
         args_s = ' '.join(args + [g.shortFileName(fn)])
         args = self.args + [fn]
         # Run mypy.

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -290,7 +290,7 @@ class MypyCommand:
             directory = self.directory
         else:
             directory = os.path.abspath(os.path.join(g.app.loadDir, '..', '..'))
-        print('  mypy directory:', directory)
+        print(' mypy cwd:', directory)
         os.chdir(directory)
         # Set the args. Set the config file only if explicitly given.
         if self.config_file:
@@ -301,12 +301,13 @@ class MypyCommand:
                 return
         else:
             args = self.args
-        final_args = args + [fn]
-        g.es_print(f"  mypy arguments: {' '.join(final_args)}")
+        if args:
+            print('mypy args:', args)
         # Run mypy.
+        final_args = args + [fn]
         result = mypy.api.run(final_args)
+        g.es('mypy: done')
         # Print result, making clickable links.
-        print('mypy exit status:', result[2])
         lines = g.splitLines(result[0] or [])  # type:ignore
         s_head = directory.lower() + os.path.sep
         for i, s in enumerate(lines):

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -215,7 +215,6 @@ def mypy_command(event):
     if c.isChanged():
         c.save()
     if mypy_api:
-        g.cls()
         MypyCommand(c).run(c.p)
     else:
         g.es_print('can not import mypy')
@@ -276,6 +275,7 @@ class MypyCommand:
         for root in roots:
             fn = os.path.normpath(g.fullPath(c, root))
             self.check_file(fn)
+        print('mypy done')
 
     #@+node:ekr.20210727212625.1: *3* mypy.check_file
     def check_file(self, fn):

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -5,7 +5,7 @@
 """Leo's file-conversion commands."""
 
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 from leo.core import leoGlobals as g
 from leo.core import leoBeautify
 from leo.commands.baseCommands import BaseEditCommandsClass
@@ -1228,7 +1228,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # Keys are argument names. Values are typescript types.
         # Typescript can infer types of initialized kwargs.
-        types_d = {}
+        types_d: Dict[str, str] = {}
 
         #@+others
         #@+node:ekr.20211020162251.1: *5* py2ts.ctor
@@ -1277,7 +1277,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             for child in p.children():
                 self.convert_node(child, target)
         #@+node:ekr.20211013102209.1: *5* py2ts.convert_body, handlers &helpers
-        patterns = []
+        patterns: Optional[Tuple[Any, Any]] = None
 
         def convert_body(self, p, target):
             """

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -16,7 +16,7 @@ def cmd(name):
 
 #@+<< class To_Python >>
 #@+node:ekr.20150514063305.123: ** << class To_Python >>
-class To_Python:
+class To_Python:  # pragma: no cover
     """The base class for x-to-python commands."""
     #@+others
     #@+node:ekr.20150514063305.125: *3* To_Python.ctor
@@ -444,7 +444,7 @@ class To_Python:
 
 #@+others
 #@+node:ekr.20210830070921.1: ** function: convert_at_test_nodes
-def convert_at_test_nodes(c, converter, root, copy_tree=False):
+def convert_at_test_nodes(c, converter, root, copy_tree=False):  # pragma: no cover
     """
     Use converter.convert() to convert all the @test nodes in the
     root's tree to children a new last top-level node.
@@ -473,10 +473,11 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         """Ctor for EditCommandsClass class."""
         # pylint: disable=super-init-not-called
         self.c = c
+
     #@+others
     #@+node:ekr.20220105151235.1: *3* ccc.add-mypy-annotations
     @cmd('add-mypy-annotations')
-    def addMypyAnnotations(self, event):
+    def addMypyAnnotations(self, event):  # pragma: no cover
         """
         The add-mypy-annotations command adds mypy annotations to function and
         method definitions based on naming conventions.
@@ -512,7 +513,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         #@+others
         #@+node:ekr.20220105154019.1: *5* ama.init_types_d
-        def init_types_d(self):
+        def init_types_d(self):  # pragma: no cover
             """Init the annotations dict."""
             c, d, tag = self.c, self.types_d, self.tag
             data = c.config.getData(tag)
@@ -529,7 +530,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 except ValueError:
                     print(f"{tag}: ignoring invalid key/value pair: {s!r}")
         #@+node:ekr.20220105154158.1: *5* ama.add_annotations
-        def add_annotations(self):
+        def add_annotations(self):  # pragma: no cover
 
             c, p, tag = self.c, self.c.p, self.tag
             # Checks.
@@ -553,7 +554,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             except Exception:
                 g.es_exception()
         #@+node:ekr.20220105155837.4: *5* ama.convert_node
-        def convert_node(self, p):
+        def convert_node(self, p):  # pragma: no cover
             # Convert p.b into child.b
             self.convert_body(p)
             # Recursively create all descendants.
@@ -564,12 +565,12 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             """Convert p.b in place."""
             c = self.c
             if not p.b.strip():
-                return
+                return  # pragma: no cover
             s = self.def_pat.sub(self.do_def, p.b)
             if p.b != s:
                 self.changed_lines += 1
                 if not g.unitTesting:
-                    print(f"changed {p.h}")
+                    print(f"changed {p.h}")  # pragma: no cover
                 p.setDirty()
                 c.setChanged()
                 p.b = s
@@ -610,7 +611,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                         result.append(f"{last.rstrip()}  {comment.strip()}\n")
                         continue
                 m = self.arg_pat.match(rest)
-                if not m:
+                if not m:  # pragma: no cover
                     g.trace('==== bad args', i, repr(rest))
                     return args
                 name1, tail = m.group(1), m.group(2)
@@ -690,11 +691,11 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 return 'Any'
             if self.string_pat.match(s):
                 return 'str'
-            return 'Any'
+            return 'Any'  # pragma: no cover
         #@-others
     #@+node:ekr.20160316091843.1: *3* ccc.c-to-python
     @cmd('c-to-python')
-    def cToPy(self, event):
+    def cToPy(self, event):  # pragma: no cover
         """
         The c-to-python command converts c or c++ text to python text.
         The conversion is not perfect, but it eliminates a lot of tedious
@@ -703,7 +704,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         self.C_To_Python(self.c).go()
         self.c.bodyWantsFocus()
     #@+node:ekr.20150514063305.160: *4* class C_To_Python (To_Python)
-    class C_To_Python(To_Python):
+    class C_To_Python(To_Python):  # pragma: no cover
         #@+others
         #@+node:ekr.20150514063305.161: *5* ctor & helpers (C_To_Python)
         def __init__(self, c):
@@ -1154,14 +1155,14 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         #@-others
     #@+node:ekr.20160111190632.1: *3* ccc.makeStubFiles
     @cmd('make-stub-files')
-    def make_stub_files(self, event):
+    def make_stub_files(self, event):  # pragma: no cover
         """
         Make stub files for all nearby @<file> nodes.
         Take configuration settings from @x stub-y nodes.
         """
         #@+others
         #@+node:ekr.20160213070235.1: *4* class MakeStubFileAdapter
-        class MakeStubFileAdapter:
+        class MakeStubFileAdapter:  # pragma: no cover
             """
             An class that adapts leo/external/make_stub_files.py to Leo.
 
@@ -1311,14 +1312,14 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         MakeStubFileAdapter(self.c).run(self.c.p)
     #@+node:ekr.20160316091923.1: *3* ccc.python-to-coffeescript
     @cmd('python-to-coffeescript')
-    def python2coffeescript(self, event):
+    def python2coffeescript(self, event):  # pragma: no cover
         """
         Converts python text to coffeescript text. The conversion is not
         perfect, but it eliminates a lot of tedious text manipulation.
         """
         #@+others
         #@+node:ekr.20160316092837.1: *4* class Python_To_Coffeescript_Adapter
-        class Python_To_Coffeescript_Adapter:
+        class Python_To_Coffeescript_Adapter:  # pragma: no cover
             """An interface class between Leo and leo/external/py2cs.py."""
             #@+others
             #@+node:ekr.20160316112717.1: *5* py2cs.ctor
@@ -1416,7 +1417,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         c.bodyWantsFocus()
     #@+node:ekr.20211013080132.1: *3* ccc.python-to-typescript
     @cmd('python-to-typescript')
-    def pythonToTypescriptCommand(self, event):
+    def pythonToTypescriptCommand(self, event):  # pragma: no cover
         """
         The python-to-typescript command converts python to typescript text.
         The conversion is not perfect, but it eliminates a lot of tedious text
@@ -1439,7 +1440,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         self.c.bodyWantsFocus()
     #@+node:ekr.20211013080132.2: *4* class PythonToTypescript
     #@@nobeautify
-    class PythonToTypescript:
+    class PythonToTypescript:  # pragma: no cover
 
         # The handlers are clear as they are.
         # pylint: disable=no-else-return
@@ -2156,7 +2157,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         #@-others
     #@+node:ekr.20160316091843.2: *3* ccc.typescript-to-py
     @cmd('typescript-to-py')
-    def tsToPy(self, event):
+    def tsToPy(self, event):  # pragma: no cover
         """
         The typescript-to-python command converts typescript text to python
         text. The conversion is not perfect, but it eliminates a lot of tedious
@@ -2164,7 +2165,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         """
         #@+others
         #@+node:ekr.20150514063305.176: *4* class TS_To_Python (To_Python)
-        class TS_To_Python(To_Python):
+        class TS_To_Python(To_Python):  # pragma: no cover
             #@+others
             #@+node:ekr.20150514063305.177: *5* ctor (TS_To_Python)
             def __init__(self, c):
@@ -2583,7 +2584,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         c.bodyWantsFocus()
     #@+node:ekr.20160321042444.1: *3* ccc.import-jupyter-notebook
     @cmd('import-jupyter-notebook')
-    def importJupyterNotebook(self, event):
+    def importJupyterNotebook(self, event):  # pragma: no cover
         """Prompt for a Jupyter (.ipynb) file and convert it to a Leo outline."""
         try:
             import nbformat
@@ -2605,7 +2606,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         c.bodyWantsFocus()
     #@+node:ekr.20160321072007.1: *3* ccc.export-jupyter-notebook
     @cmd('export-jupyter-notebook')
-    def exportJupyterNotebook(self, event):
+    def exportJupyterNotebook(self, event):  # pragma: no cover
         """Convert the present outline to a .ipynb file."""
         from leo.plugins.writers.ipynb import Export_IPYNB
         c = self.c

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -565,7 +565,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             s = self.def_pat.sub(self.do_def, p.b)
             if p.b != s:
                 self.changed_lines += 1
-                print(f"changed {p.h}")
+                if not g.unitTesting:
+                    print(f"changed {p.h}")
                 p.setDirty()
                 c.setChanged()
                 p.b = s

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -560,6 +560,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         def convert_body(self, p):
             """Convert p.b in place."""
             c = self.c
+            if not p.b.strip():
+                return
             s = self.def_pat.sub(self.do_def, p.b)
             if p.b != s:
                 self.changed_lines += 1
@@ -590,7 +592,6 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             i, result = 0, []
             while i < len(args):
                 rest = args[i:]
-                ### g.trace(i, repr(rest))
                 if not rest.strip():
                     break
                 m = self.arg_pat.match(rest)
@@ -598,31 +599,28 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     g.trace('==== bad args', i, repr(rest))
                     return args
                 name1, tail = m.group(1), m.group(2)
-                n = len(name1)
                 name = name1.strip()
+                i += len(name1)
                 if name == 'self':
                     # Don't annotate self.
                     result.append(f"{lws}{name}")
-                    i += n
                 elif tail == ':':
-                    arg, i = self.find_arg(args, i + n)
+                    arg, i = self.find_arg(args, i)
                     result.append(f"{lws}{name}: {arg}")
                 elif tail == '=':
-                    arg, i = self.find_arg(args, i + n)
+                    arg, i = self.find_arg(args, i)
                     kind = self.kind(arg)
                     result.append(f"{lws}{name}: {kind}={arg}")
                 elif tail == ',':
                     kind = self.types_d.get(name.strip(), 'Any')
                     result.append(f"{lws}{name}: {kind}")
-                    i += n
                 else:
                     kind = self.types_d.get(name.strip(), 'Any')
                     result.append(f"{lws}{name}: {kind}")
-                    i += n
                 while i < len(args) and args[i] in ' \n,':
                     i += 1
             if multiline:
-                return '\n' + ',\n'.join(result) + '\n'
+                return '\n' + ',\n'.join(result) + ',\n'
             return ', '.join(result)
         #@+node:ekr.20220105190332.1: *5* ama.find_arg
         def find_arg(self, s, i):

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1277,7 +1277,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             for child in p.children():
                 self.convert_node(child, target)
         #@+node:ekr.20211013102209.1: *5* py2ts.convert_body, handlers &helpers
-        patterns: Optional[Tuple[Any, Any]] = None
+        patterns: Optional[Tuple] = None
 
         def convert_body(self, p, target):
             """

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -570,7 +570,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 c.setChanged()
                 p.b = s
         #@+node:ekr.20220105174453.1: *5* ama.do_def
-        def_pat = re.compile(r'^([ \t]*)def[ \t]+([\w_]+)\s*\((.*)\)(.*?):(.*)\n', re.MULTILINE + re.DOTALL)
+        def_pat = re.compile(r'^([ \t]*)def[ \t]+([\w_]+)\s*\((.*?)\)(.*?):(.*?)\n', re.MULTILINE + re.DOTALL)
 
         def do_def(self, m):
             lws, name, args, return_val, tail = m.group(1), m.group(2), m.group(3), m.group(4), m.group(5)

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -606,11 +606,11 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     result.append(f"{lws}{name}{comma}")
                 elif tail == ':':
                     arg, i = self.find_arg(args, i)
-                    result.append(f"{lws}{name}: {arg}")
+                    result.append(f"{lws}{name}: {arg}{comma}")
                 elif tail == '=':
                     arg, i = self.find_arg(args, i)
                     kind = self.kind(arg)
-                    result.append(f"{lws}{name}: {kind}={arg}")
+                    result.append(f"{lws}{name}: {kind}={arg}{comma}")
                 elif tail == ',':
                     kind = self.types_d.get(name.strip(), 'Any')
                     result.append(f"{lws}{name}: {kind}{comma}")
@@ -651,11 +651,14 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 elif ch in ']})"\'':
                     level -= 1
                 elif ch == ',' and level == 0:
-                    # Add the comma.
+                    # Skip the comma, but don't include it in the result.
                     break
             assert level == 0, (level, i == len(s), s)
-            g.trace(s[i1 : i].strip())
-            return s[i1 : i].strip(), i
+            result = s[i1 : i].strip()
+            if result.endswith(','):
+                result = result[:-1].strip()
+            g.trace(repr(result))
+            return result, i
         #@+node:ekr.20220105222028.1: *5* ama.kind
         bool_pat = re.compile(r'(True|False)')
         float_pat = re.compile(r'[0-9]*\.[0-9]*')

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -585,7 +585,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 tail = ''
             lines[i] = f"{lws}def {name}({args}){return_val}:{tail}\n"
         #@+node:ekr.20220105174453.2: *5* ama.do_args
-        arg_pat = re.compile(r'\s*([\w_]+\s*)([:,=])?')
+        arg_pat = re.compile(r'(\s*[\w_]+\s*)([:,=])?')
 
         def do_args(self, args):
             """Add type annotations."""
@@ -597,7 +597,11 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     return args
                 name, tail = m.group(1), m.group(2)
                 name_s = name.strip()
-                if tail == ':':
+                if name_s == 'self':
+                    # Don't annotate self.
+                    i += len(m.group(0))
+                    result.append(m.group(0))
+                elif tail == ':':
                     i += len(m.group(1))
                     j = self.find_arg(args, i)
                     assert j > i, (i, j)
@@ -632,7 +636,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             
             Scan over type annotations or initializers.
             """
-            assert s[i] in ':=', (i, s)
+            assert s[i] in ':=', (i, s[i], s)
             i += 1
             level = 0  # Assume balanced parens or brackets.
             while i < len(s):

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -580,7 +580,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             lws, name, args, return_val, tail = m.group(1), m.group(2), m.group(3), m.group(4), m.group(5)
             args = self.do_args(args)
             if not return_val.strip():
-                return_val = ' -> None'
+                return_val = ' -> Any'
             if not tail.strip():
                 tail = ''
             lines[i] = f"{lws}def {name}({args}){return_val}:{tail}\n"

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -591,11 +591,13 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             multiline = '\n' in args.strip()
             comma = ',\n' if multiline else ', '
             lws = ' '*4 if multiline else ''
-            i, result = 0, []
+            result: List[str] = []
+            i = 0
             while i < len(args):
                 rest = args[i:]
                 if not rest.strip():
                     break
+                # Handle comments following arguments.
                 if multiline and result:
                     m = self.comment_pat.match(rest)
                     if m:

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -593,6 +593,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             i, result = 0, []
             while i < len(args):
                 rest = args[i:]
+                ### g.trace(i, repr(rest))
                 if not rest.strip():
                     break
                 m = self.arg_pat.match(rest)
@@ -605,6 +606,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 if name == 'self':
                     # Don't annotate self.
                     result.append(f"{lws}{name}{comma}")
+                    if i < len(args) and args[i] == ',':
+                        i += 1
                 elif tail == ':':
                     arg, i = self.find_arg(args, i)
                     result.append(f"{lws}{name}: {arg}{comma}")
@@ -628,6 +631,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                         else:
                             i += 1
             s = ''.join(result)
+            if multiline:
+                s = '\n' + s
             if not multiline and s.endswith(', '):
                 s = s[:-2]
             return s
@@ -658,7 +663,6 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             result = s[i1 : i].strip()
             if result.endswith(','):
                 result = result[:-1].strip()
-            g.trace(repr(result))
             return result, i
         #@+node:ekr.20220105222028.1: *5* ama.kind
         bool_pat = re.compile(r'(True|False)')

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -485,8 +485,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         add-mypy-annotations. The command rewrites the @<file> tree, adding
         mypy annotations for untyped function/method arguments.
 
-        The command attempts no type analysis. It uses "None" as the type of
-        functions and methods that do not specify a return type.
+        The command attempts no type analysis. It uses "Any" as the type of
+        functions and methods that do not specify a return type. As as special
+        case, the type of __init__ methods is "None".
 
         @data add-mypy-annotations in leoSettings.leo contains a list of
         key/value pairs. Keys are argument names (as used in Leo); values are
@@ -499,6 +500,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         self.c.bodyWantsFocus()
     #@+node:ekr.20220105152521.1: *4* class Add_Mypy_Annotations
     class Add_Mypy_Annotations:
+        
+        """A class that implements the add-mypy-annotations command."""
 
         changed_lines = 0
         tag = 'add-mypy-annotations'

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -654,10 +654,12 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             while i < len(s):
                 ch = s[i]
                 i += 1
-                if ch in '[{("\'':
+                if ch in '[{(':
                     level += 1
-                elif ch in ']})"\'':
+                elif ch in ']}':
                     level -= 1
+                elif ch in '\'"':
+                    i = g.skip_python_string(s, i - 1)
                 elif ch == ',' and level == 0:
                     # Skip the comma, but don't include it in the result.
                     break

--- a/leo/commands/testCommands.py
+++ b/leo/commands/testCommands.py
@@ -23,6 +23,7 @@ def cover_all(event=None):
         ('leo.core.leoColorizer', 'leo/unittests/core/test_leoColorizer.py'),
         ('leo.core.leoCommands', 'leo/unittests/core/test_leoCommands.py'),
         ('leo.core.leoConfig', 'leo/unittests/core/test_leoConfig.py'),
+        ('leo.commands.convertCommands', 'leo/unittests/commands/convertCommands.py'),
         ('leo.commands.editCommands', 'leo/unittests/commands/test_editCommands.py'),
         ('leo.core.leoFileCommands', 'leo/unittests/core/test_leoFileCommands.py'),
         ('leo.core.leoFind', 'leo/unittests/core/test_leoFind.py'),
@@ -75,6 +76,11 @@ def cover_colorizer(event=None):
 def cover_commands(event=None):
     """Run all coverage tests for leoCommands.py."""
     g.run_coverage_tests('leo.core.leoCommands', 'leo/unittests/core/test_leoCommands.py')
+#@+node:ekr.20220109041701.1: *3* cover-convert
+@g.command('cover-convert-commands')
+def cover_checker_commands(event=None):
+    """Run all coverage tests for convertCommands.py."""
+    g.run_coverage_tests('leo.commands.convertCommands', 'leo/unittests/commands/test_convertCommands.py')
 #@+node:ekr.20210911072153.9: *3* cover-config
 @g.command('cover-config')
 def cover_config(event=None):

--- a/leo/commands/testCommands.py
+++ b/leo/commands/testCommands.py
@@ -78,7 +78,7 @@ def cover_commands(event=None):
     g.run_coverage_tests('leo.core.leoCommands', 'leo/unittests/core/test_leoCommands.py')
 #@+node:ekr.20220109041701.1: *3* cover-convert
 @g.command('cover-convert-commands')
-def cover_checker_commands(event=None):
+def cover_convert_commands(event=None):
     """Run all coverage tests for convertCommands.py."""
     g.run_coverage_tests('leo.commands.convertCommands', 'leo/unittests/commands/test_convertCommands.py')
 #@+node:ekr.20210911072153.9: *3* cover-config

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -543,7 +543,7 @@
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20180117074230.1"><vh>@bool show-tips = True</vh></v>
 <v t="ekr.20060323131801"><vh>@bool warn-about-missing-settings = False</vh></v>
-<v t="ekr.20220105172501.1"><vh>@data add-mypy-annotations settings</vh></v>
+<v t="ekr.20220105172501.1"><vh>@data add-mypy-annotations</vh></v>
 <v t="ekr.20210530064911.1"><vh>@data exec-script-commands</vh></v>
 <v t="ekr.20210530064922.1"><vh>@data exec-script-patterns</vh></v>
 <v t="ekr.20160428072005.1"><vh>@data history-list</vh></v>

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -543,9 +543,10 @@
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20180117074230.1"><vh>@bool show-tips = True</vh></v>
 <v t="ekr.20060323131801"><vh>@bool warn-about-missing-settings = False</vh></v>
-<v t="ekr.20160428072005.1"><vh>@data history-list</vh></v>
+<v t="ekr.20220105172501.1"><vh>@data add-mypy-annotations settings</vh></v>
 <v t="ekr.20210530064911.1"><vh>@data exec-script-commands</vh></v>
 <v t="ekr.20210530064922.1"><vh>@data exec-script-patterns</vh></v>
+<v t="ekr.20160428072005.1"><vh>@data history-list</vh></v>
 <v t="ekr.20211014064402.1"><vh>@data python-to-typescript-types</vh></v>
 <v t="ekr.20190608085550.1"><vh>@int max-find-long-lines-length = 110</vh></v>
 <v t="ekr.20180301060510.1"><vh>@int print-settings-at-data-limit = 20</vh></v>
@@ -11639,6 +11640,18 @@ v, VNode</t>
 <t tx="ekr.20220101093956.1">The working directory for the mypy command.
 
 Defaults to os.path.join(g.app.loadDir, '..', '..')</t>
+<t tx="ekr.20220105172501.1"># comma-separated pairs of strings: (argument-name, typescript-type)
+c, Cmdr
+ch, str
+gnx, str
+d, Dict[str, str]
+i, int
+j, int
+k, int
+n, int
+p, Pos
+s, str
+v, VNode</t>
 <t tx="jlunz.20150821113251.1">def html_tag():
     """expand &lt;tag&gt; to 
        &lt;tag&gt;\n&lt;/tag&gt; with proper indendation"""

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -590,7 +590,8 @@
 <v t="ekr.20210728045642.1"><vh>mypy settings</vh>
 <v t="ekr.20210728045723.1"><vh>@data mypy-arguments</vh></v>
 <v t="ekr.20210728045750.1"><vh>@int mypy-link-limit = 0</vh></v>
-<v t="ekr.20210802064734.1"><vh>@string mypy-config-file=''</vh></v>
+<v t="ekr.20210802064734.1"><vh>@string mypy-config-file=</vh></v>
+<v t="ekr.20220101093956.1"><vh>@string mypy-directory =</vh></v>
 </v>
 <v t="ekr.20160316111054.1"><vh>python-to-coffeescript settings</vh>
 <v t="ekr.20160316112407.2"><vh>@bool py2cs-overwrite = True</vh></v>
@@ -2312,6 +2313,7 @@
 </v>
 </v>
 <v t="ekr.20140915194122.23428"></v>
+<v t="ekr.20210728045642.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11608,9 +11610,11 @@ rust: ^\s*--&gt; (.+):([0-9]+):([0-9]+)\s*$</t>
 # --disallow-untyped-defs
 # --follow-imports=skip</t>
 <t tx="ekr.20210728045750.1"># 0 means no limit.</t>
-<t tx="ekr.20210802064734.1">Path to .mypy.ini file.
+<t tx="ekr.20210802064734.1">Path to .mypy.ini file, for the --config-file option.
 
-Relative paths are resolved starting from the location of the file being checked.</t>
+If not given, no --config-file option is added to the mypy argument list.
+
+Relative paths are relative to  @string mypy-directory.</t>
 <t tx="ekr.20210823172721.1"></t>
 <t tx="ekr.20210823172729.1"></t>
 <t tx="ekr.20210823172944.1"></t>
@@ -11632,6 +11636,9 @@ p, Position
 s, string
 v, VNode</t>
 <t tx="ekr.20211209060458.1">True: Add 'class' to the headlines of class nodes (python only).</t>
+<t tx="ekr.20220101093956.1">The working directory for the mypy command.
+
+Defaults to os.path.join(g.app.loadDir, '..', '..')</t>
 <t tx="jlunz.20150821113251.1">def html_tag():
     """expand &lt;tag&gt; to 
        &lt;tag&gt;\n&lt;/tag&gt; with proper indendation"""

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -15,7 +15,7 @@ import sys
 import textwrap
 import time
 import traceback
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 import zipfile
 import platform
 from leo.core import leoGlobals as g
@@ -2936,7 +2936,7 @@ class LoadManager:
                 }
                 # Handle keywords for g.pr and g.es_print.
                 d = g.doKeywordArgs(keys, d)
-                color = d.get('color')
+                color: Any = d.get('color')
                 if color == 'suppress':
                     return
                 if log and color is None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -15,7 +15,7 @@ import sys
 import textwrap
 import time
 import traceback
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 import zipfile
 import platform
 from leo.core import leoGlobals as g

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2902,7 +2902,7 @@ class QScintillaColorizer(BaseColorizer):
             self.lexersDict = self.makeLexersDict()
             self.nullLexer = NullScintillaLexer(c)
         else:
-            self.lexersDict = {}
+            self.lexersDict = {}  # type:ignore
             self.nullLexer = g.NullObject()  # type:ignore
 
     def reloadSettings(self):
@@ -2929,7 +2929,7 @@ class QScintillaColorizer(BaseColorizer):
         c = self.c
         wrapper = c.frame.body.wrapper
         w = wrapper.widget  # A Qsci.QsciSintilla object.
-        self.lexer = self.lexersDict.get(language, self.nullLexer)
+        self.lexer = self.lexersDict.get(language, self.nullLexer)  # type:ignore
         w.setLexer(self.lexer)
     #@+node:ekr.20140906081909.18707: *3* qsc.colorize
     def colorize(self, p):

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, Dict, List, Tuple
 #
 # Third-part tools.
 try:
-    import pygments
+    import pygments  # type:ignore
 except ImportError:
     pygments = None  # type:ignore
 #
@@ -2410,7 +2410,7 @@ class JEditColorizer(BaseJEditColorizer):
 if QtGui:
 
 
-    class LeoHighlighter(QtGui.QSyntaxHighlighter):
+    class LeoHighlighter(QtGui.QSyntaxHighlighter):  # type:ignore
         """
         A subclass of QSyntaxHighlighter that overrides
         the highlightBlock and rehighlight methods.
@@ -2539,7 +2539,8 @@ if QtGui:
         def setStyle(self, style):
             """ Sets the style to the specified Pygments style.
             """
-            from pygments.styles import get_style_by_name
+            from pygments.styles import get_style_by_name  # type:ignore
+
             if isinstance(style, str):
                 style = get_style_by_name(style)
             self._style = style
@@ -2575,7 +2576,7 @@ if QtGui:
 if Qsci:
 
 
-    class NullScintillaLexer(Qsci.QsciLexerCustom):
+    class NullScintillaLexer(Qsci.QsciLexerCustom):  # type:ignore
         """A do-nothing colorizer for Scintilla."""
 
         def __init__(self, c, parent=None):
@@ -2765,7 +2766,7 @@ class PygmentsColorizer(BaseJEditColorizer):
         self.tot_time += time.process_time() - t1
     #@+node:ekr.20190323045655.1: *4* pyg_c.at_color_callback
     def at_color_callback(self, lexer, match):
-        from pygments.token import Name, Text
+        from pygments.token import Name, Text  # type: ignore
         kind = match.group(0)
         self.color_enabled = kind == '@color'
         if self.color_enabled:
@@ -2786,7 +2787,7 @@ class PygmentsColorizer(BaseJEditColorizer):
     #@+node:ekr.20190322082533.1: *4* pyg_c.get_lexer
     def get_lexer(self, language):
         """Return the lexer for self.language, creating it if necessary."""
-        import pygments.lexers as lexers
+        import pygments.lexers as lexers  # type: ignore
         tag = 'get_lexer'
         trace = 'coloring' in g.app.debug
         try:
@@ -2805,8 +2806,8 @@ class PygmentsColorizer(BaseJEditColorizer):
     #@+node:ekr.20190322094034.1: *4* pyg_c.patch_lexer
     def patch_lexer(self, language, lexer):
 
-        from pygments.token import Comment
-        from pygments.lexer import inherit
+        from pygments.token import Comment  # type:ignore
+        from pygments.lexer import inherit  # type:ignore
 
 
         class PatchedLexer(lexer.__class__):  # type:ignore
@@ -3119,7 +3120,7 @@ if pygments:
     if QtGui:
 
 
-        class PygmentsBlockUserData(QtGui.QTextBlockUserData):
+        class PygmentsBlockUserData(QtGui.QTextBlockUserData):  # type:ignore
             """ Storage for the user data associated with each line."""
 
             syntax_stack = ('root',)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2862,7 +2862,7 @@ class Commands:
         c = self
         g.app.gui.put_help(c, s, short_title)
     #@+node:ekr.20111217154130.10285: *5* c.raise_error_dialogs
-    warnings_dict = {}
+    warnings_dict: Dict[str, bool] = {}
 
     def raise_error_dialogs(self, kind='read'):
         """Warn about read/write failures."""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2101,17 +2101,17 @@ class Tracer:
     """
     #@+others
     #@+node:ekr.20080531075119.2: *4*  __init__ (Tracer)
-    def __init__(self, limit=0, trace=False, verbose=False):
-        self.callDict = {}
+    def __init__(self, limit: int=0, trace: bool=False, verbose: bool=False) -> None:
+        self.callDict: Dict[str, Any] = {}
             # Keys are function names.
             # Values are the number of times the function was called by the caller.
-        self.calledDict = {}
+        self.calledDict: Dict[str, int] = {}
             # Keys are function names.
             # Values are the total number of times the function was called.
         self.count = 0
         self.inited = False
         self.limit = limit  # 0: no limit, otherwise, limit trace to n entries deep.
-        self.stack = []
+        self.stack: List[str] = []
         self.trace = trace
         self.verbose = verbose  # True: print returns as well as calls.
     #@+node:ekr.20080531075119.3: *4* computeName
@@ -2209,7 +2209,7 @@ class Tracer:
         self.calledDict[name] = 1 + self.calledDict.get(name, 0)
     #@-others
 
-def startTracer(limit=0, trace=False, verbose=False):
+def startTracer(limit: int=0, trace: bool=False, verbose: bool=False) -> Callable:
     t = g.Tracer(limit=limit, trace=trace, verbose=verbose)
     sys.settrace(t.tracer)
     return t

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -328,7 +328,7 @@ def standard_timestamp() -> str:
     """Return a reasonable timestamp."""
     return time.strftime("%Y%m%d-%H%M%S")
 #@+node:ekr.20201211183100.1: *3* g.get_backup_directory
-def get_backup_path(sub_directory) -> Optional[str]:
+def get_backup_path(sub_directory: str) -> Optional[str]:
     """
     Return the full path to the subdirectory of the main backup directory.
 
@@ -372,12 +372,12 @@ class BindingInfo:
     #@+node:ekr.20120129040823.10254: *4* bi.__init__
     def __init__(
         self,
-        kind,
-        commandName='',
-        func=None,
-        nextMode=None,
-        pane=None,
-        stroke=None,
+        kind: str,
+        commandName: str='',
+        func: Any=None,
+        nextMode: Any=None,
+        pane: Any=None,
+        stroke: Any=None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
             g.trace('***** (BindingInfo) oops', repr(stroke))
@@ -434,7 +434,7 @@ class Bunch:
                 point.isok = True
     """
 
-    def __init__(self, **keywords) -> None:
+    def __init__(self, **keywords: Any) -> None:
         self.__dict__.update(keywords)
 
     def __repr__(self) -> str:
@@ -481,7 +481,7 @@ class EmergencyDialog:
     """A class that creates an tkinter dialog with a single OK button."""
     #@+others
     #@+node:ekr.20120219154958.10493: *4* emergencyDialog.__init__
-    def __init__(self, title: str, message: str):
+    def __init__(self, title: str, message: str) -> Any:
         """Constructor for the leoTkinterDialog class."""
         self.answer = None  # Value returned from run()
         self.title = title
@@ -567,13 +567,13 @@ class GeneralSetting:
     """A class representing any kind of setting except shortcuts."""
 
     def __init__(self, kind,
-        encoding=None,
-        ivar=None,
-        setting=None,
-        val=None,
-        path=None,
-        tag='setting',
-        unl=None,
+        encoding: str=None,
+        ivar: str=None,
+        setting: str=None,
+        val: Any=None,
+        path: str=None,
+        tag: str='setting',
+        unl: str=None,
     ) -> None:
         self.encoding = encoding
         self.ivar = ivar

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -41,6 +41,7 @@ import unittest
 import urllib
 import urllib.parse as urlparse
 import webbrowser
+assert Iterable, Sequence  ###
 #
 # Leo never imports any other Leo module.
 if TYPE_CHECKING:  # Always False at runtime.
@@ -171,11 +172,11 @@ class Command:
     g can *not* be used anywhere in this class!
     """
 
-    def __init__(self, name, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs: Any) -> None:
         """Ctor for command decorator class."""
         self.name = name
 
-    def __call__(self, func):
+    def __call__(self, func: Callable) -> Callable:
         """Register command for all future commanders."""
         global_commands_dict[self.name] = func
         if app:
@@ -189,7 +190,7 @@ class Command:
 
 command = Command
 #@+node:ekr.20171124070654.1: *3* g.command_alias
-def command_alias(alias, func) -> None:
+def command_alias(alias: str, func: Callable) -> None:
     """Create an alias for the *already defined* method in the Commands class."""
     from leo.core import leoCommands
     assert hasattr(leoCommands.Commands, func.__name__)
@@ -212,14 +213,14 @@ class CommanderCommand:
     g can *not* be used anywhere in this class!
     """
 
-    def __init__(self, name: str, **kwargs) -> None:
+    def __init__(self, name: str, **kwargs: Any) -> None:
         """Ctor for command decorator class."""
         self.name = name
 
     def __call__(self, func: Callable) -> Callable:
         """Register command for all future commanders."""
 
-        def commander_command_wrapper(event):
+        def commander_command_wrapper(event: Any) -> None:
             c = event.get('c')
             method = getattr(c, func.__name__, None)
             method(event=event)
@@ -241,7 +242,7 @@ class CommanderCommand:
 
 commander_command = CommanderCommand
 #@+node:ekr.20150508164812.1: *3* g.ivars2instance
-def ivars2instance(c: Cmdr, g, ivars) -> Any:
+def ivars2instance(c: Cmdr, g: Any, ivars: List[str]) -> Any:
     """
     Return the instance of c given by ivars.
     ivars is a list of strings.
@@ -262,7 +263,7 @@ def ivars2instance(c: Cmdr, g, ivars) -> Any:
             break
     return obj
 #@+node:ekr.20150508134046.1: *3* g.new_cmd_decorator (decorator)
-def new_cmd_decorator(name, ivars):
+def new_cmd_decorator(name: str, ivars: List[str]) -> Callable:
     """
     Return a new decorator for a command with the given name.
     Compute the class *instance* using the ivar string or list.
@@ -271,9 +272,9 @@ def new_cmd_decorator(name, ivars):
     See https://github.com/leo-editor/leo-editor/issues/325
     """
 
-    def _decorator(func):
+    def _decorator(func: Callable) -> Callable:
 
-        def new_cmd_wrapper(event):
+        def new_cmd_wrapper(event: Any) -> None:
             if isinstance(event, dict):
                 c = event.get('c')
             else:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -565,7 +565,8 @@ class EmergencyDialog:
 class GeneralSetting:
     """A class representing any kind of setting except shortcuts."""
 
-    def __init__(self,
+    def __init__(
+        self,
         kind: str,
         encoding: str=None,
         ivar: str=None,
@@ -1085,7 +1086,8 @@ class MatchBrackets:
             # self.oops('unmatched string')
         return i + offset
     #@+node:tbrown.20180226113621.1: *4* mb.expand_range
-    def expand_range(self,
+    def expand_range(
+        self,
         s: str,
         left: int,
         right: int,
@@ -1898,7 +1900,8 @@ class SherlockTracer:
     ignored_files: List[str] = []  # List of files.
     ignored_functions: List[str] = []  # List of files.
 
-    def is_enabled(self,
+    def is_enabled(
+        self,
         file_name: str,
         function_name: str,
         patterns: List[str]=None,
@@ -5054,7 +5057,7 @@ def skip_string(s: str, i: int) -> int:
     """Scan forward to the end of a string."""
     delim = s[i]
     i += 1
-    assert(delim == '"' or delim == '\'')
+    assert delim in '\'"', (repr(delim), repr(s))
     n = len(s)
     while i < n and s[i] != delim:
         if s[i] == '\\':
@@ -7472,7 +7475,9 @@ def findTopLevelNode(c: Cmdr, headline: str, exact: bool=True) -> Optional[Pos]:
     return None
 #@-others
 #@+node:EKR.20040614071102.1: *3* g.getScript & helpers
-def getScript(c: Cmdr, p: Pos,
+def getScript(
+    c: Cmdr,
+    p: Pos,
     useSelectedText: bool=True,
     forcePythonSentinels: bool=True,
     useSentinels: bool=True,

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2058,18 +2058,18 @@ class TkIDDialog(EmergencyDialog):
 
     title = 'Enter Leo id'
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(self.title, self.message)
         self.val = ''
 
     #@+others
     #@+node:ekr.20191013145710.1: *4* leo_id_dialog.onKey
-    def onKey(self, event):
+    def onKey(self, event: Any) -> None:
         """Handle Key events in askOk dialogs."""
         if event.char in '\n\r':
             self.okButton()
     #@+node:ekr.20191013145757.1: *4* leo_id_dialog.createTopFrame
-    def createTopFrame(self):
+    def createTopFrame(self) -> None:
         """Create the Tk.Toplevel widget for a leoTkinterDialog."""
         import tkinter as Tk
         self.root = Tk.Tk()  # type:ignore
@@ -2084,7 +2084,7 @@ class TkIDDialog(EmergencyDialog):
         self.entry.pack()
         self.entry.focus_set()
     #@+node:ekr.20191013150158.1: *4* leo_id_dialog.okButton
-    def okButton(self):
+    def okButton(self) -> None:
         """Do default click action in ok button."""
         self.val = self.entry.get()
             # Return is not possible.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -99,7 +99,7 @@ directives_pat = None  # Set below.
 # The cmd_instance_dict supports per-class @cmd decorators. For example, the
 # following appears in leo.commands.
 #
-#     def cmd(name: Any) -> None:
+#     def cmd(name: Any) -> Any:
 #         """Command decorator for the abbrevCommands class."""
 #         return g.new_cmd_decorator(name, ['c', 'abbrevCommands',])
 #
@@ -164,7 +164,7 @@ class Command:
     commands that could befined inside a class. The typical usage is:
 
         @g.command('command-name')
-        def A_Command(event: Any) -> None:
+        def A_Command(event):
             c = event.get('c')
             ...
 
@@ -203,7 +203,7 @@ class CommanderCommand:
     Usage:
 
         @g.command('command-name')
-        def command_name(self, *args, **kwargs) -> None:
+        def command_name(self, *args, **kwargs):
             ...
 
     The decorator injects command_name into the Commander class and calls
@@ -6882,7 +6882,7 @@ def windows() -> None:
 #@+at Note: all these methods return Unicode strings. It is up to the user to
 # convert to an encoded string as needed, say when opening a file.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
-def glob_glob(pattern: Any) -> None:
+def glob_glob(pattern: Any) -> List:
     """Return the regularized glob.glob(pattern)"""
     aList = glob.glob(pattern)
     # os.path.normpath does the *reverse* of what we want.
@@ -6890,7 +6890,7 @@ def glob_glob(pattern: Any) -> None:
         aList = [z.replace('\\', '/') for z in aList]
     return aList
 #@+node:ekr.20031218072017.2146: *3* g.os_path_abspath
-def os_path_abspath(path: str) -> None:
+def os_path_abspath(path: str) -> str:
     """Convert a path to an absolute path."""
     if not path:
         return ''
@@ -6903,7 +6903,7 @@ def os_path_abspath(path: str) -> None:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2147: *3* g.os_path_basename
-def os_path_basename(path: str) -> None:
+def os_path_basename(path: str) -> str:
     """Return the second half of the pair returned by split(path)."""
     if not path:
         return ''
@@ -6913,7 +6913,7 @@ def os_path_basename(path: str) -> None:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2148: *3* g.os_path_dirname
-def os_path_dirname(path: str) -> None:
+def os_path_dirname(path: str) -> str:
     """Return the first half of the pair returned by split(path)."""
     if not path:
         return ''
@@ -6923,7 +6923,7 @@ def os_path_dirname(path: str) -> None:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2149: *3* g.os_path_exists
-def os_path_exists(path: str) -> None:
+def os_path_exists(path: str) -> bool:
     """Return True if path exists."""
     if not path:
         return False
@@ -6932,7 +6932,7 @@ def os_path_exists(path: str) -> None:
         path = path.replace('\x00', '')  # Fix Python 3 bug on Windows 10.
     return os.path.exists(path)
 #@+node:ekr.20080921060401.13: *3* g.os_path_expanduser
-def os_path_expanduser(path: str) -> None:
+def os_path_expanduser(path: str) -> str:
     """wrap os.path.expanduser"""
     if not path:
         return ''
@@ -6942,7 +6942,7 @@ def os_path_expanduser(path: str) -> None:
         path = path.replace('\\', '/')
     return result
 #@+node:ekr.20080921060401.14: *3* g.os_path_finalize
-def os_path_finalize(path: str) -> None:
+def os_path_finalize(path: str) -> str:
     """
     Expand '~', then return os.path.normpath, os.path.abspath of the path.
     There is no corresponding os.path method
@@ -6959,7 +6959,7 @@ def os_path_finalize(path: str) -> None:
     # calling os.path.realpath here would cause problems in some situations.
     return path
 #@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join
-def os_path_finalize_join(*args, **keys) -> None:
+def os_path_finalize_join(*args, **keys) -> str:
     """
     Join and finalize.
 
@@ -6969,7 +6969,7 @@ def os_path_finalize_join(*args, **keys) -> None:
     path = g.os_path_finalize(path)
     return path
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
-def os_path_getmtime(path: str) -> None:
+def os_path_getmtime(path: str) -> int:
     """Return the modification time of path."""
     if not path:
         return 0
@@ -6978,11 +6978,11 @@ def os_path_getmtime(path: str) -> None:
     except Exception:
         return 0
 #@+node:ekr.20080729142651.2: *3* g.os_path_getsize
-def os_path_getsize(path: str) -> None:
+def os_path_getsize(path: str) -> int:
     """Return the size of path."""
     return os.path.getsize(path) if path else 0
 #@+node:ekr.20031218072017.2151: *3* g.os_path_isabs
-def os_path_isabs(path: str) -> None:
+def os_path_isabs(path: str) -> bool:
     """Return True if path is an absolute path."""
     return os.path.isabs(path) if path else False
 #@+node:ekr.20031218072017.2152: *3* g.os_path_isdir
@@ -6990,11 +6990,11 @@ def os_path_isdir(path: str) -> None:
     """Return True if the path is a directory."""
     return os.path.isdir(path) if path else False
 #@+node:ekr.20031218072017.2153: *3* g.os_path_isfile
-def os_path_isfile(path: str) -> None:
+def os_path_isfile(path: str) -> bool:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
 #@+node:ekr.20031218072017.2154: *3* g.os_path_join
-def os_path_join(*args, **keys) -> None:
+def os_path_join(*args, **keys) -> str:
     """
     Join paths, like os.path.join, with enhancements:
 
@@ -7027,7 +7027,7 @@ def os_path_join(*args, **keys) -> None:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2156: *3* g.os_path_normcase
-def os_path_normcase(path: str) -> None:
+def os_path_normcase(path: str) -> str:
     """Normalize the path's case."""
     if not path:
         return ''
@@ -7036,7 +7036,7 @@ def os_path_normcase(path: str) -> None:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2157: *3* g.os_path_normpath
-def os_path_normpath(path: str) -> None:
+def os_path_normpath(path: str) -> str:
     """Normalize the path."""
     if not path:
         return ''
@@ -7046,14 +7046,14 @@ def os_path_normpath(path: str) -> None:
         path = path.replace('\\', '/').lower()  # #2049: ignore case!
     return path
 #@+node:ekr.20180314081254.1: *3* g.os_path_normslashes
-def os_path_normslashes(path: str) -> None:
+def os_path_normslashes(path: str) -> str:
 
     # os.path.normpath does the *reverse* of what we want.
     if g.isWindows and path:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20080605064555.2: *3* g.os_path_realpath
-def os_path_realpath(path: str) -> None:
+def os_path_realpath(path: str) -> str:
     """Return the canonical path of the specified filename, eliminating any
     symbolic links encountered in the path (if they are supported by the
     operating system).
@@ -7066,16 +7066,16 @@ def os_path_realpath(path: str) -> None:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2158: *3* g.os_path_split
-def os_path_split(path: str) -> None:
+def os_path_split(path: str) -> Tuple[str, str]:
     if not path:
         return '', ''
     head, tail = os.path.split(path)
     return head, tail
 #@+node:ekr.20031218072017.2159: *3* g.os_path_splitext
-def os_path_splitext(path: str) -> None:
+def os_path_splitext(path: str) -> Tuple[str, str]:
 
     if not path:
-        return ''
+        return '', ''
     head, tail = os.path.splitext(path)
     return head, tail
 #@+node:ekr.20090829140232.6036: *3* g.os_startfile
@@ -7803,7 +7803,7 @@ def traceUrl(c: Cmdr, path: str, parsed: Any, url: Any) -> None:
     g.trace('parsed.path  ', parsed.path)
     g.trace('parsed.scheme', repr(parsed.scheme))
 #@+node:ekr.20170221063527.1: *3* g.handleUnl
-def handleUnl(unl: Any, c: Cmdr) -> None:
+def handleUnl(unl: Any, c: Cmdr) -> Any:
     """
     Handle a Leo UNL. This must *never* open a browser.
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -41,7 +41,6 @@ import unittest
 import urllib
 import urllib.parse as urlparse
 import webbrowser
-assert Iterable, Sequence  ###
 #
 # Leo never imports any other Leo module.
 if TYPE_CHECKING:  # Always False at runtime.
@@ -803,7 +802,7 @@ class KeyStroke:
         # Translate shifted keys to their appropriate alternatives.
         return self.strip_shift(s)
     #@+node:ekr.20180502104829.1: *5* ks.strip_shift
-    def strip_shift(self, s):
+    def strip_shift(self, s: str) -> str:
         """
         Handle supposedly shifted keys.
 
@@ -844,21 +843,21 @@ class KeyStroke:
         }
         if 'shift' in self.mods and s in shift_d:
             self.mods.remove('shift')
-            s = shift_d.get(s)
+            s = shift_d.get(s)  # type:ignore
         return s
     #@+node:ekr.20120203053243.10124: *4* ks.find, lower & startswith
     # These may go away later, but for now they make conversion of string strokes easier.
 
-    def find(self, pattern):
+    def find(self, pattern: str) -> int:
         return self.s.find(pattern)
 
-    def lower(self):
+    def lower(self) -> str:
         return self.s.lower()
 
-    def startswith(self, s: str):
+    def startswith(self, s: str) -> bool:
         return self.s.startswith(s)
     #@+node:ekr.20180415081209.2: *4* ks.find_mods
-    def find_mods(self, s: str):
+    def find_mods(self, s: str) -> List[str]:
         """Return the list of all modifiers seen in s."""
         s = s.lower()
         table = (
@@ -881,15 +880,15 @@ class KeyStroke:
                         break
         return result
     #@+node:ekr.20180417101435.1: *4* ks.isAltCtl
-    def isAltCtrl(self):
+    def isAltCtrl(self) -> bool:
         """Return True if this is an Alt-Ctrl character."""
         mods = self.find_mods(self.s)
         return 'alt' in mods and 'ctrl' in mods
     #@+node:ekr.20120203053243.10121: *4* ks.isFKey
-    def isFKey(self):
+    def isFKey(self) -> bool:
         return self.s in g.app.gui.FKeys
     #@+node:ekr.20180417102341.1: *4* ks.isPlainKey (does not handle alt-ctrl chars)
-    def isPlainKey(self):
+    def isPlainKey(self) -> bool:
         """
         Return True if self.s represents a plain key.
 
@@ -913,20 +912,20 @@ class KeyStroke:
             return False
         return True
     #@+node:ekr.20180511092713.1: *4* ks.isNumPadKey, ks.isPlainNumPad & ks.removeNumPadModifier
-    def isNumPadKey(self):
+    def isNumPadKey(self) -> bool:
         return self.s.find('Keypad+') > -1
 
-    def isPlainNumPad(self):
+    def isPlainNumPad(self) -> bool:
         return (
             self.isNumPadKey() and
             len(self.s.replace('Keypad+', '')) == 1
         )
 
-    def removeNumPadModifier(self):
+    def removeNumPadModifier(self) -> None:
 
         self.s = self.s.replace('Keypad+', '')
     #@+node:ekr.20180419170934.1: *4* ks.prettyPrint
-    def prettyPrint(self):
+    def prettyPrint(self) -> str:
 
         s = self.s
         if not s:
@@ -935,7 +934,7 @@ class KeyStroke:
         ch = s[-1]
         return s[:-1] + d.get(ch, ch)
     #@+node:ekr.20180415124853.1: *4* ks.strip_mods
-    def strip_mods(self, s: str):
+    def strip_mods(self, s: str) -> str:
         """Remove all modifiers from s, without changing the case of s."""
         table = (
             'alt',
@@ -954,7 +953,7 @@ class KeyStroke:
                     break
         return s
     #@+node:ekr.20120203053243.10125: *4* ks.toGuiChar
-    def toGuiChar(self):
+    def toGuiChar(self) -> str:
         """Replace special chars by the actual gui char."""
         s = self.s.lower()
         if s in ('\n', 'return'):
@@ -967,7 +966,7 @@ class KeyStroke:
             s = '.'
         return s
     #@+node:ekr.20180417100834.1: *4* ks.toInsertableChar
-    def toInsertableChar(self):
+    def toInsertableChar(self) -> str:
         """Convert self to an (insertable) char."""
         # pylint: disable=len-as-condition
         s = self.s
@@ -982,7 +981,7 @@ class KeyStroke:
             'Tab': '\t',
         }
         if s in d:
-            return d.get(s)
+            return d.get(s)  # type:ignore
         return s if len(s) == 1 else ''
     #@-others
 
@@ -1002,7 +1001,7 @@ class MatchBrackets:
     """
     #@+others
     #@+node:ekr.20160119104510.1: *4* mb.ctor
-    def __init__(self, c: Cmdr, p: Pos, language):
+    def __init__(self, c: Cmdr, p: Pos, language: str) -> None:
         """Ctor for MatchBrackets class."""
         self.c = c
         self.p = p.copy()
@@ -1019,7 +1018,7 @@ class MatchBrackets:
         c.user_dict.setdefault('_match_brackets', {'count': 0, 'range': (0, 0)})
     #@+node:ekr.20160121164723.1: *4* mb.bi-directional helpers
     #@+node:ekr.20160121112812.1: *5* mb.is_regex
-    def is_regex(self, s: str, i: int):
+    def is_regex(self, s: str, i: int) -> bool:
         """Return true if there is another slash on the line."""
         if self.language in ('javascript', 'perl',):
             assert s[i] == '/'
@@ -1060,7 +1059,7 @@ class MatchBrackets:
             return i1 + offset
         return found
     #@+node:ekr.20160121112303.1: *5* mb.scan_string
-    def scan_string(self, s: str, i: int):
+    def scan_string(self, s: str, i: int) -> int:
         """
         Scan the string starting at s[i] (forward or backward).
         Return the index of the next character.
@@ -1086,7 +1085,13 @@ class MatchBrackets:
             # self.oops('unmatched string')
         return i + offset
     #@+node:tbrown.20180226113621.1: *4* mb.expand_range
-    def expand_range(self, s: str, left, right, max_right, expand=False):
+    def expand_range(self,
+        s: str,
+        left: int,
+        right: int,
+        max_right: int,
+        expand: bool=False,
+    ) -> Tuple[Any, Any, Any, Any]:
         """
         Find the bracket nearest the cursor searching outwards left and right.
 
@@ -1132,7 +1137,7 @@ class MatchBrackets:
             return left, right, s[right], right
         return None, None, None, None
     #@+node:ekr.20061113221414: *4* mb.find_matching_bracket
-    def find_matching_bracket(self, ch1, s: str, i: int):
+    def find_matching_bracket(self, ch1: str, s: str, i: int) -> Any:
         """Find the bracket matching s[i] for self.language."""
         self.forward = ch1 in self.open_brackets
         # Find the character matching the initial bracket.
@@ -1145,7 +1150,7 @@ class MatchBrackets:
         f = self.scan if self.forward else self.scan_back
         return f(ch1, target, s, i)
     #@+node:ekr.20160121164556.1: *4* mb.scan & helpers
-    def scan(self, ch1, target, s: str, i: int):
+    def scan(self, ch1: str, target: str, s: str, i: int) -> Optional[int]:
         """Scan forward for target."""
         level = 0
         while 0 <= i < len(s):
@@ -1155,7 +1160,7 @@ class MatchBrackets:
                 # Scan to the end/beginning of the string.
                 i = self.scan_string(s, i)
             elif self.starts_comment(s, i):
-                i = self.scan_comment(s, i)
+                i = self.scan_comment(s, i)  # type:ignore
             elif ch == '/' and self.is_regex(s, i):
                 i = self.scan_regex(s, i)
             elif ch == ch1:
@@ -1172,7 +1177,7 @@ class MatchBrackets:
         # Not found
         return None
     #@+node:ekr.20160119090634.1: *5* mb.scan_comment
-    def scan_comment(self, s: str, i: int):
+    def scan_comment(self, s: str, i: int) -> Optional[int]:
         """Return the index of the character after a comment."""
         i1 = i
         start = self.start_comment if self.forward else self.end_comment
@@ -1211,7 +1216,7 @@ class MatchBrackets:
             return found
         return i
     #@+node:ekr.20160119101851.1: *5* mb.starts_comment
-    def starts_comment(self, s: str, i: int):
+    def starts_comment(self, s: str, i: int) -> bool:
         """Return True if s[i] starts a comment."""
         assert 0 <= i < len(s)
         if self.forward:
@@ -1235,7 +1240,7 @@ class MatchBrackets:
             g.match(s, i, self.end_comment)
         )
     #@+node:ekr.20160119230141.1: *4* mb.scan_back & helpers
-    def scan_back(self, ch1, target, s: str, i: int):
+    def scan_back(self, ch1: str, target: str, s: str, i: int) -> Optional[int]:
         """Scan backwards for delim."""
         level = 0
         while i >= 0:
@@ -1262,7 +1267,7 @@ class MatchBrackets:
         # Not found
         return None
     #@+node:ekr.20160119230141.2: *5* mb.back_scan_comment
-    def back_scan_comment(self, s: str, i: int):
+    def back_scan_comment(self, s: str, i: int) -> int:
         """Return the index of the character after a comment."""
         i1 = i
         if g.match(s, i, self.end_comment):
@@ -1287,7 +1292,7 @@ class MatchBrackets:
             found = 0
         return found
     #@+node:ekr.20160119230141.4: *5* mb.ends_comment
-    def ends_comment(self, s: str, i: int):
+    def ends_comment(self, s: str, i: int) -> bool:
         """
         Return True if s[i] ends a comment. This is called while scanning
         backward, so this is a bit of a guess.
@@ -1332,13 +1337,13 @@ class MatchBrackets:
             self.end_comment and
             g.match(s, i, self.end_comment))
     #@+node:ekr.20160119104148.1: *4* mb.oops
-    def oops(self, s: str):
+    def oops(self, s: str) -> None:
         """Report an error in the match-brackets command."""
         g.es(s, color='red')
     #@+node:ekr.20160119094053.1: *4* mb.run
     #@@nobeautify
 
-    def run(self):
+    def run(self) -> None:
         """The driver for the MatchBrackets class.
 
         With no selected range: find the nearest bracket and select from
@@ -1439,7 +1444,7 @@ class PosList(list):
     #@-<< docstring for PosList >>
     #@+others
     #@+node:ekr.20140531104908.17611: *4* PosList.ctor
-    def __init__(self, c: Cmdr, aList=None):
+    def __init__(self, c: Cmdr, aList: List[Cmdr]=None) -> None:
         self.c = c
         super().__init__()
         if aList is None:
@@ -1449,12 +1454,12 @@ class PosList(list):
             for p in aList:
                 self.append(p.copy())
     #@+node:ekr.20140531104908.17612: *4* PosList.dump
-    def dump(self, sort=False, verbose=False):
+    def dump(self, sort: bool=False, verbose: bool=False) -> str:
         if verbose:
             return g.listToString(self, sort=sort)
         return g.listToString([p.h for p in self], sort=sort)
     #@+node:ekr.20140531104908.17613: *4* PosList.select
-    def select(self, pat, regex=False, removeClones=True):
+    def select(self, pat: str, regex: bool=False, removeClones: bool=True) -> "PosList":
         """
         Return a new PosList containing all positions
         in self that match the given pattern.
@@ -1474,7 +1479,7 @@ class PosList(list):
             aList = self.removeClones(aList)
         return PosList(c, aList)
     #@+node:ekr.20140531104908.17614: *4* PosList.removeClones
-    def removeClones(self, aList):
+    def removeClones(self, aList: List[Pos]) -> List[Pos]:
         seen = {}
         aList2: List[Pos] = []
         for p in aList:
@@ -1487,11 +1492,11 @@ class PosList(list):
 class ReadLinesClass:
     """A class whose next method provides a readline method for Python's tokenize module."""
 
-    def __init__(self, s):
+    def __init__(self, s: str) -> None:
         self.lines = g.splitLines(s)
         self.i = 0
 
-    def next(self):
+    def next(self) -> str:
         if self.i < len(self.lines):
             line = self.lines[self.i]
             self.i += 1
@@ -1507,25 +1512,25 @@ class RedirectClass:
     #@+node:ekr.20031218072017.1656: *4* << RedirectClass methods >>
     #@+others
     #@+node:ekr.20041012082437: *5* RedirectClass.__init__
-    def __init__(self):
+    def __init__(self) -> None:
         self.old = None
         self.encoding = 'utf-8'  # 2019/03/29 For pdb.
     #@+node:ekr.20041012082437.1: *5* isRedirected
-    def isRedirected(self):
+    def isRedirected(self) -> bool:
         return self.old is not None
     #@+node:ekr.20041012082437.2: *5* flush
     # For LeoN: just for compatibility.
 
-    def flush(self, *args):
+    def flush(self, *args: Any) -> None:
         return
     #@+node:ekr.20041012091252: *5* rawPrint
-    def rawPrint(self, s: str):
+    def rawPrint(self, s: str) -> None:
         if self.old:
             self.old.write(s + '\n')
         else:
             g.pr(s)
     #@+node:ekr.20041012082437.3: *5* redirect
-    def redirect(self, stdout=1):
+    def redirect(self, stdout: bool=True) -> None:
         if g.app.batchMode:
             # Redirection is futile in batch mode.
             return
@@ -1535,7 +1540,7 @@ class RedirectClass:
             else:
                 self.old, sys.stderr = sys.stderr, self  # type:ignore
     #@+node:ekr.20041012082437.4: *5* undirect
-    def undirect(self, stdout=1):
+    def undirect(self, stdout: bool=True) -> None:
         if self.old:
             if stdout:
                 sys.stdout, self.old = self.old, None
@@ -2876,14 +2881,18 @@ def get_line_after(s: str, i: int):
 
 getLineAfter = get_line_after
 #@+node:ekr.20080729142651.1: *4* g.getIvarsDict and checkUnchangedIvars
-def getIvarsDict(obj: Any):
+def getIvarsDict(obj: Any) -> Dict[str, Any]:
     """Return a dictionary of ivars:values for non-methods of obj."""
     d: Dict[str, Any] = dict(
         [[key, getattr(obj, key)] for key in dir(obj)  # type:ignore
             if not isinstance(getattr(obj, key), types.MethodType)])
     return d
 
-def checkUnchangedIvars(obj: Any, d, exceptions=None):
+def checkUnchangedIvars(
+    obj: Any,
+    d: Dict[str, Any],
+    exceptions: Sequence[str]=None,
+) -> bool:
     if not exceptions:
         exceptions = []
     ok = True
@@ -6608,7 +6617,7 @@ def trace(*args, **keys):
 #@+node:ekr.20080220111323: *3* g.translateArgs
 console_encoding = None
 
-def translateArgs(args, d):
+def translateArgs(args: Iterable[Any], d: Dict[str, Any]) -> str:
     """
     Return the concatenation of s and all args, with odd args translated.
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2458,7 +2458,6 @@ class TypedDict:
             self._reportTypeError(val, self.valType)
 
     def _reportTypeError(self, obj: Any, objType: Any) -> str:
-        # print(f"Type mismatch: obj: {obj.__class__}, objType: {objType}")
         return (
             f"{self._name}\n"
             f"expected: {obj.__class__.__name__}\n"
@@ -2583,14 +2582,14 @@ class LinterTable():
         remove = [g.os_path_finalize_join(self.loadDir, 'external', fn) for fn in remove]
         return sorted([z for z in aList if z not in remove])
     #@+node:ekr.20160520093506.1: *4* get_files (LinterTable)
-    def get_files(self, pattern: Any) -> List:
+    def get_files(self, pattern: str) -> List:
         """Return the list of absolute file names matching the pattern."""
         aList = sorted([
             fn for fn in g.glob_glob(pattern)
                 if g.os_path_isfile(fn) and g.shortFileName(fn) != '__init__.py'])
         return aList
     #@+node:ekr.20160518074545.9: *4* get_files_for_scope
-    def get_files_for_scope(self, scope: Any, fn: Any) -> List:
+    def get_files_for_scope(self, scope: str, fn: str) -> List:
         """Return a list of absolute filenames for external linters."""
         d = {
             'all': [self.core, self.commands, self.external, self.plugins],
@@ -2793,7 +2792,7 @@ def oldDump(s: str) -> str:
             out += i
     return out
 #@+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c: Cmdr, dump_body: bool=False, msg: Any=None) -> None:
+def dump_tree(c: Cmdr, dump_body: bool=False, msg: str=None) -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2804,7 +2803,7 @@ def dump_tree(c: Cmdr, dump_body: bool=False, msg: Any=None) -> None:
             for z in g.splitLines(p.b):
                 print(z.rstrip())
 
-def tree_to_string(c: Cmdr, dump_body: bool=False, msg: Any=None) -> str:
+def tree_to_string(c: Cmdr, dump_body: bool=False, msg: str=None) -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2815,7 +2814,7 @@ def tree_to_string(c: Cmdr, dump_body: bool=False, msg: Any=None) -> str:
                 result.append(z.rstrip())
     return '\n'.join(result)
 #@+node:ekr.20150227102835.8: *4* g.dump_encoded_string
-def dump_encoded_string(encoding: Any, s: str) -> None:
+def dump_encoded_string(encoding: str, s: str) -> None:
     """Dump s, assumed to be an encoded string."""
     # Can't use g.trace here: it calls this function!
     print(f"dump_encoded_string: {g.callers()}")
@@ -2830,17 +2829,17 @@ def dump_encoded_string(encoding: Any, s: str) -> None:
         elif ch == '\n':
             in_comment = False
 #@+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: Any, format: Any=None) -> str:
+def module_date(mod: Any, format: str=None) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
-def plugin_date(plugin_mod: Any, format: Any=None) -> str:
+def plugin_date(plugin_mod: Any, format: str=None) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=str)
 
-def file_date(theFile: Any, format: Any=None) -> str:
+def file_date(theFile: Any, format: str=None) -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2920,7 +2919,7 @@ def pdb(message: str='') -> None:
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
 #@+node:ekr.20041224080039: *4* g.dictToString
-def dictToString(d: Dict[str, str], indent: str='', tag: Any=None) -> str:
+def dictToString(d: Dict[str, str], indent: str='', tag: str=None) -> str:
     """Pretty print a Python dict to a string."""
     # pylint: disable=unnecessary-lambda
     if not d:
@@ -2939,7 +2938,7 @@ def dictToString(d: Dict[str, str], indent: str='', tag: Any=None) -> str:
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20041126060136: *4* g.listToString
-def listToString(obj: Any, indent: str='', tag: Any=None) -> str:
+def listToString(obj: Any, indent: str='', tag: str=None) -> str:
     """Pretty print a Python list to a string."""
     if not obj:
         return '[]'
@@ -2957,7 +2956,7 @@ def listToString(obj: Any, indent: str='', tag: Any=None) -> str:
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
-def objToString(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> str:
+def objToString(obj: Any, indent: str='', printCaller: bool=False, tag: str=None) -> str:
     """Pretty print any Python object to a string."""
     # pylint: disable=undefined-loop-variable
         # Looks like a a pylint bug.
@@ -3053,7 +3052,7 @@ def sleep(n: float) -> None:
     from time import sleep  # type:ignore
     sleep(n)  # type:ignore
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> None:
+def printObj(obj: Any, indent: str='', printCaller: bool=False, tag: str=None) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, printCaller=printCaller, tag=tag))
 
@@ -3061,7 +3060,7 @@ printDict = printObj
 printList = printObj
 printTuple = printObj
 #@+node:ekr.20171023110057.1: *4* g.tupleToString
-def tupleToString(obj: Any, indent: str='', tag: Any=None) -> str:
+def tupleToString(obj: Any, indent: str='', tag: str=None) -> str:
     """Pretty print a Python tuple to a string."""
     if not obj:
         return '(),'
@@ -3148,7 +3147,7 @@ def printGcSummary() -> None:
     except Exception:
         traceback.print_exc()
 #@+node:ekr.20180528151850.1: *3* g.printTimes
-def printTimes(times: Any) -> None:
+def printTimes(times: List) -> None:
     """
     Print the differences in the times array.
 
@@ -3165,7 +3164,7 @@ def clearStats() -> None:
     g.app.statsDict = {}
 #@+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event: Any=None, name: Any=None) -> None:
+def printStats(event: Any=None, name: str=None) -> None:
     """
     Print all gathered statistics.
 
@@ -3192,7 +3191,7 @@ def printStats(event: Any=None, name: Any=None) -> None:
     for key in reversed(sorted(d)):
         print(f"{key:7} {d.get(key)}")
 #@+node:ekr.20031218072017.3136: *4* g.stat
-def stat(name: Any=None) -> None:
+def stat(name: str=None) -> None:
     """Increments the statistic for name in g.app.statsDict
     The caller's name is used by default.
     """
@@ -3207,24 +3206,24 @@ def stat(name: Any=None) -> None:
 def getTime() -> float:
     return time.time()
 
-def esDiffTime(message: Any, start: Any) -> float:
+def esDiffTime(message: str, start: float) -> float:
     delta = time.time() - start
     g.es('', f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def printDiffTime(message: Any, start: Any) -> float:
+def printDiffTime(message: str, start: float) -> float:
     delta = time.time() - start
     g.pr(f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def timeSince(start: Any) -> str:
+def timeSince(start: float) -> str:
     return f"{time.time()-start:5.2f} sec."
 #@+node:ekr.20031218072017.1380: ** g.Directives
 # Weird pylint bug, activated by TestLeoGlobals class.
 # Disabling this will be safe, because pyflakes will still warn about true redefinitions
 # pylint: disable=function-redefined
 #@+node:EKR.20040504150046.4: *3* g.comment_delims_from_extension
-def comment_delims_from_extension(filename: Any) -> Tuple[str, str, str]:
+def comment_delims_from_extension(filename: str) -> Tuple[str, str, str]:
     """
     Return the comment delims corresponding to the filename's extension.
     """
@@ -3326,7 +3325,7 @@ def findLanguageDirectives(c: Cmdr, p: Pos) -> Optional[str]:
 # Called from the syntax coloring method that colorizes section references.
 # Also called from write at.putRefAt.
 
-def findReference(name: Any, root: Any) -> Optional[Pos]:
+def findReference(name: str, root: Pos) -> Optional[Pos]:
     """Return the position containing the section definition for name."""
     for p in root.subtree(copy=False):
         assert p != root
@@ -3413,7 +3412,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos) -> Optional[str]:
             if parent_v not in seen:
                 yield from v_and_parents(parent_v)
 
-    def find_language(v: "VNode", phase: Any) -> Optional[str]:
+    def find_language(v: "VNode", phase: int) -> Optional[str]:
         """
         A helper for all searches.
         Phase one searches only @<file> nodes.
@@ -3470,7 +3469,7 @@ def getLanguageAtPosition(c: Cmdr, p: Pos) -> str:
     )
     return language.lower()
 #@+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr=None, name: Any=None) -> str:
+def getOutputNewline(c: Cmdr=None, name: str=None) -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3519,7 +3518,7 @@ def isDirective(s: str) -> bool:
         return bool(m.group(1) in g.globalDirectiveList)
     return False
 #@+node:ekr.20200810074755.1: *3* g.isValidLanguage
-def isValidLanguage(language: Any) -> bool:
+def isValidLanguage(language: str) -> bool:
     """True if language exists in leo/modes."""
     # 2020/08/12: A hack for c++
     if language in ('c++', 'cpp'):
@@ -3527,7 +3526,7 @@ def isValidLanguage(language: Any) -> bool:
     fn = g.os_path_join(g.app.loadDir, '..', 'modes', f"{language}.py")
     return g.os_path_exists(fn)
 #@+node:ekr.20080827175609.52: *3* g.scanAtCommentAndLanguageDirectives
-def scanAtCommentAndAtLanguageDirectives(aList: Any) -> Optional[Dict[str, str]]:
+def scanAtCommentAndAtLanguageDirectives(aList: List) -> Optional[Dict[str, str]]:
     """
     Scan aList for @comment and @language directives.
 
@@ -3548,7 +3547,7 @@ def scanAtCommentAndAtLanguageDirectives(aList: Any) -> Optional[Dict[str, str]]
             return d
     return None
 #@+node:ekr.20080827175609.32: *3* g.scanAtEncodingDirectives
-def scanAtEncodingDirectives(aList: Any) -> Optional[str]:
+def scanAtEncodingDirectives(aList: List) -> Optional[str]:
     """Scan aList for @encoding directives."""
     for d in aList:
         encoding = d.get('encoding')
@@ -3558,13 +3557,13 @@ def scanAtEncodingDirectives(aList: Any) -> Optional[str]:
             g.error("invalid @encoding:", encoding)
     return None
 #@+node:ekr.20080827175609.53: *3* g.scanAtHeaderDirectives
-def scanAtHeaderDirectives(aList: Any) -> None:
+def scanAtHeaderDirectives(aList: List) -> None:
     """scan aList for @header and @noheader directives."""
     for d in aList:
         if d.get('header') and d.get('noheader'):
             g.error("conflicting @header and @noheader directives")
 #@+node:ekr.20080827175609.33: *3* g.scanAtLineendingDirectives
-def scanAtLineendingDirectives(aList: Any) -> Optional[str]:
+def scanAtLineendingDirectives(aList: List) -> Optional[str]:
     """Scan aList for @lineending directives."""
     for d in aList:
         e = d.get('lineending')
@@ -3575,7 +3574,7 @@ def scanAtLineendingDirectives(aList: Any) -> Optional[str]:
             # g.error("invalid @lineending directive:",e)
     return None
 #@+node:ekr.20080827175609.34: *3* g.scanAtPagewidthDirectives
-def scanAtPagewidthDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[str]:
+def scanAtPagewidthDirectives(aList: List, issue_error_flag: bool=False) -> Optional[str]:
     """Scan aList for @pagewidth directives."""
     for d in aList:
         s = d.get('pagewidth')
@@ -3587,7 +3586,7 @@ def scanAtPagewidthDirectives(aList: Any, issue_error_flag: bool=False) -> Optio
                 g.error("ignoring @pagewidth", s)
     return None
 #@+node:ekr.20101022172109.6108: *3* g.scanAtPathDirectives
-def scanAtPathDirectives(c: Cmdr, aList: Any) -> str:
+def scanAtPathDirectives(c: Cmdr, aList: List) -> str:
     path = c.scanAtPathDirectives(aList)
     return path
 
@@ -3596,7 +3595,7 @@ def scanAllAtPathDirectives(c: Cmdr, p: Pos) -> str:
     path = c.scanAtPathDirectives(aList)
     return path
 #@+node:ekr.20080827175609.37: *3* g.scanAtTabwidthDirectives
-def scanAtTabwidthDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[int]:
+def scanAtTabwidthDirectives(aList: List, issue_error_flag: bool=False) -> Optional[int]:
     """Scan aList for @tabwidth directives."""
     for d in aList:
         s = d.get('tabwidth')
@@ -3618,7 +3617,7 @@ def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos) -> Optional[int]:
         ret = None
     return ret
 #@+node:ekr.20080831084419.4: *3* g.scanAtWrapDirectives
-def scanAtWrapDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[bool]:
+def scanAtWrapDirectives(aList: List, issue_error_flag: bool=False) -> Optional[bool]:
     """Scan aList for @wrap and @nowrap directives."""
     for d in aList:
         if d.get('wrap') is not None:
@@ -3671,7 +3670,7 @@ def scanForAtSettings(p: Pos) -> bool:
             return True
     return False
 #@+node:ekr.20031218072017.1382: *3* g.set_delims_from_language
-def set_delims_from_language(language: Any) -> Tuple[str, str, str]:
+def set_delims_from_language(language: str) -> Tuple[str, str, str]:
     """Return a tuple (single,start,end) of comment delims."""
     val = g.app.language_delims_dict.get(language)
     if val:
@@ -3757,7 +3756,7 @@ def set_language(s: str, i: int, issue_errors_flag: bool=False) -> Tuple:
         g.es("ignoring:", g.get_line(s, i))
     return None, None, None, None
 #@+node:ekr.20071109165315: *3* g.stripPathCruft
-def stripPathCruft(path: Any) -> str:
+def stripPathCruft(path: str) -> str:
     """Strip cruft from a path name."""
     if not path:
         return path  # Retain empty paths for warnings.
@@ -3810,7 +3809,7 @@ def computeMachineName() -> str:
 def computeStandardDirectories() -> str:
     return g.app.loadManager.computeStandardDirectories()
 #@+node:ekr.20031218072017.3103: *3* g.computeWindowTitle
-def computeWindowTitle(fileName: Any) -> str:
+def computeWindowTitle(fileName: str) -> str:
 
     branch, commit = g.gitInfoForFile(fileName)  # #1616
     if not fileName:
@@ -3845,7 +3844,7 @@ def create_temp_file(textMode: bool=False) -> Tuple[Any, str]:
         theFile, theFileName = None, ''
     return theFile, theFileName
 #@+node:ekr.20210307060731.1: *3* g.createHiddenCommander
-def createHiddenCommander(fn: Any) -> Optional[Cmdr]:
+def createHiddenCommander(fn: str) -> Optional[Cmdr]:
     """Read the file into a hidden commander (Similar to g.openWithFileName)."""
     from leo.core.leoCommands import Commands
     c = Commands(fn, gui=g.app.nullGui)
@@ -3860,7 +3859,7 @@ def defaultLeoFileExtension(c: Cmdr=None) -> str:
     conf = c.config if c else g.app.config
     return conf.getString('default-leo-extension') or '.leo'
 #@+node:ekr.20031218072017.3118: *3* g.ensure_extension
-def ensure_extension(name: Any, ext: Any) -> str:
+def ensure_extension(name: str, ext: str) -> str:
 
     theFile, old_ext = g.os_path_splitext(name)
     if not name:
@@ -3889,7 +3888,7 @@ def fullPath(c: Cmdr, p: Pos, simulate: bool=False) -> str:
             return g.os_path_finalize_join(path, fn)  # #1341.
     return ''
 #@+node:ekr.20190327192721.1: *3* g.get_files_in_directory
-def get_files_in_directory(directory: Any, kinds: Any=None, recursive: bool=True) -> List[str]:
+def get_files_in_directory(directory: str, kinds: List=None, recursive: bool=True) -> List[str]:
     """
     Return a list of all files of the given file extensions in the directory.
     Default kinds: ['*.py'].
@@ -3997,7 +3996,7 @@ def init_dialog_folder(c: Cmdr, p: Pos, use_at_path: bool=True) -> str:
 def is_binary_file(f: Any) -> bool:
     return f and isinstance(f, io.BufferedIOBase)
 
-def is_binary_external_file(fileName: Any) -> bool:
+def is_binary_external_file(fileName: str) -> bool:
     try:
         with open(fileName, 'rb') as f:
             s = f.read(1024)  # bytes, in Python 3.
@@ -4014,7 +4013,7 @@ def is_binary_string(s: str) -> bool:
     aList = [7, 8, 9, 10, 12, 13, 27] + list(range(0x20, 0x100))
     return bool(s.translate(None, bytes(aList)))  # type:ignore
 #@+node:EKR.20040504154039: *3* g.is_sentinel
-def is_sentinel(line: Any, delims: Any) -> bool:
+def is_sentinel(line: str, delims: Sequence) -> bool:
     """Return True if line starts with a sentinel comment."""
     delim1, delim2, delim3 = delims
     line = line.lstrip()
@@ -4027,7 +4026,7 @@ def is_sentinel(line: Any, delims: Any) -> bool:
     g.error(f"is_sentinel: can not happen. delims: {repr(delims)}")
     return False
 #@+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir: Any) -> Optional[str]:
+def makeAllNonExistentDirectories(theDir: str) -> Optional[str]:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -4054,7 +4053,7 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
         return s
     return fullPath
 #@+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> Cmdr:
+def openWithFileName(fileName: str, old_c: Cmdr=None, gui: str=None) -> Cmdr:
     """
     Create a Leo Frame for the indicated fileName if the file exists.
 
@@ -4062,7 +4061,7 @@ def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> Cmdr:
     """
     return g.app.loadManager.loadLocalFile(fileName, gui, old_c)
 #@+node:ekr.20150306035851.7: *3* g.readFileIntoEncodedString
-def readFileIntoEncodedString(fn: Any, silent: bool=False) -> Optional[bytes]:
+def readFileIntoEncodedString(fn: str, silent: bool=False) -> Optional[bytes]:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -4287,7 +4286,7 @@ def findAncestorVnodeByPredicate(p: Pos, v_predicate: Any) -> Optional["VNode"]:
                 parents.append(grand_parent_v)
     return None
 #@+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> List[Pos]:
+def findRootsWithPredicate(c: Cmdr, root: Pos, predicate: Any=None) -> List[Pos]:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4351,7 +4350,7 @@ def recursiveUNLSearch(
     if g.unitTesting:
         return True, maxdepth, maxp
 
-    def moveToP(c: Cmdr, p: Pos, unlList: Any) -> None:
+    def moveToP(c: Cmdr, p: Pos, unlList: List) -> None:
         # Process events, to calculate new sizes.
         g.app.gui.qtApp.processEvents()
         c.expandAllAncestors(p)
@@ -4386,7 +4385,7 @@ def recursiveUNLFind(
     depth: int=0,
     p: Pos=None,
     maxdepth: int=0,
-    maxp: Any=None,
+    maxp: Pos=None,
     soft_idx: bool=False,
     hard_idx: bool=False,
 ) -> Tuple[bool, int, Pos]:
@@ -4508,7 +4507,7 @@ def recursiveUNLFind(
             maxdepth = p.level()  # type:ignore
     return False, maxdepth, maxp
 #@+node:tbrown.20171221094755.1: *4* g.recursiveUNLParts
-def recursiveUNLParts(text: Any) -> Tuple:
+def recursiveUNLParts(text: str) -> Tuple:
     """Parse the tail, returning whatever follows ':'.
 
     Examples: foo or foo:2 or foo:2,0,4,10.
@@ -4533,7 +4532,7 @@ def scanError(s: str) -> None:
 #@+node:ekr.20031218072017.3157: *3* g.scanf
 # A quick and dirty sscanf.  Understands only %s and %d.
 
-def scanf(s: str, pat: Any) -> List[str]:
+def scanf(s: str, pat: str) -> List[str]:
     count = pat.count("%s") + pat.count("%d")
     pat = pat.replace("%s", r"(\S+)")
     pat = pat.replace("%d", r"(\d+)")
@@ -4863,14 +4862,14 @@ def find_line_start(s: str, i: int) -> int:
     i = s.rfind('\n', 0, i + 1)  # Finds the highest index in the range.
     return 0 if i == -1 else i + 1
 #@+node:ekr.20031218072017.3176: *4* g.find_on_line
-def find_on_line(s: str, i: int, pattern: Any) -> int:
+def find_on_line(s: str, i: int, pattern: str) -> int:
     j = s.find('\n', i)
     if j == -1:
         j = len(s)
     k = s.find(pattern, i, j)
     return k
 #@+node:ekr.20031218072017.3179: *4* g.g.is_special
-def is_special(s: str, directive: Any) -> Tuple[bool, int]:
+def is_special(s: str, directive: str) -> Tuple[bool, int]:
     """Return True if the body text contains the @ directive."""
     assert(directive and directive[0] == '@')
     lws = directive in ("@others", "@all")
@@ -4896,21 +4895,21 @@ def is_ws_or_nl(s: str, i: int) -> bool:
 #@+node:ekr.20031218072017.3181: *4* g.match
 # Warning: this code makes no assumptions about what follows pattern.
 
-def match(s: str, i: int, pattern: Any) -> bool:
+def match(s: str, i: int, pattern: str) -> bool:
     return bool(s and pattern and s.find(pattern, i, i + len(pattern)) == i)
 #@+node:ekr.20031218072017.3182: *4* g.match_c_word
-def match_c_word(s: str, i: int, name: Any) -> bool:
+def match_c_word(s: str, i: int, name: str) -> bool:
     n = len(name)
-    return (
+    return bool(
         name and
         name == s[i : i + n] and
         (i + n == len(s) or not g.is_c_id(s[i + n]))
     )
 #@+node:ekr.20031218072017.3183: *4* g.match_ignoring_case
-def match_ignoring_case(s1: Any, s2: Any) -> bool:
-    return s1 and s2 and s1.lower() == s2.lower()
+def match_ignoring_case(s1: str, s2: str) -> bool:
+    return bool(s1 and s2 and s1.lower() == s2.lower())
 #@+node:ekr.20031218072017.3184: *4* g.match_word & g.match_words
-def match_word(s: str, i: int, pattern: Any) -> bool:
+def match_word(s: str, i: int, pattern: str) -> bool:
 
     # Using a regex is surprisingly tricky.
     if pattern is None:
@@ -4927,7 +4926,7 @@ def match_word(s: str, i: int, pattern: Any) -> bool:
     ch = s[i + j]
     return not g.isWordChar(ch)
 
-def match_words(s: str, i: int, patterns: Any) -> bool:
+def match_words(s: str, i: int, patterns: Sequence[str]) -> bool:
     return any(g.match_word(s, i, pattern) for pattern in patterns)
 #@+node:ekr.20031218072017.3185: *4* g.skip_blank_lines
 # This routine differs from skip_ws_and_nl in that
@@ -4952,7 +4951,7 @@ def skip_c_id(s: str, i: int) -> int:
         i += 1
     return i
 #@+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: Any=None) -> int:
+def skip_id(s: str, i: int, chars: str=None) -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -5087,7 +5086,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
     return i
 #@+node:ekr.20170414034616.1: ** g.Git
 #@+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url: Any=None) -> None:
+def backupGitIssues(c: Cmdr, base_url: str=None) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -5101,7 +5100,7 @@ def backupGitIssues(c: Cmdr, base_url: Any=None) -> None:
     c.redraw()
     g.trace('done')
 #@+node:ekr.20170616102324.1: *3* g.execGitCommand
-def execGitCommand(command: Any, directory: Any) -> List[str]:
+def execGitCommand(command: str, directory: str) -> List[str]:
     """Execute the given git command in the given directory."""
     git_dir = g.os_path_finalize_join(directory, '.git')
     if not g.os_path_exists(git_dir):
@@ -5155,7 +5154,7 @@ class GitIssueController:
     """
     #@+others
     #@+node:ekr.20180325023336.1: *5* git.backup_issues
-    def backup_issues(self, base_url: Any, c: Cmdr, label_list: Any, root: Any, state: Any=None) -> None:
+    def backup_issues(self, base_url: str, c: Cmdr, label_list: List, root: Pos, state: Any=None) -> None:
 
         self.base_url = base_url
         self.root = root
@@ -5174,7 +5173,7 @@ class GitIssueController:
         else:
             g.es_print('state must be in (None, "open", "closed")')
     #@+node:ekr.20180325024334.1: *5* git.get_all_issues
-    def get_all_issues(self, label_list: Any, root: Any, state: Any, limit: int=100) -> None:
+    def get_all_issues(self, label_list: List, root: Pos, state: Any, limit: int=100) -> None:
         """Get all issues for the base url."""
         try:
             import requests
@@ -5205,7 +5204,7 @@ class GitIssueController:
                 g.trace('too many pages')
                 break
     #@+node:ekr.20180126044850.1: *5* git.get_issues
-    def get_issues(self, base_url: Any, label_list: Any, milestone: Any, root: Any, state: Any) -> None:
+    def get_issues(self, base_url: str, label_list: List, milestone: Any, root: Pos, state: Any) -> None:
         """Create a list of issues for each label in label_list."""
         self.base_url = base_url
         self.milestone = milestone
@@ -5213,7 +5212,7 @@ class GitIssueController:
         for label in label_list:
             self.get_one_issue(label, state)
     #@+node:ekr.20180126043719.3: *5* git.get_one_issue
-    def get_one_issue(self, label: Any, state: Any, limit: int=20) -> None:
+    def get_one_issue(self, label: str, state: Any, limit: int=20) -> None:
         """Create a list of issues with the given label."""
         try:
             import requests
@@ -5248,7 +5247,7 @@ class GitIssueController:
         else:
             root.h = f"{total} {state} {label} issues"
     #@+node:ekr.20180126043719.4: *5* git.get_one_page
-    def get_one_page(self, label: Any, page: Any, r: Any, root: Any) -> Tuple[bool, int]:
+    def get_one_page(self, label: str, page: int, r: Any, root: Pos) -> Tuple[bool, int]:
 
         if self.milestone:
             aList = [
@@ -5311,7 +5310,7 @@ def getGitVersion(directory: str=None) -> Tuple[str, str, str]:
 
     info = [g.toUnicode(z) for z in s.splitlines()]
 
-    def find(kind: Any) -> str:
+    def find(kind: str) -> str:
         """Return the given type of log line."""
         for z in info:
             if z.startswith(kind):
@@ -5488,11 +5487,11 @@ def doHook(tag: str, *args: Any, **keywords: Any) -> Any:
 #@+node:ekr.20100910075900.5950: *3* g.Wrappers for g.app.pluginController methods
 # Important: we can not define g.pc here!
 #@+node:ekr.20100910075900.5951: *4* g.Loading & registration
-def loadOnePlugin(pluginName: Any, verbose: bool=False) -> Any:
+def loadOnePlugin(pluginName: str, verbose: bool=False) -> Any:
     pc = g.app.pluginsController
     return pc.loadOnePlugin(pluginName, verbose=verbose)
 
-def registerExclusiveHandler(tags: Any, fn: Any) -> Any:
+def registerExclusiveHandler(tags: List[str], fn: str) -> Any:
     pc = g.app.pluginsController
     return pc.registerExclusiveHandler(tags, fn)
 
@@ -5500,11 +5499,11 @@ def registerHandler(tags: Any, fn: Any) -> Any:
     pc = g.app.pluginsController
     return pc.registerHandler(tags, fn)
 
-def plugin_signon(module_name: Any, verbose: bool=False) -> Any:
+def plugin_signon(module_name: str, verbose: bool=False) -> Any:
     pc = g.app.pluginsController
     return pc.plugin_signon(module_name, verbose)
 
-def unloadOnePlugin(moduleOrFileName: Any, verbose: bool=False) -> Any:
+def unloadOnePlugin(moduleOrFileName: str, verbose: bool=False) -> Any:
     pc = g.app.pluginsController
     return pc.unloadOnePlugin(moduleOrFileName, verbose)
 
@@ -5537,7 +5536,7 @@ def enableIdleTimeHook(*args: Any, **keys: Any) -> None:
     """Enable idle-time processing."""
     g.app.idle_time_hooks_enabled = True
 #@+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Any, delay: int=500, tag: Any=None) -> Any:
+def IdleTime(handler: Any, delay: int=500, tag: str=None) -> Any:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
@@ -5635,7 +5634,7 @@ def convertPythonIndexToRowCol(s: str, i: int) -> Tuple[int, int]:
     prevNL = s.rfind('\n', 0, i)  # Don't include i
     return row, i - prevNL - 1
 #@+node:ekr.20050315071727: *4* g.convertRowColToPythonIndex
-def convertRowColToPythonIndex(s: str, row: Any, col: Any, lines: Any=None) -> int:
+def convertRowColToPythonIndex(s: str, row: int, col: int, lines: List[str]=None) -> int:
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
@@ -5733,7 +5732,7 @@ def ensureTrailingNewlines(s: str, n: int) -> str:
     s = g.removeTrailing(s, '\t\n\r ')
     return s + '\n' * n
 #@+node:ekr.20050920084036.4: *4* g.longestCommonPrefix & g.itemsMatchingPrefixInList
-def longestCommonPrefix(s1: Any, s2: Any) -> str:
+def longestCommonPrefix(s1: str, s2: str) -> str:
     """Find the longest prefix common to strings s1 and s2."""
     prefix = ''
     for ch in s1:
@@ -5743,7 +5742,7 @@ def longestCommonPrefix(s1: Any, s2: Any) -> str:
             return prefix
     return prefix
 
-def itemsMatchingPrefixInList(s: str, aList: Any, matchEmptyPrefix: bool=False) -> Tuple[List, str]:
+def itemsMatchingPrefixInList(s: str, aList: List[str], matchEmptyPrefix: bool=False) -> Tuple[List, str]:
     """This method returns a sorted list items of aList whose prefix is s.
 
     It also returns the longest common prefix of all the matches.
@@ -5941,7 +5940,7 @@ def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> 
 #@+node:ekr.20050208093800.1: *4* g.toUnicode
 unicode_warnings: Dict[str, bool] = {}  # Keys are g.callers.
 
-def toUnicode(s: Any, encoding: Optional[str]=None, reportErrors: bool=False) -> str:
+def toUnicode(s: Any, encoding: str=None, reportErrors: bool=False) -> str:
     """Convert bytes to unicode if necessary."""
     if isinstance(s, str):
         return s
@@ -5973,7 +5972,7 @@ def toUnicode(s: Any, encoding: Optional[str]=None, reportErrors: bool=False) ->
 #@+node:ekr.20031218072017.3198: *4* g.computeLeadingWhitespace
 # Returns optimized whitespace corresponding to width with the indicated tab_width.
 
-def computeLeadingWhitespace(width: Any, tab_width: Any) -> str:
+def computeLeadingWhitespace(width: int, tab_width: int) -> str:
     if width <= 0:
         return ""
     if tab_width > 1:
@@ -5985,7 +5984,7 @@ def computeLeadingWhitespace(width: Any, tab_width: Any) -> str:
 #@+node:ekr.20120605172139.10263: *4* g.computeLeadingWhitespaceWidth
 # Returns optimized whitespace corresponding to width with the indicated tab_width.
 
-def computeLeadingWhitespaceWidth(s: str, tab_width: Any) -> int:
+def computeLeadingWhitespaceWidth(s: str, tab_width: int) -> int:
     w = 0
     for ch in s:
         if ch == ' ':
@@ -5998,7 +5997,7 @@ def computeLeadingWhitespaceWidth(s: str, tab_width: Any) -> int:
 #@+node:ekr.20031218072017.3199: *4* g.computeWidth
 # Returns the width of s, assuming s starts a line, with indicated tab_width.
 
-def computeWidth(s: str, tab_width: Any) -> int:
+def computeWidth(s: str, tab_width: int) -> int:
     w = 0
     for ch in s:
         if ch == '\t':
@@ -6021,7 +6020,7 @@ def computeWidth(s: str, tab_width: Any) -> int:
 #@@c
 #@@language python
 
-def wrap_lines(lines: Any, pageWidth: Any, firstLineWidth: Any=None) -> List[str]:
+def wrap_lines(lines: List[str], pageWidth: int, firstLineWidth: int=None) -> List[str]:
     """Returns a list of lines, consisting of the input lines wrapped to the given pageWidth."""
     if pageWidth < 10:
         pageWidth = 10
@@ -6097,7 +6096,7 @@ def get_leading_ws(s: str) -> str:
 #@+node:ekr.20031218072017.3201: *4* g.optimizeLeadingWhitespace
 # Optimize leading whitespace in s with the given tab_width.
 
-def optimizeLeadingWhitespace(line: Any, tab_width: Any) -> str:
+def optimizeLeadingWhitespace(line: str, tab_width: int) -> str:
     i, width = g.skip_leading_ws_with_indent(line, 0, tab_width)
     s = g.computeLeadingWhitespace(width, tab_width) + line[i:]
     return s
@@ -6110,7 +6109,7 @@ def optimizeLeadingWhitespace(line: Any, tab_width: Any) -> str:
 # the meaning of program or data.
 #@@c
 
-def regularizeTrailingNewlines(s: str, kind: Any) -> None:
+def regularizeTrailingNewlines(s: str, kind: str) -> None:
     """Kind is 'asis', 'zero' or 'one'."""
     pass
 #@+node:ekr.20091229090857.11698: *4* g.removeBlankLines
@@ -6162,7 +6161,7 @@ def removeTrailingWs(s: str) -> str:
 #@+node:ekr.20031218072017.3204: *4* g.skip_leading_ws
 # Skips leading up to width leading whitespace.
 
-def skip_leading_ws(s: str, i: int, ws: Any, tab_width: Any) -> int:
+def skip_leading_ws(s: str, i: int, ws: int, tab_width: int) -> int:
     count = 0
     while count < ws and i < len(s):
         ch = s[i]
@@ -6207,7 +6206,7 @@ def stripBlankLines(s: str) -> str:
 # g.pr prints to the console.
 # g.es_print and related print to both the Log window and the console.
 #@+node:ekr.20080821073134.2: *3* g.doKeywordArgs
-def doKeywordArgs(keys: Any, d: Dict=None) -> Dict:
+def doKeywordArgs(keys: Dict, d: Dict=None) -> Dict:
     """
     Return a result dict that is a copy of the keys dict
     with missing items replaced by defaults in d dict.
@@ -6454,7 +6453,7 @@ def internalError(*args: Any) -> None:
     g.es_print('Called from', ', '.join(callers[:-1]))
     g.es_print('Please report this error to Leo\'s developers', color='red')
 #@+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn: Any=None) -> None:
+def log_to_file(s: str, fn: str=None) -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.os_path_expanduser('~/test/leo_log.txt')
@@ -6523,7 +6522,7 @@ def prettyPrintType(obj: Any) -> str:
         t = t[:-2]
     return t
 #@+node:ekr.20031218072017.3113: *3* g.printBindings
-def print_bindings(name: Any, window: Any) -> None:
+def print_bindings(name: str, window: Any) -> None:
     bindings = window.bind()
     g.pr("\nBindings for", name)
     for b in bindings:
@@ -6535,7 +6534,7 @@ def printEntireTree(c: Cmdr, tag: str='') -> None:
     for p in c.all_positions():
         g.pr('..' * p.level(), p.v)
 #@+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message: Any=None) -> None:
+def printGlobals(message: str=None) -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6546,7 +6545,7 @@ def printGlobals(message: Any=None) -> None:
     for name in globs:
         g.pr(name)
 #@+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message: Any=None) -> None:
+def printLeoModules(message: str=None) -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6704,10 +6703,10 @@ def actualColor(color: str) -> str:
 # Simplified version by EKR: stringCompare not used.
 
 def CheckVersion(
-    s1: Any,
-    s2: Any,
+    s1: str,
+    s2: str,
     condition: str=">=",
-    stringCompare: Any=None,
+    stringCompare: bool=None,
     delimiter: str='.',
     trace: bool=False,
 ) -> bool:
@@ -6755,7 +6754,7 @@ def cls(event: Any=None) -> None:
     if sys.platform.lower().startswith('win'):
         os.system('cls')
 #@+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName: Any=None) -> None:
+def createScratchCommander(fileName: str=None) -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6763,7 +6762,7 @@ def createScratchCommander(fileName: Any=None) -> None:
     frame.setInitialWindowGeometry()
     frame.resizePanesToRatio(frame.ratio, frame.secondary_ratio)
 #@+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f: Any, theClass: Any, name: Any=None) -> None:
+def funcToMethod(f: Any, theClass: Any, name: str=None) -> None:
     """
     From the Python Cookbook...
 
@@ -6785,7 +6784,7 @@ init_zodb_import_failed = False
 init_zodb_failed: Dict[str, bool] = {}  # Keys are paths, values are True.
 init_zodb_db: Dict[str, Any] = {}  # Keys are paths, values are ZODB.DB instances.
 
-def init_zodb(pathToZodbStorage: Any, verbose: bool=True) -> Any:
+def init_zodb(pathToZodbStorage: str, verbose: bool=True) -> Any:
     """
     Return an ZODB.DB instance from the given path.
     return None on any error.
@@ -6836,7 +6835,7 @@ def input_(message: str='', c: Cmdr=None) -> str:
 def isMacOS() -> bool:
     return sys.platform == 'darwin'
 #@+node:ekr.20181027133311.1: *3* g.issueSecurityWarning
-def issueSecurityWarning(setting: Any) -> None:
+def issueSecurityWarning(setting: str) -> None:
     g.es('Security warning! Ignoring...', color='red')
     g.es(setting, color='red')
     g.es('This setting can be set only in')
@@ -6892,7 +6891,7 @@ def windows() -> Optional[List]:
 #@+at Note: all these methods return Unicode strings. It is up to the user to
 # convert to an encoded string as needed, say when opening a file.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
-def glob_glob(pattern: Any) -> List:
+def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
     aList = glob.glob(pattern)
     # os.path.normpath does the *reverse* of what we want.
@@ -7092,7 +7091,7 @@ def os_path_splitext(path: str) -> Tuple[str, str]:
 def os_startfile(fname: str) -> None:
     #@+others
     #@+node:bob.20170516112250.1: *4* stderr2log()
-    def stderr2log(g: Any, ree: Any, fname: Any) -> None:
+    def stderr2log(g: Any, ree: Any, fname: str) -> None:
         """ Display stderr output in the Leo-Editor log pane
 
         Arguments:
@@ -7111,7 +7110,7 @@ def os_startfile(fname: str) -> None:
             else:
                 break
     #@+node:bob.20170516112304.1: *4* itPoll()
-    def itPoll(fname: Any, ree: Any, subPopen: Any, g: Any, ito: Any) -> None:
+    def itPoll(fname: str, ree: Any, subPopen: Any, g: Any, ito: Any) -> None:
         """ Poll for subprocess done
 
         Arguments:
@@ -7276,7 +7275,7 @@ def python_tokenize(s: str) -> List:
     return result
 #@+node:ekr.20040327103735.2: ** g.Scripting
 #@+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d: Dict[str, str], script: Any=None) -> None:
+def exec_file(path: str, d: Dict[str, str], script: str=None) -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
@@ -7412,7 +7411,7 @@ def executeFile(filename: str, options: str='') -> None:
 #@+node:ekr.20040321065415: *3* g.find*Node*
 #@+others
 #@+node:ekr.20210303123423.3: *4* findNodeAnywhere
-def findNodeAnywhere(c: Cmdr, headline: Any, exact: bool=True) -> Optional[Pos]:
+def findNodeAnywhere(c: Cmdr, headline: str, exact: bool=True) -> Optional[Pos]:
     h = headline.strip()
     for p in c.all_unique_positions(copy=False):
         if p.h.strip() == h:
@@ -7435,7 +7434,7 @@ def findNodeByPath(c: Cmdr, path: str) -> Optional[Pos]:
                 return p
     return None
 #@+node:ekr.20210303123423.1: *4* findNodeInChildren
-def findNodeInChildren(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> Optional[Pos]:
+def findNodeInChildren(c: Cmdr, p: Pos, headline: str, exact: bool=True) -> Optional[Pos]:
     """Search for a node in v's tree matching the given headline."""
     p1 = p.copy()
     h = headline.strip()
@@ -7570,7 +7569,7 @@ def extractExecutableString(c: Cmdr, p: Pos, s: str) -> str:
             result.append(line)
     return ''.join(result)
 #@+node:ekr.20060624085200: *3* g.handleScriptException
-def handleScriptException(c: Cmdr, p: Pos, script: Any, script1: Any) -> None:
+def handleScriptException(c: Cmdr, p: Pos, script: str, script1: str) -> None:
     g.warning("exception executing script")
     full = c.config.getBool('show-full-tracebacks-in-scripts')
     fileName, n = g.es_exception(full=full)
@@ -7628,7 +7627,7 @@ def run_coverage_tests(module: str='', filename: str='') -> None:
     command = f"{prefix} {module} {filename}"
     g.execute_shell_commands(command, trace=False)
 #@+node:ekr.20200221050038.1: *3* g.run_unit_test_in_separate_process
-def run_unit_test_in_separate_process(command: Any) -> None:
+def run_unit_test_in_separate_process(command: str) -> None:
     """
     A script to be run from unitTest.leo.
 
@@ -7658,7 +7657,7 @@ def run_unit_test_in_separate_process(command: Any) -> None:
         g.printObj(err_lines, tag='err_lines')
         assert False
 #@+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests: Any=None, verbose: bool=False) -> None:
+def run_unit_tests(tests: str=None, verbose: bool=False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -7771,7 +7770,7 @@ def handleUrl(url: str, c: Cmdr=None, p: Pos=None) -> Any:
         g.es_exception()
         return None
 #@+node:ekr.20170226054459.1: *4* g.handleUrlHelper
-def handleUrlHelper(url: Any, c: Cmdr, p: Pos) -> None:
+def handleUrlHelper(url: str, c: Cmdr, p: Pos) -> None:
     """Open a url.  Most browsers should handle:
         ftp://ftp.uu.net/public/whatever
         http://localhost/MySiteUnderDevelopment/index.html
@@ -7812,7 +7811,7 @@ def handleUrlHelper(url: Any, c: Cmdr, p: Pos) -> None:
             except Exception:
                 pass
 #@+node:ekr.20170226060816.1: *4* g.traceUrl
-def traceUrl(c: Cmdr, path: str, parsed: Any, url: Any) -> None:
+def traceUrl(c: Cmdr, path: str, parsed: Any, url: str) -> None:
 
     print()
     g.trace('url          ', url)
@@ -7823,7 +7822,7 @@ def traceUrl(c: Cmdr, path: str, parsed: Any, url: Any) -> None:
     g.trace('parsed.path  ', parsed.path)
     g.trace('parsed.scheme', repr(parsed.scheme))
 #@+node:ekr.20170221063527.1: *3* g.handleUnl
-def handleUnl(unl: Any, c: Cmdr) -> Any:
+def handleUnl(unl: str, c: Cmdr) -> Any:
     """
     Handle a Leo UNL. This must *never* open a browser.
 
@@ -7893,7 +7892,7 @@ def handleUnl(unl: Any, c: Cmdr) -> Any:
         return c2
     return None
 #@+node:ekr.20120311151914.9918: *3* g.isValidUrl
-def isValidUrl(url: Any) -> bool:
+def isValidUrl(url: str) -> bool:
     """Return true if url *looks* like a valid url."""
     table = (
         'file', 'ftp', 'gopher', 'hdl', 'http', 'https', 'imap',

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1814,7 +1814,7 @@ class SherlockTracer:
                 ret = self.format_ret(arg)
             print(f"{path}{dots}-{full_name}{ret}")
     #@+node:ekr.20130111120935.10192: *5* sherlock.format_ret
-    def format_ret(self, arg):
+    def format_ret(self, arg: Any) -> str:
         """Format arg, the value returned by a "return" statement."""
         try:
             if isinstance(arg, types.GeneratorType):
@@ -1837,12 +1837,12 @@ class SherlockTracer:
             ret = f" ->\n    {s}" if len(s) > 40 else f" -> {s}"
         return f" -> {ret}"
     #@+node:ekr.20121128111829.12185: *4* sherlock.fn_is_enabled (not used)
-    def fn_is_enabled(self, func, patterns):
+    def fn_is_enabled(self, func: Any, patterns: List[str]) -> bool:
         """Return True if tracing for the given function is enabled."""
         if func in self.ignored_functions:
             return False
 
-        def ignore_function():
+        def ignore_function() -> None:
             if func not in self.ignored_functions:
                 self.ignored_functions.append(func)
                 print(f"Ignore function: {func}")
@@ -1884,7 +1884,7 @@ class SherlockTracer:
             self.bad_pattern(pattern)
             return False
     #@+node:ekr.20130112093655.10195: *4* get_full_name
-    def get_full_name(self, locals_, name):
+    def get_full_name(self, locals_: Any, name: str) -> str:
         """Return class_name::name if possible."""
         full_name = name
         try:
@@ -1898,7 +1898,11 @@ class SherlockTracer:
     ignored_files: List[str] = []  # List of files.
     ignored_functions: List[str] = []  # List of files.
 
-    def is_enabled(self, file_name, function_name, patterns=None):
+    def is_enabled(self,
+        file_name: str,
+        function_name: str,
+        patterns: List[str]=None,
+    ) -> bool:
         """Return True if tracing for function_name in the given file is enabled."""
         #
         # New in Leo 6.3. Never trace through some files.
@@ -1970,7 +1974,7 @@ class SherlockTracer:
                 self.bad_pattern(pattern)
         return enabled
     #@+node:ekr.20121128111829.12182: *4* print_stats
-    def print_stats(self, patterns=None):
+    def print_stats(self, patterns: List[str]=None) -> None:
         """Print all accumulated statisitics."""
         print('\nSherlock statistics...')
         if not patterns:
@@ -1978,9 +1982,9 @@ class SherlockTracer:
         for fn in sorted(self.stats.keys()):
             d = self.stats.get(fn)
             if self.fn_is_enabled(fn, patterns):
-                result = sorted(d.keys())
+                result = sorted(d.keys())  # type:ignore
             else:
-                result = [key for key in sorted(d.keys())
+                result = [key for key in sorted(d.keys())  # type:ignore
                     if self.is_enabled(fn, key, patterns)]
             if result:
                 print('')
@@ -1992,7 +1996,7 @@ class SherlockTracer:
     #@+node:ekr.20121128031949.12614: *4* run
     # Modified from pdb.Pdb.set_trace.
 
-    def run(self, frame=None):
+    def run(self, frame: Any=None) -> None:
         """Trace from the given frame or the caller's frame."""
         print("SherlockTracer.run:patterns:\n%s" % '\n'.join(self.patterns))
         if frame is None:
@@ -2005,25 +2009,25 @@ class SherlockTracer:
         # Pass self to sys.settrace to give easy access to all methods.
         sys.settrace(self)
     #@+node:ekr.20140322090829.16834: *4* push & pop
-    def push(self, patterns):
+    def push(self, patterns: List[str]) -> None:
         """Push the old patterns and set the new."""
-        self.pattern_stack.append(self.patterns)
+        self.pattern_stack.append(self.patterns)  # type:ignore
         self.set_patterns(patterns)
         print(f"SherlockTracer.push: {self.patterns}")
 
-    def pop(self):
+    def pop(self) -> None:
         """Restore the pushed patterns."""
         if self.pattern_stack:
-            self.patterns = self.pattern_stack.pop()
+            self.patterns = self.pattern_stack.pop()  # type:ignore
             print(f"SherlockTracer.pop: {self.patterns}")
         else:
             print('SherlockTracer.pop: pattern stack underflow')
     #@+node:ekr.20140326100337.16845: *4* set_patterns
-    def set_patterns(self, patterns):
+    def set_patterns(self, patterns: List[str]) -> None:
         """Set the patterns in effect."""
         self.patterns = [z for z in patterns if self.check_pattern(z)]
     #@+node:ekr.20140322090829.16831: *4* show
-    def show(self, item):
+    def show(self, item: Any) -> str:
         """return the best representation of item."""
         if not item:
             return repr(item)
@@ -2036,7 +2040,7 @@ class SherlockTracer:
             return s[:17] + '...'
         return repr(item)
     #@+node:ekr.20121128093229.12616: *4* stop
-    def stop(self):
+    def stop(self) -> None:
         """Stop all tracing."""
         sys.settrace(None)
     #@-others

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -36,7 +36,7 @@ import time
 import traceback
 import types
 from typing import TYPE_CHECKING
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -141,7 +141,7 @@ cmd_instance_dict = {
 #@+node:ekr.20150508165324.1: ** << define g.Decorators >>
 #@+others
 #@+node:ekr.20150510104148.1: *3* g.check_cmd_instance_dict
-def check_cmd_instance_dict(c: Cmdr, g) -> None:
+def check_cmd_instance_dict(c: Cmdr, g: Any) -> None:
     """
     Check g.check_cmd_instance_dict.
     This is a permanent unit test, called from c.finishCreate.
@@ -149,7 +149,7 @@ def check_cmd_instance_dict(c: Cmdr, g) -> None:
     d = cmd_instance_dict
     for key in d:
         ivars = d.get(key)
-        obj = ivars2instance(c, g, ivars)
+        obj = ivars2instance(c, g, ivars)  # type:ignore
             # Produces warnings.
         if obj:
             name = obj.__class__.__name__

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -99,7 +99,7 @@ directives_pat = None  # Set below.
 # The cmd_instance_dict supports per-class @cmd decorators. For example, the
 # following appears in leo.commands.
 #
-#     def cmd(name):
+#     def cmd(name: Any) -> None:
 #         """Command decorator for the abbrevCommands class."""
 #         return g.new_cmd_decorator(name, ['c', 'abbrevCommands',])
 #
@@ -164,7 +164,7 @@ class Command:
     commands that could befined inside a class. The typical usage is:
 
         @g.command('command-name')
-        def A_Command(event):
+        def A_Command(event: Any) -> None:
             c = event.get('c')
             ...
 
@@ -203,7 +203,7 @@ class CommanderCommand:
     Usage:
 
         @g.command('command-name')
-        def command_name(self, *args, **kwargs):
+        def command_name(self, *args, **kwargs) -> None:
             ...
 
     The decorator injects command_name into the Commander class and calls
@@ -1912,12 +1912,12 @@ class SherlockTracer:
         if base_name in self.ignored_files:
             return False
 
-        def ignore_file():
+        def ignore_file() -> None:
             if not base_name in self.ignored_files:
                 self.ignored_files.append(base_name)
                 # print(f"Ignore file: {base_name}")
 
-        def ignore_function():
+        def ignore_function() -> None:
             if function_name not in self.ignored_functions:
                 self.ignored_functions.append(function_name)
                 # print(f"Ignore function: {function_name}")
@@ -2514,7 +2514,7 @@ class TypedDict:
 class UiTypeException(Exception):
     pass
 
-def assertUi(uitype):
+def assertUi(uitype: Any) -> None:
     if not g.app.gui.guiName() == uitype:
         raise UiTypeException
 #@+node:ekr.20200219071828.1: *3* class TestLeoGlobals (leoGlobals.py)
@@ -2522,7 +2522,7 @@ class TestLeoGlobals(unittest.TestCase):
     """Tests for leoGlobals.py."""
     #@+others
     #@+node:ekr.20200219071958.1: *4* test_comment_delims_from_extension
-    def test_comment_delims_from_extension(self):
+    def test_comment_delims_from_extension(self) -> None:
 
         # pylint: disable=import-self
         from leo.core import leoGlobals as leo_g
@@ -2532,7 +2532,7 @@ class TestLeoGlobals(unittest.TestCase):
         assert leo_g.comment_delims_from_extension(".c") == ('//', '/*', '*/')
         assert leo_g.comment_delims_from_extension(".html") == ('', '<!--', '-->')
     #@+node:ekr.20200219072957.1: *4* test_is_sentinel
-    def test_is_sentinel(self):
+    def test_is_sentinel(self) -> None:
 
         # pylint: disable=import-self
         from leo.core import leoGlobals as leo_g
@@ -2550,27 +2550,27 @@ class TestLeoGlobals(unittest.TestCase):
         assert not leo_g.is_sentinel("<!--comment-->", html_delims)
     #@-others
 #@+node:ekr.20140904112935.18526: *3* g.isTextWrapper & isTextWidget
-def isTextWidget(w):
+def isTextWidget(w: Any) -> None:
     return g.app.gui.isTextWidget(w)
 
-def isTextWrapper(w):
+def isTextWrapper(w: Any) -> None:
     return g.app.gui.isTextWrapper(w)
 #@+node:ekr.20160518074224.1: *3* class g.LinterTable
 class LinterTable():
     """A class to encapsulate lists of leo modules under test."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Ctor for LinterTable class."""
         # Define self. relative to leo.core.leoGlobals
         self.loadDir = g.os_path_finalize_join(g.__file__, '..', '..')
     #@+others
     #@+node:ekr.20160518074545.2: *4* commands
-    def commands(self):
+    def commands(self) -> None:
         """Return list of all command modules in leo/commands."""
         pattern = g.os_path_finalize_join(self.loadDir, 'commands', '*.py')
         return self.get_files(pattern)
     #@+node:ekr.20160518074545.3: *4* core
-    def core(self):
+    def core(self) -> None:
         """Return list of all of Leo's core files."""
         pattern = g.os_path_finalize_join(self.loadDir, 'core', 'leo*.py')
         aList = self.get_files(pattern)
@@ -2578,7 +2578,7 @@ class LinterTable():
             aList.append(g.os_path_finalize_join(self.loadDir, 'core', fn))
         return sorted(aList)
     #@+node:ekr.20160518074545.4: *4* external
-    def external(self):
+    def external(self) -> None:
         """Return list of files in leo/external"""
         pattern = g.os_path_finalize_join(self.loadDir, 'external', 'leo*.py')
         aList = self.get_files(pattern)
@@ -2589,14 +2589,14 @@ class LinterTable():
         remove = [g.os_path_finalize_join(self.loadDir, 'external', fn) for fn in remove]
         return sorted([z for z in aList if z not in remove])
     #@+node:ekr.20160520093506.1: *4* get_files (LinterTable)
-    def get_files(self, pattern):
+    def get_files(self, pattern: Any) -> None:
         """Return the list of absolute file names matching the pattern."""
         aList = sorted([
             fn for fn in g.glob_glob(pattern)
                 if g.os_path_isfile(fn) and g.shortFileName(fn) != '__init__.py'])
         return aList
     #@+node:ekr.20160518074545.9: *4* get_files_for_scope
-    def get_files_for_scope(self, scope, fn):
+    def get_files_for_scope(self, scope: Any, fn: Any) -> None:
         """Return a list of absolute filenames for external linters."""
         d = {
             'all': [self.core, self.commands, self.external, self.plugins],
@@ -2631,7 +2631,7 @@ class LinterTable():
         print('LinterTable.get_table: bad scope', scope)
         return []
     #@+node:ekr.20160518074545.5: *4* gui_plugins
-    def gui_plugins(self):
+    def gui_plugins(self) -> None:
         """Return list of all of Leo's gui-related files."""
         pattern = g.os_path_finalize_join(self.loadDir, 'plugins', 'qt_*.py')
         aList = self.get_files(pattern)
@@ -2645,12 +2645,12 @@ class LinterTable():
         remove = [g.os_path_finalize_join(self.loadDir, 'plugins', fn) for fn in remove]
         return sorted(set([z for z in aList if z not in remove]))
     #@+node:ekr.20160518074545.6: *4* modes
-    def modes(self):
+    def modes(self) -> None:
         """Return list of all files in leo/modes"""
         pattern = g.os_path_finalize_join(self.loadDir, 'modes', '*.py')
         return self.get_files(pattern)
     #@+node:ekr.20160518074545.8: *4* plugins (LinterTable)
-    def plugins(self):
+    def plugins(self) -> None:
         """Return a list of all important plugins."""
         aList = []
         for theDir in ('', 'importers', 'writers'):
@@ -2678,7 +2678,7 @@ class LinterTable():
         aList = sorted([z for z in aList if z not in remove])
         return sorted(set(aList))
     #@+node:ekr.20211115103929.1: *4* tests (LinterTable)
-    def tests(self):
+    def tests(self) -> None:
         """Return list of files in leo/unittests"""
         aList = []
         for theDir in ('', 'commands', 'core', 'plugins'):
@@ -2693,7 +2693,7 @@ class LinterTable():
 #@+node:ekr.20140711071454.17649: ** g.Debugging, GC, Stats & Timing
 #@+node:ekr.20031218072017.3104: *3* g.Debugging
 #@+node:ekr.20180415144534.1: *4* g.assert_is
-def assert_is(obj: Any, list_or_class, warn=True):
+def assert_is(obj: Any, list_or_class: Any, warn: bool=True) -> None:
 
     if warn:
         ok = isinstance(obj, list_or_class)
@@ -2708,7 +2708,7 @@ def assert_is(obj: Any, list_or_class, warn=True):
     assert ok, (obj, obj.__class__.__name__, g.callers())
     return ok
 #@+node:ekr.20180420081530.1: *4* g._assert
-def _assert(condition, show_callers=True):
+def _assert(condition: Any, show_callers: bool=True) -> None:
     """A safer alternative to a bare assert."""
     if g.unitTesting:
         assert condition
@@ -2721,7 +2721,7 @@ def _assert(condition, show_callers=True):
         g.es_print(g.callers())
     return False
 #@+node:ekr.20051023083258: *4* g.callers & g.caller & _callerName
-def callers(n=4, count=0, excludeCaller=True, verbose=False):
+def callers(n: int=4, count: int=0, excludeCaller: bool=True, verbose: bool=False) -> None:
     """
     Return a string containing a comma-separated list of the callers
     of the function that called g.callerList.
@@ -2748,7 +2748,7 @@ def callers(n=4, count=0, excludeCaller=True, verbose=False):
         return ''.join([f"\n  {z}" for z in result])
     return ','.join(result)
 #@+node:ekr.20031218072017.3107: *5* g._callerName
-def _callerName(n, verbose=False):
+def _callerName(n: int, verbose: bool=False) -> None:
     try:
         # get the function name from the call stack.
         f1 = sys._getframe(n)  # The stack frame, n levels up.
@@ -2770,17 +2770,17 @@ def _callerName(n, verbose=False):
         es_exception()
         return ''  # "<no caller name>"
 #@+node:ekr.20180328170441.1: *5* g.caller
-def caller(i: int=1):
+def caller(i: int=1) -> None:
     """Return the caller name i levels up the stack."""
     return g.callers(i + 1).split(',')[0]
 #@+node:ekr.20031218072017.3109: *4* g.dump
-def dump(s: str):
+def dump(s: str) -> None:
     out = ""
     for i in s:
         out += str(ord(i)) + ","
     return out
 
-def oldDump(s: str):
+def oldDump(s: str) -> None:
     out = ""
     for i in s:
         if i == '\n':
@@ -2799,7 +2799,7 @@ def oldDump(s: str):
             out += i
     return out
 #@+node:ekr.20210904114446.1: *4* g.dump_tree & g.tree_to_string
-def dump_tree(c, dump_body=False, msg=None):
+def dump_tree(c: Cmdr, dump_body: bool=False, msg: Any=None) -> None:
     if msg:
         print(msg.rstrip())
     else:
@@ -2810,7 +2810,7 @@ def dump_tree(c, dump_body=False, msg=None):
             for z in g.splitLines(p.b):
                 print(z.rstrip())
 
-def tree_to_string(c, dump_body=False, msg=None):
+def tree_to_string(c: Cmdr, dump_body: bool=False, msg: Any=None) -> None:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2821,7 +2821,7 @@ def tree_to_string(c, dump_body=False, msg=None):
                 result.append(z.rstrip())
     return '\n'.join(result)
 #@+node:ekr.20150227102835.8: *4* g.dump_encoded_string
-def dump_encoded_string(encoding, s: str):
+def dump_encoded_string(encoding: Any, s: str) -> None:
     """Dump s, assumed to be an encoded string."""
     # Can't use g.trace here: it calls this function!
     print(f"dump_encoded_string: {g.callers()}")
@@ -2836,17 +2836,17 @@ def dump_encoded_string(encoding, s: str):
         elif ch == '\n':
             in_comment = False
 #@+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod, format=None):
+def module_date(mod: Any, format: Any=None) -> None:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
-def plugin_date(plugin_mod, format=None):
+def plugin_date(plugin_mod: Any, format: Any=None) -> None:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
-def file_date(theFile, format=None):
+def file_date(theFile: Any, format: Any=None) -> None:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2859,7 +2859,7 @@ def file_date(theFile, format=None):
 #@+node:ekr.20031218072017.3127: *4* g.get_line & get_line__after
 # Very useful for tracing.
 
-def get_line(s: str, i: int):
+def get_line(s: str, i: int) -> None:
     nl = ""
     if g.is_nl(s, i):
         i = g.skip_nl(s, i)
@@ -2871,7 +2871,7 @@ def get_line(s: str, i: int):
 # Important: getLine is a completely different function.
 # getLine = get_line
 
-def get_line_after(s: str, i: int):
+def get_line_after(s: str, i: int) -> None:
     nl = ""
     if g.is_nl(s, i):
         i = g.skip_nl(s, i)
@@ -2906,13 +2906,13 @@ def checkUnchangedIvars(
                 ok = False
     return ok
 #@+node:ekr.20031218072017.3128: *4* g.pause
-def pause(s: str):
+def pause(s: str) -> None:
     g.pr(s)
     i = 0
     while i < 1000 * 1000:
         i += 1
 #@+node:ekr.20041105091148: *4* g.pdb
-def pdb(message=''):
+def pdb(message: str='') -> None:
     """Fall into pdb."""
     import pdb  # Required: we have just defined pdb as a function!
     if app and not app.useIpython:
@@ -2926,7 +2926,7 @@ def pdb(message=''):
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
 #@+node:ekr.20041224080039: *4* g.dictToString
-def dictToString(d, indent='', tag=None):
+def dictToString(d: Dict[str, str], indent: str='', tag: Any=None) -> None:
     """Pretty print a Python dict to a string."""
     # pylint: disable=unnecessary-lambda
     if not d:
@@ -2945,7 +2945,7 @@ def dictToString(d, indent='', tag=None):
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20041126060136: *4* g.listToString
-def listToString(obj: Any, indent='', tag=None):
+def listToString(obj: Any, indent: str='', tag: Any=None) -> None:
     """Pretty print a Python list to a string."""
     if not obj:
         return '[]'
@@ -2963,7 +2963,7 @@ def listToString(obj: Any, indent='', tag=None):
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
-def objToString(obj: Any, indent: str='', printCaller=False, tag=None):
+def objToString(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> None:
     """Pretty print any Python object to a string."""
     # pylint: disable=undefined-loop-variable
         # Looks like a a pylint bug.
@@ -3052,12 +3052,12 @@ def run_pylint(fn, rc,
             # When not waiting, printing from severl process can be interspersed.
             pass
 #@+node:ekr.20120912153732.10597: *4* g.wait
-def sleep(n):
+def sleep(n: int) -> None:
     """Wait about n milliseconds."""
     from time import sleep
     sleep(n)  #sleeps for 5 seconds
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: Any, indent='', printCaller=False, tag=None):
+def printObj(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> None:
     """Pretty print any Python object using g.pr."""
     g.pr(objToString(obj, indent=indent, printCaller=printCaller, tag=tag))
 
@@ -3065,7 +3065,7 @@ printDict = printObj
 printList = printObj
 printTuple = printObj
 #@+node:ekr.20171023110057.1: *4* g.tupleToString
-def tupleToString(obj: Any, indent='', tag=None):
+def tupleToString(obj: Any, indent: str='', tag: Any=None) -> None:
     """Pretty print a Python tuple to a string."""
     if not obj:
         return '(),'
@@ -3084,12 +3084,12 @@ def tupleToString(obj: Any, indent='', tag=None):
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20031218072017.1588: *3* g.Garbage Collection
 #@+node:ekr.20031218072017.1589: *4* g.clearAllIvars
-def clearAllIvars(o):
+def clearAllIvars(o: Any) -> None:
     """Clear all ivars of o, a member of some class."""
     if o:
         o.__dict__.clear()
 #@+node:ekr.20060127162818: *4* g.enable_gc_debug
-def enable_gc_debug():
+def enable_gc_debug() -> None:
 
     gc.set_debug(
         gc.DEBUG_STATS |  # prints statistics.
@@ -3102,7 +3102,7 @@ def enable_gc_debug():
 #@+node:ekr.20031218072017.1592: *4* g.printGc
 # Formerly called from unit tests.
 
-def printGc():
+def printGc() -> None:
     """Called from trace_gc_plugin."""
     g.printGcSummary()
     g.printGcObjects()
@@ -3110,7 +3110,7 @@ def printGc():
 #@+node:ekr.20060127164729.1: *4* g.printGcObjects
 lastObjectCount = 0
 
-def printGcObjects():
+def printGcObjects() -> None:
     """Print a summary of GC statistics."""
     global lastObjectCount
     n = len(gc.garbage)
@@ -3136,12 +3136,12 @@ def printGcObjects():
     lastObjectCount = count
     return delta
 #@+node:ekr.20031218072017.1593: *4* g.printGcRefs
-def printGcRefs():
+def printGcRefs() -> None:
 
     refs = gc.get_referrers(app.windowList[0])
     print(f"{len(refs):d} referers")
 #@+node:ekr.20060205043324.1: *4* g.printGcSummary
-def printGcSummary():
+def printGcSummary() -> None:
 
     g.enable_gc_debug()
     try:
@@ -3152,7 +3152,7 @@ def printGcSummary():
     except Exception:
         traceback.print_exc()
 #@+node:ekr.20180528151850.1: *3* g.printTimes
-def printTimes(times):
+def printTimes(times: Any) -> None:
     """
     Print the differences in the times array.
 
@@ -3164,12 +3164,12 @@ def printTimes(times):
             g.trace(f"*** {n} {t:5.4f} sec.")
 #@+node:ekr.20031218072017.3133: *3* g.Statistics
 #@+node:ekr.20031218072017.3134: *4* g.clearStats
-def clearStats():
+def clearStats() -> None:
 
     g.app.statsDict = {}
 #@+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event=None, name=None):
+def printStats(event: Any=None, name: Any=None) -> None:
     """
     Print all gathered statistics.
 
@@ -3196,7 +3196,7 @@ def printStats(event=None, name=None):
     for key in reversed(sorted(d)):
         print(f"{key:7} {d.get(key)}")
 #@+node:ekr.20031218072017.3136: *4* g.stat
-def stat(name=None):
+def stat(name: Any=None) -> None:
     """Increments the statistic for name in g.app.statsDict
     The caller's name is used by default.
     """
@@ -3208,27 +3208,27 @@ def stat(name=None):
         name = g._callerName(n=2)  # Get caller name 2 levels back.
     d[name] = 1 + d.get(name, 0)
 #@+node:ekr.20031218072017.3137: *3* g.Timing
-def getTime():
+def getTime() -> None:
     return time.time()
 
-def esDiffTime(message, start):
+def esDiffTime(message: Any, start: Any) -> None:
     delta = time.time() - start
     g.es('', f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def printDiffTime(message, start):
+def printDiffTime(message: Any, start: Any) -> None:
     delta = time.time() - start
     g.pr(f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def timeSince(start):
+def timeSince(start: Any) -> None:
     return f"{time.time()-start:5.2f} sec."
 #@+node:ekr.20031218072017.1380: ** g.Directives
 # Weird pylint bug, activated by TestLeoGlobals class.
 # Disabling this will be safe, because pyflakes will still warn about true redefinitions
 # pylint: disable=function-redefined
 #@+node:EKR.20040504150046.4: *3* g.comment_delims_from_extension
-def comment_delims_from_extension(filename):
+def comment_delims_from_extension(filename: Any) -> None:
     """
     Return the comment delims corresponding to the filename's extension.
     """
@@ -3247,7 +3247,7 @@ def comment_delims_from_extension(filename):
         f"root: {root!r}")
     return '', '', ''
 #@+node:ekr.20170201150505.1: *3* g.findAllValidLanguageDirectives
-def findAllValidLanguageDirectives(s: str):
+def findAllValidLanguageDirectives(s: str) -> None:
     """Return list of all valid @language directives in p.b"""
     if not s.strip():
         return []
@@ -3258,7 +3258,7 @@ def findAllValidLanguageDirectives(s: str):
             languages.add(language)
     return list(sorted(languages))
 #@+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Pos):
+def findTabWidthDirectives(c: Cmdr, p: Pos) -> None:
     """Return the language in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -3280,7 +3280,7 @@ def findTabWidthDirectives(c: Cmdr, p: Pos):
                     w = None
     return w
 #@+node:ekr.20170127142001.5: *3* g.findFirstAtLanguageDirective
-def findFirstValidAtLanguageDirective(s: str):
+def findFirstValidAtLanguageDirective(s: str) -> None:
     """Return the first *valid* @language directive ins."""
     if not s.strip():
         return None
@@ -3290,14 +3290,14 @@ def findFirstValidAtLanguageDirective(s: str):
             return language
     return None
 #@+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
-def findLanguageDirectives(c: Cmdr, p: Pos):
+def findLanguageDirectives(c: Cmdr, p: Pos) -> None:
     """Return the language in effect at position p."""
     if c is None or p is None:
         return None  # c may be None for testing.
 
     v0 = p.v
 
-    def find_language(p_or_v):
+    def find_language(p_or_v: Any) -> None:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
@@ -3330,7 +3330,7 @@ def findLanguageDirectives(c: Cmdr, p: Pos):
 # Called from the syntax coloring method that colorizes section references.
 # Also called from write at.putRefAt.
 
-def findReference(name, root):
+def findReference(name: Any, root: Any) -> None:
     """Return the position containing the section definition for name."""
     for p in root.subtree(copy=False):
         assert p != root
@@ -3341,7 +3341,7 @@ def findReference(name, root):
 # The caller passes [root_node] or None as the second arg.
 # This allows us to distinguish between None and [None].
 
-def get_directives_dict(p: Pos, root=None):
+def get_directives_dict(p: Pos, root: Any=None) -> None:
     """
     Scan p for Leo directives found in globalDirectiveList.
 
@@ -3381,7 +3381,7 @@ def get_directives_dict(p: Pos, root=None):
             break
     return d
 #@+node:ekr.20080827175609.1: *3* g.get_directives_dict_list (must be fast)
-def get_directives_dict_list(p: Pos):
+def get_directives_dict_list(p: Pos) -> None:
     """Scans p and all its ancestors for directives.
 
     Returns a list of dicts containing pointers to
@@ -3394,7 +3394,7 @@ def get_directives_dict_list(p: Pos):
         result.append(g.get_directives_dict(p, root=root))
     return result
 #@+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode
-def getLanguageFromAncestorAtFileNode(p: Pos):
+def getLanguageFromAncestorAtFileNode(p: Pos) -> None:
     """
     Return the language in effect at node p.
     
@@ -3408,7 +3408,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
     # Original idea by Виталије Милошевић (Vitalije Milosevic).
     # Modified by EKR.
 
-    def v_and_parents(v):
+    def v_and_parents(v: "VNode") -> None:
         if v in seen:
             return
         seen.add(v)
@@ -3417,7 +3417,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
             if parent_v not in seen:
                 yield from v_and_parents(parent_v)
 
-    def find_language(v, phase):
+    def find_language(v: "VNode", phase: Any) -> None:
         """
         A helper for all searches.
         Phase one searches only @<file> nodes.
@@ -3459,7 +3459,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos):
                 return language
     return None
 #@+node:ekr.20150325075144.1: *3* g.getLanguageFromPosition
-def getLanguageAtPosition(c: Cmdr, p: Pos):
+def getLanguageAtPosition(c: Cmdr, p: Pos) -> None:
     """
     Return the language in effect at position p.
     This is always a lowercase language name, never None.
@@ -3474,7 +3474,7 @@ def getLanguageAtPosition(c: Cmdr, p: Pos):
     )
     return language.lower()
 #@+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr=None, name=None):
+def getOutputNewline(c: Cmdr=None, name: Any=None) -> None:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3504,7 +3504,7 @@ def getOutputNewline(c: Cmdr=None, name=None):
     assert isinstance(s, str), repr(s)
     return s
 #@+node:ekr.20200521075143.1: *3* g.inAtNosearch
-def inAtNosearch(p: Pos):
+def inAtNosearch(p: Pos) -> None:
     """Return True if p or p's ancestors contain an @nosearch directive."""
     if not p:
         return False  # #2288.
@@ -3513,7 +3513,7 @@ def inAtNosearch(p: Pos):
             return True
     return False
 #@+node:ekr.20131230090121.16528: *3* g.isDirective
-def isDirective(s: str):
+def isDirective(s: str) -> None:
     """Return True if s starts with a directive."""
     m = g_is_directive_pattern.match(s)
     if m:
@@ -3523,7 +3523,7 @@ def isDirective(s: str):
         return bool(m.group(1) in g.globalDirectiveList)
     return False
 #@+node:ekr.20200810074755.1: *3* g.isValidLanguage
-def isValidLanguage(language):
+def isValidLanguage(language: Any) -> None:
     """True if language exists in leo/modes."""
     # 2020/08/12: A hack for c++
     if language in ('c++', 'cpp'):
@@ -3531,7 +3531,7 @@ def isValidLanguage(language):
     fn = g.os_path_join(g.app.loadDir, '..', 'modes', f"{language}.py")
     return g.os_path_exists(fn)
 #@+node:ekr.20080827175609.52: *3* g.scanAtCommentAndLanguageDirectives
-def scanAtCommentAndAtLanguageDirectives(aList):
+def scanAtCommentAndAtLanguageDirectives(aList: Any) -> None:
     """
     Scan aList for @comment and @language directives.
 
@@ -3552,7 +3552,7 @@ def scanAtCommentAndAtLanguageDirectives(aList):
             return d
     return None
 #@+node:ekr.20080827175609.32: *3* g.scanAtEncodingDirectives
-def scanAtEncodingDirectives(aList):
+def scanAtEncodingDirectives(aList: Any) -> None:
     """Scan aList for @encoding directives."""
     for d in aList:
         encoding = d.get('encoding')
@@ -3562,13 +3562,13 @@ def scanAtEncodingDirectives(aList):
             g.error("invalid @encoding:", encoding)
     return None
 #@+node:ekr.20080827175609.53: *3* g.scanAtHeaderDirectives
-def scanAtHeaderDirectives(aList):
+def scanAtHeaderDirectives(aList: Any) -> None:
     """scan aList for @header and @noheader directives."""
     for d in aList:
         if d.get('header') and d.get('noheader'):
             g.error("conflicting @header and @noheader directives")
 #@+node:ekr.20080827175609.33: *3* g.scanAtLineendingDirectives
-def scanAtLineendingDirectives(aList):
+def scanAtLineendingDirectives(aList: Any) -> None:
     """Scan aList for @lineending directives."""
     for d in aList:
         e = d.get('lineending')
@@ -3579,7 +3579,7 @@ def scanAtLineendingDirectives(aList):
             # g.error("invalid @lineending directive:",e)
     return None
 #@+node:ekr.20080827175609.34: *3* g.scanAtPagewidthDirectives
-def scanAtPagewidthDirectives(aList, issue_error_flag=False):
+def scanAtPagewidthDirectives(aList: Any, issue_error_flag: bool=False) -> None:
     """Scan aList for @pagewidth directives."""
     for d in aList:
         s = d.get('pagewidth')
@@ -3591,16 +3591,16 @@ def scanAtPagewidthDirectives(aList, issue_error_flag=False):
                 g.error("ignoring @pagewidth", s)
     return None
 #@+node:ekr.20101022172109.6108: *3* g.scanAtPathDirectives
-def scanAtPathDirectives(c: Cmdr, aList):
+def scanAtPathDirectives(c: Cmdr, aList: Any) -> None:
     path = c.scanAtPathDirectives(aList)
     return path
 
-def scanAllAtPathDirectives(c: Cmdr, p: Pos):
+def scanAllAtPathDirectives(c: Cmdr, p: Pos) -> None:
     aList = g.get_directives_dict_list(p)
     path = c.scanAtPathDirectives(aList)
     return path
 #@+node:ekr.20080827175609.37: *3* g.scanAtTabwidthDirectives
-def scanAtTabwidthDirectives(aList, issue_error_flag=False):
+def scanAtTabwidthDirectives(aList: Any, issue_error_flag: bool=False) -> None:
     """Scan aList for @tabwidth directives."""
     for d in aList:
         s = d.get('tabwidth')
@@ -3612,7 +3612,7 @@ def scanAtTabwidthDirectives(aList, issue_error_flag=False):
                 g.error("ignoring @tabwidth", s)
     return None
 
-def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos):
+def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos) -> None:
     """Scan p and all ancestors looking for @tabwidth directives."""
     if c and p:
         aList = g.get_directives_dict_list(p)
@@ -3622,7 +3622,7 @@ def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos):
         ret = None
     return ret
 #@+node:ekr.20080831084419.4: *3* g.scanAtWrapDirectives
-def scanAtWrapDirectives(aList, issue_error_flag=False):
+def scanAtWrapDirectives(aList: Any, issue_error_flag: bool=False) -> None:
     """Scan aList for @wrap and @nowrap directives."""
     for d in aList:
         if d.get('wrap') is not None:
@@ -3631,7 +3631,7 @@ def scanAtWrapDirectives(aList, issue_error_flag=False):
             return False
     return None
 
-def scanAllAtWrapDirectives(c: Cmdr, p: Pos):
+def scanAllAtWrapDirectives(c: Cmdr, p: Pos) -> None:
     """Scan p and all ancestors looking for @wrap/@nowrap directives."""
     if c and p:
         default = c and c.config.getBool("body-pane-wraps")
@@ -3642,7 +3642,7 @@ def scanAllAtWrapDirectives(c: Cmdr, p: Pos):
         ret = None
     return ret
 #@+node:ekr.20040715155607: *3* g.scanForAtIgnore
-def scanForAtIgnore(c: Cmdr, p: Pos):
+def scanForAtIgnore(c: Cmdr, p: Pos) -> None:
     """Scan position p and its ancestors looking for @ignore directives."""
     if g.unitTesting:
         return False  # For unit tests.
@@ -3652,7 +3652,7 @@ def scanForAtIgnore(c: Cmdr, p: Pos):
             return True
     return False
 #@+node:ekr.20040712084911.1: *3* g.scanForAtLanguage
-def scanForAtLanguage(c: Cmdr, p: Pos):
+def scanForAtLanguage(c: Cmdr, p: Pos) -> None:
     """Scan position p and p's ancestors looking only for @language and @ignore directives.
 
     Returns the language found, or c.target_language."""
@@ -3666,7 +3666,7 @@ def scanForAtLanguage(c: Cmdr, p: Pos):
                 return language
     return c.target_language
 #@+node:ekr.20041123094807: *3* g.scanForAtSettings
-def scanForAtSettings(p: Pos):
+def scanForAtSettings(p: Pos) -> None:
     """Scan position p and its ancestors looking for @settings nodes."""
     for p in p.self_and_parents(copy=False):
         h = p.h
@@ -3675,7 +3675,7 @@ def scanForAtSettings(p: Pos):
             return True
     return False
 #@+node:ekr.20031218072017.1382: *3* g.set_delims_from_language
-def set_delims_from_language(language):
+def set_delims_from_language(language: Any) -> None:
     """Return a tuple (single,start,end) of comment delims."""
     val = g.app.language_delims_dict.get(language)
     if val:
@@ -3687,7 +3687,7 @@ def set_delims_from_language(language):
     return '', '', ''
         # Indicate that no change should be made
 #@+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str):
+def set_delims_from_string(s: str) -> None:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3736,7 +3736,7 @@ def set_delims_from_string(s: str):
                 delims[i] = delims[i].replace("__", '\n').replace('_', ' ')
     return delims[0], delims[1], delims[2]
 #@+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(s: str, i: int, issue_errors_flag=False):
+def set_language(s: str, i: int, issue_errors_flag: bool=False) -> None:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3761,7 +3761,7 @@ def set_language(s: str, i: int, issue_errors_flag=False):
         g.es("ignoring:", g.get_line(s, i))
     return None, None, None, None
 #@+node:ekr.20071109165315: *3* g.stripPathCruft
-def stripPathCruft(path):
+def stripPathCruft(path: Any) -> None:
     """Strip cruft from a path name."""
     if not path:
         return path  # Retain empty paths for warnings.
@@ -3774,7 +3774,7 @@ def stripPathCruft(path):
     # We want a *relative* path, not an absolute path.
     return path
 #@+node:ekr.20090214075058.10: *3* g.update_directives_pat
-def update_directives_pat():
+def update_directives_pat() -> None:
     """Init/update g.directives_pat"""
     global globalDirectiveList, directives_pat
     # Use a pattern that guarantees word matches.
@@ -3788,7 +3788,7 @@ def update_directives_pat():
 update_directives_pat()
 #@+node:ekr.20031218072017.3116: ** g.Files & Directories
 #@+node:ekr.20080606074139.2: *3* g.chdir
-def chdir(path: str):
+def chdir(path: str) -> None:
     if not g.os_path_isdir(path):
         path = g.os_path_dirname(path)
     if g.os_path_isdir(path) and g.os_path_exists(path):
@@ -3796,25 +3796,25 @@ def chdir(path: str):
 #@+node:ekr.20120222084734.10287: *3* g.compute...Dir
 # For compatibility with old code.
 
-def computeGlobalConfigDir():
+def computeGlobalConfigDir() -> None:
     return g.app.loadManager.computeGlobalConfigDir()
 
-def computeHomeDir():
+def computeHomeDir() -> None:
     return g.app.loadManager.computeHomeDir()
 
-def computeLeoDir():
+def computeLeoDir() -> None:
     return g.app.loadManager.computeLeoDir()
 
-def computeLoadDir():
+def computeLoadDir() -> None:
     return g.app.loadManager.computeLoadDir()
 
-def computeMachineName():
+def computeMachineName() -> None:
     return g.app.loadManager.computeMachineName()
 
-def computeStandardDirectories():
+def computeStandardDirectories() -> None:
     return g.app.loadManager.computeStandardDirectories()
 #@+node:ekr.20031218072017.3103: *3* g.computeWindowTitle
-def computeWindowTitle(fileName):
+def computeWindowTitle(fileName: Any) -> None:
 
     branch, commit = g.gitInfoForFile(fileName)  # #1616
     if not fileName:
@@ -3831,7 +3831,7 @@ def computeWindowTitle(fileName):
         title = branch + ": " + title
     return title
 #@+node:ekr.20031218072017.3117: *3* g.create_temp_file
-def create_temp_file(textMode=False):
+def create_temp_file(textMode: bool=False) -> None:
     """
     Return a tuple (theFile,theFileName)
 
@@ -3849,7 +3849,7 @@ def create_temp_file(textMode=False):
         theFile, theFileName = None, ''
     return theFile, theFileName
 #@+node:ekr.20210307060731.1: *3* g.createHiddenCommander
-def createHiddenCommander(fn):
+def createHiddenCommander(fn: Any) -> None:
     """Read the file into a hidden commander (Similar to g.openWithFileName)."""
     from leo.core.leoCommands import Commands
     c = Commands(fn, gui=g.app.nullGui)
@@ -3860,11 +3860,11 @@ def createHiddenCommander(fn):
         return c
     return None
 #@+node:vitalije.20170714085545.1: *3* g.defaultLeoFileExtension
-def defaultLeoFileExtension(c: Cmdr=None):
+def defaultLeoFileExtension(c: Cmdr=None) -> None:
     conf = c.config if c else g.app.config
     return conf.getString('default-leo-extension') or '.leo'
 #@+node:ekr.20031218072017.3118: *3* g.ensure_extension
-def ensure_extension(name, ext):
+def ensure_extension(name: Any, ext: Any) -> None:
 
     theFile, old_ext = g.os_path_splitext(name)
     if not name:
@@ -3875,7 +3875,7 @@ def ensure_extension(name, ext):
         return name
     return name + ext
 #@+node:ekr.20150403150655.1: *3* g.fullPath
-def fullPath(c: Cmdr, p: Pos, simulate=False):
+def fullPath(c: Cmdr, p: Pos, simulate: bool=False) -> None:
     """
     Return the full path (including fileName) in effect at p. Neither the
     path nor the fileName will be created if it does not exist.
@@ -3893,7 +3893,7 @@ def fullPath(c: Cmdr, p: Pos, simulate=False):
             return g.os_path_finalize_join(path, fn)  # #1341.
     return ''
 #@+node:ekr.20190327192721.1: *3* g.get_files_in_directory
-def get_files_in_directory(directory, kinds=None, recursive=True):
+def get_files_in_directory(directory: Any, kinds: Any=None, recursive: bool=True) -> None:
     """
     Return a list of all files of the given file extensions in the directory.
     Default kinds: ['*.py'].
@@ -3924,7 +3924,7 @@ def get_files_in_directory(directory, kinds=None, recursive=True):
 #@+node:ekr.20031218072017.1264: *3* g.getBaseDirectory
 # Handles the conventions applying to the "relative_path_base_directory" configuration option.
 
-def getBaseDirectory(c: Cmdr):
+def getBaseDirectory(c: Cmdr) -> None:
     """Convert '!' or '.' to proper directory references."""
     base = app.config.relative_path_base_directory
     if base and base == "!":
@@ -3941,7 +3941,7 @@ def getBaseDirectory(c: Cmdr):
         return base  # base need not exist yet.
     return ""  # No relative base given.
 #@+node:ekr.20170223093758.1: *3* g.getEncodingAt
-def getEncodingAt(p: Pos, s: str=None):
+def getEncodingAt(p: Pos, s: str=None) -> None:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3959,7 +3959,7 @@ def getEncodingAt(p: Pos, s: str=None):
         e = 'utf-8'
     return e
 #@+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr=None):
+def guessExternalEditor(c: Cmdr=None) -> None:
     """ Return a 'sensible' external editor """
     editor = (
         os.environ.get("LEO_EDITOR") or
@@ -3981,7 +3981,7 @@ or do g.app.db['LEO_EDITOR'] = "gvim"''',
     )
     return None
 #@+node:ekr.20160330204014.1: *3* g.init_dialog_folder
-def init_dialog_folder(c: Cmdr, p: Pos, use_at_path=True):
+def init_dialog_folder(c: Cmdr, p: Pos, use_at_path: bool=True) -> None:
     """Return the most convenient folder to open or save a file."""
     if c and p and use_at_path:
         path = g.fullPath(c, p)
@@ -3998,10 +3998,10 @@ def init_dialog_folder(c: Cmdr, p: Pos, use_at_path=True):
             return dir_
     return ''
 #@+node:ekr.20100329071036.5744: *3* g.is_binary_file/external_file/string
-def is_binary_file(f):
+def is_binary_file(f: Any) -> None:
     return f and isinstance(f, io.BufferedIOBase)
 
-def is_binary_external_file(fileName):
+def is_binary_external_file(fileName: Any) -> None:
     try:
         with open(fileName, 'rb') as f:
             s = f.read(1024)  # bytes, in Python 3.
@@ -4012,13 +4012,13 @@ def is_binary_external_file(fileName):
         g.es_exception()
         return False
 
-def is_binary_string(s: str):
+def is_binary_string(s: str) -> None:
     # http://stackoverflow.com/questions/898669
     # aList is a list of all non-binary characters.
     aList = [7, 8, 9, 10, 12, 13, 27] + list(range(0x20, 0x100))
     return bool(s.translate(None, bytes(aList)))  # type:ignore
 #@+node:EKR.20040504154039: *3* g.is_sentinel
-def is_sentinel(line, delims):
+def is_sentinel(line: Any, delims: Any) -> None:
     """Return True if line starts with a sentinel comment."""
     delim1, delim2, delim3 = delims
     line = line.lstrip()
@@ -4031,7 +4031,7 @@ def is_sentinel(line, delims):
     g.error(f"is_sentinel: can not happen. delims: {repr(delims)}")
     return False
 #@+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir):
+def makeAllNonExistentDirectories(theDir: Any) -> None:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -4050,7 +4050,7 @@ def makeAllNonExistentDirectories(theDir):
     except Exception:
         return None
 #@+node:ekr.20071114113736: *3* g.makePathRelativeTo
-def makePathRelativeTo(fullPath, basePath):
+def makePathRelativeTo(fullPath: Any, basePath: Any) -> None:
     if fullPath.startswith(basePath):
         s = fullPath[len(basePath) :]
         if s.startswith(os.path.sep):
@@ -4058,14 +4058,14 @@ def makePathRelativeTo(fullPath, basePath):
         return s
     return fullPath
 #@+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName, old_c=None, gui=None):
+def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> None:
     """Create a Leo Frame for the indicated fileName if the file exists.
 
     returns the commander of the newly-opened outline.
     """
     return g.app.loadManager.loadLocalFile(fileName, gui, old_c)
 #@+node:ekr.20150306035851.7: *3* g.readFileIntoEncodedString
-def readFileIntoEncodedString(fn, silent=False):
+def readFileIntoEncodedString(fn: Any, silent: bool=False) -> None:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -4132,7 +4132,7 @@ def readFileIntoString(fileName,
         g.es_exception()
     return None, None
 #@+node:ekr.20160504062833.1: *3* g.readFileToUnicodeString
-def readFileIntoUnicodeString(fn, encoding=None, silent=False):
+def readFileIntoUnicodeString(fn: Any, encoding: Any=None, silent: bool=False) -> None:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -4154,7 +4154,7 @@ def readFileIntoUnicodeString(fn, encoding=None, silent=False):
 # same.
 #@@c
 
-def readlineForceUnixNewline(f, fileName=None):
+def readlineForceUnixNewline(f: Any, fileName: Any=None) -> None:
     try:
         s = f.readline()
     except UnicodeDecodeError:
@@ -4164,7 +4164,7 @@ def readlineForceUnixNewline(f, fileName=None):
         s = s[0:-2] + "\n"
     return s
 #@+node:ekr.20031218072017.3124: *3* g.sanitize_filename
-def sanitize_filename(s: str):
+def sanitize_filename(s: str) -> None:
     """
     Prepares string s to be a valid file name:
 
@@ -4192,12 +4192,12 @@ def sanitize_filename(s: str):
             break
     return s[:128]
 #@+node:ekr.20060328150113: *3* g.setGlobalOpenDir
-def setGlobalOpenDir(fileName):
+def setGlobalOpenDir(fileName: Any) -> None:
     if fileName:
         g.app.globalOpenDir = g.os_path_dirname(fileName)
         # g.es('current directory:',g.app.globalOpenDir)
 #@+node:ekr.20031218072017.3125: *3* g.shortFileName & shortFilename
-def shortFileName(fileName, n=None):
+def shortFileName(fileName: Any, n: Any=None) -> None:
     """Return the base name of a path."""
     if n is not None:
         g.trace('"n" keyword argument is no longer used')
@@ -4205,7 +4205,7 @@ def shortFileName(fileName, n=None):
 
 shortFilename = shortFileName
 #@+node:ekr.20150610125813.1: *3* g.splitLongFileName
-def splitLongFileName(fn, limit=40):
+def splitLongFileName(fn: Any, limit: int=40) -> None:
     """Return fn, split into lines at slash characters."""
     aList = fn.replace('\\', '/').split('/')
     n, result = 0, []
@@ -4220,7 +4220,7 @@ def splitLongFileName(fn, limit=40):
             n = 0
     return ''.join(result)
 #@+node:ekr.20190114061452.26: *3* g.writeFile
-def writeFile(contents, encoding, fileName):
+def writeFile(contents: Any, encoding: Any, fileName: Any) -> None:
     """Create a file with the given contents."""
     try:
         if isinstance(contents, str):
@@ -4236,7 +4236,7 @@ def writeFile(contents, encoding, fileName):
         return False
 #@+node:ekr.20031218072017.3151: ** g.Finding & Scanning
 #@+node:ekr.20140602083643.17659: *3* g.find_word
-def find_word(s: str, word, i: int=0):
+def find_word(s: str, word: Any, i: int=0) -> None:
     """
     Return the index of the first occurance of word in s, or -1 if not found.
 
@@ -4260,7 +4260,7 @@ def find_word(s: str, word, i: int=0):
         assert progress < i
     return -1
 #@+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p, v_predicate):
+def findAncestorVnodeByPredicate(p: Pos, v_predicate: Any) -> None:
     """
     Return first ancestor vnode matching the predicate.
     
@@ -4289,7 +4289,7 @@ def findAncestorVnodeByPredicate(p, v_predicate):
                 parents.append(grand_parent_v)
     return None
 #@+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root, predicate=None):
+def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> None:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4305,7 +4305,7 @@ def findRootsWithPredicate(c: Cmdr, root, predicate=None):
         # A useful default predicate for python.
         # pylint: disable=function-redefined
 
-        def predicate(p):
+        def predicate(p: Pos) -> None:
             return p.isAnyAtFileNode() and p.h.strip().endswith('.py')
 
     # 1. Search p's tree.
@@ -4345,7 +4345,7 @@ def recursiveUNLSearch(unlList, c: Cmdr, depth=0, p: Pos=None, maxdepth=0, maxp=
     if g.unitTesting:
         return True, maxdepth, maxp
 
-    def moveToP(c, p, unlList):
+    def moveToP(c: Cmdr, p: Pos, unlList: Any) -> None:
         # Process events, to calculate new sizes.
         g.app.gui.qtApp.processEvents()
         c.expandAllAncestors(p)
@@ -4494,7 +4494,7 @@ def recursiveUNLFind(unlList, c: Cmdr, depth=0, p: Pos=None, maxdepth=0, maxp=No
             maxdepth = p.level()  # type:ignore
     return False, maxdepth, maxp
 #@+node:tbrown.20171221094755.1: *4* g.recursiveUNLParts
-def recursiveUNLParts(text):
+def recursiveUNLParts(text: Any) -> None:
     """Parse the tail, returning whatever follows ':'.
 
     Examples: foo or foo:2 or foo:2,0,4,10.
@@ -4511,7 +4511,7 @@ def recursiveUNLParts(text):
 #@+node:ekr.20031218072017.3156: *3* g.scanError
 # It is dubious to bump the Tangle error count here, but it really doesn't hurt.
 
-def scanError(s: str):
+def scanError(s: str) -> None:
     """Bump the error count in the tangle command."""
     # New in Leo 4.4b1: just set this global.
     g.app.scanErrors += 1
@@ -4519,7 +4519,7 @@ def scanError(s: str):
 #@+node:ekr.20031218072017.3157: *3* g.scanf
 # A quick and dirty sscanf.  Understands only %s and %d.
 
-def scanf(s: str, pat):
+def scanf(s: str, pat: Any) -> None:
     count = pat.count("%s") + pat.count("%d")
     pat = pat.replace("%s", r"(\S+)")
     pat = pat.replace("%d", r"(\d+)")
@@ -4539,7 +4539,7 @@ def scanf(s: str, pat):
 #@+node:ekr.20031218072017.3159: *4* g.skip_block_comment
 # Scans past a block comment (an old_style C comment).
 
-def skip_block_comment(s: str, i: int):
+def skip_block_comment(s: str, i: int) -> None:
     assert g.match(s, i, "/*")
     j = i
     i += 2
@@ -4555,7 +4555,7 @@ def skip_block_comment(s: str, i: int):
 # if blocks.
 #@@c
 
-def skip_braces(s: str, i: int):
+def skip_braces(s: str, i: int) -> None:
     """
     Skips from the opening to the matching brace.
 
@@ -4592,7 +4592,7 @@ def skip_braces(s: str, i: int):
         else: i += 1
     return i
 #@+node:ekr.20031218072017.3162: *4* g.skip_parens
-def skip_parens(s: str, i: int):
+def skip_parens(s: str, i: int) -> None:
     """
     Skips from the opening ( to the matching ).
 
@@ -4621,7 +4621,7 @@ def skip_parens(s: str, i: int):
             i += 1
     return i
 #@+node:ekr.20031218072017.3163: *4* g.skip_pascal_begin_end
-def skip_pascal_begin_end(s: str, i: int):
+def skip_pascal_begin_end(s: str, i: int) -> None:
     """
     Skips from begin to matching end.
     If found, i points to the end. Otherwise, i >= len(s)
@@ -4655,7 +4655,7 @@ def skip_pascal_begin_end(s: str, i: int):
             i += 1
     return i
 #@+node:ekr.20031218072017.3164: *4* g.skip_pascal_block_comment
-def skip_pascal_block_comment(s: str, i: int):
+def skip_pascal_block_comment(s: str, i: int) -> None:
     """Scan past a pascal comment delimited by (* and *)."""
     j = i
     assert g.match(s, i, "(*")
@@ -4665,7 +4665,7 @@ def skip_pascal_block_comment(s: str, i: int):
     g.scanError("Run on comment" + s[j:i])
     return len(s)
 #@+node:ekr.20031218072017.3165: *4* g.skip_pascal_string
-def skip_pascal_string(s: str, i: int):
+def skip_pascal_string(s: str, i: int) -> None:
     j = i
     delim = s[i]
     i += 1
@@ -4677,7 +4677,7 @@ def skip_pascal_string(s: str, i: int):
     g.scanError("Run on string: " + s[j:i])
     return i
 #@+node:ekr.20031218072017.3166: *4* g.skip_heredoc_string
-def skip_heredoc_string(s: str, i: int):
+def skip_heredoc_string(s: str, i: int) -> None:
     """
     08-SEP-2002 DTHEIN.
     A heredoc string in PHP looks like:
@@ -4709,7 +4709,7 @@ def skip_heredoc_string(s: str, i: int):
         i += len(delim)
     return i
 #@+node:ekr.20031218072017.3167: *4* g.skip_pp_directive
-def skip_pp_directive(s: str, i: int):
+def skip_pp_directive(s: str, i: int) -> None:
     """Now handles continuation lines and block comments."""
     while i < len(s):
         if g.is_nl(s, i):
@@ -4727,7 +4727,7 @@ def skip_pp_directive(s: str, i: int):
 #@+node:ekr.20031218072017.3168: *4* g.skip_pp_if
 # Skips an entire if or if def statement, including any nested statements.
 
-def skip_pp_if(s: str, i: int):
+def skip_pp_if(s: str, i: int) -> None:
     start_line = g.get_line(s, i)  # used for error messages.
     assert(
         g.match_word(s, i, "#if") or
@@ -4751,7 +4751,7 @@ def skip_pp_if(s: str, i: int):
 #@+node:ekr.20031218072017.3169: *4* g.skip_pp_part
 # Skip to an #else or #endif.  The caller has eaten the #if, #ifdef, #ifndef or #else
 
-def skip_pp_part(s: str, i: int):
+def skip_pp_part(s: str, i: int) -> None:
 
     delta = 0
     while i < len(s):
@@ -4783,7 +4783,7 @@ def skip_pp_part(s: str, i: int):
 #@+node:ekr.20031218072017.3171: *4* g.skip_to_semicolon
 # Skips to the next semicolon that is not in a comment or a string.
 
-def skip_to_semicolon(s: str, i: int):
+def skip_to_semicolon(s: str, i: int) -> None:
     n = len(s)
     while i < n:
         c = s[i]
@@ -4799,7 +4799,7 @@ def skip_to_semicolon(s: str, i: int):
             i += 1
     return i
 #@+node:ekr.20031218072017.3172: *4* g.skip_typedef
-def skip_typedef(s: str, i: int):
+def skip_typedef(s: str, i: int) -> None:
     n = len(s)
     while i < n and g.is_c_id(s[i]):
         i = g.skip_c_id(s, i)
@@ -4809,7 +4809,7 @@ def skip_typedef(s: str, i: int):
         i = g.skip_to_semicolon(s, i)
     return i
 #@+node:ekr.20201127143342.1: *3* g.see_more_lines
-def see_more_lines(s: str, ins, n=4):
+def see_more_lines(s: str, ins: Any, n: int=4) -> None:
     """
     Extend index i within string s to include n more lines.
     """
@@ -4822,7 +4822,7 @@ def see_more_lines(s: str, ins, n=4):
             ins = j
     return max(0, min(ins, len(s)))
 #@+node:ekr.20031218072017.3195: *3* g.splitLines
-def splitLines(s: str):
+def splitLines(s: str) -> None:
     """
     Split s into lines, preserving the number of lines and
     the endings of all lines, including the last line.
@@ -4834,14 +4834,14 @@ splitlines = splitLines
 #@+node:ekr.20031218072017.3174: *4* g.escaped
 # Returns True if s[i] is preceded by an odd number of backslashes.
 
-def escaped(s: str, i: int):
+def escaped(s: str, i: int) -> None:
     count = 0
     while i - 1 >= 0 and s[i - 1] == '\\':
         count += 1
         i -= 1
     return (count % 2) == 1
 #@+node:ekr.20031218072017.3175: *4* g.find_line_start
-def find_line_start(s: str, i: int):
+def find_line_start(s: str, i: int) -> None:
     """Return the index in s of the start of the line containing s[i]."""
     if i < 0:
         return 0  # New in Leo 4.4.5: add this defensive code.
@@ -4851,14 +4851,14 @@ def find_line_start(s: str, i: int):
     # if i == -1: return 0
     # else: return i + 1
 #@+node:ekr.20031218072017.3176: *4* g.find_on_line
-def find_on_line(s: str, i: int, pattern):
+def find_on_line(s: str, i: int, pattern: Any) -> None:
     j = s.find('\n', i)
     if j == -1:
         j = len(s)
     k = s.find(pattern, i, j)
     return k
 #@+node:ekr.20031218072017.3179: *4* g.g.is_special
-def is_special(s: str, directive):
+def is_special(s: str, directive: Any) -> None:
     """Return True if the body text contains the @ directive."""
     assert(directive and directive[0] == '@')
     lws = directive in ("@others", "@all")
@@ -4870,24 +4870,24 @@ def is_special(s: str, directive):
         return True, m.start(1)
     return False, -1
 #@+node:ekr.20031218072017.3177: *4* g.is_c_id
-def is_c_id(ch):
+def is_c_id(ch: str) -> None:
     return g.isWordChar(ch)
 #@+node:ekr.20031218072017.3178: *4* g.is_nl
-def is_nl(s: str, i: int):
+def is_nl(s: str, i: int) -> None:
     return i < len(s) and (s[i] == '\n' or s[i] == '\r')
 #@+node:ekr.20031218072017.3180: *4* g.is_ws & is_ws_or_nl
-def is_ws(ch: str):
+def is_ws(ch: str) -> None:
     return ch == '\t' or ch == ' '
 
-def is_ws_or_nl(s: str, i: int):
+def is_ws_or_nl(s: str, i: int) -> None:
     return g.is_nl(s, i) or (i < len(s) and g.is_ws(s[i]))
 #@+node:ekr.20031218072017.3181: *4* g.match
 # Warning: this code makes no assumptions about what follows pattern.
 
-def match(s: str, i: int, pattern):
+def match(s: str, i: int, pattern: Any) -> None:
     return s and pattern and s.find(pattern, i, i + len(pattern)) == i
 #@+node:ekr.20031218072017.3182: *4* g.match_c_word
-def match_c_word(s: str, i: int, name):
+def match_c_word(s: str, i: int, name: Any) -> None:
     n = len(name)
     return (
         name and
@@ -4895,10 +4895,10 @@ def match_c_word(s: str, i: int, name):
         (i + n == len(s) or not g.is_c_id(s[i + n]))
     )
 #@+node:ekr.20031218072017.3183: *4* g.match_ignoring_case
-def match_ignoring_case(s1, s2):
+def match_ignoring_case(s1: Any, s2: Any) -> None:
     return s1 and s2 and s1.lower() == s2.lower()
 #@+node:ekr.20031218072017.3184: *4* g.match_word & g.match_words
-def match_word(s: str, i: int, pattern):
+def match_word(s: str, i: int, pattern: Any) -> None:
 
     # Using a regex is surprisingly tricky.
     if pattern is None:
@@ -4915,14 +4915,14 @@ def match_word(s: str, i: int, pattern):
     ch = s[i + j]
     return not g.isWordChar(ch)
 
-def match_words(s: str, i: int, patterns):
+def match_words(s: str, i: int, patterns: Any) -> None:
     return any(g.match_word(s, i, pattern) for pattern in patterns)
 #@+node:ekr.20031218072017.3185: *4* g.skip_blank_lines
 # This routine differs from skip_ws_and_nl in that
 # it does not advance over whitespace at the start
 # of a non-empty or non-nl terminated line
 
-def skip_blank_lines(s: str, i: int):
+def skip_blank_lines(s: str, i: int) -> None:
     while i < len(s):
         if g.is_nl(s, i):
             i = g.skip_nl(s, i)
@@ -4934,13 +4934,13 @@ def skip_blank_lines(s: str, i: int):
         else: break
     return i
 #@+node:ekr.20031218072017.3186: *4* g.skip_c_id
-def skip_c_id(s: str, i: int):
+def skip_c_id(s: str, i: int) -> None:
     n = len(s)
     while i < n and g.isWordChar(s[i]):
         i += 1
     return i
 #@+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars=None):
+def skip_id(s: str, i: int, chars: Any=None) -> None:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4953,7 +4953,7 @@ def skip_id(s: str, i: int, chars=None):
 # string.
 #@@c
 
-def skip_line(s: str, i: int):
+def skip_line(s: str, i: int) -> None:
     if i >= len(s):
         return len(s)
     if i < 0:
@@ -4963,7 +4963,7 @@ def skip_line(s: str, i: int):
         return len(s)
     return i + 1
 
-def skip_to_end_of_line(s: str, i: int):
+def skip_to_end_of_line(s: str, i: int) -> None:
     if i >= len(s):
         return len(s)
     if i < 0:
@@ -4973,7 +4973,7 @@ def skip_to_end_of_line(s: str, i: int):
         return len(s)
     return i
 
-def skip_to_start_of_line(s: str, i: int):
+def skip_to_start_of_line(s: str, i: int) -> None:
     if i >= len(s):
         return len(s)
     if i <= 0:
@@ -4984,7 +4984,7 @@ def skip_to_start_of_line(s: str, i: int):
         return 0
     return i + 1
 #@+node:ekr.20031218072017.3188: *4* g.skip_long
-def skip_long(s: str, i: int):
+def skip_long(s: str, i: int) -> None:
     """
     Scan s[i:] for a valid int.
     Return (i, val) or (i, None) if s[i] does not point at a number.
@@ -5007,7 +5007,7 @@ def skip_long(s: str, i: int):
 #@+node:ekr.20031218072017.3190: *4* g.skip_nl
 # We need this function because different systems have different end-of-line conventions.
 
-def skip_nl(s: str, i: int):
+def skip_nl(s: str, i: int) -> None:
     """Skips a single "logical" end-of-line character."""
     if g.match(s, i, "\r\n"):
         return i + 2
@@ -5015,7 +5015,7 @@ def skip_nl(s: str, i: int):
         return i + 1
     return i
 #@+node:ekr.20031218072017.3191: *4* g.skip_non_ws
-def skip_non_ws(s: str, i: int):
+def skip_non_ws(s: str, i: int) -> None:
     n = len(s)
     while i < n and not g.is_ws(s[i]):
         i += 1
@@ -5023,13 +5023,13 @@ def skip_non_ws(s: str, i: int):
 #@+node:ekr.20031218072017.3192: *4* g.skip_pascal_braces
 # Skips from the opening { to the matching }.
 
-def skip_pascal_braces(s: str, i: int):
+def skip_pascal_braces(s: str, i: int) -> None:
     # No constructs are recognized inside Pascal block comments!
     if i == -1:
         return len(s)
     return s.find('}', i)
 #@+node:ekr.20031218072017.3170: *4* g.skip_python_string
-def skip_python_string(s: str, i: int):
+def skip_python_string(s: str, i: int) -> None:
     if g.match(s, i, "'''") or g.match(s, i, '"""'):
         delim = s[i] * 3
         i += 3
@@ -5039,7 +5039,7 @@ def skip_python_string(s: str, i: int):
         return len(s)
     return g.skip_string(s, i)
 #@+node:ekr.20031218072017.2369: *4* g.skip_string
-def skip_string(s: str, i: int):
+def skip_string(s: str, i: int) -> None:
     """Scan forward to the end of a string."""
     delim = s[i]
     i += 1
@@ -5056,7 +5056,7 @@ def skip_string(s: str, i: int):
         i += 1
     return i
 #@+node:ekr.20031218072017.3193: *4* g.skip_to_char
-def skip_to_char(s: str, i: int, ch):
+def skip_to_char(s: str, i: int, ch: str) -> None:
     j = s.find(ch, i)
     if j == -1:
         return len(s), s[i:]
@@ -5075,7 +5075,7 @@ def skip_ws_and_nl(s: str, i: int) -> int:
     return i
 #@+node:ekr.20170414034616.1: ** g.Git
 #@+node:ekr.20180325025502.1: *3* g.backupGitIssues
-def backupGitIssues(c: Cmdr, base_url=None):
+def backupGitIssues(c: Cmdr, base_url: Any=None) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -5089,7 +5089,7 @@ def backupGitIssues(c: Cmdr, base_url=None):
     c.redraw()
     g.trace('done')
 #@+node:ekr.20170616102324.1: *3* g.execGitCommand
-def execGitCommand(command, directory):
+def execGitCommand(command: Any, directory: Any) -> None:
     """Execute the given git command in the given directory."""
     git_dir = g.os_path_finalize_join(directory, '.git')
     if not g.os_path_exists(git_dir):
@@ -5143,7 +5143,7 @@ class GitIssueController:
     """
     #@+others
     #@+node:ekr.20180325023336.1: *5* git.backup_issues
-    def backup_issues(self, base_url, c: Cmdr, label_list, root, state=None):
+    def backup_issues(self, base_url: Any, c: Cmdr, label_list: Any, root: Any, state: Any=None) -> None:
 
         self.base_url = base_url
         self.root = root
@@ -5162,7 +5162,7 @@ class GitIssueController:
         else:
             g.es_print('state must be in (None, "open", "closed")')
     #@+node:ekr.20180325024334.1: *5* git.get_all_issues
-    def get_all_issues(self, label_list, root, state, limit=100):
+    def get_all_issues(self, label_list: Any, root: Any, state: Any, limit: int=100) -> None:
         """Get all issues for the base url."""
         try:
             import requests
@@ -5193,7 +5193,7 @@ class GitIssueController:
                 g.trace('too many pages')
                 break
     #@+node:ekr.20180126044850.1: *5* git.get_issues
-    def get_issues(self, base_url, label_list, milestone, root, state):
+    def get_issues(self, base_url: Any, label_list: Any, milestone: Any, root: Any, state: Any) -> None:
         """Create a list of issues for each label in label_list."""
         self.base_url = base_url
         self.milestone = milestone
@@ -5201,7 +5201,7 @@ class GitIssueController:
         for label in label_list:
             self.get_one_issue(label, state)
     #@+node:ekr.20180126043719.3: *5* git.get_one_issue
-    def get_one_issue(self, label, state, limit=20):
+    def get_one_issue(self, label: Any, state: Any, limit: int=20) -> None:
         """Create a list of issues with the given label."""
         try:
             import requests
@@ -5236,7 +5236,7 @@ class GitIssueController:
         else:
             root.h = f"{total} {state} {label} issues"
     #@+node:ekr.20180126043719.4: *5* git.get_one_page
-    def get_one_page(self, label, page, r, root):
+    def get_one_page(self, label: Any, page: Any, r: Any, root: Any) -> None:
 
         if self.milestone:
             aList = [
@@ -5257,7 +5257,7 @@ class GitIssueController:
         done = not link or link.find('rel="next"') == -1
         return done, len(aList)
     #@+node:ekr.20180127092201.1: *5* git.print_header
-    def print_header(self, r):
+    def print_header(self, r: Any) -> None:
 
         # r.headers is a CaseInsensitiveDict
         # so g.printObj(r.headers) is just repr(r.headers)
@@ -5268,7 +5268,7 @@ class GitIssueController:
                 print(f"{key:35}: {r.headers.get(key)}")
     #@-others
 #@+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory=None):
+def getGitVersion(directory: Any=None) -> None:
     """Return a tuple (author, build, date) from the git log, or None."""
     #
     # -n: Get only the last log.
@@ -5299,7 +5299,7 @@ def getGitVersion(directory=None):
 
     info = [g.toUnicode(z) for z in s.splitlines()]
 
-    def find(kind):
+    def find(kind: Any) -> None:
         """Return the given type of log line."""
         for z in info:
             if z.startswith(kind):
@@ -5308,7 +5308,7 @@ def getGitVersion(directory=None):
 
     return find('Author'), find('commit')[:10], find('Date')
 #@+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str=None):
+def gitBranchName(path: str=None) -> None:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5317,7 +5317,7 @@ def gitBranchName(path: str=None):
     branch, commit = g.gitInfo(path)
     return branch
 #@+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str=None):
+def gitCommitNumber(path: str=None) -> None:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5326,20 +5326,20 @@ def gitCommitNumber(path: str=None):
     branch, commit = g.gitInfo(path)
     return commit
 #@+node:ekr.20200724132432.1: *3* g.gitInfoForFile
-def gitInfoForFile(filename):
+def gitInfoForFile(filename: Any) -> None:
     """
     Return the git (branch, commit) info associated for the given file.
     """
     # g.gitInfo and g.gitHeadPath now do all the work.
     return g.gitInfo(filename)
 #@+node:ekr.20200724133754.1: *3* g.gitInfoForOutline
-def gitInfoForOutline(c: Cmdr):
+def gitInfoForOutline(c: Cmdr) -> None:
     """
     Return the git (branch, commit) info associated for commander c.
     """
     return g.gitInfoForFile(c.fileName())
 #@+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str=None):
+def gitDescribe(path: str=None) -> None:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.
@@ -5356,7 +5356,7 @@ def gitDescribe(path: str=None):
     commit = commit.rstrip()
     return tag, distance, commit
 #@+node:ekr.20170414034616.6: *3* g.gitHeadPath
-def gitHeadPath(path_s: str):
+def gitHeadPath(path_s: str) -> None:
     """
     Compute the path to .git/HEAD given the path.
     """
@@ -5371,7 +5371,7 @@ def gitHeadPath(path_s: str):
         path = path.parent
     return None
 #@+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str=None):
+def gitInfo(path: str=None) -> None:
     """
     Path may be a directory or file.
 
@@ -5422,7 +5422,7 @@ def gitInfo(path: str=None):
     return branch, commit
 #@+node:ekr.20031218072017.3139: ** g.Hooks & Plugins
 #@+node:ekr.20101028131948.5860: *3* g.act_on_node
-def dummy_act_on_node(c: Cmdr, p: Pos, event):
+def dummy_act_on_node(c: Cmdr, p: Pos, event: Any) -> None:
     pass
 
 # This dummy definition keeps pylint happy.
@@ -5433,7 +5433,7 @@ act_on_node = dummy_act_on_node
 childrenModifiedSet: Set["VNode"] = set()
 contentModifiedSet: Set["VNode"] = set()
 #@+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag, *args, **keywords):
+def doHook(tag, *args, **keywords) -> None:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -5476,63 +5476,63 @@ def doHook(tag, *args, **keywords):
 #@+node:ekr.20100910075900.5950: *3* g.Wrappers for g.app.pluginController methods
 # Important: we can not define g.pc here!
 #@+node:ekr.20100910075900.5951: *4* g.Loading & registration
-def loadOnePlugin(pluginName, verbose=False):
+def loadOnePlugin(pluginName: Any, verbose: bool=False) -> None:
     pc = g.app.pluginsController
     return pc.loadOnePlugin(pluginName, verbose=verbose)
 
-def registerExclusiveHandler(tags, fn):
+def registerExclusiveHandler(tags: Any, fn: Any) -> None:
     pc = g.app.pluginsController
     return pc.registerExclusiveHandler(tags, fn)
 
-def registerHandler(tags, fn):
+def registerHandler(tags: Any, fn: Any) -> None:
     pc = g.app.pluginsController
     return pc.registerHandler(tags, fn)
 
-def plugin_signon(module_name, verbose=False):
+def plugin_signon(module_name: Any, verbose: bool=False) -> None:
     pc = g.app.pluginsController
     return pc.plugin_signon(module_name, verbose)
 
-def unloadOnePlugin(moduleOrFileName, verbose=False):
+def unloadOnePlugin(moduleOrFileName: Any, verbose: bool=False) -> None:
     pc = g.app.pluginsController
     return pc.unloadOnePlugin(moduleOrFileName, verbose)
 
-def unregisterHandler(tags, fn):
+def unregisterHandler(tags: Any, fn: Any) -> None:
     pc = g.app.pluginsController
     return pc.unregisterHandler(tags, fn)
 #@+node:ekr.20100910075900.5952: *4* g.Information
-def getHandlersForTag(tags):
+def getHandlersForTag(tags: Any) -> None:
     pc = g.app.pluginsController
     return pc.getHandlersForTag(tags)
 
-def getLoadedPlugins():
+def getLoadedPlugins() -> None:
     pc = g.app.pluginsController
     return pc.getLoadedPlugins()
 
-def getPluginModule(moduleName):
+def getPluginModule(moduleName: Any) -> None:
     pc = g.app.pluginsController
     return pc.getPluginModule(moduleName)
 
-def pluginIsLoaded(fn):
+def pluginIsLoaded(fn: Any) -> None:
     pc = g.app.pluginsController
     return pc.isLoaded(fn)
 #@+node:ekr.20031218072017.1315: ** g.Idle time functions
 #@+node:EKR.20040602125018.1: *3* g.disableIdleTimeHook
-def disableIdleTimeHook():
+def disableIdleTimeHook() -> None:
     """Disable the global idle-time hook."""
     g.app.idle_time_hooks_enabled = False
 #@+node:EKR.20040602125018: *3* g.enableIdleTimeHook
-def enableIdleTimeHook(*args, **keys):
+def enableIdleTimeHook(*args, **keys) -> None:
     """Enable idle-time processing."""
     g.app.idle_time_hooks_enabled = True
 #@+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler, delay=500, tag=None):
+def IdleTime(handler: Any, delay: int=500, tag: Any=None) -> None:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
     The IdleTime class executes a handler with a given delay at idle time.
     The handler takes a single argument, the IdleTime instance::
 
-        def handler(timer):
+        def handler(timer: Any) -> None:
             '''IdleTime handler.  timer is an IdleTime instance.'''
             delta_t = timer.time-timer.starting_time
             g.trace(timer.count, '%2.4f' % (delta_t))
@@ -5546,14 +5546,14 @@ def IdleTime(handler, delay=500, tag=None):
 
     Timer instances are completely independent::
 
-        def handler1(timer):
+        def handler1(timer: Any) -> None:
             delta_t = timer.time-timer.starting_time
             g.trace('%2s %2.4f' % (timer.count,delta_t))
             if timer.count >= 5:
                 g.trace('done')
                 timer.stop()
 
-        def handler2(timer):
+        def handler2(timer: Any) -> None:
             delta_t = timer.time-timer.starting_time
             g.trace('%2s %2.4f' % (timer.count,delta_t))
             if timer.count >= 10:
@@ -5571,13 +5571,13 @@ def IdleTime(handler, delay=500, tag=None):
     except Exception:
         return None
 #@+node:ekr.20161027205025.1: *3* g.idleTimeHookHandler (stub)
-def idleTimeHookHandler(timer):
+def idleTimeHookHandler(timer: Any) -> None:
     """This function exists for compatibility."""
     g.es_print('Replaced by IdleTimeManager.on_idle')
     g.trace(g.callers())
 #@+node:ekr.20041219095213: ** g.Importing
 #@+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName, pluginName=None, verbose=True):
+def cantImport(moduleName: Any, pluginName: Any=None, verbose: bool=True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5589,7 +5589,7 @@ def cantImport(moduleName, pluginName=None, verbose=True):
     else:
         g.warning('', s)
 #@+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name, package=None):
+def import_module(name: Any, package: Any=None) -> None:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -5611,7 +5611,7 @@ def import_module(name, package=None):
 #@+node:ekr.20140711071454.17650: ** g.Indices, Strings, Unicode & Whitespace
 #@+node:ekr.20140711071454.17647: *3* g.Indices
 #@+node:ekr.20050314140957: *4* g.convertPythonIndexToRowCol
-def convertPythonIndexToRowCol(s: str, i: int):
+def convertPythonIndexToRowCol(s: str, i: int) -> None:
     """Convert index i into string s into zero-based row/col indices."""
     if not s or i <= 0:
         return 0, 0
@@ -5623,7 +5623,7 @@ def convertPythonIndexToRowCol(s: str, i: int):
     prevNL = s.rfind('\n', 0, i)  # Don't include i
     return row, i - prevNL - 1
 #@+node:ekr.20050315071727: *4* g.convertRowColToPythonIndex
-def convertRowColToPythonIndex(s: str, row, col, lines=None):
+def convertRowColToPythonIndex(s: str, row: Any, col: Any, lines: Any=None) -> None:
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
@@ -5638,7 +5638,7 @@ def convertRowColToPythonIndex(s: str, row, col, lines=None):
         prev += len(line)
     return prev + col
 #@+node:ekr.20061031102333.2: *4* g.getWord & getLine
-def getWord(s: str, i: int):
+def getWord(s: str, i: int) -> None:
     """Return i,j such that s[i:j] is the word surrounding s[i]."""
     if i >= len(s):
         i = len(s) - 1
@@ -5654,7 +5654,7 @@ def getWord(s: str, i: int):
         j += 1
     return i, j
 
-def getLine(s: str, i: int):
+def getLine(s: str, i: int) -> None:
     """
     Return i,j such that s[i:j] is the line surrounding s[i].
     s[i] is a newline only if the line is empty.
@@ -5677,7 +5677,7 @@ def getLine(s: str, i: int):
         k = k + 1
     return j, k
 #@+node:ekr.20111114151846.9847: *4* g.toPythonIndex
-def toPythonIndex(s: str, index):
+def toPythonIndex(s: str, index: Any) -> None:
     """
     Convert index to a Python int.
 
@@ -5701,11 +5701,11 @@ def toPythonIndex(s: str, index):
     return 0
 #@+node:ekr.20140526144610.17601: *3* g.Strings
 #@+node:ekr.20190503145501.1: *4* g.isascii
-def isascii(s: str):
+def isascii(s: str) -> None:
     # s.isascii() is defined in Python 3.7.
     return all(ord(ch) < 128 for ch in s)
 #@+node:ekr.20031218072017.3106: *4* g.angleBrackets & virtual_event_name
-def angleBrackets(s: str):
+def angleBrackets(s: str) -> None:
     """Returns < < s > >"""
     lt = "<<"
     rt = ">>"
@@ -5713,15 +5713,15 @@ def angleBrackets(s: str):
 
 virtual_event_name = angleBrackets
 #@+node:ekr.20090516135452.5777: *4* g.ensureLeading/TrailingNewlines
-def ensureLeadingNewlines(s: str, n):
+def ensureLeadingNewlines(s: str, n: int) -> None:
     s = g.removeLeading(s, '\t\n\r ')
     return ('\n' * n) + s
 
-def ensureTrailingNewlines(s: str, n):
+def ensureTrailingNewlines(s: str, n: int) -> None:
     s = g.removeTrailing(s, '\t\n\r ')
     return s + '\n' * n
 #@+node:ekr.20050920084036.4: *4* g.longestCommonPrefix & g.itemsMatchingPrefixInList
-def longestCommonPrefix(s1, s2):
+def longestCommonPrefix(s1: Any, s2: Any) -> None:
     """Find the longest prefix common to strings s1 and s2."""
     prefix = ''
     for ch in s1:
@@ -5731,7 +5731,7 @@ def longestCommonPrefix(s1, s2):
             return prefix
     return prefix
 
-def itemsMatchingPrefixInList(s: str, aList, matchEmptyPrefix=False):
+def itemsMatchingPrefixInList(s: str, aList: Any, matchEmptyPrefix: bool=False) -> None:
     """This method returns a sorted list items of aList whose prefix is s.
 
     It also returns the longest common prefix of all the matches.
@@ -5751,14 +5751,14 @@ def itemsMatchingPrefixInList(s: str, aList, matchEmptyPrefix=False):
 # Warning: g.removeTrailingWs already exists.
 # Do not change it!
 
-def removeLeading(s: str, chars):
+def removeLeading(s: str, chars: Any) -> None:
     """Remove all characters in chars from the front of s."""
     i = 0
     while i < len(s) and s[i] in chars:
         i += 1
     return s[i:]
 
-def removeTrailing(s: str, chars):
+def removeTrailing(s: str, chars: Any) -> None:
     """Remove all characters in chars from the end of s."""
     i = len(s) - 1
     while i >= 0 and s[i] in chars:
@@ -5766,7 +5766,7 @@ def removeTrailing(s: str, chars):
     i += 1
     return s[:i]
 #@+node:ekr.20060410112600: *4* g.stripBrackets
-def stripBrackets(s: str):
+def stripBrackets(s: str) -> None:
     """Strip leading and trailing angle brackets."""
     if s.startswith('<'):
         s = s[1:]
@@ -5774,7 +5774,7 @@ def stripBrackets(s: str):
         s = s[:-1]
     return s
 #@+node:ekr.20170317101100.1: *4* g.unCamel
-def unCamel(s: str):
+def unCamel(s: str) -> None:
     """Return a list of sub-words in camelCased string s."""
     result: List[str] = []
     word: List[str] = []
@@ -5795,7 +5795,7 @@ def unCamel(s: str):
 #@+node:ekr.20190505052756.1: *4* g.checkUnicode
 checkUnicode_dict: Dict[str, bool] = {}
 
-def checkUnicode(s: str, encoding=None):
+def checkUnicode(s: str, encoding: Any=None) -> None:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -5835,7 +5835,7 @@ def checkUnicode(s: str, encoding=None):
         g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
     return s
 #@+node:ekr.20100125073206.8709: *4* g.getPythonEncodingFromString
-def getPythonEncodingFromString(s: str):
+def getPythonEncodingFromString(s: str) -> None:
     """Return the encoding given by Python's encoding line.
     s is the entire file.
     """
@@ -5861,7 +5861,7 @@ def getPythonEncodingFromString(s: str):
                     encoding = e
     return encoding
 #@+node:ekr.20031218072017.1500: *4* g.isValidEncoding
-def isValidEncoding(encoding):
+def isValidEncoding(encoding: Any) -> None:
     """Return True if the encooding is valid."""
     if not encoding:
         return False
@@ -5880,14 +5880,14 @@ def isValidEncoding(encoding):
         g.es_exception()
         return False
 #@+node:ekr.20061006152327: *4* g.isWordChar & g.isWordChar1
-def isWordChar(ch):
+def isWordChar(ch: str) -> None:
     """Return True if ch should be considered a letter."""
     return ch and (ch.isalnum() or ch == '_')
 
-def isWordChar1(ch):
+def isWordChar1(ch: str) -> None:
     return ch and (ch.isalpha() or ch == '_')
 #@+node:ekr.20130910044521.11304: *4* g.stripBOM
-def stripBOM(s: str):
+def stripBOM(s: str) -> None:
     """
     If there is a BOM, return (e,s2) where e is the encoding
     implied by the BOM and s2 is the s stripped of the BOM.
@@ -5911,7 +5911,7 @@ def stripBOM(s: str):
                 return e, s[len(bom) :]
     return None, s
 #@+node:ekr.20050208093800: *4* g.toEncodedString
-def toEncodedString(s: str, encoding='utf-8', reportErrors=False):
+def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> None:
     """Convert unicode string to an encoded string."""
     if not isinstance(s, str):
         return s
@@ -5963,7 +5963,7 @@ def toUnicode(s: Any, encoding: Optional[str]=None, reportErrors: bool=False) ->
 #@+node:ekr.20031218072017.3198: *4* g.computeLeadingWhitespace
 # Returns optimized whitespace corresponding to width with the indicated tab_width.
 
-def computeLeadingWhitespace(width, tab_width):
+def computeLeadingWhitespace(width: Any, tab_width: Any) -> None:
     if width <= 0:
         return ""
     if tab_width > 1:
@@ -5975,7 +5975,7 @@ def computeLeadingWhitespace(width, tab_width):
 #@+node:ekr.20120605172139.10263: *4* g.computeLeadingWhitespaceWidth
 # Returns optimized whitespace corresponding to width with the indicated tab_width.
 
-def computeLeadingWhitespaceWidth(s: str, tab_width):
+def computeLeadingWhitespaceWidth(s: str, tab_width: Any) -> None:
     w = 0
     for ch in s:
         if ch == ' ':
@@ -5988,7 +5988,7 @@ def computeLeadingWhitespaceWidth(s: str, tab_width):
 #@+node:ekr.20031218072017.3199: *4* g.computeWidth
 # Returns the width of s, assuming s starts a line, with indicated tab_width.
 
-def computeWidth(s: str, tab_width):
+def computeWidth(s: str, tab_width: Any) -> None:
     w = 0
     for ch in s:
         if ch == '\t':
@@ -6011,7 +6011,7 @@ def computeWidth(s: str, tab_width):
 #@@c
 #@@language python
 
-def wrap_lines(lines, pageWidth, firstLineWidth=None):
+def wrap_lines(lines: Any, pageWidth: Any, firstLineWidth: Any=None) -> None:
     """Returns a list of lines, consisting of the input lines wrapped to the given pageWidth."""
     if pageWidth < 10:
         pageWidth = 10
@@ -6077,7 +6077,7 @@ def wrap_lines(lines, pageWidth, firstLineWidth=None):
         result.append(line)
     return result
 #@+node:ekr.20031218072017.3200: *4* g.get_leading_ws
-def get_leading_ws(s: str):
+def get_leading_ws(s: str) -> None:
     """Returns the leading whitespace of 's'."""
     i = 0
     n = len(s)
@@ -6087,7 +6087,7 @@ def get_leading_ws(s: str):
 #@+node:ekr.20031218072017.3201: *4* g.optimizeLeadingWhitespace
 # Optimize leading whitespace in s with the given tab_width.
 
-def optimizeLeadingWhitespace(line, tab_width):
+def optimizeLeadingWhitespace(line: Any, tab_width: Any) -> None:
     i, width = g.skip_leading_ws_with_indent(line, 0, tab_width)
     s = g.computeLeadingWhitespace(width, tab_width) + line[i:]
     return s
@@ -6100,16 +6100,16 @@ def optimizeLeadingWhitespace(line, tab_width):
 # the meaning of program or data.
 #@@c
 
-def regularizeTrailingNewlines(s: str, kind):
+def regularizeTrailingNewlines(s: str, kind: Any) -> None:
     """Kind is 'asis', 'zero' or 'one'."""
     pass
 #@+node:ekr.20091229090857.11698: *4* g.removeBlankLines
-def removeBlankLines(s: str):
+def removeBlankLines(s: str) -> None:
     lines = g.splitLines(s)
     lines = [z for z in lines if z.strip()]
     return ''.join(lines)
 #@+node:ekr.20091229075924.6235: *4* g.removeLeadingBlankLines
-def removeLeadingBlankLines(s: str):
+def removeLeadingBlankLines(s: str) -> None:
     lines = g.splitLines(s)
     result = []
     remove = True
@@ -6123,7 +6123,7 @@ def removeLeadingBlankLines(s: str):
 #@+node:ekr.20031218072017.3202: *4* g.removeLeadingWhitespace
 # Remove whitespace up to first_ws wide in s, given tab_width, the width of a tab.
 
-def removeLeadingWhitespace(s: str, first_ws, tab_width):
+def removeLeadingWhitespace(s: str, first_ws: Any, tab_width: Any) -> None:
     j = 0
     ws = 0
     first_ws = abs(first_ws)
@@ -6144,7 +6144,7 @@ def removeLeadingWhitespace(s: str, first_ws, tab_width):
 #@+node:ekr.20031218072017.3203: *4* g.removeTrailingWs
 # Warning: string.rstrip also removes newlines!
 
-def removeTrailingWs(s: str):
+def removeTrailingWs(s: str) -> None:
     j = len(s) - 1
     while j >= 0 and (s[j] == ' ' or s[j] == '\t'):
         j -= 1
@@ -6152,7 +6152,7 @@ def removeTrailingWs(s: str):
 #@+node:ekr.20031218072017.3204: *4* g.skip_leading_ws
 # Skips leading up to width leading whitespace.
 
-def skip_leading_ws(s: str, i: int, ws, tab_width):
+def skip_leading_ws(s: str, i: int, ws: Any, tab_width: Any) -> None:
     count = 0
     while count < ws and i < len(s):
         ch = s[i]
@@ -6165,7 +6165,7 @@ def skip_leading_ws(s: str, i: int, ws, tab_width):
         else: break
     return i
 #@+node:ekr.20031218072017.3205: *4* g.skip_leading_ws_with_indent
-def skip_leading_ws_with_indent(s: str, i: int, tab_width):
+def skip_leading_ws_with_indent(s: str, i: int, tab_width: Any) -> None:
     """Skips leading whitespace and returns (i, indent),
 
     - i points after the whitespace
@@ -6183,7 +6183,7 @@ def skip_leading_ws_with_indent(s: str, i: int, tab_width):
         else: break
     return i, count
 #@+node:ekr.20040723093558.1: *4* g.stripBlankLines
-def stripBlankLines(s: str):
+def stripBlankLines(s: str) -> None:
     lines = g.splitLines(s)
     for i, line in enumerate(lines):
         j = g.skip_ws(line, 0)
@@ -6197,7 +6197,7 @@ def stripBlankLines(s: str):
 # g.pr prints to the console.
 # g.es_print and related print to both the Log window and the console.
 #@+node:ekr.20080821073134.2: *3* g.doKeywordArgs
-def doKeywordArgs(keys, d=None):
+def doKeywordArgs(keys: Any, d: Any=None) -> None:
     """
     Return a result dict that is a copy of the keys dict
     with missing items replaced by defaults in d dict.
@@ -6218,37 +6218,37 @@ def doKeywordArgs(keys, d=None):
             result[key] = val
     return result
 #@+node:ekr.20031218072017.1474: *3* g.enl, ecnl & ecnls
-def ecnl(tabName='Log'):
+def ecnl(tabName: str='Log') -> None:
     g.ecnls(1, tabName)
 
-def ecnls(n, tabName='Log'):
+def ecnls(n: int, tabName: str='Log') -> None:
     log = app.log
     if log and not log.isNull:
         while log.newlines < n:
             g.enl(tabName)
 
-def enl(tabName='Log'):
+def enl(tabName: str='Log') -> None:
     log = app.log
     if log and not log.isNull:
         log.newlines += 1
         log.putnl(tabName)
 #@+node:ekr.20100914094836.5892: *3* g.error, g.note, g.warning, g.red, g.blue
-def blue(*args, **keys):
+def blue(*args, **keys) -> None:
     g.es_print(color='blue', *args, **keys)
 
-def error(*args, **keys):
+def error(*args, **keys) -> None:
     g.es_print(color='error', *args, **keys)
 
-def note(*args, **keys):
+def note(*args, **keys) -> None:
     g.es_print(color='note', *args, **keys)
 
-def red(*args, **keys):
+def red(*args, **keys) -> None:
     g.es_print(color='red', *args, **keys)
 
-def warning(*args, **keys):
+def warning(*args, **keys) -> None:
     g.es_print(color='warning', *args, **keys)
 #@+node:ekr.20070626132332: *3* g.es
-def es(*args, **keys):
+def es(*args, **keys) -> None:
     """Put all non-keyword args to the log pane.
     The first, third, fifth, etc. arg translated by g.translateString.
     Supports color, comma, newline, spaces and tabName keyword arguments.
@@ -6299,7 +6299,7 @@ def es(*args, **keys):
 
 log = es
 #@+node:ekr.20190608090856.1: *3* g.es_clickable_link
-def es_clickable_link(c: Cmdr, p: Pos, line_number, message):
+def es_clickable_link(c: Cmdr, p: Pos, line_number: Any, message: Any) -> None:
     """
     Write a clickable message to the given line number of p.b.
 
@@ -6314,7 +6314,7 @@ def es_clickable_link(c: Cmdr, p: Pos, line_number, message):
     else:
         log.put(message)
 #@+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n=30, title=None):
+def es_dump(s: str, n: int=30, title: Any=None) -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6323,19 +6323,19 @@ def es_dump(s: str, n=30, title=None):
         g.es_print('', aList)
         i += n
 #@+node:ekr.20031218072017.3110: *3* g.es_error & es_print_error
-def es_error(*args, **keys):
+def es_error(*args, **keys) -> None:
     color = keys.get('color')
     if color is None and g.app.config:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es(*args, **keys)
 
-def es_print_error(*args, **keys):
+def es_print_error(*args, **keys) -> None:
     color = keys.get('color')
     if color is None and g.app.config:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es_print(*args, **keys)
 #@+node:ekr.20031218072017.3111: *3* g.es_event_exception
-def es_event_exception(eventName, full=False):
+def es_event_exception(eventName: Any, full: bool=False) -> None:
     g.es("exception handling ", eventName, "event")
     typ, val, tb = sys.exc_info()
     if full:
@@ -6347,7 +6347,7 @@ def es_event_exception(eventName, full=False):
     if not g.stdErrIsRedirected():  # 2/16/04
         traceback.print_exc()
 #@+node:ekr.20031218072017.3112: *3* g.es_exception
-def es_exception(full=True, c: Cmdr=None, color="red"):
+def es_exception(full: bool=True, c: Cmdr=None, color: str="red") -> None:
     typ, val, tb = sys.exc_info()
     # val is the second argument to the raise statement.
     if full:
@@ -6359,14 +6359,14 @@ def es_exception(full=True, c: Cmdr=None, color="red"):
     fileName, n = g.getLastTracebackFileAndLineNumber()
     return fileName, n
 #@+node:ekr.20061015090538: *3* g.es_exception_type
-def es_exception_type(c: Cmdr=None, color="red"):
+def es_exception_type(c: Cmdr=None, color: str="red") -> None:
     # exctype is a Exception class object; value is the error message.
     exctype, value = sys.exc_info()[:2]
     g.es_print('', f"{exctype.__name__}, {value}", color=color)  # type:ignore
 #@+node:ekr.20050707064040: *3* g.es_print
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def es_print(*args, **keys):
+def es_print(*args, **keys) -> None:
     """
     Print all non-keyword args, and put them to the log pane.
 
@@ -6377,7 +6377,7 @@ def es_print(*args, **keys):
     if g.app and not g.unitTesting:
         g.es(*args, **keys)
 #@+node:ekr.20111107181638.9741: *3* g.print_exception
-def print_exception(full=True, c: Cmdr=None, flush=False, color="red"):
+def print_exception(full: bool=True, c: Cmdr=None, flush: bool=False, color: str="red") -> None:
     """Print exception info about the last exception."""
     typ, val, tb = sys.exc_info()
         # val is the second argument to the raise statement.
@@ -6392,7 +6392,7 @@ def print_exception(full=True, c: Cmdr=None, flush=False, color="red"):
     except Exception:
         return "<no file>", 0
 #@+node:ekr.20050707065530: *3* g.es_trace
-def es_trace(*args, **keys):
+def es_trace(*args, **keys) -> None:
     if args:
         try:
             s = args[0]
@@ -6401,7 +6401,7 @@ def es_trace(*args, **keys):
             pass
     g.es(*args, **keys)
 #@+node:ekr.20040731204831: *3* g.getLastTracebackFileAndLineNumber
-def getLastTracebackFileAndLineNumber():
+def getLastTracebackFileAndLineNumber() -> None:
     typ, val, tb = sys.exc_info()
     if typ == SyntaxError:
         # IndentationError is a subclass of SyntaxError.
@@ -6417,7 +6417,7 @@ def getLastTracebackFileAndLineNumber():
     # Should never happen.
     return '<string>', 0
 #@+node:ekr.20150621095017.1: *3* g.goto_last_exception
-def goto_last_exception(c: Cmdr):
+def goto_last_exception(c: Cmdr) -> None:
     """Go to the line given by sys.last_traceback."""
     typ, val, tb = sys.exc_info()
     if tb:
@@ -6435,7 +6435,7 @@ def goto_last_exception(c: Cmdr):
     else:
         g.trace('No previous exception')
 #@+node:ekr.20100126062623.6240: *3* g.internalError
-def internalError(*args):
+def internalError(*args) -> None:
     """Report a serious interal error in Leo."""
     callers = g.callers(20).split(',')
     caller = callers[-1]
@@ -6444,7 +6444,7 @@ def internalError(*args):
     g.es_print('Called from', ', '.join(callers[:-1]))
     g.es_print('Please report this error to Leo\'s developers', color='red')
 #@+node:ekr.20150127060254.5: *3* g.log_to_file
-def log_to_file(s: str, fn=None):
+def log_to_file(s: str, fn: Any=None) -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
         fn = g.os_path_expanduser('~/test/leo_log.txt')
@@ -6458,7 +6458,7 @@ def log_to_file(s: str, fn=None):
 #@+node:ekr.20080710101653.1: *3* g.pr
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def pr(*args, **keys):
+def pr(*args, **keys) -> None:
     """
     Print all non-keyword args. This is a wrapper for the print statement.
 
@@ -6495,7 +6495,7 @@ def pr(*args, **keys):
     except Exception:
         pass
 #@+node:ekr.20060221083356: *3* g.prettyPrintType
-def prettyPrintType(obj: Any):
+def prettyPrintType(obj: Any) -> None:
     if isinstance(obj, str):
         return 'string'
     t = type(obj)
@@ -6513,19 +6513,19 @@ def prettyPrintType(obj: Any):
         t = t[:-2]
     return t
 #@+node:ekr.20031218072017.3113: *3* g.printBindings
-def print_bindings(name, window):
+def print_bindings(name: Any, window: Any) -> None:
     bindings = window.bind()
     g.pr("\nBindings for", name)
     for b in bindings:
         g.pr(b)
 #@+node:ekr.20070510074941: *3* g.printEntireTree
-def printEntireTree(c: Cmdr, tag=''):
+def printEntireTree(c: Cmdr, tag: str='') -> None:
     g.pr('printEntireTree', '=' * 50)
     g.pr('printEntireTree', tag, 'root', c.rootPosition())
     for p in c.all_positions():
         g.pr('..' * p.level(), p.v)
 #@+node:ekr.20031218072017.3114: *3* g.printGlobals
-def printGlobals(message=None):
+def printGlobals(message: Any=None) -> None:
     # Get the list of globals.
     globs = list(globals())
     globs.sort()
@@ -6536,7 +6536,7 @@ def printGlobals(message=None):
     for name in globs:
         g.pr(name)
 #@+node:ekr.20031218072017.3115: *3* g.printLeoModules
-def printLeoModules(message=None):
+def printLeoModules(message: Any=None) -> None:
     # Create the list.
     mods = []
     for name in sys.modules:
@@ -6551,10 +6551,10 @@ def printLeoModules(message=None):
         g.pr(m, newline=False)
     g.pr('')
 #@+node:ekr.20041122153823: *3* g.printStack
-def printStack():
+def printStack() -> None:
     traceback.print_stack()
 #@+node:ekr.20031218072017.2317: *3* g.trace
-def trace(*args, **keys):
+def trace(*args, **keys) -> None:
     """Print a tracing message."""
     # Don't use g here: in standalone mode g is a NullObject!
     # Compute the effective args.
@@ -6646,7 +6646,7 @@ def translateArgs(args: Iterable[Any], d: Dict[str, Any]) -> str:
             result.append(arg)
     return ''.join(result)
 #@+node:ekr.20060810095921: *3* g.translateString & tr
-def translateString(s: str):
+def translateString(s: str) -> None:
     """Return the translated text of s."""
     # pylint: disable=undefined-loop-variable
     # looks like a pylint bug
@@ -6662,7 +6662,7 @@ def translateString(s: str):
 tr = translateString
 #@+node:EKR.20040612114220: ** g.Miscellaneous
 #@+node:ekr.20120928142052.10116: *3* g.actualColor
-def actualColor(color):
+def actualColor(color: Any) -> None:
     """Return the actual color corresponding to the requested color."""
     c = g.app.log and g.app.log.c
     # Careful: c.config may not yet exist.
@@ -6693,7 +6693,14 @@ def actualColor(color):
 #@+node:ekr.20060921100435: *3* g.CheckVersion & helpers
 # Simplified version by EKR: stringCompare not used.
 
-def CheckVersion(s1, s2, condition=">=", stringCompare=None, delimiter='.', trace=False):
+def CheckVersion(
+    s1: Any,
+    s2: Any,
+    condition: str=">=",
+    stringCompare: Any=None,
+    delimiter: str='.',
+    trace: bool=False,
+) -> None:
     # CheckVersion is called early in the startup process.
     vals1 = [g.CheckVersionToInt(s) for s in s1.split(delimiter)]
     n1 = len(vals1)
@@ -6717,7 +6724,7 @@ def CheckVersion(s1, s2, condition=">=", stringCompare=None, delimiter='.', trac
             "condition must be one of '>=', '>', '==', '!=', '<', or '<='.")
     return result
 #@+node:ekr.20070120123930: *4* g.CheckVersionToInt
-def CheckVersionToInt(s: str):
+def CheckVersionToInt(s: str) -> None:
     try:
         return int(s)
     except ValueError:
@@ -6733,12 +6740,12 @@ def CheckVersionToInt(s: str):
         return 0
 #@+node:ekr.20111103205308.9657: *3* g.cls
 @command('cls')
-def cls(event=None):
+def cls(event: Any=None) -> None:
     """Clear the screen."""
     if sys.platform.lower().startswith('win'):
         os.system('cls')
 #@+node:ekr.20131114124839.16665: *3* g.createScratchCommander
-def createScratchCommander(fileName=None):
+def createScratchCommander(fileName: Any=None) -> None:
     c = g.app.newCommander(fileName)
     frame = c.frame
     frame.createFirstTreeNode()
@@ -6746,7 +6753,7 @@ def createScratchCommander(fileName=None):
     frame.setInitialWindowGeometry()
     frame.resizePanesToRatio(frame.ratio, frame.secondary_ratio)
 #@+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
-def funcToMethod(f, theClass, name=None):
+def funcToMethod(f: Any, theClass: Any, name: Any=None) -> None:
     """
     From the Python Cookbook...
 
@@ -6768,7 +6775,7 @@ init_zodb_import_failed = False
 init_zodb_failed: Dict[str, bool] = {}  # Keys are paths, values are True.
 init_zodb_db: Dict[str, Any] = {}  # Keys are paths, values are ZODB.DB instances.
 
-def init_zodb(pathToZodbStorage, verbose=True):
+def init_zodb(pathToZodbStorage: Any, verbose: bool=True) -> None:
     """
     Return an ZODB.DB instance from the given path.
     return None on any error.
@@ -6801,7 +6808,7 @@ def init_zodb(pathToZodbStorage, verbose=True):
         init_zodb_failed[pathToZodbStorage] = True
         return None
 #@+node:ekr.20170206080908.1: *3* g.input_
-def input_(message='', c: Cmdr=None):
+def input_(message: str='', c: Cmdr=None) -> None:
     """
     Safely execute python's input statement.
 
@@ -6816,10 +6823,10 @@ def input_(message='', c: Cmdr=None):
     QtCore.pyqtRemoveInputHook()
     return input(message)
 #@+node:ekr.20110609125359.16493: *3* g.isMacOS
-def isMacOS():
+def isMacOS() -> None:
     return sys.platform == 'darwin'
 #@+node:ekr.20181027133311.1: *3* g.issueSecurityWarning
-def issueSecurityWarning(setting):
+def issueSecurityWarning(setting: Any) -> None:
     g.es('Security warning! Ignoring...', color='red')
     g.es(setting, color='red')
     g.es('This setting can be set only in')
@@ -6827,11 +6834,11 @@ def issueSecurityWarning(setting):
 #@+node:ekr.20031218072017.3144: *3* g.makeDict (Python Cookbook)
 # From the Python cookbook.
 
-def makeDict(**keys):
+def makeDict(**keys) -> None:
     """Returns a Python dictionary from using the optional keyword arguments."""
     return keys
 #@+node:ekr.20140528065727.17963: *3* g.pep8_class_name
-def pep8_class_name(s: str):
+def pep8_class_name(s: str) -> None:
     """Return the proper class name for s."""
     # Warning: s.capitalize() does not work.
     # It lower cases all but the first letter!
@@ -6851,7 +6858,7 @@ if 0:  # Testing:
     for s in aList:
         print(pep8_class_name(s))
 #@+node:ekr.20160417174224.1: *3* g.plural
-def plural(obj: Any):
+def plural(obj: Any) -> None:
     """Return "s" or "" depending on n."""
     if isinstance(obj, (list, tuple, str)):
         n = len(obj)
@@ -6859,7 +6866,7 @@ def plural(obj: Any):
         n = obj
     return '' if n == 1 else 's'
 #@+node:ekr.20160331194701.1: *3* g.truncate
-def truncate(s: str, n):
+def truncate(s: str, n: int) -> None:
     """Return s truncated to n characters."""
     if len(s) <= n:
         return s
@@ -6869,13 +6876,13 @@ def truncate(s: str, n):
         return s2 + '\n'
     return s2
 #@+node:ekr.20031218072017.3150: *3* g.windows
-def windows():
+def windows() -> None:
     return app and app.windowList
 #@+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers
 #@+at Note: all these methods return Unicode strings. It is up to the user to
 # convert to an encoded string as needed, say when opening a file.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
-def glob_glob(pattern):
+def glob_glob(pattern: Any) -> None:
     """Return the regularized glob.glob(pattern)"""
     aList = glob.glob(pattern)
     # os.path.normpath does the *reverse* of what we want.
@@ -6883,7 +6890,7 @@ def glob_glob(pattern):
         aList = [z.replace('\\', '/') for z in aList]
     return aList
 #@+node:ekr.20031218072017.2146: *3* g.os_path_abspath
-def os_path_abspath(path: str):
+def os_path_abspath(path: str) -> None:
     """Convert a path to an absolute path."""
     if not path:
         return ''
@@ -6896,7 +6903,7 @@ def os_path_abspath(path: str):
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2147: *3* g.os_path_basename
-def os_path_basename(path: str):
+def os_path_basename(path: str) -> None:
     """Return the second half of the pair returned by split(path)."""
     if not path:
         return ''
@@ -6906,7 +6913,7 @@ def os_path_basename(path: str):
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2148: *3* g.os_path_dirname
-def os_path_dirname(path: str):
+def os_path_dirname(path: str) -> None:
     """Return the first half of the pair returned by split(path)."""
     if not path:
         return ''
@@ -6916,7 +6923,7 @@ def os_path_dirname(path: str):
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2149: *3* g.os_path_exists
-def os_path_exists(path: str):
+def os_path_exists(path: str) -> None:
     """Return True if path exists."""
     if not path:
         return False
@@ -6925,7 +6932,7 @@ def os_path_exists(path: str):
         path = path.replace('\x00', '')  # Fix Python 3 bug on Windows 10.
     return os.path.exists(path)
 #@+node:ekr.20080921060401.13: *3* g.os_path_expanduser
-def os_path_expanduser(path: str):
+def os_path_expanduser(path: str) -> None:
     """wrap os.path.expanduser"""
     if not path:
         return ''
@@ -6935,7 +6942,7 @@ def os_path_expanduser(path: str):
         path = path.replace('\\', '/')
     return result
 #@+node:ekr.20080921060401.14: *3* g.os_path_finalize
-def os_path_finalize(path: str):
+def os_path_finalize(path: str) -> None:
     """
     Expand '~', then return os.path.normpath, os.path.abspath of the path.
     There is no corresponding os.path method
@@ -6952,7 +6959,7 @@ def os_path_finalize(path: str):
     # calling os.path.realpath here would cause problems in some situations.
     return path
 #@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join
-def os_path_finalize_join(*args, **keys):
+def os_path_finalize_join(*args, **keys) -> None:
     """
     Join and finalize.
 
@@ -6962,7 +6969,7 @@ def os_path_finalize_join(*args, **keys):
     path = g.os_path_finalize(path)
     return path
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
-def os_path_getmtime(path: str):
+def os_path_getmtime(path: str) -> None:
     """Return the modification time of path."""
     if not path:
         return 0
@@ -6971,23 +6978,23 @@ def os_path_getmtime(path: str):
     except Exception:
         return 0
 #@+node:ekr.20080729142651.2: *3* g.os_path_getsize
-def os_path_getsize(path: str):
+def os_path_getsize(path: str) -> None:
     """Return the size of path."""
     return os.path.getsize(path) if path else 0
 #@+node:ekr.20031218072017.2151: *3* g.os_path_isabs
-def os_path_isabs(path: str):
+def os_path_isabs(path: str) -> None:
     """Return True if path is an absolute path."""
     return os.path.isabs(path) if path else False
 #@+node:ekr.20031218072017.2152: *3* g.os_path_isdir
-def os_path_isdir(path: str):
+def os_path_isdir(path: str) -> None:
     """Return True if the path is a directory."""
     return os.path.isdir(path) if path else False
 #@+node:ekr.20031218072017.2153: *3* g.os_path_isfile
-def os_path_isfile(path: str):
+def os_path_isfile(path: str) -> None:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
 #@+node:ekr.20031218072017.2154: *3* g.os_path_join
-def os_path_join(*args, **keys):
+def os_path_join(*args, **keys) -> None:
     """
     Join paths, like os.path.join, with enhancements:
 
@@ -7020,7 +7027,7 @@ def os_path_join(*args, **keys):
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2156: *3* g.os_path_normcase
-def os_path_normcase(path: str):
+def os_path_normcase(path: str) -> None:
     """Normalize the path's case."""
     if not path:
         return ''
@@ -7029,7 +7036,7 @@ def os_path_normcase(path: str):
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2157: *3* g.os_path_normpath
-def os_path_normpath(path: str):
+def os_path_normpath(path: str) -> None:
     """Normalize the path."""
     if not path:
         return ''
@@ -7039,14 +7046,14 @@ def os_path_normpath(path: str):
         path = path.replace('\\', '/').lower()  # #2049: ignore case!
     return path
 #@+node:ekr.20180314081254.1: *3* g.os_path_normslashes
-def os_path_normslashes(path: str):
+def os_path_normslashes(path: str) -> None:
 
     # os.path.normpath does the *reverse* of what we want.
     if g.isWindows and path:
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20080605064555.2: *3* g.os_path_realpath
-def os_path_realpath(path: str):
+def os_path_realpath(path: str) -> None:
     """Return the canonical path of the specified filename, eliminating any
     symbolic links encountered in the path (if they are supported by the
     operating system).
@@ -7059,23 +7066,23 @@ def os_path_realpath(path: str):
         path = path.replace('\\', '/')
     return path
 #@+node:ekr.20031218072017.2158: *3* g.os_path_split
-def os_path_split(path: str):
+def os_path_split(path: str) -> None:
     if not path:
         return '', ''
     head, tail = os.path.split(path)
     return head, tail
 #@+node:ekr.20031218072017.2159: *3* g.os_path_splitext
-def os_path_splitext(path: str):
+def os_path_splitext(path: str) -> None:
 
     if not path:
         return ''
     head, tail = os.path.splitext(path)
     return head, tail
 #@+node:ekr.20090829140232.6036: *3* g.os_startfile
-def os_startfile(fname):
+def os_startfile(fname: Any) -> None:
     #@+others
     #@+node:bob.20170516112250.1: *4* stderr2log()
-    def stderr2log(g, ree, fname):
+    def stderr2log(g: Any, ree: Any, fname: Any) -> None:
         """ Display stderr output in the Leo-Editor log pane
 
         Arguments:
@@ -7094,7 +7101,7 @@ def os_startfile(fname):
             else:
                 break
     #@+node:bob.20170516112304.1: *4* itPoll()
-    def itPoll(fname, ree, subPopen, g, ito):
+    def itPoll(fname: Any, ree: Any, subPopen: Any, g: Any, ito: Any) -> None:
         """ Poll for subprocess done
 
         Arguments:
@@ -7163,7 +7170,7 @@ def os_startfile(fname):
             g.es_exception(f"exception executing g.startfile for {fname!r}")
 #@+node:ekr.20111115155710.9859: ** g.Parsing & Tokenizing
 #@+node:ekr.20031218072017.822: *3* g.createTopologyList
-def createTopologyList(c: Cmdr, root=None, useHeadlines=False):
+def createTopologyList(c: Cmdr, root: Any=None, useHeadlines: bool=False) -> None:
     """Creates a list describing a node and all its descendents"""
     if not root:
         root = c.rootPosition()
@@ -7178,7 +7185,7 @@ def createTopologyList(c: Cmdr, root=None, useHeadlines=False):
         child = child.next()
     return aList
 #@+node:ekr.20111017204736.15898: *3* g.getDocString
-def getDocString(s: str):
+def getDocString(s: str) -> None:
     """Return the text of the first docstring found in s."""
     tags = ('"""', "'''")
     tag1, tag2 = tags
@@ -7196,13 +7203,13 @@ def getDocString(s: str):
         return s[i + 3 : j]
     return ''
 #@+node:ekr.20111017211256.15905: *3* g.getDocStringForFunction
-def getDocStringForFunction(func):
+def getDocStringForFunction(func: Any) -> None:
     """Return the docstring for a function that creates a Leo command."""
 
-    def name(func):
+    def name(func: Any) -> None:
         return func.__name__ if hasattr(func, '__name__') else '<no __name__>'
 
-    def get_defaults(func, i):
+    def get_defaults(func: Any, i: int) -> None:
         defaults = inspect.getfullargspec(func)[3]
         return defaults[i]
 
@@ -7226,7 +7233,7 @@ def getDocStringForFunction(func):
         s = func.docstring
     return s
 #@+node:ekr.20111115155710.9814: *3* g.python_tokenize (not used)
-def python_tokenize(s: str):
+def python_tokenize(s: str) -> None:
     """
     Tokenize string s and return a list of tokens (kind, value, line_number)
 
@@ -7259,14 +7266,14 @@ def python_tokenize(s: str):
     return result
 #@+node:ekr.20040327103735.2: ** g.Scripting
 #@+node:ekr.20161223090721.1: *3* g.exec_file
-def exec_file(path: str, d, script=None):
+def exec_file(path: str, d: Dict[str, str], script: Any=None) -> None:
     """Simulate python's execfile statement for python 3."""
     if script is None:
         with open(path) as f:
             script = f.read()
     exec(compile(script, path, 'exec'), d)
 #@+node:ekr.20131016032805.16721: *3* g.execute_shell_commands
-def execute_shell_commands(commands, trace=False):
+def execute_shell_commands(commands: Any, trace: bool=False) -> None:
     """
     Execute each shell command in a separate process.
     Wait for each command to complete, except those starting with '&'
@@ -7287,7 +7294,7 @@ def execute_shell_commands(commands, trace=False):
                 print('Start:', proc)
             # #1489: call proc.poll at idle time.
 
-            def proc_poller(timer, proc=proc):
+            def proc_poller(timer: Any, proc=proc) -> None:
                 val = proc.poll()
                 if val is not None:
                     # This trace can be disruptive.
@@ -7327,7 +7334,7 @@ def execute_shell_commands_with_options(
     os.chdir(base_dir)  # Can't do this in the commands list.
     g.execute_shell_commands(commands)
 #@+node:ekr.20180217152624.1: *4* g.computeBaseDir
-def computeBaseDir(c: Cmdr, base_dir, path_setting, trace=False):
+def computeBaseDir(c: Cmdr, base_dir: Any, path_setting: Any, trace: bool=False) -> None:
     """
     Compute a base_directory.
     If given, @string path_setting takes precedence.
@@ -7351,7 +7358,7 @@ def computeBaseDir(c: Cmdr, base_dir, path_setting, trace=False):
         return g.es_print(f"base_dir not found: {base_dir!r}")
     return g.es_print(f"Please use @string {path_setting}")
 #@+node:ekr.20180217153459.1: *4* g.computeCommands
-def computeCommands(c: Cmdr, commands, command_setting, trace=False):
+def computeCommands(c: Cmdr, commands: Any, command_setting: Any, trace: bool=False) -> None:
     """
     Get the list of commands.
     If given, @data command_setting takes precedence.
@@ -7370,13 +7377,13 @@ def computeCommands(c: Cmdr, commands, command_setting, trace=False):
         return []
     return commands
 #@+node:ekr.20050503112513.7: *3* g.executeFile
-def executeFile(filename, options=''):
+def executeFile(filename: Any, options: str='') -> None:
     if not os.access(filename, os.R_OK):
         return
     fdir, fname = g.os_path_split(filename)
     # New in Leo 4.10: alway use subprocess.
 
-    def subprocess_wrapper(cmdlst):
+    def subprocess_wrapper(cmdlst: Any) -> None:
 
         p = subprocess.Popen(cmdlst, cwd=fdir,
             universal_newlines=True,
@@ -7391,7 +7398,7 @@ def executeFile(filename, options=''):
 #@+node:ekr.20040321065415: *3* g.find*Node*
 #@+others
 #@+node:ekr.20210303123423.3: *4* findNodeAnywhere
-def findNodeAnywhere(c: Cmdr, headline, exact=True):
+def findNodeAnywhere(c: Cmdr, headline: Any, exact: bool=True) -> None:
     h = headline.strip()
     for p in c.all_unique_positions(copy=False):
         if p.h.strip() == h:
@@ -7402,7 +7409,7 @@ def findNodeAnywhere(c: Cmdr, headline, exact=True):
                 return p.copy()
     return None
 #@+node:ekr.20210303123525.1: *4* findNodeByPath
-def findNodeByPath(c: Cmdr, path: str):
+def findNodeByPath(c: Cmdr, path: str) -> None:
     """Return the first @<file> node in Cmdr c whose path is given."""
     if not os.path.isabs(path):  # #2049. Only absolute paths could possibly work.
         g.trace(f"path not absolute: {path}")
@@ -7414,7 +7421,7 @@ def findNodeByPath(c: Cmdr, path: str):
                 return p
     return None
 #@+node:ekr.20210303123423.1: *4* findNodeInChildren
-def findNodeInChildren(c: Cmdr, p: Pos, headline, exact=True):
+def findNodeInChildren(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> None:
     """Search for a node in v's tree matching the given headline."""
     p1 = p.copy()
     h = headline.strip()
@@ -7427,7 +7434,7 @@ def findNodeInChildren(c: Cmdr, p: Pos, headline, exact=True):
                 return p.copy()
     return None
 #@+node:ekr.20210303123423.2: *4* findNodeInTree
-def findNodeInTree(c: Cmdr, p: Pos, headline, exact=True):
+def findNodeInTree(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> None:
     """Search for a node in v's tree matching the given headline."""
     h = headline.strip()
     p1 = p.copy()
@@ -7440,7 +7447,7 @@ def findNodeInTree(c: Cmdr, p: Pos, headline, exact=True):
                 return p.copy()
     return None
 #@+node:ekr.20210303123423.4: *4* findTopLevelNode
-def findTopLevelNode(c: Cmdr, headline, exact=True):
+def findTopLevelNode(c: Cmdr, headline: Any, exact: bool=True) -> None:
     h = headline.strip()
     for p in c.rootPosition().self_and_siblings(copy=False):
         if p.h.strip() == h:
@@ -7484,7 +7491,7 @@ def getScript(c: Cmdr, p: Pos,
         script = ''
     return script
 #@+node:ekr.20170228082641.1: *4* g.composeScript
-def composeScript(c: Cmdr, p: Pos, s: str, forcePythonSentinels=True, useSentinels=True):
+def composeScript(c: Cmdr, p: Pos, s: str, forcePythonSentinels: bool=True, useSentinels: bool=True) -> None:
     """Compose a script from p.b."""
     # This causes too many special cases.
         # if not g.unitTesting and forceEncoding:
@@ -7510,7 +7517,7 @@ def composeScript(c: Cmdr, p: Pos, s: str, forcePythonSentinels=True, useSentine
         g.app.inScript = g.inScript = old_in_script
     return script
 #@+node:ekr.20170123074946.1: *4* g.extractExecutableString
-def extractExecutableString(c: Cmdr, p: Pos, s: str):
+def extractExecutableString(c: Cmdr, p: Pos, s: str) -> None:
     """
     Return all lines for the given @language directive.
 
@@ -7543,7 +7550,7 @@ def extractExecutableString(c: Cmdr, p: Pos, s: str):
             result.append(line)
     return ''.join(result)
 #@+node:ekr.20060624085200: *3* g.handleScriptException
-def handleScriptException(c: Cmdr, p: Pos, script, script1):
+def handleScriptException(c: Cmdr, p: Pos, script: Any, script1: Any) -> None:
     g.warning("exception executing script")
     full = c.config.getBool('show-full-tracebacks-in-scripts')
     fileName, n = g.es_exception(full=full)
@@ -7573,7 +7580,7 @@ def handleScriptException(c: Cmdr, p: Pos, script, script1):
             g.es_print('Unexpected exception in g.handleScriptException')
             g.es_exception()
 #@+node:ekr.20140209065845.16767: *3* g.insertCodingLine
-def insertCodingLine(encoding, script):
+def insertCodingLine(encoding: Any, script: Any) -> None:
     """
     Insert a coding line at the start of script s if no such line exists.
     The coding line must start with @first because it will be passed to
@@ -7591,7 +7598,7 @@ def insertCodingLine(encoding, script):
     return script
 #@+node:ekr.20070524083513: ** g.Unit Tests
 #@+node:ekr.20210901071523.1: *3* g.run_coverage_tests
-def run_coverage_tests(module='', filename=''):
+def run_coverage_tests(module: str='', filename: str='') -> None:
     """
     Run the coverage tests given by the module and filename strings.
     """
@@ -7601,7 +7608,7 @@ def run_coverage_tests(module='', filename=''):
     command = f"{prefix} {module} {filename}"
     g.execute_shell_commands(command, trace=False)
 #@+node:ekr.20200221050038.1: *3* g.run_unit_test_in_separate_process
-def run_unit_test_in_separate_process(command):
+def run_unit_test_in_separate_process(command: Any) -> None:
     """
     A script to be run from unitTest.leo.
 
@@ -7631,7 +7638,7 @@ def run_unit_test_in_separate_process(command):
         g.printObj(err_lines, tag='err_lines')
         assert False
 #@+node:ekr.20210901065224.1: *3* g.run_unit_tests
-def run_unit_tests(tests=None, verbose=False):
+def run_unit_tests(tests: Any=None, verbose: bool=False) -> None:
     """
     Run the unit tests given by the "tests" string.
 
@@ -7650,11 +7657,11 @@ unl_regex = re.compile(r'\bunl:.*$')
 kinds = '(file|ftp|gopher|http|https|mailto|news|nntp|prospero|telnet|wais)'
 url_regex = re.compile(fr"""{kinds}://[^\s'"]+[\w=/]""")
 #@+node:ekr.20170226093349.1: *3* g.unquoteUrl
-def unquoteUrl(url):
+def unquoteUrl(url: Any) -> None:
     """Replace special characters (especially %20, by their equivalent)."""
     return urllib.parse.unquote(url)
 #@+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn, c: Cmdr=None, p: Pos=None):
+def computeFileUrl(fn: Any, c: Cmdr=None, p: Pos=None) -> None:
     """
     Compute finalized url for filename fn.
     """
@@ -7690,7 +7697,7 @@ def computeFileUrl(fn, c: Cmdr=None, p: Pos=None):
         url = f"{tag}{path}"
     return url
 #@+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
-def getUrlFromNode(p: Pos):
+def getUrlFromNode(p: Pos) -> None:
     """
     Get an url from node p:
     1. Use the headline if it contains a valid url.
@@ -7724,7 +7731,7 @@ def getUrlFromNode(p: Pos):
             return s
     return None
 #@+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url, c: Cmdr=None, p: Pos=None):
+def handleUrl(url: Any, c: Cmdr=None, p: Pos=None) -> None:
     """Open a url or a unl."""
     if c and not p:
         p = c.p
@@ -7744,7 +7751,7 @@ def handleUrl(url, c: Cmdr=None, p: Pos=None):
         g.es_exception()
         return None
 #@+node:ekr.20170226054459.1: *4* g.handleUrlHelper
-def handleUrlHelper(url, c: Cmdr, p: Pos):
+def handleUrlHelper(url: Any, c: Cmdr, p: Pos) -> None:
     """Open a url.  Most browsers should handle:
         ftp://ftp.uu.net/public/whatever
         http://localhost/MySiteUnderDevelopment/index.html
@@ -7785,7 +7792,7 @@ def handleUrlHelper(url, c: Cmdr, p: Pos):
             except Exception:
                 pass
 #@+node:ekr.20170226060816.1: *4* g.traceUrl
-def traceUrl(c: Cmdr, path: str, parsed, url):
+def traceUrl(c: Cmdr, path: str, parsed: Any, url: Any) -> None:
 
     print()
     g.trace('url          ', url)
@@ -7796,7 +7803,7 @@ def traceUrl(c: Cmdr, path: str, parsed, url):
     g.trace('parsed.path  ', parsed.path)
     g.trace('parsed.scheme', repr(parsed.scheme))
 #@+node:ekr.20170221063527.1: *3* g.handleUnl
-def handleUnl(unl, c: Cmdr):
+def handleUnl(unl: Any, c: Cmdr) -> None:
     """
     Handle a Leo UNL. This must *never* open a browser.
 
@@ -7866,7 +7873,7 @@ def handleUnl(unl, c: Cmdr):
         return c2
     return None
 #@+node:ekr.20120311151914.9918: *3* g.isValidUrl
-def isValidUrl(url) -> bool:
+def isValidUrl(url: Any) -> bool:
     """Return true if url *looks* like a valid url."""
     table = (
         'file', 'ftp', 'gopher', 'hdl', 'http', 'https', 'imap',

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2319,7 +2319,7 @@ class TracingNullObject:
         g.null_object_print(id(self), '__setitem__')
         # pylint doesn't like trailing return None.
 #@+node:ekr.20190330062625.1: *4* g.null_object_print_attr
-def null_object_print_attr(id_, attr):
+def null_object_print_attr(id_: int, attr: str) -> None:
     suppress = True
     suppress_callers: List[str] = []
     suppress_attrs: List[str] = []
@@ -2370,7 +2370,7 @@ def null_object_print_attr(id_, attr):
             tracing_signatures[signature] = True
             g.pr(f"{s:40} {callers}")
 #@+node:ekr.20190330072832.1: *4* g.null_object_print
-def null_object_print(id_, kind, *args):
+def null_object_print(id_: int, kind: Any, *args: Any) -> None:
     tag = tracing_tags.get(id_, "<NO TAG>")
     callers = g.callers(3).split(',')
     callers = ','.join(callers[:-1])

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -480,7 +480,7 @@ class EmergencyDialog:
     """A class that creates an tkinter dialog with a single OK button."""
     #@+others
     #@+node:ekr.20120219154958.10493: *4* emergencyDialog.__init__
-    def __init__(self, title: str, message: str) -> Any:
+    def __init__(self, title: str, message: str) -> None:
         """Constructor for the leoTkinterDialog class."""
         self.answer = None  # Value returned from run()
         self.title = title
@@ -565,7 +565,8 @@ class EmergencyDialog:
 class GeneralSetting:
     """A class representing any kind of setting except shortcuts."""
 
-    def __init__(self, kind,
+    def __init__(self,
+        kind: str,
         encoding: str=None,
         ivar: str=None,
         setting: str=None,
@@ -1650,13 +1651,13 @@ class SherlockTracer:
         verbose: bool=True,
     ) -> None:
         """SherlockTracer ctor."""
-        self.bad_patterns = []  # List of bad patterns.
+        self.bad_patterns: List[str] = []  # List of bad patterns.
         self.dots = dots  # True: print level dots.
-        self.contents_d = {}  # Keys are file names, values are file lines.
+        self.contents_d: Dict[str, List] = {}  # Keys are file names, values are file lines.
         self.n = 0  # The frame level on entry to run.
-        self.stats = {}  # Keys are full file names, values are dicts.
-        self.patterns = None  # A list of regex patterns to match.
-        self.pattern_stack = []
+        self.stats: Dict[str, Dict] = {}  # Keys are full file names, values are dicts.
+        self.patterns: List[Any] = None  # A list of regex patterns to match.
+        self.pattern_stack: List[str] = []
         self.show_args = show_args  # True: show args for each function call.
         self.show_return = show_return  # True: show returns from each function.
         self.trace_lines = True  # True: trace lines in enabled functions.
@@ -2214,7 +2215,7 @@ def startTracer(limit: int=0, trace: bool=False, verbose: bool=False) -> Callabl
 #@@nobeautify
 
 tracing_tags: Dict[int, str] = {}  # Keys are id's, values are tags.
-tracing_vars: Dict[int, str] = {}  # Keys are id's, values are names of ivars.
+tracing_vars: Dict[int, List] = {}  # Keys are id's, values are names of ivars.
 # Keys are signatures: '%s.%s:%s' % (tag, attr, callers). Values not important.
 tracing_signatures: Dict[str, Any] = {}
 
@@ -2265,10 +2266,6 @@ class TracingNullObject:
         if isinstance(ivars, str):
             ivars = [ivars]
         tracing_vars [id(self)] = ivars or []
-        if 0:
-            suppress = ('tree item',)
-            if tag not in suppress:
-                print('='*10, 'NullObject.__init__:', id(self), tag)
     def __call__(self, *args: Any, **kwargs: Any) -> "TracingNullObject":
         return self
     def __repr__(self) -> str:
@@ -2838,7 +2835,7 @@ def module_date(mod: Any, format: Any=None) -> str:
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
 
-def plugin_date(plugin_mod: Any, format: Any=None) -> None:
+def plugin_date(plugin_mod: Any, format: Any=None) -> str:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=str)
@@ -2997,14 +2994,16 @@ def objToString(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None
 
 toString = objToString
 #@+node:ekr.20140401054342.16844: *4* g.run_pylint
-def run_pylint(fn, rc,
-    dots=True,  # Show level dots in Sherlock traces.
-    patterns=None,  # List of Sherlock trace patterns.
-    sherlock=False,  # Enable Sherlock tracing.
-    show_return=True,  # Show returns in Sherlock traces.
-    stats_patterns=None,  # Patterns for Sherlock statistics.
-    verbose=True,  # Show filenames in Sherlock traces.
-):
+def run_pylint(
+    fn: str,  # Path to file under test.
+    rc: str,  # Path to settings file.
+    dots: bool=True,  # Show level dots in Sherlock traces.
+    patterns: List[str]=None,  # List of Sherlock trace patterns.
+    sherlock: bool=False,  # Enable Sherlock tracing.
+    show_return: bool=True,  # Show returns in Sherlock traces.
+    stats_patterns: bool=None,  # Patterns for Sherlock statistics.
+    verbose: bool=True,  # Show filenames in Sherlock traces.
+) -> None:
     """
     Run pylint with the given args, with Sherlock tracing if requested.
 
@@ -3049,10 +3048,10 @@ def run_pylint(fn, rc,
             # When not waiting, printing from severl process can be interspersed.
             pass
 #@+node:ekr.20120912153732.10597: *4* g.wait
-def sleep(n: int) -> None:
+def sleep(n: float) -> None:
     """Wait about n milliseconds."""
-    from time import sleep
-    sleep(n)  #sleeps for 5 seconds
+    from time import sleep  # type:ignore
+    sleep(n)  # type:ignore
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
 def printObj(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> None:
     """Pretty print any Python object using g.pr."""
@@ -3218,7 +3217,7 @@ def printDiffTime(message: Any, start: Any) -> float:
     g.pr(f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def timeSince(start: Any) -> float:
+def timeSince(start: Any) -> str:
     return f"{time.time()-start:5.2f} sec."
 #@+node:ekr.20031218072017.1380: ** g.Directives
 # Weird pylint bug, activated by TestLeoGlobals class.
@@ -3327,7 +3326,7 @@ def findLanguageDirectives(c: Cmdr, p: Pos) -> Optional[str]:
 # Called from the syntax coloring method that colorizes section references.
 # Also called from write at.putRefAt.
 
-def findReference(name: Any, root: Any) -> Optional["Pos"]:
+def findReference(name: Any, root: Any) -> Optional[Pos]:
     """Return the position containing the section definition for name."""
     for p in root.subtree(copy=False):
         assert p != root
@@ -3631,7 +3630,7 @@ def scanAtWrapDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[b
 def scanAllAtWrapDirectives(c: Cmdr, p: Pos) -> Optional[bool]:
     """Scan p and all ancestors looking for @wrap/@nowrap directives."""
     if c and p:
-        default = c and c.config.getBool("body-pane-wraps")
+        default = bool(c and c.config.getBool("body-pane-wraps"))
         aList = g.get_directives_dict_list(p)
         val = g.scanAtWrapDirectives(aList)
         ret = default if val is None else val
@@ -3846,7 +3845,7 @@ def create_temp_file(textMode: bool=False) -> Tuple[Any, str]:
         theFile, theFileName = None, ''
     return theFile, theFileName
 #@+node:ekr.20210307060731.1: *3* g.createHiddenCommander
-def createHiddenCommander(fn: Any) -> Optional["Cmdr"]:
+def createHiddenCommander(fn: Any) -> Optional[Cmdr]:
     """Read the file into a hidden commander (Similar to g.openWithFileName)."""
     from leo.core.leoCommands import Commands
     c = Commands(fn, gui=g.app.nullGui)
@@ -4055,7 +4054,7 @@ def makePathRelativeTo(fullPath: str, basePath: str) -> str:
         return s
     return fullPath
 #@+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> "Cmdr":
+def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> Cmdr:
     """
     Create a Leo Frame for the indicated fileName if the file exists.
 
@@ -4063,7 +4062,7 @@ def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> "Cmdr":
     """
     return g.app.loadManager.loadLocalFile(fileName, gui, old_c)
 #@+node:ekr.20150306035851.7: *3* g.readFileIntoEncodedString
-def readFileIntoEncodedString(fn: Any, silent: bool=False) -> Optional[str]:
+def readFileIntoEncodedString(fn: Any, silent: bool=False) -> Optional[bytes]:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -4077,11 +4076,12 @@ def readFileIntoEncodedString(fn: Any, silent: bool=False) -> Optional[str]:
             g.es_exception()
     return None
 #@+node:ekr.20100125073206.8710: *3* g.readFileIntoString
-def readFileIntoString(fileName,
-    encoding='utf-8',  # BOM may override this.
-    kind=None,  # @file, @edit, ...
-    verbose=True,
-):
+def readFileIntoString(
+    fileName: str,
+    encoding: str='utf-8',  # BOM may override this.
+    kind: str=None,  # @file, @edit, ...
+    verbose: bool=True,
+) -> Tuple[Any, Any]:
     """
     Return the contents of the file whose full path is fileName.
 
@@ -4218,14 +4218,14 @@ def splitLongFileName(fn: str, limit: int=40) -> str:
             n = 0
     return ''.join(result)
 #@+node:ekr.20190114061452.26: *3* g.writeFile
-def writeFile(contents: str, encoding: str, fileName: str) -> bool:
+def writeFile(contents: Union[bytes, str], encoding: str, fileName: str) -> bool:
     """Create a file with the given contents."""
     try:
         if isinstance(contents, str):
             contents = g.toEncodedString(contents, encoding=encoding)
         # 'wb' preserves line endings.
         with open(fileName, 'wb') as f:
-            f.write(contents)
+            f.write(contents)  # type:ignore
         return True
     except Exception as e:
         print(f"exception writing: {fileName}:\n{e}")
@@ -4287,7 +4287,7 @@ def findAncestorVnodeByPredicate(p: Pos, v_predicate: Any) -> Optional["VNode"]:
                 parents.append(grand_parent_v)
     return None
 #@+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> List["Pos"]:
+def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> List[Pos]:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4331,8 +4331,16 @@ def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> List["Pos
                         return [p.copy()]
     return []
 #@+node:tbrown.20140311095634.15188: *3* g.recursiveUNLSearch & helpers
-def recursiveUNLSearch(unlList, c: Cmdr, depth=0, p: Pos=None, maxdepth=0, maxp=None,
-                       soft_idx=False, hard_idx=False):
+def recursiveUNLSearch(
+    unlList: List[str],
+    c: Cmdr,
+    depth: int=0,
+    p: Pos=None,
+    maxdepth: int=0,
+    maxp: Pos=None,
+    soft_idx: bool=False,
+    hard_idx: bool=False,
+) -> Tuple[bool, int, Pos]:
     """try and move to unl in the commander c
 
     All parameters passed on to recursiveUNLFind(), see that for docs.
@@ -4372,8 +4380,16 @@ def recursiveUNLSearch(unlList, c: Cmdr, depth=0, p: Pos=None, maxdepth=0, maxp=
         moveToP(c, maxp, unlList)
     return found, maxdepth, maxp
 #@+node:ekr.20140711071454.17654: *4* g.recursiveUNLFind
-def recursiveUNLFind(unlList, c: Cmdr, depth=0, p: Pos=None, maxdepth=0, maxp=None,
-                     soft_idx=False, hard_idx=False):
+def recursiveUNLFind(
+    unlList: list[str],
+    c: Cmdr,
+    depth: int=0,
+    p: Pos=None,
+    maxdepth: int=0,
+    maxp: Any=None,
+    soft_idx: bool=False,
+    hard_idx: bool=False,
+) -> Tuple[bool, int, Pos]:
     """
     Internal part of recursiveUNLSearch which doesn't change the
     selected position or call c.frame.bringToFront()
@@ -4881,7 +4897,7 @@ def is_ws_or_nl(s: str, i: int) -> bool:
 # Warning: this code makes no assumptions about what follows pattern.
 
 def match(s: str, i: int, pattern: Any) -> bool:
-    return s and pattern and s.find(pattern, i, i + len(pattern)) == i
+    return bool(s and pattern and s.find(pattern, i, i + len(pattern)) == i)
 #@+node:ekr.20031218072017.3182: *4* g.match_c_word
 def match_c_word(s: str, i: int, name: Any) -> bool:
     n = len(name)
@@ -5112,11 +5128,11 @@ def execGitCommand(command: Any, directory: Any) -> List[str]:
     return lines
 #@+node:ekr.20180126043905.1: *3* g.getGitIssues
 def getGitIssues(c: Cmdr,
-    base_url=None,
-    label_list=None,
-    milestone=None,
-    state=None,  # in (None, 'closed', 'open')
-):
+    base_url: str=None,
+    label_list: List=None,
+    milestone: str=None,
+    state: Optional[str]=None,  # in (None, 'closed', 'open')
+) -> None:
     """Get a list of issues from Leo's GitHub site."""
     if base_url is None:
         base_url = 'https://api.github.com/repos/leo-editor/leo-editor/issues'
@@ -5429,7 +5445,7 @@ act_on_node = dummy_act_on_node
 childrenModifiedSet: Set["VNode"] = set()
 contentModifiedSet: Set["VNode"] = set()
 #@+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag: str, *args, **keywords) -> Any:
+def doHook(tag: str, *args: Any, **keywords: Any) -> Any:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -5517,7 +5533,7 @@ def disableIdleTimeHook() -> None:
     """Disable the global idle-time hook."""
     g.app.idle_time_hooks_enabled = False
 #@+node:EKR.20040602125018: *3* g.enableIdleTimeHook
-def enableIdleTimeHook(*args, **keys) -> None:
+def enableIdleTimeHook(*args: Any, **keys: Any) -> None:
     """Enable idle-time processing."""
     g.app.idle_time_hooks_enabled = True
 #@+node:ekr.20140825042850.18410: *3* g.IdleTime
@@ -5770,7 +5786,7 @@ def stripBrackets(s: str) -> str:
         s = s[:-1]
     return s
 #@+node:ekr.20170317101100.1: *4* g.unCamel
-def unCamel(s: str) -> str:
+def unCamel(s: str) -> List[str]:
     """Return a list of sub-words in camelCased string s."""
     result: List[str] = []
     word: List[str] = []
@@ -5878,10 +5894,10 @@ def isValidEncoding(encoding: str) -> bool:
 #@+node:ekr.20061006152327: *4* g.isWordChar & g.isWordChar1
 def isWordChar(ch: str) -> bool:
     """Return True if ch should be considered a letter."""
-    return ch and (ch.isalnum() or ch == '_')
+    return bool(ch and (ch.isalnum() or ch == '_'))
 
 def isWordChar1(ch: str) -> bool:
-    return ch and (ch.isalpha() or ch == '_')
+    return bool(ch and (ch.isalpha() or ch == '_'))
 #@+node:ekr.20130910044521.11304: *4* g.stripBOM
 def stripBOM(s: str) -> Tuple[Optional[str], str]:
     """
@@ -5907,7 +5923,7 @@ def stripBOM(s: str) -> Tuple[Optional[str], str]:
                 return e, s[len(bom) :]
     return None, s
 #@+node:ekr.20050208093800: *4* g.toEncodedString
-def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> str:
+def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> bytes:
     """Convert unicode string to an encoded string."""
     if not isinstance(s, str):
         return s
@@ -5921,9 +5937,7 @@ def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> 
         if reportErrors:
             g.error(f"Error converting {s} from unicode to {encoding} encoding")
     # Tracing these calls directly yields thousands of calls.
-    # Never call g.trace here!
-        # g.dump_encoded_string(encoding,s)
-    return s
+    return s  # type:ignore
 #@+node:ekr.20050208093800.1: *4* g.toUnicode
 unicode_warnings: Dict[str, bool] = {}  # Keys are g.callers.
 
@@ -6119,7 +6133,7 @@ def removeLeadingBlankLines(s: str) -> str:
 #@+node:ekr.20031218072017.3202: *4* g.removeLeadingWhitespace
 # Remove whitespace up to first_ws wide in s, given tab_width, the width of a tab.
 
-def removeLeadingWhitespace(s: str, first_ws: str, tab_width: int) -> str:
+def removeLeadingWhitespace(s: str, first_ws: int, tab_width: int) -> str:
     j = 0
     ws = 0
     first_ws = abs(first_ws)
@@ -6229,22 +6243,22 @@ def enl(tabName: str='Log') -> None:
         log.newlines += 1
         log.putnl(tabName)
 #@+node:ekr.20100914094836.5892: *3* g.error, g.note, g.warning, g.red, g.blue
-def blue(*args, **keys) -> None:
+def blue(*args: Any, **keys: Any) -> None:
     g.es_print(color='blue', *args, **keys)
 
-def error(*args, **keys) -> None:
+def error(*args: Any, **keys: Any) -> None:
     g.es_print(color='error', *args, **keys)
 
-def note(*args, **keys) -> None:
+def note(*args: Any, **keys: Any) -> None:
     g.es_print(color='note', *args, **keys)
 
-def red(*args, **keys) -> None:
+def red(*args: Any, **keys: Any) -> None:
     g.es_print(color='red', *args, **keys)
 
-def warning(*args, **keys) -> None:
+def warning(*args: Any, **keys: Any) -> None:
     g.es_print(color='warning', *args, **keys)
 #@+node:ekr.20070626132332: *3* g.es
-def es(*args, **keys) -> None:
+def es(*args: Any, **keys: Any) -> None:
     """Put all non-keyword args to the log pane.
     The first, third, fifth, etc. arg translated by g.translateString.
     Supports color, comma, newline, spaces and tabName keyword arguments.
@@ -6295,7 +6309,7 @@ def es(*args, **keys) -> None:
 
 log = es
 #@+node:ekr.20190608090856.1: *3* g.es_clickable_link
-def es_clickable_link(c: Cmdr, p: Pos, line_number: Any, message: Any) -> None:
+def es_clickable_link(c: Cmdr, p: Pos, line_number: int, message: str) -> None:
     """
     Write a clickable message to the given line number of p.b.
 
@@ -6319,13 +6333,13 @@ def es_dump(s: str, n: int=30, title: str=None) -> None:
         g.es_print('', aList)
         i += n
 #@+node:ekr.20031218072017.3110: *3* g.es_error & es_print_error
-def es_error(*args, **keys) -> None:
+def es_error(*args: Any, **keys: Any) -> None:
     color = keys.get('color')
     if color is None and g.app.config:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es(*args, **keys)
 
-def es_print_error(*args, **keys) -> None:
+def es_print_error(*args: Any, **keys: Any) -> None:
     color = keys.get('color')
     if color is None and g.app.config:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
@@ -6343,7 +6357,7 @@ def es_event_exception(eventName: str, full: bool=False) -> None:
     if not g.stdErrIsRedirected():  # 2/16/04
         traceback.print_exc()
 #@+node:ekr.20031218072017.3112: *3* g.es_exception
-def es_exception(full: bool=True, c: Cmdr=None, color: str="red") -> None:
+def es_exception(full: bool=True, c: Cmdr=None, color: str="red") -> Tuple[str, int]:
     typ, val, tb = sys.exc_info()
     # val is the second argument to the raise statement.
     if full:
@@ -6362,7 +6376,7 @@ def es_exception_type(c: Cmdr=None, color: str="red") -> None:
 #@+node:ekr.20050707064040: *3* g.es_print
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def es_print(*args, **keys) -> None:
+def es_print(*args: Any, **keys: Any) -> None:
     """
     Print all non-keyword args, and put them to the log pane.
 
@@ -6373,7 +6387,7 @@ def es_print(*args, **keys) -> None:
     if g.app and not g.unitTesting:
         g.es(*args, **keys)
 #@+node:ekr.20111107181638.9741: *3* g.print_exception
-def print_exception(full: bool=True, c: Cmdr=None, flush: bool=False, color: str="red") -> None:
+def print_exception(full: bool=True, c: Cmdr=None, flush: bool=False, color: str="red") -> Tuple[str, int]:
     """Print exception info about the last exception."""
     typ, val, tb = sys.exc_info()
         # val is the second argument to the raise statement.
@@ -6388,7 +6402,7 @@ def print_exception(full: bool=True, c: Cmdr=None, flush: bool=False, color: str
     except Exception:
         return "<no file>", 0
 #@+node:ekr.20050707065530: *3* g.es_trace
-def es_trace(*args, **keys) -> None:
+def es_trace(*args: Any, **keys: Any) -> None:
     if args:
         try:
             s = args[0]
@@ -6431,7 +6445,7 @@ def goto_last_exception(c: Cmdr) -> None:
     else:
         g.trace('No previous exception')
 #@+node:ekr.20100126062623.6240: *3* g.internalError
-def internalError(*args) -> None:
+def internalError(*args: Any) -> None:
     """Report a serious interal error in Leo."""
     callers = g.callers(20).split(',')
     caller = callers[-1]
@@ -6454,7 +6468,7 @@ def log_to_file(s: str, fn: Any=None) -> None:
 #@+node:ekr.20080710101653.1: *3* g.pr
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def pr(*args, **keys) -> None:
+def pr(*args: Any, **keys: Any) -> None:
     """
     Print all non-keyword args. This is a wrapper for the print statement.
 
@@ -6492,9 +6506,9 @@ def pr(*args, **keys) -> None:
         pass
 #@+node:ekr.20060221083356: *3* g.prettyPrintType
 def prettyPrintType(obj: Any) -> str:
-    if isinstance(obj, str):
+    if isinstance(obj, str):  # type:ignore
         return 'string'
-    t = type(obj)
+    t: Any = type(obj)
     if t in (types.BuiltinFunctionType, types.FunctionType):
         return 'function'
     if t == types.ModuleType:
@@ -6550,7 +6564,7 @@ def printLeoModules(message: Any=None) -> None:
 def printStack() -> None:
     traceback.print_stack()
 #@+node:ekr.20031218072017.2317: *3* g.trace
-def trace(*args, **keys) -> None:
+def trace(*args: Any, **keys: Any) -> None:
     """Print a tracing message."""
     # Don't use g here: in standalone mode g is a NullObject!
     # Compute the effective args.
@@ -6830,11 +6844,11 @@ def issueSecurityWarning(setting: Any) -> None:
 #@+node:ekr.20031218072017.3144: *3* g.makeDict (Python Cookbook)
 # From the Python cookbook.
 
-def makeDict(**keys) -> Dict:
+def makeDict(**keys: Any) -> Dict:
     """Returns a Python dictionary from using the optional keyword arguments."""
     return keys
 #@+node:ekr.20140528065727.17963: *3* g.pep8_class_name
-def pep8_class_name(s: str) -> None:
+def pep8_class_name(s: str) -> str:
     """Return the proper class name for s."""
     # Warning: s.capitalize() does not work.
     # It lower cases all but the first letter!
@@ -6955,7 +6969,7 @@ def os_path_finalize(path: str) -> str:
     # calling os.path.realpath here would cause problems in some situations.
     return path
 #@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join
-def os_path_finalize_join(*args, **keys) -> str:
+def os_path_finalize_join(*args: Any, **keys: Any) -> str:
     """
     Join and finalize.
 
@@ -6965,7 +6979,7 @@ def os_path_finalize_join(*args, **keys) -> str:
     path = g.os_path_finalize(path)
     return path
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
-def os_path_getmtime(path: str) -> int:
+def os_path_getmtime(path: str) -> float:
     """Return the modification time of path."""
     if not path:
         return 0
@@ -6990,7 +7004,7 @@ def os_path_isfile(path: str) -> bool:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
 #@+node:ekr.20031218072017.2154: *3* g.os_path_join
-def os_path_join(*args, **keys) -> str:
+def os_path_join(*args: Any, **keys: Any) -> str:
     """
     Join paths, like os.path.join, with enhancements:
 
@@ -7172,12 +7186,12 @@ def createTopologyList(c: Cmdr, root: Pos=None, useHeadlines: bool=False) -> Lis
         root = c.rootPosition()
     v = root
     if useHeadlines:
-        aList = [(v.numberOfChildren(), v.headString()),]
+        aList = [(v.numberOfChildren(), v.headString()),]  # type: ignore
     else:
-        aList = [v.numberOfChildren()]
+        aList = [v.numberOfChildren()]  # type: ignore
     child = v.firstChild()
     while child:
-        aList.append(g.createTopologyList(c, child, useHeadlines))
+        aList.append(g.createTopologyList(c, child, useHeadlines))  # type: ignore
         child = child.next()
     return aList
 #@+node:ekr.20111017204736.15898: *3* g.getDocString
@@ -7290,7 +7304,7 @@ def execute_shell_commands(commands: Any, trace: bool=False) -> None:
                 print('Start:', proc)
             # #1489: call proc.poll at idle time.
 
-            def proc_poller(timer: Any, proc=proc) -> None:
+            def proc_poller(timer: Any, proc: Any=proc) -> None:
                 val = proc.poll()
                 if val is not None:
                     # This trace can be disruptive.
@@ -7301,14 +7315,14 @@ def execute_shell_commands(commands: Any, trace: bool=False) -> None:
             g.IdleTime(proc_poller, delay=0).start()
 #@+node:ekr.20180217113719.1: *3* g.execute_shell_commands_with_options & helpers
 def execute_shell_commands_with_options(
-    base_dir=None,
-    c=None,
-    command_setting=None,
-    commands=None,
-    path_setting=None,
-    trace=False,
-    warning=None,
-):
+    base_dir: str=None,
+    c: Cmdr=None,
+    command_setting: str=None,
+    commands: List=None,
+    path_setting: str=None,
+    trace: bool=False,
+    warning: str=None,
+) -> None:
     """
     A helper for prototype commands or any other code that
     runs programs in a separate process.
@@ -7383,7 +7397,7 @@ def executeFile(filename: str, options: str='') -> None:
     fdir, fname = g.os_path_split(filename)
     # New in Leo 4.10: alway use subprocess.
 
-    def subprocess_wrapper(cmdlst: List) -> Tuple:
+    def subprocess_wrapper(cmdlst: str) -> Tuple:
 
         p = subprocess.Popen(cmdlst, cwd=fdir,
             universal_newlines=True,
@@ -7460,10 +7474,10 @@ def findTopLevelNode(c: Cmdr, headline: str, exact: bool=True) -> Optional[Pos]:
 #@-others
 #@+node:EKR.20040614071102.1: *3* g.getScript & helpers
 def getScript(c: Cmdr, p: Pos,
-    useSelectedText=True,
-    forcePythonSentinels=True,
-    useSentinels=True,
-):
+    useSelectedText: bool=True,
+    forcePythonSentinels: bool=True,
+    useSentinels: bool=True,
+) -> str:
     """
     Return the expansion of the selected text of node p.
     Return the expansion of all of node p's body text if
@@ -7663,7 +7677,7 @@ unl_regex = re.compile(r'\bunl:.*$')
 kinds = '(file|ftp|gopher|http|https|mailto|news|nntp|prospero|telnet|wais)'
 url_regex = re.compile(fr"""{kinds}://[^\s'"]+[\w=/]""")
 #@+node:ekr.20170226093349.1: *3* g.unquoteUrl
-def unquoteUrl(url: str) -> None:
+def unquoteUrl(url: str) -> str:
     """Replace special characters (especially %20, by their equivalent)."""
     return urllib.parse.unquote(url)
 #@+node:ekr.20120320053907.9776: *3* g.computeFileUrl

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -36,7 +36,7 @@ import time
 import traceback
 import types
 from typing import TYPE_CHECKING
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -439,10 +439,10 @@ class Bunch:
     def __repr__(self) -> str:
         return self.toString()
 
-    def ivars(self) -> Any:
+    def ivars(self) -> List:
         return sorted(self.__dict__)
 
-    def keys(self) -> Any:
+    def keys(self) -> List:
         return sorted(self.__dict__)
 
     def toString(self) -> str:
@@ -922,7 +922,6 @@ class KeyStroke:
         )
 
     def removeNumPadModifier(self) -> None:
-
         self.s = self.s.replace('Keypad+', '')
     #@+node:ekr.20180419170934.1: *4* ks.prettyPrint
     def prettyPrint(self) -> str:
@@ -1915,12 +1914,10 @@ class SherlockTracer:
         def ignore_file() -> None:
             if not base_name in self.ignored_files:
                 self.ignored_files.append(base_name)
-                # print(f"Ignore file: {base_name}")
 
         def ignore_function() -> None:
             if function_name not in self.ignored_functions:
                 self.ignored_functions.append(function_name)
-                # print(f"Ignore function: {function_name}")
 
         if f"{os.sep}lib{os.sep}" in file_name:
             ignore_file()
@@ -2550,10 +2547,10 @@ class TestLeoGlobals(unittest.TestCase):
         assert not leo_g.is_sentinel("<!--comment-->", html_delims)
     #@-others
 #@+node:ekr.20140904112935.18526: *3* g.isTextWrapper & isTextWidget
-def isTextWidget(w: Any) -> None:
+def isTextWidget(w: Any) -> bool:
     return g.app.gui.isTextWidget(w)
 
-def isTextWrapper(w: Any) -> None:
+def isTextWrapper(w: Any) -> bool:
     return g.app.gui.isTextWrapper(w)
 #@+node:ekr.20160518074224.1: *3* class g.LinterTable
 class LinterTable():
@@ -2565,12 +2562,12 @@ class LinterTable():
         self.loadDir = g.os_path_finalize_join(g.__file__, '..', '..')
     #@+others
     #@+node:ekr.20160518074545.2: *4* commands
-    def commands(self) -> None:
+    def commands(self) -> List:
         """Return list of all command modules in leo/commands."""
         pattern = g.os_path_finalize_join(self.loadDir, 'commands', '*.py')
         return self.get_files(pattern)
     #@+node:ekr.20160518074545.3: *4* core
-    def core(self) -> None:
+    def core(self) -> List:
         """Return list of all of Leo's core files."""
         pattern = g.os_path_finalize_join(self.loadDir, 'core', 'leo*.py')
         aList = self.get_files(pattern)
@@ -2578,7 +2575,7 @@ class LinterTable():
             aList.append(g.os_path_finalize_join(self.loadDir, 'core', fn))
         return sorted(aList)
     #@+node:ekr.20160518074545.4: *4* external
-    def external(self) -> None:
+    def external(self) -> List:
         """Return list of files in leo/external"""
         pattern = g.os_path_finalize_join(self.loadDir, 'external', 'leo*.py')
         aList = self.get_files(pattern)
@@ -2589,14 +2586,14 @@ class LinterTable():
         remove = [g.os_path_finalize_join(self.loadDir, 'external', fn) for fn in remove]
         return sorted([z for z in aList if z not in remove])
     #@+node:ekr.20160520093506.1: *4* get_files (LinterTable)
-    def get_files(self, pattern: Any) -> None:
+    def get_files(self, pattern: Any) -> List:
         """Return the list of absolute file names matching the pattern."""
         aList = sorted([
             fn for fn in g.glob_glob(pattern)
                 if g.os_path_isfile(fn) and g.shortFileName(fn) != '__init__.py'])
         return aList
     #@+node:ekr.20160518074545.9: *4* get_files_for_scope
-    def get_files_for_scope(self, scope: Any, fn: Any) -> None:
+    def get_files_for_scope(self, scope: Any, fn: Any) -> List:
         """Return a list of absolute filenames for external linters."""
         d = {
             'all': [self.core, self.commands, self.external, self.plugins],
@@ -2631,7 +2628,7 @@ class LinterTable():
         print('LinterTable.get_table: bad scope', scope)
         return []
     #@+node:ekr.20160518074545.5: *4* gui_plugins
-    def gui_plugins(self) -> None:
+    def gui_plugins(self) -> List:
         """Return list of all of Leo's gui-related files."""
         pattern = g.os_path_finalize_join(self.loadDir, 'plugins', 'qt_*.py')
         aList = self.get_files(pattern)
@@ -2645,12 +2642,12 @@ class LinterTable():
         remove = [g.os_path_finalize_join(self.loadDir, 'plugins', fn) for fn in remove]
         return sorted(set([z for z in aList if z not in remove]))
     #@+node:ekr.20160518074545.6: *4* modes
-    def modes(self) -> None:
+    def modes(self) -> List:
         """Return list of all files in leo/modes"""
         pattern = g.os_path_finalize_join(self.loadDir, 'modes', '*.py')
         return self.get_files(pattern)
     #@+node:ekr.20160518074545.8: *4* plugins (LinterTable)
-    def plugins(self) -> None:
+    def plugins(self) -> List:
         """Return a list of all important plugins."""
         aList = []
         for theDir in ('', 'importers', 'writers'):
@@ -2678,7 +2675,7 @@ class LinterTable():
         aList = sorted([z for z in aList if z not in remove])
         return sorted(set(aList))
     #@+node:ekr.20211115103929.1: *4* tests (LinterTable)
-    def tests(self) -> None:
+    def tests(self) -> List:
         """Return list of files in leo/unittests"""
         aList = []
         for theDir in ('', 'commands', 'core', 'plugins'):
@@ -2693,7 +2690,7 @@ class LinterTable():
 #@+node:ekr.20140711071454.17649: ** g.Debugging, GC, Stats & Timing
 #@+node:ekr.20031218072017.3104: *3* g.Debugging
 #@+node:ekr.20180415144534.1: *4* g.assert_is
-def assert_is(obj: Any, list_or_class: Any, warn: bool=True) -> None:
+def assert_is(obj: Any, list_or_class: Any, warn: bool=True) -> bool:
 
     if warn:
         ok = isinstance(obj, list_or_class)
@@ -2708,7 +2705,7 @@ def assert_is(obj: Any, list_or_class: Any, warn: bool=True) -> None:
     assert ok, (obj, obj.__class__.__name__, g.callers())
     return ok
 #@+node:ekr.20180420081530.1: *4* g._assert
-def _assert(condition: Any, show_callers: bool=True) -> None:
+def _assert(condition: Any, show_callers: bool=True) -> bool:
     """A safer alternative to a bare assert."""
     if g.unitTesting:
         assert condition
@@ -2721,7 +2718,7 @@ def _assert(condition: Any, show_callers: bool=True) -> None:
         g.es_print(g.callers())
     return False
 #@+node:ekr.20051023083258: *4* g.callers & g.caller & _callerName
-def callers(n: int=4, count: int=0, excludeCaller: bool=True, verbose: bool=False) -> None:
+def callers(n: int=4, count: int=0, excludeCaller: bool=True, verbose: bool=False) -> str:
     """
     Return a string containing a comma-separated list of the callers
     of the function that called g.callerList.
@@ -2748,7 +2745,7 @@ def callers(n: int=4, count: int=0, excludeCaller: bool=True, verbose: bool=Fals
         return ''.join([f"\n  {z}" for z in result])
     return ','.join(result)
 #@+node:ekr.20031218072017.3107: *5* g._callerName
-def _callerName(n: int, verbose: bool=False) -> None:
+def _callerName(n: int, verbose: bool=False) -> str:
     try:
         # get the function name from the call stack.
         f1 = sys._getframe(n)  # The stack frame, n levels up.
@@ -2770,17 +2767,17 @@ def _callerName(n: int, verbose: bool=False) -> None:
         es_exception()
         return ''  # "<no caller name>"
 #@+node:ekr.20180328170441.1: *5* g.caller
-def caller(i: int=1) -> None:
+def caller(i: int=1) -> str:
     """Return the caller name i levels up the stack."""
     return g.callers(i + 1).split(',')[0]
 #@+node:ekr.20031218072017.3109: *4* g.dump
-def dump(s: str) -> None:
+def dump(s: str) -> str:
     out = ""
     for i in s:
         out += str(ord(i)) + ","
     return out
 
-def oldDump(s: str) -> None:
+def oldDump(s: str) -> str:
     out = ""
     for i in s:
         if i == '\n':
@@ -2810,7 +2807,7 @@ def dump_tree(c: Cmdr, dump_body: bool=False, msg: Any=None) -> None:
             for z in g.splitLines(p.b):
                 print(z.rstrip())
 
-def tree_to_string(c: Cmdr, dump_body: bool=False, msg: Any=None) -> None:
+def tree_to_string(c: Cmdr, dump_body: bool=False, msg: Any=None) -> str:
     result = ['\n']
     if msg:
         result.append(msg)
@@ -2836,7 +2833,7 @@ def dump_encoded_string(encoding: Any, s: str) -> None:
         elif ch == '\n':
             in_comment = False
 #@+node:ekr.20031218072017.1317: *4* g.file/module/plugin_date
-def module_date(mod: Any, format: Any=None) -> None:
+def module_date(mod: Any, format: Any=None) -> str:
     theFile = g.os_path_join(app.loadDir, mod.__file__)
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=format)
@@ -2844,9 +2841,9 @@ def module_date(mod: Any, format: Any=None) -> None:
 def plugin_date(plugin_mod: Any, format: Any=None) -> None:
     theFile = g.os_path_join(app.loadDir, "..", "plugins", plugin_mod.__file__)
     root, ext = g.os_path_splitext(theFile)
-    return g.file_date(root + ".py", format=format)
+    return g.file_date(root + ".py", format=str)
 
-def file_date(theFile: Any, format: Any=None) -> None:
+def file_date(theFile: Any, format: Any=None) -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2859,7 +2856,7 @@ def file_date(theFile: Any, format: Any=None) -> None:
 #@+node:ekr.20031218072017.3127: *4* g.get_line & get_line__after
 # Very useful for tracing.
 
-def get_line(s: str, i: int) -> None:
+def get_line(s: str, i: int) -> str:
     nl = ""
     if g.is_nl(s, i):
         i = g.skip_nl(s, i)
@@ -2871,7 +2868,7 @@ def get_line(s: str, i: int) -> None:
 # Important: getLine is a completely different function.
 # getLine = get_line
 
-def get_line_after(s: str, i: int) -> None:
+def get_line_after(s: str, i: int) -> str:
     nl = ""
     if g.is_nl(s, i):
         i = g.skip_nl(s, i)
@@ -2926,7 +2923,7 @@ def pdb(message: str='') -> None:
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
 #@+node:ekr.20041224080039: *4* g.dictToString
-def dictToString(d: Dict[str, str], indent: str='', tag: Any=None) -> None:
+def dictToString(d: Dict[str, str], indent: str='', tag: Any=None) -> str:
     """Pretty print a Python dict to a string."""
     # pylint: disable=unnecessary-lambda
     if not d:
@@ -2945,7 +2942,7 @@ def dictToString(d: Dict[str, str], indent: str='', tag: Any=None) -> None:
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20041126060136: *4* g.listToString
-def listToString(obj: Any, indent: str='', tag: Any=None) -> None:
+def listToString(obj: Any, indent: str='', tag: Any=None) -> str:
     """Pretty print a Python list to a string."""
     if not obj:
         return '[]'
@@ -2963,7 +2960,7 @@ def listToString(obj: Any, indent: str='', tag: Any=None) -> None:
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
-def objToString(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> None:
+def objToString(obj: Any, indent: str='', printCaller: bool=False, tag: Any=None) -> str:
     """Pretty print any Python object to a string."""
     # pylint: disable=undefined-loop-variable
         # Looks like a a pylint bug.
@@ -3065,7 +3062,7 @@ printDict = printObj
 printList = printObj
 printTuple = printObj
 #@+node:ekr.20171023110057.1: *4* g.tupleToString
-def tupleToString(obj: Any, indent: str='', tag: Any=None) -> None:
+def tupleToString(obj: Any, indent: str='', tag: Any=None) -> str:
     """Pretty print a Python tuple to a string."""
     if not obj:
         return '(),'
@@ -3110,7 +3107,7 @@ def printGc() -> None:
 #@+node:ekr.20060127164729.1: *4* g.printGcObjects
 lastObjectCount = 0
 
-def printGcObjects() -> None:
+def printGcObjects() -> int:
     """Print a summary of GC statistics."""
     global lastObjectCount
     n = len(gc.garbage)
@@ -3208,27 +3205,27 @@ def stat(name: Any=None) -> None:
         name = g._callerName(n=2)  # Get caller name 2 levels back.
     d[name] = 1 + d.get(name, 0)
 #@+node:ekr.20031218072017.3137: *3* g.Timing
-def getTime() -> None:
+def getTime() -> float:
     return time.time()
 
-def esDiffTime(message: Any, start: Any) -> None:
+def esDiffTime(message: Any, start: Any) -> float:
     delta = time.time() - start
     g.es('', f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def printDiffTime(message: Any, start: Any) -> None:
+def printDiffTime(message: Any, start: Any) -> float:
     delta = time.time() - start
     g.pr(f"{message} {delta:5.2f} sec.")
     return time.time()
 
-def timeSince(start: Any) -> None:
+def timeSince(start: Any) -> float:
     return f"{time.time()-start:5.2f} sec."
 #@+node:ekr.20031218072017.1380: ** g.Directives
 # Weird pylint bug, activated by TestLeoGlobals class.
 # Disabling this will be safe, because pyflakes will still warn about true redefinitions
 # pylint: disable=function-redefined
 #@+node:EKR.20040504150046.4: *3* g.comment_delims_from_extension
-def comment_delims_from_extension(filename: Any) -> None:
+def comment_delims_from_extension(filename: Any) -> Tuple[str, str, str]:
     """
     Return the comment delims corresponding to the filename's extension.
     """
@@ -3247,7 +3244,7 @@ def comment_delims_from_extension(filename: Any) -> None:
         f"root: {root!r}")
     return '', '', ''
 #@+node:ekr.20170201150505.1: *3* g.findAllValidLanguageDirectives
-def findAllValidLanguageDirectives(s: str) -> None:
+def findAllValidLanguageDirectives(s: str) -> List:
     """Return list of all valid @language directives in p.b"""
     if not s.strip():
         return []
@@ -3258,7 +3255,7 @@ def findAllValidLanguageDirectives(s: str) -> None:
             languages.add(language)
     return list(sorted(languages))
 #@+node:ekr.20090214075058.8: *3* g.findAtTabWidthDirectives (must be fast)
-def findTabWidthDirectives(c: Cmdr, p: Pos) -> None:
+def findTabWidthDirectives(c: Cmdr, p: Pos) -> Optional[str]:
     """Return the language in effect at position p."""
     if c is None:
         return None  # c may be None for testing.
@@ -3280,7 +3277,7 @@ def findTabWidthDirectives(c: Cmdr, p: Pos) -> None:
                     w = None
     return w
 #@+node:ekr.20170127142001.5: *3* g.findFirstAtLanguageDirective
-def findFirstValidAtLanguageDirective(s: str) -> None:
+def findFirstValidAtLanguageDirective(s: str) -> Optional[str]:
     """Return the first *valid* @language directive ins."""
     if not s.strip():
         return None
@@ -3290,14 +3287,14 @@ def findFirstValidAtLanguageDirective(s: str) -> None:
             return language
     return None
 #@+node:ekr.20090214075058.6: *3* g.findLanguageDirectives (must be fast)
-def findLanguageDirectives(c: Cmdr, p: Pos) -> None:
+def findLanguageDirectives(c: Cmdr, p: Pos) -> Optional[str]:
     """Return the language in effect at position p."""
     if c is None or p is None:
         return None  # c may be None for testing.
 
     v0 = p.v
 
-    def find_language(p_or_v: Any) -> None:
+    def find_language(p_or_v: Any) -> Optional[str]:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
@@ -3330,7 +3327,7 @@ def findLanguageDirectives(c: Cmdr, p: Pos) -> None:
 # Called from the syntax coloring method that colorizes section references.
 # Also called from write at.putRefAt.
 
-def findReference(name: Any, root: Any) -> None:
+def findReference(name: Any, root: Any) -> Optional["Pos"]:
     """Return the position containing the section definition for name."""
     for p in root.subtree(copy=False):
         assert p != root
@@ -3341,7 +3338,7 @@ def findReference(name: Any, root: Any) -> None:
 # The caller passes [root_node] or None as the second arg.
 # This allows us to distinguish between None and [None].
 
-def get_directives_dict(p: Pos, root: Any=None) -> None:
+def get_directives_dict(p: Pos, root: Any=None) -> Dict[str, str]:
     """
     Scan p for Leo directives found in globalDirectiveList.
 
@@ -3381,7 +3378,7 @@ def get_directives_dict(p: Pos, root: Any=None) -> None:
             break
     return d
 #@+node:ekr.20080827175609.1: *3* g.get_directives_dict_list (must be fast)
-def get_directives_dict_list(p: Pos) -> None:
+def get_directives_dict_list(p: Pos) -> List[Dict]:
     """Scans p and all its ancestors for directives.
 
     Returns a list of dicts containing pointers to
@@ -3394,7 +3391,7 @@ def get_directives_dict_list(p: Pos) -> None:
         result.append(g.get_directives_dict(p, root=root))
     return result
 #@+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode
-def getLanguageFromAncestorAtFileNode(p: Pos) -> None:
+def getLanguageFromAncestorAtFileNode(p: Pos) -> Optional[str]:
     """
     Return the language in effect at node p.
     
@@ -3408,7 +3405,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos) -> None:
     # Original idea by Виталије Милошевић (Vitalije Milosevic).
     # Modified by EKR.
 
-    def v_and_parents(v: "VNode") -> None:
+    def v_and_parents(v: "VNode") -> Generator:
         if v in seen:
             return
         seen.add(v)
@@ -3417,7 +3414,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos) -> None:
             if parent_v not in seen:
                 yield from v_and_parents(parent_v)
 
-    def find_language(v: "VNode", phase: Any) -> None:
+    def find_language(v: "VNode", phase: Any) -> Optional[str]:
         """
         A helper for all searches.
         Phase one searches only @<file> nodes.
@@ -3459,7 +3456,7 @@ def getLanguageFromAncestorAtFileNode(p: Pos) -> None:
                 return language
     return None
 #@+node:ekr.20150325075144.1: *3* g.getLanguageFromPosition
-def getLanguageAtPosition(c: Cmdr, p: Pos) -> None:
+def getLanguageAtPosition(c: Cmdr, p: Pos) -> str:
     """
     Return the language in effect at position p.
     This is always a lowercase language name, never None.
@@ -3474,7 +3471,7 @@ def getLanguageAtPosition(c: Cmdr, p: Pos) -> None:
     )
     return language.lower()
 #@+node:ekr.20031218072017.1386: *3* g.getOutputNewline
-def getOutputNewline(c: Cmdr=None, name: Any=None) -> None:
+def getOutputNewline(c: Cmdr=None, name: Any=None) -> str:
     """Convert the name of a line ending to the line ending itself.
 
     Priority:
@@ -3504,7 +3501,7 @@ def getOutputNewline(c: Cmdr=None, name: Any=None) -> None:
     assert isinstance(s, str), repr(s)
     return s
 #@+node:ekr.20200521075143.1: *3* g.inAtNosearch
-def inAtNosearch(p: Pos) -> None:
+def inAtNosearch(p: Pos) -> bool:
     """Return True if p or p's ancestors contain an @nosearch directive."""
     if not p:
         return False  # #2288.
@@ -3513,7 +3510,7 @@ def inAtNosearch(p: Pos) -> None:
             return True
     return False
 #@+node:ekr.20131230090121.16528: *3* g.isDirective
-def isDirective(s: str) -> None:
+def isDirective(s: str) -> bool:
     """Return True if s starts with a directive."""
     m = g_is_directive_pattern.match(s)
     if m:
@@ -3523,7 +3520,7 @@ def isDirective(s: str) -> None:
         return bool(m.group(1) in g.globalDirectiveList)
     return False
 #@+node:ekr.20200810074755.1: *3* g.isValidLanguage
-def isValidLanguage(language: Any) -> None:
+def isValidLanguage(language: Any) -> bool:
     """True if language exists in leo/modes."""
     # 2020/08/12: A hack for c++
     if language in ('c++', 'cpp'):
@@ -3531,7 +3528,7 @@ def isValidLanguage(language: Any) -> None:
     fn = g.os_path_join(g.app.loadDir, '..', 'modes', f"{language}.py")
     return g.os_path_exists(fn)
 #@+node:ekr.20080827175609.52: *3* g.scanAtCommentAndLanguageDirectives
-def scanAtCommentAndAtLanguageDirectives(aList: Any) -> None:
+def scanAtCommentAndAtLanguageDirectives(aList: Any) -> Optional[Dict[str, str]]:
     """
     Scan aList for @comment and @language directives.
 
@@ -3552,7 +3549,7 @@ def scanAtCommentAndAtLanguageDirectives(aList: Any) -> None:
             return d
     return None
 #@+node:ekr.20080827175609.32: *3* g.scanAtEncodingDirectives
-def scanAtEncodingDirectives(aList: Any) -> None:
+def scanAtEncodingDirectives(aList: Any) -> Optional[str]:
     """Scan aList for @encoding directives."""
     for d in aList:
         encoding = d.get('encoding')
@@ -3568,7 +3565,7 @@ def scanAtHeaderDirectives(aList: Any) -> None:
         if d.get('header') and d.get('noheader'):
             g.error("conflicting @header and @noheader directives")
 #@+node:ekr.20080827175609.33: *3* g.scanAtLineendingDirectives
-def scanAtLineendingDirectives(aList: Any) -> None:
+def scanAtLineendingDirectives(aList: Any) -> Optional[str]:
     """Scan aList for @lineending directives."""
     for d in aList:
         e = d.get('lineending')
@@ -3579,7 +3576,7 @@ def scanAtLineendingDirectives(aList: Any) -> None:
             # g.error("invalid @lineending directive:",e)
     return None
 #@+node:ekr.20080827175609.34: *3* g.scanAtPagewidthDirectives
-def scanAtPagewidthDirectives(aList: Any, issue_error_flag: bool=False) -> None:
+def scanAtPagewidthDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[str]:
     """Scan aList for @pagewidth directives."""
     for d in aList:
         s = d.get('pagewidth')
@@ -3591,16 +3588,16 @@ def scanAtPagewidthDirectives(aList: Any, issue_error_flag: bool=False) -> None:
                 g.error("ignoring @pagewidth", s)
     return None
 #@+node:ekr.20101022172109.6108: *3* g.scanAtPathDirectives
-def scanAtPathDirectives(c: Cmdr, aList: Any) -> None:
+def scanAtPathDirectives(c: Cmdr, aList: Any) -> str:
     path = c.scanAtPathDirectives(aList)
     return path
 
-def scanAllAtPathDirectives(c: Cmdr, p: Pos) -> None:
+def scanAllAtPathDirectives(c: Cmdr, p: Pos) -> str:
     aList = g.get_directives_dict_list(p)
     path = c.scanAtPathDirectives(aList)
     return path
 #@+node:ekr.20080827175609.37: *3* g.scanAtTabwidthDirectives
-def scanAtTabwidthDirectives(aList: Any, issue_error_flag: bool=False) -> None:
+def scanAtTabwidthDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[int]:
     """Scan aList for @tabwidth directives."""
     for d in aList:
         s = d.get('tabwidth')
@@ -3612,7 +3609,7 @@ def scanAtTabwidthDirectives(aList: Any, issue_error_flag: bool=False) -> None:
                 g.error("ignoring @tabwidth", s)
     return None
 
-def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos) -> None:
+def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos) -> Optional[int]:
     """Scan p and all ancestors looking for @tabwidth directives."""
     if c and p:
         aList = g.get_directives_dict_list(p)
@@ -3622,7 +3619,7 @@ def scanAllAtTabWidthDirectives(c: Cmdr, p: Pos) -> None:
         ret = None
     return ret
 #@+node:ekr.20080831084419.4: *3* g.scanAtWrapDirectives
-def scanAtWrapDirectives(aList: Any, issue_error_flag: bool=False) -> None:
+def scanAtWrapDirectives(aList: Any, issue_error_flag: bool=False) -> Optional[bool]:
     """Scan aList for @wrap and @nowrap directives."""
     for d in aList:
         if d.get('wrap') is not None:
@@ -3631,7 +3628,7 @@ def scanAtWrapDirectives(aList: Any, issue_error_flag: bool=False) -> None:
             return False
     return None
 
-def scanAllAtWrapDirectives(c: Cmdr, p: Pos) -> None:
+def scanAllAtWrapDirectives(c: Cmdr, p: Pos) -> Optional[bool]:
     """Scan p and all ancestors looking for @wrap/@nowrap directives."""
     if c and p:
         default = c and c.config.getBool("body-pane-wraps")
@@ -3642,7 +3639,7 @@ def scanAllAtWrapDirectives(c: Cmdr, p: Pos) -> None:
         ret = None
     return ret
 #@+node:ekr.20040715155607: *3* g.scanForAtIgnore
-def scanForAtIgnore(c: Cmdr, p: Pos) -> None:
+def scanForAtIgnore(c: Cmdr, p: Pos) -> bool:
     """Scan position p and its ancestors looking for @ignore directives."""
     if g.unitTesting:
         return False  # For unit tests.
@@ -3652,7 +3649,7 @@ def scanForAtIgnore(c: Cmdr, p: Pos) -> None:
             return True
     return False
 #@+node:ekr.20040712084911.1: *3* g.scanForAtLanguage
-def scanForAtLanguage(c: Cmdr, p: Pos) -> None:
+def scanForAtLanguage(c: Cmdr, p: Pos) -> str:
     """Scan position p and p's ancestors looking only for @language and @ignore directives.
 
     Returns the language found, or c.target_language."""
@@ -3666,7 +3663,7 @@ def scanForAtLanguage(c: Cmdr, p: Pos) -> None:
                 return language
     return c.target_language
 #@+node:ekr.20041123094807: *3* g.scanForAtSettings
-def scanForAtSettings(p: Pos) -> None:
+def scanForAtSettings(p: Pos) -> bool:
     """Scan position p and its ancestors looking for @settings nodes."""
     for p in p.self_and_parents(copy=False):
         h = p.h
@@ -3675,7 +3672,7 @@ def scanForAtSettings(p: Pos) -> None:
             return True
     return False
 #@+node:ekr.20031218072017.1382: *3* g.set_delims_from_language
-def set_delims_from_language(language: Any) -> None:
+def set_delims_from_language(language: Any) -> Tuple[str, str, str]:
     """Return a tuple (single,start,end) of comment delims."""
     val = g.app.language_delims_dict.get(language)
     if val:
@@ -3687,7 +3684,7 @@ def set_delims_from_language(language: Any) -> None:
     return '', '', ''
         # Indicate that no change should be made
 #@+node:ekr.20031218072017.1383: *3* g.set_delims_from_string
-def set_delims_from_string(s: str) -> None:
+def set_delims_from_string(s: str) -> Tuple[str, str, str]:
     """
     Return (delim1, delim2, delim2), the delims following the @comment
     directive.
@@ -3736,7 +3733,7 @@ def set_delims_from_string(s: str) -> None:
                 delims[i] = delims[i].replace("__", '\n').replace('_', ' ')
     return delims[0], delims[1], delims[2]
 #@+node:ekr.20031218072017.1384: *3* g.set_language
-def set_language(s: str, i: int, issue_errors_flag: bool=False) -> None:
+def set_language(s: str, i: int, issue_errors_flag: bool=False) -> Tuple:
     """Scan the @language directive that appears at s[i:].
 
     The @language may have been stripped away.
@@ -3761,7 +3758,7 @@ def set_language(s: str, i: int, issue_errors_flag: bool=False) -> None:
         g.es("ignoring:", g.get_line(s, i))
     return None, None, None, None
 #@+node:ekr.20071109165315: *3* g.stripPathCruft
-def stripPathCruft(path: Any) -> None:
+def stripPathCruft(path: Any) -> str:
     """Strip cruft from a path name."""
     if not path:
         return path  # Retain empty paths for warnings.
@@ -3796,25 +3793,25 @@ def chdir(path: str) -> None:
 #@+node:ekr.20120222084734.10287: *3* g.compute...Dir
 # For compatibility with old code.
 
-def computeGlobalConfigDir() -> None:
+def computeGlobalConfigDir() -> str:
     return g.app.loadManager.computeGlobalConfigDir()
 
-def computeHomeDir() -> None:
+def computeHomeDir() -> str:
     return g.app.loadManager.computeHomeDir()
 
-def computeLeoDir() -> None:
+def computeLeoDir() -> str:
     return g.app.loadManager.computeLeoDir()
 
-def computeLoadDir() -> None:
+def computeLoadDir() -> str:
     return g.app.loadManager.computeLoadDir()
 
-def computeMachineName() -> None:
+def computeMachineName() -> str:
     return g.app.loadManager.computeMachineName()
 
-def computeStandardDirectories() -> None:
+def computeStandardDirectories() -> str:
     return g.app.loadManager.computeStandardDirectories()
 #@+node:ekr.20031218072017.3103: *3* g.computeWindowTitle
-def computeWindowTitle(fileName: Any) -> None:
+def computeWindowTitle(fileName: Any) -> str:
 
     branch, commit = g.gitInfoForFile(fileName)  # #1616
     if not fileName:
@@ -3831,7 +3828,7 @@ def computeWindowTitle(fileName: Any) -> None:
         title = branch + ": " + title
     return title
 #@+node:ekr.20031218072017.3117: *3* g.create_temp_file
-def create_temp_file(textMode: bool=False) -> None:
+def create_temp_file(textMode: bool=False) -> Tuple[Any, str]:
     """
     Return a tuple (theFile,theFileName)
 
@@ -3849,7 +3846,7 @@ def create_temp_file(textMode: bool=False) -> None:
         theFile, theFileName = None, ''
     return theFile, theFileName
 #@+node:ekr.20210307060731.1: *3* g.createHiddenCommander
-def createHiddenCommander(fn: Any) -> None:
+def createHiddenCommander(fn: Any) -> Optional["Cmdr"]:
     """Read the file into a hidden commander (Similar to g.openWithFileName)."""
     from leo.core.leoCommands import Commands
     c = Commands(fn, gui=g.app.nullGui)
@@ -3860,11 +3857,11 @@ def createHiddenCommander(fn: Any) -> None:
         return c
     return None
 #@+node:vitalije.20170714085545.1: *3* g.defaultLeoFileExtension
-def defaultLeoFileExtension(c: Cmdr=None) -> None:
+def defaultLeoFileExtension(c: Cmdr=None) -> str:
     conf = c.config if c else g.app.config
     return conf.getString('default-leo-extension') or '.leo'
 #@+node:ekr.20031218072017.3118: *3* g.ensure_extension
-def ensure_extension(name: Any, ext: Any) -> None:
+def ensure_extension(name: Any, ext: Any) -> str:
 
     theFile, old_ext = g.os_path_splitext(name)
     if not name:
@@ -3875,7 +3872,7 @@ def ensure_extension(name: Any, ext: Any) -> None:
         return name
     return name + ext
 #@+node:ekr.20150403150655.1: *3* g.fullPath
-def fullPath(c: Cmdr, p: Pos, simulate: bool=False) -> None:
+def fullPath(c: Cmdr, p: Pos, simulate: bool=False) -> str:
     """
     Return the full path (including fileName) in effect at p. Neither the
     path nor the fileName will be created if it does not exist.
@@ -3893,7 +3890,7 @@ def fullPath(c: Cmdr, p: Pos, simulate: bool=False) -> None:
             return g.os_path_finalize_join(path, fn)  # #1341.
     return ''
 #@+node:ekr.20190327192721.1: *3* g.get_files_in_directory
-def get_files_in_directory(directory: Any, kinds: Any=None, recursive: bool=True) -> None:
+def get_files_in_directory(directory: Any, kinds: Any=None, recursive: bool=True) -> List[str]:
     """
     Return a list of all files of the given file extensions in the directory.
     Default kinds: ['*.py'].
@@ -3924,7 +3921,7 @@ def get_files_in_directory(directory: Any, kinds: Any=None, recursive: bool=True
 #@+node:ekr.20031218072017.1264: *3* g.getBaseDirectory
 # Handles the conventions applying to the "relative_path_base_directory" configuration option.
 
-def getBaseDirectory(c: Cmdr) -> None:
+def getBaseDirectory(c: Cmdr) -> str:
     """Convert '!' or '.' to proper directory references."""
     base = app.config.relative_path_base_directory
     if base and base == "!":
@@ -3941,7 +3938,7 @@ def getBaseDirectory(c: Cmdr) -> None:
         return base  # base need not exist yet.
     return ""  # No relative base given.
 #@+node:ekr.20170223093758.1: *3* g.getEncodingAt
-def getEncodingAt(p: Pos, s: str=None) -> None:
+def getEncodingAt(p: Pos, s: str=None) -> str:
     """
     Return the encoding in effect at p and/or for string s.
 
@@ -3959,7 +3956,7 @@ def getEncodingAt(p: Pos, s: str=None) -> None:
         e = 'utf-8'
     return e
 #@+node:ville.20090701144325.14942: *3* g.guessExternalEditor
-def guessExternalEditor(c: Cmdr=None) -> None:
+def guessExternalEditor(c: Cmdr=None) -> Optional[str]:
     """ Return a 'sensible' external editor """
     editor = (
         os.environ.get("LEO_EDITOR") or
@@ -3981,7 +3978,7 @@ or do g.app.db['LEO_EDITOR'] = "gvim"''',
     )
     return None
 #@+node:ekr.20160330204014.1: *3* g.init_dialog_folder
-def init_dialog_folder(c: Cmdr, p: Pos, use_at_path: bool=True) -> None:
+def init_dialog_folder(c: Cmdr, p: Pos, use_at_path: bool=True) -> str:
     """Return the most convenient folder to open or save a file."""
     if c and p and use_at_path:
         path = g.fullPath(c, p)
@@ -3998,10 +3995,10 @@ def init_dialog_folder(c: Cmdr, p: Pos, use_at_path: bool=True) -> None:
             return dir_
     return ''
 #@+node:ekr.20100329071036.5744: *3* g.is_binary_file/external_file/string
-def is_binary_file(f: Any) -> None:
+def is_binary_file(f: Any) -> bool:
     return f and isinstance(f, io.BufferedIOBase)
 
-def is_binary_external_file(fileName: Any) -> None:
+def is_binary_external_file(fileName: Any) -> bool:
     try:
         with open(fileName, 'rb') as f:
             s = f.read(1024)  # bytes, in Python 3.
@@ -4012,13 +4009,13 @@ def is_binary_external_file(fileName: Any) -> None:
         g.es_exception()
         return False
 
-def is_binary_string(s: str) -> None:
+def is_binary_string(s: str) -> bool:
     # http://stackoverflow.com/questions/898669
     # aList is a list of all non-binary characters.
     aList = [7, 8, 9, 10, 12, 13, 27] + list(range(0x20, 0x100))
     return bool(s.translate(None, bytes(aList)))  # type:ignore
 #@+node:EKR.20040504154039: *3* g.is_sentinel
-def is_sentinel(line: Any, delims: Any) -> None:
+def is_sentinel(line: Any, delims: Any) -> bool:
     """Return True if line starts with a sentinel comment."""
     delim1, delim2, delim3 = delims
     line = line.lstrip()
@@ -4031,7 +4028,7 @@ def is_sentinel(line: Any, delims: Any) -> None:
     g.error(f"is_sentinel: can not happen. delims: {repr(delims)}")
     return False
 #@+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories
-def makeAllNonExistentDirectories(theDir: Any) -> None:
+def makeAllNonExistentDirectories(theDir: Any) -> Optional[str]:
     """
     A wrapper from os.makedirs.
     Attempt to make all non-existent directories.
@@ -4050,7 +4047,7 @@ def makeAllNonExistentDirectories(theDir: Any) -> None:
     except Exception:
         return None
 #@+node:ekr.20071114113736: *3* g.makePathRelativeTo
-def makePathRelativeTo(fullPath: Any, basePath: Any) -> None:
+def makePathRelativeTo(fullPath: str, basePath: str) -> str:
     if fullPath.startswith(basePath):
         s = fullPath[len(basePath) :]
         if s.startswith(os.path.sep):
@@ -4058,14 +4055,15 @@ def makePathRelativeTo(fullPath: Any, basePath: Any) -> None:
         return s
     return fullPath
 #@+node:ekr.20090520055433.5945: *3* g.openWithFileName
-def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> None:
-    """Create a Leo Frame for the indicated fileName if the file exists.
+def openWithFileName(fileName: Any, old_c: Any=None, gui: Any=None) -> "Cmdr":
+    """
+    Create a Leo Frame for the indicated fileName if the file exists.
 
-    returns the commander of the newly-opened outline.
+    Return the commander of the newly-opened outline.
     """
     return g.app.loadManager.loadLocalFile(fileName, gui, old_c)
 #@+node:ekr.20150306035851.7: *3* g.readFileIntoEncodedString
-def readFileIntoEncodedString(fn: Any, silent: bool=False) -> None:
+def readFileIntoEncodedString(fn: Any, silent: bool=False) -> Optional[str]:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -4132,7 +4130,7 @@ def readFileIntoString(fileName,
         g.es_exception()
     return None, None
 #@+node:ekr.20160504062833.1: *3* g.readFileToUnicodeString
-def readFileIntoUnicodeString(fn: Any, encoding: Any=None, silent: bool=False) -> None:
+def readFileIntoUnicodeString(fn: str, encoding: Optional[str]=None, silent: bool=False) -> Optional[str]:
     """Return the raw contents of the file whose full path is fn."""
     try:
         with open(fn, 'rb') as f:
@@ -4154,7 +4152,7 @@ def readFileIntoUnicodeString(fn: Any, encoding: Any=None, silent: bool=False) -
 # same.
 #@@c
 
-def readlineForceUnixNewline(f: Any, fileName: Any=None) -> None:
+def readlineForceUnixNewline(f: Any, fileName: Optional[str]=None) -> str:
     try:
         s = f.readline()
     except UnicodeDecodeError:
@@ -4164,7 +4162,7 @@ def readlineForceUnixNewline(f: Any, fileName: Any=None) -> None:
         s = s[0:-2] + "\n"
     return s
 #@+node:ekr.20031218072017.3124: *3* g.sanitize_filename
-def sanitize_filename(s: str) -> None:
+def sanitize_filename(s: str) -> str:
     """
     Prepares string s to be a valid file name:
 
@@ -4192,12 +4190,12 @@ def sanitize_filename(s: str) -> None:
             break
     return s[:128]
 #@+node:ekr.20060328150113: *3* g.setGlobalOpenDir
-def setGlobalOpenDir(fileName: Any) -> None:
+def setGlobalOpenDir(fileName: str) -> None:
     if fileName:
         g.app.globalOpenDir = g.os_path_dirname(fileName)
         # g.es('current directory:',g.app.globalOpenDir)
 #@+node:ekr.20031218072017.3125: *3* g.shortFileName & shortFilename
-def shortFileName(fileName: Any, n: Any=None) -> None:
+def shortFileName(fileName: str, n: int=None) -> str:
     """Return the base name of a path."""
     if n is not None:
         g.trace('"n" keyword argument is no longer used')
@@ -4205,7 +4203,7 @@ def shortFileName(fileName: Any, n: Any=None) -> None:
 
 shortFilename = shortFileName
 #@+node:ekr.20150610125813.1: *3* g.splitLongFileName
-def splitLongFileName(fn: Any, limit: int=40) -> None:
+def splitLongFileName(fn: str, limit: int=40) -> str:
     """Return fn, split into lines at slash characters."""
     aList = fn.replace('\\', '/').split('/')
     n, result = 0, []
@@ -4220,7 +4218,7 @@ def splitLongFileName(fn: Any, limit: int=40) -> None:
             n = 0
     return ''.join(result)
 #@+node:ekr.20190114061452.26: *3* g.writeFile
-def writeFile(contents: Any, encoding: Any, fileName: Any) -> None:
+def writeFile(contents: str, encoding: str, fileName: str) -> bool:
     """Create a file with the given contents."""
     try:
         if isinstance(contents, str):
@@ -4236,7 +4234,7 @@ def writeFile(contents: Any, encoding: Any, fileName: Any) -> None:
         return False
 #@+node:ekr.20031218072017.3151: ** g.Finding & Scanning
 #@+node:ekr.20140602083643.17659: *3* g.find_word
-def find_word(s: str, word: Any, i: int=0) -> None:
+def find_word(s: str, word: str, i: int=0) -> int:
     """
     Return the index of the first occurance of word in s, or -1 if not found.
 
@@ -4260,7 +4258,7 @@ def find_word(s: str, word: Any, i: int=0) -> None:
         assert progress < i
     return -1
 #@+node:ekr.20211029090118.1: *3* g.findAncestorVnodeByPredicate
-def findAncestorVnodeByPredicate(p: Pos, v_predicate: Any) -> None:
+def findAncestorVnodeByPredicate(p: Pos, v_predicate: Any) -> Optional["VNode"]:
     """
     Return first ancestor vnode matching the predicate.
     
@@ -4289,7 +4287,7 @@ def findAncestorVnodeByPredicate(p: Pos, v_predicate: Any) -> None:
                 parents.append(grand_parent_v)
     return None
 #@+node:ekr.20170220103251.1: *3* g.findRootsWithPredicate
-def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> None:
+def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> List["Pos"]:
     """
     Commands often want to find one or more **roots**, given a position p.
     A root is the position of any node matching a predicate.
@@ -4305,7 +4303,7 @@ def findRootsWithPredicate(c: Cmdr, root: Any, predicate: Any=None) -> None:
         # A useful default predicate for python.
         # pylint: disable=function-redefined
 
-        def predicate(p: Pos) -> None:
+        def predicate(p: Pos) -> bool:
             return p.isAnyAtFileNode() and p.h.strip().endswith('.py')
 
     # 1. Search p's tree.
@@ -4494,7 +4492,7 @@ def recursiveUNLFind(unlList, c: Cmdr, depth=0, p: Pos=None, maxdepth=0, maxp=No
             maxdepth = p.level()  # type:ignore
     return False, maxdepth, maxp
 #@+node:tbrown.20171221094755.1: *4* g.recursiveUNLParts
-def recursiveUNLParts(text: Any) -> None:
+def recursiveUNLParts(text: Any) -> Tuple:
     """Parse the tail, returning whatever follows ':'.
 
     Examples: foo or foo:2 or foo:2,0,4,10.
@@ -4519,7 +4517,7 @@ def scanError(s: str) -> None:
 #@+node:ekr.20031218072017.3157: *3* g.scanf
 # A quick and dirty sscanf.  Understands only %s and %d.
 
-def scanf(s: str, pat: Any) -> None:
+def scanf(s: str, pat: Any) -> List[str]:
     count = pat.count("%s") + pat.count("%d")
     pat = pat.replace("%s", r"(\S+)")
     pat = pat.replace("%d", r"(\d+)")
@@ -4539,7 +4537,7 @@ def scanf(s: str, pat: Any) -> None:
 #@+node:ekr.20031218072017.3159: *4* g.skip_block_comment
 # Scans past a block comment (an old_style C comment).
 
-def skip_block_comment(s: str, i: int) -> None:
+def skip_block_comment(s: str, i: int) -> int:
     assert g.match(s, i, "/*")
     j = i
     i += 2
@@ -4555,7 +4553,7 @@ def skip_block_comment(s: str, i: int) -> None:
 # if blocks.
 #@@c
 
-def skip_braces(s: str, i: int) -> None:
+def skip_braces(s: str, i: int) -> int:
     """
     Skips from the opening to the matching brace.
 
@@ -4592,7 +4590,7 @@ def skip_braces(s: str, i: int) -> None:
         else: i += 1
     return i
 #@+node:ekr.20031218072017.3162: *4* g.skip_parens
-def skip_parens(s: str, i: int) -> None:
+def skip_parens(s: str, i: int) -> int:
     """
     Skips from the opening ( to the matching ).
 
@@ -4621,7 +4619,7 @@ def skip_parens(s: str, i: int) -> None:
             i += 1
     return i
 #@+node:ekr.20031218072017.3163: *4* g.skip_pascal_begin_end
-def skip_pascal_begin_end(s: str, i: int) -> None:
+def skip_pascal_begin_end(s: str, i: int) -> int:
     """
     Skips from begin to matching end.
     If found, i points to the end. Otherwise, i >= len(s)
@@ -4655,7 +4653,7 @@ def skip_pascal_begin_end(s: str, i: int) -> None:
             i += 1
     return i
 #@+node:ekr.20031218072017.3164: *4* g.skip_pascal_block_comment
-def skip_pascal_block_comment(s: str, i: int) -> None:
+def skip_pascal_block_comment(s: str, i: int) -> int:
     """Scan past a pascal comment delimited by (* and *)."""
     j = i
     assert g.match(s, i, "(*")
@@ -4665,7 +4663,7 @@ def skip_pascal_block_comment(s: str, i: int) -> None:
     g.scanError("Run on comment" + s[j:i])
     return len(s)
 #@+node:ekr.20031218072017.3165: *4* g.skip_pascal_string
-def skip_pascal_string(s: str, i: int) -> None:
+def skip_pascal_string(s: str, i: int) -> int:
     j = i
     delim = s[i]
     i += 1
@@ -4677,7 +4675,7 @@ def skip_pascal_string(s: str, i: int) -> None:
     g.scanError("Run on string: " + s[j:i])
     return i
 #@+node:ekr.20031218072017.3166: *4* g.skip_heredoc_string
-def skip_heredoc_string(s: str, i: int) -> None:
+def skip_heredoc_string(s: str, i: int) -> int:
     """
     08-SEP-2002 DTHEIN.
     A heredoc string in PHP looks like:
@@ -4709,7 +4707,7 @@ def skip_heredoc_string(s: str, i: int) -> None:
         i += len(delim)
     return i
 #@+node:ekr.20031218072017.3167: *4* g.skip_pp_directive
-def skip_pp_directive(s: str, i: int) -> None:
+def skip_pp_directive(s: str, i: int) -> int:
     """Now handles continuation lines and block comments."""
     while i < len(s):
         if g.is_nl(s, i):
@@ -4727,7 +4725,7 @@ def skip_pp_directive(s: str, i: int) -> None:
 #@+node:ekr.20031218072017.3168: *4* g.skip_pp_if
 # Skips an entire if or if def statement, including any nested statements.
 
-def skip_pp_if(s: str, i: int) -> None:
+def skip_pp_if(s: str, i: int) -> Tuple[int, int]:
     start_line = g.get_line(s, i)  # used for error messages.
     assert(
         g.match_word(s, i, "#if") or
@@ -4751,7 +4749,7 @@ def skip_pp_if(s: str, i: int) -> None:
 #@+node:ekr.20031218072017.3169: *4* g.skip_pp_part
 # Skip to an #else or #endif.  The caller has eaten the #if, #ifdef, #ifndef or #else
 
-def skip_pp_part(s: str, i: int) -> None:
+def skip_pp_part(s: str, i: int) -> Tuple[int, int]:
 
     delta = 0
     while i < len(s):
@@ -4783,7 +4781,7 @@ def skip_pp_part(s: str, i: int) -> None:
 #@+node:ekr.20031218072017.3171: *4* g.skip_to_semicolon
 # Skips to the next semicolon that is not in a comment or a string.
 
-def skip_to_semicolon(s: str, i: int) -> None:
+def skip_to_semicolon(s: str, i: int) -> int:
     n = len(s)
     while i < n:
         c = s[i]
@@ -4799,7 +4797,7 @@ def skip_to_semicolon(s: str, i: int) -> None:
             i += 1
     return i
 #@+node:ekr.20031218072017.3172: *4* g.skip_typedef
-def skip_typedef(s: str, i: int) -> None:
+def skip_typedef(s: str, i: int) -> int:
     n = len(s)
     while i < n and g.is_c_id(s[i]):
         i = g.skip_c_id(s, i)
@@ -4809,7 +4807,7 @@ def skip_typedef(s: str, i: int) -> None:
         i = g.skip_to_semicolon(s, i)
     return i
 #@+node:ekr.20201127143342.1: *3* g.see_more_lines
-def see_more_lines(s: str, ins: Any, n: int=4) -> None:
+def see_more_lines(s: str, ins: int, n: int=4) -> int:
     """
     Extend index i within string s to include n more lines.
     """
@@ -4822,7 +4820,7 @@ def see_more_lines(s: str, ins: Any, n: int=4) -> None:
             ins = j
     return max(0, min(ins, len(s)))
 #@+node:ekr.20031218072017.3195: *3* g.splitLines
-def splitLines(s: str) -> None:
+def splitLines(s: str) -> List[str]:
     """
     Split s into lines, preserving the number of lines and
     the endings of all lines, including the last line.
@@ -4834,31 +4832,29 @@ splitlines = splitLines
 #@+node:ekr.20031218072017.3174: *4* g.escaped
 # Returns True if s[i] is preceded by an odd number of backslashes.
 
-def escaped(s: str, i: int) -> None:
+def escaped(s: str, i: int) -> bool:
     count = 0
     while i - 1 >= 0 and s[i - 1] == '\\':
         count += 1
         i -= 1
     return (count % 2) == 1
 #@+node:ekr.20031218072017.3175: *4* g.find_line_start
-def find_line_start(s: str, i: int) -> None:
+def find_line_start(s: str, i: int) -> int:
     """Return the index in s of the start of the line containing s[i]."""
     if i < 0:
         return 0  # New in Leo 4.4.5: add this defensive code.
     # bug fix: 11/2/02: change i to i+1 in rfind
     i = s.rfind('\n', 0, i + 1)  # Finds the highest index in the range.
     return 0 if i == -1 else i + 1
-    # if i == -1: return 0
-    # else: return i + 1
 #@+node:ekr.20031218072017.3176: *4* g.find_on_line
-def find_on_line(s: str, i: int, pattern: Any) -> None:
+def find_on_line(s: str, i: int, pattern: Any) -> int:
     j = s.find('\n', i)
     if j == -1:
         j = len(s)
     k = s.find(pattern, i, j)
     return k
 #@+node:ekr.20031218072017.3179: *4* g.g.is_special
-def is_special(s: str, directive: Any) -> None:
+def is_special(s: str, directive: Any) -> Tuple[bool, int]:
     """Return True if the body text contains the @ directive."""
     assert(directive and directive[0] == '@')
     lws = directive in ("@others", "@all")
@@ -4870,24 +4866,24 @@ def is_special(s: str, directive: Any) -> None:
         return True, m.start(1)
     return False, -1
 #@+node:ekr.20031218072017.3177: *4* g.is_c_id
-def is_c_id(ch: str) -> None:
+def is_c_id(ch: str) -> bool:
     return g.isWordChar(ch)
 #@+node:ekr.20031218072017.3178: *4* g.is_nl
-def is_nl(s: str, i: int) -> None:
+def is_nl(s: str, i: int) -> bool:
     return i < len(s) and (s[i] == '\n' or s[i] == '\r')
 #@+node:ekr.20031218072017.3180: *4* g.is_ws & is_ws_or_nl
-def is_ws(ch: str) -> None:
+def is_ws(ch: str) -> bool:
     return ch == '\t' or ch == ' '
 
-def is_ws_or_nl(s: str, i: int) -> None:
+def is_ws_or_nl(s: str, i: int) -> bool:
     return g.is_nl(s, i) or (i < len(s) and g.is_ws(s[i]))
 #@+node:ekr.20031218072017.3181: *4* g.match
 # Warning: this code makes no assumptions about what follows pattern.
 
-def match(s: str, i: int, pattern: Any) -> None:
+def match(s: str, i: int, pattern: Any) -> bool:
     return s and pattern and s.find(pattern, i, i + len(pattern)) == i
 #@+node:ekr.20031218072017.3182: *4* g.match_c_word
-def match_c_word(s: str, i: int, name: Any) -> None:
+def match_c_word(s: str, i: int, name: Any) -> bool:
     n = len(name)
     return (
         name and
@@ -4895,10 +4891,10 @@ def match_c_word(s: str, i: int, name: Any) -> None:
         (i + n == len(s) or not g.is_c_id(s[i + n]))
     )
 #@+node:ekr.20031218072017.3183: *4* g.match_ignoring_case
-def match_ignoring_case(s1: Any, s2: Any) -> None:
+def match_ignoring_case(s1: Any, s2: Any) -> bool:
     return s1 and s2 and s1.lower() == s2.lower()
 #@+node:ekr.20031218072017.3184: *4* g.match_word & g.match_words
-def match_word(s: str, i: int, pattern: Any) -> None:
+def match_word(s: str, i: int, pattern: Any) -> bool:
 
     # Using a regex is surprisingly tricky.
     if pattern is None:
@@ -4915,14 +4911,14 @@ def match_word(s: str, i: int, pattern: Any) -> None:
     ch = s[i + j]
     return not g.isWordChar(ch)
 
-def match_words(s: str, i: int, patterns: Any) -> None:
+def match_words(s: str, i: int, patterns: Any) -> bool:
     return any(g.match_word(s, i, pattern) for pattern in patterns)
 #@+node:ekr.20031218072017.3185: *4* g.skip_blank_lines
 # This routine differs from skip_ws_and_nl in that
 # it does not advance over whitespace at the start
 # of a non-empty or non-nl terminated line
 
-def skip_blank_lines(s: str, i: int) -> None:
+def skip_blank_lines(s: str, i: int) -> int:
     while i < len(s):
         if g.is_nl(s, i):
             i = g.skip_nl(s, i)
@@ -4934,13 +4930,13 @@ def skip_blank_lines(s: str, i: int) -> None:
         else: break
     return i
 #@+node:ekr.20031218072017.3186: *4* g.skip_c_id
-def skip_c_id(s: str, i: int) -> None:
+def skip_c_id(s: str, i: int) -> int:
     n = len(s)
     while i < n and g.isWordChar(s[i]):
         i += 1
     return i
 #@+node:ekr.20040705195048: *4* g.skip_id
-def skip_id(s: str, i: int, chars: Any=None) -> None:
+def skip_id(s: str, i: int, chars: Any=None) -> int:
     chars = g.toUnicode(chars) if chars else ''
     n = len(s)
     while i < n and (g.isWordChar(s[i]) or s[i] in chars):
@@ -4953,7 +4949,7 @@ def skip_id(s: str, i: int, chars: Any=None) -> None:
 # string.
 #@@c
 
-def skip_line(s: str, i: int) -> None:
+def skip_line(s: str, i: int) -> int:
     if i >= len(s):
         return len(s)
     if i < 0:
@@ -4963,7 +4959,7 @@ def skip_line(s: str, i: int) -> None:
         return len(s)
     return i + 1
 
-def skip_to_end_of_line(s: str, i: int) -> None:
+def skip_to_end_of_line(s: str, i: int) -> int:
     if i >= len(s):
         return len(s)
     if i < 0:
@@ -4973,7 +4969,7 @@ def skip_to_end_of_line(s: str, i: int) -> None:
         return len(s)
     return i
 
-def skip_to_start_of_line(s: str, i: int) -> None:
+def skip_to_start_of_line(s: str, i: int) -> int:
     if i >= len(s):
         return len(s)
     if i <= 0:
@@ -4984,7 +4980,7 @@ def skip_to_start_of_line(s: str, i: int) -> None:
         return 0
     return i + 1
 #@+node:ekr.20031218072017.3188: *4* g.skip_long
-def skip_long(s: str, i: int) -> None:
+def skip_long(s: str, i: int) -> Tuple[int, Optional[int]]:
     """
     Scan s[i:] for a valid int.
     Return (i, val) or (i, None) if s[i] does not point at a number.
@@ -5007,7 +5003,7 @@ def skip_long(s: str, i: int) -> None:
 #@+node:ekr.20031218072017.3190: *4* g.skip_nl
 # We need this function because different systems have different end-of-line conventions.
 
-def skip_nl(s: str, i: int) -> None:
+def skip_nl(s: str, i: int) -> int:
     """Skips a single "logical" end-of-line character."""
     if g.match(s, i, "\r\n"):
         return i + 2
@@ -5015,7 +5011,7 @@ def skip_nl(s: str, i: int) -> None:
         return i + 1
     return i
 #@+node:ekr.20031218072017.3191: *4* g.skip_non_ws
-def skip_non_ws(s: str, i: int) -> None:
+def skip_non_ws(s: str, i: int) -> int:
     n = len(s)
     while i < n and not g.is_ws(s[i]):
         i += 1
@@ -5023,13 +5019,13 @@ def skip_non_ws(s: str, i: int) -> None:
 #@+node:ekr.20031218072017.3192: *4* g.skip_pascal_braces
 # Skips from the opening { to the matching }.
 
-def skip_pascal_braces(s: str, i: int) -> None:
+def skip_pascal_braces(s: str, i: int) -> int:
     # No constructs are recognized inside Pascal block comments!
     if i == -1:
         return len(s)
     return s.find('}', i)
 #@+node:ekr.20031218072017.3170: *4* g.skip_python_string
-def skip_python_string(s: str, i: int) -> None:
+def skip_python_string(s: str, i: int) -> int:
     if g.match(s, i, "'''") or g.match(s, i, '"""'):
         delim = s[i] * 3
         i += 3
@@ -5039,7 +5035,7 @@ def skip_python_string(s: str, i: int) -> None:
         return len(s)
     return g.skip_string(s, i)
 #@+node:ekr.20031218072017.2369: *4* g.skip_string
-def skip_string(s: str, i: int) -> None:
+def skip_string(s: str, i: int) -> int:
     """Scan forward to the end of a string."""
     delim = s[i]
     i += 1
@@ -5056,7 +5052,7 @@ def skip_string(s: str, i: int) -> None:
         i += 1
     return i
 #@+node:ekr.20031218072017.3193: *4* g.skip_to_char
-def skip_to_char(s: str, i: int, ch: str) -> None:
+def skip_to_char(s: str, i: int, ch: str) -> Tuple[int, str]:
     j = s.find(ch, i)
     if j == -1:
         return len(s), s[i:]
@@ -5089,7 +5085,7 @@ def backupGitIssues(c: Cmdr, base_url: Any=None) -> None:
     c.redraw()
     g.trace('done')
 #@+node:ekr.20170616102324.1: *3* g.execGitCommand
-def execGitCommand(command: Any, directory: Any) -> None:
+def execGitCommand(command: Any, directory: Any) -> List[str]:
     """Execute the given git command in the given directory."""
     git_dir = g.os_path_finalize_join(directory, '.git')
     if not g.os_path_exists(git_dir):
@@ -5236,7 +5232,7 @@ class GitIssueController:
         else:
             root.h = f"{total} {state} {label} issues"
     #@+node:ekr.20180126043719.4: *5* git.get_one_page
-    def get_one_page(self, label: Any, page: Any, r: Any, root: Any) -> None:
+    def get_one_page(self, label: Any, page: Any, r: Any, root: Any) -> Tuple[bool, int]:
 
         if self.milestone:
             aList = [
@@ -5268,7 +5264,7 @@ class GitIssueController:
                 print(f"{key:35}: {r.headers.get(key)}")
     #@-others
 #@+node:ekr.20190428173354.1: *3* g.getGitVersion
-def getGitVersion(directory: Any=None) -> None:
+def getGitVersion(directory: str=None) -> Tuple[str, str, str]:
     """Return a tuple (author, build, date) from the git log, or None."""
     #
     # -n: Get only the last log.
@@ -5299,7 +5295,7 @@ def getGitVersion(directory: Any=None) -> None:
 
     info = [g.toUnicode(z) for z in s.splitlines()]
 
-    def find(kind: Any) -> None:
+    def find(kind: Any) -> str:
         """Return the given type of log line."""
         for z in info:
             if z.startswith(kind):
@@ -5308,7 +5304,7 @@ def getGitVersion(directory: Any=None) -> None:
 
     return find('Author'), find('commit')[:10], find('Date')
 #@+node:ekr.20170414034616.2: *3* g.gitBranchName
-def gitBranchName(path: str=None) -> None:
+def gitBranchName(path: str=None) -> str:
     """
     Return the git branch name associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5317,7 +5313,7 @@ def gitBranchName(path: str=None) -> None:
     branch, commit = g.gitInfo(path)
     return branch
 #@+node:ekr.20170414034616.4: *3* g.gitCommitNumber
-def gitCommitNumber(path: str=None) -> None:
+def gitCommitNumber(path: str=None) -> str:
     """
     Return the git commit number associated with path/.git, or the empty
     string if path/.git does not exist. If path is None, use the leo-editor
@@ -5326,20 +5322,20 @@ def gitCommitNumber(path: str=None) -> None:
     branch, commit = g.gitInfo(path)
     return commit
 #@+node:ekr.20200724132432.1: *3* g.gitInfoForFile
-def gitInfoForFile(filename: Any) -> None:
+def gitInfoForFile(filename: str) -> Tuple[str, str]:
     """
     Return the git (branch, commit) info associated for the given file.
     """
     # g.gitInfo and g.gitHeadPath now do all the work.
     return g.gitInfo(filename)
 #@+node:ekr.20200724133754.1: *3* g.gitInfoForOutline
-def gitInfoForOutline(c: Cmdr) -> None:
+def gitInfoForOutline(c: Cmdr) -> Tuple[str, str]:
     """
     Return the git (branch, commit) info associated for commander c.
     """
     return g.gitInfoForFile(c.fileName())
 #@+node:maphew.20171112205129.1: *3* g.gitDescribe
-def gitDescribe(path: str=None) -> None:
+def gitDescribe(path: str=None) -> Tuple[str, str, str]:
     """
     Return the Git tag, distance-from-tag, and commit hash for the
     associated path. If path is None, use the leo-editor directory.
@@ -5356,7 +5352,7 @@ def gitDescribe(path: str=None) -> None:
     commit = commit.rstrip()
     return tag, distance, commit
 #@+node:ekr.20170414034616.6: *3* g.gitHeadPath
-def gitHeadPath(path_s: str) -> None:
+def gitHeadPath(path_s: str) -> Optional[str]:
     """
     Compute the path to .git/HEAD given the path.
     """
@@ -5371,7 +5367,7 @@ def gitHeadPath(path_s: str) -> None:
         path = path.parent
     return None
 #@+node:ekr.20170414034616.3: *3* g.gitInfo
-def gitInfo(path: str=None) -> None:
+def gitInfo(path: str=None) -> Tuple[str, str]:
     """
     Path may be a directory or file.
 
@@ -5433,7 +5429,7 @@ act_on_node = dummy_act_on_node
 childrenModifiedSet: Set["VNode"] = set()
 contentModifiedSet: Set["VNode"] = set()
 #@+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag, *args, **keywords) -> None:
+def doHook(tag: str, *args, **keywords) -> Any:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -5476,43 +5472,43 @@ def doHook(tag, *args, **keywords) -> None:
 #@+node:ekr.20100910075900.5950: *3* g.Wrappers for g.app.pluginController methods
 # Important: we can not define g.pc here!
 #@+node:ekr.20100910075900.5951: *4* g.Loading & registration
-def loadOnePlugin(pluginName: Any, verbose: bool=False) -> None:
+def loadOnePlugin(pluginName: Any, verbose: bool=False) -> Any:
     pc = g.app.pluginsController
     return pc.loadOnePlugin(pluginName, verbose=verbose)
 
-def registerExclusiveHandler(tags: Any, fn: Any) -> None:
+def registerExclusiveHandler(tags: Any, fn: Any) -> Any:
     pc = g.app.pluginsController
     return pc.registerExclusiveHandler(tags, fn)
 
-def registerHandler(tags: Any, fn: Any) -> None:
+def registerHandler(tags: Any, fn: Any) -> Any:
     pc = g.app.pluginsController
     return pc.registerHandler(tags, fn)
 
-def plugin_signon(module_name: Any, verbose: bool=False) -> None:
+def plugin_signon(module_name: Any, verbose: bool=False) -> Any:
     pc = g.app.pluginsController
     return pc.plugin_signon(module_name, verbose)
 
-def unloadOnePlugin(moduleOrFileName: Any, verbose: bool=False) -> None:
+def unloadOnePlugin(moduleOrFileName: Any, verbose: bool=False) -> Any:
     pc = g.app.pluginsController
     return pc.unloadOnePlugin(moduleOrFileName, verbose)
 
-def unregisterHandler(tags: Any, fn: Any) -> None:
+def unregisterHandler(tags: Any, fn: Any) -> Any:
     pc = g.app.pluginsController
     return pc.unregisterHandler(tags, fn)
 #@+node:ekr.20100910075900.5952: *4* g.Information
-def getHandlersForTag(tags: Any) -> None:
+def getHandlersForTag(tags: List[str]) -> List:
     pc = g.app.pluginsController
     return pc.getHandlersForTag(tags)
 
-def getLoadedPlugins() -> None:
+def getLoadedPlugins() -> List:
     pc = g.app.pluginsController
     return pc.getLoadedPlugins()
 
-def getPluginModule(moduleName: Any) -> None:
+def getPluginModule(moduleName: str) -> Any:
     pc = g.app.pluginsController
     return pc.getPluginModule(moduleName)
 
-def pluginIsLoaded(fn: Any) -> None:
+def pluginIsLoaded(fn: str) -> bool:
     pc = g.app.pluginsController
     return pc.isLoaded(fn)
 #@+node:ekr.20031218072017.1315: ** g.Idle time functions
@@ -5525,14 +5521,14 @@ def enableIdleTimeHook(*args, **keys) -> None:
     """Enable idle-time processing."""
     g.app.idle_time_hooks_enabled = True
 #@+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Any, delay: int=500, tag: Any=None) -> None:
+def IdleTime(handler: Any, delay: int=500, tag: Any=None) -> Any:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 
     The IdleTime class executes a handler with a given delay at idle time.
     The handler takes a single argument, the IdleTime instance::
 
-        def handler(timer: Any) -> None:
+        def handler(timer):
             '''IdleTime handler.  timer is an IdleTime instance.'''
             delta_t = timer.time-timer.starting_time
             g.trace(timer.count, '%2.4f' % (delta_t))
@@ -5546,22 +5542,22 @@ def IdleTime(handler: Any, delay: int=500, tag: Any=None) -> None:
 
     Timer instances are completely independent::
 
-        def handler1(timer: Any) -> None:
+        def handler1(timer):
             delta_t = timer.time-timer.starting_time
             g.trace('%2s %2.4f' % (timer.count,delta_t))
             if timer.count >= 5:
                 g.trace('done')
                 timer.stop()
 
-        def handler2(timer: Any) -> None:
+        def handler2(timer):
             delta_t = timer.time-timer.starting_time
             g.trace('%2s %2.4f' % (timer.count,delta_t))
             if timer.count >= 10:
                 g.trace('done')
                 timer.stop()
 
-        timer1 = g.IdleTime(handler1,delay=500)
-        timer2 = g.IdleTime(handler2,delay=1000)
+        timer1 = g.IdleTime(handler1, delay=500)
+        timer2 = g.IdleTime(handler2, delay=1000)
         if timer1 and timer2:
             timer1.start()
             timer2.start()
@@ -5577,7 +5573,7 @@ def idleTimeHookHandler(timer: Any) -> None:
     g.trace(g.callers())
 #@+node:ekr.20041219095213: ** g.Importing
 #@+node:ekr.20040917061619: *3* g.cantImport
-def cantImport(moduleName: Any, pluginName: Any=None, verbose: bool=True) -> None:
+def cantImport(moduleName: str, pluginName: str=None, verbose: bool=True) -> None:
     """Print a "Can't Import" message and return None."""
     s = f"Can not import {moduleName}"
     if pluginName:
@@ -5589,7 +5585,7 @@ def cantImport(moduleName: Any, pluginName: Any=None, verbose: bool=True) -> Non
     else:
         g.warning('', s)
 #@+node:ekr.20191220044128.1: *3* g.import_module
-def import_module(name: Any, package: Any=None) -> None:
+def import_module(name: str, package: str=None) -> Any:
     """
     A thin wrapper over importlib.import_module.
     """
@@ -5611,7 +5607,7 @@ def import_module(name: Any, package: Any=None) -> None:
 #@+node:ekr.20140711071454.17650: ** g.Indices, Strings, Unicode & Whitespace
 #@+node:ekr.20140711071454.17647: *3* g.Indices
 #@+node:ekr.20050314140957: *4* g.convertPythonIndexToRowCol
-def convertPythonIndexToRowCol(s: str, i: int) -> None:
+def convertPythonIndexToRowCol(s: str, i: int) -> Tuple[int, int]:
     """Convert index i into string s into zero-based row/col indices."""
     if not s or i <= 0:
         return 0, 0
@@ -5623,7 +5619,7 @@ def convertPythonIndexToRowCol(s: str, i: int) -> None:
     prevNL = s.rfind('\n', 0, i)  # Don't include i
     return row, i - prevNL - 1
 #@+node:ekr.20050315071727: *4* g.convertRowColToPythonIndex
-def convertRowColToPythonIndex(s: str, row: Any, col: Any, lines: Any=None) -> None:
+def convertRowColToPythonIndex(s: str, row: Any, col: Any, lines: Any=None) -> int:
     """Convert zero-based row/col indices into a python index into string s."""
     if row < 0:
         return 0
@@ -5638,7 +5634,7 @@ def convertRowColToPythonIndex(s: str, row: Any, col: Any, lines: Any=None) -> N
         prev += len(line)
     return prev + col
 #@+node:ekr.20061031102333.2: *4* g.getWord & getLine
-def getWord(s: str, i: int) -> None:
+def getWord(s: str, i: int) -> Tuple[int, int]:
     """Return i,j such that s[i:j] is the word surrounding s[i]."""
     if i >= len(s):
         i = len(s) - 1
@@ -5654,7 +5650,7 @@ def getWord(s: str, i: int) -> None:
         j += 1
     return i, j
 
-def getLine(s: str, i: int) -> None:
+def getLine(s: str, i: int) -> Tuple[int, int]:
     """
     Return i,j such that s[i:j] is the line surrounding s[i].
     s[i] is a newline only if the line is empty.
@@ -5677,7 +5673,7 @@ def getLine(s: str, i: int) -> None:
         k = k + 1
     return j, k
 #@+node:ekr.20111114151846.9847: *4* g.toPythonIndex
-def toPythonIndex(s: str, index: Any) -> None:
+def toPythonIndex(s: str, index: int) -> int:
     """
     Convert index to a Python int.
 
@@ -5701,11 +5697,11 @@ def toPythonIndex(s: str, index: Any) -> None:
     return 0
 #@+node:ekr.20140526144610.17601: *3* g.Strings
 #@+node:ekr.20190503145501.1: *4* g.isascii
-def isascii(s: str) -> None:
+def isascii(s: str) -> bool:
     # s.isascii() is defined in Python 3.7.
     return all(ord(ch) < 128 for ch in s)
 #@+node:ekr.20031218072017.3106: *4* g.angleBrackets & virtual_event_name
-def angleBrackets(s: str) -> None:
+def angleBrackets(s: str) -> str:
     """Returns < < s > >"""
     lt = "<<"
     rt = ">>"
@@ -5713,15 +5709,15 @@ def angleBrackets(s: str) -> None:
 
 virtual_event_name = angleBrackets
 #@+node:ekr.20090516135452.5777: *4* g.ensureLeading/TrailingNewlines
-def ensureLeadingNewlines(s: str, n: int) -> None:
+def ensureLeadingNewlines(s: str, n: int) -> str:
     s = g.removeLeading(s, '\t\n\r ')
     return ('\n' * n) + s
 
-def ensureTrailingNewlines(s: str, n: int) -> None:
+def ensureTrailingNewlines(s: str, n: int) -> str:
     s = g.removeTrailing(s, '\t\n\r ')
     return s + '\n' * n
 #@+node:ekr.20050920084036.4: *4* g.longestCommonPrefix & g.itemsMatchingPrefixInList
-def longestCommonPrefix(s1: Any, s2: Any) -> None:
+def longestCommonPrefix(s1: Any, s2: Any) -> str:
     """Find the longest prefix common to strings s1 and s2."""
     prefix = ''
     for ch in s1:
@@ -5731,7 +5727,7 @@ def longestCommonPrefix(s1: Any, s2: Any) -> None:
             return prefix
     return prefix
 
-def itemsMatchingPrefixInList(s: str, aList: Any, matchEmptyPrefix: bool=False) -> None:
+def itemsMatchingPrefixInList(s: str, aList: Any, matchEmptyPrefix: bool=False) -> Tuple[List, str]:
     """This method returns a sorted list items of aList whose prefix is s.
 
     It also returns the longest common prefix of all the matches.
@@ -5751,14 +5747,14 @@ def itemsMatchingPrefixInList(s: str, aList: Any, matchEmptyPrefix: bool=False) 
 # Warning: g.removeTrailingWs already exists.
 # Do not change it!
 
-def removeLeading(s: str, chars: Any) -> None:
+def removeLeading(s: str, chars: str) -> str:
     """Remove all characters in chars from the front of s."""
     i = 0
     while i < len(s) and s[i] in chars:
         i += 1
     return s[i:]
 
-def removeTrailing(s: str, chars: Any) -> None:
+def removeTrailing(s: str, chars: str) -> str:
     """Remove all characters in chars from the end of s."""
     i = len(s) - 1
     while i >= 0 and s[i] in chars:
@@ -5766,7 +5762,7 @@ def removeTrailing(s: str, chars: Any) -> None:
     i += 1
     return s[:i]
 #@+node:ekr.20060410112600: *4* g.stripBrackets
-def stripBrackets(s: str) -> None:
+def stripBrackets(s: str) -> str:
     """Strip leading and trailing angle brackets."""
     if s.startswith('<'):
         s = s[1:]
@@ -5774,7 +5770,7 @@ def stripBrackets(s: str) -> None:
         s = s[:-1]
     return s
 #@+node:ekr.20170317101100.1: *4* g.unCamel
-def unCamel(s: str) -> None:
+def unCamel(s: str) -> str:
     """Return a list of sub-words in camelCased string s."""
     result: List[str] = []
     word: List[str] = []
@@ -5795,7 +5791,7 @@ def unCamel(s: str) -> None:
 #@+node:ekr.20190505052756.1: *4* g.checkUnicode
 checkUnicode_dict: Dict[str, bool] = {}
 
-def checkUnicode(s: str, encoding: Any=None) -> None:
+def checkUnicode(s: str, encoding: str=None) -> str:
     """
     Warn when converting bytes. Report *all* errors.
 
@@ -5835,7 +5831,7 @@ def checkUnicode(s: str, encoding: Any=None) -> None:
         g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
     return s
 #@+node:ekr.20100125073206.8709: *4* g.getPythonEncodingFromString
-def getPythonEncodingFromString(s: str) -> None:
+def getPythonEncodingFromString(s: str) -> str:
     """Return the encoding given by Python's encoding line.
     s is the entire file.
     """
@@ -5861,7 +5857,7 @@ def getPythonEncodingFromString(s: str) -> None:
                     encoding = e
     return encoding
 #@+node:ekr.20031218072017.1500: *4* g.isValidEncoding
-def isValidEncoding(encoding: Any) -> None:
+def isValidEncoding(encoding: str) -> bool:
     """Return True if the encooding is valid."""
     if not encoding:
         return False
@@ -5880,14 +5876,14 @@ def isValidEncoding(encoding: Any) -> None:
         g.es_exception()
         return False
 #@+node:ekr.20061006152327: *4* g.isWordChar & g.isWordChar1
-def isWordChar(ch: str) -> None:
+def isWordChar(ch: str) -> bool:
     """Return True if ch should be considered a letter."""
     return ch and (ch.isalnum() or ch == '_')
 
-def isWordChar1(ch: str) -> None:
+def isWordChar1(ch: str) -> bool:
     return ch and (ch.isalpha() or ch == '_')
 #@+node:ekr.20130910044521.11304: *4* g.stripBOM
-def stripBOM(s: str) -> None:
+def stripBOM(s: str) -> Tuple[Optional[str], str]:
     """
     If there is a BOM, return (e,s2) where e is the encoding
     implied by the BOM and s2 is the s stripped of the BOM.
@@ -5911,7 +5907,7 @@ def stripBOM(s: str) -> None:
                 return e, s[len(bom) :]
     return None, s
 #@+node:ekr.20050208093800: *4* g.toEncodedString
-def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> None:
+def toEncodedString(s: str, encoding: str='utf-8', reportErrors: bool=False) -> str:
     """Convert unicode string to an encoded string."""
     if not isinstance(s, str):
         return s
@@ -5963,7 +5959,7 @@ def toUnicode(s: Any, encoding: Optional[str]=None, reportErrors: bool=False) ->
 #@+node:ekr.20031218072017.3198: *4* g.computeLeadingWhitespace
 # Returns optimized whitespace corresponding to width with the indicated tab_width.
 
-def computeLeadingWhitespace(width: Any, tab_width: Any) -> None:
+def computeLeadingWhitespace(width: Any, tab_width: Any) -> str:
     if width <= 0:
         return ""
     if tab_width > 1:
@@ -5975,7 +5971,7 @@ def computeLeadingWhitespace(width: Any, tab_width: Any) -> None:
 #@+node:ekr.20120605172139.10263: *4* g.computeLeadingWhitespaceWidth
 # Returns optimized whitespace corresponding to width with the indicated tab_width.
 
-def computeLeadingWhitespaceWidth(s: str, tab_width: Any) -> None:
+def computeLeadingWhitespaceWidth(s: str, tab_width: Any) -> int:
     w = 0
     for ch in s:
         if ch == ' ':
@@ -5988,7 +5984,7 @@ def computeLeadingWhitespaceWidth(s: str, tab_width: Any) -> None:
 #@+node:ekr.20031218072017.3199: *4* g.computeWidth
 # Returns the width of s, assuming s starts a line, with indicated tab_width.
 
-def computeWidth(s: str, tab_width: Any) -> None:
+def computeWidth(s: str, tab_width: Any) -> int:
     w = 0
     for ch in s:
         if ch == '\t':
@@ -6011,7 +6007,7 @@ def computeWidth(s: str, tab_width: Any) -> None:
 #@@c
 #@@language python
 
-def wrap_lines(lines: Any, pageWidth: Any, firstLineWidth: Any=None) -> None:
+def wrap_lines(lines: Any, pageWidth: Any, firstLineWidth: Any=None) -> List[str]:
     """Returns a list of lines, consisting of the input lines wrapped to the given pageWidth."""
     if pageWidth < 10:
         pageWidth = 10
@@ -6077,7 +6073,7 @@ def wrap_lines(lines: Any, pageWidth: Any, firstLineWidth: Any=None) -> None:
         result.append(line)
     return result
 #@+node:ekr.20031218072017.3200: *4* g.get_leading_ws
-def get_leading_ws(s: str) -> None:
+def get_leading_ws(s: str) -> str:
     """Returns the leading whitespace of 's'."""
     i = 0
     n = len(s)
@@ -6087,7 +6083,7 @@ def get_leading_ws(s: str) -> None:
 #@+node:ekr.20031218072017.3201: *4* g.optimizeLeadingWhitespace
 # Optimize leading whitespace in s with the given tab_width.
 
-def optimizeLeadingWhitespace(line: Any, tab_width: Any) -> None:
+def optimizeLeadingWhitespace(line: Any, tab_width: Any) -> str:
     i, width = g.skip_leading_ws_with_indent(line, 0, tab_width)
     s = g.computeLeadingWhitespace(width, tab_width) + line[i:]
     return s
@@ -6104,12 +6100,12 @@ def regularizeTrailingNewlines(s: str, kind: Any) -> None:
     """Kind is 'asis', 'zero' or 'one'."""
     pass
 #@+node:ekr.20091229090857.11698: *4* g.removeBlankLines
-def removeBlankLines(s: str) -> None:
+def removeBlankLines(s: str) -> str:
     lines = g.splitLines(s)
     lines = [z for z in lines if z.strip()]
     return ''.join(lines)
 #@+node:ekr.20091229075924.6235: *4* g.removeLeadingBlankLines
-def removeLeadingBlankLines(s: str) -> None:
+def removeLeadingBlankLines(s: str) -> str:
     lines = g.splitLines(s)
     result = []
     remove = True
@@ -6123,7 +6119,7 @@ def removeLeadingBlankLines(s: str) -> None:
 #@+node:ekr.20031218072017.3202: *4* g.removeLeadingWhitespace
 # Remove whitespace up to first_ws wide in s, given tab_width, the width of a tab.
 
-def removeLeadingWhitespace(s: str, first_ws: Any, tab_width: Any) -> None:
+def removeLeadingWhitespace(s: str, first_ws: str, tab_width: int) -> str:
     j = 0
     ws = 0
     first_ws = abs(first_ws)
@@ -6144,7 +6140,7 @@ def removeLeadingWhitespace(s: str, first_ws: Any, tab_width: Any) -> None:
 #@+node:ekr.20031218072017.3203: *4* g.removeTrailingWs
 # Warning: string.rstrip also removes newlines!
 
-def removeTrailingWs(s: str) -> None:
+def removeTrailingWs(s: str) -> str:
     j = len(s) - 1
     while j >= 0 and (s[j] == ' ' or s[j] == '\t'):
         j -= 1
@@ -6152,7 +6148,7 @@ def removeTrailingWs(s: str) -> None:
 #@+node:ekr.20031218072017.3204: *4* g.skip_leading_ws
 # Skips leading up to width leading whitespace.
 
-def skip_leading_ws(s: str, i: int, ws: Any, tab_width: Any) -> None:
+def skip_leading_ws(s: str, i: int, ws: Any, tab_width: Any) -> int:
     count = 0
     while count < ws and i < len(s):
         ch = s[i]
@@ -6165,7 +6161,7 @@ def skip_leading_ws(s: str, i: int, ws: Any, tab_width: Any) -> None:
         else: break
     return i
 #@+node:ekr.20031218072017.3205: *4* g.skip_leading_ws_with_indent
-def skip_leading_ws_with_indent(s: str, i: int, tab_width: Any) -> None:
+def skip_leading_ws_with_indent(s: str, i: int, tab_width: int) -> Tuple[int, int]:
     """Skips leading whitespace and returns (i, indent),
 
     - i points after the whitespace
@@ -6183,7 +6179,7 @@ def skip_leading_ws_with_indent(s: str, i: int, tab_width: Any) -> None:
         else: break
     return i, count
 #@+node:ekr.20040723093558.1: *4* g.stripBlankLines
-def stripBlankLines(s: str) -> None:
+def stripBlankLines(s: str) -> str:
     lines = g.splitLines(s)
     for i, line in enumerate(lines):
         j = g.skip_ws(line, 0)
@@ -6197,7 +6193,7 @@ def stripBlankLines(s: str) -> None:
 # g.pr prints to the console.
 # g.es_print and related print to both the Log window and the console.
 #@+node:ekr.20080821073134.2: *3* g.doKeywordArgs
-def doKeywordArgs(keys: Any, d: Any=None) -> None:
+def doKeywordArgs(keys: Any, d: Dict=None) -> Dict:
     """
     Return a result dict that is a copy of the keys dict
     with missing items replaced by defaults in d dict.
@@ -6314,7 +6310,7 @@ def es_clickable_link(c: Cmdr, p: Pos, line_number: Any, message: Any) -> None:
     else:
         log.put(message)
 #@+node:ekr.20060917120951: *3* g.es_dump
-def es_dump(s: str, n: int=30, title: Any=None) -> None:
+def es_dump(s: str, n: int=30, title: str=None) -> None:
     if title:
         g.es_print('', title)
     i = 0
@@ -6335,7 +6331,7 @@ def es_print_error(*args, **keys) -> None:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es_print(*args, **keys)
 #@+node:ekr.20031218072017.3111: *3* g.es_event_exception
-def es_event_exception(eventName: Any, full: bool=False) -> None:
+def es_event_exception(eventName: str, full: bool=False) -> None:
     g.es("exception handling ", eventName, "event")
     typ, val, tb = sys.exc_info()
     if full:
@@ -6401,7 +6397,7 @@ def es_trace(*args, **keys) -> None:
             pass
     g.es(*args, **keys)
 #@+node:ekr.20040731204831: *3* g.getLastTracebackFileAndLineNumber
-def getLastTracebackFileAndLineNumber() -> None:
+def getLastTracebackFileAndLineNumber() -> Tuple[str, int]:
     typ, val, tb = sys.exc_info()
     if typ == SyntaxError:
         # IndentationError is a subclass of SyntaxError.
@@ -6495,7 +6491,7 @@ def pr(*args, **keys) -> None:
     except Exception:
         pass
 #@+node:ekr.20060221083356: *3* g.prettyPrintType
-def prettyPrintType(obj: Any) -> None:
+def prettyPrintType(obj: Any) -> str:
     if isinstance(obj, str):
         return 'string'
     t = type(obj)
@@ -6646,7 +6642,7 @@ def translateArgs(args: Iterable[Any], d: Dict[str, Any]) -> str:
             result.append(arg)
     return ''.join(result)
 #@+node:ekr.20060810095921: *3* g.translateString & tr
-def translateString(s: str) -> None:
+def translateString(s: str) -> str:
     """Return the translated text of s."""
     # pylint: disable=undefined-loop-variable
     # looks like a pylint bug
@@ -6662,7 +6658,7 @@ def translateString(s: str) -> None:
 tr = translateString
 #@+node:EKR.20040612114220: ** g.Miscellaneous
 #@+node:ekr.20120928142052.10116: *3* g.actualColor
-def actualColor(color: Any) -> None:
+def actualColor(color: str) -> str:
     """Return the actual color corresponding to the requested color."""
     c = g.app.log and g.app.log.c
     # Careful: c.config may not yet exist.
@@ -6700,7 +6696,7 @@ def CheckVersion(
     stringCompare: Any=None,
     delimiter: str='.',
     trace: bool=False,
-) -> None:
+) -> bool:
     # CheckVersion is called early in the startup process.
     vals1 = [g.CheckVersionToInt(s) for s in s1.split(delimiter)]
     n1 = len(vals1)
@@ -6724,7 +6720,7 @@ def CheckVersion(
             "condition must be one of '>=', '>', '==', '!=', '<', or '<='.")
     return result
 #@+node:ekr.20070120123930: *4* g.CheckVersionToInt
-def CheckVersionToInt(s: str) -> None:
+def CheckVersionToInt(s: str) -> int:
     try:
         return int(s)
     except ValueError:
@@ -6775,7 +6771,7 @@ init_zodb_import_failed = False
 init_zodb_failed: Dict[str, bool] = {}  # Keys are paths, values are True.
 init_zodb_db: Dict[str, Any] = {}  # Keys are paths, values are ZODB.DB instances.
 
-def init_zodb(pathToZodbStorage: Any, verbose: bool=True) -> None:
+def init_zodb(pathToZodbStorage: Any, verbose: bool=True) -> Any:
     """
     Return an ZODB.DB instance from the given path.
     return None on any error.
@@ -6808,7 +6804,7 @@ def init_zodb(pathToZodbStorage: Any, verbose: bool=True) -> None:
         init_zodb_failed[pathToZodbStorage] = True
         return None
 #@+node:ekr.20170206080908.1: *3* g.input_
-def input_(message: str='', c: Cmdr=None) -> None:
+def input_(message: str='', c: Cmdr=None) -> str:
     """
     Safely execute python's input statement.
 
@@ -6823,7 +6819,7 @@ def input_(message: str='', c: Cmdr=None) -> None:
     QtCore.pyqtRemoveInputHook()
     return input(message)
 #@+node:ekr.20110609125359.16493: *3* g.isMacOS
-def isMacOS() -> None:
+def isMacOS() -> bool:
     return sys.platform == 'darwin'
 #@+node:ekr.20181027133311.1: *3* g.issueSecurityWarning
 def issueSecurityWarning(setting: Any) -> None:
@@ -6834,7 +6830,7 @@ def issueSecurityWarning(setting: Any) -> None:
 #@+node:ekr.20031218072017.3144: *3* g.makeDict (Python Cookbook)
 # From the Python cookbook.
 
-def makeDict(**keys) -> None:
+def makeDict(**keys) -> Dict:
     """Returns a Python dictionary from using the optional keyword arguments."""
     return keys
 #@+node:ekr.20140528065727.17963: *3* g.pep8_class_name
@@ -6858,7 +6854,7 @@ if 0:  # Testing:
     for s in aList:
         print(pep8_class_name(s))
 #@+node:ekr.20160417174224.1: *3* g.plural
-def plural(obj: Any) -> None:
+def plural(obj: Any) -> str:
     """Return "s" or "" depending on n."""
     if isinstance(obj, (list, tuple, str)):
         n = len(obj)
@@ -6866,7 +6862,7 @@ def plural(obj: Any) -> None:
         n = obj
     return '' if n == 1 else 's'
 #@+node:ekr.20160331194701.1: *3* g.truncate
-def truncate(s: str, n: int) -> None:
+def truncate(s: str, n: int) -> str:
     """Return s truncated to n characters."""
     if len(s) <= n:
         return s
@@ -6876,7 +6872,7 @@ def truncate(s: str, n: int) -> None:
         return s2 + '\n'
     return s2
 #@+node:ekr.20031218072017.3150: *3* g.windows
-def windows() -> None:
+def windows() -> Optional[List]:
     return app and app.windowList
 #@+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers
 #@+at Note: all these methods return Unicode strings. It is up to the user to
@@ -6986,7 +6982,7 @@ def os_path_isabs(path: str) -> bool:
     """Return True if path is an absolute path."""
     return os.path.isabs(path) if path else False
 #@+node:ekr.20031218072017.2152: *3* g.os_path_isdir
-def os_path_isdir(path: str) -> None:
+def os_path_isdir(path: str) -> bool:
     """Return True if the path is a directory."""
     return os.path.isdir(path) if path else False
 #@+node:ekr.20031218072017.2153: *3* g.os_path_isfile
@@ -7079,7 +7075,7 @@ def os_path_splitext(path: str) -> Tuple[str, str]:
     head, tail = os.path.splitext(path)
     return head, tail
 #@+node:ekr.20090829140232.6036: *3* g.os_startfile
-def os_startfile(fname: Any) -> None:
+def os_startfile(fname: str) -> None:
     #@+others
     #@+node:bob.20170516112250.1: *4* stderr2log()
     def stderr2log(g: Any, ree: Any, fname: Any) -> None:
@@ -7170,7 +7166,7 @@ def os_startfile(fname: Any) -> None:
             g.es_exception(f"exception executing g.startfile for {fname!r}")
 #@+node:ekr.20111115155710.9859: ** g.Parsing & Tokenizing
 #@+node:ekr.20031218072017.822: *3* g.createTopologyList
-def createTopologyList(c: Cmdr, root: Any=None, useHeadlines: bool=False) -> None:
+def createTopologyList(c: Cmdr, root: Pos=None, useHeadlines: bool=False) -> List:
     """Creates a list describing a node and all its descendents"""
     if not root:
         root = c.rootPosition()
@@ -7185,7 +7181,7 @@ def createTopologyList(c: Cmdr, root: Any=None, useHeadlines: bool=False) -> Non
         child = child.next()
     return aList
 #@+node:ekr.20111017204736.15898: *3* g.getDocString
-def getDocString(s: str) -> None:
+def getDocString(s: str) -> str:
     """Return the text of the first docstring found in s."""
     tags = ('"""', "'''")
     tag1, tag2 = tags
@@ -7203,13 +7199,13 @@ def getDocString(s: str) -> None:
         return s[i + 3 : j]
     return ''
 #@+node:ekr.20111017211256.15905: *3* g.getDocStringForFunction
-def getDocStringForFunction(func: Any) -> None:
+def getDocStringForFunction(func: Any) -> str:
     """Return the docstring for a function that creates a Leo command."""
 
-    def name(func: Any) -> None:
+    def name(func: Any) -> str:
         return func.__name__ if hasattr(func, '__name__') else '<no __name__>'
 
-    def get_defaults(func: Any, i: int) -> None:
+    def get_defaults(func: str, i: int) -> Any:
         defaults = inspect.getfullargspec(func)[3]
         return defaults[i]
 
@@ -7233,7 +7229,7 @@ def getDocStringForFunction(func: Any) -> None:
         s = func.docstring
     return s
 #@+node:ekr.20111115155710.9814: *3* g.python_tokenize (not used)
-def python_tokenize(s: str) -> None:
+def python_tokenize(s: str) -> List:
     """
     Tokenize string s and return a list of tokens (kind, value, line_number)
 
@@ -7334,7 +7330,7 @@ def execute_shell_commands_with_options(
     os.chdir(base_dir)  # Can't do this in the commands list.
     g.execute_shell_commands(commands)
 #@+node:ekr.20180217152624.1: *4* g.computeBaseDir
-def computeBaseDir(c: Cmdr, base_dir: Any, path_setting: Any, trace: bool=False) -> None:
+def computeBaseDir(c: Cmdr, base_dir: str, path_setting: str, trace: bool=False) -> Optional[str]:
     """
     Compute a base_directory.
     If given, @string path_setting takes precedence.
@@ -7342,23 +7338,27 @@ def computeBaseDir(c: Cmdr, base_dir: Any, path_setting: Any, trace: bool=False)
     # Prefer the path setting to the base_dir argument.
     if path_setting:
         if not c:
-            return g.es_print('@string path_setting requires valid c arg')
+            g.es_print('@string path_setting requires valid c arg')
+            return None
         # It's not an error for the setting to be empty.
         base_dir2 = c.config.getString(path_setting)
         if base_dir2:
             base_dir2 = base_dir2.replace('\\', '/')
             if g.os_path_exists(base_dir2):
                 return base_dir2
-            return g.es_print(f"@string {path_setting} not found: {base_dir2!r}")
+            g.es_print(f"@string {path_setting} not found: {base_dir2!r}")
+            return None
     # Fall back to given base_dir.
     if base_dir:
         base_dir = base_dir.replace('\\', '/')
         if g.os_path_exists(base_dir):
             return base_dir
-        return g.es_print(f"base_dir not found: {base_dir!r}")
-    return g.es_print(f"Please use @string {path_setting}")
+        g.es_print(f"base_dir not found: {base_dir!r}")
+        return None
+    g.es_print(f"Please use @string {path_setting}")
+    return None
 #@+node:ekr.20180217153459.1: *4* g.computeCommands
-def computeCommands(c: Cmdr, commands: Any, command_setting: Any, trace: bool=False) -> None:
+def computeCommands(c: Cmdr, commands: List[str], command_setting: str, trace: bool=False) -> List[str]:
     """
     Get the list of commands.
     If given, @data command_setting takes precedence.
@@ -7377,13 +7377,13 @@ def computeCommands(c: Cmdr, commands: Any, command_setting: Any, trace: bool=Fa
         return []
     return commands
 #@+node:ekr.20050503112513.7: *3* g.executeFile
-def executeFile(filename: Any, options: str='') -> None:
+def executeFile(filename: str, options: str='') -> None:
     if not os.access(filename, os.R_OK):
         return
     fdir, fname = g.os_path_split(filename)
     # New in Leo 4.10: alway use subprocess.
 
-    def subprocess_wrapper(cmdlst: Any) -> None:
+    def subprocess_wrapper(cmdlst: List) -> Tuple:
 
         p = subprocess.Popen(cmdlst, cwd=fdir,
             universal_newlines=True,
@@ -7398,7 +7398,7 @@ def executeFile(filename: Any, options: str='') -> None:
 #@+node:ekr.20040321065415: *3* g.find*Node*
 #@+others
 #@+node:ekr.20210303123423.3: *4* findNodeAnywhere
-def findNodeAnywhere(c: Cmdr, headline: Any, exact: bool=True) -> None:
+def findNodeAnywhere(c: Cmdr, headline: Any, exact: bool=True) -> Optional[Pos]:
     h = headline.strip()
     for p in c.all_unique_positions(copy=False):
         if p.h.strip() == h:
@@ -7409,7 +7409,7 @@ def findNodeAnywhere(c: Cmdr, headline: Any, exact: bool=True) -> None:
                 return p.copy()
     return None
 #@+node:ekr.20210303123525.1: *4* findNodeByPath
-def findNodeByPath(c: Cmdr, path: str) -> None:
+def findNodeByPath(c: Cmdr, path: str) -> Optional[Pos]:
     """Return the first @<file> node in Cmdr c whose path is given."""
     if not os.path.isabs(path):  # #2049. Only absolute paths could possibly work.
         g.trace(f"path not absolute: {path}")
@@ -7421,7 +7421,7 @@ def findNodeByPath(c: Cmdr, path: str) -> None:
                 return p
     return None
 #@+node:ekr.20210303123423.1: *4* findNodeInChildren
-def findNodeInChildren(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> None:
+def findNodeInChildren(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> Optional[Pos]:
     """Search for a node in v's tree matching the given headline."""
     p1 = p.copy()
     h = headline.strip()
@@ -7434,7 +7434,7 @@ def findNodeInChildren(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> None
                 return p.copy()
     return None
 #@+node:ekr.20210303123423.2: *4* findNodeInTree
-def findNodeInTree(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> None:
+def findNodeInTree(c: Cmdr, p: Pos, headline: str, exact: bool=True) -> Optional[Pos]:
     """Search for a node in v's tree matching the given headline."""
     h = headline.strip()
     p1 = p.copy()
@@ -7447,7 +7447,7 @@ def findNodeInTree(c: Cmdr, p: Pos, headline: Any, exact: bool=True) -> None:
                 return p.copy()
     return None
 #@+node:ekr.20210303123423.4: *4* findTopLevelNode
-def findTopLevelNode(c: Cmdr, headline: Any, exact: bool=True) -> None:
+def findTopLevelNode(c: Cmdr, headline: str, exact: bool=True) -> Optional[Pos]:
     h = headline.strip()
     for p in c.rootPosition().self_and_siblings(copy=False):
         if p.h.strip() == h:
@@ -7491,7 +7491,13 @@ def getScript(c: Cmdr, p: Pos,
         script = ''
     return script
 #@+node:ekr.20170228082641.1: *4* g.composeScript
-def composeScript(c: Cmdr, p: Pos, s: str, forcePythonSentinels: bool=True, useSentinels: bool=True) -> None:
+def composeScript(
+    c: Cmdr,
+    p: Pos,
+    s: str,
+    forcePythonSentinels: bool=True,
+    useSentinels: bool=True,
+) -> str:
     """Compose a script from p.b."""
     # This causes too many special cases.
         # if not g.unitTesting and forceEncoding:
@@ -7517,7 +7523,7 @@ def composeScript(c: Cmdr, p: Pos, s: str, forcePythonSentinels: bool=True, useS
         g.app.inScript = g.inScript = old_in_script
     return script
 #@+node:ekr.20170123074946.1: *4* g.extractExecutableString
-def extractExecutableString(c: Cmdr, p: Pos, s: str) -> None:
+def extractExecutableString(c: Cmdr, p: Pos, s: str) -> str:
     """
     Return all lines for the given @language directive.
 
@@ -7580,7 +7586,7 @@ def handleScriptException(c: Cmdr, p: Pos, script: Any, script1: Any) -> None:
             g.es_print('Unexpected exception in g.handleScriptException')
             g.es_exception()
 #@+node:ekr.20140209065845.16767: *3* g.insertCodingLine
-def insertCodingLine(encoding: Any, script: Any) -> None:
+def insertCodingLine(encoding: str, script: str) -> str:
     """
     Insert a coding line at the start of script s if no such line exists.
     The coding line must start with @first because it will be passed to
@@ -7657,11 +7663,11 @@ unl_regex = re.compile(r'\bunl:.*$')
 kinds = '(file|ftp|gopher|http|https|mailto|news|nntp|prospero|telnet|wais)'
 url_regex = re.compile(fr"""{kinds}://[^\s'"]+[\w=/]""")
 #@+node:ekr.20170226093349.1: *3* g.unquoteUrl
-def unquoteUrl(url: Any) -> None:
+def unquoteUrl(url: str) -> None:
     """Replace special characters (especially %20, by their equivalent)."""
     return urllib.parse.unquote(url)
 #@+node:ekr.20120320053907.9776: *3* g.computeFileUrl
-def computeFileUrl(fn: Any, c: Cmdr=None, p: Pos=None) -> None:
+def computeFileUrl(fn: str, c: Cmdr=None, p: Pos=None) -> str:
     """
     Compute finalized url for filename fn.
     """
@@ -7697,7 +7703,7 @@ def computeFileUrl(fn: Any, c: Cmdr=None, p: Pos=None) -> None:
         url = f"{tag}{path}"
     return url
 #@+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
-def getUrlFromNode(p: Pos) -> None:
+def getUrlFromNode(p: Pos) -> Optional[str]:
     """
     Get an url from node p:
     1. Use the headline if it contains a valid url.
@@ -7731,7 +7737,7 @@ def getUrlFromNode(p: Pos) -> None:
             return s
     return None
 #@+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: Any, c: Cmdr=None, p: Pos=None) -> None:
+def handleUrl(url: str, c: Cmdr=None, p: Pos=None) -> Any:
     """Open a url or a unl."""
     if c and not p:
         p = c.p

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -607,51 +607,51 @@ class KeyStroke:
         if binding:
             self.s = self.finalize_binding(binding)
         else:
-            self.s = None
+            self.s = None  # type:ignore
     #@+node:ekr.20120203053243.10117: *4* ks.__eq__, etc
     #@+at All these must be defined in order to say, for example:
     #     for key in sorted(d)
     # where the keys of d are KeyStroke objects.
     #@@c
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not other:
             return False
         if hasattr(other, 's'):
             return self.s == other.s
         return self.s == other
 
-    def __lt__(self, other) -> bool:
+    def __lt__(self, other: Any) -> bool:
         if not other:
             return False
         if hasattr(other, 's'):
             return self.s < other.s
         return self.s < other
 
-    def __le__(self, other) -> bool:
+    def __le__(self, other: Any) -> bool:
         return self.__lt__(other) or self.__eq__(other)
 
-    def __ne__(self, other) -> bool:
+    def __ne__(self, other: Any) -> bool:
         return not self.__eq__(other)
 
-    def __gt__(self, other) -> bool:
+    def __gt__(self, other: Any) -> bool:
         return not self.__lt__(other) and not self.__eq__(other)
 
-    def __ge__(self, other) -> bool:
+    def __ge__(self, other: Any) -> bool:
         return not self.__lt__(other)
     #@+node:ekr.20120203053243.10118: *4* ks.__hash__
     # Allow KeyStroke objects to be keys in dictionaries.
 
-    def __hash__(self):
+    def __hash__(self) -> Any:
         return self.s.__hash__() if self.s else 0
     #@+node:ekr.20120204061120.10067: *4* ks.__repr___ & __str__
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<KeyStroke: {repr(self.s)}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return repr(self.s)
     #@+node:ekr.20180417160703.1: *4* ks.dump
-    def dump(self):
+    def dump(self) -> None:
         """Show results of printable chars."""
         for i in range(128):
             s = chr(i)
@@ -662,7 +662,7 @@ class KeyStroke:
             stroke = g.KeyStroke(ch)
             print(f'{"":2} {ch!r:10} {stroke.s!r}')
     #@+node:ekr.20180415082249.1: *4* ks.finalize_binding
-    def finalize_binding(self, binding):
+    def finalize_binding(self, binding: str) -> str:
 
         trace = False and 'keys' in g.app.debug
             # This trace is good for devs only.
@@ -675,7 +675,7 @@ class KeyStroke:
             g.trace(f"{binding:20}:{self.mods:>20} ==> {mods+s}")
         return mods + s
     #@+node:ekr.20180415083926.1: *4* ks.finalize_char & helper
-    def finalize_char(self, s):
+    def finalize_char(self, s: str) -> str:
         """Perform very-last-minute translations on bindings."""
         #
         # Retain "bigger" spelling for gang-of-four bindings with modifiers.
@@ -689,8 +689,8 @@ class KeyStroke:
             'tab': 'Tab',
         }
         if self.mods and s.lower() in shift_d:
-            return shift_d.get(s.lower())
-                # Returning '' breaks existing code.
+            # Returning '' breaks existing code.
+            return shift_d.get(s.lower())  # type:ignore
         #
         # Make all other translations...
         #
@@ -776,7 +776,7 @@ class KeyStroke:
             return 'None'
         if s.lower() in translate_d:
             s = translate_d.get(s.lower())
-            return self.strip_shift(s)
+            return self.strip_shift(s)  # type:ignore
         if len(s) > 1 and s.find(' ') > -1:
             # #917: not a pure, but should be ignored.
             return ''
@@ -986,10 +986,10 @@ class KeyStroke:
         return s if len(s) == 1 else ''
     #@-others
 
-def isStroke(obj: Any):
+def isStroke(obj: Any) -> bool:
     return isinstance(obj, KeyStroke)
 
-def isStrokeOrNone(obj: Any):
+def isStrokeOrNone(obj: Any) -> bool:
     return obj is None or isinstance(obj, KeyStroke)
 #@+node:ekr.20160119093947.1: *3* class g.MatchBrackets
 class MatchBrackets:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2409,14 +2409,14 @@ class TypedDict:
     update:       Updates self.d from either a dict or a TypedDict.
     """
 
-    def __init__(self, name, keyType, valType):
-        self.d = {}
+    def __init__(self, name: str, keyType: Any, valType: Any) -> None:
+        self.d: Dict[str, Any] = {}
         self._name = name  # For __repr__ only.
         self.keyType = keyType
         self.valType = valType
     #@+others
     #@+node:ekr.20120205022040.17770: *4* td.__repr__ & __str__
-    def __str__(self):
+    def __str__(self) -> str:
         """Concise: used by repr."""
         return (
             f"<TypedDict name:{self._name} "
@@ -2425,11 +2425,11 @@ class TypedDict:
             f"len(keys): {len(list(self.keys()))}>"
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Suitable for g.printObj"""
         return f"{g.dictToString(self.d)}\n{str(self)}\n"
     #@+node:ekr.20120205022040.17774: *4* td.__setitem__
-    def __setitem__(self, key, val):
+    def __setitem__(self, key: Any, val: Any) -> None:
         """Allow d[key] = val"""
         if key is None:
             g.trace('TypeDict: None is not a valid key', g.callers())
@@ -2443,7 +2443,7 @@ class TypedDict:
             self._checkValType(val)  # val is not iterable.
         self.d[key] = val
     #@+node:ekr.20190904052828.1: *4* td.add_to_list
-    def add_to_list(self, key, val):
+    def add_to_list(self, key: Any, val: Any) -> None:
         """Update the *list*, self.d [key]"""
         if key is None:
             g.trace('TypeDict: None is not a valid key', g.callers())
@@ -2455,55 +2455,55 @@ class TypedDict:
             aList.append(val)
             self.d[key] = aList
     #@+node:ekr.20120206134955.10150: *4* td.checking
-    def _checkKeyType(self, key):
+    def _checkKeyType(self, key: str) -> None:
         if key and key.__class__ != self.keyType:
             self._reportTypeError(key, self.keyType)
 
-    def _checkValType(self, val):
+    def _checkValType(self, val: Any) -> None:
         if val.__class__ != self.valType:
             self._reportTypeError(val, self.valType)
 
-    def _reportTypeError(self, obj: Any, objType):
+    def _reportTypeError(self, obj: Any, objType: Any) -> str:
         # print(f"Type mismatch: obj: {obj.__class__}, objType: {objType}")
         return (
             f"{self._name}\n"
             f"expected: {obj.__class__.__name__}\n"
             f"     got: {objType.__name__}")
     #@+node:ekr.20120223062418.10422: *4* td.copy
-    def copy(self, name=None):
+    def copy(self, name: str=None) -> Any:
         """Return a new dict with the same contents."""
         import copy
         return copy.deepcopy(self)
     #@+node:ekr.20120205022040.17771: *4* td.get & keys & values
-    def get(self, key, default=None):
+    def get(self, key: Any, default: Any=None) -> Any:
         return self.d.get(key, default)
 
-    def items(self):
+    def items(self) -> Any:
         return self.d.items()
 
-    def keys(self):
+    def keys(self) -> Any:
         return self.d.keys()
 
-    def values(self):
+    def values(self) -> Any:
         return self.d.values()
     #@+node:ekr.20190903181030.1: *4* td.get_getting & get_string_setting
-    def get_setting(self, key):
+    def get_setting(self, key: str) -> Any:
         key = key.replace('-', '').replace('_', '')
         gs = self.get(key)
         val = gs and gs.val
         return val
 
-    def get_string_setting(self, key):
+    def get_string_setting(self, key: str) -> Optional[str]:
         val = self.get_setting(key)
         return val if val and isinstance(val, str) else None
     #@+node:ekr.20190904103552.1: *4* td.name & setName
-    def name(self):
+    def name(self) -> str:
         return self._name
 
-    def setName(self, name):
+    def setName(self, name: str) -> None:
         self._name = name
     #@+node:ekr.20120205022040.17807: *4* td.update
-    def update(self, d):
+    def update(self, d: Dict[Any, Any]) -> None:
         """Update self.d from a the appropriate dict."""
         if isinstance(d, TypedDict):
             self.d.update(d.d)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2115,7 +2115,7 @@ class Tracer:
         self.trace = trace
         self.verbose = verbose  # True: print returns as well as calls.
     #@+node:ekr.20080531075119.3: *4* computeName
-    def computeName(self, frame):
+    def computeName(self, frame: Any) -> str:
         if not frame:
             return ''
         code = frame.f_code
@@ -2140,7 +2140,7 @@ class Tracer:
         result.append(code.co_name)
         return '.'.join(result)
     #@+node:ekr.20080531075119.4: *4* report
-    def report(self):
+    def report(self) -> None:
         if 0:
             g.pr('\nstack')
             for z in self.stack:
@@ -2151,14 +2151,14 @@ class Tracer:
             g.pr(f"{self.calledDict.get(key,0):d}", key)
             # Print the called functions.
             d = self.callDict.get(key)
-            for key2 in sorted(d):
-                g.pr(f"{d.get(key2):8d}", key2)
+            for key2 in sorted(d):  # type:ignore
+                g.pr(f"{d.get(key2):8d}", key2)  # type:ignore
     #@+node:ekr.20080531075119.5: *4* stop
-    def stop(self):
+    def stop(self) -> None:
         sys.settrace(None)
         self.report()
     #@+node:ekr.20080531075119.6: *4* tracer
-    def tracer(self, frame, event, arg):
+    def tracer(self, frame: Any, event: Any, arg: Any) -> Optional[Callable]:
         """A function to be passed to sys.settrace."""
         n = len(self.stack)
         if event == 'return':
@@ -2196,13 +2196,13 @@ class Tracer:
             return None
         return self.tracer
     #@+node:ekr.20080531075119.7: *4* updateStats
-    def updateStats(self, name):
+    def updateStats(self, name: str) -> None:
         if not self.stack:
             return
         caller = self.stack[-1]
-        d = self.callDict.get(caller, {})
-            # d is a dict reprenting the called functions.
-            # Keys are called functions, values are counts.
+        # d is a dict reprenting the called functions.
+        # Keys are called functions, values are counts.
+        d: Dict[str, int] = self.callDict.get(caller, {})
         d[name] = 1 + d.get(name, 0)
         self.callDict[caller] = d
         # Update the total counts.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2216,45 +2216,43 @@ def startTracer(limit: int=0, trace: bool=False, verbose: bool=False) -> Callabl
 #@+node:ekr.20031219074948.1: *3* class g.Tracing/NullObject & helpers
 #@@nobeautify
 
-tracing_tags = {}
-    # Keys are id's, values are tags.
-tracing_vars = {}
-    # Keys are id's, values are names of ivars.
-tracing_signatures = {}
-    # Keys are signatures: '%s.%s:%s' % (tag, attr, callers). Values not important.
+tracing_tags: Dict[int, str] = {}  # Keys are id's, values are tags.
+tracing_vars: Dict[int, str] = {}  # Keys are id's, values are names of ivars.
+# Keys are signatures: '%s.%s:%s' % (tag, attr, callers). Values not important.
+tracing_signatures: Dict[str, Any] = {}
 
 class NullObject:
     """An object that does nothing, and does it very well."""
-    def __init__(self, ivars=None, *args, **kwargs):
+    def __init__(self, ivars: List[str]=None, *args: Any, **kwargs: Any) -> None:
         if isinstance(ivars, str):
             ivars = [ivars]
         tracing_vars [id(self)] = ivars or []
-    def __call__(self, *args, **keys):
+    def __call__(self, *args: Any, **keys: Any) -> "NullObject":
         return self
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "NullObject"
-    def __str__(self):
+    def __str__(self) -> str:
         return "NullObject"
     # Attribute access...
-    def __delattr__(self, attr):
+    def __delattr__(self, attr: str) -> None:
         return None
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         if attr in tracing_vars.get(id(self), []):
             return getattr(self, attr, None)
         return self # Required.
-    def __setattr__(self, attr, val):
+    def __setattr__(self, attr: str, val: Any) -> None:
         if attr in tracing_vars.get(id(self), []):
             object.__setattr__(self, attr, val)
     # Container methods..
     def __bool__(self) -> bool:
         return False
-    def __contains__(self, item) -> bool:
+    def __contains__(self, item: Any) -> bool:
         return False
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> None:
         raise KeyError
-    def __setitem__(self, key, val) -> None:
+    def __setitem__(self, key: str, val: Any) -> None:
         pass
-    def __iter__(self):
+    def __iter__(self) -> "NullObject":
         return self
     def __len__(self) -> int:
         return 0
@@ -2265,7 +2263,7 @@ class NullObject:
 
 class TracingNullObject:
     """Tracing NullObject."""
-    def __init__(self, tag, ivars=None, *args, **kwargs):
+    def __init__(self, tag: str, ivars: List[Any]=None, *args: Any, **kwargs: Any) -> None:
         tracing_tags [id(self)] = tag
         if isinstance(ivars, str):
             ivars = [ivars]
@@ -2274,7 +2272,7 @@ class TracingNullObject:
             suppress = ('tree item',)
             if tag not in suppress:
                 print('='*10, 'NullObject.__init__:', id(self), tag)
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> "TracingNullObject":
         return self
     def __repr__(self) -> str:
         return f'TracingNullObject: {tracing_tags.get(id(self), "<NO TAG>")}'
@@ -2282,14 +2280,14 @@ class TracingNullObject:
         return f'TracingNullObject: {tracing_tags.get(id(self), "<NO TAG>")}'
     #
     # Attribute access...
-    def __delattr__(self, attr):
-        return self
-    def __getattr__(self, attr):
+    def __delattr__(self, attr: str) -> None:
+        return None
+    def __getattr__(self, attr: str) -> "TracingNullObject":
         null_object_print_attr(id(self), attr)
         if attr in tracing_vars.get(id(self), []):
             return getattr(self, attr, None)
         return self # Required.
-    def __setattr__(self, attr, val):
+    def __setattr__(self, attr: str, val: Any) -> None:
         g.null_object_print(id(self), '__setattr__', attr, val)
         if attr in tracing_vars.get(id(self), []):
             object.__setattr__(self, attr, val)
@@ -2302,26 +2300,24 @@ class TracingNullObject:
             if not callers.endswith(suppress):
                 g.null_object_print(id(self), '__bool__')
         return False
-    def __contains__(self, item):
+    def __contains__(self, item: Any) -> bool:
         g.null_object_print(id(self), '__contains__')
         return False
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> None:
         g.null_object_print(id(self), '__getitem__')
         # pylint doesn't like trailing return None.
-        # return None
-    def __iter__(self):
+    def __iter__(self) -> "TracingNullObject":
         g.null_object_print(id(self), '__iter__')
         return self
-    def __len__(self):
+    def __len__(self) -> int:
         # g.null_object_print(id(self), '__len__')
         return 0
-    def __next__(self):
+    def __next__(self) -> None:
         g.null_object_print(id(self), '__next__')
         raise StopIteration
-    def __setitem__(self, key, val):
+    def __setitem__(self, key: str, val: Any) -> None:
         g.null_object_print(id(self), '__setitem__')
         # pylint doesn't like trailing return None.
-        # return None
 #@+node:ekr.20190330062625.1: *4* g.null_object_print_attr
 def null_object_print_attr(id_, attr):
     suppress = True

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1547,7 +1547,7 @@ class RedirectClass:
             else:
                 sys.stderr, self.old = self.old, None
     #@+node:ekr.20041012082437.5: *5* write
-    def write(self, s: str):
+    def write(self, s: str) -> None:
 
         if self.old:
             if app.log:
@@ -1570,35 +1570,35 @@ redirectStdOutObj = RedirectClass()
 #@+node:ekr.20041012090942: *5* redirectStderr & redirectStdout
 # Redirect streams to the current log window.
 
-def redirectStderr():
+def redirectStderr() -> None:
     global redirectStdErrObj
     redirectStdErrObj.redirect(stdout=False)
 
-def redirectStdout():
+def redirectStdout() -> None:
     global redirectStdOutObj
     redirectStdOutObj.redirect()
 #@+node:ekr.20041012090942.1: *5* restoreStderr & restoreStdout
 # Restore standard streams.
 
-def restoreStderr():
+def restoreStderr() -> None:
     global redirectStdErrObj
     redirectStdErrObj.undirect(stdout=False)
 
-def restoreStdout():
+def restoreStdout() -> None:
     global redirectStdOutObj
     redirectStdOutObj.undirect()
 #@+node:ekr.20041012090942.2: *5* stdErrIsRedirected & stdOutIsRedirected
-def stdErrIsRedirected():
+def stdErrIsRedirected() -> bool:
     global redirectStdErrObj
     return redirectStdErrObj.isRedirected()
 
-def stdOutIsRedirected():
+def stdOutIsRedirected() -> bool:
     global redirectStdOutObj
     return redirectStdOutObj.isRedirected()
 #@+node:ekr.20041012090942.3: *5* rawPrint
 # Send output to original stdout.
 
-def rawPrint(s: str):
+def rawPrint(s: str) -> None:
     global redirectStdOutObj
     redirectStdOutObj.rawPrint(s)
 #@-others
@@ -1644,12 +1644,12 @@ class SherlockTracer:
     #@+node:ekr.20121128031949.12602: *4* __init__
     def __init__(
         self,
-        patterns,
-        dots=True,
-        show_args=True,
-        show_return=True,
-        verbose=True,
-    ):
+        patterns: List[Any],
+        dots: bool=True,
+        show_args: bool=True,
+        show_return: bool=True,
+        verbose: bool=True,
+    ) -> None:
         """SherlockTracer ctor."""
         self.bad_patterns = []  # List of bad patterns.
         self.dots = dots  # True: print level dots.
@@ -1668,17 +1668,17 @@ class SherlockTracer:
             # pylint: disable=no-member
             QtCore.pyqtRemoveInputHook()
     #@+node:ekr.20140326100337.16844: *4* __call__
-    def __call__(self, frame, event, arg):
+    def __call__(self, frame: Any, event: Any, arg: Any) -> Any:
         """Exists so that self.dispatch can return self."""
         return self.dispatch(frame, event, arg)
     #@+node:ekr.20140326100337.16846: *4* sherlock.bad_pattern
-    def bad_pattern(self, pattern):
+    def bad_pattern(self, pattern: Any) -> None:
         """Report a bad Sherlock pattern."""
         if pattern not in self.bad_patterns:
             self.bad_patterns.append(pattern)
             print(f"\nignoring bad pattern: {pattern}\n")
     #@+node:ekr.20140326100337.16847: *4* sherlock.check_pattern
-    def check_pattern(self, pattern):
+    def check_pattern(self, pattern: str) -> bool:
         """Give an error and return False for an invalid pattern."""
         try:
             for prefix in ('+:', '-:', '+', '-'):
@@ -1691,7 +1691,7 @@ class SherlockTracer:
             self.bad_pattern(pattern)
             return False
     #@+node:ekr.20121128031949.12609: *4* sherlock.dispatch
-    def dispatch(self, frame, event, arg):
+    def dispatch(self, frame: Any, event: Any, arg: Any) -> Any:
         """The dispatch method."""
         if event == 'call':
             self.do_call(frame, arg)
@@ -1702,7 +1702,7 @@ class SherlockTracer:
         # Queue the SherlockTracer instance again.
         return self
     #@+node:ekr.20121128031949.12603: *4* sherlock.do_call & helper
-    def do_call(self, frame, unused_arg):
+    def do_call(self, frame: Any, unused_arg: Any) -> None:
         """Trace through a function call."""
         frame1 = frame
         code = frame.f_code
@@ -1730,7 +1730,7 @@ class SherlockTracer:
         d[full_name] = 1 + d.get(full_name, 0)
         self.stats[file_name] = d
     #@+node:ekr.20130111185820.10194: *5* sherlock.get_args
-    def get_args(self, frame):
+    def get_args(self, frame: Any) -> str:
         """Return name=val for each arg in the function call."""
         code = frame.f_code
         locals_ = frame.f_locals
@@ -1758,7 +1758,7 @@ class SherlockTracer:
     #@+node:ekr.20140402060647.16845: *4* sherlock.do_line (not used)
     bad_fns: List[str] = []
 
-    def do_line(self, frame, arg):
+    def do_line(self, frame: Any, arg: Any) -> None:
         """print each line of enabled functions."""
         if 1:
             return
@@ -1790,7 +1790,7 @@ class SherlockTracer:
         else:
             print(f"{g.shortFileName(file_name)} {n} {full_name} {line}")
     #@+node:ekr.20130109154743.10172: *4* sherlock.do_return & helper
-    def do_return(self, frame, arg):  # Arg *is* used below.
+    def do_return(self, frame: Any, arg: Any) -> None:  # Arg *is* used below.
         """Trace a return statement."""
         code = frame.f_code
         fn = code.co_filename

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
 else:
     Cmdr = None

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -10,10 +10,14 @@ import copy
 import itertools
 import time
 import re
-from typing import Dict, List, Optional, Tuple  # Any, Callable, Generator, Sequence, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
-from leo.core.leoCommands import Commands as Cmdr
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+else:
+    Cmdr = None
 #@-<< imports >>
 #@+others
 #@+node:ekr.20031218072017.1991: ** class NodeIndices
@@ -24,7 +28,7 @@ class NodeIndices:
 
     #@+others
     #@+node:ekr.20031218072017.1992: *3* ni.__init__
-    def __init__(self, id_):
+    def __init__(self, id_: str) -> None:
         """Ctor for NodeIndices class."""
         self.defaultId = id_
         self.lastIndex = 0
@@ -34,7 +38,7 @@ class NodeIndices:
         # Assign the initial timestamp.
         self.setTimeStamp()
     #@+node:ekr.20150321161305.8: *3* ni.check_gnx
-    def check_gnx(self, c, gnx, v):
+    def check_gnx(self, c: "Cmdr", gnx: str, v: "VNode") -> None:
         """Check that no vnode exists with the given gnx in fc.gnxDict."""
         fc = c.fileCommands
         if gnx == 'hidden-root-vnode-gnx':
@@ -48,7 +52,7 @@ class NodeIndices:
                 f"          v: {v}\n"
                 f"         v2: {v2}")
     #@+node:ekr.20150302061758.14: *3* ni.compute_last_index
-    def compute_last_index(self, c):
+    def compute_last_index(self, c: "Cmdr") -> None:
         """Scan the entire leo outline to compute ni.last_index."""
         ni = self
         # Partial, experimental, fix for #658.
@@ -66,7 +70,7 @@ class NodeIndices:
                         g.es_exception()
                         self.lastIndex += 1
     #@+node:ekr.20200528131303.1: *3* ni.computeNewIndex
-    def computeNewIndex(self):
+    def computeNewIndex(self) -> str:
         """Return a new gnx."""
         t_s = self.update()
             # Updates self.lastTime and self.lastIndex.
@@ -75,15 +79,15 @@ class NodeIndices:
     #@+node:ekr.20031218072017.1994: *3* ni.get/setDefaultId
     # These are used by the FileCommands read/write code.
 
-    def getDefaultId(self):
+    def getDefaultId(self) -> str:
         """Return the id to be used by default in all gnx's"""
         return self.defaultId
 
-    def setDefaultId(self, theId):
+    def setDefaultId(self, theId: str) -> None:
         """Set the id to be used by default in all gnx's"""
         self.defaultId = theId
     #@+node:ekr.20031218072017.1995: *3* ni.getNewIndex
-    def getNewIndex(self, v, cached=False):
+    def getNewIndex(self, v: "VNode", cached: bool=False) -> str:
         """
         Create a new gnx for v or an empty string if the hold flag is set.
         **Important**: the method must allocate a new gnx even if v.fileIndex exists.
@@ -101,7 +105,7 @@ class NodeIndices:
         fc.gnxDict[gnx] = v
         return gnx
     #@+node:ekr.20150322134954.1: *3* ni.new_vnode_helper
-    def new_vnode_helper(self, c, gnx, v):
+    def new_vnode_helper(self, c: "Cmdr", gnx: str, v: "VNode") -> None:
         """Handle all gnx-related tasks for VNode.__init__."""
         ni = self
         if gnx:
@@ -111,7 +115,7 @@ class NodeIndices:
         else:
             v.fileIndex = ni.getNewIndex(v)
     #@+node:ekr.20031218072017.1997: *3* ni.scanGnx
-    def scanGnx(self, s):
+    def scanGnx(self, s: str) -> Tuple[str, str, str]:
         """Create a gnx from its string representation."""
         if not isinstance(s, str):
             g.error("scanGnx: unexpected index type:", type(s), '', s)
@@ -128,7 +132,7 @@ class NodeIndices:
             theId = self.defaultId
         return theId, t, n
     #@+node:ekr.20031218072017.1998: *3* ni.setTimeStamp
-    def setTimestamp(self):
+    def setTimestamp(self) -> None:
         """Set the timestamp string to be used by getNewIndex until further notice"""
         self.timeString = time.strftime(
             "%Y%m%d%H%M%S",  # Help comparisons; avoid y2k problems.
@@ -136,7 +140,7 @@ class NodeIndices:
 
     setTimeStamp = setTimestamp
     #@+node:ekr.20141015035853.18304: *3* ni.tupleToString
-    def tupleToString(self, aTuple):
+    def tupleToString(self, aTuple: Tuple) -> str:
         """
         Convert a gnx tuple returned by scanGnx
         to its string representation.
@@ -150,7 +154,7 @@ class NodeIndices:
             s = f"{theId}.{t}.{n}"
         return g.toUnicode(s)
     #@+node:ekr.20150321161305.13: *3* ni.update
-    def update(self):
+    def update(self) -> str:
         """Update self.timeString and self.lastIndex"""
         t_s = time.strftime("%Y%m%d%H%M%S", time.localtime())
         if self.timeString == t_s:
@@ -160,7 +164,7 @@ class NodeIndices:
             self.timeString = t_s
         return t_s
     #@+node:ekr.20141023110422.4: *3* ni.updateLastIndex
-    def updateLastIndex(self, gnx):
+    def updateLastIndex(self, gnx: str) -> None:
         """Update ni.lastIndex if the gnx affects it."""
         id_, t, n = self.scanGnx(gnx)
         # pylint: disable=literal-comparison
@@ -210,7 +214,7 @@ class Position:
     #@+others
     #@+node:ekr.20040228094013: *3*  p.ctor & other special methods...
     #@+node:ekr.20080920052058.3: *4* p.__eq__ & __ne__
-    def __eq__(self, p2):  # Use Any, not Position.
+    def __eq__(self, p2: Any) -> bool:  # Use Any, not Position.
         """Return True if two positions are equivalent."""
         p1 = self
         # Don't use g.trace: it might call p.__eq__ or p.__ne__.
@@ -222,11 +226,11 @@ class Position:
             p1._childIndex == p2._childIndex and
             p1.stack == p2.stack)
 
-    def __ne__(self, p2):  # Use Any, not Position.
+    def __ne__(self, p2: Any) -> bool:  # Use Any, not Position.
         """Return True if two postions are not equivalent."""
         return not self.__eq__(p2)
     #@+node:ekr.20080416161551.190: *4*  p.__init__
-    def __init__(self, v, childIndex=0, stack=None):
+    def __init__(self, v: "VNode", childIndex: int=0, stack: Optional[List]=None) -> None:
         """Create a new position with the given childIndex and parent stack."""
         self._childIndex = childIndex
         self.v = v
@@ -237,16 +241,16 @@ class Position:
             self.stack = []
         g.app.positions += 1
     #@+node:ekr.20091210082012.6230: *4* p.__ge__ & __le__& __lt__
-    def __ge__(self, other):
+    def __ge__(self, other: Any) -> bool:
         return self.__eq__(other) or self.__gt__(other)
 
-    def __le__(self, other):
+    def __le__(self, other: Any) -> bool:
         return self.__eq__(other) or self.__lt__(other)
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         return not self.__eq__(other) and not self.__gt__(other)
     #@+node:ekr.20091210082012.6233: *4* p.__gt__
-    def __gt__(self, other):
+    def __gt__(self, other: Any) -> bool:
         """Return True if self appears after other in outline order."""
         stack1, stack2 = self.stack, other.stack
         n1, n2 = len(stack1), len(stack2)
@@ -273,7 +277,7 @@ class Position:
         v2, x2 = self.stack[n]
         return x2 >= x1
     #@+node:ekr.20040117173448: *4* p.__nonzero__ & __bool__
-    def __bool__(self):
+    def __bool__(self) -> bool:
         """
         Return True if a position is valid.
 
@@ -284,7 +288,7 @@ class Position:
         """
         return self.v is not None
     #@+node:ekr.20040301205720: *4* p.__str__ and p.__repr__
-    def __str__(self):
+    def __str__(self) -> str:
         p = self
         if p.v:
             return (
@@ -300,7 +304,7 @@ class Position:
 
     __repr__ = __str__
     #@+node:ekr.20061006092649: *4* p.archivedPosition
-    def archivedPosition(self, root_p=None):
+    def archivedPosition(self, root_p: Optional["Position"]=None) -> List[int]:
         """Return a representation of a position suitable for use in .leo files."""
         p = self
         if root_p is None:
@@ -316,15 +320,15 @@ class Position:
         aList.reverse()
         return aList
     #@+node:ekr.20040310153624: *4* p.dump
-    def dumpLink(self, link):
+    def dumpLink(self, link: Optional[str]) -> str:
         return link if link else "<none>"
 
-    def dump(self, label=""):
+    def dump(self, label: str="") -> None:
         p = self
         if p.v:
             p.v.dump()  # Don't print a label
     #@+node:ekr.20080416161551.191: *4* p.key & p.sort_key & __hash__
-    def key(self):
+    def key(self) -> str:
         p = self
         # For unified nodes we must include a complete key,
         # so we can distinguish between clones.
@@ -335,7 +339,7 @@ class Position:
         result.append(f"{id(p.v)}:{p._childIndex}")
         return '.'.join(result)
 
-    def sort_key(self, p):
+    def sort_key(self, p: "Position") -> List[int]:
         return [int(s.split(':')[1]) for s in p.key().split('.')]
 
     # Positions should *not* be hashable.
@@ -354,7 +358,7 @@ class Position:
     # - convertTreeToString and moreHead can't be VNode methods because they uses level().
     # - moreBody could be anywhere: it may as well be a postion method.
     #@+node:ekr.20040315023430.1: *4* p.convertTreeToString
-    def convertTreeToString(self):
+    def convertTreeToString(self) -> str:
         """Convert a positions  suboutline to a string in MORE format."""
         p = self
         level1 = p.level()
@@ -366,7 +370,7 @@ class Position:
                 array.append(body + '\n')
         return ''.join(array)
     #@+node:ekr.20040315023430.2: *4* p.moreHead
-    def moreHead(self, firstLevel, useVerticalBar=False):
+    def moreHead(self, firstLevel: int, useVerticalBar: bool=False) -> str:
         """Return the headline string in MORE format."""
         # useVerticalBar is unused, but it would be useful in over-ridden methods.
         p = self
@@ -387,7 +391,7 @@ class Position:
     #@@c
     #@@language python
 
-    def moreBody(self):
+    def moreBody(self) -> str:
         """Returns the body string in MORE format.
 
         Inserts a backslash before any leading plus, minus or backslash."""
@@ -402,7 +406,7 @@ class Position:
         return '\n'.join(array)
     #@+node:ekr.20091001141621.6060: *3* p.generators
     #@+node:ekr.20091001141621.6055: *4* p.children
-    def children(self, copy=True):
+    def children(self, copy: bool=True) -> Generator:
         """Yield all child positions of p."""
         p = self
         p = p.firstChild()
@@ -414,7 +418,7 @@ class Position:
 
     children_iter = children
     #@+node:ekr.20091002083910.6102: *4* p.following_siblings
-    def following_siblings(self, copy=True):
+    def following_siblings(self, copy: bool=True) -> Generator:
         """Yield all siblings positions that follow p, not including p."""
         p = self
         p = p.next()  # pylint: disable=not-callable
@@ -426,7 +430,7 @@ class Position:
 
     following_siblings_iter = following_siblings
     #@+node:ekr.20161120105707.1: *4* p.nearest_roots
-    def nearest_roots(self, copy=True, predicate=None):
+    def nearest_roots(self, copy: bool=True, predicate: Optional[Callable]=None) -> Generator:
         """
         A generator yielding all the root positions "near" p1 = self that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -438,7 +442,7 @@ class Position:
         Otherwise, the generator yields all nodes in p.subtree() that satisfy
         the predicate. Once a root is found, the generator skips its subtree.
         """
-        def default_predicate(p):
+        def default_predicate(p: "Position") -> bool:
             return p.isAnyAtFileNode()
 
         the_predicate = predicate or default_predicate
@@ -459,7 +463,7 @@ class Position:
             else:
                 p.moveToThreadNext()
     #@+node:ekr.20161120163203.1: *4* p.nearest_unique_roots (aka p.nearest)
-    def nearest_unique_roots(self, copy=True, predicate=None):
+    def nearest_unique_roots(self, copy: bool=True, predicate: Callable=None) -> Generator:
         """
         A generator yielding all unique root positions "near" p1 = self that
         satisfy the given predicate. p.isAnyAtFileNode is the default
@@ -473,7 +477,7 @@ class Position:
         subtree.
         """
 
-        def default_predicate(p):
+        def default_predicate(p: "Position") -> bool:
             return p.isAnyAtFileNode()
 
         the_predicate = predicate or default_predicate
@@ -499,7 +503,7 @@ class Position:
 
     nearest = nearest_unique_roots
     #@+node:ekr.20091002083910.6104: *4* p.nodes
-    def nodes(self):
+    def nodes(self) -> Generator:
         """Yield p.v and all vnodes in p's subtree."""
         p = self
         p = p.copy()
@@ -512,7 +516,7 @@ class Position:
 
     vnodes_iter = nodes
     #@+node:ekr.20091001141621.6058: *4* p.parents
-    def parents(self, copy=True):
+    def parents(self, copy: bool=True) -> Generator:
         """Yield all parent positions of p."""
         p = self
         p = p.parent()
@@ -524,7 +528,7 @@ class Position:
 
     parents_iter = parents
     #@+node:ekr.20091002083910.6099: *4* p.self_and_parents
-    def self_and_parents(self, copy=True):
+    def self_and_parents(self, copy: bool=True) -> Generator:
         """Yield p and all parent positions of p."""
         p = self
         p = p.copy()
@@ -536,7 +540,7 @@ class Position:
 
     self_and_parents_iter = self_and_parents
     #@+node:ekr.20091001141621.6057: *4* p.self_and_siblings
-    def self_and_siblings(self, copy=True):
+    def self_and_siblings(self, copy: bool=True) -> Generator:
         """Yield all sibling positions of p including p."""
         p = self
         p = p.copy()
@@ -550,7 +554,7 @@ class Position:
 
     self_and_siblings_iter = self_and_siblings
     #@+node:ekr.20091001141621.6066: *4* p.self_and_subtree
-    def self_and_subtree(self, copy=True):
+    def self_and_subtree(self, copy: bool=True) -> Generator:
         """Yield p and all positions in p's subtree."""
         p = self
         p = p.copy()
@@ -563,7 +567,7 @@ class Position:
 
     self_and_subtree_iter = self_and_subtree
     #@+node:ekr.20091001141621.6056: *4* p.subtree
-    def subtree(self, copy=True):
+    def subtree(self, copy: bool=True) -> Generator:
         """Yield all positions in p's subtree, but not p."""
         p = self
         p = p.copy()
@@ -577,7 +581,7 @@ class Position:
 
     subtree_iter = subtree
     #@+node:ekr.20091002083910.6105: *4* p.unique_nodes
-    def unique_nodes(self):
+    def unique_nodes(self) -> Generator:
         """Yield p.v and all unique vnodes in p's subtree."""
         p = self
         seen = set()
@@ -590,7 +594,7 @@ class Position:
 
     unique_vnodes_iter = unique_nodes
     #@+node:ekr.20091002083910.6103: *4* p.unique_subtree
-    def unique_subtree(self):
+    def unique_subtree(self) -> Generator:
         """Yield p and all other unique positions in p's subtree."""
         p = self
         seen = set()
@@ -606,77 +610,77 @@ class Position:
     #@+node:ekr.20040306212636: *3* p.Getters
     #@+node:ekr.20040306210951: *4* p.VNode proxies
     #@+node:ekr.20040306211032: *5* p.Comparisons
-    def anyAtFileNodeName(self):
+    def anyAtFileNodeName(self) -> str:
         return self.v.anyAtFileNodeName()
 
-    def atAutoNodeName(self):
+    def atAutoNodeName(self) -> str:
         return self.v.atAutoNodeName()
 
-    def atCleanNodeName(self):
+    def atCleanNodeName(self) -> str:
         return self.v.atCleanNodeName()
 
-    def atEditNodeName(self):
+    def atEditNodeName(self) -> str:
         return self.v.atEditNodeName()
 
-    def atFileNodeName(self):
+    def atFileNodeName(self) -> str:
         return self.v.atFileNodeName()
 
-    def atNoSentinelsFileNodeName(self):
+    def atNoSentinelsFileNodeName(self) -> str:
         return self.v.atNoSentinelsFileNodeName()
 
-    def atShadowFileNodeName(self):
+    def atShadowFileNodeName(self) -> str:
         return self.v.atShadowFileNodeName()
 
-    def atSilentFileNodeName(self):
+    def atSilentFileNodeName(self) -> str:
         return self.v.atSilentFileNodeName()
 
-    def atThinFileNodeName(self):
+    def atThinFileNodeName(self) -> str:
         return self.v.atThinFileNodeName()
 
     # New names, less confusing
     atNoSentFileNodeName = atNoSentinelsFileNodeName
     atAsisFileNodeName = atSilentFileNodeName
 
-    def isAnyAtFileNode(self):
+    def isAnyAtFileNode(self) -> bool:
         return self.v.isAnyAtFileNode()
 
-    def isAtAllNode(self):
+    def isAtAllNode(self) -> bool:
         return self.v.isAtAllNode()
 
-    def isAtAutoNode(self):
+    def isAtAutoNode(self) -> bool:
         return self.v.isAtAutoNode()
 
-    def isAtAutoRstNode(self):
+    def isAtAutoRstNode(self) -> bool:
         return self.v.isAtAutoRstNode()
 
-    def isAtCleanNode(self):
+    def isAtCleanNode(self) -> bool:
         return self.v.isAtCleanNode()
 
-    def isAtEditNode(self):
+    def isAtEditNode(self) -> bool:
         return self.v.isAtEditNode()
 
-    def isAtFileNode(self):
+    def isAtFileNode(self) -> bool:
         return self.v.isAtFileNode()
 
-    def isAtIgnoreNode(self):
+    def isAtIgnoreNode(self) -> bool:
         return self.v.isAtIgnoreNode()
 
-    def isAtNoSentinelsFileNode(self):
+    def isAtNoSentinelsFileNode(self) -> bool:
         return self.v.isAtNoSentinelsFileNode()
 
-    def isAtOthersNode(self):
+    def isAtOthersNode(self) -> bool:
         return self.v.isAtOthersNode()
 
-    def isAtRstFileNode(self):
+    def isAtRstFileNode(self) -> bool:
         return self.v.isAtRstFileNode()
 
-    def isAtSilentFileNode(self):
+    def isAtSilentFileNode(self) -> bool:
         return self.v.isAtSilentFileNode()
 
-    def isAtShadowFileNode(self):
+    def isAtShadowFileNode(self) -> bool:
         return self.v.isAtShadowFileNode()
 
-    def isAtThinFileNode(self):
+    def isAtThinFileNode(self) -> bool:
         return self.v.isAtThinFileNode()
 
     # New names, less confusing:
@@ -685,95 +689,95 @@ class Position:
 
     # Utilities.
 
-    def matchHeadline(self, pattern):
+    def matchHeadline(self, pattern: str) -> bool:
         return self.v.matchHeadline(pattern)
     #@+node:ekr.20040306220230: *5* p.Headline & body strings
-    def bodyString(self):
+    def bodyString(self) -> str:
         return self.v.bodyString()
 
-    def headString(self):
+    def headString(self) -> str:
         return self.v.headString()
     #@+node:ekr.20040306214401: *5* p.Status bits
-    def isDirty(self):
+    def isDirty(self) -> bool:
         return self.v.isDirty()
 
-    def isMarked(self):
+    def isMarked(self) -> bool:
         return self.v.isMarked()
 
-    def isOrphan(self):
+    def isOrphan(self) -> bool:
         return self.v.isOrphan()
 
-    def isSelected(self):
+    def isSelected(self) -> bool:
         return self.v.isSelected()
 
-    def isTopBitSet(self):
+    def isTopBitSet(self) -> bool:
         return self.v.isTopBitSet()
 
-    def isVisited(self):
+    def isVisited(self) -> bool:
         return self.v.isVisited()
 
-    def status(self):
+    def status(self) -> int:
         return self.v.status()
     #@+node:ekr.20040306214240.2: *4* p.children & parents
     #@+node:ekr.20040326064330: *5* p.childIndex
     # This used to be time-critical code.
 
-    def childIndex(self):
+    def childIndex(self) -> int:
         p = self
         return p._childIndex
     #@+node:ekr.20040323160302: *5* p.directParents
-    def directParents(self):
+    def directParents(self) -> List["VNode"]:
         return self.v.directParents()
     #@+node:ekr.20040306214240.3: *5* p.hasChildren & p.numberOfChildren
-    def hasChildren(self):
+    def hasChildren(self) -> bool:
         p = self
         return len(p.v.children) > 0
 
     hasFirstChild = hasChildren
 
-    def numberOfChildren(self):
+    def numberOfChildren(self) -> int:
         p = self
         return len(p.v.children)
     #@+node:ekr.20031218072017.915: *4* p.getX & VNode compatibility traversal routines
     # These methods are useful abbreviations.
     # Warning: they make copies of positions, so they should be used _sparingly_
 
-    def getBack(self):
+    def getBack(self) -> "Position":
         return self.copy().moveToBack()
 
-    def getFirstChild(self):
+    def getFirstChild(self) -> "Position":
         return self.copy().moveToFirstChild()
 
-    def getLastChild(self):
+    def getLastChild(self) -> "Position":
         return self.copy().moveToLastChild()
 
-    def getLastNode(self):
+    def getLastNode(self) -> "Position":
         return self.copy().moveToLastNode()
-    # def getLastVisible   (self): return self.copy().moveToLastVisible()
 
-    def getNext(self):
+    def getNext(self) -> "Position":
         return self.copy().moveToNext()
 
-    def getNodeAfterTree(self):
+    def getNodeAfterTree(self) -> "Position":
         return self.copy().moveToNodeAfterTree()
 
-    def getNthChild(self, n):
+    def getNthChild(self, n: int) -> "Position":
         return self.copy().moveToNthChild(n)
 
-    def getParent(self):
+    def getParent(self) -> "Position":
         return self.copy().moveToParent()
 
-    def getThreadBack(self):
+    def getThreadBack(self) -> "Position":
         return self.copy().moveToThreadBack()
 
-    def getThreadNext(self):
+    def getThreadNext(self) -> "Position":
         return self.copy().moveToThreadNext()
+        
     # New in Leo 4.4.3 b2: add c args.
 
-    def getVisBack(self, c):
+    def getVisBack(self, c: "Cmdr") -> "Position":
         return self.copy().moveToVisBack(c)
 
-    def getVisNext(self, c):
+    def getVisNext(self, c: "Cmdr") -> "Position":
         return self.copy().moveToVisNext(c)
     # These are efficient enough now that iterators are the normal way to traverse the tree!
     back = getBack
@@ -793,7 +797,12 @@ class Position:
     hasVisBack = visBack
     hasVisNext = visNext
     #@+node:tbrown.20111010104549.26758: *4* p.get_UNL
-    def get_UNL(self, with_file=True, with_proto=False, with_index=True, with_count=False):
+    def get_UNL(self,
+        with_file: bool=True,
+        with_proto: bool=False,
+        with_index: bool=True,
+        with_count: bool=False,
+    ) -> str:
         """
         Return a UNL representing a clickable link.
 
@@ -829,11 +838,11 @@ class Position:
             return f"{self.v.context.fileName()}#{UNL}"
         return UNL
     #@+node:ekr.20080416161551.192: *4* p.hasBack/Next/Parent/ThreadBack
-    def hasBack(self):
+    def hasBack(self) -> bool:
         p = self
         return bool(p.v and p._childIndex > 0)
 
-    def hasNext(self):
+    def hasNext(self) -> bool:
         p = self
         try:
             parent_v = p._parentVnode()
@@ -844,16 +853,16 @@ class Position:
             g.es_exception()
             return None
 
-    def hasParent(self):
+    def hasParent(self) -> bool:
         p = self
         return bool(p.v and p.stack)
 
-    def hasThreadBack(self):
+    def hasThreadBack(self) -> bool:
         p = self
         return bool(p.hasParent() or p.hasBack())
             # Much cheaper than computing the actual value.
     #@+node:ekr.20080416161551.193: *5* hasThreadNext (the only complex hasX method)
-    def hasThreadNext(self):
+    def hasThreadNext(self) -> bool:
         p = self
         if not p.v:
             return False
@@ -873,13 +882,13 @@ class Position:
             n -= 1
         return False
     #@+node:ekr.20060920203352: *4* p.findRootPosition
-    def findRootPosition(self):
+    def findRootPosition(self) -> "Position":
         # 2011/02/25: always use c.rootPosition
         p = self
         c = p.v.context
         return c.rootPosition()
     #@+node:ekr.20080416161551.194: *4* p.isAncestorOf
-    def isAncestorOf(self, p2):
+    def isAncestorOf(self, p2: "Position") -> bool:
         """Return True if p is one of the direct ancestors of p2."""
         p = self
         c = p.v.context
@@ -893,19 +902,19 @@ class Position:
                 return True
         return False
     #@+node:ekr.20040306215056: *4* p.isCloned
-    def isCloned(self):
+    def isCloned(self) -> bool:
         p = self
         return p.v.isCloned()
     #@+node:ekr.20040307104131.2: *4* p.isRoot
-    def isRoot(self):
+    def isRoot(self) -> bool:
         p = self
         return not p.hasParent() and not p.hasBack()
     #@+node:ekr.20080416161551.196: *4* p.isVisible
-    def isVisible(self, c):
+    def isVisible(self, c: "Cmdr") -> bool:
         """Return True if p is visible in c's outline."""
         p = self
 
-        def visible(p, root=None):
+        def visible(p: "Position", root: Optional["Position"]=None) -> bool:
             for parent in p.parents(copy=False):
                 if parent and parent == root:
                     # #12.
@@ -925,14 +934,14 @@ class Position:
                 return visible(p)
         return False
     #@+node:ekr.20080416161551.197: *4* p.level & simpleLevel
-    def level(self):
+    def level(self) -> int:
         """Return the number of p's parents."""
         p = self
         return len(p.stack) if p.v else 0
 
     simpleLevel = level
     #@+node:ekr.20111005152227.15566: *4* p.positionAfterDeletedTree
-    def positionAfterDeletedTree(self):
+    def positionAfterDeletedTree(self) -> "Position":
         """Return the position corresponding to p.nodeAfterTree() after this node is
         deleted. This will be p.nodeAfterTree() unless p.next() exists.
 
@@ -967,7 +976,7 @@ class Position:
             return p
         return p.nodeAfterTree()
     #@+node:shadow.20080825171547.2: *4* p.textOffset
-    def textOffset(self):
+    def textOffset(self) -> Optional[int]:
         """
         Return the fcol offset of self.
         Return None if p is has no ancestor @<file> node.
@@ -995,7 +1004,7 @@ class Position:
                     break
         return offset if found else None
     #@+node:ekr.20150410101842.1: *3* p.isOutsideAtFileTree
-    def isOutsideAnyAtFileTree(self):
+    def isOutsideAnyAtFileTree(self) -> bool:
         """Select the first clone of target that is outside any @file node."""
         p = self
         for parent in p.self_and_parents(copy=False):
@@ -1006,7 +1015,7 @@ class Position:
     # These methods are only for the use of low-level code
     # in leoNodes.py, leoFileCommands.py and leoUndo.py.
     #@+node:ekr.20080427062528.4: *4* p._adjustPositionBeforeUnlink
-    def _adjustPositionBeforeUnlink(self, p2):
+    def _adjustPositionBeforeUnlink(self, p2: "Position") -> None:
         """Adjust position p before unlinking p2."""
         # p will change if p2 is a previous sibling of p or
         # p2 is a previous sibling of any ancestor of p.
@@ -1039,7 +1048,7 @@ class Position:
         if changed:
             p.stack = stack
     #@+node:ekr.20080416161551.214: *4* p._linkAfter
-    def _linkAfter(self, p_after):
+    def _linkAfter(self, p_after: "Position") -> None:
         """Link self after p_after."""
         p = self
         parent_v = p_after._parentVnode()
@@ -1049,7 +1058,7 @@ class Position:
         n = p_after._childIndex + 1
         child._addLink(n, parent_v)
     #@+node:ekr.20180709181718.1: *4* p._linkCopiedAfter
-    def _linkCopiedAfter(self, p_after):
+    def _linkCopiedAfter(self, p_after: "Position") -> None:
         """Link self, a newly copied tree, after p_after."""
         p = self
         parent_v = p_after._parentVnode()
@@ -1059,7 +1068,7 @@ class Position:
         n = p_after._childIndex + 1
         child._addCopiedLink(n, parent_v)
     #@+node:ekr.20080416161551.215: *4* p._linkAsNthChild
-    def _linkAsNthChild(self, parent, n):
+    def _linkAsNthChild(self, parent: "Position", n: int) -> None:
         """Link self as the n'th child of the parent."""
         p = self
         parent_v = parent.v
@@ -1069,7 +1078,7 @@ class Position:
         child = p.v
         child._addLink(n, parent_v)
     #@+node:ekr.20180709180140.1: *4* p._linkCopiedAsNthChild
-    def _linkCopiedAsNthChild(self, parent, n):
+    def _linkCopiedAsNthChild(self, parent: "Position", n: int) -> None:
         """Link a copied self as the n'th child of the parent."""
         p = self
         parent_v = parent.v
@@ -1079,7 +1088,7 @@ class Position:
         child = p.v
         child._addCopiedLink(n, parent_v)
     #@+node:ekr.20080416161551.216: *4* p._linkAsRoot
-    def _linkAsRoot(self):
+    def _linkAsRoot(self) -> "Position":
         """Link self as the root node."""
         p = self
         assert p.v
@@ -1094,7 +1103,7 @@ class Position:
         p.v._addLink(0, parent_v)
         return p
     #@+node:ekr.20080416161551.212: *4* p._parentVnode
-    def _parentVnode(self):
+    def _parentVnode(self) -> "VNode":
         """
         Return the parent VNode.
         Return the hiddenRootNode if there is no other parent.
@@ -1108,7 +1117,7 @@ class Position:
             return p.v.context.hiddenRootNode
         return None
     #@+node:ekr.20131219220412.16582: *4* p._relinkAsCloneOf
-    def _relinkAsCloneOf(self, p2):
+    def _relinkAsCloneOf(self, p2: "Position") -> None:
         """A low-level method to replace p.v by a p2.v."""
         p = self
         v, v2 = p.v, p2.v
@@ -1126,7 +1135,7 @@ class Position:
                 'parent_v.children[childIndex] != v',
                 p, parent_v.children, p._childIndex, v)
     #@+node:ekr.20080416161551.217: *4* p._unlink
-    def _unlink(self):
+    def _unlink(self) -> None:
         """Unlink the receiver p from the tree."""
         p = self
         n = p._childIndex
@@ -1144,7 +1153,7 @@ class Position:
         else:
             self.badUnlink(parent_v, n, child)
     #@+node:ekr.20090706171333.6226: *5* p.badUnlink
-    def badUnlink(self, parent_v, n, child):
+    def badUnlink(self, parent_v: "VNode", n: int, child: "VNode") -> None:
 
         if 0 <= n < len(parent_v.children):
             g.trace(f"**can not happen: children[{n}] != p.v")
@@ -1177,7 +1186,7 @@ class Position:
     # These routines all return self on exit so the following kind of code will work:
     #     after = p.copy().moveToNodeAfterTree()
     #@+node:ekr.20080416161551.200: *4* p.moveToBack
-    def moveToBack(self):
+    def moveToBack(self) -> "Position":
         """Move self to its previous sibling."""
         p = self
         n = p._childIndex
@@ -1191,7 +1200,7 @@ class Position:
             p.v = None
         return p
     #@+node:ekr.20080416161551.201: *4* p.moveToFirstChild
-    def moveToFirstChild(self):
+    def moveToFirstChild(self) -> "Position":
         """Move a position to it's first child's position."""
         p = self
         if p.v and p.v.children:
@@ -1202,7 +1211,7 @@ class Position:
             p.v = None
         return p
     #@+node:ekr.20080416161551.202: *4* p.moveToLastChild
-    def moveToLastChild(self):
+    def moveToLastChild(self) -> "Position":
         """Move a position to it's last child's position."""
         p = self
         if p.v and p.v.children:
@@ -1214,7 +1223,7 @@ class Position:
             p.v = None
         return p
     #@+node:ekr.20080416161551.203: *4* p.moveToLastNode
-    def moveToLastNode(self):
+    def moveToLastNode(self) -> "Position":
         """Move a position to last node of its tree.
 
         N.B. Returns p if p has no children."""
@@ -1224,7 +1233,7 @@ class Position:
             p.moveToLastChild()
         return p
     #@+node:ekr.20080416161551.204: *4* p.moveToNext
-    def moveToNext(self):
+    def moveToNext(self) -> "Position":
         """Move a position to its next sibling."""
         p = self
         n = p._childIndex
@@ -1239,7 +1248,7 @@ class Position:
             p.v = None
         return p
     #@+node:ekr.20080416161551.205: *4* p.moveToNodeAfterTree
-    def moveToNodeAfterTree(self):
+    def moveToNodeAfterTree(self) -> "Position":
         """Move a position to the node after the position's tree."""
         p = self
         while p:
@@ -1249,7 +1258,7 @@ class Position:
             p.moveToParent()
         return p
     #@+node:ekr.20080416161551.206: *4* p.moveToNthChild
-    def moveToNthChild(self, n):
+    def moveToNthChild(self, n: int) -> "Position":
         p = self
         if p.v and len(p.v.children) > n:
             p.stack.append((p.v, p._childIndex),)
@@ -1261,7 +1270,7 @@ class Position:
             p.v = None  # type:ignore
         return p
     #@+node:ekr.20080416161551.207: *4* p.moveToParent
-    def moveToParent(self):
+    def moveToParent(self) -> "Position":
         """Move a position to its parent position."""
         p = self
         if p.v and p.stack:
@@ -1272,7 +1281,7 @@ class Position:
             p.v = None  # type:ignore
         return p
     #@+node:ekr.20080416161551.208: *4* p.moveToThreadBack
-    def moveToThreadBack(self):
+    def moveToThreadBack(self) -> "Position":
         """Move a position to it's threadBack position."""
         p = self
         if p.hasBack():
@@ -1282,7 +1291,7 @@ class Position:
             p.moveToParent()
         return p
     #@+node:ekr.20080416161551.209: *4* p.moveToThreadNext
-    def moveToThreadNext(self):
+    def moveToThreadNext(self) -> "Position":
         """Move a position to threadNext position."""
         p = self
         if p.v:
@@ -1300,7 +1309,7 @@ class Position:
                 # not found.
         return p
     #@+node:ekr.20080416161551.210: *4* p.moveToVisBack & helper
-    def moveToVisBack(self, c):
+    def moveToVisBack(self, c: "Cmdr") -> "Position":
         """Move a position to the position of the previous visible node."""
         p = self
         limit, limitIsVisible = c.visLimit()
@@ -1322,7 +1331,11 @@ class Position:
                     return p
         return p
     #@+node:ekr.20090715145956.6166: *5* checkVisBackLimit
-    def checkVisBackLimit(self, limit, limitIsVisible, p):
+    def checkVisBackLimit(self,
+        limit: "Position",
+        limitIsVisible: bool,
+        p: "Position",
+    ) -> Tuple[bool, Optional["Position"]]:
         """Return done, p or None"""
         c = p.v.context
         if limit == p:
@@ -1333,7 +1346,7 @@ class Position:
             return False, None
         return True, None
     #@+node:ekr.20080416161551.211: *4* p.moveToVisNext & helper
-    def moveToVisNext(self, c):
+    def moveToVisNext(self, c: "Cmdr") -> "Position":
         """Move a position to the position of the next visible node."""
         p = self
         limit, limitIsVisible = c.visLimit()
@@ -1354,11 +1367,11 @@ class Position:
                     return p
         return p
     #@+node:ekr.20090715145956.6167: *5* checkVisNextLimit
-    def checkVisNextLimit(self, limit, p):
+    def checkVisNextLimit(self, limit: "Position", p: "Position") -> bool:
         """Return True is p is outside limit of visible nodes."""
         return limit != p and not limit.isAncestorOf(p)
     #@+node:ekr.20150316175921.6: *4* p.safeMoveToThreadNext
-    def safeMoveToThreadNext(self):
+    def safeMoveToThreadNext(self) -> "Position":
         """
         Move a position to threadNext position.
         Issue an error if any vnode is an ancestor of itself.
@@ -1406,7 +1419,7 @@ class Position:
     #@+node:ekr.20150316175921.7: *5* p.checkChild
     #@+node:ekr.20040303175026: *3* p.Moving, Inserting, Deleting, Cloning, Sorting
     #@+node:ekr.20040303175026.8: *4* p.clone
-    def clone(self):
+    def clone(self) -> "Position":
         """Create a clone of back.
 
         Returns the newly created position."""
@@ -1415,7 +1428,7 @@ class Position:
         p2._linkAfter(p)  # This should "just work"
         return p2
     #@+node:ekr.20040117171654: *4* p.copy
-    def copy(self):
+    def copy(self) -> "Position":
         """"Return an independent copy of a position."""
         return Position(self.v, self._childIndex, self.stack)
     #@+node:ekr.20040303175026.9: *4* p.copyTreeAfter, copyTreeTo
@@ -1424,7 +1437,7 @@ class Position:
 
     # To do: use v.copyTree instead.
 
-    def copyTreeAfter(self, copyGnxs=False):
+    def copyTreeAfter(self, copyGnxs: bool=False) -> "Position":
         """Copy p and insert it after itself."""
         p = self
         p2 = p.insertAfter()
@@ -1432,7 +1445,7 @@ class Position:
         return p2
 
 
-    def copyTreeFromSelfTo(self, p2, copyGnxs=False):
+    def copyTreeFromSelfTo(self, p2: "Position", copyGnxs: bool=False) -> None:
         p = self
         p2.v._headString = g.toUnicode(p.h, reportErrors=True)  # 2017/01/24
         p2.v._bodyString = g.toUnicode(p.b, reportErrors=True)  # 2017/01/24
@@ -1446,7 +1459,7 @@ class Position:
             child2 = p2.insertAsLastChild()
             child.copyTreeFromSelfTo(child2, copyGnxs=copyGnxs)
     #@+node:ekr.20160502095354.1: *4* p.copyWithNewVnodes
-    def copyWithNewVnodes(self, copyMarked=False):
+    def copyWithNewVnodes(self, copyMarked: bool=False) -> "Position":
         """
         Return an **unlinked** copy of p with a new vnode v.
         The new vnode is complete copy of v and all its descendants.
@@ -1454,7 +1467,7 @@ class Position:
         p = self
         return Position(v=p.v.copyTree(copyMarked))
     #@+node:peckj.20131023115434.10115: *4* p.createNodeHierarchy
-    def createNodeHierarchy(self, heads, forcecreate=False):
+    def createNodeHierarchy(self, heads: List, forcecreate: bool=False) -> "Position":
         """ Create the proper hierarchy of nodes with headlines defined in
             'heads' as children of the current position
 
@@ -1472,7 +1485,7 @@ class Position:
         c = self.v.context
         return c.createNodeHierarchy(heads, parent=self, forcecreate=forcecreate)
     #@+node:ekr.20131230090121.16552: *4* p.deleteAllChildren
-    def deleteAllChildren(self):
+    def deleteAllChildren(self) -> None:
         """
         Delete all children of the receiver and set p.dirty().
         """
@@ -1481,7 +1494,7 @@ class Position:
         while p.hasChildren():
             p.firstChild().doDelete()
     #@+node:ekr.20040303175026.2: *4* p.doDelete
-    def doDelete(self, newNode=None):
+    def doDelete(self, newNode: Optional["Position"]=None) -> None:
         """
         Deletes position p from the outline.
 
@@ -1500,7 +1513,7 @@ class Position:
                 break
         p._unlink()
     #@+node:ekr.20040303175026.3: *4* p.insertAfter
-    def insertAfter(self):
+    def insertAfter(self) -> "Position":
         """
         Inserts a new position after self.
 
@@ -1514,7 +1527,7 @@ class Position:
         p2._linkAfter(p)
         return p2
     #@+node:ekr.20040303175026.4: *4* p.insertAsLastChild
-    def insertAsLastChild(self):
+    def insertAsLastChild(self) -> "Position":
         """
         Insert a new VNode as the last child of self.
 
@@ -1524,7 +1537,7 @@ class Position:
         n = p.numberOfChildren()
         return p.insertAsNthChild(n)
     #@+node:ekr.20040303175026.5: *4* p.insertAsNthChild
-    def insertAsNthChild(self, n):
+    def insertAsNthChild(self, n: int) -> "Position":
         """
         Inserts a new node as the the nth child of self.
         self must have at least n-1 children.
@@ -1539,7 +1552,7 @@ class Position:
         p2._linkAsNthChild(p, n)
         return p2
     #@+node:ekr.20130923111858.11572: *4* p.insertBefore
-    def insertBefore(self):
+    def insertBefore(self) -> "Position":
         """
         Insert a new position before self.
 
@@ -1557,7 +1570,7 @@ class Position:
             p.moveToRoot()
         return p
     #@+node:ekr.20040310062332.1: *4* p.invalidOutline
-    def invalidOutline(self, message):
+    def invalidOutline(self, message: str) -> None:
         p = self
         if p.hasParent():
             node = p.parent()
@@ -1565,7 +1578,7 @@ class Position:
             node = p
         p.v.context.alert(f"invalid outline: {message}\n{node}")
     #@+node:ekr.20040303175026.10: *4* p.moveAfter
-    def moveAfter(self, a):
+    def moveAfter(self, a: "Position") -> "Position":
         """Move a position after position a."""
         p = self  # Do NOT copy the position!
         a._adjustPositionBeforeUnlink(p)
@@ -1573,12 +1586,12 @@ class Position:
         p._linkAfter(a)
         return p
     #@+node:ekr.20040306060312: *4* p.moveToFirst/LastChildOf
-    def moveToFirstChildOf(self, parent):
+    def moveToFirstChildOf(self, parent: "Position") -> "Position":
         """Move a position to the first child of parent."""
         p = self  # Do NOT copy the position!
         return p.moveToNthChildOf(parent, 0)  # Major bug fix: 2011/12/04
 
-    def moveToLastChildOf(self, parent):
+    def moveToLastChildOf(self, parent: "Position") -> "Position":
         """Move a position to the last child of parent."""
         p = self  # Do NOT copy the position!
         n = parent.numberOfChildren()
@@ -1586,7 +1599,7 @@ class Position:
             n -= 1  # 2011/12/10: Another bug fix.
         return p.moveToNthChildOf(parent, n)  # Major bug fix: 2011/12/04
     #@+node:ekr.20040303175026.11: *4* p.moveToNthChildOf
-    def moveToNthChildOf(self, parent, n):
+    def moveToNthChildOf(self, parent: "Position", n: int) -> "Position":
         """Move a position to the nth child of parent."""
         p = self  # Do NOT copy the position!
         parent._adjustPositionBeforeUnlink(p)
@@ -1594,7 +1607,7 @@ class Position:
         p._linkAsNthChild(parent, n)
         return p
     #@+node:ekr.20040303175026.6: *4* p.moveToRoot
-    def moveToRoot(self):
+    def moveToRoot(self) -> "Position":
         """Move self to the root position."""
         p = self  # Do NOT copy the position!
         #
@@ -1603,7 +1616,7 @@ class Position:
         p._linkAsRoot()
         return p
     #@+node:ekr.20180123062833.1: *4* p.promote
-    def promote(self):
+    def promote(self) -> None:
         """A low-level promote helper."""
         p = self  # Do NOT copy the position.
         parent_v = p._parentVnode()
@@ -1624,7 +1637,7 @@ class Position:
     #@+node:ekr.20040303175026.13: *4* p.validateOutlineWithParent
     # This routine checks the structure of the receiver's tree.
 
-    def validateOutlineWithParent(self, pv):
+    def validateOutlineWithParent(self, pv: "Position") -> bool:
         p = self
         result = True  # optimists get only unpleasant surprises.
         parent = p.getParent()
@@ -1657,12 +1670,12 @@ class Position:
         return result
     #@+node:ekr.20090128083459.74: *3* p.Properties
     #@+node:ekr.20090128083459.75: *4* p.b property
-    def __get_b(self):
+    def __get_b(self) -> str:
         """Return the body text of a position."""
         p = self
         return p.bodyString()
 
-    def __set_b(self, val):
+    def __set_b(self, val: str) -> None:
         """
         Set the body text of a position.
 
@@ -1687,11 +1700,11 @@ class Position:
         __get_b, __set_b,
         doc="position body string property")
     #@+node:ekr.20090128083459.76: *4* p.h property
-    def __get_h(self):
+    def __get_h(self) -> str:
         p = self
         return p.headString()
 
-    def __set_h(self, val):
+    def __set_h(self, val: str) -> None:
         """
         Set the headline text of a position.
 
@@ -1716,7 +1729,7 @@ class Position:
         __get_h, __set_h,
         doc="position property returning the headline string")
     #@+node:ekr.20090215165030.3: *4* p.gnx property
-    def __get_gnx(self):
+    def __get_gnx(self) -> str:
         p = self
         return p.v.fileIndex
 
@@ -1724,7 +1737,7 @@ class Position:
         __get_gnx,  # __set_gnx,
         doc="position gnx property")
     #@+node:ekr.20140203082618.15486: *4* p.script property
-    def __get_script(self):
+    def __get_script(self) -> str:
         p = self
         return g.getScript(p.v.context, p,
             useSelectedText=False,  # Always return the entire expansion.
@@ -1735,7 +1748,7 @@ class Position:
         __get_script,  # __set_script,
         doc="position property returning the script formed by p and its descendants")
     #@+node:ekr.20140218040104.16761: *4* p.nosentinels property
-    def __get_nosentinels(self):
+    def __get_nosentinels(self) -> str:
         p = self
         return ''.join([z for z in g.splitLines(p.b) if not g.isDirective(z)])
 
@@ -1743,11 +1756,11 @@ class Position:
         __get_nosentinels,  # __set_nosentinels
         doc="position property returning the body text without sentinels")
     #@+node:ekr.20160129073222.1: *4* p.u Property
-    def __get_u(self):
+    def __get_u(self) -> Any:
         p = self
         return p.v.u
 
-    def __set_u(self, val):
+    def __set_u(self, val: Any) -> None:
         p = self
         p.v.u = val
 
@@ -1757,13 +1770,13 @@ class Position:
     #@+node:ekr.20040305222924: *3* p.Setters
     #@+node:ekr.20040306220634: *4* p.VNode proxies
     #@+node:ekr.20131222112420.16371: *5* p.contract/expand/isExpanded
-    def contract(self):
+    def contract(self) -> None:
         """Contract p.v and clear p.v.expandedPositions list."""
         p, v = self, self.v
         v.expandedPositions = [z for z in v.expandedPositions if z != p]
         v.contract()
 
-    def expand(self):
+    def expand(self) -> None:
         p = self
         v = self.v
         v.expandedPositions = [z for z in v.expandedPositions if z != p]
@@ -1774,7 +1787,7 @@ class Position:
             v.expandedPositions.append(p.copy())
         v.expand()
 
-    def isExpanded(self):
+    def isExpanded(self) -> bool:
         p = self
         if p.isCloned():
             c = p.v.context
@@ -1784,52 +1797,52 @@ class Position:
     # Clone bits are no longer used.
     # Dirty bits are handled carefully by the position class.
 
-    def clearMarked(self):
+    def clearMarked(self) -> None:
         self.v.clearMarked()
 
-    def clearOrphan(self):
+    def clearOrphan(self) -> None:
         self.v.clearOrphan()
 
-    def clearVisited(self):
+    def clearVisited(self) -> None:
         self.v.clearVisited()
 
-    def initExpandedBit(self):
+    def initExpandedBit(self) -> None:
         self.v.initExpandedBit()
 
-    def initMarkedBit(self):
+    def initMarkedBit(self) -> None:
         self.v.initMarkedBit()
 
-    def initStatus(self, status):
+    def initStatus(self, status: int) -> None:
         self.v.initStatus(status)
 
-    def setMarked(self):
+    def setMarked(self) -> None:
         self.v.setMarked()
 
-    def setOrphan(self):
+    def setOrphan(self) -> None:
         self.v.setOrphan()
 
-    def setSelected(self):
+    def setSelected(self) -> None:
         self.v.setSelected()
 
-    def setVisited(self):
+    def setVisited(self) -> None:
         self.v.setVisited()
     #@+node:ekr.20040306220634.8: *5* p.computeIcon & p.setIcon
-    def computeIcon(self):
+    def computeIcon(self) -> int:
         return self.v.computeIcon()
 
-    def setIcon(self):
+    def setIcon(self) -> None:
         pass  # Compatibility routine for old scripts
     #@+node:ekr.20040306220634.29: *5* p.setSelection
-    def setSelection(self, start, length):
+    def setSelection(self, start: int, length: int) -> None:
         self.v.setSelection(start, length)
     #@+node:ekr.20100303074003.5637: *5* p.restore/saveCursorAndScroll
-    def restoreCursorAndScroll(self):
+    def restoreCursorAndScroll(self) -> None:
         self.v.restoreCursorAndScroll()
 
-    def saveCursorAndScroll(self):
+    def saveCursorAndScroll(self) -> None:
         self.v.saveCursorAndScroll()
     #@+node:ekr.20040315034158: *4* p.setBodyString & setHeadString
-    def setBodyString(self, s):
+    def setBodyString(self, s: str) -> None:
         p = self
         return p.v.setBodyString(s)
 
@@ -1837,11 +1850,11 @@ class Position:
     setTnodeText = setBodyString
     scriptSetBodyString = setBodyString
 
-    def initHeadString(self, s):
+    def initHeadString(self, s: str) -> None:
         p = self
         p.v.initHeadString(s)
 
-    def setHeadString(self, s):
+    def setHeadString(self, s: str) -> None:
         p = self
         p.v.initHeadString(s)
         p.setDirty()
@@ -1849,22 +1862,22 @@ class Position:
     #@+node:ekr.20040306220634.17: *5* p.clearVisitedInTree
     # Compatibility routine for scripts.
 
-    def clearVisitedInTree(self):
+    def clearVisitedInTree(self) -> None:
         for p in self.self_and_subtree(copy=False):
             p.clearVisited()
     #@+node:ekr.20031218072017.3388: *5* p.clearAllVisitedInTree
-    def clearAllVisitedInTree(self):
+    def clearAllVisitedInTree(self) -> None:
         for p in self.self_and_subtree(copy=False):
             p.v.clearVisited()
             p.v.clearWriteBit()
     #@+node:ekr.20040305162628: *4* p.Dirty bits
     #@+node:ekr.20040311113514: *5* p.clearDirty
-    def clearDirty(self):
+    def clearDirty(self) -> None:
         """(p) Set p.v dirty."""
         p = self
         p.v.clearDirty()
     #@+node:ekr.20040702104823: *5* p.inAtIgnoreRange
-    def inAtIgnoreRange(self):
+    def inAtIgnoreRange(self) -> bool:
         """Returns True if position p or one of p's parents is an @ignore node."""
         p = self
         for p in p.self_and_parents(copy=False):
@@ -1872,14 +1885,14 @@ class Position:
                 return True
         return False
     #@+node:ekr.20040303214038: *5* p.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self):
+    def setAllAncestorAtFileNodesDirty(self) -> None:
         """
         Set all ancestor @<file> nodes dirty, including ancestors of all clones of p.
         """
         p = self
         p.v.setAllAncestorAtFileNodesDirty()
     #@+node:ekr.20040303163330: *5* p.setDirty
-    def setDirty(self):
+    def setDirty(self) -> None:
         """
         Mark a node and all ancestor @file nodes dirty.
 
@@ -1890,14 +1903,14 @@ class Position:
         p.v.setDirty()
     #@+node:ekr.20160225153333.1: *3* p.Predicates
     #@+node:ekr.20160225153414.1: *4* p.is_at_all & is_at_all_tree
-    def is_at_all(self):
+    def is_at_all(self) -> bool:
         """Return True if p.b contains an @all directive."""
         p = self
         return (
             p.isAnyAtFileNode()
             and any(g.match_word(s, 0, '@all') for s in g.splitLines(p.b)))
 
-    def in_at_all_tree(self):
+    def in_at_all_tree(self) -> bool:
         """Return True if p or one of p's ancestors is an @all node."""
         p = self
         for p in p.self_and_parents(copy=False):
@@ -1905,12 +1918,12 @@ class Position:
                 return True
         return False
     #@+node:ekr.20160225153430.1: *4* p.is_at_ignore & in_at_ignore_tree
-    def is_at_ignore(self):
+    def is_at_ignore(self) -> bool:
         """Return True if p is an @ignore node."""
         p = self
         return g.match_word(p.h, 0, '@ignore')
 
-    def in_at_ignore_tree(self):
+    def in_at_ignore_tree(self) -> bool:
         """Return True if p or one of p's ancestors is an @ignore node."""
         p = self
         for p in p.self_and_parents(copy=False):
@@ -1927,7 +1940,7 @@ class PosList(list):
 
     #@+others
     #@+node:bob.20101215134608.5897: *3* PosList.children
-    def children(self):
+    def children(self) -> "PosList":
         """ Return a PosList instance containing pointers to
         all the immediate children of nodes in PosList self.
         """
@@ -1937,7 +1950,7 @@ class PosList(list):
                 res.append(child_p.copy())
         return res
     #@+node:ville.20090311190405.69: *3* PosList.filter_h
-    def filter_h(self, regex, flags=re.IGNORECASE):
+    def filter_h(self, regex: str, flags: Any=re.IGNORECASE) -> "PosList":
         """
         Find all the nodes in PosList self where zero or more characters at
         the beginning of the headline match regex.
@@ -1952,7 +1965,7 @@ class PosList(list):
                 res.append(pc)
         return res
     #@+node:ville.20090311195550.1: *3* PosList.filter_b
-    def filter_b(self, regex, flags=re.IGNORECASE):
+    def filter_b(self, regex: str, flags: Any=re.IGNORECASE) -> "PosList":
         """ Find all the nodes in PosList self where body matches regex
         one or more times.
 
@@ -2009,7 +2022,7 @@ class VNode:
     #@+others
     #@+node:ekr.20031218072017.3342: *3* v.Birth & death
     #@+node:ekr.20031218072017.3344: *4* v.__init__
-    def __init__(self, context, gnx=None):
+    def __init__(self, context: "Cmdr", gnx: Optional[str]=None):
         """
         Ctor for the VNode class.
         To support ZODB, the code must set v._p_changed = True whenever
@@ -2059,15 +2072,15 @@ class VNode:
         g.app.nodeIndices.new_vnode_helper(context, gnx, self)
         assert self.fileIndex, g.callers()
     #@+node:ekr.20031218072017.3345: *4* v.__repr__ & v.__str__
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<VNode {self.gnx} {self.headString()}>"
 
     __str__ = __repr__
     #@+node:ekr.20040312145256: *4* v.dump
-    def dumpLink(self, link):
+    def dumpLink(self, link: Optional[str]) -> str:
         return link if link else "<none>"
 
-    def dump(self, label=""):
+    def dump(self, label: str="") -> None:
         v = self
         s = '-' * 10
         print(f"{s} {label} {v}")
@@ -2078,8 +2091,8 @@ class VNode:
         print(f"children: {g.listToString(v.children)}")
     #@+node:ekr.20031218072017.3346: *3* v.Comparisons
     #@+node:ekr.20040705201018: *4* v.findAtFileName
-    def findAtFileName(self, names, h=''):
-        """Return the name following one of the names in nameList or """ ""
+    def findAtFileName(self, names: Tuple, h: Optional[str]=None) -> str:
+        """Return the name following one of the names in nameList or """
         # Allow h argument for unit testing.
         if not h:
             h = self.headString()
@@ -2092,7 +2105,7 @@ class VNode:
             return name
         return ""
     #@+node:ekr.20031218072017.3350: *4* v.anyAtFileNodeName
-    def anyAtFileNodeName(self):
+    def anyAtFileNodeName(self) -> str:
         """Return the file name following an @file node or an empty string."""
         return (
             self.findAtFileName(g.app.atAutoNames) or
@@ -2101,47 +2114,47 @@ class VNode:
     # These return the filename following @xxx, in v.headString.
     # Return the the empty string if v is not an @xxx node.
 
-    def atAutoNodeName(self, h=None):
+    def atAutoNodeName(self, h: Optional[str]=None) -> str:
         return self.findAtFileName(g.app.atAutoNames, h=h)
 
     # Retain this special case as part of the "escape hatch".
     # That is, we fall back on code in leoRst.py if no
     # importer or writer for reStructuredText exists.
 
-    def atAutoRstNodeName(self, h=None):
+    def atAutoRstNodeName(self, h: Optional[str]=None) -> str:
         names = ("@auto-rst",)
         return self.findAtFileName(names, h=h)
 
-    def atCleanNodeName(self):
+    def atCleanNodeName(self) -> str:
         names = ("@clean",)
         return self.findAtFileName(names)
 
-    def atEditNodeName(self):
+    def atEditNodeName(self) -> str:
         names = ("@edit",)
         return self.findAtFileName(names)
 
-    def atFileNodeName(self):
+    def atFileNodeName(self) -> str:
         names = ("@file", "@thin")
             # Fix #403.
         return self.findAtFileName(names)
 
-    def atNoSentinelsFileNodeName(self):
+    def atNoSentinelsFileNodeName(self) -> str:
         names = ("@nosent", "@file-nosent",)
         return self.findAtFileName(names)
 
-    def atRstFileNodeName(self):
+    def atRstFileNodeName(self) -> str:
         names = ("@rst",)
         return self.findAtFileName(names)
 
-    def atShadowFileNodeName(self):
+    def atShadowFileNodeName(self) -> str:
         names = ("@shadow",)
         return self.findAtFileName(names)
 
-    def atSilentFileNodeName(self):
+    def atSilentFileNodeName(self) -> str:
         names = ("@asis", "@file-asis",)
         return self.findAtFileName(names)
 
-    def atThinFileNodeName(self):
+    def atThinFileNodeName(self) -> str:
         names = ("@thin", "@file-thin",)
         return self.findAtFileName(names)
 
@@ -2150,43 +2163,43 @@ class VNode:
     atNoSentFileNodeName = atNoSentinelsFileNodeName
     atAsisFileNodeName = atSilentFileNodeName
     #@+node:EKR.20040430152000: *4* v.isAtAllNode
-    def isAtAllNode(self):
+    def isAtAllNode(self) -> bool:
         """Returns True if the receiver contains @others in its body at the start of a line."""
         flag, i = g.is_special(self._bodyString, "@all")
         return flag
     #@+node:ekr.20040326031436: *4* v.isAnyAtFileNode
-    def isAnyAtFileNode(self):
+    def isAnyAtFileNode(self) -> bool:
         """Return True if v is any kind of @file or related node."""
         return bool(self.anyAtFileNodeName())
     #@+node:ekr.20040325073709: *4* v.isAt...FileNode
-    def isAtAutoNode(self):
+    def isAtAutoNode(self) -> bool:
         return bool(self.atAutoNodeName())
 
-    def isAtAutoRstNode(self):
+    def isAtAutoRstNode(self) -> bool:
         return bool(self.atAutoRstNodeName())
 
-    def isAtCleanNode(self):
+    def isAtCleanNode(self) -> bool:
         return bool(self.atCleanNodeName())
 
-    def isAtEditNode(self):
+    def isAtEditNode(self) -> bool:
         return bool(self.atEditNodeName())
 
-    def isAtFileNode(self):
+    def isAtFileNode(self) -> bool:
         return bool(self.atFileNodeName())
 
-    def isAtRstFileNode(self):
+    def isAtRstFileNode(self) -> bool:
         return bool(self.atRstFileNodeName())
 
-    def isAtNoSentinelsFileNode(self):
+    def isAtNoSentinelsFileNode(self) -> bool:
         return bool(self.atNoSentinelsFileNodeName())
 
-    def isAtSilentFileNode(self):
+    def isAtSilentFileNode(self) -> bool:
         return bool(self.atSilentFileNodeName())
 
-    def isAtShadowFileNode(self):
+    def isAtShadowFileNode(self) -> bool:
         return bool(self.atShadowFileNodeName())
 
-    def isAtThinFileNode(self):
+    def isAtThinFileNode(self) -> bool:
         return bool(self.atThinFileNodeName())
 
     # New names, less confusing:
@@ -2194,7 +2207,7 @@ class VNode:
     isAtNoSentFileNode = isAtNoSentinelsFileNode
     isAtAsisFileNode = isAtSilentFileNode
     #@+node:ekr.20031218072017.3351: *4* v.isAtIgnoreNode
-    def isAtIgnoreNode(self):
+    def isAtIgnoreNode(self) -> bool:
         """
         Returns True if:
 
@@ -2208,12 +2221,12 @@ class VNode:
         flag, i = g.is_special(self._bodyString, "@ignore")
         return flag
     #@+node:ekr.20031218072017.3352: *4* v.isAtOthersNode
-    def isAtOthersNode(self):
+    def isAtOthersNode(self) -> bool:
         """Returns True if the receiver contains @others in its body at the start of a line."""
         flag, i = g.is_special(self._bodyString, "@others")
         return flag
     #@+node:ekr.20031218072017.3353: *4* v.matchHeadline
-    def matchHeadline(self, pattern):
+    def matchHeadline(self, pattern: str) -> bool:
         """
         Returns True if the headline matches the pattern ignoring whitespace and case.
 
@@ -2227,8 +2240,7 @@ class VNode:
         pattern = pattern.lower().replace(' ', '').replace('\t', '')
         return h.startswith(pattern)
     #@+node:ekr.20160502100151.1: *3* v.copyTree
-
-    def copyTree(self, copyMarked=False):
+    def copyTree(self, copyMarked: bool=False) -> "VNode":
         """
         Return an all-new tree of vnodes that are copies of self and all its
         descendants.
@@ -2254,7 +2266,7 @@ class VNode:
         return v2
     #@+node:ekr.20031218072017.3359: *3* v.Getters
     #@+node:ekr.20031218072017.3378: *4* v.bodyString
-    def bodyString(self):
+    def bodyString(self) -> str:
         # This message should never be printed and we want to avoid crashing here!
         if isinstance(self._bodyString, str):
             return self._bodyString
@@ -2262,45 +2274,45 @@ class VNode:
         return g.toUnicode(self._bodyString)
     #@+node:ekr.20031218072017.3360: *4* v.Children
     #@+node:ekr.20031218072017.3362: *5* v.firstChild
-    def firstChild(self):
+    def firstChild(self) -> Optional["VNode"]:
         v = self
         return v.children[0] if v.children else None
     #@+node:ekr.20040307085922: *5* v.hasChildren & hasFirstChild
-    def hasChildren(self):
+    def hasChildren(self) -> bool:
         v = self
         return len(v.children) > 0
 
     hasFirstChild = hasChildren
     #@+node:ekr.20031218072017.3364: *5* v.lastChild
-    def lastChild(self):
+    def lastChild(self) -> Optional["VNode"]:
         v = self
         return v.children[-1] if v.children else None
     #@+node:ekr.20031218072017.3365: *5* v.nthChild
     # childIndex and nthChild are zero-based.
 
-    def nthChild(self, n):
+    def nthChild(self, n: int) -> Optional["VNode"]:
         v = self
         if 0 <= n < len(v.children):
             return v.children[n]
         return None
     #@+node:ekr.20031218072017.3366: *5* v.numberOfChildren
-    def numberOfChildren(self):
+    def numberOfChildren(self) -> int:
         v = self
         return len(v.children)
     #@+node:ekr.20040323100443: *4* v.directParents
-    def directParents(self):
+    def directParents(self) -> List["VNode"]:
         """(New in 4.2) Return a list of all direct parent vnodes of a VNode.
 
         This is NOT the same as the list of ancestors of the VNode."""
         v = self
         return v.parents
     #@+node:ekr.20080429053831.6: *4* v.hasBody
-    def hasBody(self):
+    def hasBody(self) -> bool:
         """Return True if this VNode contains body text."""
         s = self._bodyString
         return bool(s) and len(s) > 0
     #@+node:ekr.20031218072017.1581: *4* v.headString
-    def headString(self):
+    def headString(self) -> str:
         """Return the headline string."""
         # This message should never be printed and we want to avoid crashing here!
         if isinstance(self._headString, str):
@@ -2308,7 +2320,7 @@ class VNode:
         g.internalError(f"headline not unicode: {self._headString!r}")
         return g.toUnicode(self._headString)
     #@+node:ekr.20131223064351.16351: *4* v.isNthChildOf
-    def isNthChildOf(self, n, parent_v):
+    def isNthChildOf(self, n: int, parent_v: "VNode") -> bool:
         """Return True if v is the n'th child of parent_v."""
         v = self
         if not parent_v:
@@ -2319,85 +2331,85 @@ class VNode:
         return 0 <= n < len(children) and children[n] == v
     #@+node:ekr.20031218072017.3367: *4* v.Status Bits
     #@+node:ekr.20031218072017.3368: *5* v.isCloned
-    def isCloned(self):
+    def isCloned(self) -> bool:
         return len(self.parents) > 1
     #@+node:ekr.20031218072017.3369: *5* v.isDirty
-    def isDirty(self):
+    def isDirty(self) -> bool:
         return (self.statusBits & self.dirtyBit) != 0
     #@+node:ekr.20031218072017.3371: *5* v.isMarked
-    def isMarked(self):
+    def isMarked(self) -> bool:
         return (self.statusBits & VNode.markedBit) != 0
     #@+node:ekr.20031218072017.3372: *5* v.isOrphan
-    def isOrphan(self):
+    def isOrphan(self) -> bool:
         return (self.statusBits & VNode.orphanBit) != 0
     #@+node:ekr.20031218072017.3373: *5* v.isSelected
-    def isSelected(self):
+    def isSelected(self) -> bool:
         return (self.statusBits & VNode.selectedBit) != 0
     #@+node:ekr.20031218072017.3374: *5* v.isTopBitSet
-    def isTopBitSet(self):
+    def isTopBitSet(self) -> bool:
         return (self.statusBits & self.topBit) != 0
     #@+node:ekr.20031218072017.3376: *5* v.isVisited
-    def isVisited(self):
+    def isVisited(self) -> bool:
         return (self.statusBits & VNode.visitedBit) != 0
     #@+node:ekr.20080429053831.10: *5* v.isWriteBit
-    def isWriteBit(self):
+    def isWriteBit(self) -> bool:
         v = self
         return (v.statusBits & v.writeBit) != 0
     #@+node:ekr.20031218072017.3377: *5* v.status
-    def status(self):
+    def status(self) -> int:
         return self.statusBits
     #@+node:ekr.20031218072017.3384: *3* v.Setters
     #@+node:ekr.20031218072017.3386: *4*  v.Status bits
     #@+node:ekr.20031218072017.3389: *5* v.clearClonedBit
-    def clearClonedBit(self):
+    def clearClonedBit(self) -> None:
         self.statusBits &= ~self.clonedBit
     #@+node:ekr.20031218072017.3390: *5* v.clearDirty
-    def clearDirty(self):
+    def clearDirty(self) -> None:
         """Clear the vnode dirty bit."""
         v = self
         v.statusBits &= ~v.dirtyBit
     #@+node:ekr.20031218072017.3391: *5* v.clearMarked
-    def clearMarked(self):
+    def clearMarked(self) -> None:
         self.statusBits &= ~self.markedBit
     #@+node:ekr.20031218072017.3392: *5* v.clearOrphan
-    def clearOrphan(self):
+    def clearOrphan(self) -> None:
         self.statusBits &= ~self.orphanBit
     #@+node:ekr.20031218072017.3393: *5* v.clearVisited
-    def clearVisited(self):
+    def clearVisited(self) -> None:
         self.statusBits &= ~self.visitedBit
     #@+node:ekr.20080429053831.8: *5* v.clearWriteBit
-    def clearWriteBit(self):
+    def clearWriteBit(self) -> None:
         self.statusBits &= ~self.writeBit
     #@+node:ekr.20031218072017.3395: *5* v.contract/expand/initExpandedBit/isExpanded
-    def contract(self):
+    def contract(self) -> None:
         """Contract the node."""
         self.statusBits &= ~self.expandedBit
 
-    def expand(self):
+    def expand(self) -> None:
         """Expand the node."""
         self.statusBits |= self.expandedBit
 
-    def initExpandedBit(self):
+    def initExpandedBit(self) -> None:
         """Init self.statusBits."""
         self.statusBits |= self.expandedBit
 
-    def isExpanded(self):
+    def isExpanded(self) -> bool:
         """Return True if the VNode expansion bit is set."""
         return (self.statusBits & self.expandedBit) != 0
     #@+node:ekr.20031218072017.3396: *5* v.initStatus
-    def initStatus(self, status):
+    def initStatus(self, status: int) -> None:
         self.statusBits = status
     #@+node:ekr.20031218072017.3397: *5* v.setClonedBit & initClonedBit
-    def setClonedBit(self):
+    def setClonedBit(self) -> None:
         self.statusBits |= self.clonedBit
 
-    def initClonedBit(self, val):
+    def initClonedBit(self, val: bool) -> None:
         if val:
             self.statusBits |= self.clonedBit
         else:
             self.statusBits &= ~self.clonedBit
     #@+node:ekr.20080429053831.12: *5* v.setDirty
-    def setDirty(self):
+    def setDirty(self) -> None:
         """
         Set the vnode dirty bit.
 
@@ -2406,33 +2418,33 @@ class VNode:
         """
         self.statusBits |= self.dirtyBit
     #@+node:ekr.20031218072017.3398: *5* v.setMarked & initMarkedBit
-    def setMarked(self):
+    def setMarked(self) -> None:
         self.statusBits |= self.markedBit
 
-    def initMarkedBit(self):
+    def initMarkedBit(self) -> None:
         self.statusBits |= self.markedBit
     #@+node:ekr.20031218072017.3399: *5* v.setOrphan
-    def setOrphan(self):
+    def setOrphan(self) -> None:
         """Set the vnode's orphan bit."""
         self.statusBits |= self.orphanBit
     #@+node:ekr.20031218072017.3400: *5* v.setSelected
     # This only sets the selected bit.
 
-    def setSelected(self):
+    def setSelected(self) -> None:
         self.statusBits |= self.selectedBit
     #@+node:ekr.20031218072017.3401: *5* v.setVisited
     # Compatibility routine for scripts
 
-    def setVisited(self):
+    def setVisited(self) -> None:
         self.statusBits |= self.visitedBit
     #@+node:ekr.20080429053831.9: *5* v.setWriteBit
-    def setWriteBit(self):
+    def setWriteBit(self) -> None:
         self.statusBits |= self.writeBit
     #@+node:ville.20120502221057.7499: *4* v.childrenModified
-    def childrenModified(self):
+    def childrenModified(self) -> None:
         g.childrenModifiedSet.add(self)
     #@+node:ekr.20031218072017.3385: *4* v.computeIcon & setIcon
-    def computeIcon(self):
+    def computeIcon(self) -> int:
         v = self
         val = 0
         if v.hasBody():
@@ -2445,15 +2457,15 @@ class VNode:
             val += 8
         return val
 
-    def setIcon(self):
+    def setIcon(self) -> None:
         pass  # Compatibility routine for old scripts
     #@+node:ville.20120502221057.7498: *4* v.contentModified
-    def contentModified(self):
+    def contentModified(self) -> None:
         g.contentModifiedSet.add(self)
     #@+node:ekr.20100303074003.5636: *4* v.restoreCursorAndScroll
     # Called only by LeoTree.selectHelper.
 
-    def restoreCursorAndScroll(self):
+    def restoreCursorAndScroll(self) -> None:
         """Restore the cursor position and scroll so it is visible."""
         traceTime = False and not g.unitTesting
         v = self
@@ -2481,7 +2493,7 @@ class VNode:
             v.scrollBarSpot = spot
         # Never call w.see here.
     #@+node:ekr.20100303074003.5638: *4* v.saveCursorAndScroll
-    def saveCursorAndScroll(self):
+    def saveCursorAndScroll(self) -> None:
 
         v = self
         c = v.context
@@ -2495,7 +2507,7 @@ class VNode:
             # 2011/03/21: w may not support the high-level interface.
             pass
     #@+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self):
+    def setAllAncestorAtFileNodesDirty(self) -> None:
         """
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 
@@ -2504,7 +2516,7 @@ class VNode:
         v = self
         seen = set([v.context.hiddenRootNode])
 
-        def v_and_parents(v):
+        def v_and_parents(v: "VNode") -> Generator:
             if v in seen:
                 return
             seen.add(v)
@@ -2517,7 +2529,7 @@ class VNode:
             if v2.isAnyAtFileNode():
                 v2.setDirty()
     #@+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
-    def setBodyString(self, s):
+    def setBodyString(self, s: Any) -> None:
         v = self
         if isinstance(s, str):
             v._bodyString = s
@@ -2526,7 +2538,7 @@ class VNode:
         self.contentModified()  # #1413.
         signal_manager.emit(self.context, 'body_changed', self)
 
-    def setHeadString(self, s):
+    def setHeadString(self, s: Any) -> None:
         # Fix bug: https://bugs.launchpad.net/leo-editor/+bug/1245535
         # API allows headlines to contain newlines.
         v = self
@@ -2542,26 +2554,26 @@ class VNode:
     setHeadText = setHeadString
     setTnodeText = setBodyString
     #@+node:ekr.20031218072017.3402: *4* v.setSelection
-    def setSelection(self, start, length):
+    def setSelection(self, start: int, length: int) -> None:
         v = self
         v.selectionStart = start
         v.selectionLength = length
     #@+node:ekr.20130524063409.10700: *3* v.Inserting & cloning
-    def cloneAsNthChild(self, parent_v, n):
+    def cloneAsNthChild(self, parent_v: "VNode", n: int) -> "VNode":
         # Does not check for illegal clones!
         v = self
         v._linkAsNthChild(parent_v, n)
         return v
 
-    def insertAsFirstChild(self):
+    def insertAsFirstChild(self) -> "VNode":
         v = self
         return v.insertAsNthChild(0)
 
-    def insertAsLastChild(self):
+    def insertAsLastChild(self) -> "VNode":
         v = self
         return v.insertAsNthChild(len(v.children))
 
-    def insertAsNthChild(self, n):
+    def insertAsNthChild(self, n: int) -> "VNode":
         v = self
         assert 0 <= n <= len(v.children)
         v2 = VNode(v.context)
@@ -2570,7 +2582,7 @@ class VNode:
         return v2
     #@+node:ekr.20080427062528.9: *3* v.Low level methods
     #@+node:ekr.20180709175203.1: *4* v._addCopiedLink
-    def _addCopiedLink(self, childIndex, parent_v):
+    def _addCopiedLink(self, childIndex: int, parent_v: "VNode") -> None:
         """Adjust links after adding a link to v."""
         v = self
         v.context.frame.tree.generation += 1
@@ -2583,7 +2595,7 @@ class VNode:
         v._p_changed = True
         parent_v._p_changed = True
     #@+node:ekr.20090706110836.6135: *4* v._addLink & _addParentLinks
-    def _addLink(self, childIndex, parent_v):
+    def _addLink(self, childIndex: int, parent_v: "VNode") -> None:
         """Adjust links after adding a link to v."""
         v = self
         v.context.frame.tree.generation += 1
@@ -2602,7 +2614,7 @@ class VNode:
             for child in v.children:
                 child._addParentLinks(parent=v)
     #@+node:ekr.20090804184658.6129: *5* v._addParentLinks
-    def _addParentLinks(self, parent):
+    def _addParentLinks(self, parent: "VNode") -> None:
 
         v = self
         v.parents.append(parent)
@@ -2610,7 +2622,7 @@ class VNode:
             for child in v.children:
                 child._addParentLinks(parent=v)
     #@+node:ekr.20090804184658.6128: *4* v._cutLink & _cutParentLinks
-    def _cutLink(self, childIndex, parent_v):
+    def _cutLink(self, childIndex: int, parent_v: "VNode") -> None:
         """Adjust links after cutting a link to v."""
         v = self
         v.context.frame.tree.generation += 1
@@ -2633,7 +2645,7 @@ class VNode:
             for child in v.children:
                 child._cutParentLinks(parent=v)
     #@+node:ekr.20090804190529.6133: *5* v._cutParentLinks
-    def _cutParentLinks(self, parent):
+    def _cutParentLinks(self, parent: "VNode") -> None:
 
         v = self
         v.parents.remove(parent)
@@ -2641,7 +2653,7 @@ class VNode:
             for child in v.children:
                 child._cutParentLinks(parent=v)
     #@+node:ekr.20180709064515.1: *4* v._deleteAllChildren
-    def _deleteAllChildren(self):
+    def _deleteAllChildren(self) -> None:
         """
         Delete all children of self.
 
@@ -2658,17 +2670,17 @@ class VNode:
                 g.printObj(v2.parents)
         v.children = []
     #@+node:ekr.20031218072017.3425: *4* v._linkAsNthChild
-    def _linkAsNthChild(self, parent_v, n):
+    def _linkAsNthChild(self, parent_v: "VNode", n: int) -> None:
         """Links self as the n'th child of VNode pv"""
         v = self  # The child node.
         v._addLink(n, parent_v)
     #@+node:ekr.20090130065000.1: *3* v.Properties
     #@+node:ekr.20090130114732.5: *4* v.b Property
-    def __get_b(self):
+    def __get_b(self) -> str:
         v = self
         return v.bodyString()
 
-    def __set_b(self, val):
+    def __set_b(self, val: str) -> None:
         v = self
         v.setBodyString(val)
 
@@ -2676,11 +2688,11 @@ class VNode:
         __get_b, __set_b,
         doc="VNode body string property")
     #@+node:ekr.20090130125002.1: *4* v.h property
-    def __get_h(self):
+    def __get_h(self) -> str:
         v = self
         return v.headString()
 
-    def __set_h(self, val):
+    def __set_h(self, val: str) -> None:
         v = self
         v.setHeadString(val)
 
@@ -2688,7 +2700,7 @@ class VNode:
         __get_h, __set_h,
         doc="VNode headline string property")
     #@+node:ekr.20090130114732.6: *4* v.u Property
-    def __get_u(self):
+    def __get_u(self) -> Dict:
         v = self
         # Wrong: return getattr(v, 'unknownAttributes', {})
         # It is does not set v.unknownAttributes, which can cause problems.
@@ -2696,7 +2708,7 @@ class VNode:
             v.unknownAttributes = {}  # type:ignore
         return v.unknownAttributes  # type:ignore
 
-    def __set_u(self, val):
+    def __set_u(self, val: Any) -> None:
         v = self
         if val is None:
             if hasattr(v, 'unknownAttributes'):
@@ -2710,7 +2722,7 @@ class VNode:
         __get_u, __set_u,
         doc="VNode u property")
     #@+node:ekr.20090215165030.1: *4* v.gnx Property
-    def __get_gnx(self):
+    def __get_gnx(self) -> str:
         v = self
         return v.fileIndex
 

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -7,8 +7,9 @@ import asyncio
 import json
 import time
 import websockets
-from typing import Dict
-from typing import List
+"""An example client for leoserver.py"""
+
+from typing import Dict, List
 from leo.core import leoGlobals as g
 from leo.core import leoserver
 

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -7,8 +7,6 @@ import asyncio
 import json
 import time
 import websockets
-"""An example client for leoserver.py"""
-
 from typing import Dict, List
 from leo.core import leoGlobals as g
 from leo.core import leoserver

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -6,8 +6,9 @@ An example client for leoserver.py, based on work by Félix Malboeuf. Used by pe
 import asyncio
 import json
 import time
-import websockets
 from typing import Dict, List
+# Third party.
+import websockets
 from leo.core import leoGlobals as g
 from leo.core import leoserver
 

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -7,6 +7,8 @@ import asyncio
 import json
 import time
 import websockets
+from typing import Dict
+from typing import List
 from leo.core import leoGlobals as g
 from leo.core import leoserver
 
@@ -19,7 +21,7 @@ tag = 'client'
 trace = True
 verbose = False
 timeout = 0.1
-times_d = {}  # Keys are n, values are time sent.
+times_d: Dict[int, float] = {}  # Keys are n, values are time sent.
 tot_response_time = 0.0
 n_known_response_times = 0
 n_unknown_response_times = 0
@@ -99,10 +101,10 @@ def _get_action_list():
     # Add all remaining methods to the middle.
     tests = inspect.getmembers(server, inspect.ismethod)
     test_names = sorted([name for (name, value) in tests if not name.startswith('_')])
-    middle = [("!"+z, {}) for z in test_names
+    middle: List = [("!"+z, {}) for z in test_names
         if z not in head_names + tail_names + exclude_names]
-    middle_names = [name for (name, package) in middle]
-    all_tests = head + middle + tail
+    middle_names = [name for (name, package) in middle]  # type:ignore
+    all_tests = head + middle + tail  # type:ignore
     if 0:
         g.printObj(middle_names, tag='middle_names')
         all_names = sorted([name for (name, package) in all_tests])

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -20,6 +20,7 @@ import socket
 import textwrap
 import time
 import tkinter as Tk
+from typing import List, Union
 # Third-party.
 # #2300
 try:
@@ -44,11 +45,12 @@ g = None  # The bridge's leoGlobals module.
 
 # Server defaults
 SERVER_STARTED_TOKEN = "LeoBridge started" # Output when started successfully
-connectionsPool = set() # Websocket connections (to be sent 'notify' messages)
+# Websocket connections (to be sent 'notify' messages)
+connectionsPool = set()  # type:ignore
 connectionsTotal = 0 # Current connected client total
 # Customizable server options
 argFile = ""
-traces = []
+traces: List = []
 wsLimit = 1
 wsPersist = False
 wsSkipDirty = False
@@ -89,7 +91,7 @@ class ServerExternalFilesController(ExternalFilesController):
         # Keys are full paths, values are modification times.
         # DO NOT alter directly, use set_time(path) and
         # get_time(path), see set_time() for notes.
-        self.yesno_all_time = 0  # previous yes/no to all answer, time of answer
+        self.yesno_all_time: Union[None, bool, float] = None  # previous yes/no to all answer, time of answer
         self.yesno_all_answer = None  # answer, 'yes-all', or 'no-all'
 
         # if yesAll/noAll forced, then just show info message after idle_check_commander
@@ -845,7 +847,7 @@ class LeoServer:
                 w.clear()
                 w.insert(s)
             # Check boxes.
-            table = (
+            table2 = (
                 ('ignore_case', 'check_box_ignore_case'),
                 ('mark_changes', 'check_box_mark_changes'),
                 ('mark_finds', 'check_box_mark_finds'),
@@ -854,19 +856,19 @@ class LeoServer:
                 ('search_headline', 'check_box_search_headline'),
                 ('whole_word', 'check_box_whole_word'),
             )
-            for setting_name, widget_ivar in table:
+            for setting_name, widget_ivar in table2:
                 w = getattr(ftm, widget_ivar)
                 val = searchSettings.get(setting_name)
                 setattr(find, setting_name, val)
                 if val != w.isChecked():
                     w.toggle()
             # Radio buttons
-            table = (
+            table3 = (
                 ('node_only', 'node_only', 'radio_button_node_only'),
                 ('entire_outline', None, 'radio_button_entire_outline'),
                 ('suboutline_only', 'suboutline_only', 'radio_button_suboutline_only'),
             )
-            for setting_name, ivar, widget_ivar in table:
+            for setting_name, ivar, widget_ivar in table3:
                 w = getattr(ftm, widget_ivar)
                 val = searchSettings.get(setting_name, False)
                 if ivar is not None:
@@ -3718,7 +3720,7 @@ def main():  # pragma: no cover (tested in client)
             # None of these grabs focus from the console window.
             dialog.raise_()
             dialog.setFocus()
-            app.processEvents()
+            app.processEvents()  # type:ignore
             # val is the same as the creation order.
             # Tested with both Qt6 and Qt5.
             val = dialog.exec() if isQt6 else dialog.exec_()

--- a/leo/plugins/editpane/clicky_splitter.py
+++ b/leo/plugins/editpane/clicky_splitter.py
@@ -12,7 +12,7 @@ from leo.core.leoQt import QtWidgets
 from leo.core.leoQt import MouseButton, Orientation
 
 
-class ClickySplitterHandle(QtWidgets.QSplitterHandle):
+class ClickySplitterHandle(QtWidgets.QSplitterHandle):  # type:ignore
     """Handle which notifies splitter when it's clicked"""
 
     def mouseReleaseEvent(self, event):
@@ -26,7 +26,7 @@ class ClickySplitterHandle(QtWidgets.QSplitterHandle):
         self.splitter().flip_spin()
 
 
-class ClickySplitter(QtWidgets.QSplitter):
+class ClickySplitter(QtWidgets.QSplitter):  # type:ignore
     """Splitter that rotates / flips when its handle's clicked"""
 
     def __init__(self, *args, **kwargs):

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -69,7 +69,7 @@ def edit_pane_csv(event):
         w = w.parent()
     w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
 #@+node:tbrown.20171028115438.4: ** class LeoEditPane
-class LeoEditPane(QtWidgets.QWidget):
+class LeoEditPane(QtWidgets.QWidget):  # type:ignore
     """
     Leo node body editor / viewer
     """

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -12,7 +12,7 @@ def init():
     # but it should never be necessary to do so.
     return True
 #@+node:tbrown.20120418121002.25711: ** class NestedSplitterTopLevel (QWidget)
-class NestedSplitterTopLevel(QtWidgets.QWidget):
+class NestedSplitterTopLevel(QtWidgets.QWidget):  # type:ignore
     """A QWidget to wrap a NestedSplitter to allow it to live in a top
     level window and handle close events properly.
 
@@ -67,7 +67,7 @@ class NestedSplitterTopLevel(QtWidgets.QWidget):
             event.ignore()
     #@-others
 #@+node:ekr.20110605121601.17959: ** class NestedSplitterChoice (QWidget)
-class NestedSplitterChoice(QtWidgets.QWidget):
+class NestedSplitterChoice(QtWidgets.QWidget):  # type:ignore
     """When a new pane is opened in a nested splitter layout, this widget
     presents a button, labled 'Action', which provides a popup menu
     for the user to select what to do in the new pane"""
@@ -86,7 +86,7 @@ class NestedSplitterChoice(QtWidgets.QWidget):
         button.clicked.connect(lambda: self.parent().choice_menu(self, button.pos()))
     #@-others
 #@+node:ekr.20110605121601.17961: ** class NestedSplitterHandle (QSplitterHandle)
-class NestedSplitterHandle(QtWidgets.QSplitterHandle):
+class NestedSplitterHandle(QtWidgets.QSplitterHandle):  # type:ignore
     """Show the context menu on a NestedSplitter splitter-handle to access
     NestedSplitter's special features"""
     #@+others
@@ -360,7 +360,7 @@ class NestedSplitterHandle(QtWidgets.QSplitterHandle):
         self.splitter()._splitter_clicked(self, event, release=True, double=True)
     #@-others
 #@+node:ekr.20110605121601.17966: ** class NestedSplitter (QSplitter)
-class NestedSplitter(QtWidgets.QSplitter):
+class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
     enabled = True
         # allow special behavior to be turned of at import stage
         # useful if other code must run to set up callbacks, that

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -71,7 +71,7 @@ class LossageData:
 
     __str__ = __repr__
 #@+node:ekr.20141028061518.17: ** class LeoQtEventFilter
-class LeoQtEventFilter(QtCore.QObject):
+class LeoQtEventFilter(QtCore.QObject):  # type:ignore
     #@+others
     #@+node:ekr.20110605121601.18539: *3* filter.ctor
     def __init__(self, c, w, tag=''):

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -71,7 +71,7 @@ def contractOutlinePane(event):
 expandBodyPane = contractOutlinePane
 #@+node:ekr.20200303084226.1: *3* 'expand-log-pane'
 @g.command('expand-log-pane')
-def expandLogPane(event):
+def expandLogPane(event):  # type:ignore
     """Expand the log pane. Contract the outline pane."""
     c = event.get('c')
     if not c:
@@ -117,7 +117,7 @@ def log_cmd(name):
     """Command decorator for the LeoQtLog class."""
     return g.new_cmd_decorator(name, ['c', 'frame', 'log'])
 #@+node:ekr.20110605121601.18137: ** class  DynamicWindow (QMainWindow)
-class DynamicWindow(QtWidgets.QMainWindow):
+class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     """
     A class representing all parts of the main Qt window.
 
@@ -433,7 +433,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         label = self.createLabel(frame, 'minibufferLabel', 'Minibuffer:')
 
 
-        class VisLineEdit(QtWidgets.QLineEdit):
+        class VisLineEdit(QtWidgets.QLineEdit):  # type:ignore
             """In case user has hidden minibuffer with gui-minibuffer-hide"""
 
             def focusInEvent(self, event):
@@ -4373,7 +4373,7 @@ class LeoQtTreeTab:
     def createControl(self):
 
 
-        class LeoQComboBox(QtWidgets.QComboBox):
+        class LeoQComboBox(QtWidgets.QComboBox):  # type:ignore
             """Create a subclass in order to handle focusInEvents."""
 
             def __init__(self, tt):
@@ -4458,7 +4458,7 @@ class LeoTabbedTopLevel(LeoBaseTabWidget):
         tb = QtTabBarWrapper(self)
         self.setTabBar(tb)
 #@+node:peckj.20140505102552.10377: ** class QtTabBarWrapper (QTabBar)
-class QtTabBarWrapper(QtWidgets.QTabBar):
+class QtTabBarWrapper(QtWidgets.QTabBar):  # type:ignore
     #@+others
     #@+node:peckj.20140516114832.10108: *3* __init__
     def __init__(self, parent=None):
@@ -4473,7 +4473,7 @@ class QtTabBarWrapper(QtWidgets.QTabBar):
         QtWidgets.QTabBar.mouseReleaseEvent(self, event)
     #@-others
 #@+node:ekr.20110605121601.18458: ** class QtMenuWrapper (LeoQtMenu,QMenu)
-class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):
+class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     #@+others
     #@+node:ekr.20110605121601.18459: *3* ctor and __repr__(QtMenuWrapper)
     def __init__(self, c, frame, parent, label):

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1364,7 +1364,7 @@ class FindTabManager:
             find.show_find_options_in_status_area()
     #@-others
 #@+node:ekr.20131115120119.17376: ** class LeoBaseTabWidget(QTabWidget)
-class LeoBaseTabWidget(QtWidgets.QTabWidget):
+class LeoBaseTabWidget(QtWidgets.QTabWidget):  # type:ignore
     """Base class for all QTabWidgets in Leo."""
     #@+others
     #@+node:ekr.20131115120119.17390: *3* qt_base_tab.__init__
@@ -2495,7 +2495,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
             # image = keys.get('image')
 
 
-            class leoIconBarButton(QtWidgets.QWidgetAction):
+            class leoIconBarButton(QtWidgets.QWidgetAction):  # type:ignore
 
                 def __init__(self, parent, text, toolbar):
                     super().__init__(parent)
@@ -3742,7 +3742,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         return None
     #@-others
 #@+node:ekr.20110605121601.18363: ** class LeoQTreeWidget (QTreeWidget)
-class LeoQTreeWidget(QtWidgets.QTreeWidget):
+class LeoQTreeWidget(QtWidgets.QTreeWidget):  # type:ignore
 
     # To do: Generate @auto or @file nodes when appropriate.
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -322,7 +322,7 @@ class LeoQtGui(leoGui.LeoGui):
         #@+node:ekr.20211005103909.1: *5* << define date/time classes >>
 
 
-        class DateTimeEditStepped(QtWidgets.QDateTimeEdit):
+        class DateTimeEditStepped(QtWidgets.QDateTimeEdit):  # type:ignore
             """QDateTimeEdit which allows you to set minimum steps on fields, e.g.
               DateTimeEditStepped(parent, {QtWidgets.QDateTimeEdit.MinuteSection: 5})
             for a minimum 5 minute increment on the minute field.
@@ -344,7 +344,7 @@ class LeoQtGui(leoGui.LeoGui):
                 QtWidgets.QDateTimeEdit.stepBy(self, step)
 
 
-        class Calendar(QtWidgets.QDialog):
+        class Calendar(QtWidgets.QDialog):  # type:ignore
 
             def __init__(self,
                 parent=None,
@@ -1292,7 +1292,7 @@ class LeoQtGui(leoGui.LeoGui):
         g.app.gui.show_tips(force=True)
 
 
-    class DialogWithCheckBox(QtWidgets.QMessageBox):
+    class DialogWithCheckBox(QtWidgets.QMessageBox):  # type:ignore
 
         def __init__(self, controller, tip):
             super().__init__()

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -438,7 +438,7 @@ class QLineEditWrapper(QTextMixin):
     # setSelectionRangeHelper = setSelectionRange
     #@-others
 #@+node:ekr.20150403094619.1: ** class LeoLineTextWidget(QFrame)
-class LeoLineTextWidget(QtWidgets.QFrame):
+class LeoLineTextWidget(QtWidgets.QFrame):  # type:ignore
     """
     A QFrame supporting gutter line numbers.
 
@@ -479,7 +479,7 @@ class LeoLineTextWidget(QtWidgets.QFrame):
 if QtWidgets:
 
 
-    class LeoQTextBrowser(QtWidgets.QTextBrowser):
+    class LeoQTextBrowser(QtWidgets.QTextBrowser):  # type:ignore
         """A subclass of QTextBrowser that overrides the mouse event handlers."""
         #@+others
         #@+node:ekr.20110605121601.18006: *3*  lqtb.ctor
@@ -524,7 +524,7 @@ if QtWidgets:
         __str__ = __repr__
         #@+node:ekr.20110605121601.18008: *3* lqtb.Auto completion
         #@+node:ekr.20110605121601.18009: *4* class LeoQListWidget(QListWidget)
-        class LeoQListWidget(QtWidgets.QListWidget):
+        class LeoQListWidget(QtWidgets.QListWidget):  # type:ignore
             #@+others
             #@+node:ekr.20110605121601.18010: *5* lqlw.ctor
             def __init__(self, c):
@@ -1021,7 +1021,7 @@ if QtWidgets:
             QtWidgets.QTextBrowser.wheelEvent(self, event)
         #@-others
 #@+node:ekr.20150403094706.2: ** class NumberBar(QFrame)
-class NumberBar(QtWidgets.QFrame):
+class NumberBar(QtWidgets.QFrame):  # type:ignore
     #@+others
     #@+node:ekr.20150403094706.3: *3* NumberBar.__init__
     def __init__(self, c, e, *args):

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -130,6 +130,20 @@ class TestAddMypyAnnotations(LeoUnitTest):
     ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, contents)
+    #@+node:ekr.20220108093044.1: *3* test_ama.test_initializers
+    def test_initializers(self):
+        # Convert a copy of the Position class
+        p = self.p
+        p.b = contents = textwrap.dedent('''\
+            def f3(i = 2, f = 1.1, b = True, x = None):
+                pass
+    ''')
+        expected = textwrap.dedent('''\
+            def f3(i: int=2, f: float=1.1, b: bool=True, x: Any=None) -> Any:
+                pass
+    ''')
+        self.x.convert_body(p)
+        self.assertEqual(p.b, expected)
     #@-others
 #@-others
 

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -88,6 +88,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
     
     def setUp(self):
         super().setUp()
+        # print(self.id())
         c = self.c
         self.p = self.root_p
         self.x = c.convertCommands.Add_Mypy_Annotations(c)
@@ -125,8 +126,11 @@ class TestAddMypyAnnotations(LeoUnitTest):
         # Convert a copy of the Position class
         p = self.p
         p.b = contents = textwrap.dedent('''\
-            def f2(i: int, s: str) -> str:
+            def f1(i: int, s: str) -> str:
                 return s
+                
+            def f2(self, c: Cmdr, g: Any, ivars: List[str]) -> Any:
+                pass
     ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, contents)
@@ -140,6 +144,34 @@ class TestAddMypyAnnotations(LeoUnitTest):
     ''')
         expected = textwrap.dedent('''\
             def f3(i: int=2, f: float=1.1, b: bool=True, x: Any=None) -> Any:
+                pass
+    ''')
+        self.x.convert_body(p)
+        self.assertEqual(p.b, expected)
+    #@+node:ekr.20220108093621.1: *3* test_ama.test_multiline_def
+    def test_multiline_def(self):
+        # Convert a copy of the Position class
+        p = self.p
+        p.b = contents = textwrap.dedent('''\
+            def f (
+                self,
+                a,
+                b=1,
+                c = 2 ,
+                *args,
+                **kwargs,
+            ):
+                pass
+    ''')
+        expected = textwrap.dedent('''\
+            def f(
+                self,
+                a: Any,
+                b: int=1,
+                c: int=2,
+                *args: Any,
+                **kwargs: Any,
+            ) -> Any:
                 pass
     ''')
         self.x.convert_body(p)

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -136,11 +136,11 @@ class TestAddMypyAnnotations(LeoUnitTest):
     def test_initializers(self):
         p = self.p
         p.b = contents = textwrap.dedent('''\
-            def f3(i = 2, f = 1.1, b = True, x = None):
+            def f3(i = 2, f = 1.1, b = True, s = 'abc', x = None):
                 pass
     ''')
         expected = textwrap.dedent('''\
-            def f3(i: int=2, f: float=1.1, b: bool=True, x: Any=None) -> Any:
+            def f3(i: int=2, f: float=1.1, b: bool=True, s: str='abc', x: Any=None) -> Any:
                 pass
     ''')
         self.x.convert_body(p)

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -5,13 +5,14 @@
 """Tests of leo.commands.leoConvertCommands."""
 import os
 import re
+import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 
 #@+others
 #@+node:ekr.20211013081200.1: ** class TestPythonToTypeScript(LeoUnitTest):
 class TestPythonToTypeScript(LeoUnitTest):
-    """Test cases for leo/commands/leoConvertCommands.py"""
+    """Test cases for python-to-typescript command"""
 
     #@+others
     #@+node:ekr.20211013090653.1: *3*  test_py2ts.setUp
@@ -80,6 +81,45 @@ class TestPythonToTypeScript(LeoUnitTest):
             lines = [source]
             x.do_f_strings(lines)
             self.assertEqual(lines[-1], expected)
+    #@-others
+#@+node:ekr.20220108083112.1: ** class TestAddMypyAnnotations(LeoUnitTest):
+class TestAddMypyAnnotations(LeoUnitTest):
+    """Test cases for add-mypy-annotations command"""
+    
+    def setUp(self):
+        super().setUp()
+        c = self.c
+        self.p = self.root_p
+        self.x = c.convertCommands.Add_Mypy_Annotations(c)
+        self.x.types_d = {
+            'c': 'Cmdr',
+            'ch': 'str',
+            'gnx': 'str',
+            'd': 'Dict[str, str]',
+            'i': 'int',
+            'j': 'int',
+            'k': 'int',
+            'n': 'int',
+            'p': 'Pos',
+            's': 'str',
+            'v': 'VNode',
+        }
+
+    #@+others
+    #@+node:ekr.20220108083112.4: *3* test_ama.test_plain_args
+    def test_plain_args(self):
+        # Convert a copy of the Position class
+        p = self.p
+        p.b = contents = textwrap.dedent('''\
+            def f1(i, s):
+                pass
+    ''')
+        expected = textwrap.dedent('''\
+            def f1(i: int, s: str) -> Any:
+                pass
+    ''')
+        self.x.convert_body(p)
+        self.assertEqual(p.b, expected)
     #@-others
 #@-others
 

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -109,7 +109,6 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+others
     #@+node:ekr.20220108083112.4: *3* test_ama.test_plain_args
     def test_plain_args(self):
-        # Convert a copy of the Position class
         p = self.p
         p.b = contents = textwrap.dedent('''\
             def f1(i, s):
@@ -123,7 +122,6 @@ class TestAddMypyAnnotations(LeoUnitTest):
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220108091352.1: *3* test_ama.test_already_annotated
     def test_already_annotated(self):
-        # Convert a copy of the Position class
         p = self.p
         p.b = contents = textwrap.dedent('''\
             def f1(i: int, s: str) -> str:
@@ -136,7 +134,6 @@ class TestAddMypyAnnotations(LeoUnitTest):
         self.assertEqual(p.b, contents)
     #@+node:ekr.20220108093044.1: *3* test_ama.test_initializers
     def test_initializers(self):
-        # Convert a copy of the Position class
         p = self.p
         p.b = contents = textwrap.dedent('''\
             def f3(i = 2, f = 1.1, b = True, x = None):
@@ -150,7 +147,6 @@ class TestAddMypyAnnotations(LeoUnitTest):
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220108093621.1: *3* test_ama.test_multiline_def
     def test_multiline_def(self):
-        # Convert a copy of the Position class
         p = self.p
         p.b = contents = textwrap.dedent('''\
             def f (
@@ -175,6 +171,33 @@ class TestAddMypyAnnotations(LeoUnitTest):
                 pass
     ''')
         self.x.convert_body(p)
+        self.assertEqual(p.b, expected)
+    #@+node:ekr.20220108153333.1: *3* test_ama.test_multiline_def_with_comments
+    def test_multiline_def_with_comments(self):
+        p = self.p
+        p.b = contents = textwrap.dedent('''\
+            def f (
+                self,# comment 1
+                a,   # comment, 2
+                b=1,
+                d=2,     # comment with trailing comma,
+                e=3,
+            ):
+                pass
+    ''')
+        # Note: The command insert exactly two spaces before comments.
+        expected = textwrap.dedent('''\
+            def f(
+                self,  # comment 1
+                a: Any,  # comment, 2
+                b: int=1,
+                d: int=2,  # comment with trailing comma,
+                e: int=3,
+            ) -> Any:
+                pass
+    ''')
+        self.x.convert_body(p)
+        # g.printObj(p.b)
         self.assertEqual(p.b, expected)
     #@-others
 #@-others

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -120,6 +120,16 @@ class TestAddMypyAnnotations(LeoUnitTest):
     ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
+    #@+node:ekr.20220108091352.1: *3* test_ama.test_already_annotated
+    def test_already_annotated(self):
+        # Convert a copy of the Position class
+        p = self.p
+        p.b = contents = textwrap.dedent('''\
+            def f2(i: int, s: str) -> str:
+                return s
+    ''')
+        self.x.convert_body(p)
+        self.assertEqual(p.b, contents)
     #@-others
 #@-others
 


### PR DESCRIPTION
- [x] Run mypy from `@string mypy-directory`, defaulting to leo-editor directory.
- [x] `add-mypy-annotations` specifies the types for individual variable/argument names.
- [x] Create script to add annotations based on Leo's naming conventions. A much simpler version of make-stub-files.
- [x] Pass `mypy leo\core\leoNodes.py` with required prototypes in leoNodes.py.
- [x] Pass `mypy leo\core\leoGlobals.py` with required prototypes in leoGlobals.py.
- [x] Pass `mypy leo`.
- [x] Add type suppressions and hints so that mypy passes files not excluded in .mypy.ini.
     In general, mypy can not determine the base type of Qt subclasses.
- [x] Add unit tests covering all of the Add_Mypy_Annotations class. See exclusions.