### PR TITLE
PR: Remove underindented comments and beautify all files.

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -244,8 +244,7 @@ def convertTabs(self, event=None):
     changed, result = False, []
     for line in lines:
         i, width = g.skip_leading_ws_with_indent(line, 0, tabWidth)
-        s = g.computeLeadingWhitespace(width, -abs(tabWidth)) + line[i:]
-            # use negative width.
+        s = g.computeLeadingWhitespace(width, -abs(tabWidth)) + line[i:]  # use negative width.
         if s != line:
             changed = True
         result.append(s)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -672,7 +672,7 @@ def save_as_xml(self, event=None):
     c.fileCommands.putSavedMessage(fileName)
 #@+node:tom.20220310092720.1: *3* c_file.save-node-as-xml
 @g.commander_command('save-node-as-xml')
-def save_node_as_xml_outline(self, event = None):
+def save_node_as_xml_outline(self, event=None):
     """Save a node with its subtree as a Leo outline file."""
     c = event.c
     xml = c.fileCommands.outline_to_clipboard_string()

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -41,19 +41,17 @@ def reloadSettingsHelper(c):
     for c2 in g.app.commanders():
         if c2.isChanged():
             c2.save()
+    # Read leoSettings.leo and myLeoSettings.leo, using a null gui.
     lm.readGlobalSettingsFiles()
-        # Read leoSettings.leo and myLeoSettings.leo, using a null gui.
     for c in g.app.commanders():
+        # Read the local file, using a null gui.
         previousSettings = lm.getPreviousSettings(fn=c.mFileName)
-            # Read the local file, using a null gui.
+        # Init the config classes.
         c.initSettings(previousSettings)
-            # Init the config classes.
+        # Init the commander config ivars.
         c.initConfigSettings()
-            # Init the commander config ivars.
+        # Reload settings in all configurable classes
         c.reloadConfigurableSettings()
-            # Reload settings in all configurable classes
-        # c.redraw()
-            # Redraw so a pasted temp node isn't visible
 #@+node:ekr.20200422075655.1: ** c_file.restartLeo
 @g.commander_command('restart-leo')
 def restartLeo(self, event=None):
@@ -457,16 +455,13 @@ def save(self, event=None, fileName=None):
             c.mFileName = g.ensure_extension(fileName, g.defaultLeoFileExtension(c))
             c.frame.title = c.computeWindowTitle(c.mFileName)
             c.frame.setTitle(c.computeWindowTitle(c.mFileName))
-                # 2013/08/04: use c.computeWindowTitle.
             c.openDirectory = c.frame.openDirectory = g.os_path_dirname(c.mFileName)
-                # Bug fix in 4.4b2.
             if hasattr(c.frame, 'top'):
                 c.frame.top.leo_master.setTabName(c, c.mFileName)
             c.fileCommands.save(c.mFileName)
             g.app.recentFilesManager.updateRecentFiles(c.mFileName)
             g.chdir(c.mFileName)
-    # Done in FileCommands.save.
-    # c.redraw_after_icons_changed()
+    # FileCommands.save calls c.redraw_after_icons_changed()
     c.raise_error_dialogs(kind='write')
     # *Safely* restore focus, without using the old w directly.
     if inBody:
@@ -533,17 +528,14 @@ def saveAs(self, event=None, fileName=None):
         # Part of the fix for https://bugs.launchpad.net/leo-editor/+bug/1194209
         c.frame.title = title = c.computeWindowTitle(c.mFileName)
         c.frame.setTitle(title)
-            # 2013/08/04: use c.computeWindowTitle.
         c.openDirectory = c.frame.openDirectory = g.os_path_dirname(c.mFileName)
-            # Bug fix in 4.4b2.
         # Calls c.clearChanged() if no error.
         if hasattr(c.frame, 'top'):
             c.frame.top.leo_master.setTabName(c, c.mFileName)
         c.fileCommands.saveAs(c.mFileName)
         g.app.recentFilesManager.updateRecentFiles(c.mFileName)
         g.chdir(c.mFileName)
-    # Done in FileCommands.saveAs.
-    # c.redraw_after_icons_changed()
+    # FileCommands.saveAs calls c.redraw_after_icons_changed()
     c.raise_error_dialogs(kind='write')
     # *Safely* restore focus, without using the old w directly.
     if inBody:

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -171,8 +171,7 @@ class To_Python:  # pragma: no cover
     #@+node:ekr.20150514063305.141: *5* removeExessWsFromLine
     def removeExcessWsFromLine(self, aList, i):
         assert(i == 0 or aList[i - 1] == '\n')
-        i = self.skip_ws(aList, i)
-            # Retain the leading whitespace.
+        i = self.skip_ws(aList, i)  # Retain the leading whitespace.
         while i < len(aList):
             if self.is_string_or_comment(aList, i):
                 break  # safe
@@ -1174,8 +1173,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 """MakeStubFile.ctor. From StandAloneMakeStubFile.ctor."""
                 self.c = c
                 self.msf = msf = g.import_module('make_stub_files')
-                x = msf.StandAloneMakeStubFile()
-                    # x is used *only* to init ivars.
+                x = msf.StandAloneMakeStubFile()  # x is used *only* to init ivars.
                 # Ivars set on the command line...
                 self.config_fn = None
                 self.enable_unit_tests = False
@@ -1270,8 +1268,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     return
                 out_fn = out_fn[:-3] + '.pyi'
                 out_fn = g.os_path_normpath(out_fn)
-                self.output_fn = out_fn
-                    # compatibility with stand-alone script
+                self.output_fn = out_fn  # compatibility with stand-alone script
                 s = open(abs_fn).read()
                 node = ast.parse(s, filename=fn, mode='exec')
                 # Make the traverser *after* creating output_fn and output_directory ivars.

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -270,9 +270,8 @@ class EditCommandsClass(BaseEditCommandsClass):
             # Values are tuples, (i, j, ins)
         self.extendMode = False  # True: all cursor move commands extend the selection.
         self.fillPrefix = ''  # For fill prefix functions.
-        self.fillColumn = 0  # For line centering.
-            # Set by the set-fill-column command.
-            # If zero, @pagewidth value is used.
+        # Set by the set-fill-column command.
+        self.fillColumn = 0  # For line centering. If zero, use @pagewidth value.
         self.moveSpotNode = None  # A VNode.
         self.moveSpot = None  # For retaining preferred column when moving up or down.
         self.moveCol = None  # For retaining preferred column when moving up or down.
@@ -369,10 +368,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         if g.app.batchMode:
             c.notValidInBatchMode("Insert Headline Time")
             return
+        # #131: Do not get w from self.editWidget()!
         w = c.frame.tree.edit_widget(p)
-            # 2015/06/09: Fix bug 131: Insert time in headline now inserts time in body
-            # Get the wrapper from the tree itself.
-            # Do *not* set w = self.editWidget!
         if w:
             # Fix bug https://bugs.launchpad.net/leo-editor/+bug/1185933
             # insert-headline-time should insert at cursor.
@@ -1897,8 +1894,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         # Pick the correct curly quote.
         s = w.getAllText() or ""
         i2 = g.skip_to_start_of_line(s, max(0, ins - 1))
-        open_curly = ins == i2 or ins > i2 and s[ins - 1] in ' \t'
-            # not s[ins-1].isalnum()
+        open_curly = ins == i2 or ins > i2 and s[ins - 1] in ' \t'  # not s[ins-1].isalnum()
         if open_curly:
             ch = '‘' if ch == "'" else "“"
         else:
@@ -2037,8 +2033,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         Add spaces equivalent to a tab.
         """
         c = self.c
-        i, j = w.getSelectionRange()
-            # Returns insert point if no selection, with i <= j.
+        i, j = w.getSelectionRange()  # Returns insert point if no selection, with i <= j.
         if i != j:
             c.indentBody(event)
             return
@@ -2051,8 +2046,6 @@ class EditCommandsClass(BaseEditCommandsClass):
             after = after[:-1]
         # Only do smart tab at the start of a blank line.
         doSmartTab = (smartTab and c.smart_tab and i == start)
-            # Truly at the start of the line.
-            # and not after # Nothing *at all* after the cursor.
         if doSmartTab:
             self.updateAutoIndent(p, w)
             # Add a tab if otherwise nothing would happen.

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -806,17 +806,14 @@ class GitDiffController:
         """The main line of the git diff command."""
         if not self.get_directory():
             return
-        #
         # Diff the given revs.
         ok = self.diff_revs(rev1, rev2)
         if ok:
             return
-        #
         # Go back at most 5 revs...
         n1, n2 = 1, 0
         while n1 <= 5:
             ok = self.diff_revs(
-                # Clearer w/o f-strings.
                 rev1=f"HEAD@{{{n1}}}",
                 rev2=f"HEAD@{{{n2}}}")
             if ok:

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -24,13 +24,13 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         # pylint: disable=super-init-not-called
         self.c = c
         self.kbiterator = self.iterateKillBuffer()
+        # For interacting with system clipboard.
         self.last_clipboard = None
-            # For interacting with system clipboard.
+        # Position of the last item returned by iterateKillBuffer.
         self.lastYankP = None
-            # Position of the last item returned by iterateKillBuffer.
+        # The index of the next item to be returned in
+        # g.app.globalKillBuffer by iterateKillBuffer.
         self.reset = None
-            # The index of the next item to be returned in
-            # g.app.globalKillBuffer by iterateKillBuffer.
         self.reloadSettings()
 
     def reloadSettings(self):

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -426,8 +426,7 @@ class SpellCommandsClass(BaseEditCommandsClass):
     def reloadSettings(self):
         """SpellCommandsClass.reloadSettings."""
         c = self.c
-        self.page_width = c.config.getInt("page-width")
-            # for wrapping
+        self.page_width = c.config.getInt("page-width")  # for wrapping
     #@+node:ekr.20150514063305.484: *3* openSpellTab
     @cmd('spell-tab-open')
     def openSpellTab(self, event=None):
@@ -675,11 +674,9 @@ class SpellTabHandler:
             r"([^\W\d_]+)(['`][^\W\d_]+)?",
             flags=re.UNICODE)
         self.outerScrolledFrame = None
-        self.seen = set()
-            # Adding a word to seen will ignore it until restart.
+        self.seen = set()  # Adding a word to seen will ignore it until restart.
+        # A text widget for scanning. # Must have a parent frame.
         self.workCtrl = g.app.gui.plainTextWidget(c.frame.top)
-            # A text widget for scanning.
-            # Must have a parent frame even though it is not packed.
         if enchant:
             self.spellController = EnchantWrapper(c)
             self.tab = g.app.gui.createSpellTab(c, self, tabName)

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -673,7 +673,7 @@ class SpellTabHandler:
         self.re_word = re.compile(r"([^\W\d_]+)(['`][^\W\d_]+)?", flags=re.UNICODE)
         self.outerScrolledFrame = None
         self.seen = set()  # Adding a word to seen will ignore it until restart.
-        # A text widget for scanning. # Must have a parent frame.
+        # A text widget for scanning. Must have a parent frame.
         self.workCtrl = g.app.gui.plainTextWidget(c.frame.top)
         if enchant:
             self.spellController = EnchantWrapper(c)

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -668,11 +668,9 @@ class SpellTabHandler:
         self.c = c
         self.body = c.frame.body
         self.currentWord = None
-        self.re_word = re.compile(
-            # Don't include underscores in words. It just complicates things.
-            # [^\W\d_] means any unicode char except underscore or digit.
-            r"([^\W\d_]+)(['`][^\W\d_]+)?",
-            flags=re.UNICODE)
+        # Don't include underscores in words. It just complicates things.
+        # [^\W\d_] means any unicode char except underscore or digit.
+        self.re_word = re.compile(r"([^\W\d_]+)(['`][^\W\d_]+)?", flags=re.UNICODE)
         self.outerScrolledFrame = None
         self.seen = set()  # Adding a word to seen will ignore it until restart.
         # A text widget for scanning. # Must have a parent frame.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -166,42 +166,24 @@ class LeoApp:
         #@-<< LeoApp: global data >>
         #@+<< LeoApp: global controller/manager objects >>
         #@+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
-        # Most of these are defined in initApp.
-        self.backgroundProcessManager = None
-            # The singleton BackgroundProcessManager instance.
-        self.commander_cacher = None
-            # The singleton leoCacher.CommanderCacher instance.
-        self.commander_db = None
-            # The singleton db, managed by g.app.commander_cacher.
-        self.config = None
-            # The singleton leoConfig instance.
-        self.db = None
-            # The singleton global db, managed by g.app.global_cacher.
-        self.externalFilesController = None
-            # The singleton ExternalFilesController instance.
-        self.global_cacher = None
-            # The singleton leoCacher.GlobalCacher instance.
-        self.idleTimeManager = None
-            # The singleton IdleTimeManager instance.
-        self.ipk = None
-            # python kernel instance
-        self.loadManager = None
-            # The singleton LoadManager instance.
-        # self.logManager = None
-            # The singleton LogManager instance.
-        # self.openWithManager = None
-            # The singleton OpenWithManager instance.
-        self.nodeIndices = None
-            # The singleton nodeIndices instance.
-        self.pluginsController = None
-            # The singleton PluginsManager instance.
-        self.sessionManager = None
-            # The singleton SessionManager instance.
-        # The Commands class...
-        self.commandName = None
-            # The name of the command being executed.
-        self.commandInterruptFlag = False
-            # True: command within a command.
+        # Singleton applications objects...
+        self.backgroundProcessManager = None  # A BackgroundProcessManager.
+        self.commander_cacher = None  # A leoCacher.CommanderCacher.
+        self.commander_db = None  # Managed by g.app.commander_cacher.
+        self.config = None  # g.app.config.
+        self.db = None  # A global db, managed by g.app.global_cacher.
+        self.externalFilesController = None  # An ExternalFilesController.
+        self.global_cacher = None  # A leoCacher.GlobalCacher.
+        self.idleTimeManager = None  # An IdleTimeManager.
+        self.ipk = None  # A python kernel.
+        self.loadManager = None  # A LoadManager.
+        self.nodeIndices = None  # A NodeIndices.
+        self.pluginsController = None  # A PluginsManager.
+        self.sessionManager = None  # A SessionManager.
+
+        # Global status vars for the Commands class...
+        self.commandName = None  # The name of the command being executed.
+        self.commandInterruptFlag = False  # True: command within a command.
         #@-<< LeoApp: global controller/manager objects >>
         #@+<< LeoApp: global reader/writer data >>
         #@+node:ekr.20170302075110.1: *5* << LeoApp: global reader/writer data >>
@@ -233,17 +215,11 @@ class LeoApp:
         #@-<< LeoApp: global status vars >>
         #@+<< LeoApp: the global log >>
         #@+node:ekr.20161028040141.1: *5* << LeoApp: the global log >>
-        # To be moved to the LogManager.
-        self.log = None
-            # The LeoFrame containing the present log.
-        self.logInited = False
-            # False: all log message go to logWaiting list.
-        self.logIsLocked = False
-            # True: no changes to log are allowed.
-        self.logWaiting = []
-            # List of tuples (s, color, newline) waiting to go to a log.
-        self.printWaiting = []
-            # Queue of messages to be sent to the printer.
+        self.log = None  # The LeoFrame containing the present log.
+        self.logInited = False  # False: all log message go to logWaiting list.
+        self.logIsLocked = False  # True: no changes to log are allowed.
+        self.logWaiting = []  # List of tuples (s, color, newline) waiting to go to a log.
+        self.printWaiting = []  # Queue of messages to be sent to the printer.
         self.signon = ''
         self.signon1 = ''
         self.signon2 = ''
@@ -1076,8 +1052,8 @@ class LeoApp:
         id_ = getattr(sys, "leoID", None)
         if id_:
             # Careful: periods in the id field of a gnx will corrupt the .leo file!
+            # cleanLeoID raises a warning dialog.
             id_ = self.cleanLeoID(id_, 'sys.leoID')
-                # cleanLeoID raises a warning dialog.
             if len(id_) > 2:
                 self.leoID = id_
                 if verbose:
@@ -1096,8 +1072,8 @@ class LeoApp:
                 if not s:
                     continue
                 # #1404: Ensure valid ID.
+                # cleanLeoID raises a warning dialog.
                 id_ = self.cleanLeoID(s, tag)
-                    # cleanLeoID raises a warning dialog.
                 if len(id_) > 2:
                     self.leoID = id_
                     return
@@ -1115,8 +1091,8 @@ class LeoApp:
                 if verbose:
                     g.blue("setting leoID from os.getenv('USER'):", repr(id_))
                 # Careful: periods in the gnx would corrupt the .leo file!
+                # cleanLeoID raises a warning dialog.
                 id_ = self.cleanLeoID(id_, "os.getenv('USER')")
-                    # cleanLeoID raises a warning dialog.
                 if len(id_) > 2:
                     self.leoID = id_
         except Exception:
@@ -1300,13 +1276,12 @@ class LeoApp:
         if hasattr(g.app, 'pyzo_close_handler'):
             # pylint: disable=no-member
             g.app.pyzo_close_handler()
+        # Disable all further hooks and events.
+        # Alas, "idle" events can still be called
+        # even after the following code.
         g.app.killed = True
-            # Disable all further hooks and events.
-            # Alas, "idle" events can still be called
-            # even after the following code.
         if g.app.gui:
-            g.app.gui.destroySelf()
-                # Calls qtApp.quit()
+            g.app.gui.destroySelf()  # Calls qtApp.quit()
     #@+node:ekr.20031218072017.2616: *4* app.forceShutdown
     def forceShutdown(self):
         """
@@ -1522,37 +1497,33 @@ class LoadManager:
     #@+node:ekr.20120214060149.15851: *3*  LM.ctor
     def __init__(self):
 
-        #
         # Global settings & shortcuts dicts...
         # The are the defaults for computing settings and shortcuts for all loaded files.
-        #
+
+        # A g.TypedDict: the join of settings in leoSettings.leo & myLeoSettings.leo
         self.globalSettingsDict = None
-            # A g.TypedDict: the join of settings in leoSettings.leo & myLeoSettings.leo
+        # A g.TypedDict: the join of shortcuts in leoSettings.leo & myLeoSettings.leo.
         self.globalBindingsDict = None
-            # A g.TypedDict: the join of shortcuts in leoSettings.leo & myLeoSettings.leo.
-        #
+
         # LoadManager ivars corresponding to user options...
-        #
-        self.files = []
-            # List of files to be loaded.
-        self.options = {}
-            # Dictionary of user options. Keys are option names.
-        self.old_argv = []
-            # A copy of sys.argv for debugging.
+
+        self.files = []  # List of files to be loaded.
+        self.options = {}  # Keys are option names; values are user options.
+        self.old_argv = []  # A copy of sys.argv for debugging.
+
+        # True when more files remain on the command line to be loaded.
+        # If the user is answering "No" to each file as Leo asks
+        # "file already open, open again".
+        # This must be False for a complete exit to be appropriate
+        # (finish_quit=True param for closeLeoWindow())
         self.more_cmdline_files = False
-            # True when more files remain on the command line to be
-            # loaded.  If the user is answering "No" to each file as Leo asks
-            # "file already open, open again", this must be False for
-            # a complete exit to be appropriate (finish_quit=True param for
-            # closeLeoWindow())
-        #
-        # Themes.
+
+        # Themes...
         self.leo_settings_c = None
         self.leo_settings_path = None
         self.my_settings_c = None
         self.my_settings_path = None
-        self.theme_c = None
-            # #1374.
+        self.theme_c = None  # #1374.
         self.theme_path = None
     #@+node:ekr.20120211121736.10812: *3* LM.Directory & file utils
     #@+node:ekr.20120219154958.10481: *4* LM.completeFileName
@@ -1646,9 +1617,9 @@ class LoadManager:
     #@+node:ekr.20120209051836.10254: *5* LM.computeHomeDir
     def computeHomeDir(self):
         """Returns the user's home directory."""
+        # Windows searches the HOME, HOMEPATH and HOMEDRIVE
+        # environment vars, then gives up.
         home = os.path.expanduser("~")
-            # Windows searches the HOME, HOMEPATH and HOMEDRIVE
-            # environment vars, then gives up.
         if home and len(home) > 1 and home[0] == '%' and home[-1] == '%':
             # Get the indirect reference to the true home.
             home = os.getenv(home[1:-1], default=None)
@@ -1810,8 +1781,7 @@ class LoadManager:
         if not fn.endswith('.leo'):
             fn += '.leo'
         for directory in self.computeThemeDirectories():
-            path = g.os_path_join(directory, fn)
-                # Normalizes slashes, etc.
+            path = g.os_path_join(directory, fn)  # Normalizes slashes, etc.
             if g.os_path_exists(path):
                 return path
         print(f"theme .leo file not found: {fn}")
@@ -1906,8 +1876,8 @@ class LoadManager:
 
         from leo.core import leoConfig
         if c:
+            # returns the *raw* shortcutsDict, not a *merged* shortcuts dict.
             parser = leoConfig.SettingsTreeParser(c, localFlag)
-                # returns the *raw* shortcutsDict, not a *merged* shortcuts dict.
             shortcutsDict, settingsDict = parser.traverse()
             return shortcutsDict, settingsDict
         return None, None
@@ -2016,12 +1986,10 @@ class LoadManager:
 
         Duplicates happen only if panes conflict.
         """
-        # lm = self
         # Fix bug 951921: check for duplicate shortcuts only in the new file.
         for ks in sorted(list(d.keys())):
             duplicates, panes = [], ['all']
-            aList = d.get(ks)
-                # A list of bi objects.
+            aList = d.get(ks)  # A list of bi objects.
             aList2 = [z for z in aList if not z.pane.startswith('mode')]
             if len(aList) > 1:
                 for bi in aList2:
@@ -2151,9 +2119,8 @@ class LoadManager:
                 settings_d, junk_shortcuts_d = lm.computeLocalSettings(
                     lm.theme_c, settings_d, bindings_d, localFlag=False)
                 lm.globalSettingsDict = settings_d
-                # Set global vars
+                # Set global var used by the StyleSheetManager.
                 g.app.theme_directory = g.os_path_dirname(lm.theme_path)
-                    # Used by the StyleSheetManager.
                 if trace:
                     g.trace('g.app.theme_directory', g.app.theme_directory)
         # Clear the cache entries for the commanders.
@@ -2204,8 +2171,8 @@ class LoadManager:
             return
         if not g.app.gui:
             return
+        # Disable redraw until all files are loaded.
         g.app.disable_redraw = True
-            # Disable redraw until all files are loaded.
         #
         # Phase 2: load plugins: the gui has already been set.
         t2 = time.process_time()
@@ -2279,8 +2246,8 @@ class LoadManager:
             try:  # #1403.
                 for n, fn in enumerate(lm.files):
                     lm.more_cmdline_files = n < len(lm.files) - 1
+                    # Returns None if the file is open in another instance of Leo.
                     c = lm.loadLocalFile(fn, gui=g.app.gui, old_c=None)
-                        # Returns None if the file is open in another instance of Leo.
                     if c and not c1:  # #1416:
                         c1 = c
             except Exception:
@@ -2386,8 +2353,7 @@ class LoadManager:
         lm = self
         lm.computeStandardDirectories()
         # Scan the options as early as possible.
-        lm.options = options = lm.scanOptions(fileName, pymacs)
-            # also sets lm.files.
+        lm.options = options = lm.scanOptions(fileName, pymacs)  # also sets lm.files.
         if options.get('version'):
             return
         script = options.get('script')
@@ -2402,10 +2368,10 @@ class LoadManager:
         if g.app.quit_after_load:
             localConfigFile = None
         else:
+            # Read only standard settings files, using a null gui.
+            # uses lm.files[0] to compute the local directory
+            # that might contain myLeoSettings.leo.
             lm.readGlobalSettingsFiles()
-                # reads only standard settings files, using a null gui.
-                # uses lm.files[0] to compute the local directory
-                # that might contain myLeoSettings.leo.
             # Read the recent files file.
             localConfigFile = lm.files[0] if lm.files else None
             g.app.recentFilesManager.readRecentFiles(localConfigFile)
@@ -2481,8 +2447,8 @@ class LoadManager:
     #@+node:ekr.20140728040812.17990: *6* LM.createWritersData & helper
     def createWritersData(self):
         """Create the data structures describing writer plugins."""
+        # Do *not* remove this trace.
         trace = False and 'createWritersData' not in g.app.debug_dict
-            # Do *not* remove this trace.
         if trace:
             # Suppress multiple traces.
             g.app.debug_dict['createWritersData'] = True
@@ -2508,7 +2474,6 @@ class LoadManager:
             g.printDict(g.app.writersDispatchDict)
             g.trace('LM.atAutoWritersDict')
             g.printDict(g.app.atAutoWritersDict)
-        # Creates problems: See #40.
     #@+node:ekr.20140728040812.17991: *7* LM.parse_writer_dict
     def parse_writer_dict(self, sfn, m):
         """
@@ -2849,8 +2814,7 @@ class LoadManager:
             # g.app.config does not exist yet.
         #
         # --trace-setting=setting
-        g.app.trace_setting = args.trace_setting
-            # g.app.config does not exist yet.
+        g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
     #@+node:ekr.20210927034148.9: *6* LM.doWindowSpotOption
     def doWindowSpotOption(self, args):
 
@@ -3265,17 +3229,12 @@ class RecentFilesManager:
     def __init__(self):
 
         self.edit_headline = 'Recent files. Do not change this headline!'
-            # Headline used by
-        self.groupedMenus = []
-            # Set in rf.createRecentFilesMenuItems.
-        self.recentFiles = []
-            # List of g.Bunches describing .leoRecentFiles.txt files.
-        self.recentFilesMenuName = 'Recent Files'
-            # May be changed later.
-        self.recentFileMessageWritten = False
-            # To suppress all but the first message.
-        self.write_recent_files_as_needed = False
-            # Will be set later.
+        self.groupedMenus = []  # Set in rf.createRecentFilesMenuItems.
+        self.recentFiles = []  # List of g.Bunches describing .leoRecentFiles.txt files.
+        self.recentFilesMenuName = 'Recent Files'  # May be changed later.
+        self.recentFileMessageWritten = False  # To suppress all but the first message.
+        self.write_recent_files_as_needed = False  # Will be set later.
+
     #@+others
     #@+node:ekr.20041201080436: *3* rf.appendToRecentFiles
     def appendToRecentFiles(self, files):

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2273,8 +2273,7 @@ class LoadManager:
         g.app.disable_redraw = False
         if not c1:
             try:  # #1403.
-                c1 = lm.openEmptyWorkBook()
-                    # Calls LM.loadLocalFile.
+                c1 = lm.openEmptyWorkBook()  # Calls LM.loadLocalFile.
             except Exception:
                 g.es_print('Can not create empty workbook')
                 g.es_exception()
@@ -2810,8 +2809,7 @@ class LoadManager:
         #
         # These are not bool args.
         # --trace-binding
-        g.app.trace_binding = args.trace_binding
-            # g.app.config does not exist yet.
+        g.app.trace_binding = args.trace_binding  # g.app.config does not exist yet.
         #
         # --trace-setting=setting
         g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
@@ -2989,18 +2987,17 @@ class LoadManager:
         g.doHook('open0')
         theFile = lm.openAnyLeoFile(fn)
         if isinstance(theFile, sqlite3.Connection):
-            # this commander is associated with sqlite db
+            # This commander is associated with sqlite db.
             c.sqlite_connection = theFile
         # Enable the log.
         g.app.unlockLog()
         c.frame.log.enable(True)
-        # Phase 2: Create the outline.
+        # Create the outline.
         g.doHook("open1", old_c=None, c=c, new_c=c, fileName=fn)
         if theFile:
             readAtFileNodesFlag = bool(previousSettings)
-            # The log is not set properly here.
+            # Read the Leo file.
             ok = lm.readOpenedLeoFile(c, fn, readAtFileNodesFlag, theFile)
-                # Call c.fileCommands.openLeoFile to read the .leo file.
             if not ok:
                 return None
         else:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -403,8 +403,8 @@ if 1:  # pragma: no cover
         """Regularize newlines within s."""
         return s.replace('\r\n', '\n').replace('\r', '\n')
     #@+node:ekr.20200106171502.1: *4* function: get_encoding_directive
+    # This is the pattern in PEP 263.
     encoding_pattern = re.compile(r'^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)')
