### PR TITLE
Add Right Margin Guideline

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1516,9 +1516,11 @@
 <v t="ekr.20131213135427.22361"><vh>@item help-for-&amp;debugging-commands</vh></v>
 <v t="ekr.20180403100800.1"><vh>@item help-for-&amp;dynamic-abbreviations</vh></v>
 <v t="ekr.20131213135427.22362"><vh>@item help-for-&amp;find-commands</vh></v>
+<v t="tom.20220424213334.1"><vh>@item help-for-&amp;highlight-current-line</vh></v>
 <v t="ekr.20180403100839.1"><vh>@item help-for-&amp;keystroke</vh></v>
 <v t="ekr.20131213135427.22363"><vh>@item help-for-&amp;minibuffer</vh></v>
 <v t="ekr.20180403100900.1"><vh>@item help-for-&amp;python</vh></v>
+<v t="tom.20220424213426.1"><vh>@item help-for-&amp;right-margin-guide</vh></v>
 <v t="ekr.20131215083347.18148"><vh>@item help-for-&amp;scripting</vh></v>
 <v t="ekr.20180403100919.1"><vh>@item help-for-&amp;regular-expressions</vh></v>
 <v t="ekr.20180403100935.1"><vh>@item help-for-&amp;settings</vh></v>
@@ -12282,6 +12284,8 @@ AltControlShift hoist
 If False, does not do the above, useful if you don't use clones and don't
 want the visual clutter of repeated class / file names.</t>
 <t tx="tom.20210922141748.1"></t>
+<t tx="tom.20220424213334.1"></t>
+<t tx="tom.20220424213426.1"></t>
 <t tx="ville.20090701225947.3902"># Open current node in external editor. 'v' is mnemonic for 'vi', because vi users request this most
 # cm-external-editor = Alt-v</t>
 <t tx="ville.20091008201813.3909">Qt ui uses a different (simpler) setup for creating context menus,

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -905,21 +905,6 @@ if QtWidgets:
 
             editor.setExtraSelections([selection])
             #@-<< Apply Highlight >>
-        #@+node:tom.20210905130804.1: *4* Add Help Menu Items
-        # Add entry to Help menu
-        hilite_entry = ('@item', 'help-for-&highlight-current-line', '')
-        guide_entry = ('@item', 'help-for-&right-margin-guide', '')
-
-        if g.app.config:
-            for item in g.app.config.menusList:
-                if 'Help' in item[0]:
-                    for entry in item[1]:
-                        if entry[0].lower() == '@menu &open help topics':
-                            menu_items = entry[1]
-                            menu_items.append(hilite_entry)
-                            menu_items.append(guide_entry)
-                            menu_items.sort()
-                            break
         #@+node:ekr.20141103061944.31: *3* lqtb.get/setXScrollPosition
         def getXScrollPosition(self):
             """Get the horizontal scrollbar position."""

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -406,6 +406,7 @@ class QLineEditWrapper(QTextMixin):
     #@+node:ekr.20110605121601.18124: *4* qlew.see & seeInsertPoint
     def see(self, i):
         """QHeadlineWrapper."""
+
         pass
 
     def seeInsertPoint(self):
@@ -995,6 +996,7 @@ if QtWidgets:
 
             New in Leo 6.4: Draw a box around the cursor in command mode.
                             This is as close as possible to vim's look.
