### PR TITLE
PR for #2631: show-commands

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2304,10 +2304,10 @@ class LoadManager:
         if screenshot_fn:
             lm.make_screen_shot(screenshot_fn)
             return False  # Force an immediate exit.
-        ###
-        print('')
-        g.trace('=====', id(c), c.shortFileName(), g.callers(8))  ###
-        if 1:
+        if 0:  ###
+            print('')
+            g.trace('=====', id(c), c.shortFileName(), g.callers(8))  ###
+        if 0:  ###
             for z in c.k.bindingsDict:
                 if 'F4' in repr(z):
                     # g.trace(z)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2272,6 +2272,7 @@ class LoadManager:
             except Exception:
                 g.es_print('Can not load session')
                 g.es_exception()
+
         # Enable redraws.
         g.app.disable_redraw = False
         if not c1:
@@ -2303,6 +2304,13 @@ class LoadManager:
         if screenshot_fn:
             lm.make_screen_shot(screenshot_fn)
             return False  # Force an immediate exit.
+        ###
+        print('')
+        g.trace('=====', c.shortFileName(), g.callers(8))  ###
+        for z in sorted(c.k.bindingsDict):
+            if 'F4' in repr(z):
+                g.trace(z)
+                print(c.k.bindingsDict[z])
         return True
     #@+node:ekr.20120219154958.10489: *5* LM.make_screen_shot
     def make_screen_shot(self, fn):

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2237,7 +2237,7 @@ class LoadManager:
         if len(commanders) == 2:
             c = commanders[0]
             c.editFileCommands.compareAnyTwoFiles(event=None)
-    #@+node:ekr.20120219154958.10487: *4* LM.doPostPluginsInit & helpers ###
+    #@+node:ekr.20120219154958.10487: *4* LM.doPostPluginsInit & helpers
     def doPostPluginsInit(self):
         """Create a Leo window for each file in the lm.files list."""
         # Clear g.app.initing _before_ creating commanders.
@@ -2304,14 +2304,6 @@ class LoadManager:
         if screenshot_fn:
             lm.make_screen_shot(screenshot_fn)
             return False  # Force an immediate exit.
-        if 0:  ###
-            print('')
-            g.trace('=====', id(c), c.shortFileName(), g.callers(8))  ###
-        if 0:  ###
-            for z in c.k.bindingsDict:
-                if 'F4' in repr(z):
-                    # g.trace(z)
-                    print(c.k.bindingsDict[z])
         return True
     #@+node:ekr.20120219154958.10489: *5* LM.make_screen_shot
     def make_screen_shot(self, fn):

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2237,7 +2237,7 @@ class LoadManager:
         if len(commanders) == 2:
             c = commanders[0]
             c.editFileCommands.compareAnyTwoFiles(event=None)
-    #@+node:ekr.20120219154958.10487: *4* LM.doPostPluginsInit & helpers
+    #@+node:ekr.20120219154958.10487: *4* LM.doPostPluginsInit & helpers ###
     def doPostPluginsInit(self):
         """Create a Leo window for each file in the lm.files list."""
         # Clear g.app.initing _before_ creating commanders.
@@ -2306,11 +2306,12 @@ class LoadManager:
             return False  # Force an immediate exit.
         ###
         print('')
-        g.trace('=====', c.shortFileName(), g.callers(8))  ###
-        for z in sorted(c.k.bindingsDict):
-            if 'F4' in repr(z):
-                g.trace(z)
-                print(c.k.bindingsDict[z])
+        g.trace('=====', id(c), c.shortFileName(), g.callers(8))  ###
+        if 1:
+            for z in sorted(c.k.bindingsDict):
+                if 'F4' in repr(z):
+                    # g.trace(z)
+                    print(c.k.bindingsDict[z])
         return True
     #@+node:ekr.20120219154958.10489: *5* LM.make_screen_shot
     def make_screen_shot(self, fn):

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2308,7 +2308,7 @@ class LoadManager:
         print('')
         g.trace('=====', id(c), c.shortFileName(), g.callers(8))  ###
         if 1:
-            for z in sorted(c.k.bindingsDict):
+            for z in c.k.bindingsDict:
                 if 'F4' in repr(z):
                     # g.trace(z)
                     print(c.k.bindingsDict[z])

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -428,7 +428,7 @@ class BindingInfo:
                     s = f"{ivar}: {val!r}"
                     result.append(s)
         # Clearer w/o f-string.
