### PR TITLE
PR: Fix mypy complaints

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -15,15 +15,11 @@ disable_error_code=attr-defined
 
 # For v0.931, per https://github.com/python/mypy/issues/11936
 
-exclude = dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|plugins/|scripts/|test/|themes/|unittests/|www/
+# Only folders
+exclude = dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|plugins/|scripts/|test/|themes/|unittests/|www/
 
-# editpane/|leo_babel/|obsolete/
-
-# Best so far
-# exclude = pygeotag|mod_http|qt_main|stickynotes|todo|viewrendered|((dist|doc|editpane|extensions|external|examples|Icons|leo_babel|modes|mypy_stubs|obsolete|scripts|test|themes|unittests|www)/)
-
-
-
+# Individual files first, then folders (each followed by /)
+# exclude = editpane|geotag|mod_|read_only_nodes|python_terminal|qt_main|stickynotes|todo|viewrendered|dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|scripts/|test/|themes/|unittests/|www/
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -21,30 +21,8 @@ disable_error_code=attr-defined
 # |leo/plugins/examples/
 
 # Rem: for v0.931, per  https://github.com/python/mypy/issues/11936
-exclude = leo/dist/|leo/doc/|leo/extensions/|leo/external/|leo/modes/|leo/plugins|leo/scripts|leo/test/|leo/unittests
-
-#    |leo/plugins/obsolete/
-#    |leo/plugins/test/
-#    |leo/scripts/
-#    |leo/test/
- #   |leo/unittests/
-
-    #leo/dist/$
-    #leo/doc/$
-    #leo/core/leoQt6.py$
-    #leo/core/format-code\.py$
-    #leo/doc/sphinx-docs/conf\.py$
-    #leo/extensions/$
-    #leo/external/$
-    #leo/modes/$
-    #^leo/plugins/(?!qt_).*\.py$
-    #^leo/plugins/qt_main\.py$
-    #leo/plugins/examples/$
-    #leo/plugins/obsolete/$
-    #leo/plugins/test/$
-    #leo/scripts/$
-    #leo/test/$
-    #leo/unittests/$
+exclude =
+    leo/dist/|leo/doc/|leo/extensions/|leo/external/|leo/modes/|leo/scripts|leo/test/|leo/unittests|leo/plugins/obsolete/|leo/plugins/editpane/|leo/plugins/pygeotag/|leo/plugins/test/|leo/plugins/viewrendered.?\.py
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -15,8 +15,10 @@ disable_error_code=attr-defined
 
 # For v0.931, per https://github.com/python/mypy/issues/11936
 
+
+exclude = qt_main|todo|dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|scripts/|test/|themes/|unittests/|www/
 # Only folders
-exclude = dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|plugins/|scripts/|test/|themes/|unittests/|www/
+# exclude = dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|plugins/|scripts/|test/|themes/|unittests/|www/
 
 # Individual files first, then folders (each followed by /)
 # exclude = editpane|geotag|mod_|read_only_nodes|python_terminal|qt_main|stickynotes|todo|viewrendered|dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|scripts/|test/|themes/|unittests/|www/

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -21,8 +21,9 @@ disable_error_code=attr-defined
 # |leo/plugins/examples/
 
 # Rem: for v0.931, per  https://github.com/python/mypy/issues/11936
-exclude =
-    leo/dist/|leo/doc/|leo/extensions/|leo/external/|leo/modes/|leo/scripts|leo/test/|leo/unittests|leo/plugins/obsolete/|leo/plugins/editpane/|leo/plugins/pygeotag/|leo/plugins/test/|leo/plugins/viewrendered.?\.py
+exclude = leo/(dist|doc|extensions|external|modes|plugins|scripts|test|unittests)/
+    
+ #   /|leo/modes/|leo/scripts|leo/test/|leo/unittests|leo/plugins/obsolete/|leo/plugins/editpane/|leo/plugins/pygeotag/|leo/plugins/test/|leo/plugins/viewrendered.?\.py
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -13,23 +13,38 @@ check_untyped_defs = True
 strict_optional = False
 disable_error_code=attr-defined
 
