### PR TITLE
Prevent Leo from inserting cheat sheet into workbook.leo 

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2358,7 +2358,7 @@ class LoadManager:
         c = lm.loadLocalFile(fn, gui=g.app.gui, old_c=None)
         if not c:
             return None  # #1201: AttributeError below.
-        if g.app.batchMode and g.os_path_exists(fn):
+        if g.app.batchMode or g.os_path_exists(fn):
             return c
         # Open the cheatsheet.
         fn = g.os_path_finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -63,11 +63,15 @@ class SessionManager:
         """Open a tab for each item in UNLs & select the indicated node in each."""
         if not unls:
             return
+
         unls = [z.strip() for z in unls or [] if z.strip()]
         for unl in unls:
             i = unl.find("#")
             if i > -1:
                 fn, unl = unl[:i], unl[i:]
+                fn_ = fn.split('unl://')  # #2412.
+                if len(fn_) > 1:
+                    fn = fn_[1]
             else:
                 fn, unl = unl, ''
             fn = fn.strip()


### PR DESCRIPTION
unless workbook.leo does not exist.

Test for presence of "unl://" so Leo can open last session's files on startup.