### PR TITLE
Update VR for Qt6

### DIFF
--- a/leo/plugins/pyplot_backend.py
+++ b/leo/plugins/pyplot_backend.py
@@ -21,6 +21,8 @@ try:
     from matplotlib import pyplot as plt
 except ImportError:
     g.es_exception()
+
+import matplotlib
 #@-<< pyplot_backend imports >>
 #@+others
 #@+node:ekr.20160928073605.1: ** init
@@ -119,9 +121,8 @@ class LeoFigureManagerQT(FigureManager):
 
         self.canvas.figure.add_axobserver(notify_axes_change)
 
-        # close the figure so that we don't create too many figure instances
+        # Close the figure so that we don't create too many figure instances
         plt.close(canvas.figure)
-
     #@+node:ekr.20160929083114.1: *4* destroy
     def destroy(self, *args):
         # Causes problems.

--- a/leo/plugins/pyplot_backend.py
+++ b/leo/plugins/pyplot_backend.py
@@ -8,21 +8,17 @@
 #@+node:ekr.20160928074801.1: ** << pyplot_backend imports >>
 from leo.core import leoGlobals as g
 from leo.plugins import viewrendered as vr
-from leo.core.leoQt import isQt5, isQt6, QtWidgets
 from leo.core.leoQt import FocusPolicy
 try:
-    if isQt5 or isQt6:
-        import matplotlib.backends.backend_qt5agg as backend_qt5agg
-        FigureCanvasQTAgg = backend_qt5agg.FigureCanvasQTAgg
-    else:
-        import matplotlib.backends.backend_qt4agg as backend_qt4agg
-        FigureCanvasQTAgg = backend_qt4agg.FigureCanvasQTAgg
-    # Common imports
-    import matplotlib.backends.backend_qt5 as backend_qt5
     import matplotlib.backend_bases as backend_bases
-    from matplotlib.figure import Figure
     FigureManagerBase = backend_bases.FigureManagerBase
 
+    from matplotlib.backends.qt_compat import QtWidgets
+    from matplotlib.backends.backend_qtagg import (
+        FigureCanvas, FigureManager)
+    from matplotlib.figure import Figure
+
+    from matplotlib import pyplot as plt
 except ImportError:
     g.es_exception()
 #@-<< pyplot_backend imports >>
@@ -46,7 +42,7 @@ def new_figure_manager_given_figure(num, figure):
     """
     Create a new figure manager instance for the given figure.
     """
-    canvas = FigureCanvasQTAgg(figure)
+    canvas = FigureCanvas(figure)
     return LeoFigureManagerQT(canvas, num)
 #@+node:ekr.20160929050151.1: *3* class LeoFigureManagerQT
 # From backend_qt5.py
@@ -55,7 +51,7 @@ def new_figure_manager_given_figure(num, figure):
     # matplotlib.backends.backend_qt5.FigureManager probably does exist. See:
     # https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/backends/backend_qt5.py
 