-        # This is the pattern in PEP 263.
 
     def get_encoding_directive(bb):
         """
@@ -1235,17 +1235,11 @@ class TokenOrderGenerator:
         """
         #
         # Init all ivars.
-        self.file_name = file_name
-            # For tests.
-        self.level = 0
-            # Python indentation level.
-        self.node = None
-            # The node being visited.
-            # The parent of the about-to-be visited node.
-        self.tokens = tokens
-            # The immutable list of input tokens.
-        self.tree = tree
-            # The tree of ast.AST nodes.
+        self.file_name = file_name  # For tests.
+        self.level = 0  # Python indentation level.
+        self.node = None # The node being visited.
+        self.tokens = tokens  # The immutable list of input tokens.
+        self.tree = tree  # The tree of ast.AST nodes.
         #
         # Traverse the tree.
         try:
@@ -3964,12 +3958,12 @@ class Token:
         # Injected by Tokenizer.add_token.
         self.five_tuple = None
         self.index = 0
+        # The entire line containing the token.
+        # Same as five_tuple.line.
         self.line = ''
-            # The entire line containing the token.
-            # Same as five_tuple.line.
+        # The line number, for errors and dumps.
+        # Same as five_tuple.start[0]
         self.line_number = 0
-            # The line number, for errors and dumps.
-            # Same as five_tuple.start[0]
         #
         # Injected by Tokenizer.add_token.
         self.level = 0

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1237,7 +1237,7 @@ class TokenOrderGenerator:
         # Init all ivars.
         self.file_name = file_name  # For tests.
         self.level = 0  # Python indentation level.
-        self.node = None # The node being visited.
+        self.node = None  # The node being visited.
         self.tokens = tokens  # The immutable list of input tokens.
         self.tree = tree  # The tree of ast.AST nodes.
         #

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -572,16 +572,15 @@ class AtFile:
     def read_at_clean_lines(self, fn):  # pragma: no cover
         """Return all lines of the @clean/@nosent file at fn."""
         at = self
+        # Use the standard helper. Better error reporting.
+        # Important: uses 'rb' to open the file.
         s = at.openFileHelper(fn)
-            # Use the standard helper. Better error reporting.
-            # Important: uses 'rb' to open the file.
         # #1798.
         if s is None:
             s = ''
         else:
             s = g.toUnicode(s, encoding=at.encoding)
-            s = s.replace('\r\n', '\n')
-                # Suppress meaningless "node changed" messages.
+            s = s.replace('\r\n', '\n')  # Suppress meaningless "node changed" messages.
         return g.splitLines(s)
     #@+node:ekr.20150204165040.9: *6* at.write_at_clean_sentinels
     def write_at_clean_sentinels(self, root):  # pragma: no cover
@@ -731,8 +730,7 @@ class AtFile:
         Returns the string, or None on failure.
         """
         at = self
-        s = at.openFileHelper(fileName)
-            # Catches all exceptions.
+        s = at.openFileHelper(fileName)  # Catches all exceptions.
         # #1798.
         if s is None:
             return None
@@ -851,11 +849,11 @@ class AtFile:
 
         This is a kludgy method used only by the import code."""
         at = self
+        # Set at.encoding, regularize whitespace and call at.initReadLines.
         at.readFileToUnicode(fileName)
-            # Sets at.encoding, regularizes whitespace and calls at.initReadLines.
+        # scanHeader uses at.readline instead of its args.
+        # scanHeader also sets at.encoding.
         junk, junk, isThin = at.scanHeader(None)
-            # scanHeader uses at.readline instead of its args.
-            # scanHeader also sets at.encoding.
         return isThin
     #@+node:ekr.20041005105605.132: *3* at.Writing
     #@+node:ekr.20041005105605.133: *4* Writing (top level)
@@ -3158,8 +3156,8 @@ class FastAtRead:
             if m:
                 in_doc = False
                 gnx, head = m.group(2), m.group(5)
+                # m.group(3) is the level number, m.group(4) is the number of stars.
                 level = int(m.group(3)) if m.group(3) else 1 + len(m.group(4))
-                    # m.group(3) is the level number, m.group(4) is the number of stars.
                 v = gnx2vnode.get(gnx)
                 #
                 # Case 1: The root @file node. Don't change the headline.
@@ -3318,7 +3316,7 @@ class FastAtRead:
                 # Whatever happens, retain the @delims line.
                 body.append(f"@comment {delims}\n")
                 delim1, delim2, delim3 = g.set_delims_from_string(delims)
-                    # delim1 is always the single-line delimiter.
+                # delim1 is always the single-line delimiter.
                 if delim1:
                     comment_delim1, comment_delim2 = delim1, ''
                 else:

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -53,12 +53,9 @@ class BackgroundProcessManager:
     #@+node:ekr.20180522085807.1: *3* bpm.__init__
     def __init__(self):
         """Ctor for the base BackgroundProcessManager class."""
-        self.data = None
-            # a ProcessData instance.
-        self.process_queue = []
-            # List of g.Bunches.
-        self.pid = None
-            # The process id of the running process.
+        self.data = None  # a ProcessData instance.
+        self.process_queue = []  # List of g.Bunches.
+        self.pid = None  # The process id of the running process.
         g.app.idleTimeManager.add_callback(self.on_idle)
     #@+node:ekr.20161028090624.1: *3* class BPM.ProcessData
     class ProcessData:

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -292,16 +292,11 @@ class CPrettyPrinter:
     def __init__(self, c):
         """Ctor for CPrettyPrinter class."""
         self.c = c
-        self.brackets = 0
-            # The brackets indentation level.
-        self.p = None
-            # Set in indent.
-        self.parens = 0
-            # The parenthesis nesting level.
-        self.result = []
-            # The list of tokens that form the final result.
-        self.tab_width = 4
-            # The number of spaces in each unit of leading indentation.
+        self.brackets = 0  # The brackets indentation level.
+        self.p = None  # Set in indent.
+        self.parens = 0  # The parenthesis nesting level.
+        self.result = []  # The list of tokens that form the final result.
+        self.tab_width = 4  # The number of spaces in each unit of leading indentation.
     #@+node:ekr.20191104195610.1: *3* cpp.pretty_print_tree
     def pretty_print_tree(self, p):
 

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -117,9 +117,9 @@ class BridgeController:
         #
         # Create the application object.
         try:
+            # Tell leoApp.createDefaultGui not to create a gui.
+            # This module will create the gui later.
             g.in_bridge = self.vs_code_flag  # #2098.
-                # Tell leoApp.createDefaultGui not to create a gui.
-                # This module will create the gui later.
             g.in_vs_code = True  # 2098.
             from leo.core import leoApp
             g.app = leoApp.LeoApp()

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -18,19 +18,12 @@ class ChapterController:
     def __init__(self, c):
         """Ctor for ChapterController class."""
         self.c = c
-        self.chaptersDict = {}
-            # Keys are chapter names, values are chapters.
-            # Important: chapter names never change,
-            # even if their @chapter node changes.
-        self.initing = True
-            # #31
-            # True: suppress undo when creating chapters.
-        self.re_chapter = None
-            # Set where used.
+        # Note: chapter names never change, even if their @chapter node changes.
+        self.chaptersDict = {}  # Keys are chapter names, values are chapters.
+        self.initing = True  # #31: True: suppress undo when creating chapters.
+        self.re_chapter = None  # Set where used.
         self.selectedChapter = None
-        self.selectChapterLockout = False
-            # True: cc.selectChapterForPosition does nothing.
-            # Note: Used in qt_frame.py.
+        self.selectChapterLockout = False  # True: cc.selectChapterForPosition does nothing.
         self.tt = None  # May be set in finishCreate.
         self.reloadSettings()
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -94,9 +94,9 @@ class BaseColorizer:
     def configure_colors(self):
         """Configure all colors in the default colors dict."""
         c, wrapper = self.c, self.wrapper
+        # getColor puts the color name in standard form:
+        # color = color.replace(' ', '').lower().strip()
         getColor = c.config.getColor
-            # getColor puts the color name in standard form:
-            # color = color.replace(' ', '').lower().strip()
         for key in sorted(self.default_colors_dict.keys()):
             option_name, default_color = self.default_colors_dict[key]
             color = (
@@ -552,7 +552,6 @@ class BaseColorizer:
             if trace:
                 g.es_print(f"{setting:35}: {val}")
 
-        #
         # Set self.use_pygments only once: it can't be changed later.
         # There is no easy way to re-instantiate classes created by make_colorizer.
         if self.prev_use_pygments is None:
@@ -565,24 +564,19 @@ class BaseColorizer:
                 f"{'Can not change @bool use-pygments':35}: "
                 f"{self.prev_use_pygments}",
                 color='red')
-        #
-        # Report everything if we are tracing.
+        # This setting is used only in the LeoHighlighter class
         style_name = c.config.getString('pygments-style-name') or 'default'
-            # Don't set an ivar. It's not used in this class.
-            # This setting is used only in the LeoHighlighter class
+        # Report everything if we are tracing.
         show('@bool use-pytments-styles', self.use_pygments_styles)
         show('@string pygments-style-name', style_name)
-        #
         # Report changes to @bool use-pygments-style
         if self.prev_use_styles is None:
             self.prev_use_styles = self.use_pygments_styles
         elif self.use_pygments_styles != self.prev_use_styles:
             g.es_print(f"using pygments styles: {self.use_pygments_styles}")
-        #
         # Report @string pygments-style-name only if we are using styles.
         if not self.use_pygments_styles:
             return
-        #
         # Report changes to @string pygments-style-name
         if self.prev_style is None:
             self.prev_style = style_name
@@ -663,11 +657,9 @@ class BaseColorizer:
         dots = tag.startswith('dots')
         if dots:
             tag = tag[len('dots') :]
-        colorName = wrapper.configDict.get(tag)
-            # This color name should already be valid.
+        colorName = wrapper.configDict.get(tag)  # This color name should already be valid.
         if not colorName:
             return
