### PR TITLE
PR for simplified UNLs

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -338,7 +338,7 @@ class MypyCommand:
             # Look for the @<file> node.
             link_root = g.findNodeByPath(c, path)
             if link_root:
-                unl = link_root.get_UNL(with_proto=True, with_count=True)
+                unl = link_root.get_UNL()
                 if s.lower().startswith(s_head):
                     s = s[len(s_head) :]  # Do *not* strip the line!
                 c.frame.log.put(s, nodeLink=f"{unl}::{-line_number}")  # Global line
@@ -396,7 +396,7 @@ class PyflakesCommand:
                 try:
                     root = roots[fn_n]
                     line = int(s.split(':')[1])
-                    unl = root.get_UNL(with_proto=True, with_count=True)
+                    unl = root.get_UNL()
                     g.es(s, nodeLink=f"{unl}::{(-line)}")  # Global line
                 except(IndexError, TypeError, ValueError):
                     # in case any assumptions fail

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -65,6 +65,7 @@ def find_long_lines(event):
                 return True
         return False
     #@-others
+    log = c.frame.log
     max_line = c.config.getInt('max-find-long-lines-length') or 110
     count, files, ignore = 0, [], []
     for p in c.all_unique_positions():
@@ -88,7 +89,8 @@ def find_long_lines(event):
                     g.es_print(root.h)
                     g.es_print(p.h)
                     print(short_s)
