### PR TITLE
VR3 Add Table Mode, Improve Math Mode, Update Docstring

### DIFF
--- a/leo/extensions/mdx_math_gi.py
+++ b/leo/extensions/mdx_math_gi.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+"""
+Math extension for Python-Markdown
+==================================
+
+Adds support for displaying math formulas using MathJax / KaTeX
+
+Copyright 2019-2020 Gautam Iyer <gi1242+mdxmath@gmail.com>
+
+Based on code originally written by Dmitry Shachnev <mitya57@gmail.com>
+
+See https://github.com/gi1242/python-markdown-math for license, more info.
+"""
+
+from markdown.inlinepatterns import InlineProcessor
+from markdown.extensions import Extension
+
+class inlineMathProcessor( InlineProcessor ):
+    def handleMatch( self, m, data ):
+        # MathJAX handles all the math. Just set the uses_math flag, and
+        # protect the contents from markdown expansion.
+        self.md.uses_math = True
+        return m.group(0), m.start(0), m.end(0)
+
+class MathExtension(Extension):
+    def __init__(self, *args, **kwargs):
+        self.config = {
+            'enable_dollar_delimiter':
+                [False, 'Enable single-dollar delimiter'],
+        }
+        super(MathExtension, self).__init__(*args, **kwargs)
+
+    def extendMarkdown(self, md):
+        md.registerExtension(self)
+
+        mathRegExps = [
+            r'(?<!\\)\\\((.+?)\\\)',    # \( ... \)
+            r'(?<!\\)\$\$.+?\$\$',      # $$ ... $$
+            r'(?<!\\)\\\[.+?\\\]',      # \[ ... \]
+            r'(?<!\\)\\begin{([a-z]+?\*?)}.+?\\end{\1}',
+        ]
+        if self.getConfig('enable_dollar_delimiter'):
+            md.ESCAPED_CHARS.append('$')
+            mathRegExps.append( r'(?<!\\|\$)\$.+?\$' ) # $ ... $
+        for i, pattern in enumerate(mathRegExps):
+            # we should have higher priority than 'escape' which has 180
+            md.inlinePatterns.register(
+                inlineMathProcessor( pattern, md ), f'math-inline-{i}', 185)
+
+        md.uses_math = False
+        self.md = md
+
+    def reset(self):
+        self.md.uses_math = False
+
+def makeExtension(*args, **kwargs):
+    return MathExtension(*args, **kwargs)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -466,6 +466,48 @@ the language instead::
 .. note::
     No space is allowed between the fence characters and the language.
 
+Mathematics
+------------
+Mathematics symbols and equations can be rendered with MathJax.  When enabled by the *vr3-md-math-output* setting, inline formulas and separate equation blocks can be specifed.  Equations are written in a Latex dialect.
+
+Inline Formulas
+________________
+Inline formulas are enclosed with the symbol pairs *\\(* and *\\)*.
+
+Equation Blocks
+________________
+There are several ways to enclose equation blocks.  The Markdown (semi-)standard way is to use a math fence, similar to a literal or code block::
+
+    ```math
+    \begin{align*}
+        α_t(i) &=P(O_1,O_2,…O_t,q_t)=S_iλ\\
+        k &=\int_{0}^{10}xdx\\
+        E &=mc^2
+    \end{align*}
+    ```
+The fence must start at the beginning of a line.
+
+Blocks may also be enclosed with the standard MathJax delimiters, either double *$* characters::
+
+    $$
+    \begin{align*}
+        α_t(i) &=P(O_1,O_2,…O_t,q_t)=S_iλ\\
+        k &=\int_{0}^{10}xdx\\
+        E &=mc^2
+    \end{align*}
+    $$
+
+or *\\[*, *\\]* pairs::
+
+    \[
+    \begin{align*}
+        α_t(i) &=P(O_1,O_2,…O_t,q_t)=S_iλ\\
+        k &=\int_{0}^{10}xdx\\
+        E &=mc^2
+    \end{align*}
+    \]
+
+
 Tables
 -------
 Tables may be created using the `PHP Markdown Extra` syntax: https://python-markdown.github.io/extensions/tables/.  Here is an example from the Markdown package documentation::
