### PR TITLE
PR for #2533: minor beautifier problems

### DIFF
--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2906,18 +2906,13 @@ class Orange:
     def do_op(self):
         """Handle an op token."""
         val = self.val
-        ### node = self.token.node
         if val == '.':
             self.clean('blank')
             prev = self.code_list[-1]
             # #2495 & #2533: Special case for 'from .'
             if prev.kind == 'word' and prev.value == 'from':
                 self.blank()
-                self.add_token('op-no-blanks', val)
-            ### elif isinstance(node, ast.ImportFrom):
-                ### self.add_token('op-no-blanks', val)
-            else:
-                self.add_token('op-no-blanks', val)
+            self.add_token('op-no-blanks', val)
         elif val == '@':
             if self.black_mode:  # pragma: no cover (black)
                 if not self.decorator_seen:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -254,6 +254,7 @@ class LeoGlobals:  # pragma: no cover
     #@+node:ekr.20220327132500.1: *3* LeoGlobals.pdb
     def pdb(self):
         import pdb as _pdb
+        # pylint: disable=forgotten-debug-statement
         _pdb.set_trace()
     #@+node:ekr.20191226190425.1: *3* LeoGlobals.plural
     def plural(self, obj):

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2906,21 +2906,16 @@ class Orange:
     def do_op(self):
         """Handle an op token."""
         val = self.val
-        node = self.token.node
+        ### node = self.token.node
         if val == '.':
             self.clean('blank')
             prev = self.code_list[-1]
+            # #2495 & #2533: Special case for 'from .'
             if prev.kind == 'word' and prev.value == 'from':
                 self.blank()
-                ### self.add_token('op', val)
-                ### self.blank()
                 self.add_token('op-no-blanks', val)
-                # Don't add a trailing blank here.
-            # #2495: Special case for 'from .'
-            elif isinstance(node, ast.ImportFrom):
-                ### self.blank()
-                self.add_token('op-no-blanks', val)
-                # Don't add a trailing blank here.
+            ### elif isinstance(node, ast.ImportFrom):
+                ### self.add_token('op-no-blanks', val)
             else:
                 self.add_token('op-no-blanks', val)
         elif val == '@':

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -251,6 +251,10 @@ class LeoGlobals:  # pragma: no cover
             result.append(repr(obj))
         result.append('')
         return '\n'.join(result)
+    #@+node:ekr.20220327132500.1: *3* LeoGlobals.pdb
+    def pdb(self):
+        import pdb as _pdb
+        _pdb.set_trace()
     #@+node:ekr.20191226190425.1: *3* LeoGlobals.plural
     def plural(self, obj):
         """Return "s" or "" depending on n."""
@@ -2630,7 +2634,9 @@ class Orange:
     def oops(self):  # pragma: no cover
         g.trace(f"Unknown kind: {self.kind}")
 
-    def beautify(self, contents, filename, tokens, tree, max_join_line_length=None, max_split_line_length=None):
+    def beautify(self, contents, filename, tokens, tree,
+        max_join_line_length=None, max_split_line_length=None,
+    ):
         """
         The main line. Create output tokens and return the result as a string.
         """
@@ -3092,8 +3098,10 @@ class Orange:
             """True if node is any expression other than += number."""
             if isinstance(node, (ast.BinOp, ast.Call, ast.IfExp)):
                 return True
-            return isinstance(
-                node, ast.UnaryOp) and not isinstance(node.operand, ast.Num)
+            return (
+                isinstance(node, ast.UnaryOp)
+                and not isinstance(node.operand, ast.Num)
+            )
 
         node = self.token.node
         self.clean('blank')
@@ -3200,7 +3208,12 @@ class Orange:
     def star_op(self):
         """Put a '*' op, with special cases for *args."""
         val = '*'
+        node = self.token.node
         self.clean('blank')
+        if isinstance(node, ast.arguments):
+            self.blank()
+            self.add_token('op', val)
+            return  # #2533
         if self.paren_level > 0:
             prev = self.code_list[-1]
             if prev.kind == 'lt' or (prev.kind, prev.value) == ('op', ','):
@@ -3214,7 +3227,12 @@ class Orange:
     def star_star_op(self):
         """Put a ** operator, with a special case for **kwargs."""
         val = '**'
+        node = self.token.node
         self.clean('blank')
+        if isinstance(node, ast.arguments):
+            self.blank()
+            self.add_token('op', val)
+            return  # #2533
         if self.paren_level > 0:
             prev = self.code_list[-1]
             if prev.kind == 'lt' or (prev.kind, prev.value) == ('op', ','):

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2909,15 +2909,16 @@ class Orange:
         node = self.token.node
         if val == '.':
             self.clean('blank')