-exclude =
-    ^leo/dist/$
-    ^leo/doc/$
-    ^leo/core/leoQt6.py$
-    ^leo/core/format-code\.py$
-    ^leo/doc/sphinx-docs/conf\.py$
-    ^leo/extensions/$
-    ^leo/external/$
-    ^leo/modes/*\.py$
-    ^leo/plugins/(?!qt_).*\.py$
-    ^leo/plugins/qt_main\.py$
-    ^leo/plugins/examples/$
-    ^leo/plugins/obsolete/$
-    ^leo/plugins/test/$
-    ^leo/scripts/$
-    ^leo/test/$
-    ^leo/unittests/$
+#  |leo/plugins/(?!qt_).*\.py
+# |leo/plugins/qt_main\.py
+# |leo/core/leoQt6\.py
+# |leo/doc/sphinx-docs/conf\.py
+# |leo/core/format-code\.py
+# |leo/plugins/examples/
+
+# Rem: for v0.931, per  https://github.com/python/mypy/issues/11936
+exclude = leo/dist/|leo/doc/|leo/extensions/|leo/external/|leo/modes/|leo/plugins|leo/scripts|leo/test/|leo/unittests
+
+#    |leo/plugins/obsolete/
+#    |leo/plugins/test/
+#    |leo/scripts/
+#    |leo/test/
+ #   |leo/unittests/
+
+    #leo/dist/$
+    #leo/doc/$
+    #leo/core/leoQt6.py$
+    #leo/core/format-code\.py$
+    #leo/doc/sphinx-docs/conf\.py$
+    #leo/extensions/$
+    #leo/external/$
+    #leo/modes/$
+    #^leo/plugins/(?!qt_).*\.py$
+    #^leo/plugins/qt_main\.py$
+    #leo/plugins/examples/$
+    #leo/plugins/obsolete/$
+    #leo/plugins/test/$
+    #leo/scripts/$
+    #leo/test/$
+    #leo/unittests/$
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -15,13 +15,8 @@ disable_error_code=attr-defined
 
 # For v0.931, per https://github.com/python/mypy/issues/11936
 
-
-exclude = qt_main|todo|dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|scripts/|test/|themes/|unittests/|www/
-# Only folders
-# exclude = dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|plugins/|scripts/|test/|themes/|unittests/|www/
-
-# Individual files first, then folders (each followed by /)
-# exclude = editpane|geotag|mod_|read_only_nodes|python_terminal|qt_main|stickynotes|todo|viewrendered|dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|obsolete/|scripts/|test/|themes/|unittests/|www/
+# Exclude qt_main.* and all plugins. Plugins can be tested individually.
+exclude = qt_main|dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|plugins/|scripts/|test/|themes/|unittests/|www/
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -21,9 +21,11 @@ disable_error_code=attr-defined
 # |leo/plugins/examples/
 
 # Rem: for v0.931, per  https://github.com/python/mypy/issues/11936
+
+# Fails:
+# exclude = leo/(dist|doc|extensions|external|modes|plugins/pygeotag|plugins/obsolete|scripts|test|unittests)/
+
 exclude = leo/(dist|doc|extensions|external|modes|plugins|scripts|test|unittests)/
-    
- #   /|leo/modes/|leo/scripts|leo/test/|leo/unittests|leo/plugins/obsolete/|leo/plugins/editpane/|leo/plugins/pygeotag/|leo/plugins/test/|leo/plugins/viewrendered.?\.py
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -13,19 +13,11 @@ check_untyped_defs = True
 strict_optional = False
 disable_error_code=attr-defined
 
-#  |leo/plugins/(?!qt_).*\.py
-# |leo/plugins/qt_main\.py
-# |leo/core/leoQt6\.py
-# |leo/doc/sphinx-docs/conf\.py
-# |leo/core/format-code\.py
-# |leo/plugins/examples/
-
-# Rem: for v0.931, per  https://github.com/python/mypy/issues/11936
+# For v0.931, per https://github.com/python/mypy/issues/11936
+exclude = leo/(dist|doc|extensions|external|modes|plugins|scripts|test|unittests)/
 
 # Fails:
 # exclude = leo/(dist|doc|extensions|external|modes|plugins/pygeotag|plugins/obsolete|scripts|test|unittests)/
-
-exclude = leo/(dist|doc|extensions|external|modes|plugins|scripts|test|unittests)/
 
 # Settings for particular files...
 

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -14,10 +14,16 @@ strict_optional = False
 disable_error_code=attr-defined
 
 # For v0.931, per https://github.com/python/mypy/issues/11936
-exclude = leo/(dist|doc|extensions|external|modes|plugins|scripts|test|unittests)/
 
-# Fails:
-# exclude = leo/(dist|doc|extensions|external|modes|plugins/pygeotag|plugins/obsolete|scripts|test|unittests)/
+exclude = dist/|doc/|extensions/|external/|examples/|Icons/|modes/|mypy_stubs/|plugins/|scripts/|test/|themes/|unittests/|www/
+
+# editpane/|leo_babel/|obsolete/
+
+# Best so far
+# exclude = pygeotag|mod_http|qt_main|stickynotes|todo|viewrendered|((dist|doc|editpane|extensions|external|examples|Icons|leo_babel|modes|mypy_stubs|obsolete|scripts|test|themes|unittests|www)/)
+
+
+
 
 # Settings for particular files...
 

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -44,7 +44,7 @@ class BaseSpellWrapper:
                 s2 = s2[1:]
             if s != s2:
                 g.es_print('cleaning', fn)
-                f = open(fn, mode='wb')
+                f = open(fn, mode='wb')  # type:ignore
                 f.write(s2)
                 f.close()
     #@+node:ekr.20180207071114.5: *3* spell.create
@@ -362,21 +362,6 @@ class EnchantWrapper(BaseSpellWrapper):
             # A fallback.  Unlikely to happen.
             d = enchant.Dict(language)
         return d
-    #@+node:ekr.20150514063305.513: *3* spell.clean_dict
-    def clean_dict(self, fn):
-        if g.os_path_exists(fn):
-            f = open(fn, mode='rb')
-            s = f.read()
-            f.close()
-            # Blanks lines cause troubles.
-            s2 = s.replace(b'\r', b'').replace(b'\n\n', b'\n')
-            if s2.startswith(b'\n'):
-                s2 = s2[1:]
-            if s != s2:
-                g.es_print('cleaning', fn)
-                f = open(fn, mode='wb')
-                f.write(s2)
-                f.close()
     #@+node:ekr.20150514063305.515: *3* spell.ignore
     def ignore(self, word):
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1343,7 +1343,7 @@ class LeoApp:
         if 'shutdown' in g.app.debug:
             g.trace()
         # #2433 - use the same method as clicking on the close box.
-        g.app.gui.close_event(QCloseEvent())
+        g.app.gui.close_event(QCloseEvent())  # type:ignore
     #@+node:ville.20090602181814.6219: *3* app.commanders
     def commanders(self):
         """ Return list of currently active controllers """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7509,7 +7509,7 @@ def computeFileUrl(fn: str, c: Cmdr=None, p: Pos=None) -> str:
         url = f"{tag}{path}"
     return url
 #@+node:ekr.20190608090856.1: *3* g.es_clickable_link
-def es_clickable_link(c: Cmdr, p: Pos, line_number, message):
+def es_clickable_link(c: Cmdr, p: Pos, line_number: int, message: str) -> None:
     """
     Write a clickable message to the given line number of p.b.
 

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -11,8 +11,8 @@ try:  # #1973
     from leo.core.leoQt import printsupport, QtGui
     from leo.core.leoQt import DialogCode
 except Exception:
-    printsupport = QtGui = None
-    DialogCode = None
+    printsupport = QtGui = None  # type:ignore
+    DialogCode = None  # type:ignore
 #@+others
 #@+node:ekr.20150509035503.1: ** cmd (decorator)
 def cmd(name):

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -35,7 +35,7 @@ if not g.in_bridge:
     try:
         if 0:  # Testing: Force Qt5.
             raise AttributeError
-        from leo.core.leoQt6 import *
+        from leo.core.leoQt6 import *  # type:ignore
         #
         # Restore the exec_method!
         def exec_(self, *args, **kwargs):

--- a/leo/core/leoQt6.py
+++ b/leo/core/leoQt6.py
@@ -17,6 +17,7 @@ from PyQt6.QtCore import pyqtSignal as Signal
 # For pyflakes.
 assert QtCore and QtGui and QtWidgets
 assert QAction and QActionGroup
+assert QCloseEvent
 assert Qt and QUrl and Signal
 #
 # Standard abbreviations.
@@ -89,19 +90,19 @@ try:
     WindowState = QtCore.Qt.WindowState
 except AttributeError:
     # Old spellings (6.0): mostly plural.
-    Alignment = QtCore.Qt.Alignment
-    ControlType = QtWidgets.QSizePolicy.ControlTypes
-    DropAction = QtCore.Qt.DropActions
-    ItemFlag = QtCore.Qt.ItemFlags
-    KeyboardModifier = QtCore.Qt.KeyboardModifiers
-    Modifier = QtCore.Qt.Modifiers
-    MouseButton = QtCore.Qt.MouseButtons
-    Orientation = QtCore.Qt.Orientations
-    StandardButton = QtWidgets.QDialog.StandardButtons
-    TextInteractionFlag = QtCore.Qt.TextInteractionFlags
-    ToolBarArea = QtCore.Qt.ToolBarAreas
-    WindowType = QtCore.Qt.WindowFlags
-    WindowState = QtCore.Qt.WindowStates
+    Alignment = QtCore.Qt.Alignment  # type:ignore
+    ControlType = QtWidgets.QSizePolicy.ControlTypes  # type:ignore
+    DropAction = QtCore.Qt.DropActions  # type:ignore
+    ItemFlag = QtCore.Qt.ItemFlags  # type:ignore
+    KeyboardModifier = QtCore.Qt.KeyboardModifiers  # type:ignore
+    Modifier = QtCore.Qt.Modifiers  # type:ignore
+    MouseButton = QtCore.Qt.MouseButtons  # type:ignore
+    Orientation = QtCore.Qt.Orientations  # type:ignore
+    StandardButton = QtWidgets.QDialog.StandardButtons  # type:ignore
+    TextInteractionFlag = QtCore.Qt.TextInteractionFlags  # type:ignore
+    ToolBarArea = QtCore.Qt.ToolBarAreas  # type:ignore
+    WindowType = QtCore.Qt.WindowFlags  # type:ignore
+    WindowState = QtCore.Qt.WindowStates  # type:ignore
 #
 # Other enums.
 ButtonRole = QtWidgets.QMessageBox.ButtonRole
@@ -115,7 +116,6 @@ GlobalColor = QtCore.Qt.GlobalColor
 Icon = QtWidgets.QMessageBox.Icon
 Information = QtWidgets.QMessageBox.Icon.Information
 ItemDataRole = QtCore.Qt.ItemDataRole  # 2347
-ItemFlag = QtCore.Qt.ItemFlag
 Key = QtCore.Qt.Key
 MoveMode = QtGui.QTextCursor.MoveMode
 MoveOperation = QtGui.QTextCursor.MoveOperation

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -37,8 +37,8 @@ try:  # #1973
     from leo.core.leoQt import MouseButton
     from leo.plugins.nested_splitter import NestedSplitter  # NestedSplitterChoice
 except Exception:
-    QtWidgets = None
-    MouseButton = None
+    QtWidgets = None  # type:ignore
+    MouseButton = None  # type:ignore
     NestedSplitter = None  # type:ignore
 #
 # Do not call g.assertUi('qt') here. It's too early in the load process.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1595,7 +1595,7 @@ class LeoQtBody(leoFrame.LeoBody):
         wrap = g.scanAllAtWrapDirectives(c, p)
         policy = ScrollBarPolicy.ScrollBarAlwaysOff if wrap else ScrollBarPolicy.ScrollBarAsNeeded
         w.setHorizontalScrollBarPolicy(policy)
-        wrap = WrapMode.WrapAtWordBoundaryOrAnywhere if wrap else WrapMode.NoWrap
+        wrap = WrapMode.WrapAtWordBoundaryOrAnywhere if wrap else WrapMode.NoWrap  # type:ignore
         w.setWordWrapMode(wrap)
     #@+node:ekr.20110605121601.18193: *3* LeoQtBody.Editors
     #@+node:ekr.20110605121601.18194: *4* LeoQtBody.entries
@@ -3193,9 +3193,9 @@ class LeoQtLog(leoFrame.LeoLog):
             (Weight.DemiBold, 'demibold'),
             (Weight.Bold, 'bold'),
             (Weight.Black, 'black'))
-        for val, name in table2:
-            if weight == val:
-                weight = name
+        for val2, name2 in table2:
+            if weight == val2:
+                weight = name2
                 break
         else:
             weight = ''
@@ -3205,9 +3205,9 @@ class LeoQtLog(leoFrame.LeoLog):
             ('style ', style),
             ('weight', weight),
         )
-        for key, val in table3:
-            if val:
-                g.es(key, val, tabName='Fonts')
+        for key3, val3 in table3:
+            if val3:
+                g.es(key3, val3, tabName='Fonts')
     #@+node:ekr.20110605121601.18339: *4* LeoQtLog.hideFontTab
     def hideFontTab(self, event=None):
         c = self.c

--- a/leo/plugins/remove_duplicate_pictures.py
+++ b/leo/plugins/remove_duplicate_pictures.py
@@ -54,6 +54,7 @@ import os
 import pathlib
 import sys
 import time
+from typing import Any, Dict, List
 # Third party
 try:
     from PIL import Image
@@ -160,8 +161,9 @@ def main():
 #@+node:ekr.20220126054240.13: ** class RemoveDuplicates
 class RemoveDuplicates:
     
-    filename_dict = {}  # Keys are filenames, values are hashes.
-    hash_dict = defaultdict(list)  # Keys are hashes, values are lists of filenames.
+    dup_list: List[str] = []
+    filename_dict: Dict[str, Any] = {}  # Keys are filenames, values are hashes.
+    hash_dict: Dict[Any, List[Any]] = defaultdict(list)  # Keys are hashes, values are lists of filenames.
     hash_size = 8
     window_height = 900
             

--- a/leo/plugins/threadutil.py
+++ b/leo/plugins/threadutil.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import time
 import traceback
+from typing import Any, List
 from leo.core import leoGlobals as g
 from leo.core.leoQt import isQt6, QtCore, QtWidgets
 #
@@ -55,7 +56,7 @@ def leo_echo_cb(out, err, code, ent):
         g.es_error(err)
 
 #@+node:ekr.20121126095734.12430: *3* log_filedes
-garbage = []
+garbage: List[Any] = []
 
 def log_filedes(f, level):
 
@@ -100,7 +101,7 @@ class NowOrLater:
 
         self.w = worker
         self.l = []
-        self.lasttime = 1
+        self.lasttime = 1.0
         self.granularity = gran
         self.scheduled = False
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -215,6 +215,7 @@ import os
 from pathlib import Path
 import shutil
 import textwrap
+from typing import Any, Dict
 from urllib.request import urlopen
 from leo.core import leoGlobals as g
 
@@ -254,7 +255,7 @@ else:
 try:
     from jinja2 import Template
 except ImportError:
-    Template = None
+    Template = None  # type:ignore
 #
 # Markdown.
 try:
@@ -262,7 +263,7 @@ try:
     from markdown import markdown
     got_markdown = True
 except ImportError:
-    got_markdown = False
+    got_markdown = False  # type:ignore
 #
 # nbformat (@jupyter) support.
 try:
@@ -320,7 +321,7 @@ latex_template = '''\
 </html>
 '''
 #@-<< define html templates >>
-controllers = {}
+controllers: Dict[int, Any] = {}
     # Keys are c.hash(): values are PluginControllers (QWidget's).
 layouts = {}
     # Keys are c.hash(): values are tuples (layout_when_closed, layout_when_open)


### PR DESCRIPTION
mypy.cmd now uses leo-editor/.mypy.ini to set exclusions, as it should.

**Notes**
- These exclusions only work when mypy checks the "leo" directory.
- For unknown reasons, excluding individual plugins does not work well.
  See the (closed) mypy issue referenced in .mypy.ini.
- mypy complains about several standard plugins.