### PR TITLE
This fixes bug that was introduced in 'dehoist' command in the 'Mass update using regex-repl script' changes.

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -926,7 +926,8 @@ def dehoist(self, event=None):
         return
     bunch = c.hoistStack.pop()
     p = bunch.p
-    if not p:
+    # Checks 'expanded' property, which was preserved by 'hoist' method
+    if bunch.expanded:
         p.expand()
     else:
         p.contract()


### PR DESCRIPTION
Fixes #2643

I made sure to run tests on Windows too just in case: all tests pass.