### PR TITLE
PR for #2594: run mypy without blocking Leo

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -302,7 +302,7 @@ class MypyCommand:
             link_pattern=g.mypy_pat,
             link_root=root,
         )
-        
+
     #@+node:ekr.20210302111935.5: *3* mypy.finalize
     def finalize(self, p):
         """Finalize p's path."""

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -267,11 +267,6 @@ class MypyCommand:
         self.c = c
         self.link_limit = None  # Set in check_file.
         self.unknown_path_names = []
-        # Settings.
-        self.args = c.config.getData('mypy-arguments') or []
-        self.config_file = c.config.getString('mypy-config-file') or None
-        self.directory = c.config.getString('mypy-directory') or None
-        self.link_limit = c.config.getInt('mypy-link-limit') or 0
 
     #@+others
     #@+node:ekr.20210302111935.3: *3* mypy.check_all
@@ -303,12 +298,6 @@ class MypyCommand:
             link_root=root,
         )
 
-    #@+node:ekr.20210302111935.5: *3* mypy.finalize
-    def finalize(self, p):
-        """Finalize p's path."""
-        c = self.c
-        # Use os.path.normpath to give system separators.
-        return os.path.normpath(g.fullPath(c, p))  # #1914.
     #@+node:ekr.20210302111935.7: *3* mypy.run
     def run(self, p):
         """Run mypy on all Python @<file> nodes in c.p's tree."""

--- a/leo/commands/testCommands.py
+++ b/leo/commands/testCommands.py
@@ -203,7 +203,7 @@ def test_bridge(event=None):
 @g.command('test-checker-commands')
 def test_checker_commands(event=None):
     """Run all unit tests for leoCheckerCommands.py."""
-    g.run_unit_tests('leo.unittests.commands.test_leoCheckerCommands')
+    g.run_unit_tests('leo.unittests.commands.test_checkerCommands')
 #@+node:ekr.20210907103024.17: *3* test-colorizer
 @g.command('test-colorizer')
 def test_colorizer(event=None):

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -588,12 +588,6 @@
 <v t="ekr.20160317062151.1"><vh>@data stub-regex-patterns</vh></v>
 <v t="ekr.20160127051243.1"><vh>@string stub-output-directory = ~/stubs</vh></v>
 </v>
-<v t="ekr.20210728045642.1"><vh>mypy settings</vh>
-<v t="ekr.20210728045723.1"><vh>@data mypy-arguments</vh></v>
-<v t="ekr.20210728045750.1"><vh>@int mypy-link-limit = 0</vh></v>
-<v t="ekr.20210802064734.1"><vh>@string mypy-config-file=</vh></v>
-<v t="ekr.20220101093956.1"><vh>@string mypy-directory =</vh></v>
-</v>
 <v t="ekr.20160316111054.1"><vh>python-to-coffeescript settings</vh>
 <v t="ekr.20160316112407.2"><vh>@bool py2cs-overwrite = True</vh></v>
 <v t="ekr.20160316112407.8"><vh>@string py2cs-output-directory = ~/py2cs</vh></v>
@@ -11599,18 +11593,6 @@ rust: rustc
 go: ^\s*(.*):([0-9]+):([0-9]+):.+$
 python: ^\s*File "(.+)", line ([0-9]+), in .+$
 rust: ^\s*--&gt; (.+):([0-9]+):([0-9]+)\s*$</t>
-<t tx="ekr.20210728045642.1"></t>
-<t tx="ekr.20210728045723.1"># Arguments to mypy.api, excluding the file name.
-
-# --disable-error-code=attr-defined
-# --disallow-untyped-defs
-# --follow-imports=skip</t>
-<t tx="ekr.20210728045750.1"># 0 means no limit.</t>
-<t tx="ekr.20210802064734.1">Path to .mypy.ini file, for the --config-file option.
-
-If not given, no --config-file option is added to the mypy argument list.
-
-Relative paths are relative to  @string mypy-directory.</t>
 <t tx="ekr.20210823172721.1"></t>
 <t tx="ekr.20210823172729.1"></t>
 <t tx="ekr.20210823172944.1"></t>
@@ -11632,9 +11614,6 @@ p, Position
 s, string
 v, VNode</t>
 <t tx="ekr.20211209060458.1">True: Add 'class' to the headlines of class nodes (python only).</t>
-<t tx="ekr.20220101093956.1">The working directory for the mypy command.
-
-Defaults to os.path.join(g.app.loadDir, '..', '..')</t>
 <t tx="ekr.20220105172501.1"># comma-separated pairs of strings: (argument-name, typescript-type)
 c, Cmdr
 ch, str

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -215,8 +215,7 @@ class BackgroundProcessManager:
         print(s)
         # Let log.put_html_links do all the work!
         log = c.frame.log