-            ###
-                # prev = self.code_list[-1]
-                # if prev.kind == 'word' and prev.value == 'from':
-                    # self.blank()
-                    # self.add_token('op', val)
-                    # self.blank()
-            # #2495: Special case for 'from .'
-            if isinstance(node, ast.ImportFrom):
+            prev = self.code_list[-1]
+            if prev.kind == 'word' and prev.value == 'from':
                 self.blank()
+                ### self.add_token('op', val)
+                ### self.blank()
+                self.add_token('op-no-blanks', val)
+                # Don't add a trailing blank here.
+            # #2495: Special case for 'from .'
+            elif isinstance(node, ast.ImportFrom):
+                ### self.blank()
                 self.add_token('op-no-blanks', val)
                 # Don't add a trailing blank here.
             else:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2906,14 +2906,20 @@ class Orange:
     def do_op(self):
         """Handle an op token."""
         val = self.val
+        node = self.token.node
         if val == '.':
             self.clean('blank')
-            prev = self.code_list[-1]
+            ###
+                # prev = self.code_list[-1]
+                # if prev.kind == 'word' and prev.value == 'from':
+                    # self.blank()
+                    # self.add_token('op', val)
+                    # self.blank()
             # #2495: Special case for 'from .'
-            if prev.kind == 'word' and prev.value == 'from':
+            if isinstance(node, ast.ImportFrom):
                 self.blank()
-                self.add_token('op', val)
-                self.blank()
+                self.add_token('op-no-blanks', val)
+                # Don't add a trailing blank here.
             else:
                 self.add_token('op-no-blanks', val)
         elif val == '@':
@@ -3246,7 +3252,12 @@ class Orange:
     def word(self, s):
         """Add a word request to the code list."""
         assert s and isinstance(s, str), repr(s)
-        if self.square_brackets_stack:
+        node = self.token.node
+        if isinstance(node, ast.ImportFrom) and s == 'import':  # #2533
+            self.clean('blank')
+            self.add_token('blank', ' ')
+            self.add_token('word', s)
+        elif self.square_brackets_stack:
             # A previous 'op-no-blanks' token may cancel this blank.
             self.blank()
             self.add_token('word', s)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2916,7 +2916,7 @@ class KeyHandlerClass:
         allowBinding=False,
         pane='all',
         shortcut=None,  # Must be None unless allowBindings is True.
-        ** kwargs
+        **kwargs
     ):
         """
         Make the function available as a minibuffer command.

--- a/leo/plugins/importers/leo_json.py
+++ b/leo/plugins/importers/leo_json.py
@@ -17,7 +17,7 @@ class JSON_Scanner:
         importCommands,
         language='json',
         alternate_language=None,
-        ** kwargs
+        **kwargs
     ):
         """The ctor for the JSON_Scanner class."""
         self.c = c = importCommands.c

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -100,7 +100,7 @@ class Importer:
         name=None,  # The kind of importer, usually the same as language
         state_class=None,  # For i.scan_line
         strict=False,
-        ** kwargs
+        **kwargs
     ):
         """
         Importer.__init__: New in Leo 6.1.1: ic and c may be None for unit tests.

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1208,7 +1208,7 @@ class TestOrange(BaseTest):
     """)
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
-        self.assertEqual(results, expected)
+        self.assertEqual(expected, results)
     #@+node:ekr.20200108075541.1: *4* TestOrange.test_leo_sentinels
     def test_leo_sentinels_1(self):
 
@@ -1385,16 +1385,20 @@ class TestOrange(BaseTest):
             from . module2 import x
             from ..module1 import y
             from .. module2 import z
+            from . import a
+            from.import b
     """
         expected = textwrap.dedent("""\
             from .module1 import w
             from .module2 import x
             from ..module1 import y
-            from . module2 import z
+            from ..module2 import z
+            from . import a
+            from . import b
     """)
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
-        self.assertEqual(results, expected)
+        self.assertEqual(expected, results)
     #@+node:ekr.20200210050646.1: *4* TestOrange.test_return
     def test_return(self):
 

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1470,6 +1470,25 @@ class TestOrange(BaseTest):
             fails += 1
             print(f"Fail: {fails}\n{message}")
         self.assertEqual(fails, 0)
+    #@+node:ekr.20220327131225.1: *4* TestOrange.test_leading_stars
+    def test_leading_stars(self):
+
+        # #2533.
+        contents = """\
+            def f(
+                arg1,
+                *args,
+                **kwargs
+            ):
+                pass
+    """
+        expected = textwrap.dedent("""\
+            def f(arg1, *args, **kwargs):
+                pass
+    """)
+        contents, tokens, tree = self.make_data(contents)
+        results = self.beautify(contents, tokens, tree)
+        self.assertEqual(results, expected)
     #@+node:ekr.20200119155207.1: *4* TestOrange.test_sync_tokens
     def test_sync_tokens(self):
 

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1387,6 +1387,8 @@ class TestOrange(BaseTest):
             from .. module2 import z
             from . import a
             from.import b