-        #
         # New in Leo 5.8.1: allow symbolic color names here.
         # This now works because all keys in leo_color_database are normalized.
         colorName = colorName.replace(
@@ -1039,8 +1031,8 @@ class JEditColorizer(BaseColorizer):
         """
         if not name:
             return ''
+        # #1334. Lower-case the name, regardless of the spelling in @language.
         name = name.lower()
-            # #1334. Lower-case the name, regardless of the spelling in @language.
         i = name.find('::')
         if i == -1:
             language = name
@@ -2432,19 +2424,17 @@ if QtGui:
                 return
             if not c.config.getBool('use-pygments', default=False):
                 return
-            #
             # Init pygments ivars.
             self._brushes = {}
             self._document = document
             self._formats = {}
             self.colorizer.style_name = 'default'
+            # Style gallery: https://help.farbox.com/pygments.html
+            # Dark styles: fruity, monokai, native, vim
+            # https://github.com/gthank/solarized-dark-pygments
             style_name = c.config.getString('pygments-style-name') or 'default'
-                # Style gallery: https://help.farbox.com/pygments.html
-                # Dark styles: fruity, monokai, native, vim
-                # https://github.com/gthank/solarized-dark-pygments
             if not c.config.getBool('use-pygments-styles', default=True):
                 return
-            #
             # Init pygments style.
             try:
                 self.setStyle(style_name)
@@ -2618,8 +2608,8 @@ class PygmentsColorizer(BaseColorizer):
 
     def getLegacyFormat(self, token, text):
         """Return a jEdit tag for the given pygments token."""
+        # Tables and setTag assume lower-case.
         r = repr(token).lstrip('Token.').lstrip('Literal.').lower()
-            # Tables and setTag assume lower-case.
         if r == 'name':
             # Avoid a colision with existing Leo tag.
             r = 'name.pygments'

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -58,8 +58,7 @@ class Commands:
         self.frame = None
         self.parentFrame = parentFrame  # New in Leo 6.0.
         self.gui = gui or g.app.gui
-        self.ipythonController = None
-            # Set only by the ipython plugin.
+        self.ipythonController = None  # Set only by the ipython plugin.
         # The order of these calls does not matter.
         c.initCommandIvars()
         c.initDebugIvars()
@@ -68,8 +67,8 @@ class Commands:
         c.initFileIvars(fileName, relativeFileName)
         c.initOptionsIvars()
         c.initObjectIvars()
+        # Init the settings *before* initing the objects.
         c.initSettings(previousSettings)
-            # Init the settings *before* initing the objects.
         # Initialize all subsidiary objects, including subcommanders.
         c.initObjects(self.gui)
         assert c.frame
@@ -223,21 +222,19 @@ class Commands:
         self.nodeHistory = leoHistory.NodeHistory(c)
         self.initConfigSettings()
         c.setWindowPosition() # Do this after initing settings.
+        
         # Break circular import dependencies by doing imports here.
-        # These imports take almost 3/4 sec in the leoBridge.
+        # All these imports take almost 3/4 sec in the leoBridge.
+
         from leo.core import leoAtFile
         from leo.core import leoBeautify  # So decorators are executed.
         assert leoBeautify  # for pyflakes.
         from leo.core import leoChapters
-        # from leo.core import leoTest2  # So decorators are executed.
-        # assert leoTest2  # For pyflakes.
         # User commands...
         from leo.commands import abbrevCommands
         from leo.commands import bufferCommands
-        from leo.commands import checkerCommands
-        assert checkerCommands
-            # To suppress a pyflakes warning.
-            # The import *is* required to define commands.
+        from leo.commands import checkerCommands  # The import *is* required to define commands.
+        assert checkerCommands  # To suppress a pyflakes warning.
         from leo.commands import controlCommands
         from leo.commands import convertCommands
         from leo.commands import debugCommands
@@ -374,8 +371,7 @@ class Commands:
         t1 = time.process_time()
         c.frame.finishCreate()  # Slightly slow.
         t2 = time.process_time()
-        c.miniBufferWidget = c.frame.miniBufferWidget
-            # Will be None for nullGui.
+        c.miniBufferWidget = c.frame.miniBufferWidget  # Will be None for nullGui.
         # Only c.abbrevCommands needs a finishCreate method.
         c.abbrevCommands.finishCreate()
         # Finish other objects...
@@ -388,15 +384,14 @@ class Commands:
                 g.app.pluginsController.loadingModuleNameStack.append('leo.core.leoCommands')
                 g.registerHandler('idle', c.idle_focus_helper)
             finally:
-                g.app.pluginsController.loadingModuleNameStack.pop() 
+                g.app.pluginsController.loadingModuleNameStack.pop()
         if getattr(c.frame, 'menu', None):
             c.frame.menu.finishCreate()
         if getattr(c.frame, 'log', None):
             c.frame.log.finishCreate()
         c.undoer.clearUndoState()
         if c.vimCommands and c.vim_mode:
-            c.vimCommands.finishCreate()
-            # Menus must exist at this point.
+            c.vimCommands.finishCreate()  # Menus must exist at this point.
         # Do not call chapterController.finishCreate here:
         # It must be called after the first real redraw.
         g.check_cmd_instance_dict(c, g)
@@ -708,12 +703,10 @@ class Commands:
             if c.forceExecuteEntireBody:
                 useSelectedText = False
             script = g.getScript(c, p or c.p, useSelectedText=useSelectedText)
-        script_p = p or c.p
-            # Only for error reporting below.
+        script_p = p or c.p  # Only for error reporting below.
         # #532: check all scripts with pyflakes.
         if run_pyflakes and not g.unitTesting:
             from leo.commands import checkerCommands as cc
-            # at = c.atFileCommands
             prefix = ('c,g,p,script_gnx=None,None,None,None;'
                       'assert c and g and p and script_gnx;\n')
             cc.PyflakesCommand(c).check_script(script_p, prefix + script)
@@ -762,14 +755,12 @@ class Commands:
         d['script_gnx'] = g.app.scriptDict.get('script_gnx')
         if namespace:
             d.update(namespace)
-        #
         # A kludge: reset c.inCommand here to handle the case where we *never* return.
         # (This can happen when there are multiple event loops.)
         # This does not prevent zombie windows if the script puts up a dialog...
         try:
             c.inCommand = False
-            g.inScript = g.app.inScript = True
-                # g.inScript is a synonym for g.app.inScript.
+            g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
                 exec(compile(script, scriptFile, 'exec'), d)
@@ -2098,14 +2089,14 @@ class Commands:
         if g.unitTesting:
             return
         if stroke and (stroke.find('Alt+') > -1 or stroke.find('Ctrl+') > -1):
+            # Alas, Alt and Ctrl bindings must *retain* the char field,
+            # so there is no way to know what char field to expect.
             expected = event.char
-                # Alas, Alt and Ctrl bindings must *retain* the char field,
-                # so there is no way to know what char field to expect.
         else:
+            # disable the test.
+            # We will use the (weird) key value for, say, Ctrl-s,
+            # if there is no binding for Ctrl-s.
             expected = event.char
-                # disable the test.
-                # We will use the (weird) key value for, say, Ctrl-s,
-                # if there is no binding for Ctrl-s.
         if not isinstance(event, leoGui.LeoKeyEvent):
             if g.app.gui.guiName() not in ('browser', 'console', 'curses'):  # #1839.
                 g.trace(f"not leo event: {event!r}, callers: {g.callers(8)}")
@@ -2482,14 +2473,11 @@ class Commands:
                     cm.mb_keywords = None
                     cm.mb_retval = retval
 
-        minibufferCallback.__doc__ = function.__doc__
-            # For g.getDocStringForFunction
-        minibufferCallback.source_c = source_c
-            # For GetArgs.command_source
+        minibufferCallback.__doc__ = function.__doc__  # For g.getDocStringForFunction
+        minibufferCallback.source_c = source_c  # For GetArgs.command_source
         return minibufferCallback
 
-    #fix bobjack's spelling error
-
+    # fix bobjack's spelling error.
     universallCallback = universalCallback
     #@+node:ekr.20070115135502: *4* c.writeScriptFile (changed: does not expand expressions)
     def writeScriptFile(self, script):
@@ -2868,10 +2856,8 @@ class Commands:
         if g.unitTesting:
             c.init_error_dialogs()
             return
-        #
         # Issue one or two dialogs or messages.
-        saved_body = c.rootPosition().b
-            # Save the root's body. Somehow the dialog destroys it!
+        saved_body = c.rootPosition().b  # Save the root's body. The dialog destroys it!
         if c.import_error_nodes or c.ignored_at_file_nodes or c.orphan_at_file_nodes:
             g.app.gui.dismiss_splash_screen()
         else:
@@ -2903,7 +2889,6 @@ class Commands:
                     ignored_dialog_message = f"{ignored_message}\n{files}"
                     g.app.gui.runAskOkDialog(c,
                         message=ignored_dialog_message, title=f"Not {kind.capitalize()}")
-        #
         # #1050: always raise a dialog for orphan @<file> nodes.
         if c.orphan_at_file_nodes:
             message = '\n'.join([
@@ -2922,8 +2907,7 @@ class Commands:
             c.setChanged()
             c.redraw()
         # Restore the root position's body.
-        c.rootPosition().v.b = saved_body
-            # #1007: just set v.b.
+        c.rootPosition().v.b = saved_body  # #1007: just set v.b.
         c.init_error_dialogs()
     #@+node:ekr.20150710083827.1: *5* c.syntaxErrorDialog
     def syntaxErrorDialog(self):
@@ -4208,8 +4192,8 @@ class Commands:
         for obj in table:
             if obj:
                 c.registerReloadSettings(obj)
+        # Useful now that instances add themselves to c.configurables.
         c.configurables = list(set(c.configurables))
-            # Useful now that instances add themselves to c.configurables.
         c.configurables.sort(key=lambda obj: obj.__class__.__name__.lower())
         for obj in c.configurables:
             func = getattr(obj, 'reloadSettings', None)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -331,8 +331,8 @@ class Commands:
             self.undoer,
         ]
         # Other objects
+        # A list of other classes that have a reloadSettings method
         c.configurables = c.subCommanders[:]
-            # A list of other classes that have a reloadSettings method
         c.db = g.app.commander_cacher.get_wrapper(c)
         # #2485: Load the free_layout plugin in the proper context.
         #        g.app.pluginsController.loadOnePlugin won't work here.

--- a/leo/core/leoDebugger.py
+++ b/leo/core/leoDebugger.py
@@ -203,14 +203,11 @@ class Xdb(pdb.Pdb, threading.Thread):
             else:
                 self.stdout.write(self.prompt)
                 self.stdout.flush()
-                line = self.stdin.readline()
-                    # QueueStdin.readline.
-                    # Get the input from Leo's main thread.
+                # Get the input from Leo's main thread.
+                line = self.stdin.readline()  # QueueStdin.readline:
                 line = line.rstrip('\r\n') if line else 'EOF'
-            line = self.precmd(line)
-                # Pdb.precmd.
-            stop = self.onecmd(line)
-                # Pdb.onecmd.
+            line = self.precmd(line)  # Pdb.precmd.
+            stop = self.onecmd(line)  # Pdb.onecmd.
             # Show the line in Leo.
             if stop:
                 self.select_line(self.saved_frame, self.saved_traceback)

--- a/leo/core/leoDynamicTest.py
+++ b/leo/core/leoDynamicTest.py
@@ -16,14 +16,11 @@ cwd = os.getcwd()
 if cwd not in sys.path:
     sys.path.append(cwd)
 #@-<< imports >>
-g_trace = False
-    # Enables the trace in main.
+g_trace = False  # Enables the trace in main.
+# Enable trace of argv. For debugging this file: it duplicate of the trace in main()
 trace_argv = False
-    # Enable trace of argv. For debugging this file: it duplicate of the trace in main()
-trace_main = False
-    # Enable trace of options in main().
-trace_time = False
-    # Enables tracing of the overhead take to run tests externally.
+trace_main = False  # Enable trace of options in main().
+trace_time = False  # Enables tracing of the overhead take to run tests externally.
 # Do not define g here. Use the g returned by the bridge.
 #@+others
 #@+node:ekr.20080730161153.6: ** main & helpers (leoDynamicTest.py)

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -16,11 +16,10 @@ class ExternalFile:
         """Ctor for ExternalFile class."""
         self.c = c
         self.ext = ext
-        self.p = p and p.copy()
-            # The nearest @<file> node.
+        self.p = p and p.copy()  # The nearest @<file> node.
         self.path = path
-        self.time = time  # Used to inhibit endless dialog loop.
-                          # See efc.idle_check_open_with_file.
+        # Inhibit endless dialog loop. See efc.idle_check_open_with_file.
+        self.time = time
 
     def __repr__(self):
         return f"<ExternalFile: {self.time:20} {g.shortFilename(self.path)}>"

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1108,14 +1108,13 @@ class LeoFind:
 
         Return (found, new text)
         """
+        # This hack would be dangerous on MacOs: it uses '\r' instead of '\n' (!)
         if sys.platform.lower().startswith('win'):
+            # Ignore '\r' characters, which may appear in @edit nodes.
+            # Fixes this bug: https://groups.google.com/forum/#!topic/leo-editor/yR8eL5cZpi4
             s = s.replace('\r', '')
-                # Ignore '\r' characters, which may appear in @edit nodes.
-                # Fixes this bug: https://groups.google.com/forum/#!topic/leo-editor/yR8eL5cZpi4
-                # This hack would be dangerous on MacOs: it uses '\r' instead of '\n' (!)
         if not s:
             return False, None
-        #
         # Order matters: regex matches ignore whole-word.
         if self.pattern_match:
             return self._change_all_regex(s)
@@ -1215,14 +1214,13 @@ class LeoFind:
 
         Return (found, new text)
         """
+        # This hack would be dangerous on MacOs: it uses '\r' instead of '\n' (!)
         if sys.platform.lower().startswith('win'):
+            # Ignore '\r' characters, which may appear in @edit nodes.
+            # Fixes this bug: https://groups.google.com/forum/#!topic/leo-editor/yR8eL5cZpi4
             s = s.replace('\r', '')
-                # Ignore '\r' characters, which may appear in @edit nodes.
-                # Fixes this bug: https://groups.google.com/forum/#!topic/leo-editor/yR8eL5cZpi4
-                # This hack would be dangerous on MacOs: it uses '\r' instead of '\n' (!)
         if not s:
             return False, None
-        #
         # Order matters: regex matches ignore whole-word.
         if self.pattern_match:
             return self.batch_regex_replace(s)
@@ -2252,11 +2250,11 @@ class LeoFind:
         """
         index = self.work_sel[2]
         s = self.work_s
+        # This hack would be dangerous on MacOs: it uses '\r' instead of '\n' (!)
         if sys.platform.lower().startswith('win'):
+            # Ignore '\r' characters, which may appear in @edit nodes.
+            # Fixes this bug: https://groups.google.com/forum/#!topic/leo-editor/yR8eL5cZpi4
             s = s.replace('\r', '')
-                # Ignore '\r' characters, which may appear in @edit nodes.
-                # Fixes this bug: https://groups.google.com/forum/#!topic/leo-editor/yR8eL5cZpi4
-                # This hack would be dangerous on MacOs: it uses '\r' instead of '\n' (!)
         if not s:  # pragma: no cover
             return None, None
         stopindex = 0 if self.reverse else len(s)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -307,8 +307,7 @@ class LeoBody:
         # Must be overridden in subclasses...
         self.colorizer = None
         # Init user settings.
-        self.use_chapters = False
-            # May be overridden in subclasses.
+        self.use_chapters = False  # May be overridden in subclasses.
     #@+node:ekr.20031218072017.3677: *3* LeoBody.Coloring
     def forceFullRecolor(self):
         pass
@@ -724,8 +723,7 @@ class LeoFrame:
         self.es_newlines = 0  # newline count for this log stream
         self.openDirectory = ""
         self.saved = False  # True if ever saved
-        self.splitVerticalFlag = True
-            # Set by initialRatios later.
+        self.splitVerticalFlag = True  # Set by initialRatios later.
         self.startupWindow = False  # True if initially opened window
         self.stylesheet = None  # The contents of <?xml-stylesheet...?> line.
         self.tab_width = 0  # The tab width in effect in this pane.
@@ -1017,8 +1015,7 @@ class LeoFrame:
         bunch = u.beforeChangeBody(p)
         if self.cursorStay and wname.startswith('body'):
             tCurPosition = w.getInsertPoint()
-        i, j = w.getSelectionRange()
-            # Returns insert point if no selection.
+        i, j = w.getSelectionRange()  # Returns insert point if no selection.
         if middleButton and c.k.previousSelection is not None:
             start, end = c.k.previousSelection
             s = w.getAllText()
@@ -1194,9 +1191,8 @@ class LeoLog:
         self.isNull = False
         # Official ivars...
         self.canvasCtrl = None  # Set below. Same as self.canvasDict.get(self.tabName)
+        # Important: depending on the log *tab*, logCtrl may be either a wrapper or a widget.
         self.logCtrl = None  # Set below. Same as self.textDict.get(self.tabName)
-            # Important: depeding on the log *tab*,
-            # logCtrl may be either a wrapper or a widget.
         self.tabName = None  # The name of the active tab.
         self.tabFrame = None  # Same as self.frameDict.get(self.tabName)
         self.canvasDict = {}  # Keys are page names.  Values are Tk.Canvas's.
@@ -1297,23 +1293,6 @@ class LeoLog:
 class LeoTree:
     """The base class for the outline pane in Leo windows."""
     #@+others
-    #@+node:ekr.20031218072017.3705: *3* LeoTree.__init__
-    def __init__(self, frame):
-        """Ctor for the LeoTree class."""
-        self.frame = frame
-        self.c = frame.c
-        self.edit_text_dict = {}
-            # New in 3.12: keys vnodes, values are edit_widgets.
-            # New in 4.2: keys are vnodes, values are pairs (p,edit widgets).
-        # "public" ivars: correspond to setters & getters.
-        self.drag_p = None
-        self.generation = 0
-            # Leo 5.6: low-level vnode methods increment
-            # this count whenever the tree changes.
-        self.redrawCount = 0  # For traces
-        self.use_chapters = False  # May be overridden in subclasses.
-        # Define these here to keep pylint happy.
-        self.canvas = None
     #@+node:ekr.20081005065934.8: *3* LeoTree.May be defined in subclasses
     # These are new in Leo 4.6.
 
@@ -1386,6 +1365,21 @@ class LeoTree:
         c.redraw_after_head_changed()
             # Fix bug 1280689: don't call the non-existent c.treeEditFocusHelper
         g.doHook("headkey2", c=c, p=p, ch=ch, changed=changed)
+    #@+node:ekr.20031218072017.3705: *3* LeoTree.__init__
+    def __init__(self, frame):
+        """Ctor for the LeoTree class."""
+        self.frame = frame
+        self.c = frame.c
+        # New in 3.12: keys vnodes, values are edit_widgets.
+        # New in 4.2: keys are vnodes, values are pairs (p,edit widgets).
+        self.edit_text_dict = {}
+        # "public" ivars: correspond to setters & getters.
+        self.drag_p = None
+        self.generation = 0  # low-level vnode methods increment this count.
+        self.redrawCount = 0  # For traces
+        self.use_chapters = False  # May be overridden in subclasses.
+        # Define these here to keep pylint happy.
+        self.canvas = None
     #@+node:ekr.20061109165848: *3* LeoTree.Must be defined in base class
     #@+node:ekr.20040803072955.126: *4* LeoTree.endEditLabel
     def endEditLabel(self):
@@ -1971,9 +1965,9 @@ class NullLog(LeoLog):
 
         super().__init__(frame, parentFrame)
         self.isNull = True
+        # self.logCtrl is now a property of the base LeoLog class.
         self.logNumber = 0
         self.widget = self.createControl(parentFrame)
-            # self.logCtrl is now a property of the base LeoLog class.
     #@+node:ekr.20120216123546.10951: *4* NullLog.finishCreate
     def finishCreate(self):
         pass
@@ -2236,8 +2230,7 @@ class StringTextWrapper:
     #@+node:ekr.20140903172510.18592: *4* stw.appendText
     def appendText(self, s):
         """StringTextWrapper."""
-        self.s = self.s + g.toUnicode(s)
-            # defensive
+        self.s = self.s + g.toUnicode(s)  # defensive
         self.ins = len(self.s)
         self.sel = self.ins, self.ins
     #@+node:ekr.20140903172510.18593: *4* stw.delete

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -149,8 +149,8 @@ def check_cmd_instance_dict(c: Cmdr, g: Any) -> None:
     d = cmd_instance_dict
     for key in d:
         ivars = d.get(key)
+        # Produces warnings.
         obj = ivars2instance(c, g, ivars)  # type:ignore
-            # Produces warnings.
         if obj:
             name = obj.__class__.__name__
             if name != key:
@@ -313,8 +313,7 @@ g_tabwidth_pat = re.compile(r'(^@tabwidth)', re.MULTILINE)
 g_section_delims_pat = re.compile(r'^@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*$')
 #@-<< define regex's >>
 tree_popup_handlers: List[Callable] = []  # Set later.
-user_dict: Dict[Any, Any] = {}
-    # Non-persistent dictionary for free use by scripts and plugins.
+user_dict: Dict[Any, Any] = {}  # Non-persistent dictionary for scripts and plugins.
 app: Any = None  # The singleton app object. Set by runLeo.py.
 # Global status vars.
 inScript = False  # A synonym for app.inScript
@@ -384,8 +383,7 @@ class BindingInfo:
         self.func = func
         self.nextMode = nextMode
         self.pane = pane
-        self.stroke = stroke
-            # The *caller* must canonicalize the shortcut.
+        self.stroke = stroke  # The *caller* must canonicalize the shortcut.
     #@+node:ekr.20120203153754.10031: *4* bi.__hash__
     def __hash__(self) -> Any:
         return self.stroke.__hash__() if self.stroke else 0
@@ -485,9 +483,8 @@ class EmergencyDialog:
         self.title = title
         self.message = message
         self.buttonsFrame = None  # Frame to hold typical dialog buttons.
+        # Command to call when user click's the window's close box.
         self.defaultButtonCommand = None
-            # Command to call when user closes the window
-            # by clicking the close box.
         self.frame = None  # The outermost frame.
         self.root = None  # Created in createTopFrame.
         self.top = None  # The toplevel Tk widget.
@@ -664,12 +661,11 @@ class KeyStroke:
     #@+node:ekr.20180415082249.1: *4* ks.finalize_binding
     def finalize_binding(self, binding: str) -> str:
 
+        # This trace is good for devs only.
         trace = False and 'keys' in g.app.debug
-            # This trace is good for devs only.
         self.mods = self.find_mods(binding)
         s = self.strip_mods(binding)
-        s = self.finalize_char(s)
-            # May change self.mods.
+        s = self.finalize_char(s)  # May change self.mods.
         mods = ''.join([f"{z.capitalize()}+" for z in self.mods])
         if trace and 'meta' in self.mods:
             g.trace(f"{binding:20}:{self.mods:>20} ==> {mods+s}")
@@ -1425,22 +1421,22 @@ class PosList(list):
 
         This is deprecated, use leoNodes.PosList instead!
 
+        # Creates a PosList containing all positions in c.
         aList = g.PosList(c)
-            # Creates a PosList containing all positions in c.
 
+        # Creates a PosList from aList2.
         aList = g.PosList(c,aList2)
-            # Creates a PosList from aList2.
 
+        # Creates a PosList containing all positions p in aList
+        # such that p.h matches the pattern.
+        # The pattern is a regular expression if regex is True.
+        # if removeClones is True, all positions p2 are removed
+        # if a position p is already in the list and p2.v == p.v.
         aList2 = aList.select(pattern,regex=False,removeClones=True)
-            # Creates a PosList containing all positions p in aList
-            # such that p.h matches the pattern.
-            # The pattern is a regular expression if regex is True.
-            # if removeClones is True, all positions p2 are removed
-            # if a position p is already in the list and p2.v == p.v.
 
+        # Prints all positions in aList, sorted if sort is True.
+        # Prints p.h, or repr(p) if verbose is True.
         aList.dump(sort=False,verbose=False)
-            # Prints all positions in aList, sorted if sort is True.
-            # Prints p.h, or repr(p) if verbose is True.
     """
     #@-<< docstring for PosList >>
     #@+others
@@ -2086,8 +2082,7 @@ class TkIDDialog(EmergencyDialog):
     #@+node:ekr.20191013150158.1: *4* leo_id_dialog.okButton
     def okButton(self) -> None:
         """Do default click action in ok button."""
-        self.val = self.entry.get()
-            # Return is not possible.
+        self.val = self.entry.get()  # Return is not possible.
         self.top.destroy()
         self.top = None
     #@-others
@@ -3385,8 +3380,8 @@ def get_directives_dict_list(p: Pos) -> List[Dict]:
     result = []
     p1 = p.copy()
     for p in p1.self_and_parents(copy=False):
+        # No copy necessary: g.get_directives_dict does not change p.
         root = None if p.hasParent() else [p]
-            # No copy necessary: g.get_directives_dict does not change p.
         result.append(g.get_directives_dict(p, root=root))
     return result
 #@+node:ekr.20111010082822.15545: *3* g.getLanguageFromAncestorAtFileNode
@@ -3881,8 +3876,7 @@ def fullPath(c: Cmdr, p: Pos, simulate: bool=False) -> str:
     for p in p.self_and_parents(copy=False):
         aList = g.get_directives_dict_list(p)
         path = c.scanAtPathDirectives(aList)
-        fn = p.h if simulate else p.anyAtFileNodeName()
-            # Use p.h for unit tests.
+        fn = p.h if simulate else p.anyAtFileNodeName()  # Use p.h for unit tests.
         if fn:
             # Fix #102: expand path expressions.
             fn = c.expand_path_expression(fn)  # #1341.
@@ -4682,8 +4676,8 @@ def find_on_line(s: str, i: int, pattern: str) -> int:
 def is_special(s: str, directive: str) -> Tuple[bool, int]:
     """Return True if the body text contains the @ directive."""
     assert(directive and directive[0] == '@')
+    # Most directives must start the line.
     lws = directive in ("@others", "@all")
-        # Most directives must start the line.
     pattern_s = r'^\s*(%s\b)' if lws else r'^(%s\b)'
     pattern = re.compile(pattern_s % directive, re.MULTILINE)
     m = re.search(pattern, s)
@@ -5169,10 +5163,10 @@ def gitDescribe(path: str=None) -> Tuple[str, str, str]:
     This function returns ('x-leo-v5.6', '55', 'e1129da')
     """
     describe = g.execGitCommand('git describe --tags --long', path)
+    # rsplit not split, as '-' might be in tag name.
     tag, distance, commit = describe[0].rsplit('-', 2)
-        # rsplit not split, as '-' might be in tag name
     if 'g' in commit[0:]:
-        # leading 'g' isn't part of the commit hash
+        # leading 'g' isn't part of the commit hash.
         commit = commit[1:]
     commit = commit.rstrip()
     return tag, distance, commit
@@ -5423,8 +5417,8 @@ def import_module(name: str, package: str=None) -> Any:
         if trace:
             t, v, tb = sys.exc_info()
             del tb  # don't need the traceback
+            # In case v is empty, we'll at least have the execption type
             v = v or str(t)  # type:ignore
-                # # in case v is empty, we'll at least have the execption type
             if v not in exceptions:
                 exceptions.append(v)
                 g.trace(f"Can not import {name}: {e}")
@@ -6183,8 +6177,8 @@ def es_print(*args: Any, **keys: Any) -> None:
 #@+node:ekr.20111107181638.9741: *3* g.print_exception
 def print_exception(full: bool=True, c: Cmdr=None, flush: bool=False, color: str="red") -> Tuple[str, int]:
     """Print exception info about the last exception."""
+    # val is the second argument to the raise statement.
     typ, val, tb = sys.exc_info()
-        # val is the second argument to the raise statement.
     if full:
         lines = traceback.format_exception(typ, val, tb)
     else:
@@ -6226,15 +6220,14 @@ def goto_last_exception(c: Cmdr) -> None:
     typ, val, tb = sys.exc_info()
     if tb:
         file_name, line_number = g.getLastTracebackFileAndLineNumber()
-        line_number = max(0, line_number - 1)
-            # Convert to zero-based.
+        line_number = max(0, line_number - 1)  # Convert to zero-based.
         if file_name.endswith('scriptFile.py'):
             # A script.
             c.goToScriptLineNumber(line_number, c.p)
         else:
             for p in c.all_nodes():
                 if p.isAnyAtFileNode() and p.h.endswith(file_name):
-                    c.goToLineNumber(line_number)  # 2021/07/28: fixed by mypy.
+                    c.goToLineNumber(line_number)
                     return
     else:
         g.trace('No previous exception')
@@ -6273,8 +6266,8 @@ def pr(*args: Any, **keys: Any) -> None:
     d = {'commas': False, 'newline': True, 'spaces': True}
     d = doKeywordArgs(keys, d)
     newline = d.get('newline')
+    # Unit tests require sys.stdout.
     stdout = sys.stdout if sys.stdout and g.unitTesting else sys.__stdout__
-        # Unit tests require sys.stdout.
     if not stdout:
         # #541.
         return
@@ -6285,12 +6278,10 @@ def pr(*args: Any, **keys: Any) -> None:
         encoding = stdout.encoding
     else:
         encoding = 'utf-8'
-    s = translateArgs(args, d)
-        # Translates everything to unicode.
+    s = translateArgs(args, d)  # Translates everything to unicode.
     s = g.toUnicode(s, encoding=encoding, reportErrors=False)
     if newline:
         s += '\n'
-    #
     # Python's print statement *can* handle unicode, but
     # sitecustomize.py must have sys.setdefaultencoding('utf-8')
     try:
@@ -7028,8 +7019,7 @@ def getDocStringForFunction(func: Any) -> str:
             s = func.__doc__
     if not s and name(func) == 'commonCommandCallback':
         script = get_defaults(func, 1)
-        s = g.getDocString(script)
-            # Do a text scan for the function.
+        s = g.getDocString(script)  # Do a text scan for the function.
     # Now the general cases.  Prefer __doc__ to docstring()
     if not s and hasattr(func, '__doc__'):
         s = func.__doc__
@@ -7326,8 +7316,8 @@ def composeScript(
         script = at.stringToString(p.copy(), s,
             forcePythonSentinels=forcePythonSentinels,
             sentinels=useSentinels)
+        # Important, the script is an **encoded string**, not a unicode string.
         script = script.replace("\r\n", "\n")  # Use brute force.
-            # Important, the script is an **encoded string**, not a unicode string.
         g.app.scriptDict["script2"] = script
     finally:
         g.app.inScript = g.inScript = old_in_script
@@ -7886,8 +7876,7 @@ def openUrlHelper(event: Any, url: str=None) -> Optional[str]:
                     return None
     elif not isinstance(url, str):
         url = url.toString()
-        url = g.toUnicode(url)
-            # Fix #571
+        url = g.toUnicode(url)  # #571
     if url and g.isValidUrl(url):
         # Part 2: handle the url
         p = c.p

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -53,9 +53,7 @@ else:
 # Abbreviations...
 StringIO = io.StringIO
 #@-<< imports >>
-in_bridge = False
-    # Set to True in leoBridge.py just before importing leo.core.leoApp.
-    # This tells leoApp to load a null Gui.
+in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.6'  # #1215.
 isPython3 = sys.version_info >= (3, 0, 0)

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -34,8 +34,7 @@ class LeoGui:
         self.leoIcon = None
         self.mGuiName = guiName
         self.mainLoop = None
-        self.plainTextWidget = None
-            # For SpellTabHandler class only.
+        self.plainTextWidget = None  # For SpellTabHandler class only.
         self.root = None
         self.script = None
         self.splashScreen = None
@@ -44,12 +43,9 @@ class LeoGui:
         self.ScriptingControllerClass = NullScriptingControllerClass
         #
         # Define special keys that may be overridden is subclasses.
-        self.ignoreChars = []
-            # Keys that are always to be ignore.
-        self.FKeys = []
-            # The representation of F-keys.
-        self.specialChars = []
-            # A list of characters/keys to be handle specially.
+        self.ignoreChars = []  # Keys that should always be ignored.
+        self.FKeys = []  # The representation of F-keys.
+        self.specialChars = []  # A list of characters/keys to be handle specially.
     #@+node:ekr.20061109212618.1: *3* LeoGui: Must be defined only in base class
     #@+node:ekr.20110605121601.18847: *4* LeoGui.create_key_event (LeoGui)
     def create_key_event(self, c,
@@ -306,8 +302,7 @@ class NullGui(LeoGui):
         self.clipboardContents = ''
         self.focusWidget = None
         self.script = None
-        self.lastFrame = None
-            # The outer frame, used only to set the g.app.log in runMainLoop.
+        self.lastFrame = None  # The outer frame, to set g.app.log in runMainLoop.
         self.isNullGui = True
         self.idleTimeClass = g.NullObject
     #@+node:ekr.20031218072017.3744: *3* NullGui.dialogs

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -83,32 +83,21 @@ class InternalIPKernel:
     #@+node:ekr.20130930062914.15994: *3* ileo.__init__
     def __init__(self, backend='qt'):
         """Ctor for InternalIPKernal class."""
-        #
         # Part 1: create the ivars.
-        self.consoles = []
-            # List of Qt consoles.
-        self.kernelApp = None
-            # The IPKernelApp instance, a subclass of
-            # BaseIPythonApplication, InteractiveShellApp, ConnectionFileMixin
-        self.namespace = None
-            # Inited below.
+        self.consoles = []  # List of Qt consoles.
+        self.kernelApp = None  # The IPKernelApp instance.
+        self.namespace = None  # Inited below.
+        # Keys present at startup so we don't print the entire pylab/numpy
+        # namespace when the user clicks the 'namespace' button
         self._init_keys = None
-            # Keys present at startup so we don't print the entire pylab/numpy
-            # namespace when the user clicks the 'namespace' button
-        #
-        # Part 2: Init the kernel and init the ivars.
-        kernelApp = self.pylab_kernel(backend)
+        # Start IPython kernel with GUI event loop and pylab support.
+        kernelApp = self.pylab_kernel(backend)  # Sets self.kernelApp.
         assert kernelApp == self.kernelApp
-            # Sets self.kernelApp.
-            # Start IPython kernel with GUI event loop and pylab support
-        self.namespace = kernelApp.shell.user_ns
-            # Import the shell namespace.
+        self.namespace = kernelApp.shell.user_ns  # Import the shell namespace.
         self._init_keys = set(self.namespace.keys())
         if 'ipython' in g.app.debug:
             self.namespace['kernelApp'] = kernelApp
             self.namespace['app_counter'] = 0
-            # Example: a variable that will be seen by the user in the shell, and
-            # that the GUI modifies (the 'Counter++' button increments it)
     #@+node:ekr.20130930062914.15998: *3* ileo.cleanup_consoles
     def cleanup_consoles(self, event=None):
         """Kill all ipython consoles.  Called from app.finishQuit."""
@@ -138,12 +127,10 @@ class InternalIPKernel:
             self.put_log('new_qt_console: connecting...')
             self.put_log(self.kernelApp.connection_file, raw=True)
         try:
-            # #213: leo --ipython fails to connect with python3.5 and jupyter
-            #
+            # #213: leo --ipython fails to connect with python3.5 and jupyter.
             # The connection file has the form kernel-nnn.json.
             # Using the defaults lets connect_qtconsole find the .json file.
-            console = connect_qtconsole()
-                # ipykernel.connect.connect_qtconsole
+            console = connect_qtconsole()  # ipykernel.connect.connect_qtconsole
             if console:
                 if trace:
                     g.trace('console:', console)
@@ -204,35 +191,34 @@ class InternalIPKernel:
     #@+node:ekr.20130930062914.15992: *3* ileo.pylab_kernel
     def pylab_kernel(self, gui):
         """Launch an IPython kernel with pylab support for the gui."""
-        trace = False and not g.unitTesting
-            # Increased logging.
+        trace = False and not g.unitTesting  # Increased logging.
+        # IPKernalApp is a singleton class.
+        # Return the singleton instance, creating it if necessary.
         self.kernelApp = kernelApp = IPKernelApp.instance()
-            # IPKernalApp is a singleton class.
-            # Return the singleton instance, creating it if necessary.
-        if kernelApp:
-            # --pylab is no longer needed to create a qt console.
-            # --pylab=qt now generates:
-                # RuntimeError: Cannot activate multiple GUI eventloops
-                # GUI event loop or pylab initialization failed
-            args = ['python', '--pylab']
-                # Fails
-                # args = ['python', '--pylab=%s' % (gui)]
-            if trace:
-                args.append('--log-level=20')
-                    # Higher is *quieter*
-                # args.append('--debug')
-                # Produces a verbose IPython log.
-                #'--log-level=10'
-                # '--pdb', # User-level debugging
-            try:
-                # self.pdb()
-                kernelApp.initialize(args)
-            except Exception:
-                sys.stdout = sys.__stdout__
-                print('kernelApp.initialize failed!')
-                raise
-        else:
+        if not kernelApp:
             g.trace('IPKernelApp.instance failed!')
+            return None
+
+        # --pylab is no longer needed to create a qt console.
+        # --pylab=qt now generates:
+            # RuntimeError: Cannot activate multiple GUI eventloops
+            # GUI event loop or pylab initialization failed
+
+        # Fails: args = ['python', '--pylab=%s' % (gui)]
+        args = ['python', '--pylab']
+        if trace:
+            args.append('--log-level=20')  # Higher is *quieter*
+            # args.append('--debug')
+            # Produces a verbose IPython log.
+            #'--log-level=10'
+            # '--pdb', # User-level debugging
+        try:
+            # self.pdb()
+            kernelApp.initialize(args)
+        except Exception:
+            sys.stdout = sys.__stdout__
+            print('kernelApp.initialize failed!')
+            raise
         return kernelApp
     #@+node:ekr.20190927100624.1: *3* ileo.run
     def run(self):
@@ -248,9 +234,9 @@ class InternalIPKernel:
         """
         # https://ipython.org/ipython-doc/dev/interactive/qtconsole.html
         # https://github.com/ipython/ipython/blob/master/IPython/core/interactiveshell.py
+        # A ZMQInteractiveShell, defined in ipkernel.zmqshell.py,
+        # a subclass of InteractiveShell, defined in ipython.core.interactiveshell.py.
         shell = self.kernelApp.shell
-            # A ZMQInteractiveShell, defined in ipkernel.zmqshell.py,
-            # a subclass of InteractiveShell, defined in ipython.core.interactiveshell.py.
         try:
             code = compile(script, file_name, 'exec')
             exec(code, shell.user_global_ns, shell.user_ns)
@@ -279,10 +265,8 @@ class LeoNameSpace:
 
     def __init__(self):
         """LeoNameSpace ctor."""
-        self.commander = None
-            # The commander returned by the c property.
-        self.commanders_list = []
-            # The list of commanders returned by the commanders property.
+        self.commander = None  # The commander returned by the c property.
+        self.commanders_list = []  # The list of commanders returned by the commanders property.
         self.g = g
         self.update()
     #@+others

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -467,8 +467,7 @@ class LeoImportCommands:
         self.setEncoding()
         firstLevel = p.level()
         try:
-            theFile = open(fileName, 'wb')
-                # Fix crasher: open in 'wb' mode.
+            theFile = open(fileName, 'wb')  # Fix crasher: open in 'wb' mode.
         except IOError:
             g.warning("can not open", fileName)
             return
@@ -639,8 +638,7 @@ class LeoImportCommands:
         """
         c = self.c
         p = parent.copy()
-        self.treeType = '@file'
-            # Fix #352.
+        self.treeType = '@file'  # Fix #352.
         fileName = g.fullPath(c, parent)
         if g.is_binary_external_file(fileName):
             return self.import_binary_file(fileName, parent)
@@ -652,9 +650,8 @@ class LeoImportCommands:
         ext, s = self.init_import(ext, fileName, s)
         if s is None:
             return None
-        # Get the so-called scanning func.
+        # The so-called scanning func is a callback. It must have a c argument.
         func = self.dispatch(ext, p)
-            # Func is a callback. It must have a c argument.
         # Call the scanning function.
         if g.unitTesting:
             assert func or ext in ('.txt', '.w', '.xxx'), (repr(func), ext, p.h)
@@ -1769,8 +1766,7 @@ class RecursiveImportController:
             verbose=self.verbose,  # Leo 6.6.
         )
         p = parent.lastChild()
-        p.h = self.kind + p.h[5:]
-            # Bug fix 2017/10/27: honor the requested kind.
+        p.h = self.kind + p.h[5:]  # Honor the requested kind.
         if self.safe_at_file:
             p.v.h = '@' + p.v.h
     #@+node:ekr.20130823083943.12607: *4* ric.post_process & helpers
@@ -1974,8 +1970,7 @@ class TabImporter:
         c = self.c
         # Self.root can be None if we are called from a script or unit test.
         if not self.root:
-            last = root if root else c.lastTopLevel()
-                # For unit testing.
+            last = root if root else c.lastTopLevel()  # For unit testing.
             self.root = last.insertAfter()
             if fn:
                 self.root.h = fn

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -163,24 +163,17 @@ class AutoCompleterClass:
         self.c = k.c
         self.k = k
         self.language = None
+        # additional namespaces to search for objects, other code
+        # can append namespaces to this to extend scope of search
         self.namespaces = []
-            # additional namespaces to search for objects, other code
-            # can append namespaces to this to extend scope of search
-        self.qw = None
-            # The object that supports qcompletion methods.
-        self.tabName = None
-            # The name of the main completion tab.
-        self.verbose = False
-            # True: print all members, regardless of how many there are.
-        self.w = None
-            # The widget that gets focus after autocomplete is done.
-        self.warnings = {}
-            # Keys are language names.
+        self.qw = None  # The object that supports qcompletion methods.
+        self.tabName = None  # The name of the main completion tab.
+        self.verbose = False  # True: print all members, regardless of how many there are.
+        self.w = None  # The widget that gets focus after autocomplete is done.
+        self.warnings = {}  # Keys are language names.
         # Codewise pre-computes...
-        self.codewiseSelfList = []
-            # The (global) completions for "self."
-        self.completionsDict = {}
-            # Keys are prefixes, values are completion lists.
+        self.codewiseSelfList = []  # The (global) completions for "self."
+        self.completionsDict = {}  # Keys are prefixes, values are completion lists.
         self.reloadSettings()
 
     def reloadSettings(self):
@@ -188,9 +181,9 @@ class AutoCompleterClass:
         self.auto_tab = c.config.getBool('auto-tab-complete', True)
         self.forbid_invalid = c.config.getBool('forbid-invalid-completions', False)
         self.use_jedi = c.config.getBool('use-jedi', False)
+        # True: show results in autocompleter tab.
+        # False: show results in a QCompleter widget.
         self.use_qcompleter = c.config.getBool('use-qcompleter', False)
-            # True: show results in autocompleter tab.
-            # False: show results in a QCompleter widget.
     #@+node:ekr.20061031131434.8: *3* ac.Top level
     #@+node:ekr.20061031131434.9: *4* ac.autoComplete
     @ac_cmd('auto-complete')
@@ -849,8 +842,7 @@ class AutoCompleterClass:
         # Compute the prefix and the list of options.
         prefix = self.get_autocompleter_prefix()
         options = self.get_completions(prefix)
-        w = self.c.frame.body.wrapper.widget
-            # A LeoQTextBrowser.  May be none for unit tests.
+        w = self.c.frame.body.wrapper.widget  # A LeoQTextBrowser.  May be none for unit tests.
         if w and options:
             self.qw = w
             self.qcompleter = w.init_completer(options)
@@ -1364,8 +1356,7 @@ class GetArg:
         handler = c.commandsDict.get(commandName)
         if hasattr(handler, 'tab_callback'):
             self.reset_tab_cycling()
-            k.functionTail = tail
-                # For k.getFileName.
+            k.functionTail = tail  # For k.getFileName.
             handler.tab_callback()
             return True
         return False
@@ -1660,18 +1651,12 @@ class KeyHandlerClass:
         """Create a key handler for c."""
         self.c = c
         self.dispatchEvent = None
-        self.fnc = None
-            # A singleton defined in k.finishCreate.
-        self.getArgInstance = None
-            # A singleton defined in k.finishCreate.
-        self.inited = False
-            # Set at end of finishCreate.
-        self.killedBindings = []
-            # A list of commands whose bindings have been set to None in the local file.
-        self.replace_meta_with_alt = False
-            # True: (Mac only) swap Meta and Alt keys.
-        self.w = None
-            # Note: will be None for NullGui.
+        self.fnc = None  # A singleton defined in k.finishCreate.
+        self.getArgInstance = None  # A singleton defined in k.finishCreate.
+        self.inited = False  # Set at end of finishCreate.
+        self.killedBindings = []  # A list of commands whose bindings have been set to None in the local file.
+        self.replace_meta_with_alt = False  # True: (Mac only) swap Meta and Alt keys.
+        self.w = None  # Will be None for NullGui.
         # Generalize...
         self.x_hasNumeric = ['sort-lines', 'sort-fields']
         self.altX_prompt = 'full-command: '
@@ -1704,23 +1689,18 @@ class KeyHandlerClass:
     #@+node:ekr.20061031131434.79: *5* k.defineInternalIvars
     def defineInternalIvars(self):
         """Define internal ivars of the KeyHandlerClass class."""
-        self.abbreviationsDict = {}
-            # Abbreviations created by @alias nodes.
+        self.abbreviationsDict = {}  # Abbreviations created by @alias nodes.
         # Previously defined bindings...
-        self.bindingsDict = {}
-            # Keys are Tk key names, values are lists of BindingInfo objects.
+        self.bindingsDict = {} # Keys are Tk key names, values are lists of BindingInfo objects.
         # Previously defined binding tags.
-        self.bindtagsDict = {}
-            # Keys are strings (the tag), values are 'True'
+        self.bindtagsDict = {}  # Keys are strings (the tag), values are 'True'
         self.commandHistory = []
-        self.commandIndex = 0
-            # List/stack of previously executed commands.
-            # Up arrow will select commandHistory[commandIndex]
+        # Up arrow will select commandHistory[commandIndex]
+        self.commandIndex = 0  # List/stack of previously executed commands.
+        # Keys are scope names: 'all','text',etc. or mode names.
+        # Values are dicts: keys are strokes, values are BindingInfo objects.
         self.masterBindingsDict = {}
-            # Keys are scope names: 'all','text',etc. or mode names.
-            # Values are dicts: keys are strokes, values are BindingInfo objects.
-        self.masterGuiBindingsDict = {}
-            # Keys are strokes; value is True;
+        self.masterGuiBindingsDict = {}  # Keys are strokes; value is True.
         # Special bindings for k.fullCommand...
         self.mb_copyKey = None
         self.mb_pasteKey = None
@@ -1937,15 +1917,12 @@ class KeyHandlerClass:
         c.commandsDict has been created when this is called.
         """
         c, k = self.c, self
-        k.w = c.frame.miniBufferWidget
-            # Will be None for NullGui.
-        k.fnc = FileNameChooser(c)
-            # A singleton. Defined here so that c.k will exist.
-        k.getArgInstance = GetArg(c)
-            # a singleton. Defined here so that c.k will exist.
+        k.w = c.frame.miniBufferWidget  # Will be None for NullGui.
+        k.fnc = FileNameChooser(c)  # A singleton. Defined here so that c.k will exist.
+        k.getArgInstance = GetArg(c)  # A singleton. Defined here so that c.k will exist.
+        # Important: This must be called this now,
+        # even though LM.load calls g.app.makeAllBindings later.
         k.makeAllBindings()
-            # Important: This must be called this now,
-            # even though LM.laod calls g.app.makeAllBindings later.
         k.initCommandHistory()
         k.inited = True
         k.setDefaultInputState()
@@ -2966,13 +2943,11 @@ class KeyHandlerClass:
                     pane = bi.pane  # 2015/05/11.
                     break
         if stroke:
-            k.bindKey(pane, stroke, func, commandName, tag='register-command')
-                # Must be a stroke.
+            k.bindKey(pane, stroke, func, commandName, tag='register-command')  # Must be a stroke.
             k.makeMasterGuiBinding(stroke)  # Must be a stroke.
         # Fixup any previous abbreviation to press-x-button commands.
         if commandName.startswith('press-') and commandName.endswith('-button'):
-            d = c.config.getAbbrevDict()
-                # Keys are full command names, values are abbreviations.
+            d = c.config.getAbbrevDict()  # Keys are full command names, values are abbreviations.
             if commandName in list(d.values()):
                 for key in d:
                     if d.get(key) == commandName:
@@ -3122,7 +3097,6 @@ class KeyHandlerClass:
         Handle mode bindings.
         Return True if k.masterKeyHandler should return.
         """
-        #
         # #1757: Leo's default vim bindings make heavy use of modes.
         #        Retain these traces!
         trace = 'keys' in g.app.debug
@@ -3131,7 +3105,6 @@ class KeyHandlerClass:
         stroke = event.stroke
         if not k.inState():
             return False
-        #
         # First, honor minibuffer bindings for all except user modes.
         if state == 'input-shortcut':
             k.handleInputShortcut(event, stroke)
@@ -3145,9 +3118,7 @@ class KeyHandlerClass:
                 if trace:
                     g.trace(state, 'k.handleMiniBindings', stroke)
                 return True
-        #
         # Second, honor general modes.
-        #
         if state == 'getArg':
             # New in Leo 5.8: Only call k.getArg for keys it can handle.
             if k.isPlainKey(stroke):
@@ -3167,18 +3138,15 @@ class KeyHandlerClass:
                 g.trace(state, 'k.getFileName', stroke)
             return True
         if state in ('full-command', 'auto-complete'):
+            # Do the default state action. Calls end-command.
             val = k.callStateFunction(event)
-                # Do the default state action.
-                # Calls end-command.
             if val != 'do-standard-keys':
                 handler = k.state.handler and k.state.handler.__name__ or '<no handler>'
                 if trace:
                     g.trace(state, 'k.callStateFunction:', handler, stroke)
                 return True
             return False
-        #
         # Third, pass keys to user modes.
-        #
         d = k.masterBindingsDict.get(state)
         if d:
             assert g.isStrokeOrNone(stroke)
@@ -3196,9 +3164,7 @@ class KeyHandlerClass:
             # Unbound keys end mode.
             k.endMode()
             return False
-        #
         # Fourth, call the state handler.
-        #
         handler = k.getStateHandler()
         if handler:
             handler(event)
@@ -3910,17 +3876,15 @@ class KeyHandlerClass:
     #@+node:ekr.20061031131434.176: *4* k.computeInverseBindingDict
     def computeInverseBindingDict(self):
         k = self
-        d = {}
-            # keys are minibuffer command names, values are shortcuts.
+        d = {}  # keys are minibuffer command names, values are shortcuts.
         for stroke in k.bindingsDict:
             assert g.isStroke(stroke), repr(stroke)
             aList = k.bindingsDict.get(stroke, [])
             for bi in aList:
                 shortcutList = k.bindingsDict.get(bi.commandName, [])
-                    # Bug fix: 2017/03/26.
                 bi_list = k.bindingsDict.get(
                     stroke, g.BindingInfo(kind='dummy', pane='all'))
-                    # Important: only bi.pane is required below.
+                # Important: only bi.pane is required below.
                 for bi in bi_list:
                     pane = f"{bi.pane}:"
                     data = (pane, stroke)
@@ -4180,8 +4144,7 @@ class ModeInfo:
     def enterMode(self):
 
         c, k = self.c, self.k
-        c.inCommand = False
-            # Allow inner commands in the mode.
+        c.inCommand = False  # Allow inner commands in the mode.
         event = None
         k.generalModeHandler(event, modeName=self.name)
     #@+node:ekr.20120208064440.10153: *3* mode_i.init

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1691,7 +1691,7 @@ class KeyHandlerClass:
         """Define internal ivars of the KeyHandlerClass class."""
         self.abbreviationsDict = {}  # Abbreviations created by @alias nodes.
         # Previously defined bindings...
-        self.bindingsDict = {} # Keys are Tk key names, values are lists of BindingInfo objects.
+        self.bindingsDict = {}  # Keys are Tk key names, values are lists of BindingInfo objects.
         # Previously defined binding tags.
         self.bindtagsDict = {}  # Keys are strings (the tag), values are 'True'
         self.commandHistory = []

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -330,9 +330,9 @@ class MarkupCommands:
         global asciidoctor_exec, asciidoc3_exec
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         # Call the external program to write the output file.
+        # The -e option deletes css.
         prog = 'asciidoctor' if asciidoctor_exec else 'asciidoc3'
         command = f"{prog} {i_path} -o {o_path} -b html5"
-            # The -e option deletes css.
         g.execute_shell_commands(command)
     #@+node:ekr.20191007043043.1: *4* markup.run_pandoc
     def run_pandoc(self, i_path, o_path):
@@ -342,8 +342,8 @@ class MarkupCommands:
         global pandoc_exec
         assert pandoc_exec, g.callers()
         # Call pandoc to write the output file.
+        # --quiet does no harm.
         command = f"pandoc {i_path} -t html5 -o {o_path}"
-            # --quiet does no harm.
         g.execute_shell_commands(command)
     #@+node:ekr.20191017165427.1: *4* markup.run_sphinx
     def run_sphinx(self, i_path, o_path):

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -226,7 +226,7 @@ class LeoMenu:
         if name2.startswith('recentfiles'):
             # Just create the menu.
             # createRecentFilesMenuItems will create the contents later.
-            g.app.recentFilesManager.recentFilesMenuName = alt_name or name # #848
+            g.app.recentFilesManager.recentFilesMenuName = alt_name or name  # #848
             self.createNewMenu(alt_name or name, parentName)
             return True
         if name2 == 'help' and g.isMac:

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -148,9 +148,9 @@ class LeoMenu:
             if kind.startswith('@menu'):
                 name = kind[len('@menu') :].strip()
                 if not self.handleSpecialMenus(name, parentName=None):
-                    # Fix #528: Don't create duplicate menu items.
+                    # #528: Don't create duplicate menu items.
+                    # Create top-level menu.
                     menu = self.createNewMenu(name)
-                        # Create top-level menu.
                     if menu:
                         self.createMenuFromConfigList(name, val, level=0)
                     else:
@@ -192,8 +192,8 @@ class LeoMenu:
                     alt_name=val2,  #848.
                     table=table,
                 ):
+                    # Create submenu of parent menu.
                     menu = self.createNewMenu(name, parentName)
-                        # Create submenu of parent menu.
                     if menu:
                         # Partial fix for #528.
                         self.createMenuFromConfigList(name, val, level + 1)
@@ -226,8 +226,7 @@ class LeoMenu:
         if name2.startswith('recentfiles'):
             # Just create the menu.
             # createRecentFilesMenuItems will create the contents later.
-            g.app.recentFilesManager.recentFilesMenuName = alt_name or name
-                #848
+            g.app.recentFilesManager.recentFilesMenuName = alt_name or name # #848
             self.createNewMenu(alt_name or name, parentName)
             return True
         if name2 == 'help' and g.isMac:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -72,8 +72,7 @@ class NodeIndices:
     #@+node:ekr.20200528131303.1: *3* ni.computeNewIndex
     def computeNewIndex(self) -> str:
         """Return a new gnx."""
-        t_s = self.update()
-            # Updates self.lastTime and self.lastIndex.
+        t_s = self.update()  # Updates self.lastTime and self.lastIndex.
         gnx = g.toUnicode(f"{self.userId}.{t_s}.{self.lastIndex:d}")
         return gnx
     #@+node:ekr.20031218072017.1995: *3* ni.getNewIndex
@@ -87,8 +86,7 @@ class NodeIndices:
             return ''
         c = v.context
         fc = c.fileCommands
-        t_s = self.update()
-            # Updates self.lastTime and self.lastIndex.
+        t_s = self.update()  # Updates self.lastTime and self.lastIndex.
         gnx = g.toUnicode(f"{self.userId}.{t_s}.{self.lastIndex:d}")
         v.fileIndex = gnx
         self.check_gnx(c, gnx, v)
@@ -823,8 +821,7 @@ class Position:
     def hasNext(self) -> bool:
         p = self
         try:
-            parent_v = p._parentVnode()
-                # Returns None if p.v is None.
+            parent_v = p._parentVnode()  # Returns None if p.v is None.
             return p.v and parent_v and p._childIndex + 1 < len(parent_v.children)  # type:ignore
         except Exception:  # pragma: no cover
             g.trace('*** Unexpected exception')
@@ -837,8 +834,8 @@ class Position:
 
     def hasThreadBack(self) -> bool:
         p = self
+        # Much cheaper than computing the actual value.
         return bool(p.hasParent() or p.hasBack())
-            # Much cheaper than computing the actual value.
     #@+node:ekr.20080416161551.193: *5* p.hasThreadNext (the only complex hasX method)
     def hasThreadNext(self) -> bool:
         p = self
@@ -1109,8 +1106,7 @@ class Position:
         """Unlink the receiver p from the tree."""
         p = self
         n = p._childIndex
-        parent_v = p._parentVnode()
-            # returns None if p.v is None
+        parent_v = p._parentVnode()  # returns None if p.v is None
         child = p.v
         assert p.v
         assert parent_v
@@ -1160,8 +1156,7 @@ class Position:
         """Move self to its previous sibling."""
         p = self
         n = p._childIndex
-        parent_v = p._parentVnode()
-            # Returns None if p.v is None.
+        parent_v = p._parentVnode()  # Returns None if p.v is None.
         # Do not assume n is in range: this is used by positionExists.
         if parent_v and p.v and 0 < n <= len(parent_v.children):
             p._childIndex -= 1
@@ -1207,8 +1202,7 @@ class Position:
         """Move a position to its next sibling."""
         p = self
         n = p._childIndex
-        parent_v = p._parentVnode()
-            # Returns None if p.v is None.
+        parent_v = p._parentVnode()  # Returns None if p.v is None.
         if p and not p.v:
             g.trace('no p.v:', p, g.callers())  # pragma: no cover
         if p.v and parent_v and len(parent_v.children) > n + 1:
@@ -1998,41 +1992,31 @@ class VNode:
         To support ZODB, the code must set v._p_changed = True whenever
         v.unknownAttributes or any mutable VNode object changes.
         """
-        # The primary data: headline and body text.
-        self._headString = 'newHeadline'
-        self._bodyString = ''
-        # For zodb.
-        self._p_changed = False
-        # Structure data...
-        self.children: List["VNode"] = []
-            # Ordered list of all children of this node.
-        self.parents: List["VNode"] = []
-            # Unordered list of all parents of this node.
-        # Other essential data...
+        self._headString = 'newHeadline'  # Headline.
+        self._bodyString = ''  # Body Text.
+        self._p_changed = False  # For zodb.
+        self.children: List["VNode"] = []  # Ordered list of all children of this node.
+        self.parents: List["VNode"] = []  # Unordered list of all parents of this node.
+        # The immutable fileIndex (gnx) for this node. Set below.
         self.fileIndex: Optional[str] = None
-            # The immutable fileIndex (gnx) for this node. Set below.
-        self.iconVal = 0
-            # The present value of the node's icon.
-        self.statusBits = 0
-            # status bits
+        self.iconVal = 0  # The present value of the node's icon.
+        self.statusBits = 0  # status bits
+
         # Information that is never written to any file...
-        self.context: Cmdr = context  # The context containing context.hiddenRootNode.
-            # Required so we can compute top-level siblings.
-            # It is named .context rather than .c to emphasize its limited usage.
-        self.expandedPositions: List[Position] = []
-            # Positions that should be expanded.
-        self.insertSpot: Optional[int] = None
-            # Location of previous insert point.
-        self.scrollBarSpot: Optional[int] = None
-            # Previous value of scrollbar position.
-        self.selectionLength = 0
-            # The length of the selected body text.
-        self.selectionStart = 0
-            # The start of the selected body text.
-        #
+
+        # The context containing context.hiddenRootNode.
+        # Required so we can compute top-level siblings.
+        # It is named .context rather than .c to emphasize its limited usage.
+        self.context: Cmdr = context
+        self.expandedPositions: List[Position] = []  # Positions that should be expanded.
+        self.insertSpot: Optional[int] = None  # Location of previous insert point.
+        self.scrollBarSpot: Optional[int] = None  # Previous value of scrollbar position.
+        self.selectionLength = 0  # The length of the selected body text.
+        self.selectionStart = 0  # The start of the selected body text.
+
         # For at.read logic.
         self.at_read: Dict[str, set] = {}
-        #
+
         # To make VNode's independent of Leo's core,
         # wrap all calls to the VNode ctor::
         #

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2242,7 +2242,7 @@ class VNode:
             return self._bodyString
         else:  # pragma: no cover
             # This message should never be printed and we want to avoid crashing here!
-            g.internalError(f"body not unicode: {self._bodyString!r}") 
+            g.internalError(f"body not unicode: {self._bodyString!r}")
             return g.toUnicode(self._bodyString)
     #@+node:ekr.20031218072017.3360: *4* v.Children
     #@+node:ekr.20031218072017.3362: *5* v.firstChild

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -39,8 +39,7 @@ class PersistenceDataController:
     def __init__(self, c):
         """Ctor for persistenceController class."""
         self.c = c
-        self.at_persistence = None
-            # The position of the @position node.
+        self.at_persistence = None  # The position of the @position node.
     #@+node:ekr.20140711111623.17793: *3* pd.Entry points
     #@+node:ekr.20140718153519.17731: *4* pd.clean
     def clean(self):
@@ -487,8 +486,8 @@ class PersistenceDataController:
     def unpickle(self, s):
         """Unhexlify and unpickle string s into p."""
         try:
+            # Throws TypeError if s is not a hex string.
             bin = binascii.unhexlify(g.toEncodedString(s))
-                # Throws TypeError if s is not a hex string.
             return pickle.loads(bin)
         except Exception:
             g.es_exception()

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -474,8 +474,8 @@ class LeoPluginsController:
             """True to call the top-level init function."""
             try:
                 # Indicate success only if init_result is True.
+                # Careful: this may throw an exception.
                 init_result = result.init()
-                    # Careful: this may throw an exception.
                 if init_result not in (True, False):
                     report(f"{moduleName}.init() did not return a bool")
                 if init_result:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -625,7 +625,7 @@ class LeoPluginsController:
             bunch = g.Bunch(fn=fn, moduleName=moduleName, tag='handler')
             aList = self.handlers.get(tag, [])
             aList.append(bunch)
-            self.handlers [tag] = aList
+            self.handlers[tag] = aList
     #@+node:ekr.20100908125007.6029: *4* plugins.registerHandler & registerOneHandler
     def registerHandler(self, tags, fn):
         """ Register one or more handlers"""

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -391,8 +391,7 @@ class ShadowController:
         x, at = self, self.c.atFileCommands
         at.errors = 0
         self.encoding = at.encoding
-        s = at.readFileToUnicode(old_private_file)
-            # Sets at.encoding and inits at.readLines.
+        s = at.readFileToUnicode(old_private_file)  # Sets at.encoding and inits at.readLines.
         old_private_lines = g.splitLines(s or '')  # #1466.
         s = at.readFileToUnicode(old_public_file)
         if at.encoding != self.encoding:
@@ -409,7 +408,7 @@ class ShadowController:
         marker = x.markerFromFileLines(old_private_lines, old_private_file)
         new_private_lines = x.propagate_changed_lines(
             old_public_lines, old_private_lines, marker)
-        # Important bug fix: Never create the private file here!
+        # Never create the private file here!
         fn = old_private_file
         exists = g.os_path_exists(fn)
         different = new_private_lines != old_private_lines

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -544,16 +544,16 @@ class Undoer:
         u = self
         if u.redoing or u.undoing:
             return
+        # createCommonBunch sets:
+        #   oldDirty = p.isDirty()
+        #   oldMarked = p.isMarked()
+        #   oldSel = w and w.getSelectionRange() or None
+        #   p = p.copy()
         bunch = u.createCommonBunch(p)
-            # Sets
-            # oldDirty = p.isDirty(),
-            # oldMarked = p.isMarked(),
-            # oldSel = w and w.getSelectionRange() or None,
-            # p = p.copy(),
-        # Set types & helpers
+        # Set types.
         bunch.kind = 'clone-marked-nodes'
         bunch.undoType = 'clone-marked-nodes'
-        # Set helpers
+        # Set helpers.
         bunch.undoHelper = u.undoCloneMarkedNodes
         bunch.redoHelper = u.redoCloneMarkedNodes
         bunch.newP = p.next()
@@ -564,16 +564,16 @@ class Undoer:
         u = self
         if u.redoing or u.undoing:
             return
+        # createCommonBunch sets:
+        #   oldDirty = p.isDirty()
+        #   oldMarked = p.isMarked()
+        #   oldSel = w and w.getSelectionRange() or None
+        #   p = p.copy()
         bunch = u.createCommonBunch(p)
-            # Sets
-            # oldDirty = p.isDirty(),
-            # oldMarked = p.isMarked(),
-            # oldSel = w and w.getSelectionRange() or None,
-            # p = p.copy(),
-        # Set types & helpers
+        # Set types.
         bunch.kind = 'copy-marked-nodes'
         bunch.undoType = 'copy-marked-nodes'
-        # Set helpers
+        # Set helpers.
         bunch.undoHelper = u.undoCopyMarkedNodes
         bunch.redoHelper = u.redoCopyMarkedNodes
         bunch.newP = p.next()
@@ -749,8 +749,7 @@ class Undoer:
     def beforeChangeBody(self, p):
         """Return data that gets passed to afterChangeBody."""
         w = self.c.frame.body.wrapper
-        bunch = self.createCommonBunch(p)
-            # Sets u.oldMarked, u.oldSel, u.p
+        bunch = self.createCommonBunch(p)  # Sets u.oldMarked, u.oldSel, u.p
         bunch.oldBody = p.b
         bunch.oldHead = p.h
         bunch.oldIns = w.getInsertPoint()
@@ -1530,12 +1529,12 @@ class Undoer:
         # Add the children to parent_v's children.
         n = u.p.childIndex() + 1
         old_children = parent_v.children[:]
+        # Add children up to the promoted nodes.
         parent_v.children = old_children[:n]
-            # Add children up to the promoted nodes.
+        # Add the promoted nodes.
         parent_v.children.extend(u.children)
-            # Add the promoted nodes.
+        # Add the children up to the promoted nodes.
         parent_v.children.extend(old_children[n:])
-            # Add the children up to the promoted nodes.
         # Remove the old children.
         u.p.v.children = []
         # Adjust the parent links in the moved children.
@@ -1878,10 +1877,10 @@ class Undoer:
         n = u.p.childIndex() + 1
         # Adjust the old parents children
         old_children = parent_v.children
+        # Add the nodes before the promoted nodes.
         parent_v.children = old_children[:n]
-            # Add the nodes before the promoted nodes.
+        # Add the nodes after the promoted nodes.
         parent_v.children.extend(old_children[n + len(u.children) :])
-            # Add the nodes after the promoted nodes.
         # Add the demoted nodes to v's children.
         u.p.v.children = u.children[:]
         # Adjust the parent links.

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -88,12 +88,12 @@ class VimCommands:
     #@+node:ekr.20140805130800.18162: *5* vc.create_dispatch_dicts
     def create_dispatch_dicts(self):
         """Create all dispatch dicts."""
+        # Dispatch table for normal mode.
         self.normal_mode_dispatch_d = d1 = self.create_normal_dispatch_d()
-            # Dispatch table for normal mode.
+        # Dispatch table for motions.
         self.motion_dispatch_d = d2 = self.create_motion_dispatch_d()
-            # Dispatch table for motions.
+        # Dispatch table for visual mode.
         self.vis_dispatch_d = d3 = self.create_vis_dispatch_d()
-            # Dispatch table for visual mode.
         # Add all entries in arrow dict to the other dicts.
         self.arrow_d = arrow_d = self.create_arrow_d()
         for d, tag in ((d1, 'normal'), (d2, 'motion'), (d3, 'visual')):
@@ -394,92 +394,63 @@ class VimCommands:
     #@+node:ekr.20140803220119.18104: *5* vc.init_dot_ivars
     def init_dot_ivars(self):
         """Init all dot-related ivars."""
-        self.in_dot = False
-            # True if we are executing the dot command.
-        self.dot_list = []
-            # This list is preserved across commands.
-        self.old_dot_list = []
-            # The dot_list saved at the start of visual mode.
+        self.in_dot = False  # True if we are executing the dot command.
+        self.dot_list = []  # This list is preserved across commands.
+        self.old_dot_list = []  # The dot_list saved at the start of visual mode.
     #@+node:ekr.20140803220119.18109: *5* vc.init_constant_ivars
     def init_constant_ivars(self):
         """Init ivars whose values never change."""
+        # List of printable characters
         self.chars = [ch for ch in string.printable if 32 <= ord(ch) < 128]
-            # List of printable characters
+        # List of register names.
         self.register_names = string.ascii_letters
-            # List of register names.
     #@+node:ekr.20140803220119.18106: *5* vc.init_state_ivars
     def init_state_ivars(self):
         """Init all ivars related to command state."""
-        self.ch = None
-            # The incoming character.
-        self.command_i = None
-            # The offset into the text at the start of a command.
-        self.command_list = []
-            # The list of all characters seen in this command.
-        self.command_n = None
-            # The repeat count in effect at the start of a command.
-        self.command_w = None
-            # The widget in effect at the start of a command.
-        self.event = None
-            # The event for the current key.
-        self.extend = False
-            # True: extending selection.
-        self.handler = self.do_normal_mode
-            # Use the handler for normal mode.
-        self.in_command = False
-            # True: we have seen some command characters.
-        self.in_motion = False
-            # True if parsing an *inner* motion, the 2j in d2j.
-        self.motion_func = None
-            # The callback handler to execute after executing an inner motion.
-        self.motion_i = None
-            # The offset into the text at the start of a motion.
-        self.n1 = 1
-            # The first repeat count.
-        self.n = 1
-            # The second repeat count.
-        self.n1_seen = False
-            # True if self.n1 has been set.
-        self.next_func = None
-            # The continuation of a multi-character command.
-        self.old_sel = None
-            # The selection range at the start of a command.
-        self.repeat_list = []
-            # The characters of the current repeat count.
+        self.ch = None  # The incoming character.
+        self.command_i = None  # The offset into the text at the start of a command.
+        self.command_list = []  # The list of all characters seen in this command.
+        self.command_n = None  # The repeat count in effect at the start of a command.
+        self.command_w = None  # The widget in effect at the start of a command.
+        self.event = None  # The event for the current key.
+        self.extend = False  # True: extending selection.
+        self.handler = self.do_normal_mode  # Use the handler for normal mode.
+        self.in_command = False  # True: we have seen some command characters.
+        self.in_motion = False  # True if parsing an *inner* motion, the 2j in d2j.
+        self.motion_func = None  # The callback handler to execute after executing an inner motion.
+        self.motion_i = None  # The offset into the text at the start of a motion.
+        self.n1 = 1  # The first repeat count.
+        self.n = 1  # The second repeat count.
+        self.n1_seen = False  # True if self.n1 has been set.
+        self.next_func = None  # The continuation of a multi-character command.
+        self.old_sel = None  # The selection range at the start of a command.
+        self.repeat_list = []  # The characters of the current repeat count.
+        # The value returned by do_key().
+        # Handlers set this to False to tell k.masterKeyHandler to handle the key.
         self.return_value = True
-            # The value returned by do_key().
-            # Handlers set this to False to tell k.masterKeyHandler to handle the key.
-        self.state = 'normal'
-            # in ('normal','insert','visual',)
-        self.stroke = None
-            # The incoming stroke.
-        self.visual_line_flag = False
-            # True: in visual-line state.
-        self.vis_mode_i = None
-            # The insertion point at the start of visual mode.
-        self.vis_mode_w = None
-            # The widget in effect at the start of visual mode.
+        self.state = 'normal'  # in ('normal','insert','visual',)
+        self.stroke = None  # The incoming stroke.
+        self.visual_line_flag = False  # True: in visual-line state.
+        self.vis_mode_i = None  # The insertion point at the start of visual mode.
+        self.vis_mode_w = None  # The widget in effect at the start of visual mode.
     #@+node:ekr.20140803220119.18107: *5* vc.init_persistent_ivars
     def init_persistent_ivars(self):
         """Init ivars that are never re-inited."""
         c = self.c
+        # The widget that has focus when a ':' command begins.  May be None.
         self.colon_w = None
-            # The widget that has focus when a ':' command begins.  May be None.
+        # True: allow f,F,h,l,t,T,x to cross line boundaries.
         self.cross_lines = c.config.getBool('vim-crosses-lines', default=True)
-            # True: allow f,F,h,l,t,T,x to cross line boundaries.
-        self.register_d = {}
-            # Keys are letters; values are strings.
+        self.register_d = {}  # Keys are letters; values are strings.
+        # The stroke ('/' or '?') that starts a vim search command.
         self.search_stroke = None
-            # The stroke ('/' or '?') that starts a vim search command.
+        # True: in vim-training mode: Mouse clicks and arrows are disabled.
         self.trainer = False
-            # True: in vim-training mode:
-            # Mouse clicks and arrows are disable.
+        # The present widget. c.frame.body.wrapper is a QTextBrowser.
         self.w = None
-            # The present widget.
-            # c.frame.body.wrapper is a QTextBrowser.
+        # False if the .leo file's change indicator should be
+        # Cleared after doing the j,j abbreviation.
         self.j_changed = True
-            # False if the .leo file's change indicator should be
-            # cleared after doing the j,j abbreviation.
     #@+node:ekr.20140802225657.18023: *3* vc.acceptance methods
     # All key handlers must end with a call to an acceptance method.
     #
@@ -523,8 +494,7 @@ class VimCommands:
         """Complete a command, preserving text and optionally updating the dot."""
         self.do_trace()
         if self.state == 'visual':
-            self.handler = self.do_visual_mode
-                # A major bug fix.
+            self.handler = self.do_visual_mode  # A major bug fix.
             if set_dot:
                 stroke2 = stroke or self.stroke if add_to_dot else None
                 self.compute_dot(stroke2)
@@ -539,8 +509,8 @@ class VimCommands:
             self.save_body()
             # Clear all state, enter normal mode & show the status.
             if self.in_motion:
-                self.next_func = None
                 # Do *not* change in_motion!
+                self.next_func = None
             else:
                 self.init_state_ivars()
             self.show_status()
@@ -759,8 +729,7 @@ class VimCommands:
                 return
             if 1:
                 # This is all we can do until there is a substitution command.
-                self.change_pattern = change_pattern
-                    # Not used at present.
+                self.change_pattern = change_pattern  # Not used at present.
                 add(self.search_stroke)
                 for ch in find_pattern:
                     add(ch)
@@ -1418,15 +1387,14 @@ class VimCommands:
         """Begin a search."""
         if self.is_text_wrapper(self.w):
             fc = self.c.findCommands
-            self.search_stroke = self.stroke
-                # A scratch ivar for update_dot_before_search().
+            self.search_stroke = self.stroke  # A scratch ivar for update_dot_before_search().
             fc.reverse = True
             fc.openFindTab(self.event)
             fc.ftm.clear_focus()
             old_node_only = fc.node_only
+            # This returns immediately, before the actual search.
+            # leoFind.show_success calls update_selection_after_search().
             fc.start_search1(self.event)
-                # This returns immediately, before the actual search.
-                # leoFind.show_success calls update_selection_after_search().
             fc.node_only = old_node_only
             self.done(add_to_dot=False, set_dot=False)
         else:
@@ -1458,15 +1426,14 @@ class VimCommands:
         """Begin a search."""
         if self.is_text_wrapper(self.w):
             fc = self.c.findCommands
-            self.search_stroke = self.stroke
-                # A scratch ivar for update_dot_before_search().
+            self.search_stroke = self.stroke  # A scratch ivar for update_dot_before_search().
             fc.reverse = False
             fc.openFindTab(self.event)
             fc.ftm.clear_focus()
             old_node_only = fc.node_only
+            # This returns immediately, before the actual search.
+            # leoFind.show_success calls update_selection_after_search().
             fc.start_search1(self.event)
-                # This returns immediately, before the actual search.
-                # leoFind.show_success calls update_selection_after_search().
             fc.node_only = old_node_only
             fc.reverse = False
             self.done(add_to_dot=False, set_dot=False)
@@ -1991,12 +1958,10 @@ class VimCommands:
 
         def __init__(self, vc, all_lines):
             """Ctor for VimCommands.tabnew class."""
-            self.all_lines = all_lines
-                # True: :%s command.  False: :s command.
+            self.all_lines = all_lines  # True: :%s command.  False: :s command.
             self.vc = vc
 
-        __name__ = ':%'
-            # Required.
+        __name__ = ':%'  # Required.
         #@+others
         #@+node:ekr.20140820063930.18321: *5* Substitution.__call__ (:%s & :s)
         def __call__(self, event=None):
@@ -2006,16 +1971,14 @@ class VimCommands:
             w = vc.w if c.vim_mode else c.frame.body
             if vc.is_text_wrapper(w):
                 fc = vc.c.findCommands
-                vc.search_stroke = None
-                    # Tell vc.update_dot_before_search not to update the dot.
+                vc.search_stroke = None  # Tell vc.update_dot_before_search not to update the dot.
                 fc.reverse = False
                 fc.openFindTab(vc.event)
                 fc.ftm.clear_focus()
-                fc.node_only = True
-                    # Doesn't work.
+                fc.node_only = True  # Doesn't work.
+                # This returns immediately, before the actual search.
+                # leoFind.show_success calls vc.update_selection_after_search.
                 fc.start_search1(vc.event)
-                    # This returns immediately, before the actual search.
-                    # leoFind.show_success calls vc.update_selection_after_search.
                 if c.vim_mode:
                     vc.done(add_to_dot=False, set_dot=False)
             elif c.vim_mode:

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -70,8 +70,8 @@ def profile_leo():
     from leo.core import leoGlobals as g
     theDir = os.getcwd()
     # On Windows, name must be a plain string.
+    # This is a binary file.
     name = str(g.os_path_normpath(g.os_path_join(theDir, 'leoProfile')))
-        # This is a binary file.
     print(f"profiling binary stats to {name}")
     profile.run('import leo ; leo.run()', name)
     p = pstats.Stats(name)

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -3079,9 +3079,9 @@ def main(files):
 #@+node:ekr.20160517222900.1: *5* get_home
 def get_home():
     """Returns the user's home directory."""
+    # Windows searches the HOME, HOMEPATH and HOMEDRIVE
+    # environment vars, then gives up.
     home = g.os_path_expanduser("~")
-        # Windows searches the HOME, HOMEPATH and HOMEDRIVE
-        # environment vars, then gives up.
     if home and len(home) > 1 and home[0] == '%' and home[-1] == '%':
         # Get the indirect reference to the true home.
         home = os.getenv(home[1:-1], default=None)
@@ -3467,8 +3467,8 @@ def runMainLoop(self, fileName=None):
         path = g.os_path_finalize_join(
             g.app.loadDir, '..', 'test', 'unittest.leo')
         c = g.openWithFileName(path, gui=self)
+        # A hack. Maybe the NullGui should do this.
         c.findCommands.ftm = g.NullObject()
-            # A hack. Maybe the NullGui should do this.
         c.debugCommands.runAllUnitTestsLocally()
     print('calling sys.exit(0)')
     sys.exit(0)
@@ -3570,10 +3570,10 @@ class LeoLog(flx.Widget):
         global window
         # https://ace.c9.io/#nav=api
         self.ace = window.ace.edit(self.node, "editor")
-            # self.ace.setValue("import os\n\ndirs = os.walk")
+        # self.ace.setValue("import os\n\ndirs = os.walk")
         self.ace.navigateFileEnd()  # otherwise all lines highlighted
         self.ace.setTheme("ace/theme/solarized_dark")
-            # self.ace.getSession().setMode("ace/mode/python")
+        # self.ace.getSession().setMode("ace/mode/python")
         print('window', window)
 
     @flx.reaction('size')
@@ -4123,8 +4123,9 @@ class OrganizerData:
         self.organized_nodes = [] # The list of positions organized by this od node.
         self.parent_od = None # The parent od node of this od node. (None is valid.)
         self.p = None # The position of this od node.
-        self.parent = None # The original parent position of all nodes organized by this od node.
-            # If parent_od is None, this will be the parent position of the od node.
+        # The original parent position of all nodes organized by this od node.
+        # If parent_od is None, this will be the parent position of the od node.
+        self.parent = None
         self.source_unl = None # The unl of self.parent.
         self.unl = unl # The unl of this od node.
         self.unls = unls # The unls contained in this od node.

--- a/leo/external/codewise.py
+++ b/leo/external/codewise.py
@@ -327,15 +327,14 @@ def pr(*args, **keys):  # (codewise!)
         encoding = sys.stdout.encoding
     else:
         encoding = 'utf-8'
+    # Translates everything to unicode.
     s = translateArgs(args, d)
-        # Translates everything to unicode.
     s = toUnicode(s, encoding=encoding, reportErrors=False)
     if newline:
         s += u('\n')
     # Python's print statement *can* handle unicode, but
     # sitecustomize.py must have sys.setdefaultencoding('utf-8')
-    sys.stdout.write(s)
-        # Codewise: unit tests do not change sys.stdout.
+    sys.stdout.write(s)  # Unit tests do not change sys.stdout.
 #@+node:ekr.20180311193230.1: *5* shortFileName (codewise)
 def shortFileName(fileName, n=None):
     '''Return the base name of a path.'''

--- a/leo/external/edb.py
+++ b/leo/external/edb.py
@@ -229,15 +229,17 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         except IOError:
             pass
 
-        self.commands = {}  # associates a command list to breakpoint numbers
-        self.commands_doprompt = {}  # for each bp num, tells if the prompt
-                                    # must be disp. after execing the cmd list
-        self.commands_silent = {}  # for each bp num, tells if the stack trace
-                                    # must be disp. after execing the cmd list
-        self.commands_defining = False  # True while in the process of defining
-                                        # a command list
-        self.commands_bnum = None  # The breakpoint number for which we are
-                                    # defining a list
+        # Associates a command list to breakpoint numbers.
+        # for each bp num, tells if the prompt must be disp. after execing the cmd list
+        self.commands = {}
+        self.commands_doprompt = {}
+        # for each bp num, tells if the stack trace
+        # must be disp. after execing the cmd list
+        self.commands_silent = {}
+        # True while in the process of defining a command list
+        self.commands_defining = False
+        # The breakpoint number for which we are defining a list
+        self.commands_bnum = None
     #@+node:ekr.20110914171443.7252: *3* sigint_handler
     def sigint_handler(self, signum, frame):
         if self.allow_kbdint:
@@ -307,10 +309,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
         # EKR.
         if filename == '<string>':
+            # EKR: frame keyword argument is new.
             filename = self._getval('__file__', frame=frame)
-                # EKR: frame keyword argument is new.
             filename = self.canonic(filename)
-
         if filename not in self.breaks:
             return False
 

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -1596,8 +1596,7 @@ class StandAloneMakeStubFile:
         self.files = []  # May also be set in the config file.
         # Ivars set in the config file...
         self.output_fn = None
-        self.output_directory = self.finalize('.')
-            # self.finalize('~/stubs')
+        self.output_directory = self.finalize('.')  # self.finalize('~/stubs')
         self.overwrite = False
         self.prefix_lines = []
         self.trace_matches = False

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -1293,8 +1293,7 @@ class Pattern:
         Return (found, new s)
         '''
         trace = False or trace
-        caller = g.callers(2).split(',')[0].strip()
-            # The caller of match_all.
+        caller = g.callers(2).split(',')[0].strip()  # The caller of match_all.
         s1 = truncate(s, 40)
         if self.is_balanced():
             j = self.full_balanced_match(s, 0)
@@ -1592,8 +1591,7 @@ class StandAloneMakeStubFile:
         '''Ctor for StandAloneMakeStubFile class.'''
         self.options = {}
         # Ivars set on the command line...
-        self.config_fn = None
-            # self.finalize('~/stubs/make_stub_files.cfg')
+        self.config_fn = None  # self.finalize('~/stubs/make_stub_files.cfg')
         self.enable_unit_tests = False
         self.files = []  # May also be set in the config file.
         # Ivars set in the config file...
@@ -1610,8 +1608,7 @@ class StandAloneMakeStubFile:
         self.verbose = False  # Trace config arguments.
         self.warn = False
         # Pattern lists, set by config sections...
-        self.section_names = (
-            'Global', 'Def Name Patterns', 'General Patterns')
+        self.section_names = ('Global', 'Def Name Patterns', 'General Patterns')
         self.def_patterns = []  # [Def Name Patterns]
         self.general_patterns = []  # [General Patterns]
         self.names_dict = {}
@@ -1769,8 +1766,8 @@ class StandAloneMakeStubFile:
                 self.output_directory = None  # inhibit run().
         if 'prefix_lines' in parser.options('Global'):
             prefix = parser.get('Global', 'prefix_lines')
+            # The parser does not preserve leading whitespace.
             self.prefix_lines = prefix.split('\n')
-                # The parser does not preserve leading whitespace.
             if trace:
                 print('Prefix lines...\n')
                 for z in self.prefix_lines:
@@ -1805,8 +1802,7 @@ class StandAloneMakeStubFile:
     #@+node:ekr.20160317054700.127: *4* msf.create_parser
     def create_parser(self):
         '''Create a RawConfigParser and return it.'''
-        parser = configparser.RawConfigParser(dict_type=OrderedDict)
-            # Requires Python 2.7
+        parser = configparser.RawConfigParser(dict_type=OrderedDict)  # Requires Python 2.7
         parser.optionxform = str
         return parser
     #@+node:ekr.20160317054700.128: *4* msf.find_pattern_ops
@@ -2025,7 +2021,6 @@ class StubFormatter(AstFormatter):
         '''Ctor for StubFormatter class.'''
         self.controller = x = controller
         self.traverser = traverser
-            # 2016/02/07: to give the formatter access to the class_stack.
         self.def_patterns = x.def_patterns
         self.general_patterns = x.general_patterns
         self.names_dict = x.names_dict
@@ -2047,8 +2042,7 @@ class StubFormatter(AstFormatter):
         d = self.matched_d
         name = node.__class__.__name__
         s1 = truncate(s, 40)
-        caller = g.callers(2).split(',')[1].strip()
-            # The direct caller of match_all.
+        caller = g.callers(2).split(',')[1].strip()  # The direct caller of match_all.
         patterns = self.patterns_dict.get(name, []) + self.regex_patterns
         for pattern in patterns:
             found, s = pattern.match(s, trace=False)
@@ -2175,12 +2169,11 @@ class StubFormatter(AstFormatter):
         if op.strip() in ('is', 'is not', 'in', 'not in'):
             s = 'bool'
         elif lhs == rhs:
+            # Perhaps not always right, but it is correct for Tuple, List, Dict.
             s = lhs
-                # Perhaps not always right,
-                # but it is correct for Tuple, List, Dict.
         elif lhs in numbers and rhs in numbers:
+            # reduce_numbers would be wrong: it returns a list.
             s = reduce_types([lhs, rhs], trace=trace)
-                # reduce_numbers would be wrong: it returns a list.
         elif lhs == 'str' and op in '%+*':
             # str + any implies any is a string.
             s = 'str'
@@ -2317,8 +2310,7 @@ class StubTraverser(ast.NodeVisitor):
     #@+node:ekr.20160317054700.163: *3* st.ctor
     def __init__(self, controller):
         '''Ctor for StubTraverser class.'''
-        self.controller = x = controller
-            # A StandAloneMakeStubFile instance.
+        self.controller = x = controller  # A StandAloneMakeStubFile instance.
         # Internal state ivars...
         self.class_name_stack = []
         self.context_stack = []
@@ -2330,8 +2322,7 @@ class StubTraverser(ast.NodeVisitor):
         self.parent_stub = None
         self.raw_format = AstFormatter().format
         self.returns = []
-        self.stubs_dict = {}
-            # Keys are stub.full_name's.  Values are stubs.
+        self.stubs_dict = {}  # Keys are stub.full_name's.  Values are stubs.
         self.warn_list = []
         # Copies of controller ivars...
         self.output_fn = x.output_fn
@@ -2538,13 +2529,11 @@ class StubTraverser(ast.NodeVisitor):
         '''
         trace = False or trace; verbose = False
         # Part 1: Delete old stubs do *not* exist in the *new* tree.
+        # check_delete checks that all ancestors of deleted nodes will be deleted.
         aList = self.check_delete(new_stubs,
-                                  old_root,
-                                  new_root,
-                                  trace and verbose)
-            # Checks that all ancestors of deleted nodes will be deleted.
+            old_root, new_root, trace and verbose)
+        # Sort old stubs so that children are deleted before parents.
         aList = list(reversed(self.sort_stubs_by_hierarchy(aList)))