-        return "[%s]" % ' '.join(result).strip()
+        return "<%s>" % ' '.join(result).strip()
     #@+node:ekr.20120129040823.10226: *4* bi.isModeBinding
     def isModeBinding(self) -> bool:
         return self.kind.startswith('*mode')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -418,7 +418,7 @@ class BindingInfo:
         # result = [f"BindingInfo kind: {self.kind}"]
         result = ['BindingInfo']
         # Print all existing ivars.
-        table = ('commandName', 'stroke') # 'pane', 'func', 'nextMode', 
+        table = ('commandName', 'stroke') # 'pane', 'func', 'nextMode',
         for ivar in table:
             if hasattr(self, ivar):
                 val = getattr(self, ivar)
@@ -7248,7 +7248,7 @@ def run_unit_tests(tests: str=None, verbose: bool=False) -> None:
     Run *all* unit tests if "tests" is not given.
     """
     # Note: `pip install leo` does not create a leo-editor folder, so this code will fail.
-    #       The workaround: run `python -m unittest` from python/Lib/sitecustomize/leo.   
+    #       The workaround: run `python -m unittest` from python/Lib/sitecustomize/leo.
     leo_editor_dir = g.os_path_finalize_join(g.app.loadDir, '..', '..')
     os.chdir(leo_editor_dir)
     verbosity = '-v' if verbose else ''

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -415,10 +415,9 @@ class BindingInfo:
     __str__ = __repr__
 
     def dump(self) -> str:
-        # result = [f"BindingInfo kind: {self.kind}"]
-        result = ['BindingInfo']
+        result = [f"BindingInfo kind: {self.kind}"]
         # Print all existing ivars.
-        table = ('commandName', 'stroke') # 'pane', 'func', 'nextMode',
+        table = ('pane', 'commandName', 'func', 'stroke') # 'nextMode',
         for ivar in table:
             if hasattr(self, ivar):
                 val = getattr(self, ivar)
@@ -426,8 +425,7 @@ class BindingInfo:
                     if ivar == 'func':
                         # pylint: disable=no-member
                         val = val.__name__
-                    # s = f"{ivar}: {val!r}"
-                    s = repr(val)
+                    s = f"{ivar}: {val!r}"
                     result.append(s)
         # Clearer w/o f-string.
         return "<%s>" % ' '.join(result).strip()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -415,9 +415,10 @@ class BindingInfo:
     __str__ = __repr__
 
     def dump(self) -> str:
-        result = [f"BindingInfo kind: {self.kind}"]
+        # result = [f"BindingInfo kind: {self.kind}"]
+        result = ['BindingInfo']
         # Print all existing ivars.
-        table = ('commandName', 'func', 'nextMode', 'pane', 'stroke')
+        table = ('commandName', 'stroke') # 'pane', 'func', 'nextMode', 
         for ivar in table:
             if hasattr(self, ivar):
                 val = getattr(self, ivar)
@@ -425,7 +426,8 @@ class BindingInfo:
                     if ivar == 'func':
                         # pylint: disable=no-member
                         val = val.__name__
-                    s = f"{ivar}: {val!r}"
+                    # s = f"{ivar}: {val!r}"
+                    s = repr(val)
                     result.append(s)
         # Clearer w/o f-string.
         return "<%s>" % ' '.join(result).strip()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -415,7 +415,7 @@ class BindingInfo:
     __str__ = __repr__
 
     def dump(self) -> str:
-        result = [f"BindingInfo {self.kind:17}"]
+        result = [f"BindingInfo kind: {self.kind}"]
         # Print all existing ivars.
         table = ('commandName', 'func', 'nextMode', 'pane', 'stroke')
         for ivar in table:
@@ -433,6 +433,7 @@ class BindingInfo:
     def isModeBinding(self) -> bool:
         return self.kind.startswith('*mode')
     #@-others
+
 def isBindingInfo(obj: Any) -> bool:
     return isinstance(obj, BindingInfo)
 #@+node:ekr.20031218072017.3098: *3* class g.Bunch (Python Cookbook)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2094,21 +2094,26 @@ class KeyHandlerClass:
                 stroke=stroke)
             if shortcut:
                 k.bindKeyToDict(pane, shortcut, bi)  # Updates k.masterBindingsDict
-            if shortcut and not modeFlag:
-                aList = k.remove_conflicting_definitions(
-                    aList, commandName, pane, shortcut)
-                # 2013/03/02: a real bug fix.
-            aList.append(bi)
+                
+            if 1:  ### Experimental
+                if trace: g.printObj(aList, tag='1')
+                aList = [z for z in aList if z.pane not in (pane, 'all')]
+                aList.append(bi)
+                if trace: g.printObj(aList, tag='2')
+            else:
+                if shortcut and not modeFlag:
+                    aList = k.remove_conflicting_definitions(
+                        aList, commandName, pane, shortcut)
+                else:
+                    aList = []
+                    # 2013/03/02: a real bug fix.
+                aList.append(bi)
             if shortcut:
                 assert stroke
                 k.bindingsDict[stroke] = aList
             if trace:  ###
                 g.trace('k.bindingsDict[stroke]...')
                 print(k.bindingsDict[stroke])
-                if 0:
-                    g.trace('aList...')
-                    for z in aList:
-                        print(z)
             return True
         except Exception:  # Could be a user error.
             if g.unitTesting or not g.app.menuWarningsGiven:
@@ -2135,7 +2140,7 @@ class KeyHandlerClass:
             g.trace('oops: ignoring mode binding', stroke, commandName, g.callers())
             return False
         return True
-    #@+node:ekr.20120130074511.10227: *5* k.kill_one_shortcut
+    #@+node:ekr.20120130074511.10227: *5* k.kill_one_shortcut  ###
     def kill_one_shortcut(self, stroke: Stroke) -> None:
         """
         Update the *configuration* dicts so that c.config.getShortcut(name)