+            from leo.core import leoExternalFiles
+            import leo.core.leoGlobals as g
     """
         expected = textwrap.dedent("""\
             from .module1 import w
@@ -1395,9 +1397,12 @@ class TestOrange(BaseTest):
             from ..module2 import z
             from . import a
             from . import b
+            from leo.core import leoExternalFiles
+            import leo.core.leoGlobals as g
     """)
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
+        ### g.printObj(results)
         self.assertEqual(expected, results)
     #@+node:ekr.20200210050646.1: *4* TestOrange.test_return
     def test_return(self):

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1402,7 +1402,6 @@ class TestOrange(BaseTest):
     """)
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
-        ### g.printObj(results)
         self.assertEqual(expected, results)
     #@+node:ekr.20200210050646.1: *4* TestOrange.test_return
     def test_return(self):

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -805,42 +805,6 @@ class TestOrange(BaseTest):
         except TypeError:  # pragma: no cover
             self.skipTest('old version of black')
         return black.format_str(contents, mode=mode)
-    #@+node:ekr.20200228074455.1: *4* TestOrange.test_bug_1429
-    def test_bug_1429(self):
-
-        contents = r'''\
-    def get_semver(tag):
-        """bug 1429 docstring"""
-        try:
-            import semantic_version
-            version = str(semantic_version.Version.coerce(tag, partial=True))
-                # tuple of major, minor, build, pre-release, patch
-                # 5.6b2 --> 5.6-b2
-        except(ImportError, ValueError) as err:
-            print('\n', err)
-            print("""*** Failed to parse Semantic Version from git tag '{0}'.
-            Expecting tag name like '5.7b2', 'leo-4.9.12', 'v4.3' for releases.
-            This version can't be uploaded to PyPi.org.""".format(tag))
-            version = tag
-        return version
-    '''
-        contents, tokens, tree = self.make_data(contents)
-        expected = contents.rstrip() + '\n'
-        results = self.beautify(contents, tokens, tree,
-            max_join_line_length=0, max_split_line_length=0)
-        self.assertEqual(results, expected)
-    #@+node:ekr.20210318055702.1: *4* TestOrange.test_bug_1851
-    def test_bug_1851(self):
-
-        contents = r'''\
-    def foo(a1):
-        pass
-    '''
-        contents, tokens, tree = self.make_data(contents)
-        expected = contents.rstrip() + '\n'
-        results = self.beautify(contents, tokens, tree,
-            max_join_line_length=0, max_split_line_length=0)
-        self.assertEqual(results, expected)
     #@+node:ekr.20200219114415.1: *4* TestOrange.test_at_doc_part
     def test_at_doc_part(self):
 
@@ -930,6 +894,42 @@ class TestOrange(BaseTest):
         contents, tokens, tree = self.make_data(contents)
         expected = contents
         results = self.beautify(contents, tokens, tree)
+        self.assertEqual(results, expected)
+    #@+node:ekr.20200228074455.1: *4* TestOrange.test_bug_1429
+    def test_bug_1429(self):
+
+        contents = r'''\
+    def get_semver(tag):
+        """bug 1429 docstring"""
+        try:
+            import semantic_version
+            version = str(semantic_version.Version.coerce(tag, partial=True))
+                # tuple of major, minor, build, pre-release, patch
+                # 5.6b2 --> 5.6-b2
+        except(ImportError, ValueError) as err:
+            print('\n', err)
+            print("""*** Failed to parse Semantic Version from git tag '{0}'.
+            Expecting tag name like '5.7b2', 'leo-4.9.12', 'v4.3' for releases.
+            This version can't be uploaded to PyPi.org.""".format(tag))
+            version = tag
+        return version
+    '''
+        contents, tokens, tree = self.make_data(contents)
+        expected = contents.rstrip() + '\n'
+        results = self.beautify(contents, tokens, tree,
+            max_join_line_length=0, max_split_line_length=0)
+        self.assertEqual(results, expected)
+    #@+node:ekr.20210318055702.1: *4* TestOrange.test_bug_1851
+    def test_bug_1851(self):
+
+        contents = r'''\
+    def foo(a1):
+        pass
+    '''
+        contents, tokens, tree = self.make_data(contents)
+        expected = contents.rstrip() + '\n'
+        results = self.beautify(contents, tokens, tree,
+            max_join_line_length=0, max_split_line_length=0)
         self.assertEqual(results, expected)
     #@+node:ekr.20200210120455.1: *4* TestOrange.test_decorator
     def test_decorator(self):
