### PR TITLE
PR: Remove 'fileName' arg from readExternalFiles

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -705,7 +705,7 @@ class FileCommands:
             if v:
                 c.setFileTimeStamp(fileName)
                 if readAtFileNodesFlag:
-                    recoveryNode = fc.readExternalFiles(fileName)
+                    recoveryNode = fc.readExternalFiles()
         finally:
             # lastTopLevel is a better fallback, imo.
             p = recoveryNode or c.p or c.lastTopLevel()
@@ -749,9 +749,9 @@ class FileCommands:
             frame.resizePanesToRatio(ratio, frame.secondary_ratio)
         return ok
     #@+node:ekr.20120212220616.10537: *5* fc.readExternalFiles & helper
-    def readExternalFiles(self, fileName):
+    def readExternalFiles(self):
         """
-        Read all external files.
+        Read all external files in the outline.
 
         A helper for fc.getLeoFile.
         """


### PR DESCRIPTION
A buglet reported by Félix.