@@ -2579,18 +2584,18 @@ class KeyHandlerClass:
             g.es('no bindings')
             return None
         legend = textwrap.dedent(legend)
-        ###
-        print('')
-        g.trace('===== bindingsDict', id(c), c.shortFileName(), g.callers(8))
-        if 0: 
-            for z in sorted(c.k.bindingsDict):
-                if 'F4' in repr(z):
-                    g.trace(z)
+        if 1: ###
+            print('')
+            g.trace('===== bindingsDict', id(c), c.shortFileName())
+        if 1: ###
+            for z in c.k.bindingsDict:
+                if 'F4' in repr(z) and "+F4" not in repr(z):
+                    ### g.trace(z)
                     print(c.k.bindingsDict[z])
-        ###
-        g.trace('===== masterBindingsDict[button]')
-        d2 = c.k.masterBindingsDict.get('button')
-        g.printObj(d2)
+        if 0: ###
+            g.trace('===== masterBindingsDict[button]')
+            d2 = c.k.masterBindingsDict.get('button')
+            g.printObj(d2)
         data = []
         for stroke in sorted(d):
             assert g.isStroke(stroke), stroke
@@ -3116,7 +3121,7 @@ class KeyHandlerClass:
                     stroke = bi.stroke
                     pane = bi.pane  # 2015/05/11.
                     break
-        if commandName == 'binding-test':  ###
+        if False: ### commandName == 'binding-test':  ###
             g.trace(id(c), c.shortFileName(), 'stroke', repr(stroke), g.callers())
         if stroke:
             k.bindKey(pane, stroke, func, commandName, tag='register-command')  # Must be a stroke.
@@ -3604,7 +3609,7 @@ class KeyHandlerClass:
         ):
             bi = k.getBindingHelper(key, name, stroke, w)
             if bi:
-                g.trace('FOUND', key, bi.commandName)
+                ### g.trace('FOUND', key, bi.commandName)
                 return bi
         return None
     #@+node:ekr.20180418105228.1: *7* getPaneBindingHelper

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2065,9 +2065,10 @@ class KeyHandlerClass:
 
         Return True if the binding was made successfully.
         """
-        trace = commandName == 'binding-test'  ### and self.c.shortFileName() == 'ekr.leo'
+        trace = 'binding-test' in commandName  ### and self.c.shortFileName() == 'ekr.leo'
         if trace:
-            g.trace(self.c.shortFileName(), commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
+            print('')
+            g.trace(id(self.c), self.c.shortFileName(), commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
         k = self
         if not shortcut:
             # Don't use this method to undo bindings.
@@ -2100,13 +2101,14 @@ class KeyHandlerClass:
             aList.append(bi)
             if shortcut:
                 assert stroke
-                if trace: ### and 'F4' in repr(stroke) and '+' not in repr(stroke):
-                    g.trace('-----', stroke, 'aList...')
+                k.bindingsDict[stroke] = aList
+            if trace:  ###
+                g.trace('k.bindingsDict[stroke]...')
+                print(k.bindingsDict[stroke])
+                if 0:
+                    g.trace('aList...')
                     for z in aList:
                         print(z)
-                k.bindingsDict[stroke] = aList
-            if trace:
-                g.trace('RESULT', k.bindingsDict[stroke])
             return True
         except Exception:  # Could be a user error.
             if g.unitTesting or not g.app.menuWarningsGiven:
@@ -2176,7 +2178,7 @@ class KeyHandlerClass:
             else:
                 result.append(bi)
         return result
-    #@+node:ekr.20061031131434.93: *5* k.bindKeyToDict
+    #@+node:ekr.20061031131434.93: *5* k.bindKeyToDict ###
     def bindKeyToDict(self, pane: str, stroke: Stroke, bi: Any) -> None:
         """Update k.masterBindingsDict for the stroke."""
         # New in Leo 4.4.1: Allow redefintions.
@@ -2184,8 +2186,7 @@ class KeyHandlerClass:
         k = self
         assert g.isStroke(stroke), stroke
         d = k.masterBindingsDict.get(pane, {})
-        if 'F4' in repr(bi):
-            g.trace(stroke, bi) ###
+        ### if 'F4' in repr(bi): g.trace(stroke, bi) ###
         d[stroke] = bi
         k.masterBindingsDict[pane] = d
     #@+node:ekr.20061031131434.94: *5* k.bindOpenWith
@@ -2580,11 +2581,12 @@ class KeyHandlerClass:
         legend = textwrap.dedent(legend)
         ###
         print('')
-        g.trace('===== bindingsDict', c.shortFileName(), g.callers(8))
-        for z in sorted(c.k.bindingsDict):
-            if 'F4' in repr(z):
-                g.trace(z)
-                print(c.k.bindingsDict[z])
+        g.trace('===== bindingsDict', id(c), c.shortFileName(), g.callers(8))
+        if 0: 
+            for z in sorted(c.k.bindingsDict):
+                if 'F4' in repr(z):
+                    g.trace(z)
+                    print(c.k.bindingsDict[z])
         ###
         g.trace('===== masterBindingsDict[button]')
         d2 = c.k.masterBindingsDict.get('button')
@@ -3081,7 +3083,7 @@ class KeyHandlerClass:
             pane=pane,
             shortcut=shortcut,
         )
-    #@+node:ekr.20171124043747.1: *4* k.registerCommandShortcut
+    #@+node:ekr.20171124043747.1: *4* k.registerCommandShortcut ###
     def registerCommandShortcut(self,
         commandName: str,
         func: Callable,
@@ -3114,9 +3116,8 @@ class KeyHandlerClass:
                     stroke = bi.stroke
                     pane = bi.pane  # 2015/05/11.
                     break
-        if commandName == 'binding-test':
-            g.trace(c.fileName(), repr(stroke))
-            # g.pdb()
+        if commandName == 'binding-test':  ###
+            g.trace(id(c), c.shortFileName(), 'stroke', repr(stroke), g.callers())
         if stroke:
             k.bindKey(pane, stroke, func, commandName, tag='register-command')  # Must be a stroke.
             k.makeMasterGuiBinding(stroke)  # Must be a stroke.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2065,6 +2065,8 @@ class KeyHandlerClass:
 
         Return True if the binding was made successfully.
         """