-            # Sort old stubs so that children are deleted before parents.
         if trace and verbose:
             dump_list('ordered delete list', aList)
         for stub in aList:
@@ -2553,9 +2542,9 @@ class StubTraverser(ast.NodeVisitor):
             parent.children.remove(stub)
             assert not self.find_stub(stub, old_root), stub
         # Part 2: Insert new stubs that *not* exist in the *old* tree.
+        # Sort new stubs so that parents are created before children.
         aList = [z for z in new_stubs if not self.find_stub(z, old_root)]
         aList = self.sort_stubs_by_hierarchy(aList)
-            # Sort new stubs so that parents are created before children.
         for stub in aList:
             if trace: g.trace('inserting %s' % stub)
             parent = self.find_parent_stub(stub, old_root) or old_root

--- a/leo/external/npyscreen/wgeditmultiline.py
+++ b/leo/external/npyscreen/wgeditmultiline.py
@@ -127,9 +127,9 @@ class MultiLineEdit(widget.Widget):
                     break
                 if place_in_string >= len(line_to_display):
                     break
+                # change this when actually have a function to do this
+                # self.find_width_of_char(string_to_print[place_in_string])
                 width_of_char_to_print = 1
-                    # self.find_width_of_char(string_to_print[place_in_string])
-                    # change this when actually have a function to do this
                 if column - 1 + width_of_char_to_print > display_width:
                     break
                 if self.do_colors():

