### PR TITLE
Add exports for setting QWebEngineSettings WebAttributes. Set attribu…

### DIFF
--- a/leo/core/leoQt5.py
+++ b/leo/core/leoQt5.py
@@ -121,6 +121,13 @@ TextOption = QtGui.QTextOption
 ToolBarArea = QtCore.Qt
 Type = QtCore.QEvent
 UnderlineStyle = QtGui.QTextCharFormat
+if has_WebEngineWidgets:
+    QWebEngineSettings = QtWebEngineWidgets.QWebEngineSettings
+    WebEngineAttribute = QtWebEngineWidgets.QWebEngineSettings
+else:
+    QWebEngineSettings = None
+    WebEngineAttribute = None
+
 Weight = QtGui.QFont
 WindowType = QtCore.Qt
 WindowState = QtCore.Qt

--- a/leo/core/leoQt6.py
+++ b/leo/core/leoQt6.py
@@ -33,6 +33,7 @@ qt_version = QtCore.QT_VERSION_STR
 has_WebEngineWidgets = False
 try:
     from PyQt6 import QtWebEngineWidgets
+    from PyQt6 import QtWebEngineCore  # included with PyQt6-WebEngine
     assert QtWebEngineWidgets
     has_WebEngineWidgets = True
 except ImportError:
@@ -138,6 +139,13 @@ Style = QtGui.QFont.Style
 TextOption = QtGui.QTextOption
 Type = QtCore.QEvent.Type
 UnderlineStyle = QtGui.QTextCharFormat.UnderlineStyle
+if has_WebEngineWidgets:
+    QWebEngineSettings = QtWebEngineCore.QWebEngineSettings
+    WebEngineAttribute = QWebEngineSettings.WebAttribute
+else:
+    QWebEngineSettings = None
+    WebEngineAttribute = None
+
 Weight = QtGui.QFont.Weight
 WrapMode = QtGui.QTextOption.WrapMode
 #@-leo

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -12,7 +12,7 @@ Markdown and Asciidoc text, images, movies, sounds, rst, html, jupyter notebooks
 
 #@+others
 #@+node:TomP.20200308230224.1: *3* About
-About Viewrendered3 V3.8
+About Viewrendered3 V3.81
 ===========================
 
 The ViewRendered3 plugin (hereafter "VR3") renders Restructured Text (RsT),
@@ -57,10 +57,11 @@ section `Special Renderings`_.
 
 New With This Version
 ======================
-Added new command *vr3-render-html-from-clip*.
+Mathjax, html pages with script imports work with PyQt6.
 
 Previous Recent Changes
 ========================
+Added new command *vr3-render-html-from-clip*.
 Added Lua to the list of supported languages.  Lua programs can be syntax-colored
 and executed using the ``@language lua`` directive. For Lua programs to be executable,
 the path to a Lua processor must be added to the *.leo/vr3/vr3_config.ini* file.
@@ -871,6 +872,7 @@ QWebView = None
 from leo.core.leoQt import has_WebEngineWidgets  # pylint: disable=wrong-import-position
 if has_WebEngineWidgets:
     from leo.core.leoQt import QtWebEngineWidgets
+    from leo.core.leoQt import WebEngineAttribute
     QWebView = QtWebEngineWidgets.QWebEngineView
 else:
     try:
@@ -1974,23 +1976,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.asciidoc_internal_ok = True
         self.using_ext_proc_msg_shown = False
 
-    #@+node:TomP.20200329223820.2: *4* vr3.create_base_text_widget
-    def create_base_text_widget(self):
-        """
-        Create a QWebView.
-
-        For QT5 and Qt6, this is actually a QWebEngineView.
-        """
-        c = self.c
-        w = QWebView()
-        n = c.config.getInt('qweb-view-font-size')
-        if hasattr(w, 'settings') and n is not None:
-            settings = w.settings()
-            try:
-                settings.setFontSize(settings.DefaultFontSize, n)
-            except Exception:
-                pass
-        return w
     #@+node:TomP.20200329223820.3: *4* vr3.create_dispatch_dict
     def create_dispatch_dict(self):
         pc = self
@@ -2013,6 +1998,26 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
         pc.dispatch_dict['rest'] = pc.dispatch_dict['rst']
         pc.dispatch_dict['markdown'] = pc.dispatch_dict['md']
+    #@+node:TomP.20200329223820.2: *4* vr3.create_base_text_widget
+    def create_base_text_widget(self):
+        """
+        Create a QWebView.
+
+        For QT5 and Qt6, this is actually a QWebEngineView.
+        """
+        c = self.c
+        w = QWebView()
+        n = c.config.getInt('qweb-view-font-size')
+        if hasattr(w, 'settings'):
+            settings = w.settings()
+            if n is not None:
+                try:
+                    settings.setFontSize(settings.DefaultFontSize, n)
+                except Exception:
+                    pass
+            wa = WebEngineAttribute.LocalContentCanAccessRemoteUrls
+            settings.setAttribute(wa, True)
+        return w
     #@+node:TomP.20200329223820.4: *4* vr3.create_md_header
     def create_md_header(self):
         """Create a header for the md HTML output.


### PR DESCRIPTION
…te in vr3 to allow loading of remote scripts by the QWebEngineView (fixes non-rendering of mathjax)..

pylint: 
`Your code has been rated at 9.95/10 (previous run: 9.95/10, +0.00)`

test-all:
`'python3' is not recognized as an internal or external command,
operable program or batch file.`