@@ -1190,6 +1190,25 @@ class TestOrange(BaseTest):
                 fails += 1
                 print(f"Fail: {fails}\n{message}")
         assert not fails, fails
+    #@+node:ekr.20220327131225.1: *4* TestOrange.test_leading_stars
+    def test_leading_stars(self):
+
+        # #2533.
+        contents = """\
+            def f(
+                arg1,
+                *args,
+                **kwargs
+            ):
+                pass
+    """
+        expected = textwrap.dedent("""\
+            def f(arg1, *args, **kwargs):
+                pass
+    """)
+        contents, tokens, tree = self.make_data(contents)
+        results = self.beautify(contents, tokens, tree)
+        self.assertEqual(results, expected)
     #@+node:ekr.20200108075541.1: *4* TestOrange.test_leo_sentinels
     def test_leo_sentinels_1(self):
 
@@ -1357,6 +1376,25 @@ class TestOrange(BaseTest):
                 fails += 1
                 print(f"Fail: {fails}\n{message}")
         self.assertEqual(fails, 0)
+    #@+node:ekr.20220327135448.1: *4* TestOrange.test_relative_imports
+    def test_relative_imports(self):
+
+        # #2533.
+        contents = """\
+            from .module1 import w
+            from . module2 import x
+            from ..module1 import y
+            from .. module2 import z
+    """
+        expected = textwrap.dedent("""\
+            from .module1 import w
+            from .module2 import x
+            from ..module1 import y
+            from . module2 import z
+    """)
+        contents, tokens, tree = self.make_data(contents)
+        results = self.beautify(contents, tokens, tree)
+        self.assertEqual(results, expected)
     #@+node:ekr.20200210050646.1: *4* TestOrange.test_return
     def test_return(self):
 
@@ -1470,25 +1508,6 @@ class TestOrange(BaseTest):
             fails += 1
             print(f"Fail: {fails}\n{message}")
         self.assertEqual(fails, 0)
-    #@+node:ekr.20220327131225.1: *4* TestOrange.test_leading_stars
-    def test_leading_stars(self):
-
-        # #2533.
-        contents = """\
-            def f(
-                arg1,
-                *args,
-                **kwargs
-            ):
-                pass
-    """
-        expected = textwrap.dedent("""\
-            def f(arg1, *args, **kwargs):
-                pass
-    """)
-        contents, tokens, tree = self.make_data(contents)
-        results = self.beautify(contents, tokens, tree)
-        self.assertEqual(results, expected)
     #@+node:ekr.20200119155207.1: *4* TestOrange.test_sync_tokens
     def test_sync_tokens(self):
 
@@ -1543,21 +1562,6 @@ class TestOrange(BaseTest):
             max_split_line_length=line_length,
         )
         self.assertEqual(results, expected, msg=contents)
-    #@+node:ekr.20200729083027.1: *4* TestOrange.verbatim2
-    def test_verbatim2(self):
-
-        contents = """\
-    #@@beautify
-    #@@nobeautify
-    #@+at Starts doc part
-    # More doc part.
-    # The @c ends the doc part.
-    #@@c
-    """
-        contents, tokens, tree = self.make_data(contents)
-        expected = contents
-        results = self.beautify(contents, tokens, tree)
-        self.assertEqual(results, expected, msg=contents)
     #@+node:ekr.20200211094209.1: *4* TestOrange.test_verbatim_with_pragma
     def test_verbatim_with_pragma(self):
 
@@ -1589,6 +1593,21 @@ class TestOrange(BaseTest):
             max_join_line_length=line_length,
             max_split_line_length=line_length,
         )
+        self.assertEqual(results, expected, msg=contents)
+    #@+node:ekr.20200729083027.1: *4* TestOrange.verbatim2
+    def test_verbatim2(self):
+
+        contents = """\
+    #@@beautify
+    #@@nobeautify
+    #@+at Starts doc part
+    # More doc part.
+    # The @c ends the doc part.
+    #@@c
+    """
+        contents, tokens, tree = self.make_data(contents)
+        expected = contents
+        results = self.beautify(contents, tokens, tree)
         self.assertEqual(results, expected, msg=contents)
     #@-others
 #@+node:ekr.20191231130208.1: *3* class TestReassignTokens (BaseTest)


### PR DESCRIPTION
See #2533.

- [x] Add LeoGlobals.pdb.

**Fix problems with *args and **kwargs**

- [x] Use the parse tree in orange.star_op and orange.star_star_op.
- [x] Add TestOrange.test_leading_stars.
- [x] Beautify all files, changing leoKeys.py, leo_json.py and linescanner.py.

**Fix problems with periods in imports**

- [x] Format `from .module import x` as given, w/o a space after the period.
    Unit tests cover several other examples.