--- a/leo/external/npyscreen/wgmultiline.py
+++ b/leo/external/npyscreen/wgmultiline.py
@@ -83,8 +83,7 @@ class MultiLine(widget.Widget):
         self.exit_right = exit_right
         self.allow_filtering = allow_filtering
         self.widgets_inherit_color = widgets_inherit_color
-        super(MultiLine, self).__init__(screen, **keywords)
-            # Call the base class.
+        super(MultiLine, self).__init__(screen, **keywords)  # Call the base class.
         if self.height < self.__class__._MINIMUM_HEIGHT:
             raise widget.NotEnoughSpaceForWidget(
                 "Height of %s allocated. Not enough space allowed for %s" % (

--- a/leo/external/npyscreen/wgwidget.py
+++ b/leo/external/npyscreen/wgwidget.py
@@ -273,8 +273,9 @@ class Widget(InputHandler, wgwidget_proto._LinePrinter, EventHandler):
         self.check_value_change=check_value_change
         self.check_cursor_move =check_cursor_move
         self.hidden = hidden
-        self.interested_in_mouse_even_when_not_editable = False# used only for rare widgets to allow user to click
-                                                        # even if can't actually select the widget.  See mutt-style forms
+        self.interested_in_mouse_even_when_not_editable = False
+            # used only for rare widgets to allow user to click
+            # even if can't actually select the widget.  See mutt-style forms
 
         try:
             self.parent = weakref.proxy(screen)

--- a/leo/external/py2cs.py
+++ b/leo/external/py2cs.py
@@ -491,10 +491,8 @@ class CoffeeScriptTraverser:
         result.append('{')
         self.level += 1
         for i, key in enumerate(node.keys):
-            head = self.leading_lines(key)
-                # Prevents leading lines from being handled again.
-            head = [z for z in head if z.strip()]
-                # Ignore blank lines.
+            head = self.leading_lines(key)  # Prevents leading lines from being handled again.
+            head = [z for z in head if z.strip()]  # Ignore blank lines.
             if head:
                 items.extend('\n' + ''.join(head))
             tail = self.trailing_comment(node.values[i])
@@ -1096,7 +1094,6 @@ class LeoGlobals:
 
         def __init__(self, s):
             self.lines = s.splitlines(True) if s else []
-                # g.splitLines(s)
             self.i = 0
 
         def next(self):

--- a/leo/external/py2cs.py
+++ b/leo/external/py2cs.py
@@ -1383,9 +1383,9 @@ class MakeCoffeeScriptController:
                 print('output directory not found: %s\n' % output_dir)
                 self.output_directory = None  # inhibit run().
         if 'prefix_lines' in parser.options('Global'):
+            # The parser does not preserve leading whitespace.
             prefix = parser.get('Global', 'prefix_lines')
             self.prefix_lines = prefix.split('\n')
-                # The parser does not preserve leading whitespace.
         #
         # self.def_patterns = self.scan_patterns('Def Name Patterns')
         # self.general_patterns = self.scan_patterns('General Patterns')

--- a/leo/plugins/at_view.py
+++ b/leo/plugins/at_view.py
@@ -26,8 +26,7 @@ win32clipboard = g.import_module('win32clipboard')
 #@+node:ekr.20111104210837.9693: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = path and win32clipboard
-        # Ok for unit testing.
+    ok = path and win32clipboard  # Ok for unit testing.
     if ok:
         g.registerHandler("after-create-leo-frame", onCreate)
     elif not g.unitTesting:

--- a/leo/plugins/bibtex.py
+++ b/leo/plugins/bibtex.py
@@ -174,14 +174,13 @@ def readBibTexFileIntoTree(c, fn, p):
     """Import a BibTeX file into a @bibtex tree."""
     root = p.copy()
     g.es('reading:', fn)
+    # Read the encoded bytes for g.getEncodingAt()
     s = g.readFileIntoEncodedString(fn)
-        # Read the encoded bytes for g.getEncodingAt()
     if not s or not s.strip():
         return
     encoding = g.getEncodingAt(p, s)
     s = g.toUnicode(s, encoding=encoding)
-    aList, entries, strings = [], [], []
-        # aList is a list of tuples (h,b).
+    aList, entries, strings = [], [], []  # aList is a list of tuples (h,b).
     s = '\n' + ''.join([z.lstrip() for z in g.splitLines(s)])
     for line in s.split('\n@')[1:]:
         kind, rest = line[:6], line[7:].strip()

--- a/leo/plugins/bigdash.py
+++ b/leo/plugins/bigdash.py
@@ -68,8 +68,8 @@ def global_search_f(event):
     """
     c = event['c']
     if hasattr(g.app, '_global_search'):
+        # Use the per-commander setting.
         g.app._global_search.fts_max_hits = c.config.getInt('fts-max-hits') or 30
-            # Use the per-commander setting.
         g.app._global_search.show()
 #@+node:ville.20120302233106.3580: *3* init (bigdash.py)
 def init():
@@ -193,8 +193,8 @@ class GlobalSearch:
     #@+node:ekr.20140919160020.17898: *3* __init__(GlobalSearch)
     def __init__(self):
         """Ctor for GlobalSearch class."""
+        # A default: will be overridden by the global-search command.
         self.fts_max_hits = g.app.config.getInt('fts-max-hits') or 30
-            # A default: will be overridden by the global-search command.
         self.bd = BigDash()
         self.gnxcache = GnxCache()
         #self.bd.show()

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -60,9 +60,10 @@ from leo.core import leoNodes
 #@-<< cursesGui2 imports >>
 # pylint: disable=arguments-differ,logging-not-lazy
 # pylint: disable=not-an-iterable,unsubscriptable-object,unsupported-delete-operation
+
+# True: use native Leo data structures, replacing the
+# the values property by a singleton LeoValues object.
 native = True
-    # True: use native Leo data structures, replacing the
-    # the values property by a singleton LeoValues object.
 #@+<< forward reference classes >>
 #@+node:ekr.20170511053555.1: **  << forward reference classes >>
 # These classes aren't necessarily base classes, but
@@ -455,10 +456,9 @@ class LeoTreeData(npyscreen.TreeData):
             sort=None,
             sort_function=None,
         ):
+            # Never change the stored position!
+            # LeoTreeData(p) makes a copy of p.
             p = self.content.copy()
-                # Never change the stored position!
-                # LeoTreeData(p) makes a copy of p.
-            # g.trace('LeoTreeData: only_expanded:', only_expanded, p.h)
             if not ignore_root:
                 yield self  # The hidden root. Probably not needed.
             if only_expanded:
@@ -1252,32 +1252,20 @@ class LeoCursesGui(leoGui.LeoGui):
     #@+node:ekr.20170608112335.1: *5* CGui.__init__
     def __init__(self):
         """Ctor for the CursesGui class."""
-        super().__init__('curses')
-            # Init the base class.
-        self.consoleOnly = False
-            # Required attribute.
-        self.curses_app = None
-            # The singleton LeoApp instance.
+        super().__init__('curses')  # Init the base class.
+        self.consoleOnly = False  # Required attribute.
+        self.curses_app = None  # The singleton LeoApp instance.
+        # The top-level curses Form instance. Form.editw is the widget with focus.
         self.curses_form = None
-            # The top-level curses Form instance.
-            # Form.editw is the widget with focus.
-        self.curses_gui_arg = None
-            # A hack for interfacing with k.getArg.
-        self.in_dialog = False
-            # True: executing a modal dialog.
-        self.log = None
-            # The present log. Used by g.es
-        self.log_inited = False
-            # True: don't use the wait_list.
-        self.minibuffer_label = ''
-            # The label set by k.setLabel.
-        self.wait_list = []
-            # Queued log messages.
+        self.curses_gui_arg = None  # A hack for interfacing with k.getArg.
+        self.in_dialog = False  # True: executing a modal dialog.
+        self.log = None  # The present log. Used by g.es
+        self.log_inited = False  # True: don't use the wait_list.
+        self.minibuffer_label = ''  # The label set by k.setLabel.
+        self.wait_list = [] # Queued log messages.
+        # Do this as early as possible. It monkey-patches g.pr and g.trace.
         self.init_logger()
-            # Do this as early as possible.
-            # It monkey-patches g.pr and g.trace.
-        self.top_form = None
-            # The top-level form. Set in createCursesTop.
+        self.top_form = None  # The top-level form. Set in createCursesTop.
         self.key_handler = KeyHandler()
     #@+node:ekr.20170502083158.1: *5* CGui.createCursesTop & helpers
     def createCursesTop(self):
@@ -1292,8 +1280,7 @@ class LeoCursesGui(leoGui.LeoGui):
             g.trace('commanders in g.app.windowList')
             g.printList([z.c.shortFileName() for z in g.app.windowList])
         # Create the top-level form.
-        self.curses_form = form = LeoForm(name='Dummy Name')
-            # This call clears the screen.
+        self.curses_form = form = LeoForm(name='Dummy Name')  # This call clears the screen.
         self.createCursesLog(c, form)
         self.createCursesTree(c, form)
         self.createCursesBody(c, form)
@@ -1487,19 +1474,17 @@ class LeoCursesGui(leoGui.LeoGui):
             leo_tree.values = LeoValues(c=c, tree=leo_tree)
         assert getattr(leo_tree, 'hidden_root_node') is None, leo_tree
         leo_tree.hidden_root_node = hidden_root_node
+        # CoreFrame is a LeoFrame
         assert isinstance(c.frame, leoFrame.LeoFrame), repr(c.frame)
-            # CoreFrame is a LeoFrame
         assert isinstance(c.frame.tree, CoreTree), repr(c.frame.tree)
+        # A standard ivar, used by Leo's core.
         assert c.frame.tree.canvas is None, repr(c.frame.canvas)
-            # A standard ivar, used by Leo's core.
-        c.frame.canvas = leo_tree
-            # A LeoMLTree.
+        c.frame.canvas = leo_tree  # A LeoMLTree.
         assert not hasattr(c.frame.tree, 'treeWidget'), repr(c.frame.tree.treeWidget)
         c.frame.tree.treeWidget = leo_tree
-            # treeWidget is an official ivar.
+        # treeWidget is an official ivar.
         assert c.frame.tree.widget is None
-        c.frame.tree.widget = leo_tree
-            # Set CoreTree.widget.
+        c.frame.tree.widget = leo_tree  # Set CoreTree.widget.
         # Inject the wrapper for get_focus.
         wrapper = c.frame.tree
         assert wrapper
@@ -1663,8 +1648,7 @@ class LeoCursesGui(leoGui.LeoGui):
         if g.unitTesting:
             return False
         self.in_dialog = True
-        val = utilNotify.notify_ok_cancel(message=message, title=title)
-            # val is True/False
+        val = utilNotify.notify_ok_cancel(message=message, title=title)  # val is True/False
         self.in_dialog = False
         return 'yes' if val else 'no'
     #@+node:ekr.20171126182120.4: *5* CGui.runAskOkDialog
@@ -1695,8 +1679,8 @@ class LeoCursesGui(leoGui.LeoGui):
         if g.unitTesting:
             return False
         self.in_dialog = True
+        # Important: don't use notify_ok_cancel.
         val = utilNotify.notify_yes_no(message=message, title=title)
-            # Important: don't use notify_ok_cancel.
         self.in_dialog = False
         return 'yes' if val else 'no'
 
@@ -1958,8 +1942,7 @@ class LeoCursesGui(leoGui.LeoGui):
                 if widget == widget3 or repr(widget) == repr(widget3):
                     if trace:
                         g.trace('FOUND INNER', i, j, widget2)
-                    form.editw = i
-                        # Select the *outer* widget.
+                    form.editw = i  # Select the *outer* widget.
                     # Like BoxTitle.edit.
                     if 1:
                         # So weird.
@@ -2091,8 +2074,7 @@ class LeoCursesGui(leoGui.LeoGui):
         c.findCommands.startSearch(event)
         options = fc.computeFindOptionsInStatusArea()
         c.frame.statusLine.put(options)
-        self.focus_to_minibuffer(c)
-            # Does not return!
+        self.focus_to_minibuffer(c)  # Does not return!
     #@-others
 #@+node:ekr.20170524124010.1: ** Leo widget classes
 # Most are subclasses Leo's base gui classes.
@@ -2121,8 +2103,7 @@ class CoreFrame(leoFrame.LeoFrame):
     def __init__(self, c, title):
 
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
-        super().__init__(c, gui=g.app.gui)
-            # Init the base class.
+        super().__init__(c, gui=g.app.gui)  # Init the base class.
         assert c and self.c == c
         c.frame = self  # Bug fix: 2017/05/10.
         self.log = CoreLog(c)
@@ -2134,8 +2115,7 @@ class CoreFrame(leoFrame.LeoFrame):
         self.top = TopFrame(c)
         self.body = CoreBody(c)
         self.menu = CoreMenu(c)
-        self.miniBufferWidget = None
-            # Set later.
+        self.miniBufferWidget = None  # Set later.
         self.statusLine = g.NullObject()  # For unit tests.
         assert self.tree is None, self.tree
         self.tree = CoreTree(c)
@@ -2350,8 +2330,7 @@ class CoreFrame(leoFrame.LeoFrame):
             return
         bunch = u.beforeChangeBody(p)
         wname = c.widget_name(w)
-        i, j = w.getSelectionRange()
-            # Returns insert point if no selection.
+        i, j = w.getSelectionRange()  # Returns insert point if no selection.
         s = g.app.gui.getTextFromClipboard()
         s = g.toUnicode(s)
         if trace:
@@ -2369,8 +2348,8 @@ class CoreFrame(leoFrame.LeoFrame):
             p.v.b = w.getAllText()
             u.afterChangeBody(p, 'Paste', bunch)
         elif wname.startswith('head'):
+            # New for Curses gui.
             c.frame.tree.onHeadChanged(c.p, s=w.getAllText(), undoType='Paste')
-                # New for Curses gui.
 
     OnPasteFromMenu = pasteText
     #@-others
@@ -2387,18 +2366,12 @@ class CoreLog(leoFrame.LeoLog):
         """Ctor for CLog class."""
         super().__init__(frame=None, parentFrame=None)
         self.c = c
-        self.enabled = True
-            # Required by Leo's core.
-        self.isNull = False
-            # Required by Leo's core.
+        self.enabled = True  # Required by Leo's core.
+        self.isNull = False  # Required by Leo's core.
+        # The npyscreen log widget. Queue all output until set. Set in CApp.main.
         self.widget = None
-            # The npyscreen log widget. Queue all output until set.
-            # Set in CApp.main.
-        #
-        self.contentsDict = {}
-            # Keys are tab names.  Values are widgets.
-        self.logDict = {}
-            # Keys are tab names text widgets.  Values are the widgets.
+        self.contentsDict = {} # Keys are tab names.  Values are widgets.
+        self.logDict = {} # Keys are tab names text widgets.  Values are the widgets.
         self.tabWidget = None
     #@+node:ekr.20170419143731.7: *4* CLog.clearLog
     @log_cmd('clear-log')
@@ -2484,10 +2457,8 @@ class CoreTree(leoFrame.LeoTree):
         assert self.c
         assert not hasattr(self, 'widget')
         self.redrawCount = 0  # For unit tests.
-        self.widget = None
-            # A LeoMLTree set by CGui.createCursesTree.
+        self.widget = None  # A LeoMLTree set by CGui.createCursesTree.
         # self.setConfigIvars()
-        #
         # Status flags, for busy()
         self.contracting = False
         self.expanding = False
@@ -3517,8 +3488,7 @@ class LeoMLTree(npyscreen.MLTree):
             p.contract()
             self.values.clear_cache()
         else:
-            if node.expanded and self._has_children(node):
-                # Collapse the node.
+            if node.expanded and self._has_children(node):  # Collapse the node.
                 node.expanded = False
             elif 0:  # Optional.
                 # Collapse all the children.
@@ -3531,8 +3501,7 @@ class LeoMLTree(npyscreen.MLTree):
                         break
                     else:
                         cursor_line -= 1
-        self._cached_tree = None
-            # Invalidate the display cache.
+        self._cached_tree = None  # Invalidate the display cache.
         self.display()
     #@+node:ekr.20170513091821.1: *5* LeoMLTree.h_cursor_line_down
     def h_cursor_line_down(self, ch):
@@ -3595,8 +3564,7 @@ class LeoMLTree(npyscreen.MLTree):
                 # Next, expand all children.
                 for z in self._walk_tree(node, only_expanded=False):
                     z.expanded = True
-        self._cached_tree = None
-            # Invalidate the cache.
+        self._cached_tree = None  # Invalidate the cache.
         self.display()
     #@+node:ekr.20170506044733.11: *5* LeoMLTree.h_insert
     def h_insert(self, ch):
@@ -3639,13 +3607,12 @@ class LeoMLTree(npyscreen.MLTree):
                 if trace:
                     g.trace('new line', self.cursor_line)
                 self.values.clear_cache()
-                self._cached_tree = None
-                    # Invalidate the cache.
+                self._cached_tree = None  # Invalidate the cache.
                 self.display()
                 c.frame.tree.select(parent)
             elif trace:
-                g.trace('no parent')
                 # This is what Leo does.
+                g.trace('no parent')
         else:
             if self._has_children(node) and node.expanded:
                 self.h_collapse_tree(ch)
@@ -3715,8 +3682,7 @@ class LeoMLTree(npyscreen.MLTree):
         super().set_up_handlers()
         assert not hasattr(self, 'hidden_root_node'), repr(self)
         self.leo_c = None  # Set later.
-        self.currentItem = None
-            # Used by CoreTree class.
+        self.currentItem = None  # Used by CoreTree class.
         self.hidden_root_node = None
         self.set_handlers()
 
@@ -3850,8 +3816,7 @@ class LeoMLTree(npyscreen.MLTree):
         trace = False
         trace_ok = True
         trace_empty = True
-        line.leo_c = self.leo_c
-            # Inject the ivar.
+        line.leo_c = self.leo_c  # Inject the ivar.
         values = self.values
         n = len(values)
         val = values[i] if 0 <= i < n else None
@@ -3863,7 +3828,7 @@ class LeoMLTree(npyscreen.MLTree):
             line._tree_expanded = False
             line._tree_has_children = False
             line._tree_ignore_root = None
-            line._tree_last_line = True  #
+            line._tree_last_line = True
             line._tree_real_value = None
             line._tree_sibling_next = False
             line.value = None
@@ -3936,20 +3901,13 @@ class LeoValues(npyscreen.TreeData):
     #@+node:ekr.20170619070717.1: *4* values.__init__
     def __init__(self, c, tree):
         """Ctor for LeoValues class."""
-        super().__init__()
-            # Init the base class.
-        self.c = c
-            # The commander of this outline.
-        self.data_cache = {}
-            # Keys are ints, values are LeoTreeData objects.
-        self.last_generation = -1
-            # The last value of c.frame.tree.generation.
-        self.last_len = 0
-            # The last computed value of the number of visible nodes.
-        self.n_refreshes = 0
-            # Number of calls to refresh_cache.
-        self.tree = tree
-            # A LeoMLTree. (not used here)
+        super().__init__()  # Init the base class.
+        self.c = c  # The commander of this outline.
+        self.data_cache = {}  # Keys are ints, values are LeoTreeData objects.
+        self.last_generation = -1  # The last value of c.frame.tree.generation.
+        self.last_len = 0  # The last computed value of the number of visible nodes.
+        self.n_refreshes = 0  # Number of calls to refresh_cache.
+        self.tree = tree  # A LeoMLTree. (not used here)
     #@+node:ekr.20170517090738.1: *4* values.__getitem__ and get_data
     def __getitem__(self, n):
         """Called from LeoMLTree._setLineValues."""
@@ -4016,16 +3974,12 @@ class TextMixin:
     def __init__(self, c=None):
         """Ctor for TextMixin class"""
         self.c = c
-        self.changingText = False
-            # A lockout for onTextChanged.
+        self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
-        self.supportsHighLevelInterface = True
-            # A flag for k.masterKeyHandler and isTextWrapper.
+        self.supportsHighLevelInterface = True  # Flag for k.masterKeyHandler and isTextWrapper.
         self.tags = {}
-        self.configDict = {}
-            # Keys are tags, values are colors (names or values).
-        self.configUnderlineDict = {}
-            # Keys are tags, values are True
+        self.configDict = {}  # Keys are tags, values are colors (names or values).
+        self.configUnderlineDict = {}  # Keys are tags, values are True
         self.virtualInsertPoint = None
         if c:
             self.injectIvars(c)
@@ -4193,11 +4147,9 @@ class BodyWrapper(leoFrame.StringTextWrapper):
     def __init__(self, c, name, w):
         """Ctor for BodyWrapper class"""
         super().__init__(c, name)
-        self.changingText = False
-            # A lockout for onTextChanged.
+        self.changingText = False  # A lockout for onTextChanged.
         self.widget = w
-        self.injectIvars(c)
-            # These are used by Leo's core.
+        self.injectIvars(c)  # These are used by Leo's core.
 
     #@+others
     #@+node:ekr.20170504034655.3: *4* bw.injectIvars

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1262,7 +1262,7 @@ class LeoCursesGui(leoGui.LeoGui):
         self.log = None  # The present log. Used by g.es
         self.log_inited = False  # True: don't use the wait_list.
         self.minibuffer_label = ''  # The label set by k.setLabel.
-        self.wait_list = [] # Queued log messages.
+        self.wait_list = []  # Queued log messages.
         # Do this as early as possible. It monkey-patches g.pr and g.trace.
         self.init_logger()
         self.top_form = None  # The top-level form. Set in createCursesTop.
@@ -2369,8 +2369,8 @@ class CoreLog(leoFrame.LeoLog):
         self.isNull = False  # Required by Leo's core.
         # The npyscreen log widget. Queue all output until set. Set in CApp.main.
         self.widget = None
-        self.contentsDict = {} # Keys are tab names.  Values are widgets.
-        self.logDict = {} # Keys are tab names text widgets.  Values are the widgets.
+        self.contentsDict = {}  # Keys are tab names.  Values are widgets.
+        self.logDict = {}  # Keys are tab names text widgets.  Values are the widgets.
         self.tabWidget = None
     #@+node:ekr.20170419143731.7: *4* CLog.clearLog
     @log_cmd('clear-log')

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2060,8 +2060,7 @@ class LeoCursesGui(leoGui.LeoGui):
         fc = c.findCommands
         ftm = c.frame.ftm
         c.inCommand = False
-        c.inFindCommand = True
-            # A new flag.
+        c.inFindCommand = True  # A new flag.
         fc.minibuffer_mode = True
         if 0:  # Allow hard settings, for tests.
             table = (

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -707,7 +707,7 @@ class QuitButton(npyscreen.MiniButtonPress):
     """Override the "Quit Leo" button so it prompts for save if needed."""
 
     def whenPressed(self):
-        
+
         # #2467.
         # Similar to qt_gui.close_event.
         for c in g.app.commanders():

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -68,43 +68,37 @@ class Demo:
         self.c = c
         # pylint: disable=import-self
         from leo.plugins import demo as module
-        #
+        # True: start calls next until finished.
         self.auto_run = False
-            # True: start calls next until finished.
+        # True: Exceptions call self.end(). Good for debugging.
         self.end_on_exception = False
-            # True: Exceptions call self.end(). Good for debugging.
+        # For converting arguments to demo.key...
         self.filter_ = qt_events.LeoQtEventFilter(c, w=None, tag='demo')
-            # For converting arguments to demo.key...
+        # The original size of the top-level Leo window. Restored in demo.end()
         self.initial_geometry = None
-            # The original size of the top-level Leo window.
-            # Restored in demo.end()
+        # Speed multiplier for simulated typing.
         self.key_speed = 1.0
-            # Speed multiplier for simulated typing.
+        # The leo.plugins.demo module.
         self.module = module
-            # The leo.plugins.demo module.
+        # Default minimal typing delay, in seconds.
         self.n1 = 0.02
-            # Default minimal typing delay, in seconds.
+        # Default maximum typing delay, in seconds.
         self.n2 = 0.175
-            # Default maximum typing delay, in seconds.
+        # The namespace for all demo script.
+        # Set in init_namespace, which subclasses may override.
         self.namespace = {}
-            # The namespace for all demo script.
-            # Set in init_namespace, which subclasses may override.
+        # List of widgets *not* to be deleted by delete_widgets.
         self.retained_widgets = []
-            # List of widgets *not* to be deleted by delete_widgets.
+        # For find_node: The outline to be searched for nodes.
         self.root = None
-            # For find_node: The outline to be searched for nodes.
+        # The root of the script tree.
         self.script_root = None
-            # The root of the script tree.
+        # Index into self.script_list.
         self.script_i = 0
-            # Index into self.script_list.
+        # A list of strings (scripts). Scripts are removed when executed.
         self.script_list = []
-            # A list of strings (scripts).
-            # Scripts are removed when executed.
-        self.user_dict = {}
-            # For use by scripts.
-        self.widgets = []
-            # References to all widgets created by this class.
-        #
+        self.user_dict = {}  # For use by scripts.
+        self.widgets = []  # References to all widgets created by this class.
         # Init...
         self.init()
         self.init_namespace()
@@ -260,8 +254,7 @@ class Demo:
         self.script_root = script_tree and script_tree.copy()
         self.delete_widgets()
         self.auto_run = auto_run
-        self.initial_geometry = self.get_top_geometry()
-            # Setup may change this.
+        self.initial_geometry = self.get_top_geometry()  # Setup may change this.
         if isinstance(p, leoNodes.Position):
             if p:
                 self.script_list = self.create_script_list(p, delim)
@@ -273,8 +266,8 @@ class Demo:
                         self.end()
                     if auto_run:
                         while self.script_i < len(self.script_list):
+                            # Helps, but widgets are not deleted.
                             g.app.gui.qtApp.processEvents()
-                                # Helps, but widgets are not deleted.
                             self.next()
                     else:
                         self.next()
@@ -490,8 +483,8 @@ class Demo:
     def open_menu(self, menu_name):
         """Activate the indicated *top-level* menu."""
         c = self.c
+        # Menu is a qtMenuWrapper, a subclass of both QMenu and leoQtMenu.
         menu = c.frame.menu.getMenu(menu_name)
-            # Menu is a qtMenuWrapper, a subclass of both QMenu and leoQtMenu.
         if menu:
             c.frame.menu.activateMenu(menu_name)
         return menu

--- a/leo/plugins/examples/chinese_menu.py
+++ b/leo/plugins/examples/chinese_menu.py
@@ -24,8 +24,7 @@ from leo.core import leoGlobals as g
 #@+node:ekr.20111104210837.9689: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = not g.unitTesting
-        # Unpleasant for unit testing.
+    ok = not g.unitTesting  # Unpleasant for unit testing.
     if ok:
         g.registerHandler("menu2", onMenu)
         g.plugin_signon(__name__)

--- a/leo/plugins/examples/french_fm.py
+++ b/leo/plugins/examples/french_fm.py
@@ -12,8 +12,7 @@ from leo.core import leoGlobals as g
 #@+node:ekr.20111104210837.9688: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = g.unitTesting
-        # Unpleasant for unit testing.
+    ok = g.unitTesting  # Unpleasant for unit testing.
     if ok:
         # Register the handlers...
         g.registerHandler("menu2", onMenu)

--- a/leo/plugins/examples/override_classes.py
+++ b/leo/plugins/examples/override_classes.py
@@ -10,8 +10,7 @@ from leo.core import leoFrame
 #@+node:ekr.20111104210837.9692: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = not g.unitTesting
-        # Not for unit testing: overrides core methods.
+    ok = not g.unitTesting  # Not for unit testing: overrides core methods.
     if ok:
         if 0:
             # Override the LeoFrame class.

--- a/leo/plugins/examples/override_commands.py
+++ b/leo/plugins/examples/override_commands.py
@@ -8,8 +8,7 @@ from leo.core import leoGlobals as g
 #@+node:ekr.20111104210837.9691: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = not g.unitTesting
-        # Not for unit testing: overrides core methods.
+    ok = not g.unitTesting  # Not for unit testing: overrides core methods.
     if ok:
         # Register the handlers...
         g.registerHandler("command1", onCommand)

--- a/leo/plugins/examples/redefine_put.py
+++ b/leo/plugins/examples/redefine_put.py
@@ -8,8 +8,7 @@ from leo.core import leoGlobals as g
 #@+node:ekr.20111104210837.9690: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = not g.unitTesting
-        # Not for unit testing: overrides core methods.
+    ok = not g.unitTesting  # Not for unit testing: overrides core methods.
     if ok:
         g.registerHandler("start2", onStart)
         g.plugin_signon(__name__)

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -18,14 +18,12 @@ class CS_Importer(Importer):
         super().__init__(
             importCommands,
             language='coffeescript',
-            state_class=CS_ScanState,
-                # Not used: This class overrides i.scan_line.
+            state_class=CS_ScanState,  # Not used: This class overrides i.scan_line.
             strict=True
         )
         self.errors = 0
         self.root = None
-        self.tab_width = None
-            # NOT the same as self.c.tabwidth.  Set in run().
+        self.tab_width = None  # NOT the same as self.c.tabwidth.  Set in run().
     #@+node:ekr.20161129024357.1: *3* coffee_i.get_new_dict
     #@@nobeautify
 

--- a/leo/plugins/importers/ipynb.py
+++ b/leo/plugins/importers/ipynb.py
@@ -19,13 +19,9 @@ class Import_IPYNB:
 
     def __init__(self, c=None, importCommands=None, **kwargs):
         self.c = importCommands.c if importCommands else c
-            # Commander of present outline.
-        self.cell_n = 0
-            # The number of untitled cells.
-        self.parent = None
-            # The parent for the next created node.
-        self.root = None
-            # The root of the to-be-created outline.
+        self.cell_n = 0  # The number of untitled cells.
+        self.parent = None  # The parent for the next created node.
+        self.root = None  # The root of the to-be-created outline.
 
     #@+others
     #@+node:ekr.20180408112531.1: *3* ipynb.Entries & helpers
@@ -165,8 +161,8 @@ class Import_IPYNB:
         # Handle the body text.
         val = cell.get('source')
         if val and val.strip():
+            # add_markup will add directives later.
             cell_p.b = val.strip() + '\n'
-                # add_markup will add directives later.
         del cell['source']
         self.set_ua(cell_p, 'cell', cell)
     #@+node:ekr.20160412101537.13: *4* ipynb.do_prefix
@@ -211,8 +207,6 @@ class Import_IPYNB:
                 payload = f.read()
             try:
                 nb = nbformat.reads(payload, as_version=4)
-                    # nbformat.NO_CONVERT: no conversion
-                    # as_version=4: Require IPython 4.
                 return nb
             except Exception:
                 g.es_exception()

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -110,22 +110,20 @@ class Importer:
         self.c = c = ic and ic.c
         self.encoding = ic and ic.encoding or 'utf-8'
         self.gen_refs = gen_refs
-        self.language = language or name
-            # For the @language directive.
+        self.language = language or name  # For the @language directive.
         self.name = name or language
         language = self.language
         name = self.name
         assert language and name
         assert self.language and self.name
         self.state_class = state_class
-        self.strict = strict
-            # True: leading whitespace is significant.
-        #
+        self.strict = strict  # True: leading whitespace is significant.
+
         # Set from ivars...
         self.has_decls = name not in ('xml', 'org-mode', 'vimoutliner')
         self.is_rst = name in ('rst',)
         self.tree_type = ic.treeType if c else None  # '@root', '@file', etc.
-        #
+
         # Constants...
         if ic:
             data = g.set_delims_from_language(self.name)
@@ -137,20 +135,20 @@ class Importer:
             self.escape_string = r'%s([0-9]+)\.' % re.escape(self.escape)
             # m.group(1) is the unindent value.
             self.escape_pattern = re.compile(self.escape_string)
-        self.ScanState = ScanState
-            # Must be set by subclasses that use general_scan_line.
+        self.ScanState = ScanState  # Must be set by subclasses that use general_scan_line.
         self.tab_width = 0  # Must be set in run, using self.root.
         self.ws_pattern = re.compile(r'^\s*$|^\s*%s' % (self.single_comment or ''))
-        #
+
         # Settings...
         self.reloadSettings()
-        #
+
         # State vars.
         self.errors = 0
         if ic:
             ic.errors = 0  # Required.
         self.parse_body = False
-        self.refs_dict: Dict[str, int] = {}  # Keys are headlines. Values are disambiguating number.
+        # Keys are headlines. Values are disambiguating number.
+        self.refs_dict: Dict[str, int] = {}
         self.root = None
         self.skip = 0  # A skip count for x.gen_lines & its helpers.
         self.vnode_info: Dict[str, Any] = {}
@@ -443,21 +441,20 @@ class Importer:
         kind = 'tabs' if self.tab_width > 0 else 'blanks'
         kind2 = 'blanks' if self.tab_width > 0 else 'tabs'
         fn = g.shortFileName(self.root.h)
-        #lines = g.splitLines(s)
         count, result, tab_width = 0, [], self.tab_width
         self.ws_error = False  # 2016/11/23
         if tab_width < 0:  # Convert tabs to blanks.
             for n, line in enumerate(lines):
                 i, w = g.skip_leading_ws_with_indent(line, 0, tab_width)
+                # Use negative width.
                 s = g.computeLeadingWhitespace(w, -abs(tab_width)) + line[i:]
-                    # Use negative width.
                 if s != line:
                     count += 1
                 result.append(s)
         elif tab_width > 0:  # Convert blanks to tabs.
             for n, line in enumerate(lines):
+                # Use positive width.
                 s = g.optimizeLeadingWhitespace(line, abs(tab_width))
-                    # Use positive width.
                 if s != line:
                     count += 1
                 result.append(s)
@@ -647,8 +644,7 @@ class Importer:
             else:
                 ref = '%s@others\n' % indent_ws
                 target.at_others_flag = True
-            target.ref_flag = True
-                # Don't generate another @others in this target.
+            target.ref_flag = True  # Don't generate another @others in this target.
             headline = h
         if ref:
             self.add_line(parent, ref)
@@ -1046,8 +1042,8 @@ class Importer:
     #@+node:ekr.20161108131153.12: *4* i.insert_ignore_directive
     def insert_ignore_directive(self, parent):
         c = self.c
+        # Do *not* update the screen by setting p.b.
         parent.v.b = parent.v.b.rstrip() + '\n@ignore\n'
-            # Do *not* update the screen by setting p.b.
         if g.unitTesting:
             pass
         elif parent.isAnyAtFileNode() and not parent.isAtAutoNode():
@@ -1276,14 +1272,10 @@ class Target:
 
     def __init__(self, p, state):
         """Target ctor."""
-        self.at_others_flag = False
-            # True: @others has been generated for this target.
+        self.at_others_flag = False  # True: @others has been generated for this target.
         self.p = p
-        self.gen_refs = False
-            # Can be forced True.
-        self.ref_flag = False
-            # True: @others or section reference should be generated.
-            # It's always True when gen_refs is True.
+        self.gen_refs = False  # Can be forced True.
+        self.ref_flag = False  # True: @others or section reference should be generated.
         self.state = state
 
     def __repr__(self):

--- a/leo/plugins/importers/org.py
+++ b/leo/plugins/importers/org.py
@@ -97,9 +97,9 @@ class Org_Importer(Importer):
         if line:
             self.add_line(child, line)
         assert isinstance(headline, str), repr(headline)
+        # #1037: do rstrip, not strip.
+        # #1087: do not strip at all!
         child.h = headline
-            # #1037: do rstrip, not strip.
-            # #1087: do not strip at all!
         return child
     #@+node:ekr.20171120084611.5: *3* org_i.load_nodetags
     def load_nodetags(self):

--- a/leo/plugins/importers/perl.py
+++ b/leo/plugins/importers/perl.py
@@ -29,8 +29,7 @@ class Perl_Importer(Importer):
         """Clean nodes as part of the perl post pass."""
         # Move trailing comments into following def nodes.
         for p in parent.subtree():
-            next = p.threadNext()
-                # This can be a node *outside* parent's tree!
+            next = p.threadNext()  # This can be a node *outside* parent's tree!
             if next and self.has_lines(next):
                 lines = self.get_lines(p)
                 if lines:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -107,7 +107,7 @@ def split_root(root, lines):
         if tok[0] != token.NAME or tok[1] not in ('async', 'def', 'class'):
             return None
 
-        # the following few values are easy to get
+        # The following few values are easy to get
         if tok[1] == 'async':
             kind = rawtokens[start + 1][1]
             name = rawtokens[start + 2][1]
@@ -123,45 +123,37 @@ def split_root(root, lines):
         # lines. At the end of this logical line, there will be a
         # NEWLINE token
         for i, t in search(start + 1, token.NEWLINE):
-            end_h = t[2][0]  # the last of the `header lines`
-                            # this lines should not be indented
-                            # in the node body as opposed to
-                            # the lines for function/method/class body
-                            # which will be indented
-
-            # in case we have oneliner, let's define end_b here
+            # The last of the `header lines`.
+            # These lines should not be indented in the node body.
+            # The body lines *will* be indented.
+            end_h = t[2][0]
+            # In case we have a oneliner, let's define end_b here
             end_b = end_h
-
             # indented body starts on the next line
             start_b = end_h + 1
             break
 
-        # to check if we have a oneline definition or not
-        # we have to look forward to see which token will come
-        # first INDENT or NEWLINE.
+        # Look ahead to check if we have a oneline definition or not.
+        # That is, see which whether INDENT or NEWLINE will come first.
         oneliner = True
         for (i1, t), (i2, t1) in zip(search(i + 1, token.INDENT), search(i + 1, token.NEWLINE)):
             # INDENT comes after the NEWLINE, means the definition is in a single line
             oneliner = i1 > i2
             break
 
-        # finally we can find the end of this definition
+        # Find the end of this definition
         if oneliner:
-            c_ind = col  # the following lines will not be indented
-                        # because the definition was in the same line
-
-            # end of the body is the same as the start of the body
+            # The following lines will not be indented
+            # because the definition was in the same line.
+            c_ind = col
+            # The end of the body is the same as the start of the body
             end_b = start_b
-
         else:
-            # we have some body lines
-            # presumably the next token is INDENT
+            # We have some body lines. Presumably the next token is INDENT.
             i += 1
-
-            # this is the indentation of the first function/method/class body line
+            # This is the indentation of the first function/method/class body line
             c_ind = len(t[1]) + col
-
-            # now we are searching to find the end of this function/method/body
+            # Now search to find the end of this function/method/body
             for i, t in itoks(i + 1):
                 col2 = t[2][1]
                 if col2 > col:
@@ -170,17 +162,15 @@ def split_root(root, lines):
                     end_b = t[2][0]
                     break
 
-
-        # now let's increase end_b to include all following blank lines
+        # Increase end_b to include all following blank lines
         for j in range(end_b, len(lines) + 1):
             if lines[j - 1].isspace():
                 end_b = j + 1
             else:
                 break
 
-        # number of `intro` lines
+        # Compute the number of `intro` lines
         intro = get_intro(a, col)
-
         return col, a - intro, end_h, start_b, kind, name, c_ind, end_b
     #@+node:vitalije.20211208101750.1: *3* body
     def bodyLine(x, ind):

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -24,16 +24,13 @@ class Xml_Importer(Importer):
         )
         self.tags_setting = tags_setting
         self.start_tags = self.add_tags()
-        self.stack = []
-            # Stack of tags.
-            # A closing tag decrements state.tag_level only if the top is an opening tag.
+        # A closing tag decrements state.tag_level only if the top is an opening tag.
+        self.stack = []  # Stack of tags.
         self.void_tags = [
             '<?xml',
             '!doctype',
         ]
-        self.tag_warning_given = False
-            # True: a structure error has been detected.
-            # Only warn once.
+        self.tag_warning_given = False  # True: a structure error has been detected.
     #@+node:ekr.20161121204918.1: *3* xml_i.add_tags
     def add_tags(self):
         """Add items to self.class/functionTags and from settings."""

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -268,9 +268,8 @@ class OpmlController:
         if not fileName:
             g.trace('no fileName')
             return None
+        # Create the new commander *now*, so that created vnodes will have the proper context.
         c = self.c.new()
-            # Create the new commander *now*
-            # so that created vnodes will have the proper context.
         # Pass one: create the intermediate nodes.
         dummyRoot = self.parse_opml_file(fileName)
         if not dummyRoot:

--- a/leo/plugins/leo_pdf.py
+++ b/leo/plugins/leo_pdf.py
@@ -540,7 +540,7 @@ if docutils:
             self.styleSheet = getStyleSheet()
             super().__init__(doctree)  # Init the base class.
             self.language = get_language(doctree)
-                # docutils.languages.get_language(doctree.settings.language_code,self.reporter)
+            # docutils.languages.get_language(doctree.settings.language_code,self.reporter)
         #@+node:ekr.20090704103932.5190: *3* as_what
         def as_what(self):
 
@@ -613,7 +613,7 @@ if docutils:  # NOQA
             self.styleSheet = getStyleSheet()
             super().__init__(doctree)  # Init the base class.
             self.language = get_language(doctree)
-                # docutils.languages.get_language(doctree.settings.language_code,self.reporter)
+            # docutils.languages.get_language(doctree.settings.language_code,self.reporter)
             self.in_docinfo = False
             self.head = []  # Set only by meta() method.
             self.body = []  # The body text being accumulated.

--- a/leo/plugins/leo_to_rtf.py
+++ b/leo/plugins/leo_to_rtf.py
@@ -118,12 +118,12 @@ def export_rtf(c):
         curLevel = p.level() + 1  # Store current level so method doesn't have to be called again
         if curLevel != myLevel:
             if myLevel != -1:
+                # If this is not the 1st level written, close the last before begin
                 f.write("}")
-                    # If this is not the 1st level written, close the last before begin
+            # Generate the pixel indent for the current level
             levelIndent = str(720 * curLevel)
-                # Generate the pixel indent for the current level
+            # Output the generic RTF level info
             f.write(levelHeader)
-                # Output the generic RTF level info
             f.write("\\li" + levelIndent + "\\tx" + levelIndent + "\\ilvl" + str(curLevel - 1) + "\\lin" + levelIndent)
             f.write("{")
         myLevel = curLevel

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -336,10 +336,8 @@ class LeoBrowserApp(flx.PyComponent):
     def init(self):
         # Set the ivars.
         global g  # Always use the imported g.
-        self.inited = False
-            # Set in finish_create
+        self.inited = False  # Set in finish_create
         self.tag = 'py.app.wrap'
-        #
         # Open or get the first file.
         if not g.app:
             print('app.init: no g.app. g:', repr(g))
@@ -351,29 +349,23 @@ class LeoBrowserApp(flx.PyComponent):
             # This can happen in strange situations.
             # print('app.init: ===== Ctrl-H ===== ?')
             return
-        #
         # We are running with --gui=browser.
         c = g.app.log.c
-        #
         # self.gui must be a synonym for g.app.gui.
         self.c = c
         self.gui = gui = g.app.gui
         # Make sure everything is as expected.
         assert self.c and c == self.c
         assert g.app.gui.guiName() == 'browser'
-        #
         # When running from Leo's core, we must wait until now to set LeoBrowserGui.root.
         gui.root = get_root()
-        #
         # Check g.app.ivars.
         assert g.app.windowList
         for frame in g.app.windowList:
             assert isinstance(frame, DummyFrame), repr(frame)
-        #
         # Instantiate all wrappers here, not in app.finish_create.
         title = c.computeWindowTitle(c.mFileName)
         c.frame = gui.lastFrame = LeoBrowserFrame(c, title, gui)
-        #
         # The main window will be created (much) later.
         main_window = LeoFlexxMainWindow()
         self._mutate('main_window', main_window)
@@ -397,8 +389,8 @@ class LeoBrowserApp(flx.PyComponent):
         if 'keys' in g.app.debug:
             g.trace(ev, ivar)
         c = self.c
+        # Essential: there is no way to pass the actual wrapper.
         browser_wrapper = getattr(c.frame, ivar)
-            # Essential: there is no way to pass the actual wrapper.
         #@+<< check browser_wrapper >>
         #@+node:ekr.20181129073812.1: *5* << check browser_wrapper >>
         assert isinstance(browser_wrapper, (

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -95,8 +95,8 @@ def get_root():
 
     This is the same as self.root for any flx.Component.
     """
+    # Only called at startup, so this will never be None.
     root = flx.loop.get_active_component().root
-        # Only called at startup, so this will never be None.
     assert isinstance(root, LeoBrowserApp), repr(root)
     return root
 #@+node:ekr.20181112165240.1: *3* info (deprecated)
@@ -335,8 +335,7 @@ class LeoBrowserApp(flx.PyComponent):
     #@+node:ekr.20181216042806.1: *5* app.init
     def init(self):
         # Set the ivars.
-        global g
-            # Always use the imported g.
+        global g  # Always use the imported g.
         self.inited = False
             # Set in finish_create
         self.tag = 'py.app.wrap'
@@ -410,9 +409,9 @@ class LeoBrowserApp(flx.PyComponent):
             LeoBrowserTree,
         )), repr(browser_wrapper)
         #@-<< check browser_wrapper >>