-class LeoFigureManagerQT(backend_qt5.FigureManager):
+class LeoFigureManagerQT(FigureManager):
     """
     Public attributes
 
@@ -95,7 +91,10 @@ class LeoFigureManagerQT(backend_qt5.FigureManager):
             def windowTitle(self):
                 return self.c.p.h
 
-        self.window = DummyWindow(c)
+            def show(self):
+                pass
+
+        self.window = None  #DummyWindow(c)
 
         # See comments in the base class ctor, in backend_qt5.py.
         self.canvas.setFocusPolicy(FocusPolicy.StrongFocus)
@@ -104,17 +103,12 @@ class LeoFigureManagerQT(backend_qt5.FigureManager):
 
         self.toolbar = self._get_toolbar(self.canvas, self.frame)
         if self.toolbar is not None:
-            # The toolbar is a backend_qt5.NavigationToolbar2QT.
+            # The toolbar is a matplotlib.backends.backend_qt.NavigationToolbar2QT.
             layout = self.frame.layout()
             layout.addWidget(self.toolbar)
             # add text label to status bar
             self.statusbar_label = QtWidgets.QLabel()
             layout.addWidget(self.statusbar_label)
-            # pylint: disable=no-member
-            if isQt5 or isQt6:
-                pass  # The status bar doesn't work yet.
-            else:
-                self.toolbar.message.connect(self._show_message)
 
         self.canvas.draw_idle()
 
@@ -124,6 +118,10 @@ class LeoFigureManagerQT(backend_qt5.FigureManager):
                 self.toolbar.update()
 
         self.canvas.figure.add_axobserver(notify_axes_change)
+
+        # close the figure so that we don't create too many figure instances
+        plt.close(canvas.figure)
+
     #@+node:ekr.20160929083114.1: *4* destroy
     def destroy(self, *args):
         # Causes problems.

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -673,7 +673,7 @@ class ViewRenderedProvider:
     #@-others
 #@+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
 if QtWidgets:  # NOQA
-
+    #pylint: disable = import-outside-toplevel
     class ViewRenderedController(QtWidgets.QWidget):
         """A class to control rendering in a rendering pane."""
         #@+others
@@ -1382,8 +1382,11 @@ if QtWidgets:  # NOQA
         #@+node:ekr.20160928023915.1: *4* vr.update_pyplot
         def update_pyplot(self, s, keywords):
             """Get the pyplot script at c.p.b and show it."""
+            from matplotlib import pyplot
             c = self.c
-            if not self.pyplot_imported:
+
+            #if not self.pyplot_imported:
+            if pyplot.get_backend() != 'module://leo.plugins.pyplot_backend':
                 self.pyplot_imported = True
                 backend = g.os_path_finalize_join(
                     g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
@@ -1428,6 +1431,9 @@ if QtWidgets:  # NOQA
                 runPyflakes=False,  # Suppress warnings about pre-defined symbols.
             )
             c.bodyWantsFocusNow()
+
+            # Be courteous to other users - restore default pyplot drawing target
+            matplotlib.use('QtAgg')
         #@+node:ekr.20110320120020.14477: *4* vr.update_rst & helpers
         def update_rst(self, s, keywords):
             """Update rst in the vr pane."""
@@ -1678,8 +1684,8 @@ if QtWidgets:  # NOQA
                 return g.findFirstValidAtLanguageDirective(p.b)
             #
             #  #1287: Honor both kind of directives node by node.
-            for p in p.self_and_parents(p):
-                language = get_language(p)
+            for p1 in p.self_and_parents(p):
+                language = get_language(p1)
                 if got_markdown and language in ('md', 'markdown'):
                     return language
                 if got_docutils and language in ('rest', 'rst'):
@@ -1726,13 +1732,13 @@ if QtWidgets:  # NOQA
         def remove_directives(self, s):
             lines = g.splitLines(s)
             result = []
-            for s in lines:
-                if s.startswith('@'):
-                    i = g.skip_id(s, 1)
-                    word = s[1:i]
+            for s1 in lines:
+                if s1.startswith('@'):
+                    i = g.skip_id(s1, 1)
+                    word = s1[1:i]
                     if word in g.globalDirectiveList:
                         continue
-                result.append(s)
+                result.append(s1)
             return ''.join(result)
         #@-others
 #@-others

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -210,6 +210,7 @@ Jacob Peck added markdown support to this plugin.
 #@-<< to do >>
 #@+<< imports >>
 #@+node:tbrown.20100318101414.5993: ** << imports >> (vr)
+# pylint: disable = c-extension-no-member
 import json
 import os
 from pathlib import Path
@@ -273,6 +274,14 @@ try:
     # from traitlets.config import Config
 except ImportError:
     nbformat = None
+
+got_pyplot = False
+try:
+    # pylint: disable=import-error
+    from matplotlib import pyplot
+    got_pyplot = True
+except ImportError:
+    pass
 #
 # Fail fast, right after all imports.
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
@@ -673,7 +682,8 @@ class ViewRenderedProvider:
     #@-others
 #@+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
 if QtWidgets:  # NOQA
-    #pylint: disable = import-outside-toplevel
+    # pylint: disable = import-outside-toplevel
+    # pylint: disable = too-many-public-methods
     class ViewRenderedController(QtWidgets.QWidget):
         """A class to control rendering in a rendering pane."""
         #@+others
@@ -691,7 +701,6 @@ if QtWidgets:  # NOQA
             self.gnx = None
             self.graphics_class = QtWidgets.QGraphicsWidget
             self.pyplot_canvas = None
-            self.pyplot_imported = False
             self.gs = None  # For @graphics-script: a QGraphicsScene
             self.gv = None  # For @graphics-script: a QGraphicsView
             self.inited = False
@@ -966,6 +975,7 @@ if QtWidgets:  # NOQA
         #@+node:ekr.20110321072702.14510: *5* vr.setBackgroundColor
         def setBackgroundColor(self, colorName, name, w):
             """Set the background color of the vr pane."""
+            # pylint: disable = using-constant-test
             if 0:  # Do not do this! It interferes with themes.
                 pc = self
                 if not colorName:
@@ -1382,12 +1392,13 @@ if QtWidgets:  # NOQA
         #@+node:ekr.20160928023915.1: *4* vr.update_pyplot
         def update_pyplot(self, s, keywords):
             """Get the pyplot script at c.p.b and show it."""
-            from matplotlib import pyplot
+            if not got_pyplot:
+                g.es(('==== Viewrendered: MISSING matplotlib.  Cannot process @pyplot node'))
+                return
+
             c = self.c
 
-            #if not self.pyplot_imported:
             if pyplot.get_backend() != 'module://leo.plugins.pyplot_backend':
-                self.pyplot_imported = True
                 backend = g.os_path_finalize_join(
                     g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
                 if g.os_path_exists(backend):
@@ -1403,7 +1414,7 @@ if QtWidgets:  # NOQA
                 import matplotlib  # Make *sure* this is imported.
                 import matplotlib.pyplot as plt
                 import numpy as np
-                import matplotlib.animation as animation
+                from matplotlib import animation
                 plt.ion()  # Automatically set interactive mode.
                 namespace = {
                     'animation': animation,

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1755,4 +1755,5 @@ if QtWidgets:  # NOQA
 #@-others
 #@@language python
 #@@tabwidth -4
+
 #@-leo

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3585,6 +3585,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:TomP.20191215195433.72: *4* vr3.update_pyplot
     def update_pyplot(self, s, keywords):
         """Get the pyplot script at c.p.b and show it."""
+        g.es('@pyplot nodes not implemented', color='gray')
+        return
         c = self.c
         if not self.pyplot_imported:
             self.pyplot_imported = True

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3587,48 +3587,51 @@ class ViewRenderedController3(QtWidgets.QWidget):
         """Get the pyplot script at c.p.b and show it."""
         g.es('@pyplot nodes not implemented', color='gray')
         return
-        c = self.c
-        if not self.pyplot_imported:
+
+        if not True:
+            # Keep old code here for possible resurrection
+            c = self.c
+            if not self.pyplot_imported:
+                self.pyplot_imported = True
+                backend = g.os_path_finalize_join(
+                    g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
+                if g.os_path_exists(backend):
+                    if matplotlib:
+                        try:
+                            matplotlib.use('module://leo.plugins.pyplot_backend')
+                        except ImportError:
+                            g.trace('===== FAIL: pyplot.backend')
+                else:
+                    g.trace('===== MISSING: pyplot.backend')
+            try:
+                plt.ion()  # Automatically set interactive mode.
+                namespace = {
+                    'animation': animation,
+                    'matplotlib': matplotlib,
+                    'numpy': np, 'np': np,
+                    'pyplot': plt, 'plt': plt,
+                }
+            except Exception:
+                g.es_print('matplotlib imports failed')
+                namespace = {}
+            # Embedding already works without this!
+                # self.embed_pyplot_widget()
             self.pyplot_imported = True
-            backend = g.os_path_finalize_join(
-                g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
-            if g.os_path_exists(backend):
-                if matplotlib:
-                    try:
-                        matplotlib.use('module://leo.plugins.pyplot_backend')
-                    except ImportError:
-                        g.trace('===== FAIL: pyplot.backend')
-            else:
-                g.trace('===== MISSING: pyplot.backend')
-        try:
-            plt.ion()  # Automatically set interactive mode.
-            namespace = {
-                'animation': animation,
-                'matplotlib': matplotlib,
-                'numpy': np, 'np': np,
-                'pyplot': plt, 'plt': plt,
-            }
-        except Exception:
-            g.es_print('matplotlib imports failed')
-            namespace = {}
-        # Embedding already works without this!
-            # self.embed_pyplot_widget()
-        self.pyplot_imported = True
-        # pyplot will throw RuntimeError if we close the pane.
-        self.pyplot_active = True
-        c.executeScript(
-            event=None,
-            args=None, p=None,
-            script=c.p.b,  #None,
-            useSelectedText=False,
-            define_g=True,
-            define_name='__main__',
-            silent=False,
-            namespace=namespace,
-            raiseFlag=False,
-            runPyflakes=False,  # Suppress warnings about pre-defined symbols.
-        )
-        c.bodyWantsFocusNow()
+            # pyplot will throw RuntimeError if we close the pane.
+            self.pyplot_active = True
+            c.executeScript(
+                event=None,
+                args=None, p=None,
+                script=c.p.b,  #None,
+                useSelectedText=False,
+                define_g=True,
+                define_name='__main__',
+                silent=False,
+                namespace=namespace,
+                raiseFlag=False,
+                runPyflakes=False,  # Suppress warnings about pre-defined symbols.
+            )
+            c.bodyWantsFocusNow()
     #@+node:TomP.20191215195433.73: *4* vr3.update_rst & helpers
     #@@language python
     def update_rst(self, node_list, keywords=None):


### PR DESCRIPTION
VR:
1. Completed @pyplot nodes transition to qt6/qt5.
2. After every @pyplot rendering in VR, restore the default pyplot back end.
   (principle of least surprise for other matplotlib users).
3. Per pylint, fix two instances of local variable shadowing calling param.

VR3:
Abort processing @pyplot nodes with "not implemented" message.

test-all: passes
pylint: pyplot_backend: 9.67
           VR: 9.96 (there are some message for Qt6 imports about "c-extension-no-member)".  This commit only covers updating @pyplot capability.