### PR TITLE
Provide QtWebEngineWidgets imports to support QtWebEngineView. 

### DIFF
--- a/leo/core/leoQt5.py
+++ b/leo/core/leoQt5.py
@@ -17,6 +17,14 @@ qt_version = QtCore.QT_VERSION_STR
 assert QUrl and Signal  # For pyflakes.
 #
 # Optional imports.
+# Must import this before creating the GUI
+has_WebEngineWidgets = False
+try:
+    from PyQt5 import QtWebEngineWidgets
+    has_WebEngineWidgets = True
+except ImportError:
+    print('No Qt5 QtWebEngineWidgets')
+
 try:
     import PyQt5.QtDeclarative as QtDeclarative
 except ImportError:

--- a/leo/core/leoQt6.py
+++ b/leo/core/leoQt6.py
@@ -24,6 +24,14 @@ QtConst = Qt
 qt_version = QtCore.QT_VERSION_STR
 #
 # Optional imports: #2005
+# Must import this before creating the GUI
+has_WebEngineWidgets = False
+try:
+    from PyQt6 import QtWebEngineWidgets
+    has_WebEngineWidgets = True
+except ImportError:
+    print('No Qt6 QtWebEngineWidgets')
+
 try:
     from PyQt6 import QtPrintSupport as printsupport
 except Exception:


### PR DESCRIPTION
 Provides a new flag has_WebEngineWidgets that will be imported by leoQt from either leoQt5.py or leoQt6.py as appropriate.

Make VR3 use QtWebEngineWidgets.QtWebEngineView if available else the PyQt5 "WebView" (which was QtWebEngineView in disguise).

VR3 version to 3.8.

Corresponding changes to Freewin will be the subject of a separate PR.