+        # ev is a dict, keys are type, source, key, modifiers
+        # mods in ('Alt', 'Shift', 'Ctrl', 'Meta')
         key, mods = ev['key'], ev['modifiers']
-            # ev is a dict, keys are type, source, key, modifiers
-            # mods in ('Alt', 'Shift', 'Ctrl', 'Meta')
         # Special case Ctrl-H and Ctrl-F.
         if mods == ['Ctrl'] and key in 'fh':
             command = 'find' if key == 'f' else 'head'
@@ -509,16 +508,16 @@ class LeoBrowserApp(flx.PyComponent):
         t1 = time.process_time()
         ap = self.p_to_ap(p)
         w.tree.select_ap(ap)
+        # Needed to compare generations, even if there are no changes.
         redraw_dict = self.make_redraw_dict(p)
-            # Needed to compare generations, even if there are no changes.
         new_flattened_outline = redrawer.flatten_outline(c)
         redraw_instructions = redrawer.make_redraw_list(
             self.old_flattened_outline,
             new_flattened_outline,
         )
+        # At present, this does a full redraw using redraw_dict.
+        # The redraw instructions are not used.
         w.tree.redraw_with_dict(redraw_dict, redraw_instructions)
-            # At present, this does a full redraw using redraw_dict.
-            # The redraw instructions are not used.
         #
         # Do not call c.setChanged() here.
         if trace:
@@ -1207,11 +1206,11 @@ class LeoBrowserFrame(leoFrame.NullFrame):
         self.menu = LeoBrowserMenu(frame)
         self.miniBufferWidget = LeoBrowserMinibuffer(c, frame)
         self.iconBar = LeoBrowserIconBar(c, frame)
+        # NullFrame does this in createStatusLine.
         self.statusLine = LeoBrowserStatusLine(c, frame)
-            # NullFrame does this in createStatusLine.
+        # This is the DynamicWindow object.
+        # There is no need to implement its methods now.
         self.top = g.NullObject()
-            # This is the DynamicWindow object.
-            # There is no need to implement its methods now.
 
     def finishCreate(self):
         """Override NullFrame.finishCreate."""
@@ -1762,16 +1761,14 @@ class JS_Editor(flx.Widget):
     @flx.emitter  # New
     def key_up(self, e):
         trace = False and 'keys' in g.app.debug
-        self.last_down = None
-            # Enable key downs.
+        self.last_down = None  # Enable key downs.
         ev = self._create_key_event(e)
         if self.ignore_up:
             if trace:
                 print('IGNORE jse.key_up: %s %r' % (self.name, ev))
             e.preventDefault()
             return ev
-        self.ignore_up = True
-            # Ignore all further key ups, until the next key down
+        self.ignore_up = True  # Ignore all further key ups, until the next key down.
         should_be_leo = bool(self.should_be_leo_key(ev))
         if trace:
             print('       jse.key_up: %s %r Leo: %s' % (self.name, ev, should_be_leo))
@@ -2089,8 +2086,8 @@ class LeoFlexxMainWindow(flx.Widget):
 class MinibufferEditor(flx.Widget):
 
     def init(self):
+        # Unlike in components, this call happens immediately.
         self.editor = make_editor_function('minibuffer', self.node)
-            # Unlike in components, this call happens immediately.
 
 class LeoFlexxMiniBuffer(JS_Editor):
 
@@ -2259,17 +2256,12 @@ class LeoFlexxTree(flx.Widget):
         self.wrapper = self
         self.tag = 'flx.tree'
         # Init local ivars...
-        self.populated_items_dict = {}
-            # Keys are ap **keys**, values are True.
-        self.populating_tree_item = None
-            # The LeoTreeItem whose children are to be populated.
-        self.selected_ap = {}
-            # The ap of the presently selected node.
-        self.tree_items_dict = {}
-            # Keys are ap's. Values are LeoTreeItems.
-        # Init the widget.
+        self.populated_items_dict = {}  # Keys are ap **keys**, values are True.
+        self.populating_tree_item = None  # The LeoTreeItem whose children are to be populated.
+        self.selected_ap = {}  # The ap of the presently selected node.
+        self.tree_items_dict = {}  # Keys are ap's. Values are LeoTreeItems.
+        # Init the widget. The max_selected property does not seem to work.
         self.tree = flx.TreeWidget(flex=1, max_selected=1)
-            # The max_selected property does not seem to work.
 
     def assert_exists(self, obj):
         # pylint: disable=undefined-variable
@@ -2543,8 +2535,7 @@ class LeoFlexxTree(flx.Widget):
         item = self.tree_items_dict.get(key)
         if item:
             item.set_selected(True)
-            self.selected_ap = ap
-                # Set the item's selected property.
+            self.selected_ap = ap  # Set the item's selected property.
         else:
             pass  # We may be in the middle of a redraw.
     #@+node:ekr.20181109083659.1: *5* flx_tree.reaction.on_selected_event
@@ -2584,8 +2575,7 @@ class LeoFlexxTreeItem(flx.TreeItem):
 
     def init(self, leo_ap):
         # pylint: disable=arguments-differ
-        self.leo_ap = leo_ap
-            # Immutable: Gives access to cloned, marked, expanded fields.
+        self.leo_ap = leo_ap  # Immutable: Gives access to cloned, marked, expanded fields.
         self.leo_children = []
 
     def getName(self):

--- a/leo/plugins/leoscreen.py
+++ b/leo/plugins/leoscreen.py
@@ -192,8 +192,7 @@ class leoscreen_Controller:
         self.reloadSettings()
         self._get_output()  # prime output diffing system
         self.popups = []  # store references to popup windows
-        self.stack_frame = 0
-            # used by jump to error commands, 0 = innermost frame
+        self.stack_frame = 0  # For jump to error commands, 0 = innermost frame
 
     def reloadSettings(self):
         c = self.c

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -139,8 +139,8 @@ def universal_line_numbers(root, target_p, delim_st, delim_en):
     #@+node:vitalije.20170726110242.1: *3* write patterns
     section_pat = re.compile(r'^(\s*)(<{2}[^>]+>>)(.*)$')
 
+    # Important: re.M used also in others_iterator
     others_pat = re.compile(r'^(\s*)@others\b', re.M)
-        # !important re.M used also in others_iterator
 
     doc_pattern = re.compile('^(@doc|@)(?:\\s(.*?)\n|\n)$')
 

--- a/leo/plugins/mod_autosave.py
+++ b/leo/plugins/mod_autosave.py
@@ -27,8 +27,7 @@ gDict = {}  # Keys are commanders, values are settings dicts.
 #@+node:ekr.20060108123141.2: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = not g.unitTesting
-        # Don't want autosave after unit testing.
+    ok = not g.unitTesting  # Don't want autosave after unit testing.
     if ok:
         # Register the handlers...
         g.registerHandler('after-create-leo-frame', onCreate)

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -333,22 +333,14 @@ class AtButtonCallback:
     #@+node:ekr.20141031053508.9: *3* __init__ (AtButtonCallback)
     def __init__(self, controller, b, c, buttonText, docstring, gnx, script):
         """AtButtonCallback.__init__."""
-        self.b = b
-            # A QButton.
-        self.buttonText = buttonText
-            # The text of the button.
-        self.c = c
-            # A Commander.
-        self.controller = controller
-            # A ScriptingController instance.
-        self.gnx = gnx
-            # Set if the script is defined in the local .leo file.
-        self.script = script
-            # Set if the script is found defined in myLeoSettings.leo or leoSettings.leo
-        self.source_c = c
-            # For GetArgs.command_source.
-        self.__doc__ = docstring
-            # The docstring for this callback for g.getDocStringForFunction.
+        self.b = b  # A QButton.
+        self.buttonText = buttonText  # The text of the button.
+        self.c = c  # A Commander.
+        self.controller = controller  # A ScriptingController instance.
+        self.gnx = gnx  # Set if the script is defined in the local .leo file.
+        self.script = script  # The script defined in myLeoSettings.leo or leoSettings.leo
+        self.source_c = c  # For GetArgs.command_source.
+        self.__doc__ = docstring  # The docstring for this callback for g.getDocStringForFunction.
     #@+node:ekr.20141031053508.10: *3* __call__ (AtButtonCallback)
     def __call__(self, event=None):
         """AtButtonCallbgack.__call__. The callback for @button nodes."""
@@ -414,17 +406,16 @@ class ScriptingController:
         kind = c.config.getString('debugger-kind') or 'idle'
         self.buttonsDict = {}  # Keys are buttons, values are button names (strings).
         self.debuggerKind = kind.lower()
+        # True: adds a button for every @button node.
         self.atButtonNodes = getBool('scripting-at-button-nodes')
-            # True: adds a button for every @button node.
+        # True: define a minibuffer command for every @command node.
         self.atCommandsNodes = getBool('scripting-at-commands-nodes')
-            # True: define a minibuffer command for every @command node.
+        # True: define a minibuffer command for every @rclick node.
         self.atRclickNodes = getBool('scripting-at-rclick-nodes')
-            # True: define a minibuffer command for every @rclick node.
+        # True: dynamically loads plugins in @plugin nodes when a window is created.
         self.atPluginNodes = getBool('scripting-at-plugin-nodes')
-            # True: dynamically loads plugins in @plugin nodes when a window is created.
+        # # DANGEROUS! True: dynamically executes script in @script nodes when a window is created.
         self.atScriptNodes = getBool('scripting-at-script-nodes')
-            # True: dynamically executes script in @script nodes when a window is created.
-            # DANGEROUS!
         # Do not allow this setting to be changed in local (non-settings) .leo files.
         if self.atScriptNodes and c.config.isLocalSetting('scripting-at-script-nodes', 'bool'):
             g.issueSecurityWarning('@bool scripting-at-script-nodes')
@@ -434,21 +425,20 @@ class ScriptingController:
                 val = False
             g.es('Restoring value to', val, color='red')
             self.atScriptNodes = val
+        # True: create Debug Script button.
         self.createDebugButton = getBool('scripting-create-debug-button')
-            # True: create Debug Script button.
+        # True: create Run Script button.
         self.createRunScriptButton = getBool('scripting-create-run-script-button')
-            # True: create Run Script button.
+        # True: create Script Button button.
         self.createScriptButtonButton = getBool('scripting-create-script-button-button')
-            # True: create Script Button button.
+        # Maximum length of button names.
         self.maxButtonSize = c.config.getInt('scripting-max-button-size') or 18
-            # Maximum length of button names.
         if not iconBar:
             self.iconBar = c.frame.getIconBarObject()
         else:
             self.iconBar = iconBar
-        self.seen = set()
-            # Fix bug 74: problems with @button if defined in myLeoSettings.leo
-            # Set of gnx's (not vnodes!) that created buttons or commands.
+        # #74: problems with @button if defined in myLeoSettings.leo
+        self.seen = set()  # Set of gnx's (not vnodes!) that created buttons or commands.
     #@+node:ekr.20150401113822.1: *3* sc.Callbacks
     #@+node:ekr.20060328125248.23: *4* sc.addScriptButtonCommand
     def addScriptButtonCommand(self, event=None):
@@ -762,8 +752,7 @@ class ScriptingController:
         # Fix bug #74: problems with @button if defined in myLeoSettings.leo
         docstring = g.getDocString(p.b).strip()
         statusLine = docstring or 'Global script button'
-        shortcut = self.getShortcut(p.h)
-            # Get the shortcut from the @key field in the headline.
+        shortcut = self.getShortcut(p.h)  # Get the shortcut from the @key field in the headline.
         if shortcut:
             statusLine = '%s = %s' % (statusLine.rstrip(), shortcut)
         # We must define the callback *after* defining b,
@@ -788,16 +777,16 @@ class ScriptingController:
             c=c,
             controller=self,
             docstring=docstring,
+            # #367: the gnx is needed for the Goto Script command.
+            #       Use gnx to search myLeoSettings.leo if it is open.
             gnx=gnx,