+        if commandName == 'binding-test':
+            g.trace(commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
         k = self
         if not shortcut:
             # Don't use this method to undo bindings.
@@ -2097,7 +2099,12 @@ class KeyHandlerClass:
             aList.append(bi)
             if shortcut:
                 assert stroke
+                if 'F4' in repr(stroke):
+                    g.trace('-----', stroke)
+                    g.printObj(aList)
                 k.bindingsDict[stroke] = aList
+                if commandName == 'binding-test':
+                    g.trace('aList', aList)
             return True
         except Exception:  # Could be a user error.
             if g.unitTesting or not g.app.menuWarningsGiven:
@@ -2546,7 +2553,7 @@ class KeyHandlerClass:
     def menuCommandKey(self, event: Event=None) -> None:
         # This method must exist, but it never gets called.
         pass
-    #@+node:ekr.20061031131434.119: *4* k.printBindings & helper
+    #@+node:ekr.20061031131434.119: *4* k.printBindings & helper ###
     @cmd('show-bindings')
     def printBindings(self, event: Event=None) -> List[str]:
         """Print all the bindings presently in effect."""
@@ -2572,11 +2579,15 @@ class KeyHandlerClass:
             assert g.isStroke(stroke), stroke
             aList = d.get(stroke, [])
             for bi in aList:
+                if 'F4' in repr(stroke):  ###
+                    g.trace('=====', stroke)
+                    ### g.printObj(bi)
                 s1 = '' if bi.pane == 'all' else bi.pane
                 s2 = k.prettyPrintKey(stroke)
                 s3 = bi.commandName
                 s4 = bi.kind or '<no hash>'
                 data.append((s1, s2, s3, s4),)
+        ### g.printObj(list(sorted(d)))
         # Print keys by type.
         result = []
         result.append('\n' + legend)
@@ -3082,6 +3093,9 @@ class KeyHandlerClass:
                     stroke = bi.stroke
                     pane = bi.pane  # 2015/05/11.
                     break
+        if commandName == 'binding-test':
+            g.trace(c.fileName(), repr(stroke))
+            # g.pdb()
         if stroke:
             k.bindKey(pane, stroke, func, commandName, tag='register-command')  # Must be a stroke.
             k.makeMasterGuiBinding(stroke)  # Must be a stroke.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2065,7 +2065,8 @@ class KeyHandlerClass:
 
         Return True if the binding was made successfully.
         """
-        if commandName == 'binding-test':
+        trace = self.c.shortFileName() == 'ekr.leo' and commandName == 'binding-test'  ###
+        if trace:
             g.trace(commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
         k = self
         if not shortcut:
@@ -2099,12 +2100,11 @@ class KeyHandlerClass:
             aList.append(bi)
             if shortcut:
                 assert stroke
-                if 'F4' in repr(stroke):
-                    g.trace('-----', stroke)
-                    g.printObj(aList)
+                if trace: ### and 'F4' in repr(stroke) and '+' not in repr(stroke):
+                    g.trace('-----', stroke, 'aList...')
+                    for z in aList:
+                        print(z)
                 k.bindingsDict[stroke] = aList
-                if commandName == 'binding-test':
-                    g.trace('aList', aList)
             return True
         except Exception:  # Could be a user error.
             if g.unitTesting or not g.app.menuWarningsGiven:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1648,16 +1648,15 @@ class GetArg:
             dataList = d.get(commandName, [])
             if dataList:
                 for z in dataList:
-                    pane, key = z
-                    s1a = '' if pane in ('all:', 'button:') else f"{pane} "
-                    s1b = k.prettyPrintKey(key)
-                    s1 = s1a + s1b
-                    s2 = self.command_source(commandName)
-                    if s2 != ' ':
+                    pane, stroke = z
+                    pane_s = '' if pane == 'all' else pane
+                    key = k.prettyPrintKey(stroke)
+                    pane_key = f"{pane_s} {key}"
+                    source = self.command_source(commandName)
+                    if source != ' ':
                         legend = True
-                    s3 = commandName
-                    data.append((s1, s2, s3),)
-                    n = max(n, len(s1))
+                    data.append((pane_key, source, commandName))
+                    n = max(n, len(pane_key))
             else:
                 # Bug fix: 2017/03/26
                 data.append(('', ' ', commandName),)
@@ -2673,9 +2672,9 @@ class KeyHandlerClass:
             dataList = inverseBindingDict.get(commandName, [('', ''),])
             for z in dataList:
                 pane, stroke = z
-                pane_s = ' '*7 if pane == 'all' else f"{pane:>7}"
+                pane_s = ' '*8 if pane in ('', 'all') else f"{pane:>7}:"
                 key = k.prettyPrintKey(stroke).replace('+Key', '')
-                pane_key = f"{pane_s}: {key}"
+                pane_key = f"{pane_s}{key}"
                 n = max(n, len(pane_key))
                 data.append((pane_key, commandName))
         # This isn't perfect in variable-width fonts.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2065,10 +2065,6 @@ class KeyHandlerClass:
 
         Return True if the binding was made successfully.
         """
-        trace = False and 'binding-test' in commandName
-        if trace:  ###
-            print('')
-            g.trace(id(self.c), self.c.shortFileName(), commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
         k = self
         if not shortcut:
             # Don't use this method to undo bindings.
@@ -2094,28 +2090,16 @@ class KeyHandlerClass:
                 stroke=stroke)
             if shortcut:
                 k.bindKeyToDict(pane, shortcut, bi)  # Updates k.masterBindingsDict
-                
-            if 0:  ### Experimental
-                if trace:
-                    g.printObj(aList, tag='1')
-                aList = [z for z in aList if z.pane not in (pane, 'all')]
-                aList.append(bi)
-                if trace:
-                    g.printObj(aList, tag='2')
-            else:  ### Legacy.
-                if shortcut and not modeFlag:
-                    aList = k.remove_conflicting_definitions(
-                        aList, commandName, pane, shortcut)
-                else:
-                    aList = []
-                    # 2013/03/02: a real bug fix.
-                aList.append(bi)
+            if shortcut and not modeFlag:
+                aList = k.remove_conflicting_definitions(
+                    aList, commandName, pane, shortcut)
+            else:
+                aList = []
+                # 2013/03/02: a real bug fix.
+            aList.append(bi)
             if shortcut:
                 assert stroke
                 k.bindingsDict[stroke] = aList
-            if trace:  ###
-                g.trace('k.bindingsDict[stroke]...')
-                print(k.bindingsDict[stroke])
             return True
         except Exception:  # Could be a user error.
             if g.unitTesting or not g.app.menuWarningsGiven:
@@ -2569,7 +2553,7 @@ class KeyHandlerClass:
     def showBindings(self, event: Event=None) -> List[str]:
         """Print all the bindings presently in effect."""
         c, k = self.c, self
-        d = k.masterBindingsDict  ### k.bindingsDict
+        d = k.masterBindingsDict
         tabName = 'Bindings'
         c.frame.log.clearTab(tabName)
         legend = '''\
@@ -2626,11 +2610,10 @@ class KeyHandlerClass:
         return result  # for unit test.
     #@+node:ekr.20061031131434.120: *5* printBindingsHelper
     def printBindingsHelper(self, result: List[str], data: List[Any], prefix: str) -> None:
-        """Helper for k.printBindings"""
+        """Helper for k.showBindings"""
         c, lm = self.c, g.app.loadManager
         data.sort(key=lambda x: x[1])
         data2, n = [], 0
-        ### for pane, key, commandName, kind in data:
         for scope, key, commandName, kind in data:
             key = key.replace('+Key', '')
             letter = lm.computeBindingLetter(c, kind)
@@ -3068,7 +3051,7 @@ class KeyHandlerClass:
             pane=pane,
             shortcut=shortcut,
         )
-    #@+node:ekr.20171124043747.1: *4* k.registerCommandShortcut ###
+    #@+node:ekr.20171124043747.1: *4* k.registerCommandShortcut
     def registerCommandShortcut(self,
         commandName: str,
         func: Callable,
@@ -3101,8 +3084,6 @@ class KeyHandlerClass:
                     stroke = bi.stroke
                     pane = bi.pane  # 2015/05/11.
                     break
-        if False: ### commandName == 'binding-test':  ###
-            g.trace(id(c), c.shortFileName(), 'stroke', repr(stroke), g.callers())
         if stroke:
             k.bindKey(pane, stroke, func, commandName, tag='register-command')  # Must be a stroke.
             k.makeMasterGuiBinding(stroke)  # Must be a stroke.
@@ -3589,7 +3570,6 @@ class KeyHandlerClass:
         ):
             bi = k.getBindingHelper(key, name, stroke, w)
             if bi:
-                ### g.trace('FOUND', key, bi.commandName)
                 return bi
         return None
     #@+node:ekr.20180418105228.1: *7* getPaneBindingHelper

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2065,9 +2065,9 @@ class KeyHandlerClass:
 
         Return True if the binding was made successfully.
         """
-        trace = self.c.shortFileName() == 'ekr.leo' and commandName == 'binding-test'  ###
+        trace = commandName == 'binding-test'  ### and self.c.shortFileName() == 'ekr.leo'
         if trace:
-            g.trace(commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
+            g.trace(self.c.shortFileName(), commandName, shortcut, 'pane', pane, 'modeFlag', modeFlag, 'tag', tag)   ###
         k = self
         if not shortcut:
             # Don't use this method to undo bindings.
@@ -2105,6 +2105,8 @@ class KeyHandlerClass:
                     for z in aList:
                         print(z)
                 k.bindingsDict[stroke] = aList
+            if trace:
+                g.trace('RESULT', k.bindingsDict[stroke])
             return True
         except Exception:  # Could be a user error.
             if g.unitTesting or not g.app.menuWarningsGiven:
@@ -2182,6 +2184,8 @@ class KeyHandlerClass:
         k = self
         assert g.isStroke(stroke), stroke
         d = k.masterBindingsDict.get(pane, {})
+        if 'F4' in repr(bi):
+            g.trace(stroke, bi) ###
         d[stroke] = bi
         k.masterBindingsDict[pane] = d
     #@+node:ekr.20061031131434.94: *5* k.bindOpenWith
@@ -2574,28 +2578,41 @@ class KeyHandlerClass:
             g.es('no bindings')
             return None
         legend = textwrap.dedent(legend)
+        ###
+        print('')
+        g.trace('===== bindingsDict', c.shortFileName(), g.callers(8))
+        for z in sorted(c.k.bindingsDict):
+            if 'F4' in repr(z):
+                g.trace(z)
+                print(c.k.bindingsDict[z])
+        ###
+        g.trace('===== masterBindingsDict[button]')
+        d2 = c.k.masterBindingsDict.get('button')
+        g.printObj(d2)
         data = []
         for stroke in sorted(d):
             assert g.isStroke(stroke), stroke
             aList = d.get(stroke, [])
             for bi in aList:
-                if 'F4' in repr(stroke):  ###
-                    g.trace('=====', stroke)
-                    ### g.printObj(bi)
                 s1 = '' if bi.pane == 'all' else bi.pane
                 s2 = k.prettyPrintKey(stroke)
                 s3 = bi.commandName
                 s4 = bi.kind or '<no hash>'
                 data.append((s1, s2, s3, s4),)
-        ### g.printObj(list(sorted(d)))
+                if False and 'F4' in repr(stroke):  ###
+                    g.trace('=====', stroke)
+                    ### g.printObj(bi, tag='bi for F4')
+                    g.trace(s1, s2, s3, s4)
+        
+        #  g.printObj(d, tag='d')
         # Print keys by type.
         result = []
         result.append('\n' + legend)
         for prefix in (
-            'Alt+Ctrl+Shift', 'Alt+Ctrl', 'Alt+Shift', 'Alt',  # 'Alt+Key': done by Alt.
-            'Ctrl+Meta+Shift', 'Ctrl+Meta', 'Ctrl+Shift', 'Ctrl',  # Ctrl+Key: done by Ctrl.
-            'Meta+Key', 'Meta+Shift', 'Meta',
-            'Shift',
+            # # # 'Alt+Ctrl+Shift', 'Alt+Ctrl', 'Alt+Shift', 'Alt',  # 'Alt+Key': done by Alt.
+            # # # 'Ctrl+Meta+Shift', 'Ctrl+Meta', 'Ctrl+Shift', 'Ctrl',  # Ctrl+Key: done by Ctrl.
+            # # # 'Meta+Key', 'Meta+Shift', 'Meta',
+            # # # 'Shift',
             'F',  # #1972
             # Careful: longer prefixes must come before shorter prefixes.
         ):
@@ -2608,11 +2625,15 @@ class KeyHandlerClass:
             self.printBindingsHelper(result, data2, prefix=prefix)
             # Remove all the items in data2 from data.
             # This must be done outside the iterator on data.
+            
+            ### F4 not in data2
+            ### g.printObj(data2, tag='data2')  ###
             for item in data2:
                 data.remove(item)
         # Print all plain bindings.
-        result.append('Plain keys...\n')
-        self.printBindingsHelper(result, data, prefix=None)
+        if 0: ###
+            result.append('Plain keys...\n')
+            self.printBindingsHelper(result, data, prefix=None)
         if not g.unitTesting:
             g.es_print('', ''.join(result), tabName=tabName)
         k.showStateAndMode()
@@ -3582,6 +3603,7 @@ class KeyHandlerClass:
         ):
             bi = k.getBindingHelper(key, name, stroke, w)
             if bi:
+                g.trace('FOUND', key, bi.commandName)
                 return bi
         return None
     #@+node:ekr.20180418105228.1: *7* getPaneBindingHelper

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -1138,7 +1138,7 @@ class ScriptingController:
                         commandName=commandName2,
                         func=registerAllCommandsCallback,
                         pane=pane,
-                        shortcut=None
+                        shortcut=None,
                     )
     #@+node:ekr.20150402021505.1: *4* sc.setButtonColor
     def setButtonColor(self, b, bg):

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -520,7 +520,7 @@ class ScriptingController:
         if 0:
             # Do not assume the script will want to remain in this commander.
             c.bodyWantsFocus()
-    #@+node:ekr.20060328125248.8: *3* sc.createAllButtons ###
+    #@+node:ekr.20060328125248.8: *3* sc.createAllButtons
     def createAllButtons(self):
         """Scan for @button, @rclick, @command, @plugin and @script nodes."""
         c = self.c
@@ -567,15 +567,6 @@ class ScriptingController:
                     func = d.get(m.group(1))
                     func(p)
                 p.moveToThreadNext()
-                
-        if 0:  ###
-            print('')
-            g.trace('=====', id(c), c.shortFileName())
-            for z in sorted(c.k.bindingsDict):
-                if 'F4' in repr(z):
-                    g.trace(z)
-                    print(c.k.bindingsDict[z])
-
     #@+node:ekr.20060328125248.24: *3* sc.createLocalAtButtonHelper
     def createLocalAtButtonHelper(self, p, h, statusLine,
         kind='at-button',
@@ -1144,11 +1135,9 @@ class ScriptingController:
                         g.trace('Already in commandsDict: %r' % commandName2)
                 else:
                     k.registerCommand(
-                        ### allowBinding=True,  # #2631
                         commandName=commandName2,
                         func=registerAllCommandsCallback,
                         pane=pane,
-                        ### shortcut=shortcut,  # #2631
                         shortcut=None
                     )
     #@+node:ekr.20150402021505.1: *4* sc.setButtonColor

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -520,7 +520,7 @@ class ScriptingController:
         if 0:
             # Do not assume the script will want to remain in this commander.
             c.bodyWantsFocus()
-    #@+node:ekr.20060328125248.8: *3* sc.createAllButtons
+    #@+node:ekr.20060328125248.8: *3* sc.createAllButtons ###
     def createAllButtons(self):
         """Scan for @button, @rclick, @command, @plugin and @script nodes."""
         c = self.c
@@ -567,6 +567,15 @@ class ScriptingController:
                     func = d.get(m.group(1))
                     func(p)
                 p.moveToThreadNext()
+                
+        ###
+        print('')
+        g.trace('=====', c.shortFileName(), g.callers(8))
+        for z in sorted(c.k.bindingsDict):
+            if 'F4' in repr(z):
+                g.trace(z)
+                print(c.k.bindingsDict[z])
+
     #@+node:ekr.20060328125248.24: *3* sc.createLocalAtButtonHelper
     def createLocalAtButtonHelper(self, p, h, statusLine,
         kind='at-button',
@@ -1135,11 +1144,12 @@ class ScriptingController:
                         g.trace('Already in commandsDict: %r' % commandName2)
                 else:
                     k.registerCommand(
-                        allowBinding=True,  # #2631
+                        ### allowBinding=True,  # #2631
                         commandName=commandName2,
                         func=registerAllCommandsCallback,
                         pane=pane,
-                        shortcut=shortcut,  # #2631
+                        ### shortcut=shortcut,  # #2631
+                        shortcut=None
                     )
     #@+node:ekr.20150402021505.1: *4* sc.setButtonColor
     def setButtonColor(self, b, bg):

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -568,10 +568,9 @@ class ScriptingController:
                     func(p)
                 p.moveToThreadNext()
                 
-        ###
-        print('')
-        g.trace('=====', id(c), c.shortFileName(), g.callers(8))
-        if 0:
+        if 0:  ###
+            print('')
+            g.trace('=====', id(c), c.shortFileName())
             for z in sorted(c.k.bindingsDict):
                 if 'F4' in repr(z):
                     g.trace(z)

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -570,11 +570,12 @@ class ScriptingController:
                 
         ###
         print('')
-        g.trace('=====', c.shortFileName(), g.callers(8))
-        for z in sorted(c.k.bindingsDict):
-            if 'F4' in repr(z):
-                g.trace(z)
-                print(c.k.bindingsDict[z])
+        g.trace('=====', id(c), c.shortFileName(), g.callers(8))
+        if 0:
+            for z in sorted(c.k.bindingsDict):
+                if 'F4' in repr(z):
+                    g.trace(z)
+                    print(c.k.bindingsDict[z])
 
     #@+node:ekr.20060328125248.24: *3* sc.createLocalAtButtonHelper
     def createLocalAtButtonHelper(self, p, h, statusLine,

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -883,7 +883,7 @@ if has_webengineview:
     try:
         from leo.core.leoQt import QtWebEngineCore
         QWebEngineSettings = QtWebEngineCore.QWebEngineSettings
-    except:
+    except Exception:
         QWebEngineSettings = QtWebEngineWidgets.QWebEngineSettings
     from leo.core.leoQt import WebEngineAttribute
 else:

--- a/leo/unittests/core/test_leoKeys.py
+++ b/leo/unittests/core/test_leoKeys.py
@@ -124,9 +124,9 @@ class TestKeys(LeoUnitTest):
             for ch in special:
                 assert not k.isPlainKey(ch), 'is plain: %s' % (ch)
     #@+node:ekr.20210909194336.54: *3* TestKeys.test_k_print_bindings
-    def test_k_print_bindings(self):
+    def test_k_show_bindings(self):
         c = self.c
-        c.k.printBindings()
+        c.k.showBindings()
     #@+node:ekr.20210909194336.55: *3* TestKeys.test_k_registerCommand
     callback_was_called = False
 


### PR DESCRIPTION
See #2631.

The code now uses k.masterBindingDict instead of k.bindingsDict. This works around a true mystery, and seems to work fairly well.

However, there seems to be no easy way to associate a single binding with various aliases of commands. I shall not do any more work in this area.