### PR TITLE
Added new command 'save-node-as-xml'.

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -674,12 +674,8 @@ def save_as_xml(self, event=None):
 @g.commander_command('save-node-as-xml')
 def save_node_as_xml_outline(self, event = None):
     """Save a node with its subtree as a Leo outline file."""
-    c = self
-
-    c.k.simulateCommand('copy-node')
-
-    xml = g.app.gui.getTextFromClipboard()
-    c.usingClipboard = True
+    c = event.c
+    xml = c.fileCommands.outline_to_clipboard_string()
 
     fileName = g.app.gui.runSaveFileDialog(c,
                 title="Save To",
@@ -689,8 +685,6 @@ def save_node_as_xml_outline(self, event = None):
     if fileName:
         with open(fileName, 'w', encoding='utf-8') as f:
             f.write(xml)
-
-    c.usingClipboard = False
 #@+node:ekr.20031218072017.2849: ** Export
 #@+node:ekr.20031218072017.2850: *3* c_file.exportHeadlines
 @g.commander_command('export-headlines')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -670,6 +670,27 @@ def save_as_xml(self, event=None):
     # Leo 6.4: Using save-to instead of save-as allows two versions of the file.
     c.saveTo(fileName=fileName)
     c.fileCommands.putSavedMessage(fileName)
+#@+node:tom.20220310092720.1: *3* c_file.save-node-as-xml
+@g.commander_command('save-node-as-xml')
+def save_node_as_xml_outline(self, event = None):
+    """Save a node with its subtree as a Leo outline file."""
+    c = self
+
+    c.k.simulateCommand('copy-node')
+
+    xml = g.app.gui.getTextFromClipboard()
+    c.usingClipboard = True
+
+    fileName = g.app.gui.runSaveFileDialog(c,
+                title="Save To",
+                filetypes=[("Leo files", "*.leo"),],
+                defaultextension=g.defaultLeoFileExtension(c))
+
+    if fileName:
+        with open(fileName, 'w', encoding='utf-8') as f:
+            f.write(xml)
+
+    c.usingClipboard = False
 #@+node:ekr.20031218072017.2849: ** Export
 #@+node:ekr.20031218072017.2850: *3* c_file.exportHeadlines
 @g.commander_command('export-headlines')


### PR DESCRIPTION
On Windows, I was able to save the entire "code" subtree from leoPyRef using this command.  Of course, it couldn't find all the @file files since they were in a different location, but all the node content for them was present.

Note:  Windows has no limit on the size of text the clipboard can accept.  I don't know about Linux.