-                # tag:#367: the gnx is needed for the Goto Script command.
-                # 2018/03/13: Use gnx to search myLeoSettings.leo if it is open.
             script=script,
         )
         # Now patch the button.
         self.iconBar.setCommandForButton(
             button=b,
             command=cb,  # This encapsulates the script.
-            command_p=p and p.copy(),  # tag:#567
+            command_p=p and p.copy(),  # #567
             controller=self,
             gnx=gnx,  # For the find-button function.
             script=script,

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -361,10 +361,9 @@ class NestedSplitterHandle(QtWidgets.QSplitterHandle):  # type:ignore
     #@-others
 #@+node:ekr.20110605121601.17966: ** class NestedSplitter (QSplitter)
 class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
+    # Allow special behavior to be turned of at import stage.
+    # useful if other code must run to set up callbacks, that other code can re-enable.
     enabled = True
-        # allow special behavior to be turned of at import stage
-        # useful if other code must run to set up callbacks, that
-        # other code can re-enable
     other_orientation = {
         Orientation.Vertical: Orientation.Horizontal,
         Orientation.Horizontal: Orientation.Vertical,

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -232,15 +232,15 @@ class TagController:
     def remove_tag(self, p, tag):
         """ removes 'tag' from the taglist of position p. """
         v = p.v
+        # In case JSON storage (leo_cloud plugin) converted to list.
         tags = set(v.u.get(self.TAG_LIST_KEY, set([])))
-            # in case JSON storage (leo_cloud plugin) converted to list.
         if tag in tags:
             tags.remove(tag)
         if tags:
             v.u[self.TAG_LIST_KEY] = tags
         else:
-            del v.u[self.TAG_LIST_KEY]
             # prevent a few corner cases, and conserve disk space
+            del v.u[self.TAG_LIST_KEY]
         self.c.setChanged()
         self.update_taglist(tag)
     #@-others

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -242,13 +242,12 @@ class PlugIn:
         # g.pr(self.version,g.shortFileName(filename))
         # Configuration...
         self.configfilename = "%s.ini" % os.path.splitext(plgMod.__file__)[0]
+        # True if this can be configured.
         self.hasconfig = os.path.isfile(self.configfilename)
-            # True if this can be configured.
+        # Look for an applyConfiguration function in the module.
+        # This is used to apply changes in configuration from the properties window
         self.hasapply = hasattr(plgMod, "applyConfiguration")
-            # Look for an applyConfiguration function in the module.
-            # This is used to apply changes in configuration from the properties window
-        self.create_menu()
-            # Create menu items from cmd_* functions.
+        self.create_menu()  # Create menu items from cmd_* functions.
         # Use a toplevel menu item instead of the default About.
         try:
             self.hastoplevel = self.mod.__dict__["topLevelMenu"]

--- a/leo/plugins/python_terminal.py
+++ b/leo/plugins/python_terminal.py
@@ -54,16 +54,16 @@ from leo.core import leoGlobals as g
 from leo.core.leoQt import QtWidgets
 from leo.core.leoQt import Key
 
+# A workaround for #1212: segfaults at startup when importing this file.
+# True: enable tab completion, at the risk of segfaults.
 use_rlcompleter = False
-    # A workaround for #1212: segfaults at startup when importing this file.
-    # True: enable tab completion, at the risk of segfaults.
 
 # Third-party imports.
 if use_rlcompleter:
     from rlcompleter import Completer
 else:
     Completer = None
-#
+
 # Fail fast, right after all imports.
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@-<< imports >>

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -536,8 +536,7 @@ class LeoQtEventFilter(QtCore.QObject):  # type:ignore
     #@+node:ekr.20131121050226.16331: *4* filter.traceWidget
     def traceWidget(self, event):
         """Show unexpected events in unusual widgets."""
-        verbose = False
-            # Not good for --trace-events
+        verbose = False  # Not good for --trace-events
         e = QtCore.QEvent
         assert isinstance(event, QtCore.QEvent)
         et = event.type()

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -48,8 +48,7 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20110605121601.18477: *3*  qt_gui.__init__ (sets qtApp)
     def __init__(self):
         """Ctor for LeoQtGui class."""
-        super().__init__('qt')
-             # Initialize the base class.
+        super().__init__('qt')  # Initialize the base class.
         self.active = True
         self.consoleOnly = False  # Console is separate from the log.
         self.iconimages = {}
@@ -67,7 +66,7 @@ class LeoQtGui(leoGui.LeoGui):
         self.qtApp = QtWidgets.QApplication(sys.argv)
         self.reloadSettings()
         self.appIcon = self.getIconImage('leoapp32.png')
-        #
+
         # Define various classes key stokes.
         #@+<< define FKeys >>
         #@+node:ekr.20180419110303.1: *4* << define FKeys >>
@@ -592,13 +591,13 @@ class LeoQtGui(leoGui.LeoGui):
         # pylint: disable=arguments-differ
         if g.unitTesting:
             return ''
-        #
+
         # 2018/03/14: Bug fixes:
         # - Use init_dialog_folder only if a path is not given
         # - *Never* Use os.curdir by default!
         if not startpath:
+            # Returns c.last_dir or os.curdir
             startpath = g.init_dialog_folder(c, c and c.p, use_at_path=True)
-                # Returns c.last_dir or os.curdir
         filter_ = self.makeFilter(filetypes)
         dialog = QtWidgets.QFileDialog()
         if c:
@@ -613,7 +612,7 @@ class LeoQtGui(leoGui.LeoGui):
                 c.in_qt_dialog = False
         else:
             val = func(parent=None, caption=title, directory=startpath, filter=filter_)
-        if isQt5 or isQt6:  # this is a *Py*Qt change rather than a Qt change
+        if isQt5 or isQt6:  # This is a *Py*Qt change rather than a Qt change
             val, junk_selected_filter = val
         if multiple:
             files = [g.os_path_normslashes(s) for s in val]
@@ -766,15 +765,12 @@ class LeoQtGui(leoGui.LeoGui):
         w_name = w and w.objectName()
         if 'focus' in g.app.debug:
             g.trace(repr(w_name))
-        self.active = False
-            # Used only by c.idle_focus_helper.
-        #
+        self.active = False  # Used only by c.idle_focus_helper.
         # Careful: never save headline widgets.
         if w_name == 'headline':
             self.deactivated_widget = c.frame.tree.treeWidget
         else:
             self.deactivated_widget = w if w_name else None
-        #
         # Causes problems elsewhere...
             # if c.exists and not self.deactivated_name:
                 # self.deactivated_name = self.widget_name(self.get_focus())
@@ -798,8 +794,7 @@ class LeoQtGui(leoGui.LeoGui):
         # #1273: add teest on c.vim_mode.
         if c.exists and c.vim_mode and c.vimCommands and not self.active and not g.app.killed:
             c.vimCommands.on_activate()
-        self.active = True
-            # Used only by c.idle_focus_helper.
+        self.active = True  # Used only by c.idle_focus_helper.
         if g.isMac:
             pass  # Fix #757: MacOS: replace-then-find does not work in headlines.
         else:
@@ -827,20 +822,17 @@ class LeoQtGui(leoGui.LeoGui):
                     # c.bodyWantsFocusNow()
         g.doHook('activate', c=c, p=c.p, v=c.p, event=event)
     #@+node:ekr.20130921043420.21175: *4* qt_gui.setFilter
-    # w's type is in (DynamicWindow,QMinibufferWrapper,LeoQtLog,LeoQtTree,
-    # QTextEditWrapper,LeoQTextBrowser,LeoQuickSearchWidget,cleoQtUI)
-
     def setFilter(self, c, obj, w, tag):
         """
         Create an event filter in obj.
         w is a wrapper object, not necessarily a QWidget.
         """
-        # gui = self
+        # w's type is in (DynamicWindow,QMinibufferWrapper,LeoQtLog,LeoQtTree,
+        # QTextEditWrapper,LeoQTextBrowser,LeoQuickSearchWidget,cleoQtUI)
         assert isinstance(obj, QtWidgets.QWidget), obj
         theFilter = qt_events.LeoQtEventFilter(c, w=w, tag=tag)
         obj.installEventFilter(theFilter)
-        w.ev_filter = theFilter
-            # Set the official ivar in w.
+        w.ev_filter = theFilter  # Set the official ivar in w.
     #@+node:ekr.20110605121601.18508: *3* qt_gui.Focus
     #@+node:ekr.20190601055031.1: *4* qt_gui.ensure_commander_visible
     def ensure_commander_visible(self, c1):
@@ -1085,10 +1077,8 @@ class LeoQtGui(leoGui.LeoGui):
         # Calling window.show() here causes flash.
         self.attachLeoIcon(window)
         # Monkey-patch
-        window.closeEvent = self.close_event
-            # Use self: g.app.gui does not exist yet.
-        self.runAtIdle(self.set_main_window_style_sheet)
-            # No StyleSheetManager exists yet.
+        window.closeEvent = self.close_event  # Use self: g.app.gui does not exist yet.
+        self.runAtIdle(self.set_main_window_style_sheet)  # No StyleSheetManager exists yet.
         return window
 
     def set_main_window_style_sheet(self):
@@ -1831,8 +1821,8 @@ class StyleSheetManager:
             selectors.append('qt-gui-user-style-sheet')
         sheets = []
         for name in selectors:
+            # don't strip `#selector_name { ...` type syntax
             sheet = c.config.getData(name, strip_comments=False)
-                # don't strip `#selector_name { ...` type syntax
             if sheet:
                 if '\n' in sheet[0]:
                     sheet = ''.join(sheet)
@@ -1927,8 +1917,8 @@ class StyleSheetManager:
                     g.es_print(f"'{const}' from style-sheet comment definition, ")
                     g.es_print("please use regular @string / @color type @settings.")
             else:
+                # lowercase, without '@','-','_', etc.
                 key = g.app.config.canonicalizeSettingName(const[1:])
-                    # lowercase, without '@','-','_', etc.
                 value = settingsDict.get(key)
                 if value is not None:
                     # New in Leo 5.5: Do NOT add comments here.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -137,8 +137,8 @@ class LeoQtGui(leoGui.LeoGui):
             not g.unitTesting
         ):
             self.splashScreen = self.createSplashScreen()
+        # qtFrame.finishCreate does all the other work.
         self.frameFactory = qt_frame.TabbedFrameFactory()
-            # qtFrame.finishCreate does all the other work.
 
     def reloadSettings(self):
         pass  # Note: self.c does not exist.
@@ -1929,13 +1929,12 @@ class StyleSheetManager:
                     # New in Leo 5.5: Do NOT add comments here.
                     # They RUIN style sheets if they appear in a nested comment!
                     value = self.color_db.get(key)
-                        # value = '%s /* %s */' % (value, key)
             if value:
                 # Partial fix for #780.
                 try:
+                    # Don't replace shorter constants occuring in larger.
                     sheet = re.sub(
                         const + "(?![-A-Za-z0-9_])",
-                            # don't replace shorter constants occuring in larger
                         value,
                         sheet,
                     )

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -2148,7 +2148,7 @@ class StyleSheetManager:
         """
         RE = r'([=:])[ ]*([.1234567890]+)(p[tx])'
 
-        def scale(matchobj, scale = factor):
+        def scale(matchobj, scale=factor):
             prefix = matchobj.group(1)
             sz = matchobj.group(2)
             units = matchobj.group(3)

--- a/leo/plugins/qt_idle_time.py
+++ b/leo/plugins/qt_idle_time.py
@@ -52,24 +52,16 @@ class IdleTime:
     def __init__(self, handler, delay=500, tag=None):
         """ctor for IdleTime class."""
         # For use by handlers...
-        self.count = 0
-            # The number of times handler has been called.
-        self.starting_time = None
-            # Time that the timer started.
-        self.time = None
-            # Time that the handle is called.
-        self.tag = tag
-            # An arbitrary string/object for use during debugging.
+        self.count = 0  # The number of times handler has been called.
+        self.starting_time = None  # Time that the timer started.
+        self.time = None  # Time that the handle is called.
+        self.tag = tag  # An arbitrary string/object for use during debugging.
         # For use by the IdleTime class...
+        # The argument to self.timer.start: 0 for idle time, otherwise a delay in msec.
         self.delay = delay
-            # The argument to self.timer.start:
-            # 0 for idle time, otherwise a delay in msec.
-        self.enabled = False
-            # True: run the timer continuously.
-        self.handler = handler
-            # The user-provided idle-time handler.
-        self.waiting_for_idle = False
-            # True if we have already waited for the minimum delay\
+        self.enabled = False  # True: run the timer continuously.
+        self.handler = handler  # The user-provided idle-time handler.
+        self.waiting_for_idle = False  # True if we have already waited for the minimum delay.
         # Create the timer, but do not fire it.
         self.timer = QtCore.QTimer()
         self.timer.timeout.connect(self.at_idle_time)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -95,8 +95,8 @@ class QTextMixin:
         self.c = c
         self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
+        # A flag for k.masterKeyHandler and isTextWrapper.
         self.supportsHighLevelInterface = True
-            # A flag for k.masterKeyHandler and isTextWrapper.
         self.tags = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.configDict = {}  # Keys are tags, values are colors (names or values).
@@ -533,8 +533,8 @@ if QtWidgets:
                 super().__init__()
                 self.setWindowFlags(WindowType.Popup | self.windowFlags())
                 # Inject the ivars
+                # A LeoQTextBrowser, a subclass of QtWidgets.QTextBrowser.
                 self.leo_w = c.frame.body.wrapper.widget
-                    # A LeoQTextBrowser, a subclass of QtWidgets.QTextBrowser.
                 self.leo_c = c
                 # A weird hack.
                 self.leo_geom_set = False  # When true, self.geom returns global coords!
@@ -1034,17 +1034,13 @@ class NumberBar(QtWidgets.QFrame):  # type:ignore
         """Ctor for NumberBar class."""
         super().__init__(*args)
         self.c = c
-        self.edit = e
-            # A QTextEdit.
-        self.d = e.document()
-            # A QTextDocument.
-        self.fm = self.fontMetrics()
-            # A QFontMetrics
+        self.edit = e  # A QTextEdit.
+        self.d = e.document()  # A QTextDocument.
+        self.fm = self.fontMetrics()  # A QFontMetrics
         self.image = QtGui.QImage(g.app.gui.getImageImage(
             g.os_path_finalize_join(g.app.loadDir,
                 '..', 'Icons', 'Tango', '16x16', 'actions', 'stop.png')))
-        self.highest_line = 0
-            # The highest line that is currently visibile.
+        self.highest_line = 0  # The highest line that is currently visibile.
         # Set the name to gutter so that the QFrame#gutter style sheet applies.
         self.offsets = []
         self.setObjectName('gutter')
@@ -1053,10 +1049,10 @@ class NumberBar(QtWidgets.QFrame):  # type:ignore
     def reloadSettings(self):
         c = self.c
         c.registerReloadSettings(self)
+        # Extra width for column.
         self.w_adjust = c.config.getInt('gutter-w-adjust') or 12
-            # Extra width for column.
+        # The y offset of the first line of the gutter.
         self.y_adjust = c.config.getInt('gutter-y-adjust') or 10
-            # The y offset of the first line of the gutter.
     #@+node:ekr.20181005085507.1: *3* NumberBar.mousePressEvent
     def mousePressEvent(self, event):
 

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -746,7 +746,7 @@ class LeoQtTree(leoFrame.LeoTree):
             self.busy = True
             p = self.item2position(item)
             if p:
-                auto_edit = self.prev_v == p.v # #1049.
+                auto_edit = self.prev_v == p.v  # #1049.
                 self.prev_v = p.v
                 event = None
                 #

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -46,8 +46,8 @@ class LeoQtTree(leoFrame.LeoTree):
         # Components.
         self.canvas = self  # An official ivar used by Leo's core.
         self.headlineWrapper = qt_text.QHeadlineWrapper  # This is a class.
+        # w is a LeoQTreeWidget, a subclass of QTreeWidget.
         self.treeWidget = w = frame.top.treeWidget  # An internal ivar.
-            # w is a LeoQTreeWidget, a subclass of QTreeWidget.
         #
         # "declutter", node appearance tweaking
         self.declutter_patterns = None  # list of pairs of patterns for decluttering
@@ -523,7 +523,6 @@ class LeoQtTree(leoFrame.LeoTree):
         v = p.v
         # Allocate the QTreeWidgetItem.
         item = self.createTreeItem(p, parent_item)
-        #
         # Update the data structures.
         itemHash = self.itemHash(item)
         self.position2itemDict[p.key()] = item
@@ -545,8 +544,8 @@ class LeoQtTree(leoFrame.LeoTree):
             return item
         # Draw the icon.
         v.iconVal = v.computeIcon()
+        # **Slow**, but allows per-vnode icons.
         icon = self.getCompositeIconImage(p, v.iconVal)
-            # **Slow**, but allows per-vnode icons.
         if icon:
             item.setIcon(0, icon)
         return item
@@ -630,8 +629,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.redrawCount += 1  # To keep a unit test happy.
         c = self.c
         try:
-            self.busy = True
-                # Suppress call to setHeadString in onItemChanged!
+            self.busy = True  # Suppress call to setHeadString in onItemChanged!
             self.getCurrentItem()
             for p in c.rootPosition().self_and_siblings(copy=False):
                 # Updates icons in p and all visible descendants of p.
@@ -748,8 +746,7 @@ class LeoQtTree(leoFrame.LeoTree):
             self.busy = True
             p = self.item2position(item)
             if p:
-                auto_edit = self.prev_v == p.v
-                    # Fix #1049.
+                auto_edit = self.prev_v == p.v # #1049.
                 self.prev_v = p.v
                 event = None
                 #

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -665,8 +665,8 @@ class quickMove:
         if c2 is None:
             return
 
-        p = self.c.vnode2position(p_v)  # in case nd was created in this outline,
-                                        # invalidating p
+        # in case nd was created in this outline, invalidating p
+        p = self.c.vnode2position(p_v)
 
         self.copy_recursively(p, nd)
 
@@ -706,8 +706,8 @@ class quickMove:
         if c2 is None:
             return
 
-        p = self.c.vnode2position(p_v)  # in case nd was created in this outline,
-                                        # invalidating p
+        # in case nd was created in this outline, invalidating p
+        p = self.c.vnode2position(p_v)
 
         in_bookmarks = False
         for i in nd.parents():

--- a/leo/plugins/read_only_nodes.py
+++ b/leo/plugins/read_only_nodes.py
@@ -75,8 +75,7 @@ insertOffTime = None
 #@+node:ekr.20050311092840: ** init
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = not g.unitTesting
-        # Not Ok for unit testing.
+    ok = not g.unitTesting  # Not Ok for unit testing.
     if ok:
         g.registerHandler(('new', 'open2'), on_open)
         g.registerHandler("bodykey1", on_bodykey1)

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -310,15 +310,8 @@ def OpenProcess(p):
     # Start the threads and open the pipe.
     OutThread = readingThread()
     ErrThread = readingThread()
-
-    # In,OutThread.File,ErrThread.File	= os.popen3(command,"t")
-    # OutThread.File,In,ErrThread.File = os.popen3(command,"t")
-    # PIPE = subprocess.PIPE
+   
     proc = subprocess.Popen(command, shell=True)
-        # bufsize=bufsize,
-        # stdin=PIPE,
-        # stdout=PIPE,
-        # stderr=PIPE) ,close_fds=True)
     In = proc.stdin
     OutThread.File = proc.stdout
     ErrThread.File = proc.stderr

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -310,7 +310,7 @@ def OpenProcess(p):
     # Start the threads and open the pipe.
     OutThread = readingThread()
     ErrThread = readingThread()
-   
+
     proc = subprocess.Popen(command, shell=True)
     In = proc.stdin
     OutThread.File = proc.stdout

--- a/leo/plugins/screencast.py
+++ b/leo/plugins/screencast.py
@@ -482,8 +482,8 @@ class ScreenCastController:
         """Activate the indicated *top-level* menu."""
         m = self
         c = m.c
+        # Menu is a qtMenuWrapper, a subclass of both QMenu and leoQtMenu.
         menu = c.frame.menu.getMenu(menu_name)
-            # Menu is a qtMenuWrapper, a subclass of both QMenu and leoQtMenu.
         if menu:
             c.frame.menu.activateMenu(menu_name)
             if 0:  # None of this works.

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -430,12 +430,11 @@ class ScreenShotController:
         # Defaults.
         self.default_screenshot_height = 700
         self.default_screenshot_width = 900
+        # Used with a dict whose keys are 'slideshow_name','slide_name','slide_number'
         self.default_slide_pattern = '%(slideshow_name)s:%(slide_number)s'
-            # Used with a dict whose keys are 'slideshow_name','slide_name','slide_number'
         self.default_verbose_flag = True
         # Options that may be set in @settings nodes.
-        self.inkscape_bin = self.get_inkscape_bin()
-            # The path to the Inkscape executable.
+        self.inkscape_bin = self.get_inkscape_bin() # The path to the Inkscape executable.
         # Options that may be set in children of
         # *either* the @slideshow node or any @slide node.
         self.screenshot_height = None
@@ -637,9 +636,8 @@ class ScreenShotController:
         # Compute simple ivars.
         sc.screenshot_height = sc.get_screenshot_height()
         sc.screenshot_width = sc.get_screenshot_width()
+        # Only an explicit pause now pauses.
         sc.edit_flag = sc.get_edit_flag(p)
-            # Only an explicit pause now pauses.
-            # or bool(sc.callouts or sc.markers)
         sc.pause_flag = sc.get_pause_flag(p)
         return True
     #@+node:ekr.20100908110845.5533: *3* lxml replacements
@@ -943,8 +941,7 @@ class ScreenShotController:
             return p.b
         s = p.h
         assert g.match_word(s, 0, '@callout')
-        i = g.skip_id(s, 0, chars='@')
-            # Match @callout or @callouts, etc.
+        i = g.skip_id(s, 0, chars='@') # Match @callout or @callouts, etc.
         s = s[i:].strip()
         return s
     #@+node:ekr.20100911044508.5620: *5* get_edit_flag

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -434,7 +434,7 @@ class ScreenShotController:
         self.default_slide_pattern = '%(slideshow_name)s:%(slide_number)s'
         self.default_verbose_flag = True
         # Options that may be set in @settings nodes.
-        self.inkscape_bin = self.get_inkscape_bin() # The path to the Inkscape executable.
+        self.inkscape_bin = self.get_inkscape_bin()  # The path to the Inkscape executable.
         # Options that may be set in children of
         # *either* the @slideshow node or any @slide node.
         self.screenshot_height = None
@@ -941,7 +941,7 @@ class ScreenShotController:
             return p.b
         s = p.h
         assert g.match_word(s, 0, '@callout')
-        i = g.skip_id(s, 0, chars='@') # Match @callout or @callouts, etc.
+        i = g.skip_id(s, 0, chars='@')  # Match @callout or @callouts, etc.
         s = s[i:].strip()
         return s
     #@+node:ekr.20100911044508.5620: *5* get_edit_flag

--- a/leo/plugins/settings_finder.py
+++ b/leo/plugins/settings_finder.py
@@ -114,8 +114,7 @@ class SettingsFinder:
         path, unl = unl.split('#', 1)
         # Undo the replacements made in p.getUNL.
         path = path.replace("file://", "")
-        path = path.replace("unl://", "")
-            # Fix #434: Potential bug in settings
+        path = path.replace("unl://", "")  # #434: Potential bug in settings
         unl = unl.replace('%20', ' ').split("-->")
         tail = []
         if which > 1:  # copying parent or grandparent but select leaf later

--- a/leo/plugins/startfile.py
+++ b/leo/plugins/startfile.py
@@ -36,8 +36,7 @@ from leo.core import leoGlobals as g
 #@+node:ekr.20100128073941.5379: ** init (startfile.py)
 def init():
     """Return True if the plugin has loaded successfully."""
-    ok = hasattr(os, "startfile")
-        # Ok for unit testing, but may be icondclick1 conflicts.
+    ok = hasattr(os, "startfile")  # Ok for unit testing, but may be icondclick1 conflicts.
     if ok:
         # Register the handlers...
         g.registerHandler("icondclick1", onIconDoubleClick)

--- a/leo/plugins/stickynotes.py
+++ b/leo/plugins/stickynotes.py
@@ -103,7 +103,7 @@ def init():
     ok = g.app.gui.guiName() == 'qt'
     if ok:
         g.plugin_signon(__name__)
-        g.registerHandler('close-frame',onCloseFrame)
+        g.registerHandler('close-frame', onCloseFrame)
     return ok
 #@+node:ekr.20220310040820.1: ** onCloseFrame
 def onCloseFrame(tag, kwargs):
@@ -116,7 +116,7 @@ def onCloseFrame(tag, kwargs):
     for gnx in d:
         w = d.get(gnx)
         w.close()
-    outer_dict [c.hash()] = {}
+    outer_dict[c.hash()] = {}
 #@+node:ekr.20160403065412.1: ** commands
 #@+node:vivainio2.20091008133028.5825: *3* g.command('stickynote')
 @g.command('stickynote')
@@ -191,8 +191,8 @@ def stickynoter_f(event):
     nf.textChanged.connect(textchanged_cb)
     nf.show()
     d = outer_dict.get(c.hash(), {})
-    d [p.gnx] = nf
-    outer_dict [c.hash()] = d
+    d[p.gnx] = nf
+    outer_dict[c.hash()] = d
 #@+node:tbrown.20100120100336.7829: *3* g.command('stickynoteenc')
 if encOK:
     @g.command('stickynoterekey')
@@ -525,7 +525,7 @@ def mknote(c, p, parent=None, focusin=None, focusout=None):
 
     def closeevent():
         pass
-        
+
     # #2471: Create a new editor only if it doesn't already exist.
     d = outer_dict.get(c.hash(), {})
     nf = d.get(p.gnx)
@@ -553,8 +553,8 @@ def mknote(c, p, parent=None, focusin=None, focusout=None):
     nf.textChanged.connect(textchanged_cb)
     nf.show()
     d = outer_dict.get(c.hash(), {})
-    d [p.gnx] = nf
-    outer_dict [c.hash()] = d
+    d[p.gnx] = nf
+    outer_dict[c.hash()] = d
     return nf
 #@+node:ville.20100703234124.9976: ** Tabula
 #@+node:ville.20100704010850.5589: *3* def tabula_show

--- a/leo/plugins/stickynotes_plus.py
+++ b/leo/plugins/stickynotes_plus.py
@@ -69,7 +69,6 @@ def decorate_window(w):
 def init():
     """Return True if the plugin has loaded successfully."""
     ok = markdown is not None and g.app.gui.guiName() == "qt"
-        # Markdown fails on Python 3k at present.
     if ok:
         #g.registerHandler('start2',onStart2)
         g.plugin_signon(__name__)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -278,8 +278,7 @@ except ImportError:
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@-<< imports >>
 #pylint: disable=no-member
-trace = False
-    # This global trace is convenient.
+trace = False  # This global trace is convenient.
 asciidoctor_exec = shutil.which('asciidoctor')
 asciidoc3_exec = shutil.which('asciidoc3')
 pandoc_exec = shutil.which('pandoc')
@@ -321,10 +320,10 @@ latex_template = '''\
 </html>
 '''
 #@-<< define html templates >>
+# Keys are c.hash(): values are PluginControllers (QWidget's).
 controllers: Dict[int, Any] = {}
-    # Keys are c.hash(): values are PluginControllers (QWidget's).
+# Keys are c.hash(): values are tuples (layout_when_closed, layout_when_open)
 layouts = {}
-    # Keys are c.hash(): values are tuples (layout_when_closed, layout_when_open)
 #@+others
 #@+node:ekr.20110320120020.14491: ** vr.Top-level
 #@+node:tbrown.20100318101414.5994: *3* vr.decorate_window
@@ -1056,8 +1055,8 @@ if QtWidgets:  # NOQA
                 f.write(s)
             # Call the external program to write the output file.
             prog = 'asciidoctor' if asciidoctor_exec else 'asciidoc3'
+            # The -e option deletes css.
             command = f"{prog} {i_path} -b html5 -o {o_path}"
-                # The -e option deletes css.
             g.execute_shell_commands(command)
             # Read the output file and return it.
             with open(o_path, 'r') as f:
@@ -1128,8 +1127,8 @@ if QtWidgets:  # NOQA
             path = path.replace('\\', '/')
             template = image_template % (path)
             # Only works in Python 3.x.
+            # Sensitive to leading blank lines.
             template = textwrap.dedent(template).strip()
-                # Sensitive to leading blank lines.
             # template = g.toUnicode(template)
             pc.show()
             w.setReadOnly(False)
@@ -1374,8 +1373,8 @@ if QtWidgets:  # NOQA
             with open(i_path, 'w') as f:
                 f.write(s)
             # Call pandoc to write the output file.
+            # --quiet does no harm.
             command = f"pandoc {i_path} -t html5 -o {o_path}"
-                # --quiet does no harm.
             g.execute_shell_commands(command)
             # Read the output file and return it.
             with open(o_path, 'r') as f:
@@ -1414,8 +1413,8 @@ if QtWidgets:  # NOQA
                 namespace = {}
             # Embedding already works without this!
                 # self.embed_pyplot_widget()
+            # pyplot will throw RuntimeError if we close the pane.
             self.pyplot_active = True
-                # pyplot will throw RuntimeError if we close the pane.
             c.executeScript(
                 event=None,
                 args=None, p=None,
@@ -1592,8 +1591,8 @@ if QtWidgets:  # NOQA
                 w = pc.w
             if s.strip().startswith('<'):
                 # Assume it is the svg (xml) source.
+                # Sensitive to leading blank lines.
                 s = textwrap.dedent(s).strip()
-                    # Sensitive to leading blank lines.
                 s = g.toEncodedString(s)
                 pc.show()
                 w.load(QtCore.QByteArray(s))

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1092,8 +1092,7 @@ asciidoc_processors = []
 #@-<< Misc Globals >>
 #@-<< declarations >>
 
-trace = False
-    # This global trace is convenient.
+trace = False  # This global trace is convenient.
 
 #@+<< define html templates >>
 #@+node:TomP.20191215195433.6: ** << define html templates >> (vr3)
@@ -1120,10 +1119,10 @@ latex_template = f'''\
 </html>
 '''
 #@-<< define html templates >>
+# Keys are c.hash(): values are PluginControllers (QWidget's).
 controllers = {}
-    # Keys are c.hash(): values are PluginControllers (QWidget's).
+# Keys are c.hash(): values are tuples (layout_when_closed, layout_when_open)
 layouts = {}
-    # Keys are c.hash(): values are tuples (layout_when_closed, layout_when_open)
 
 #@+others
 #@+node:TomP.20200508124457.1: ** find_exe()
@@ -3237,8 +3236,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
         template = image_template % (fname)
         # Only works in Python 3.x.
+        # Sensitive to leading blank lines.
         template = textwrap.dedent(template).strip()
-            # Sensitive to leading blank lines.
 
         w = pc.ensure_web_widget()
         pc.set_html(template, w)
@@ -3577,8 +3576,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         with open(i_path, 'w') as f:
             f.write(s)
         # Call pandoc to write the output file.
+        # --quiet does no harm.
         command = f"pandoc {i_path} -t html5 -o {o_path}"
-            # --quiet does no harm.
         g.execute_shell_commands(command)
         # Read the output file and return it.
         with open(o_path, 'r') as f:
@@ -3613,8 +3612,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         # Embedding already works without this!
             # self.embed_pyplot_widget()
         self.pyplot_imported = True
+        # pyplot will throw RuntimeError if we close the pane.
         self.pyplot_active = True
-            # pyplot will throw RuntimeError if we close the pane.
         c.executeScript(
             event=None,
             args=None, p=None,
@@ -4205,8 +4204,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
             w = pc.w
         if s.strip().startswith('<'):
             # Assume it is the svg (xml) source.
+            # Sensitive to leading blank lines.
             s = textwrap.dedent(s).strip()
-                # Sensitive to leading blank lines.
             bytes = g.toEncodedString(s)
             pc.show()
             w.load(QtCore.QByteArray(bytes))

--- a/leo/plugins/wikiview.py
+++ b/leo/plugins/wikiview.py
@@ -121,8 +121,8 @@ class WikiView:
     def reloadSettings(self):
         c = self.c
         c.registerReloadSettings(self)
+        # This setting is True by default, so the redundancy is harmless.
         self.active = c.config.getBool('wikiview-active')
-            # This setting is True by default, so the redundancy is harmless.
     #@+node:ekr.20170205071315.1: *3* parse_options
     leadin_pattern = re.compile(r'(\\b)?(\()*(.)')
 

--- a/leo/plugins/writers/ipynb.py
+++ b/leo/plugins/writers/ipynb.py
@@ -15,10 +15,8 @@ class Export_IPYNB(basewriter.BaseWriter):
     def __init__(self, c):
         """Ctor for Import_IPYNB class."""
         super().__init__(c)
-        self.c = c
-            # Commander of present outline.
-        self.root = None
-            # The root of the outline.
+        self.c = c  # Commander of present outline.
+        self.root = None  # The root of the outline.
 
     #@+others
     #@+node:ekr.20160412114852.1: *3*  ipy_w.Entries

--- a/leo/plugins/writers/leo_rst.py
+++ b/leo/plugins/writers/leo_rst.py
@@ -10,8 +10,8 @@ This module must **not** be named rst, so as not to conflict with docutils.
 from leo.core import leoGlobals as g
 import leo.plugins.writers.basewriter as basewriter
 import leo.plugins.importers.leo_rst as rst_importer
+# Make *sure* that reader's underlines match the writer's.
 underlines = rst_importer.underlines
-    # Make *sure* that reader's underlines match the writer's.
 #@+others
 #@+node:ekr.20140726091031.18092: ** class RstWriter
 class RstWriter(basewriter.BaseWriter):

--- a/leo/plugins/xemacs.py
+++ b/leo/plugins/xemacs.py
@@ -73,7 +73,6 @@ def open_in_emacs_helper(c, p):
     efc = g.app.externalFilesController
     path = efc and efc.find_path_for_node(p)
     emacs_cmd = c.config.getString('xemacs-exe') or _emacs_cmd
-        # 2010/01/18: found by pylint.
     if (
         not path or
         not g.os_path_exists(path) or

--- a/leo/scripts/leoScripts.txt
+++ b/leo/scripts/leoScripts.txt
@@ -10902,21 +10902,22 @@ keys.sort()
 aList = ['%3d %s' % (words.get(key),str(key)) for key in keys]
 print g.listToString(aList)
 g.es('searched %s' % p1.h)
-#@+node:ekr.20190911074705.1: *3* script: Find trailing comments
-"""Find all comments of the form:
+#@+node:ekr.20220318132328.1: *3* script: Find trailing comments
+"""
+Find and mark all nodes containing underindented trailing comments in c's outline.
+
+Such comments have the form:
     
     .. some code ..
-        A trailing, overindented comment
-        
-    Write the summary to the given file.
+        A trailing, overindented comment.
 """
 g.cls()
 import re
-file_name = 'c:/test/trailing_comments.txt'
 count = 0
 pattern = re.compile(r'\w+\s*=\s\w+')
 
-def do_node(f, p):
+def do_node(p):
+    global count
     prev_assign = False
     old_lws = 0
     lines = g.splitLines(p.b)
@@ -10925,23 +10926,20 @@ def do_node(f, p):
         if line.strip().startswith('#'):
             if prev_assign and lws > old_lws:
                 # Found a likely trailing comment.
-                f.write(f"\n{i} {p.h}")
-                f.write(g.objToString(
-                    [f"{i+i2:3} {z}" for i2, z in enumerate(lines[i-1:i+1])],
-                    tag=f"line {i} {p.h}"),
-                )
+                p.setMarked()
+                count += 1
                 return True
             prev_assign = False
         else:
             old_lws = lws
             prev_assign = pattern.search(line)
     return False
+    
+c.clearAllMarked()
+for p in c.all_unique_positions():
+    do_node(p)
 
-with open(file_name, 'w') as f:
-    for p in c.all_unique_positions():
-        if do_node(f, p):
-            count += 1
-print(f"found {count} nodes. wrote results to {file_name}")
+print(f"found {count} nodes.")
 #@+node:ekr.20190106073221.1: *3* script: Find-chains (EKR)
 '''To be run in leoPy.leo: find Leo's important chains.'''
 g.cls()

--- a/leo/scripts/leoScripts.txt
+++ b/leo/scripts/leoScripts.txt
@@ -10902,7 +10902,7 @@ keys.sort()
 aList = ['%3d %s' % (words.get(key),str(key)) for key in keys]
 print g.listToString(aList)
 g.es('searched %s' % p1.h)
-#@+node:ekr.20220318132328.1: *3* script: Find trailing comments
+#@+node:ekr.20220318141823.1: *3* script: find trailing comments
 """
 Find and mark all nodes containing underindented trailing comments in c's outline.
 
@@ -10913,7 +10913,6 @@ Such comments have the form:
 """
 g.cls()
 import re
-count = 0
 pattern = re.compile(r'\w+\s*=\s\w+')
 
 def do_node(p):
@@ -10935,10 +10934,10 @@ def do_node(p):
             prev_assign = pattern.search(line)
     return False
     
+count = 0
 c.clearAllMarked()
 for p in c.all_unique_positions():
     do_node(p)
-
 print(f"found {count} nodes.")
 #@+node:ekr.20190106073221.1: *3* script: Find-chains (EKR)
 '''To be run in leoPy.leo: find Leo's important chains.'''

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -230,7 +230,7 @@ class TestNodes(LeoUnitTest):
                 self.assertEqual(p, threadNext.getThreadBack())
     #@+node:ekr.20220306100004.1: *5* TestNodes.test_p_following_siblings
     def test_p_following_siblings(self):
-        
+
         p = self.c.rootPosition()
         while p:
             for sib in p.following_siblings():
@@ -244,7 +244,7 @@ class TestNodes(LeoUnitTest):
 
         def p_true(p):
             return True
-        
+
         def p_false(p):
             return False
 
@@ -651,7 +651,7 @@ class TestNodes(LeoUnitTest):
         self.assertFalse(p.__ne__(root))
     #@+node:ekr.20220306092728.1: *5* TestNodes.test_p__gt__
     def test_p__gt__(self):
-        
+
         # p.__gt__ is the foundation for >, <, >=, <=.
         p = self.c.rootPosition()
         n = 0
@@ -681,7 +681,7 @@ class TestNodes(LeoUnitTest):
         child.sort_key(child)
     #@+node:ekr.20210830095545.24: *5* TestNodes.test_p_comparisons
     def test_p_comparisons(self):
-        
+
         c, p = self.c, self.c.p
         root = c.rootPosition()
         self.assertEqual(root, p)
@@ -741,7 +741,7 @@ class TestNodes(LeoUnitTest):
     def test_p_getters(self):
 
         p = self.c.p
-      
+
         table1 = (
             p.anyAtFileNodeName,
             p.atAutoNodeName,
@@ -775,7 +775,7 @@ class TestNodes(LeoUnitTest):
             self.assertFalse(func(), msg=func.__name__)
         table2 = (
             p.bodyString,
-            p.headString,    
+            p.headString,
             p.isDirty,
             p.isSelected,
             p.status,
@@ -1007,7 +1007,7 @@ class TestNodes(LeoUnitTest):
     def test_v_getters(self):
 
         v = self.c.p.v
-      
+
         table1 = (
             v.anyAtFileNodeName,
             v.atAutoNodeName,
@@ -1041,7 +1041,7 @@ class TestNodes(LeoUnitTest):
             self.assertFalse(func(), msg=func.__name__)
         table2 = (
             v.bodyString,
-            v.headString,    
+            v.headString,
             v.isDirty,
             v.isSelected,
             v.status,
@@ -1104,7 +1104,7 @@ class TestNodeIndices(LeoUnitTest):
             self.assertEqual(s, s1)
     #@+node:ekr.20220306070213.1: *3* TestNodeIndices.test_updateLastIndex
     def test_updateLastIndex(self):
-        
+
         ni = g.app.nodeIndices
         old_last = ni.lastIndex
         for gnx, new_last in (


### PR DESCRIPTION
Underindented comments are violate PEP 8.

I used "script: Find trailing comments" (in leoScripts.leo) to find such comments.

pyflakes, pylint, mypy, beautify-files and unit tests all pass.

I did *not* beautify or clean most npyscreen files.