@@ -1780,27 +1822,24 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.md_stylesheet -- The URL to the stylesheet.  Must include
                                the "file:///" if it is a local file.
         self.md_mathjax_url -- The URL to the MathJax code package.  Must include
-                               the "file:///" if it is a local file. A typical URL
-                               is http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-MML-AM_HTMLorMML
+                               the "file:///" if it is a local file. The URL 
+                               should be to a MathJax V3 site.  A typical URL
+                               is https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
                                If the MathJax package has been downloaded to the
                                local computer, a typical (Windows) URL would be
                                file:///D:/utility/mathjax/es5/tex-chtml.js
         self.md_header -- where the header string gets stored.
         """
 
+        script_str = ''
         if self.md_math_output and self.mathjax_url:
-            self.md_header = fr'''
-    <head>
+            script_str = fr'<script defer type="text/javascript" src="{self.mathjax_url}"></script>'
+        self.md_header = fr'''
+    <!DOCTYPE html>
+    <html><head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <link rel="stylesheet" type="text/css" href="{self.md_stylesheet}">
-    <script type="text/javascript" src="{self.mathjax_url}"></script>
-    </head>
-    '''
-        else:
-            self.md_header = fr'''
-    <head>
-    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <link rel="stylesheet" type="text/css" href="{self.md_stylesheet}">
+    {script_str}
     </head>
     '''
     #@+node:TomP.20200329223820.5: *4* vr3.create_pane
@@ -1996,10 +2035,10 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.set_rst_stylesheet()
         self.create_md_header()
 
-        ext = ['fenced_code', 'codehilite', 'def_list', 'tables']
         if self.md_math_output:
+            ext = ['fenced_code', 'codehilite', 'def_list', 'tables']
             ext.append('leo.extensions.mdx_math_gi')
-        self.Markdown = markdown.Markdown(extensions=ext)
+            self.Markdown = markdown.Markdown(extensions=ext)
 
         self.asciidoc_path = c.config.getString('vr3-asciidoc-path') or ''
         self.prefer_asciidoc3 = c.config.getBool('vr3-prefer-asciidoc3', default=False)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -244,6 +244,7 @@ This priority scheme allow a user to modify any of the standard stylesheets in t
 
 When a specific stylesheet path is specified by the `vr3-md-stylesheet` setting, the path separators
 can be any mix of Windows and Linux separators.
+
 #@+node:tom.20210612193820.1: *4* MathJax Script Location
 MathJax Script Location
 =======================
@@ -257,9 +258,10 @@ If the MathJax scripts are installed on the local computer, it is recommended
 that one of the ``.js`` script files in the ``es`` directory be used, as shown
 in the above table.  If the script is loaded from the Internet, the URL must
 include a ``?config`` specifer.  The one shown in the example above works well.
+
 #@+node:TomP.20210422235304.1: *4* External Processors For Other Languages
 External Processors For Other Languages
-========================================
+=======================================
 
 VR3 can make use of external processors for executing code blocks in programming languages other than Python.  Examples are Javascript and Julia.  Parameters can be passed to the processor as well.  The command line must have the format::
 
@@ -282,6 +284,7 @@ This directory and .ini file must be created by the user.  VR3 will not create t
 A language that is specified here will not automatically be executed: only languages known by VR3 will be executed.  Code in known languages will be colorized provided that Leo has a colorizing mode file for that language.  This should normally be the case.  For example, colorizer mode files for both julia and javascript are included in the version of Leo that includes this version of VR3.
 
 VR3 can only successfully execute code if all code blocks in a node or subtree use the same language.
+
 #@+node:TomP.20210423000029.1: *5* @param Optional Parameters
 Optional Parameters
 ====================
@@ -322,6 +325,7 @@ Limitations
 1. The ability to launch an external processor currently works only for ReStructuredText markup language nodes or trees.
 
 2. The supported command line format is fairly simple, so a language that needs separate compile and run stages will be difficult to use.
+
 #@+node:TomP.20200115200324.1: *3* Commands
 Commands
 ========


### PR DESCRIPTION
Note that this commit includes a new file in leo/extensions called _mdx_math_gi.py_.  This is a (slightly renamed) fork of the _mdx_math_ extension to use MathJax rendering.  This fork works with Version 3 of MathJax.

This PR provides proper MD and MathJax idiomatic ways to insert equation blocks.