-        result = log.put_html_links(s)
-        if result:
+        if not log.put_html_links(s):
             log.put(s)
     #@+node:ekr.20161028063800.1: *3* bpm.start_next
     def start_next(self) -> None:

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -101,7 +101,7 @@ class BackgroundProcessManager:
             )
 
         __str__ = __repr__
-    #@+node:ekr.20180522085807.1: *3* bpm.__init__ (changed to give mypy error)
+    #@+node:ekr.20180522085807.1: *3* bpm.__init__
     def __init__(self) -> None:
         """Ctor for the base BackgroundProcessManager class."""
         self.data: Any = None  # a ProcessData instance.
@@ -109,7 +109,6 @@ class BackgroundProcessManager:
         self.pid: Any = None  # The process id of the running process.
         self.lock = thread.allocate_lock()
         self.process_return_data: List[str] = None
-
         # #2528: A timer that runs independently of idle time.
         self.timer = None
         if QtCore:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1276,19 +1276,14 @@ class LeoLog:
     def putnl(self, tabName='Log'):
         pass
     #@+node:ekr.20220410180439.1: *4* LeoLog.put_html_links & helper
-    # To do: error patterns for black and pyflakes.
 
-    mypy_pat = re.compile(r'^(.+?):([0-9]+): (error|note): (.*)\s*$')
-    pylint_pat = re.compile(r'^(.*):\s*([0-9]+)[,:]\s*[0-9]+:.*?\(.*\)\s*$')
-    python_pat = re.compile(r'^\s*File\s+"(.*?)",\s*line\s*([0-9]+)\s*$')
-
-    error_patterns = (mypy_pat, pylint_pat, python_pat)
+    error_patterns = (g.mypy_pat, g.pylint_pat, g.python_pat)
 
     link_table: List[Tuple[int, int, re.Pattern]] = [
         # (fn_i, line_i, pattern)
-        (1, 2, mypy_pat),
-        (1, 2, pylint_pat),
-        (1, 2, python_pat),
+        (1, 2, g.mypy_pat),
+        (1, 2, g.pylint_pat),
+        (1, 2, g.python_pat),
     ]
 
     def put_html_links(self, s: str) -> Optional[str]:
@@ -1299,7 +1294,7 @@ class LeoLog:
         Case 2: Return s
 
         """
-        c = self.c
+        c, log = self.c, self.c.frame.log
         lines = g.splitLines(s)
         # Step 1: return s if no lines match. This is an efficiency measure.
         if not any(pat.match(line) for line in lines for pat in self.error_patterns):
@@ -1315,13 +1310,13 @@ class LeoLog:
                     p = self.find_at_file_node(filename)  # Try to find a matching @<file> node.
                     if p:
                         url = p.get_UNL()
-                        self.put(line, nodeLink=f"{url}::-{line_number}")  # Use global line.
+                        log.put(line, nodeLink=f"{url}::-{line_number}")  # Use global line.
                     else:
                         # g.trace('Not found', filename)
-                        self.put(line)
+                        log.put(line)
                     break
             else:  # no match
-                self.put(line)
+                log.put(line)
         return None
     #@+node:ekr.20220412084258.1: *5* LeoLog.find_at_file_node
     def find_at_file_node(self, filename):

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -9,7 +9,7 @@ These classes should be overridden to create frames for a particular gui.
 #@+node:ekr.20120219194520.10464: ** << imports >> (leoFrame)
 import os
 import re
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 from leo.core import leoGlobals as g
 from leo.core import leoColorizer  # NullColorizer is a subclass of ColorizerMixin
 from leo.core import leoMenu

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -139,6 +139,18 @@ cmd_instance_dict = {
     'VimCommands':              ['c', 'vimCommands'],
 }
 #@-<< define global decorator dicts >>
+#@+<< define global error regexs >>
+#@+node:ekr.20220412193109.1: ** << define global error regexs >> (leoGlobals.py)
+# To do: error patterns for black and pyflakes.
+
+# At present, the BPM assumes that:
+# m.group(1) is the filename.
+# m.group(2) is the line number.
+
+mypy_pat = re.compile(r'^(.+?):([0-9]+): (error|note): (.*)\s*$')
+pylint_pat = re.compile(r'^(.*):\s*([0-9]+)[,:]\s*[0-9]+:.*?\(.*\)\s*$')
+python_pat = re.compile(r'^\s*File\s+"(.*?)",\s*line\s*([0-9]+)\s*$')
+#@-<< define global error regexs >>
 #@+<< define g.decorators >>
 #@+node:ekr.20150508165324.1: ** << define g.Decorators >>
 #@+others

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -143,9 +143,10 @@ cmd_instance_dict = {
 #@+node:ekr.20220412193109.1: ** << define global error regexs >> (leoGlobals.py)
 # To do: error patterns for black and pyflakes.
 
-# At present, the BPM assumes that:
-# m.group(1) is the filename.
-# m.group(2) is the line number.
+# Most code need only know about the *existence* of these patterns.
+
+# At table in LeoQtLog.put tells it how to extract filenames and line_numbers from each pattern.
+# For all *present* patterns, m.group(1) is the filename and m.group(2) is the line number.
 
 mypy_pat = re.compile(r'^(.+?):([0-9]+): (error|note): (.*)\s*$')
 pylint_pat = re.compile(r'^(.*):\s*([0-9]+)[,:]\s*[0-9]+:.*?\(.*\)\s*$')

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3244,6 +3244,7 @@ class LeoQtLog(leoFrame.LeoLog):
         c = self.c
         if g.app.quitting or not c or not c.exists:
             return
+        s = s.rstrip() + '\n'  # 2022/04/12: Amazing! This is required.
         color = self.resolve_color(color)
         self.selectTab(tabName or 'Log')
         # Must be done after the call to selectTab.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3244,7 +3244,11 @@ class LeoQtLog(leoFrame.LeoLog):
         c = self.c
         if g.app.quitting or not c or not c.exists:
             return
-        s = s.rstrip() + '\n'  # 2022/04/12: Amazing! This is required.
+        #
+        # *Note*: For reasons that I don't fully understand,
+        #         all lines sent to the log must now end in a newline.
+        #   
+        s = s.rstrip() + '\n'
         color = self.resolve_color(color)
         self.selectTab(tabName or 'Log')
         # Must be done after the call to selectTab.

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -4,6 +4,7 @@
 #@@first
 """Tests of leo.commands.leoCheckerCommands."""
 import re
+from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 import leo.commands.checkerCommands as checkerCommands
 #@+others
@@ -14,8 +15,7 @@ class TestChecker(LeoUnitTest):
     #@+node:ekr.20210904031436.1: *3* test_regex_for_pylint
     def test_regex_for_pylint(self):
         c = self.c
-        x = checkerCommands.PylintCommand(c)
-        pattern = re.compile(x.link_pattern)
+        pattern = g.pylint_pat
         table = (
             r'c:\test\pylint_links_test2.py:5:4: R1705: Unnecessary "else" after "return" (no-else-return)',
             r'c:\test\pylint_links_test.py:6:3: C1801: Do not use `len(SEQUENCE)` to determine if a sequence is empty (len-as-condition)',  # pylint: disable=line-too-long

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -3,10 +3,8 @@
 #@+node:ekr.20210904022712.2: * @file ../unittests/commands/test_checkerCommands.py
 #@@first
 """Tests of leo.commands.leoCheckerCommands."""
-import re
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
-import leo.commands.checkerCommands as checkerCommands
 #@+others
 #@+node:ekr.20210904022712.3: ** class TestChecker(LeoUnitTest):
 class TestChecker(LeoUnitTest):

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -110,22 +110,21 @@ class TestQtGui(LeoUnitTest):
         # Run the tests.
         table = (
             # python.
-            (None, 'File "test_file.py", line 5'),
+            (True, 'File "test_file.py", line 5'),
             # pylint.
-            (None, r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)'),
+            (True, r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)'),
             # mypy...
-            (None, 'test_file.py:116: error: Function is missing a return type annotation  [no-untyped-def]'),
-            (None, r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value'),
-            (True, 'Found 1 error in 1 file (checked 1 source file)'),
-            (True, 'mypy: done'),
+            (True, 'test_file.py:116: error: Function is missing a return type annotation  [no-untyped-def]'),
+            (True, r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value'),
+            (False, 'Found 1 error in 1 file (checked 1 source file)'),
+            (False, 'mypy: done'),
             # Random output.
-            (True, 'Hello world\n'),
+            (False, 'Hello world\n'),
         )
-        for flag, s in table:
+        for expected, s in table:
             s = s.rstrip() + '\n'
             result = c.frame.log.put_html_links(s)
-            expected_result = s if flag else None
-            self.assertEqual(result, expected_result)
+            self.assertEqual(result, expected, msg=repr(s))
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
See #2594. The new mypy code is substantially simpler than the old.

- [x] Amazing! LeoQtLog.put *must* ensure a trailing newline! This is an ancient bug.
- [x] Move error regexs to leoGlobals.py. 
- [x] Remove unused mypy settings, and one unused method.

The key simplifications:
- bpm.put_log now calls log.put_html_links to do the heavy lifting.
- mypy.check_file now *just* calls bpm.start_process.

