### PR TITLE
When checking the line highlight color for changes, avoid expanding stylesheet 

### DIFF
--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -848,7 +848,8 @@ if QtWidgets:
             else:
                 c1 = g.app.commanders()[-1]
                 ssm = c1.styleSheetManager
-                sheet = ssm.expand_css_constants(c1.active_stylesheet)
+                w = ssm.get_master_widget()
+                sheet = w.styleSheet()
                 h = hash(sheet)
                 params['last_color_setting'] = ''
                 if params['last_style_hash'] != h or config_setting_changed:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -856,15 +856,13 @@ if QtWidgets:
                 fg = f'#{fg_hex:x}'
                 bg = f'#{bg_hex:x}'
 
-                if (params['last_fg'] != fg or params['last_bg'] != bg) \
-                    or config_setting_changed:
-                    if not config_setting:
-                        bg_color = QColor(bg) if bg else self.assign_bg(fg)
-                        hl_color = self.calc_hl(bg_color)
-                        #g.trace(f'fg: {fg}, bg: {bg}, hl_color: {hl_color.name()}')
-                        params['last_hl_color'] = hl_color
-                        params['last_fg'] = fg
-                        params['last_bg'] = bg
+                if (params['last_fg'] != fg or params['last_bg'] != bg):
+                    bg_color = QColor(bg) if bg else self.assign_bg(fg)
+                    hl_color = self.calc_hl(bg_color)
+                    #g.trace(f'fg: {fg}, bg: {bg}, hl_color: {hl_color.name()}')
+                    params['last_hl_color'] = hl_color
+                    params['last_fg'] = fg
+                    params['last_bg'] = bg
             #@-<< Recalculate Color >>
             #@+<< Apply Highlight >>
             #@+node:tom.20210909124551.1: *5* << Apply Highlight >>

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -515,6 +515,7 @@ if QtWidgets:
             self.hiliter_params = {
                     'lastblock': -2, 'last_style_hash': 0,
                     'last_color_setting': hl_color_setting,
+                    'last_fg': '', 'last_bg': '',
                     'last_hl_color': hl_color
                     }
         #@+node:ekr.20110605121601.18007: *3* lqtb. __repr__ & __str__
@@ -846,19 +847,24 @@ if QtWidgets:
                 else:
                     hl_color = params['last_hl_color']
             else:
-                c1 = g.app.commanders()[-1]
-                ssm = c1.styleSheetManager
-                w = ssm.get_master_widget()
-                sheet = w.styleSheet()
-                h = hash(sheet)
-                params['last_color_setting'] = ''
-                if params['last_style_hash'] != h or config_setting_changed:
-                    fg, bg = self.parse_css(sheet, 'QTextEdit')
-                    bg_color = QColor(bg) if bg else self.assign_bg(fg)
-                    hl_color = self.calc_hl(bg_color)
-                    # g.trace('fg', fg, 'bg', bg, 'hl_color', hl_color.name())
-                    params['last_hl_color'] = hl_color
-                    params['last_style_hash'] = h
+                # Get current colors from the body editor widget
+                wrapper = c.frame.body.wrapper
+                w = wrapper.widget
+                pallete = w.viewport().palette()
+                fg_hex = pallete.text().color().rgb()
+                bg_hex = pallete.window().color().rgb()
+                fg = f'#{fg_hex:x}'
+                bg = f'#{bg_hex:x}'
+
+                if (params['last_fg'] != fg or params['last_bg'] != bg) \
+                    or config_setting_changed:
+                    if not config_setting:
+                        bg_color = QColor(bg) if bg else self.assign_bg(fg)
+                        hl_color = self.calc_hl(bg_color)
+                        #g.trace(f'fg: {fg}, bg: {bg}, hl_color: {hl_color.name()}')
+                        params['last_hl_color'] = hl_color
+                        params['last_fg'] = fg
+                        params['last_bg'] = bg
             #@-<< Recalculate Color >>
             #@+<< Apply Highlight >>
             #@+node:tom.20210909124551.1: *5* << Apply Highlight >>


### PR DESCRIPTION
constants by getting the expanded stylesheet directly from the actual Qt pallete of the body editor.

This change reduces the amount of computing used during idle periods, and should give a snappier response to keystrokes in the body.