### PR TITLE
PR: Fix blunder in leoApp.py

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1118,7 +1118,7 @@ class LeoApp:
                 break
         #
         # Put result in g.app.leoID.
-        if not id_ and not g.inBridge:
+        if not id_ and not g.app.inBridge:
             print('Leo can not start without an id.')
             print('Leo will now exit')
             sys.exit(1)


### PR DESCRIPTION
The guard must be g.app.inBridge, not g.inBridge.