-                    g.es_clickable_link(c, p, line_number=i, message=short_s)
+                    unl = p.get_UNL()
+                    log.put(short_s.strip() + '\n', nodeLink=f"{unl}::{i + 1}")  # Local line.
                 break
     g.es_print(
         f"found {count} long line{g.plural(count)} "
@@ -136,6 +138,7 @@ def find_missing_docstrings(event):
                 return False
         return p.isAnyAtFileNode() and p.h.strip().endswith('.py')
     #@-others
+    log = c.frame.log
     count, files, found, t1 = 0, 0, [], time.process_time()
     for root in g.findRootsWithPredicate(c, c.p, predicate=is_root):
         files += 1
@@ -149,7 +152,8 @@ def find_missing_docstrings(event):
                         g.es_print('')
                         g.es_print(root.h)
                     print(line)
-                    g.es_clickable_link(c, p, i + 1, line)  # *Local* index.
+                    unl = p.get_UNL()
+                    log.put(line.strip() + '\n', nodeLink=f"{unl}::{i + 1}")  # Local line.
                     break
     g.es_print('')
     g.es_print(

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -341,7 +341,7 @@ class MypyCommand:
                 unl = link_root.get_UNL(with_proto=True, with_count=True)
                 if s.lower().startswith(s_head):
                     s = s[len(s_head) :]  # Do *not* strip the line!
-                c.frame.log.put(s, nodeLink=f"{unl},{-line_number}")
+                c.frame.log.put(s, nodeLink=f"{unl}::{-line_number}")  # Global line
             elif path not in self.unknown_path_names:
                 self.unknown_path_names.append(path)
                 print(f"no @<file> node found: {path}")
@@ -397,7 +397,7 @@ class PyflakesCommand:
                     root = roots[fn_n]
                     line = int(s.split(':')[1])
                     unl = root.get_UNL(with_proto=True, with_count=True)
-                    g.es(s, nodeLink=f"{unl},{(-line)}")
+                    g.es(s, nodeLink=f"{unl}::{(-line)}")  # Global line
                 except(IndexError, TypeError, ValueError):
                     # in case any assumptions fail
                     g.es(s)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -218,7 +218,7 @@ def show_clone_ancestors(event=None):
             if len(parts) > 1:
                 message = '-->'.join(parts[:-1])
             c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
-#@+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
+#@+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents') *** revise
 @g.command('show-clone-parents')
 def show_clones(event=None):
     """Display links to all parent nodes of the node c.p."""
@@ -230,7 +230,13 @@ def show_clones(event=None):
         parent = clone.parent()
         if parent and parent not in seen:
             seen.append(parent)
-            g.es_clickable_link(c, clone, 1, f"{parent.h} -> {clone.h}\n")
+            unl = message = parent.get_UNL()
+            # Drop the file part.
+            i = unl.find('#')
+            if i > 0:
+                message = unl[i + 1:]
+            c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
+
 #@+node:ekr.20180210161001.1: *3* @g.command('unmark-first-parents')
 @g.command('unmark-first-parents')
 def unmark_first_parents(event=None):

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -205,13 +205,15 @@ def show_clone_ancestors(event=None):
     if not c:
         return
     p = c.p
-    g.es(f"Ancestors of '{p.h}':")
+    g.es(f"Ancestors of {p.h}...")
     for clone in c.all_positions():
         if clone.v == p.v:
-            unl = clone.get_UNL(with_file=False, with_index=False)
-            runl = " <- ".join(unl.split("-->")[::-1][1:])  # reverse and drop first
-            g.es("  ", newline=False)
-            g.es_clickable_link(c, clone, 1, runl + "\n")
+            unl = clone.get_UNL()
+            i = unl.find('#')
+            if i > 0:
+                message = unl[i + 1:]
+            c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
+               
 #@+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
 @g.command('show-clone-parents')
 def show_clones(event=None):

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -208,12 +208,16 @@ def show_clone_ancestors(event=None):
     g.es(f"Ancestors of {p.h}...")
     for clone in c.all_positions():
         if clone.v == p.v:
-            unl = clone.get_UNL()
+            unl = message = clone.get_UNL()
+            # Drop the file part.
             i = unl.find('#')
             if i > 0:
                 message = unl[i + 1:]
+            # Drop the target node from the message.
+            parts = message.split('-->')
+            if len(parts) > 1:
+                message = '-->'.join(parts[:-1])
             c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
-               
 #@+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
 @g.command('show-clone-parents')
 def show_clones(event=None):

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -218,7 +218,7 @@ def show_clone_ancestors(event=None):
             if len(parts) > 1:
                 message = '-->'.join(parts[:-1])
             c.frame.log.put(message + '\n', nodeLink=f"{unl}::1")
-#@+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents') *** revise
+#@+node:ekr.20191007034723.1: *3* @g.command('show-clone-parents')
 @g.command('show-clone-parents')
 def show_clones(event=None):
     """Display links to all parent nodes of the node c.p."""

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -349,8 +349,7 @@ class GoToCommands:
         c = self.c
         w = c.frame.body.wrapper
         # Select p and make it visible.
-        if c.p.isOutsideAnyAtFileTree():
-            p = c.findNodeOutsideAnyAtFileTree(p)
+        c.selectPosition(p)
         c.redraw(p)
         # Put the cursor on line n2 of the body text.
         s = w.getAllText()

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -445,7 +445,7 @@ class AtFile:
         at, c, ic = self, self.c, self.c.importCommands
         fileName = g.fullPath(c, p)  # #1521, #1341, #1914.
         if not g.os_path_exists(fileName):
-            g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL(with_proto=True))
+            g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL())
             return p
         # Remember that we have seen the @auto node.
         # Fix bug 889175: Remember the full fileName.
@@ -535,10 +535,7 @@ class AtFile:
         at, c, x = self, self.c, self.c.shadowController
         fileName = g.fullPath(c, root)
         if not g.os_path_exists(fileName):
-            g.es_print(
-                f"not found: {fileName}",
-                color='red',
-                nodeLink=root.get_UNL(with_proto=True))
+            g.es_print(f"not found: {fileName}", color='red', nodeLink=root.get_UNL())
             return False
         at.rememberReadPath(fileName, root)
         at.initReadIvars(root, fileName)
@@ -626,7 +623,7 @@ class AtFile:
         c, ic = self.c, self.c.importCommands
         fn = g.fullPath(c, p)  # #1521, #1341, #1914.
         if not g.os_path_exists(fn):
-            g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL(with_proto=True))
+            g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL())
             return p
         # Delete all the child nodes.
         while p.hasChildren():
@@ -2143,7 +2140,7 @@ class AtFile:
         for j in range(max(0, i - 2), min(i + 2, len(lines) - 1)):
             line = lines[j].rstrip()
             if j == i:
-                unl = p.get_UNL(with_proto=True, with_count=True)
+                unl = p.get_UNL()
                 g.es_print(f"{j+1:5}:* {line}", nodeLink=f"{unl}::-{j+1:d}")  # Global line.
                 g.es_print(' ' * (7 + offset) + '^')
             else:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2144,7 +2144,7 @@ class AtFile:
             line = lines[j].rstrip()
             if j == i:
                 unl = p.get_UNL(with_proto=True, with_count=True)
-                g.es_print(f"{j+1:5}:* {line}", nodeLink=f"{unl},-{j+1:d}")  # Global line.
+                g.es_print(f"{j+1:5}:* {line}", nodeLink=f"{unl}::-{j+1:d}")  # Global line.
                 g.es_print(' ' * (7 + offset) + '^')
             else:
                 g.es_print(f"{j+1:5}: {line}")

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -234,7 +234,7 @@ class BackgroundProcessManager:
         #
         # Put a clickable link.
         unl = link_root.get_UNL(with_proto=True, with_count=True)
-        log.put(s + '\n', nodeLink=f"{unl},{-line}")
+        log.put(s + '\n', nodeLink=f"{unl}::{-line}")  # Global line.
     #@+node:ekr.20161026193609.5: *3* bpm.start_process
     def start_process(self, c, command, kind,
         fn=None,

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -233,7 +233,7 @@ class BackgroundProcessManager:
                 return
         #
         # Put a clickable link.
-        unl = link_root.get_UNL(with_proto=True, with_count=True)
+        unl = link_root.get_UNL()
         log.put(s + '\n', nodeLink=f"{unl}::{-line}")  # Global line.
     #@+node:ekr.20161026193609.5: *3* bpm.start_process
     def start_process(self, c, command, kind,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4172,20 +4172,6 @@ class Commands:
             pc.matchiter = t2
             res.append(pc)
         return res
-    #@+node:ekr.20150410095543.1: *4* c.findNodeOutsideAnyAtFileTree
-    def findNodeOutsideAnyAtFileTree(self, target):
-        """Select the first clone of target that is outside any @file node."""
-        c = self
-        if target.isCloned():
-            v = target.v
-            for p in c.all_positions():
-                if p.v == v:
-                    for parent in p.self_and_parents(copy=False):
-                        if parent.isAnyAtFileNode():
-                            break
-                    else:
-                        return p
-        return target
     #@+node:ekr.20171124155725.1: *3* c.Settings
     #@+node:ekr.20171114114908.1: *4* c.registerReloadSettings
     def registerReloadSettings(self, obj):

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2254,7 +2254,7 @@ class Commands:
             # Find the node and offset corresponding to line n.
             p, n2 = find_line(fn, n)
             # Create the link.
-            unl = p.get_UNL(with_proto=True, with_count=True)
+            unl = p.get_UNL()
             if unl:
                 log.put(s + '\n', nodeLink=f"{unl}::{n2}")  # local line.
             else:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2256,7 +2256,7 @@ class Commands:
             # Create the link.
             unl = p.get_UNL(with_proto=True, with_count=True)
             if unl:
-                log.put(s + '\n', nodeLink=f"{unl},{n2}")
+                log.put(s + '\n', nodeLink=f"{unl}::{n2}")  # local line.
             else:
                 log.put(s + '\n')
         #@+node:ekr.20210529164957.1: *5* function: find_line

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -896,7 +896,7 @@ class ParserBaseClass:
         d[key] = g.GeneralSetting(kind,  # type:ignore
             path=c.mFileName,
             tag='setting',
-            unl=(p and p.get_UNL(with_proto=True)),
+            unl=(p and p.get_UNL()),
             val=val,
         )
     #@+node:ekr.20041119204700.1: *3* pbc.traverse

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1623,7 +1623,7 @@ class LeoFind:
             unl = p.get_UNL(with_proto=True, with_count=True)
             if self.in_headline:
                 line_number = 1
-            log.put(line.strip() + '\n', nodeLink=f"{unl},{line_number}")
+            log.put(line.strip() + '\n', nodeLink=f"{unl}::{line_number}")  # Local line.
 
         seen = []  # List of (vnode, pos).
         both = self.search_body and self.search_headline

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1620,7 +1620,7 @@ class LeoFind:
 
             if g.unitTesting:
                 return
-            unl = p.get_UNL(with_proto=True, with_count=True)
+            unl = p.get_UNL()
             if self.in_headline:
                 line_number = 1
             log.put(line.strip() + '\n', nodeLink=f"{unl}::{line_number}")  # Local line.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1629,9 +1629,8 @@ class LeoTree:
         c.frame.updateStatusLine()
             # New in Leo 4.4.1.
         c.frame.clearStatusLine()
-        ### verbose = getattr(c, 'status_line_unl_mode', '') == 'canonical'
         if p and p.v:
-            c.frame.putStatusLine(p.get_UNL())  ### with_proto=verbose, with_index=verbose))
+            c.frame.putStatusLine(p.get_UNL())
     #@+node:ekr.20031218072017.3718: *3* LeoTree.oops
     def oops(self):
         g.pr("LeoTree oops:", g.callers(4), "should be overridden in subclass")

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1629,9 +1629,9 @@ class LeoTree:
         c.frame.updateStatusLine()
             # New in Leo 4.4.1.
         c.frame.clearStatusLine()
-        verbose = getattr(c, 'status_line_unl_mode', '') == 'canonical'
+        ### verbose = getattr(c, 'status_line_unl_mode', '') == 'canonical'
         if p and p.v:
-            c.frame.putStatusLine(p.get_UNL(with_proto=verbose, with_index=verbose))
+            c.frame.putStatusLine(p.get_UNL())  ### with_proto=verbose, with_index=verbose))
     #@+node:ekr.20031218072017.3718: *3* LeoTree.oops
     def oops(self):
         g.pr("LeoTree oops:", g.callers(4), "should be overridden in subclass")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6128,7 +6128,7 @@ def es_clickable_link(c: Cmdr, p: Pos, line_number: int, message: str) -> None:
     """
     log = c.frame.log
     message = message.strip() + '\n'
-    unl = p.get_UNL(with_proto=True, with_count=True)
+    unl = p.get_UNL()
     if unl:
         log.put(message, nodeLink=f"{unl}::{line_number}")  # Local line.
     else:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6130,7 +6130,6 @@ def es_clickable_link(c: Cmdr, p: Pos, line_number: int, message: str) -> None:
     message = message.strip() + '\n'
     unl = p.get_UNL(with_proto=True, with_count=True)
     if unl:
-        ### log.put(message, nodeLink=f"{unl},{line_number}")
         log.put(message, nodeLink=f"{unl}::{line_number}")  # Local line.
     else:
         log.put(message)
@@ -7536,9 +7535,6 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
     Find and move to the unl given by the unlList in the commander c.
     Return the found position, or None.
     """
-    # pylint: disable=multiple-statements  ###
-
-    trace = True and not g.unitTesting ###
     if not unlList:
         return None
     # The code no longers supports old UNL's.
@@ -7546,42 +7542,25 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
         if not g.unitTesting:
             g.printObj(unlList, tag='Old-style UNLs not supported')
         return None
-        
-    def dump_parents(p):
-        g.trace(g.callers(2))
-        p3 = p.copy()
-        while p3:
-            print('  ', p3.h)
-            p3.moveToParent()
-        ###g.printObj([z.h for z in p.self_and_parents()], tag=f"Found line: {n} p: {p.h}") ###
-
+   
     def full_match(p: Pos) -> bool:
         """Return True if the headlines of p and all p's parents match unlList."""
         # Careful: make copies.
-        aList0, p0 = unlList[:], p.copy()  ### for traces.
         aList, p1 = unlList[:], p.copy()
         # Expect '::' only on the last element of the unlList
         m = new_unl_pat.match(aList[-1])
         if not m or m.group(1) != p1.h:
-            g.trace('fail 1')
-            dump_parents(p0)
             return False
         aList.pop()
         p1.moveToParent()
         # Check the rest of the headlines.
         while aList and p1:
             if aList[-1] != p1.h:
-                g.trace('fail 2')
-                dump_parents(p0)
                 return False
             aList.pop()
             p1.moveToParent()
         if aList:
-            g.trace('fail 2')
-            dump_parents(p0)
             return False
-        g.printObj(aList0, tag=f"full_match: found: {p0.h}")
-        dump_parents(p0)
         return True
         
     # Find all target headlines.
@@ -7592,14 +7571,8 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
     if target:
         targets.append(target)
     targets.extend(unlList[:-1])
-    
-    if trace:
-        g.printObj(unlList, tag='unlList')
-        g.printObj(targets, tag='targets')
-
     # Find all target positions. Prefer later positions.
     positions = list(reversed(list(z for z in c.all_positions() if z.h in targets)))
-    if trace: g.printObj(positions, tag='positions')  ###
     while unlList:
         g.printObj(unlList, tag='Loop')
         for p in positions:
@@ -7615,9 +7588,6 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
                         n = int(line)
                     except (TypeError, ValueError):
                         g.trace('bad line number', line)
-                if trace:
-                    f"Found line: {n} p: {p.h}"
-                    dump_parents(p)
                 if n == 0:
                     c.redraw(p)
                 elif n < 0:
@@ -7631,9 +7601,7 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
                 c.bodyWantsFocusNow()
                 return p
         # Not found. Pop the first parent from unlList.
-        if trace: g.trace('*** POP ***')  ###
         unlList.pop(0)
-    if trace: g.trace('Not found')  ###
     return None
 #@+node:ekr.20120311151914.9917: *3* g.getUrlFromNode
 def getUrlFromNode(p: Pos) -> Optional[str]:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6118,21 +6118,6 @@ def es(*args: Any, **keys: Any) -> None:
         app.logWaiting.append((s, color, newline, d),)
 
 log = es
-#@+node:ekr.20190608090856.1: *3* g.es_clickable_link
-def es_clickable_link(c: Cmdr, p: Pos, line_number: int, message: str) -> None:
-    """
-    Write a clickable message to the given line number of p.b.
-
-    Negative line numbers indicate global lines.
-
-    """
-    log = c.frame.log
-    message = message.strip() + '\n'
-    unl = p.get_UNL()
-    if unl:
-        log.put(message, nodeLink=f"{unl}::{line_number}")  # Local line.
-    else:
-        log.put(message)
 #@+node:ekr.20060917120951: *3* g.es_dump
 def es_dump(s: str, n: int=30, title: str=None) -> None:
     if title:
@@ -7574,7 +7559,6 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
     # Find all target positions. Prefer later positions.
     positions = list(reversed(list(z for z in c.all_positions() if z.h in targets)))
     while unlList:
-        g.printObj(unlList, tag='Loop')
         for p in positions:
             p1 = p.copy()
             if full_match(p):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7552,8 +7552,10 @@ def findUNL(unlList: List[str], c: Cmdr) -> Optional[Pos]:
         target = m and m.group(1)
         if target:
             targets.append(target)
+    g.printObj(targets, tag='targets')
     # Prefer later positions.
-    positions = reversed(list(p for p in c.all_positions() if p.h in targets))
+    positions = list(reversed(list(p for p in c.all_positions() if p.h in targets)))
+    g.printObj([z.h for z in positions], tag='positions')
     while unlList:
         for p in positions:
             if full_match(p):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -802,13 +802,7 @@ class Position:
     hasVisBack = visBack
     hasVisNext = visNext
     #@+node:tbrown.20111010104549.26758: *4* p.get_UNL
-    def get_UNL(self,
-        ### To be deleted.
-        with_file: bool=True,
-        with_proto: bool=False,
-        with_index: bool=True,
-        with_count: bool=False,
-    ) -> str:
+    def get_UNL(self) -> str:
         """
         Return a UNL representing a clickable link.
         
@@ -819,9 +813,9 @@ class Position:
         - a list of headlines separated by '-->'
         
         New in Leo 6.6:
-        
-        1. Never translate '-->' to '--%3E'.
-        2. Never generate child indices.
+        - Always add unl: // and file name.
+        - Never translate '-->' to '--%3E'.
+        - Never generate child indices.
         """
         return (
             'unl:' + '//'

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -801,7 +801,7 @@ class Position:
     # New in Leo 4.4.3:
     hasVisBack = visBack
     hasVisNext = visNext
-    #@+node:tbrown.20111010104549.26758: *4* p.get_UNL (with_index, with_file)
+    #@+node:tbrown.20111010104549.26758: *4* p.get_UNL
     def get_UNL(self,
         ### To be deleted.
         with_file: bool=True,
@@ -818,21 +818,21 @@ class Position:
         - self.v.context.fileName() #
         - a list of headlines separated by '-->'
         
-        New in Leo 6.6: This method *never* does the following:
+        New in Leo 6.6:
         
-        1. Translate '-->' to '--%3E'.
-        2. Add child indices.
+        1. Never translate '-->' to '--%3E'.
+        2. Never generate child indices.
         """
 
         # with_file=True - include path to Leo file
         # with_proto=False - include 'file://'
         # with_index - include ',x' at end where x is child index in parent
         # with_count - include ',x,y' at end where y zero based count of same headlines
-        
+
         return (
             'unl:' + '//'
             + self.v.context.fileName() + '#'
-            + '-->'.join(z.h for z in self.self_and_parents(copy=False))
+            + '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
         )
 
         ###

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -988,14 +988,6 @@ class Position:
                     offset += g.skip_ws(s, 0)
                     break
         return offset if found else None
-    #@+node:ekr.20150410101842.1: *3* p.isOutsideAtFileTree
-    def isOutsideAnyAtFileTree(self) -> bool:
-        """Select the first clone of target that is outside any @file node."""
-        p = self
-        for parent in p.self_and_parents(copy=False):
-            if parent.isAnyAtFileNode():
-                return False
-        return True
     #@+node:ekr.20080423062035.1: *3* p.Low level methods
     # These methods are only for the use of low-level code
     # in leoNodes.py, leoFileCommands.py and leoUndo.py.

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -823,42 +823,11 @@ class Position:
         1. Never translate '-->' to '--%3E'.
         2. Never generate child indices.
         """
-
-        # with_file=True - include path to Leo file
-        # with_proto=False - include 'file://'
-        # with_index - include ',x' at end where x is child index in parent
-        # with_count - include ',x,y' at end where y zero based count of same headlines
-
         return (
             'unl:' + '//'
             + self.v.context.fileName() + '#'
             + '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
         )
-
-        ###
-            # aList = []
-            # for i in self.self_and_parents(copy=False):
-                # if with_index or with_count:
-                    # count = 0
-                    # ind = 0
-                    # p = i.copy()
-                    # while p.hasBack():
-                        # ind = ind + 1
-                        # p.moveToBack()
-                        # if i.h == p.h:
-                            # count = count + 1
-                    # aList.append(i.h.replace('-->', '--%3E') + ":" + str(ind))
-                    # if count or with_count:
-                        # aList[-1] = aList[-1] + "," + str(count)
-                # else:
-                    # aList.append(i.h.replace('-->', '--%3E'))
-            # UNL = '-->'.join(reversed(aList))
-            # if with_proto:
-                # s = "unl:" + f"//{self.v.context.fileName()}#{UNL}"
-                # return s.replace(' ', '%20')
-            # if with_file:
-                # return f"{self.v.context.fileName()}#{UNL}"
-            # return UNL
     #@+node:ekr.20080416161551.192: *4* p.hasBack/Next/Parent/ThreadBack
     def hasBack(self) -> bool:
         p = self

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -803,6 +803,7 @@ class Position:
     hasVisNext = visNext
     #@+node:tbrown.20111010104549.26758: *4* p.get_UNL (with_index, with_file)
     def get_UNL(self,
+        ### To be deleted.
         with_file: bool=True,
         with_proto: bool=False,
         with_index: bool=True,
@@ -810,35 +811,54 @@ class Position:
     ) -> str:
         """
         Return a UNL representing a clickable link.
-
-        with_file=True - include path to Leo file
-        with_proto=False - include 'file://'
-        with_index - include ',x' at end where x is child index in parent
-        with_count - include ',x,y' at end where y zero based count of same headlines
+        
+        New in Leo 6.6: Use a single, simplified format for UNL's:
+        
+        - unl: //
+        - self.v.context.fileName() #
+        - a list of headlines separated by '-->'
+        
+        New in Leo 6.6: This method *never* does the following:
+        
+        1. Translate '-->' to '--%3E'.
+        2. Add child indices.
         """
-        aList = []
-        for i in self.self_and_parents(copy=False):
-            if with_index or with_count:
-                count = 0
-                ind = 0
-                p = i.copy()
-                while p.hasBack():
-                    ind = ind + 1
-                    p.moveToBack()
-                    if i.h == p.h:
-                        count = count + 1
-                aList.append(i.h.replace('-->', '--%3E') + ":" + str(ind))
-                if count or with_count:
-                    aList[-1] = aList[-1] + "," + str(count)
-            else:
-                aList.append(i.h.replace('-->', '--%3E'))
-        UNL = '-->'.join(reversed(aList))
-        if with_proto:
-            s = "unl:" + f"//{self.v.context.fileName()}#{UNL}"
-            return s.replace(' ', '%20')
-        if with_file:
-            return f"{self.v.context.fileName()}#{UNL}"
-        return UNL
+
+        # with_file=True - include path to Leo file
+        # with_proto=False - include 'file://'
+        # with_index - include ',x' at end where x is child index in parent
+        # with_count - include ',x,y' at end where y zero based count of same headlines
+        
+        return (
+            'unl:' + '//'
+            + self.v.context.fileName() + '#'
+            + '-->'.join(z.h for z in self.self_and_parents(copy=False))
+        )
+
+        ###
+            # aList = []
+            # for i in self.self_and_parents(copy=False):
+                # if with_index or with_count:
+                    # count = 0
+                    # ind = 0
+                    # p = i.copy()
+                    # while p.hasBack():
+                        # ind = ind + 1
+                        # p.moveToBack()
+                        # if i.h == p.h:
+                            # count = count + 1
+                    # aList.append(i.h.replace('-->', '--%3E') + ":" + str(ind))
+                    # if count or with_count:
+                        # aList[-1] = aList[-1] + "," + str(count)
+                # else:
+                    # aList.append(i.h.replace('-->', '--%3E'))
+            # UNL = '-->'.join(reversed(aList))
+            # if with_proto:
+                # s = "unl:" + f"//{self.v.context.fileName()}#{UNL}"
+                # return s.replace(' ', '%20')
+            # if with_file:
+                # return f"{self.v.context.fileName()}#{UNL}"
+            # return UNL
     #@+node:ekr.20080416161551.192: *4* p.hasBack/Next/Parent/ThreadBack
     def hasBack(self) -> bool:
         p = self

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -215,9 +215,7 @@ class backlinkController:
             url.lower().startswith('file://') and url.find('-->') > -1 or
             url.startswith('#')
         ):
-            our_unl = 'unl://' + self.c.p.get_UNL(with_index=False)
-            # don't use .get_UNL(with_proto=True), that
-            # unecessarily does ' ' -> %20 conversion
+            our_unl = 'unl:' + '//' + self.c.p.get_UNL()
             new_c = g.handleUnl(url, self.c)
             if new_c and hasattr(new_c, 'backlinkController'):
                 unlList = url.replace('%20', ' ').split('#', 1)[-1].split('-->')

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -220,8 +220,8 @@ class backlinkController:
             # unecessarily does ' ' -> %20 conversion
             new_c = g.handleUnl(url, self.c)
             if new_c and hasattr(new_c, 'backlinkController'):
-                unl = url.replace('%20', ' ').split('#', 1)[-1].split('-->')
-                new_p = g.findUNL(unl, new_c)
+                unlList = url.replace('%20', ' ').split('#', 1)[-1].split('-->')
+                new_p = g.findUNL(unlList, new_c)
                 if not new_p:
                     g.es("No perfect match, not creating backlink")
                     return

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -425,7 +425,7 @@ def cmd_bookmark_find_flat(event):
     for nd in nodes[:40]:
         new = container.insertAsLastChild()
         new.h = nd.h
-        new.b = c.vnode2position(nd).get_UNL(with_proto=True)
+        new.b = c.vnode2position(nd).get_UNL()
     bm.show_list(bm.get_list())
     if len(nodes) > 40:
         g.es("Stopped after 40 hits")

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3989,7 +3989,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):  # type:ignore
                 s = g.toUnicode(b)
                 f.close()
                 return self.doFileUrlHelper(fn, p, s)
-        nodeLink = p.get_UNL(with_proto=True, with_count=True)
+        nodeLink = p.get_UNL()
         g.es_print(f"not found: {fn}", nodeLink=nodeLink)
         return False
     #@+node:ekr.20110605121601.18371: *7* LeoQTreeWidget.doFileUrlHelper & helper

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2315,23 +2315,26 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 w.setSizePolicy(policy)
             splitter.addWidget(w1)
             splitter.addWidget(w2)
-            c.status_line_unl_mode = 'original'
+            
+            ### 
+                # c.status_line_unl_mode = 'original'
+            
+                # def cycle_unl_mode():
+                    # if c.status_line_unl_mode == 'original':
+                        # c.status_line_unl_mode = 'canonical'
+                    # else:
+                        # c.status_line_unl_mode = 'original'
+                    # verbose = c.status_line_unl_mode == 'canonical'
+                    # w2.setText(c.p.get_UNL(with_proto=verbose, with_index=verbose))
+            
+                # def add_item(event, w2=w2):
+                    # menu = w2.createStandardContextMenu()
+                    # menu.addSeparator()
+                    # menu.addAction("Toggle UNL mode", cycle_unl_mode)
+                    # menu.exec_(event.globalPos())
+            
+                # w2.contextMenuEvent = add_item
 
-            def cycle_unl_mode():
-                if c.status_line_unl_mode == 'original':
-                    c.status_line_unl_mode = 'canonical'
-                else:
-                    c.status_line_unl_mode = 'original'
-                verbose = c.status_line_unl_mode == 'canonical'
-                w2.setText(c.p.get_UNL(with_proto=verbose, with_index=verbose))
-
-            def add_item(event, w2=w2):
-                menu = w2.createStandardContextMenu()
-                menu.addSeparator()
-                menu.addAction("Toggle UNL mode", cycle_unl_mode)
-                menu.exec_(event.globalPos())
-
-            w2.contextMenuEvent = add_item
             self.put('')
             self.update()
         #@+node:ekr.20110605121601.18260: *4* QtStatusLineClass.clear, get & put/1

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2306,7 +2306,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
             self.statusBar.addWidget(splitter, True)
             sizes = c.config.getString('status-line-split-sizes') or '1 2'
             sizes = [int(i) for i in sizes.replace(',', ' ').split()]
-            # pylint: disable=consider-using-ternary
             for n, i in enumerate(sizes):
                 w = [w1, w2][n]
                 policy = w.sizePolicy()
@@ -2315,26 +2314,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 w.setSizePolicy(policy)
             splitter.addWidget(w1)
             splitter.addWidget(w2)
-            
-            ### 
-                # c.status_line_unl_mode = 'original'
-            
-                # def cycle_unl_mode():
-                    # if c.status_line_unl_mode == 'original':
-                        # c.status_line_unl_mode = 'canonical'
-                    # else:
-                        # c.status_line_unl_mode = 'original'
-                    # verbose = c.status_line_unl_mode == 'canonical'
-                    # w2.setText(c.p.get_UNL(with_proto=verbose, with_index=verbose))
-            
-                # def add_item(event, w2=w2):
-                    # menu = w2.createStandardContextMenu()
-                    # menu.addSeparator()
-                    # menu.addAction("Toggle UNL mode", cycle_unl_mode)
-                    # menu.exec_(event.globalPos())
-            
-                # w2.contextMenuEvent = add_item
-
             self.put('')
             self.update()
         #@+node:ekr.20110605121601.18260: *4* QtStatusLineClass.clear, get & put/1


### PR DESCRIPTION
See #2403. 

- [x] Rewrite g.findUNL to support only new, simplified, UNLs.
- [x] Remove all kwargs from p.get_UNL and all calls to same.
- [x] Remove g.es_clickable_link,  p.isOutsideAnyAtFileTree, and c.findNodeOutsideAnyAtFileTree.
- [x] Add convert_unl_list function. This may ensure compatibility with the backlink plugin.