+            New in Leo 6.6.2: Draw right margin guideline.
             """
             c, vc, w = self.leo_c, self.leo_c.vimCommands, self
             #
@@ -1007,7 +1009,7 @@ if QtWidgets:
                     self.leo_cursor_width = width
                     w.setCursorWidth(width)
 
-            if w == c.frame.body.widget and\
+            if w == c.frame.body.widget and \
                     c.config.getBool('show-rmargin-guide'):
                 #@+<< paint margin guides >>
                 #@+node:tom.20220423204906.1: *4* << paint margin guides  >>
@@ -1023,11 +1025,11 @@ if QtWidgets:
                 rmargin = fm.horizontalAdvance('9' * rcol) + 2
                 if vp.width() >= rmargin:
                     painter = QtGui.QPainter(vp)
-                    pen =QtGui.QPen(SolidLine)
+                    pen = QtGui.QPen(SolidLine)
 
                     # guideline color
-                    pallete = w.viewport().palette()
-                    fg_hex = pallete.text().color().rgb()
+                    palette = w.viewport().palette()
+                    fg_hex = palette.text().color().rgb()
                     # Change "r" value to "88"
                     # e.g., #bbccdd ==> #88ccdd
                     guide_rgb = '88' + f'{fg_hex:x}'[4:]
@@ -1038,7 +1040,7 @@ if QtWidgets:
                     painter.setPen(pen)
                     painter.drawLine(rmargin, 0, rmargin, vp.height())
                 #@-<< paint margin guides >>
-            
+
             #
             # Are we in vim mode?
             if self.leo_vim_mode is None:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -13,6 +13,7 @@ from leo.core.leoQt import Shadow, Shape, SliderAction, WindowType, WrapMode
 
 QColor = QtGui.QColor
 QFontMetrics = QtGui.QFontMetrics
+SolidLine = QtCore.Qt.PenStyle.SolidLine
 
 FullWidthSelection = 0x06000  # works for both Qt5 and Qt6
 
@@ -86,6 +87,30 @@ Valid values are standard css color names like `lightgrey`, and css rgb values l
 def helpForLineHighlight(self, event=None):
     """Displays Settings used by current line highlighter."""
     self.c.putHelpFor(hilite_doc)
+
+#@+node:tom.20220424002954.1: ** Show Right Margin Settings command
+# Add item to known "help-for" commands
+rmargin_doc = r'''
+Right Margin Guidelines
+-------------------------
+
+A vertical guideline may optionally shown at the right margin of the 
+body editor.  The guideline will be shown at
+
+1. The column value of an @pagewidth directive in effect; or
+2. The column value given by the setting ``@int rguide-col = <col>``; or
+3. Column 80.
+
+The guideline will be shown if the setting ``@bool show-rmargin-guide``
+is ``True``.
+
+The color of the guideline is set based on the current text color.
+'''
+
+@g.command('help-for-right-margin-guide')
+def helpForRMarginGuides(self, event=None):
+    """Displays settings used by right margin guide lines."""
+    self.c.putHelpFor(rmargin_doc)
 
 #@+node:ekr.20140901062324.18719: **   class QTextMixin
 class QTextMixin:
@@ -879,9 +904,10 @@ if QtWidgets:
 
             editor.setExtraSelections([selection])
             #@-<< Apply Highlight >>
-        #@+node:tom.20210905130804.1: *4* Add Help Menu Item
+        #@+node:tom.20210905130804.1: *4* Add Help Menu Items
         # Add entry to Help menu
-        new_entry = ('@item', 'help-for-&highlight-current-line', '')
+        hilite_entry = ('@item', 'help-for-&highlight-current-line', '')
+        guide_entry = ('@item', 'help-for-&right-margin-guide', '')
 
         if g.app.config:
             for item in g.app.config.menusList:
@@ -889,7 +915,8 @@ if QtWidgets:
                     for entry in item[1]:
                         if entry[0].lower() == '@menu &open help topics':
                             menu_items = entry[1]
-                            menu_items.append(new_entry)
+                            menu_items.append(hilite_entry)
+                            menu_items.append(guide_entry)
                             menu_items.sort()
                             break
         #@+node:ekr.20141103061944.31: *3* lqtb.get/setXScrollPosition
@@ -996,11 +1023,13 @@ if QtWidgets:
                 rmargin = fm.horizontalAdvance('9' * rcol) + 2
                 if vp.width() >= rmargin:
                     painter = QtGui.QPainter(vp)
-                    #pen =QtGui.QPen(Qt.SolidLine)
-                    pen = QtGui.QPen(1)
+                    pen =QtGui.QPen(SolidLine)
 
+                    # guideline color
                     pallete = w.viewport().palette()
                     fg_hex = pallete.text().color().rgb()
+                    # Change "r" value to "88"
+                    # e.g., #bbccdd ==> #88ccdd
                     guide_rgb = '88' + f'{fg_hex:x}'[4:]
                     guide_color = f'#{guide_rgb}'
 


### PR DESCRIPTION
Add optional right margin guideline in body. A new help menu item is also added to explain the settings.  Tested with both pyqt5 and pyqt6.

test-all:
```
Ran 923 tests in 20.029s
OK (skipped=8)
```

pylint: 9.94/10

