### PR TITLE
1. Adjust URL recognition regexes to work when URL is embedded in Res…

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1661,16 +1661,16 @@ class JEditColorizer(BaseColorizer):
     # Fix bug 893230: URL coloring does not work for many Internet protocols.
     # Added support for: gopher, mailto, news, nntp, prospero, telnet, wais
 
-    url_regex_f = re.compile(r"""(file|ftp)://[^\s'"]+[\w=/]""")
-    url_regex_g = re.compile(r"""gopher://[^\s'"]+[\w=/]""")
+    url_regex_f = re.compile(r"""(file|ftp)://[^\s'"`>]+[\w=/]""")
+    url_regex_g = re.compile(r"""gopher://[^\s'"`>]+[\w=/]""")
     url_regex_h = re.compile(r"""(http|https)://[^\s'"]+[\w=/]""")
-    url_regex_m = re.compile(r"""mailto://[^\s'"]+[\w=/]""")
-    url_regex_n = re.compile(r"""(news|nntp)://[^\s'"]+[\w=/]""")
-    url_regex_p = re.compile(r"""prospero://[^\s'"]+[\w=/]""")
-    url_regex_t = re.compile(r"""telnet://[^\s'"]+[\w=/]""")
-    url_regex_w = re.compile(r"""wais://[^\s'"]+[\w=/]""")
-    kinds = '(file|ftp|gopher|http|https|mailto|news|nntp|prospero|telnet|wais)'
-    url_regex = re.compile(fr"""{kinds}://[^\s'"]+[\w=/]""")
+    url_regex_h = re.compile(r"""(http|https)://[^\s'"`>]+[\w=/]""")
+    url_regex_m = re.compile(r"""mailto://[^\s'"`>]+[\w=/]""")
+    url_regex_n = re.compile(r"""(news|nntp)://[^\s'"`>]+[\w=/]""")
+    url_regex_p = re.compile(r"""prospero://[^\s'"`>]+[\w=/]""")
+    url_regex_t = re.compile(r"""telnet://[^\s'"`>]+[\w=/]""")
+    url_regex_w = re.compile(r"""wais://[^\s'"`>]+[\w=/]""")
+    url_regex = g.url_regex
 
     def match_any_url(self, s, i):
         return self.match_compiled_regexp(s, i, kind='url', regexp=self.url_regex)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7477,8 +7477,8 @@ def run_unit_tests(tests: str=None, verbose: bool=False) -> None:
 #@+node:ekr.20120311151914.9916: ** g.Urls & UNLs
 unl_regex = re.compile(r'\bunl:.*$')
 
-kinds = '(file|ftp|gopher|http|https|mailto|news|nntp|prospero|telnet|wais)'
-url_regex = re.compile(fr"""{kinds}://[^\s'"]+[\w=/]""")
+kinds = '(http|https|file|mailto|ftp|gopher|news|nntp|prospero|telnet|wais)'
+url_regex = re.compile(fr"""{kinds}://[^\s'"`>]+[\w=/]""")
 #@+node:ekr.20120320053907.9776: *3* g.computeFileUrl
 def computeFileUrl(fn: str, c: Cmdr=None, p: Pos=None) -> str:
     """

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -298,6 +298,8 @@ QVBoxLayout = QtWidgets.QVBoxLayout
 QWidget = QtWidgets.QWidget
 QColor = QtGui.QColor
 
+WrapMode = QtGui.QTextOption.WrapMode
+
 #@-<< imports >>
 #@+<< declarations >>
 #@+node:tom.20210527153422.1: ** << declarations >>
@@ -707,6 +709,7 @@ class ZEditorWin(QtWidgets.QMainWindow):
         #@+<<set up editor>>
         #@+node:tom.20210602172856.1: *4* <<set up editor>>
         self.doc = self.editor.document()
+        self.editor.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
 
         # Adjust editor stylesheet color to match body fg, bg
         fg, bg = get_body_colors(self.c)


### PR DESCRIPTION
…tructuredText link syntax (e.g.: `tag <url>`_).

2. In Leo colorizer, use g.url_regex instead of a locally-defined identical regex.

3. in g.url_regex, reorder the scheme alternatives so that the most common ones will be tested first.

4. Freewin editor pane now wordwraps on startup.

test-all:
```
Ran 920 tests in 19.200s
OK (skipped=8)
```
pylint - still no pylint output.