### PR TITLE
Ekr config

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -541,6 +541,7 @@
 <v t="ekr.20131112150804.18737"><vh>@bool force-execute-entire-body = False</vh></v>
 <v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
+<v t="ekr.20220624062948.1"><vh>@bool redirect-execute-script-output-to-log_pane = False</vh></v>
 <v t="ekr.20180117074230.1"><vh>@bool show-tips = True</vh></v>
 <v t="ekr.20060323131801"><vh>@bool warn-about-missing-settings = False</vh></v>
 <v t="ekr.20220105172501.1"><vh>@data add-mypy-annotations</vh></v>
@@ -2312,6 +2313,7 @@
 </v>
 </v>
 <v t="ekr.20140915194122.23428"></v>
+<v t="ekr.20220624062948.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11655,6 +11657,7 @@ False: Use the default stylesheet at leo/plugins/viewrendered3.
        If not present, create a default stylesheet and write it to a file
        at that place.</t>
 <t tx="ekr.20220524035531.1">Column number for right margin guidelines.</t>
+<t tx="ekr.20220624062948.1"></t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1868,8 +1868,6 @@ class LoadManager:
     #@+node:ekr.20121126202114.3: *4* LM.createDefaultSettingsDicts
     def createDefaultSettingsDicts(self):
         """Create lm.globalSettingsDict & lm.globalBindingsDict."""
-        ### settings_d = g.app.config.defaultsDict
-        ### assert isinstance(settings_d, g.TypedDict), settings_d
         settings_d = g.TypedDict(
             name='g.app.config.defaultsDict',
             keyType=str,

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1868,8 +1868,13 @@ class LoadManager:
     #@+node:ekr.20121126202114.3: *4* LM.createDefaultSettingsDicts
     def createDefaultSettingsDicts(self):
         """Create lm.globalSettingsDict & lm.globalBindingsDict."""
-        settings_d = g.app.config.defaultsDict
-        assert isinstance(settings_d, g.TypedDict), settings_d
+        ### settings_d = g.app.config.defaultsDict
+        ### assert isinstance(settings_d, g.TypedDict), settings_d
+        settings_d = g.TypedDict(
+            name='g.app.config.defaultsDict',
+            keyType=str,
+            valType=g.GeneralSetting,
+        )
         settings_d.setName('lm.globalSettingsDict')
         bindings_d = g.TypedDict(  # was TypedDictOfLists.
             name='lm.globalBindingsDict',

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -136,7 +136,8 @@ class AtFile:
         at, c = self, self.c
         if not c and c.config:
             return None  # pragma: no cover
-        make_dirs = c.config.create_nonexistent_directories
+        ### make_dirs = c.config.create_nonexistent_directories
+        make_dirs = c.config.getBool('create-nonexistent-directories', default=False)
         assert root
         self.initCommonIvars()
         assert at.checkPythonCodeOnWrite is not None
@@ -2459,8 +2460,9 @@ class AtFile:
     #@+node:ekr.20041005105605.211: *5* at.putInitialComment
     def putInitialComment(self):  # pragma: no cover
         c = self.c
-        s2 = c.config.output_initial_comment
-        if s2:
+        ### s2 = c.config.output_initial_comment
+        s2 = c.config.getString('output-initial-comment') or ''
+        if s2.strip():
             lines = s2.split("\\n")
             for line in lines:
                 line = line.replace("@date", time.asctime())

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -136,7 +136,6 @@ class AtFile:
         at, c = self, self.c
         if not c and c.config:
             return None  # pragma: no cover
-        ### make_dirs = c.config.create_nonexistent_directories
         make_dirs = c.config.getBool('create-nonexistent-directories', default=False)
         assert root
         self.initCommonIvars()
@@ -2460,7 +2459,6 @@ class AtFile:
     #@+node:ekr.20041005105605.211: *5* at.putInitialComment
     def putInitialComment(self):  # pragma: no cover
         c = self.c
-        ### s2 = c.config.output_initial_comment
         s2 = c.config.getString('output-initial-comment') or ''
         if s2.strip():
             lines = s2.split("\\n")

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -155,7 +155,6 @@ class BaseColorizer:
             slant = get(name + '_slant', 'slant')
             weight = get(name + '_weight', 'weight')
             if family or slant or weight or size:
-                family = family or g.app.config.defaultFontFamily
                 key = f"{key}::{setting_name}"
                 if key in self.zoom_dict:
                     old_size = self.zoom_dict.get(key)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -773,7 +773,6 @@ class Commands:
     #@+node:ekr.20171123135625.6: *4* c.redirectScriptOutput
     def redirectScriptOutput(self):
         c = self
-        ### if c.config.redirect_execute_script_output_to_log_pane:
         if c.exists and c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.redirectStdout()  # Redirect stdout
             g.redirectStderr()  # Redirect stderr
@@ -791,7 +790,6 @@ class Commands:
     #@+node:ekr.20171123135625.8: *4* c.unredirectScriptOutput
     def unredirectScriptOutput(self):
         c = self
-        ### if c.exists and c.config.redirect_execute_script_output_to_log_pane:
         if c.exists and c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.restoreStderr()
             g.restoreStdout()
@@ -2048,7 +2046,6 @@ class Commands:
         if c.openDirectory:  # Bug fix: 2008/9/18
             base = c.openDirectory
         else:
-            ### base = g.app.config.relative_path_base_directory  ### Always '!'
             base = c.config.getBool('relative-path-base-directory')
             if base and base == "!":
                 base = g.app.loadDir

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -773,7 +773,8 @@ class Commands:
     #@+node:ekr.20171123135625.6: *4* c.redirectScriptOutput
     def redirectScriptOutput(self):
         c = self
-        if c.config.redirect_execute_script_output_to_log_pane:
+        ### if c.config.redirect_execute_script_output_to_log_pane:
+        if c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.redirectStdout()  # Redirect stdout
             g.redirectStderr()  # Redirect stderr
     #@+node:ekr.20171123135625.7: *4* c.setCurrentDirectoryFromContext
@@ -2046,11 +2047,14 @@ class Commands:
         if c.openDirectory:  # Bug fix: 2008/9/18
             base = c.openDirectory
         else:
-            base = g.app.config.relative_path_base_directory
+            ### base = g.app.config.relative_path_base_directory  ### Always '!'
+            base = c.config.getBool('relative-path-base-directory')
             if base and base == "!":
                 base = g.app.loadDir
             elif base and base == ".":
                 base = c.openDirectory
+            else:
+                base = None  # Settings error.
         base = c.expand_path_expression(base)  # #1341.
         base = g.os_path_expanduser(base)  # #1889.
         absbase = g.os_path_finalize_join(g.app.loadDir, base)  # #1341.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -774,7 +774,7 @@ class Commands:
     def redirectScriptOutput(self):
         c = self
         ### if c.config.redirect_execute_script_output_to_log_pane:
-        if c.config.getBool('redirect-execute-script-output-to-log-pane'):
+        if c.exists and c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.redirectStdout()  # Redirect stdout
             g.redirectStderr()  # Redirect stderr
     #@+node:ekr.20171123135625.7: *4* c.setCurrentDirectoryFromContext
@@ -791,7 +791,8 @@ class Commands:
     #@+node:ekr.20171123135625.8: *4* c.unredirectScriptOutput
     def unredirectScriptOutput(self):
         c = self
-        if c.exists and c.config.redirect_execute_script_output_to_log_pane:
+        ### if c.exists and c.config.redirect_execute_script_output_to_log_pane:
+        if c.exists and c.config.getBool('redirect-execute-script-output-to-log-pane'):
             g.restoreStderr()
             g.restoreStdout()
     #@+node:ekr.20080514131122.12: *3* @cmd recolor

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1208,11 +1208,9 @@ class ActiveSettingsOutline:
 #@+node:ekr.20041119203941: ** class GlobalConfigManager
 class GlobalConfigManager:
     """A class to manage configuration settings."""
-    # Class data...
 
     #@+others
-    #@+node:ekr.20041117083202: *3* gcm.Birth...
-    #@+node:ekr.20041117062717.2: *4* gcm.ctor
+    #@+node:ekr.20041117062717.2: *3*  gcm.ctor
     def __init__(self) -> None:
 
         # List of info (command_p, script, rclicks) for common @buttons nodes.
@@ -1239,10 +1237,6 @@ class GlobalConfigManager:
         self.sc = None
         self.tree = None
         self.use_plugins = True  # Leo 4.3+: Use plugins by default.
-        self.initRecentFiles()
-    #@+node:ekr.20041117083202.2: *4* gcm.initRecentFiles
-    def initRecentFiles(self) -> None:
-        self.recentFiles = []
     #@+node:ekr.20120222103014.10314: *3* gcm.config_iter
     def config_iter(self, c: Cmdr) -> Generator:
         """Letters:
@@ -1303,9 +1297,8 @@ class GlobalConfigManager:
     #@+node:ekr.20041117083141: *4* gcm.get & allies
     def get(self, setting: str, kind: str) -> Any:
         """Get the setting and make sure its type matches the expected type."""
-        lm = g.app.loadManager
-        #
         # It *is* valid to call this method: it returns the global settings.
+        lm = g.app.loadManager
         d = lm.globalSettingsDict
         if d:
             assert isinstance(d, g.TypedDict), repr(d)

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1209,18 +1209,12 @@ class ActiveSettingsOutline:
 class GlobalConfigManager:
     """A class to manage configuration settings."""
     # Class data...
-   
+
     #@+others
     #@+node:ekr.20041117083202: *3* gcm.Birth...
     #@+node:ekr.20041117062717.2: *4* gcm.ctor
     def __init__(self) -> None:
-        ### if 0:  # No longer needed, now that setIvarsFromSettings always sets gcm ivars.
-            ### self.at_root_bodies_start_in_doc_mode = True
-            ### self.output_newline = 'nl'
-            ###self.redirect_execute_script_output_to_log_pane = True
-            ### self.relative_path_base_directory = '!'
-        self.use_plugins = True  # Leo 4.3+: Use plugins by default.
-        ### self.create_nonexistent_directories = False  # Required to keep pylint happy.
+
         # List of info (command_p, script, rclicks) for common @buttons nodes.
         # where rclicks is a namedtuple('RClick', 'position,children')
         self.atCommonButtonsList: List[Tuple[Cmdr, str, Any]] = []
@@ -1230,22 +1224,19 @@ class GlobalConfigManager:
         self.buttonsFileName = ''
         self.configsExist = False  # True when we successfully open a setting file.
         self.defaultFont = None  # Set in gui.getDefaultConfigFont.
-        
-        ### Experimental.
-        self.defaultsDict = g.TypedDict(
-            name='g.app.config.defaultsDict',
-            keyType=str,
-            valType=g.GeneralSetting,
-        )
-        self.ivarsDict = g.TypedDict(
-            name='g.app.config.ivarsDict',
-            keyType=str,
-            valType=g.GeneralSetting,
-        )
-        self.ivarsData = ()
-        
+
+        if 0: ### Temporary
+            self.ivarsDict = g.TypedDict(
+                name='g.app.config.ivarsDict',
+                keyType=str,
+                valType=g.GeneralSetting,
+            )
+            self.ivarsData = ()
+
         self.default_derived_file_encoding = 'utf-8'
         self.defaultFontFamily = None  # Set in gui.getDefaultConfigFont.
+
+
         self.enabledPluginsFileName = None
         self.enabledPluginsString = ''
         self.menusList: List[Any] = []  # pbc.doMenu comment: likely buggy.
@@ -1254,6 +1245,8 @@ class GlobalConfigManager:
             name='modeCommandsDict',
             keyType=str,
             valType=g.TypedDict)  # was TypedDictOfLists.
+        self.use_plugins = True  # Leo 4.3+: Use plugins by default.
+
         # Inited later...
         self.panes = None
         self.recentFiles: List[str] = []
@@ -1262,33 +1255,6 @@ class GlobalConfigManager:
         ### self.initDicts()
         ### self.initIvarsFromDicts()
         self.initRecentFiles()
-    #@+node:ekr.20041117065611.2: *4* gcm.initIvarsFromDicts & helpers
-    def initIvarsFromDicts(self) -> None:
-        for ivar in sorted(list(self.encodingIvarsDict.keys())):
-            self.initEncoding(ivar)
-        for ivar in sorted(list(self.ivarsDict.keys())):
-            self.initIvar(ivar)
-    #@+node:ekr.20041117065611.1: *5* initEncoding
-    def initEncoding(self, key: str) -> None:
-        """Init g.app.config encoding ivars during initialization."""
-        # Important: The key is munged.
-        gs = self.encodingIvarsDict.get(key)
-        setattr(self, gs.ivar, gs.encoding)
-        if gs.encoding and not g.isValidEncoding(gs.encoding):
-            g.es('g.app.config: bad encoding:', f"{gs.ivar}: {gs.encoding}")
-    #@+node:ekr.20041117065611: *5* initIvar
-    def initIvar(self, key: str) -> None:
-        """
-        Init g.app.config ivars during initialization.
-
-        This does NOT init the corresponding commander ivars.
-
-        Such initing must be done in setIvarsFromSettings.
-        """
-        # Important: the key is munged.
-        d = self.ivarsDict
-        gs = d.get(key)
-        setattr(self, gs.ivar, gs.val)
     #@+node:ekr.20041117083202.2: *4* gcm.initRecentFiles
     def initRecentFiles(self) -> None:
         self.recentFiles = []
@@ -1565,7 +1531,7 @@ class LocalConfigManager:
     """A class to hold config settings for commanders."""
     #@+others
     #@+node:ekr.20120215072959.12472: *3* c.config.Birth
-    #@+node:ekr.20041118104831.2: *4* c.config.ctor (*** changed)
+    #@+node:ekr.20041118104831.2: *4* c.config.ctor
     def __init__(self, c: Cmdr, previousSettings: str=None) -> None:
 
         self.c = c
@@ -1591,12 +1557,12 @@ class LocalConfigManager:
             ### self.default_derived_file_encoding = g.app.config.default_derived_file_encoding
             ### self.redirect_execute_script_output_to_log_pane = \
             ### g.app.config.redirect_execute_script_output_to_log_pane
-        
+
         # Default encodings.
         self.default_at_auto_file_encoding = 'utf-8'
         self.default_derived_file_encoding = 'utf-8'
         self.new_leo_file_encoding = 'utf-8'
-        
+
         # Default fonts.
         self.defaultBodyFontSize = 12  # 9 if sys.platform == "win32" else 12
         self.defaultLogFontSize = 12  # 8 if sys.platform == "win32" else 12
@@ -1608,20 +1574,6 @@ class LocalConfigManager:
                 # self.initEncoding(key)
             # for key in sorted(list(g.app.config.ivarsDict.keys())):
                 # self.initIvar(key)
-    #@+node:ekr.20041118104414: *4* c.config.initEncoding
-    def initEncoding(self, key: str) -> None:
-        # Important: the key is munged.
-        gs = g.app.config.encodingIvarsDict.get(key)
-        encodingName = gs.ivar
-        encoding = self.get(encodingName, kind='string')
-        # Use the global setting as a last resort.
-        if encoding:
-            setattr(self, encodingName, encoding)
-        else:
-            encoding = getattr(g.app.config, encodingName)
-            setattr(self, encodingName, encoding)
-        if encoding and not g.isValidEncoding(encoding):
-            g.es('bad', f"{encodingName}: {encoding}")
     #@+node:ekr.20041118104240: *4* c.config.initIvar
     def initIvar(self, key: str) -> None:
 

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1211,13 +1211,16 @@ class GlobalConfigManager:
     # Class data...
     #@+<< gcm.defaultsDict >>
     #@+node:ekr.20041117062717.1: *3* << gcm.defaultsDict >>
-    #@+at This contains only the "interesting" defaults.
+    # This contains only the "interesting" defaults.
     # Ints and bools default to 0, floats to 0.0 and strings to "".
-    #@@c
+
+    ### To do: Move these to c.config.__init__
+
     defaultBodyFontSize = 12  # 9 if sys.platform == "win32" else 12
     defaultLogFontSize = 12  # 8 if sys.platform == "win32" else 12
     defaultMenuFontSize = 12  # 9 if sys.platform == "win32" else 12
     defaultTreeFontSize = 12  # 9 if sys.platform == "win32" else 12
+
     defaultsDict = g.TypedDict(
         name='g.app.config.defaultsDict',
         keyType=str,
@@ -1225,39 +1228,44 @@ class GlobalConfigManager:
     )
     defaultsData = (
         # compare options...
-        ("ignore_blank_lines", "bool", True),
-        ("limit_count", "int", 9),
-        ("print_mismatching_lines", "bool", True),
-        ("print_trailing_lines", "bool", True),
+        ### ("ignore_blank_lines", "bool", True),
+        ### ("limit_count", "int", 9),
+        ### ("print_mismatching_lines", "bool", True),
+        ### ("print_trailing_lines", "bool", True),
         # find/change options...
+
         ("search_body", "bool", True),
         ("whole_word", "bool", True),
+        
         # Prefs panel.
         # ("default_target_language","language","python"),
-        ("target_language", "language", "python"),  # Bug fix: 6/20,2005.
-        ("tab_width", "int", -4),
+        ### ("target_language", "language", "python"),  # Bug fix: 6/20,2005.
+        ### ("tab_width", "int", -4),
         ### ("page_width", "int", 132),
-        ("output_doc_chunks", "bool", True),
-        ("tangle_outputs_header", "bool", True),
+        ### ("output_doc_chunks", "bool", True),
+        ### ("tangle_outputs_header", "bool", True),
+        
         # Syntax coloring options...
         # Defaults for colors are handled by leoColor.py.
-        ("color_directives_in_plain_text", "bool", True),
-        ("underline_undefined_section_names", "bool", True),
+        ### ("color_directives_in_plain_text", "bool", True),
+        ### ("underline_undefined_section_names", "bool", True),
+        
         # Window options...
-        ("body_pane_wraps", "bool", True),
-        ("body_text_font_family", "family", "Courier"),
-        ("body_text_font_size", "size", defaultBodyFontSize),
-        ("body_text_font_slant", "slant", "roman"),
-        ("body_text_font_weight", "weight", "normal"),
-        ("enable_drag_messages", "bool", True),
-        ("headline_text_font_family", "string", None),
-        ("headline_text_font_size", "size", defaultLogFontSize),
-        ("headline_text_font_slant", "slant", "roman"),
-        ("headline_text_font_weight", "weight", "normal"),
-        ("log_text_font_family", "string", None),
-        ("log_text_font_size", "size", defaultLogFontSize),
-        ("log_text_font_slant", "slant", "roman"),
-        ("log_text_font_weight", "weight", "normal"),
+        ### ("body_pane_wraps", "bool", True),
+        ### ("body_text_font_family", "family", "Courier"),
+        ### ("body_text_font_size", "size", defaultBodyFontSize),
+        ###
+            # # # ("body_text_font_slant", "slant", "roman"),
+            # # # ("body_text_font_weight", "weight", "normal"),
+            # # # ("enable_drag_messages", "bool", True),
+            # # # ("headline_text_font_family", "string", None),
+            # # # ("headline_text_font_size", "size", defaultLogFontSize),
+            # # # ("headline_text_font_slant", "slant", "roman"),
+            # # # ("headline_text_font_weight", "weight", "normal"),
+            # # # ("log_text_font_family", "string", None),
+            # # # ("log_text_font_size", "size", defaultLogFontSize),
+            # # # ("log_text_font_slant", "slant", "roman"),
+            # # # ("log_text_font_weight", "weight", "normal"),
         ("initial_window_height", "int", 600),
         ("initial_window_width", "int", 800),
         ("initial_window_left", "int", 10),
@@ -1315,12 +1323,12 @@ class GlobalConfigManager:
         ### ("stylesheet", "string", None),
         ### ("tab_width", "int", -4),
         # Bug fix: added: 6/20/2005.
-        ("target_language", "language", "python"),
-        ("trailing_body_newlines", "string", "asis"),
+        ### ("target_language", "language", "python"),
+        ### ("trailing_body_newlines", "string", "asis"),
         # New in 4.3: use_plugins = True by default.
-        ("use_plugins", "bool", True),
-        ("undo_granularity", "string", "word"),  # "char","word","line","node"
-        ("write_strips_blank_lines", "bool", False),
+        ### ("use_plugins", "bool", True),
+        ### ("undo_granularity", "string", "word"),  # "char","word","line","node"
+        ### ("write_strips_blank_lines", "bool", False),
     )
     #@-<< gcm.ivarsDict >>
     #@+others
@@ -1335,7 +1343,7 @@ class GlobalConfigManager:
             ### self.output_newline = 'nl'
             self.redirect_execute_script_output_to_log_pane = True
             ### self.relative_path_base_directory = '!'
-        self.use_plugins = False  # Required to keep pylint happy.
+        self.use_plugins = True  # Leo 4.3+: Use plugins by default.
         ### self.create_nonexistent_directories = False  # Required to keep pylint happy.
         # List of info (command_p, script, rclicks) for common @buttons nodes.
         # where rclicks is a namedtuple('RClick', 'position,children')

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1236,7 +1236,7 @@ class GlobalConfigManager:
         # ("default_target_language","language","python"),
         ("target_language", "language", "python"),  # Bug fix: 6/20,2005.
         ("tab_width", "int", -4),
-        ("page_width", "int", 132),
+        ### ("page_width", "int", 132),
         ("output_doc_chunks", "bool", True),
         ("tangle_outputs_header", "bool", True),
         # Syntax coloring options...
@@ -1301,19 +1301,19 @@ class GlobalConfigManager:
     )
     ivarsData = (
         # For compatibility with previous versions.
-        ("at_root_bodies_start_in_doc_mode", "bool", True),
-        ("create_nonexistent_directories", "bool", False),
+        ### ("at_root_bodies_start_in_doc_mode", "bool", True),
+        ### ("create_nonexistent_directories", "bool", False),
         # "" for compatibility with previous versions.
-        ("output_initial_comment", "string", ""),
-        ("output_newline", "string", "nl"),
-        ("page_width", "int", "132"),
-        ("read_only", "bool", True),
-        ("redirect_execute_script_output_to_log_pane", "bool", False),
-        ("relative_path_base_directory", "string", "!"),
-        ("remove_sentinels_extension", "string", ".txt"),
-        ("save_clears_undo_buffer", "bool", False),
-        ("stylesheet", "string", None),
-        ("tab_width", "int", -4),
+        ### ("output_initial_comment", "string", ""),
+        ### ("output_newline", "string", "nl"),
+        ### ("page_width", "int", "132"),
+        ### ("read_only", "bool", True),
+        ### ("redirect_execute_script_output_to_log_pane", "bool", False),
+        ### ("relative_path_base_directory", "string", "!"),
+        ### ("remove_sentinels_extension", "string", ".txt"),
+        ### ("save_clears_undo_buffer", "bool", False),
+        ### ("stylesheet", "string", None),
+        ### ("tab_width", "int", -4),
         # Bug fix: added: 6/20/2005.
         ("target_language", "language", "python"),
         ("trailing_body_newlines", "string", "asis"),
@@ -1330,13 +1330,13 @@ class GlobalConfigManager:
         #
         # Set later.  To keep pylint happy.
         if 0:  # No longer needed, now that setIvarsFromSettings always sets gcm ivars.
-            self.at_root_bodies_start_in_doc_mode = True
+            ### self.at_root_bodies_start_in_doc_mode = True
             self.default_derived_file_encoding = 'utf-8'
-            self.output_newline = 'nl'
+            ### self.output_newline = 'nl'
             self.redirect_execute_script_output_to_log_pane = True
-            self.relative_path_base_directory = '!'
+            ### self.relative_path_base_directory = '!'
         self.use_plugins = False  # Required to keep pylint happy.
-        self.create_nonexistent_directories = False  # Required to keep pylint happy.
+        ### self.create_nonexistent_directories = False  # Required to keep pylint happy.
         # List of info (command_p, script, rclicks) for common @buttons nodes.
         # where rclicks is a namedtuple('RClick', 'position,children')
         self.atCommonButtonsList: List[Tuple[Cmdr, str, Any]] = []
@@ -1703,7 +1703,8 @@ class LocalConfigManager:
             # No longer needed now that c.config.initIvar always sets
             # both c and c.config ivars.
             self.default_derived_file_encoding = g.app.config.default_derived_file_encoding
-            self.redirect_execute_script_output_to_log_pane = g.app.config.redirect_execute_script_output_to_log_pane
+            ### self.redirect_execute_script_output_to_log_pane = \
+            ### g.app.config.redirect_execute_script_output_to_log_pane
         self.defaultBodyFontSize = g.app.config.defaultBodyFontSize
         self.defaultLogFontSize = g.app.config.defaultLogFontSize
         self.defaultMenuFontSize = g.app.config.defaultMenuFontSize

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1221,9 +1221,7 @@ class GlobalConfigManager:
         self.atLocalCommandsList: List[Pos] = []  # List of positions of @command nodes.
         self.buttonsFileName = ''
         self.configsExist = False  # True when we successfully open a setting file.
-        self.defaultFont = None  # Set in gui.getDefaultConfigFont.
         self.default_derived_file_encoding = 'utf-8'
-        self.defaultFontFamily = None  # Set in gui.getDefaultConfigFont.
         self.enabledPluginsFileName = None
         self.enabledPluginsString = ''
         self.menusList: List[Any] = []  # pbc.doMenu comment: likely buggy.
@@ -1274,8 +1272,7 @@ class GlobalConfigManager:
                     val = '<xml>'
                 key2 = f"@{gs.kind:>6} {key}"
                 yield key2, val, c, letter
-    #@+node:ekr.20041117081009: *3* gcm.Getters...
-    #@+node:ekr.20041123070429: *4* gcm.canonicalizeSettingName (munge)
+    #@+node:ekr.20041123070429: *3* gcm.canonicalizeSettingName (munge)
     def canonicalizeSettingName(self, name: str) -> str:
         if name is None:
             return None
@@ -1285,6 +1282,7 @@ class GlobalConfigManager:
         return name if name else None
 
     munge = canonicalizeSettingName
+    #@+node:ekr.20041117081009: *3* gcm.Getters...
     #@+node:ekr.20051011105014: *4* gcm.exists
     def exists(self, setting: str, kind: str) -> bool:
         """Return true if a setting of the given kind exists, even if it is None."""
@@ -1435,7 +1433,7 @@ class GlobalConfigManager:
         Return None if there is no family setting so we can use system default fonts."""
         family = self.get(family, "family")
         if family in (None, ""):
-            family = self.defaultFontFamily
+            family = None
         size = self.get(size, "size")
         if size in (None, 0):
             size = str(defaultSize)  # type:ignore
@@ -1765,8 +1763,6 @@ class LocalConfigManager:
         Return None if there is no family setting so we can use system default fonts.
         """
         family = self.get(family, "family")
-        if family in (None, ""):
-            family = g.app.config.defaultFontFamily
         size = self.get(size, "size")
         if size in (None, 0):
             size = str(defaultSize)  # type:ignore

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1224,19 +1224,8 @@ class GlobalConfigManager:
         self.buttonsFileName = ''
         self.configsExist = False  # True when we successfully open a setting file.
         self.defaultFont = None  # Set in gui.getDefaultConfigFont.
-
-        if 0: ### Temporary
-            self.ivarsDict = g.TypedDict(
-                name='g.app.config.ivarsDict',
-                keyType=str,
-                valType=g.GeneralSetting,
-            )
-            self.ivarsData = ()
-
         self.default_derived_file_encoding = 'utf-8'
         self.defaultFontFamily = None  # Set in gui.getDefaultConfigFont.
-
-
         self.enabledPluginsFileName = None
         self.enabledPluginsString = ''
         self.menusList: List[Any] = []  # pbc.doMenu comment: likely buggy.
@@ -1245,15 +1234,11 @@ class GlobalConfigManager:
             name='modeCommandsDict',
             keyType=str,
             valType=g.TypedDict)  # was TypedDictOfLists.
-        self.use_plugins = True  # Leo 4.3+: Use plugins by default.
-
-        # Inited later...
         self.panes = None
         self.recentFiles: List[str] = []
         self.sc = None
         self.tree = None
-        ### self.initDicts()
-        ### self.initIvarsFromDicts()
+        self.use_plugins = True  # Leo 4.3+: Use plugins by default.
         self.initRecentFiles()
     #@+node:ekr.20041117083202.2: *4* gcm.initRecentFiles
     def initRecentFiles(self) -> None:
@@ -1533,59 +1518,27 @@ class LocalConfigManager:
     #@+node:ekr.20120215072959.12472: *3* c.config.Birth
     #@+node:ekr.20041118104831.2: *4* c.config.ctor
     def __init__(self, c: Cmdr, previousSettings: str=None) -> None:
-
         self.c = c
         lm = g.app.loadManager
-        #
-        # c.__init__ and helpers set the shortcuts and settings dicts for local files.
         if previousSettings:
             self.settingsDict = previousSettings.settingsDict
             self.shortcutsDict = previousSettings.shortcutsDict
             assert isinstance(self.settingsDict, g.TypedDict), repr(self.settingsDict)
-            # was TypedDictOfLists.
             assert isinstance(self.shortcutsDict, g.TypedDict), repr(self.shortcutsDict)
         else:
             self.settingsDict = d1 = lm.globalSettingsDict
             self.shortcutsDict = d2 = lm.globalBindingsDict
             assert d1 is None or isinstance(d1, g.TypedDict), repr(d1)
-            assert d2 is None or isinstance(
-                d2, g.TypedDict), repr(d2)  # was TypedDictOfLists.
-        # Define these explicitly to eliminate a pylint warning.
-        ### if 0:
-            # No longer needed now that c.config.initIvar always sets
-            # both c and c.config ivars.
-            ### self.default_derived_file_encoding = g.app.config.default_derived_file_encoding
-            ### self.redirect_execute_script_output_to_log_pane = \
-            ### g.app.config.redirect_execute_script_output_to_log_pane
-
+            assert d2 is None or isinstance(d2, g.TypedDict), repr(d2)
         # Default encodings.
         self.default_at_auto_file_encoding = 'utf-8'
         self.default_derived_file_encoding = 'utf-8'
         self.new_leo_file_encoding = 'utf-8'
-
         # Default fonts.
         self.defaultBodyFontSize = 12  # 9 if sys.platform == "win32" else 12
         self.defaultLogFontSize = 12  # 8 if sys.platform == "win32" else 12
         self.defaultMenuFontSize = 12  # 9 if sys.platform == "win32" else 12
         self.defaultTreeFontSize = 12  # 9 if sys.platform == "win32" else 12
-
-        ### To be removed???
-            # for key in sorted(list(g.app.config.encodingIvarsDict.keys())):
-                # self.initEncoding(key)
-            # for key in sorted(list(g.app.config.ivarsDict.keys())):
-                # self.initIvar(key)
-    #@+node:ekr.20041118104240: *4* c.config.initIvar
-    def initIvar(self, key: str) -> None:
-
-        c = self.c
-        # Important: the key is munged.
-        gs = g.app.config.ivarsDict.get(key)
-        ivarName = gs.ivar
-        val = self.get(ivarName, kind=None)
-        if val or not hasattr(self, ivarName):
-            # Set *both* the commander ivar and the c.config ivar.
-            setattr(self, ivarName, val)
-            setattr(c, ivarName, val)
     #@+node:ekr.20190831030206.1: *3* c.config.createActivesSettingsOutline (new: #852)
     def createActivesSettingsOutline(self) -> None:
         """

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1209,142 +1209,15 @@ class ActiveSettingsOutline:
 class GlobalConfigManager:
     """A class to manage configuration settings."""
     # Class data...
-    #@+<< gcm.defaultsDict >>
-    #@+node:ekr.20041117062717.1: *3* << gcm.defaultsDict >>
-    # This contains only the "interesting" defaults.
-    # Ints and bools default to 0, floats to 0.0 and strings to "".
-
-    ### To do: Move these to c.config.__init__
-
-    defaultBodyFontSize = 12  # 9 if sys.platform == "win32" else 12
-    defaultLogFontSize = 12  # 8 if sys.platform == "win32" else 12
-    defaultMenuFontSize = 12  # 9 if sys.platform == "win32" else 12
-    defaultTreeFontSize = 12  # 9 if sys.platform == "win32" else 12
-
-    defaultsDict = g.TypedDict(
-        name='g.app.config.defaultsDict',
-        keyType=str,
-        valType=g.GeneralSetting,
-    )
-    defaultsData = (
-        # compare options...
-        ### ("ignore_blank_lines", "bool", True),
-        ### ("limit_count", "int", 9),
-        ### ("print_mismatching_lines", "bool", True),
-        ### ("print_trailing_lines", "bool", True),
-        # find/change options...
-
-        ("search_body", "bool", True),
-        ("whole_word", "bool", True),
-        
-        # Prefs panel.
-        # ("default_target_language","language","python"),
-        ### ("target_language", "language", "python"),  # Bug fix: 6/20,2005.
-        ### ("tab_width", "int", -4),
-        ### ("page_width", "int", 132),
-        ### ("output_doc_chunks", "bool", True),
-        ### ("tangle_outputs_header", "bool", True),
-        
-        # Syntax coloring options...
-        # Defaults for colors are handled by leoColor.py.
-        ### ("color_directives_in_plain_text", "bool", True),
-        ### ("underline_undefined_section_names", "bool", True),
-        
-        # Window options...
-        ### ("body_pane_wraps", "bool", True),
-        ### ("body_text_font_family", "family", "Courier"),
-        ### ("body_text_font_size", "size", defaultBodyFontSize),
-        ###
-            # # # ("body_text_font_slant", "slant", "roman"),
-            # # # ("body_text_font_weight", "weight", "normal"),
-            # # # ("enable_drag_messages", "bool", True),
-            # # # ("headline_text_font_family", "string", None),
-            # # # ("headline_text_font_size", "size", defaultLogFontSize),
-            # # # ("headline_text_font_slant", "slant", "roman"),
-            # # # ("headline_text_font_weight", "weight", "normal"),
-            # # # ("log_text_font_family", "string", None),
-            # # # ("log_text_font_size", "size", defaultLogFontSize),
-            # # # ("log_text_font_slant", "slant", "roman"),
-            # # # ("log_text_font_weight", "weight", "normal"),
-        ###
-            # ("initial_window_height", "int", 600),
-            # ("initial_window_width", "int", 800),
-            # ("initial_window_left", "int", 10),
-            # ("initial_window_top", "int", 10),
-        ###
-            # ("initial_split_orientation", "string", "vertical"),  # was initial_splitter_orientation.
-            # ("initial_vertical_ratio", "ratio", 0.5),
-            # ("initial_horizontal_ratio", "ratio", 0.3),
-            # ("initial_horizontal_secondary_ratio", "ratio", 0.5),
-            # ("initial_vertical_secondary_ratio", "ratio", 0.7),
-        # ("outline_pane_scrolls_horizontally","bool",False),
-        ###
-            # ("split_bar_color", "color", "LightSteelBlue2"),
-            # ("split_bar_relief", "relief", "groove"),
-            # ("split_bar_width", "int", 7),
-    )
-    #@-<< gcm.defaultsDict >>
-    #@+<< gcm.encodingIvarsDict >>
-    #@+node:ekr.20041118062709: *3* << gcm.encodingIvarsDict >>
-    encodingIvarsDict = g.TypedDict(
-        name='g.app.config.encodingIvarsDict',
-        keyType=str,
-        valType=g.GeneralSetting,
-    )
-    encodingIvarsData = (
-        ("default_at_auto_file_encoding", "string", "utf-8"),
-        ("default_derived_file_encoding", "string", "utf-8"),
-        # Upper case for compatibility with previous versions.
-        ("new_leo_file_encoding", "string", "UTF-8"),
-        #
-        # The defaultEncoding ivar is no longer used,
-        # so it doesn't override better defaults.
-    )
-    #@-<< gcm.encodingIvarsDict >>
-    #@+<< gcm.ivarsDict >>
-    #@+node:ekr.20041117072055: *3* << gcm.ivarsDict >>
-    # Each of these settings sets the corresponding ivar.
-    # Also, the LocalConfigManager class inits the corresponding commander ivar.
-    ivarsDict = g.TypedDict(
-        name='g.app.config.ivarsDict',
-        keyType=str,
-        valType=g.GeneralSetting,
-    )
-    ivarsData = (
-        # For compatibility with previous versions.
-        ### ("at_root_bodies_start_in_doc_mode", "bool", True),
-        ### ("create_nonexistent_directories", "bool", False),
-        # "" for compatibility with previous versions.
-        ### ("output_initial_comment", "string", ""),
-        ### ("output_newline", "string", "nl"),
-        ### ("page_width", "int", "132"),
-        ### ("read_only", "bool", True),
-        ### ("redirect_execute_script_output_to_log_pane", "bool", False),
-        ### ("relative_path_base_directory", "string", "!"),
-        ### ("remove_sentinels_extension", "string", ".txt"),
-        ### ("save_clears_undo_buffer", "bool", False),
-        ### ("stylesheet", "string", None),
-        ### ("tab_width", "int", -4),
-        # Bug fix: added: 6/20/2005.
-        ### ("target_language", "language", "python"),
-        ### ("trailing_body_newlines", "string", "asis"),
-        # New in 4.3: use_plugins = True by default.
-        ### ("use_plugins", "bool", True),
-        ### ("undo_granularity", "string", "word"),  # "char","word","line","node"
-        ### ("write_strips_blank_lines", "bool", False),
-    )
-    #@-<< gcm.ivarsDict >>
+   
     #@+others
     #@+node:ekr.20041117083202: *3* gcm.Birth...
     #@+node:ekr.20041117062717.2: *4* gcm.ctor
     def __init__(self) -> None:
-        #
-        # Set later.  To keep pylint happy.
-        if 0:  # No longer needed, now that setIvarsFromSettings always sets gcm ivars.
+        ### if 0:  # No longer needed, now that setIvarsFromSettings always sets gcm ivars.
             ### self.at_root_bodies_start_in_doc_mode = True
-            self.default_derived_file_encoding = 'utf-8'
             ### self.output_newline = 'nl'
-            self.redirect_execute_script_output_to_log_pane = True
+            ###self.redirect_execute_script_output_to_log_pane = True
             ### self.relative_path_base_directory = '!'
         self.use_plugins = True  # Leo 4.3+: Use plugins by default.
         ### self.create_nonexistent_directories = False  # Required to keep pylint happy.
@@ -1357,6 +1230,21 @@ class GlobalConfigManager:
         self.buttonsFileName = ''
         self.configsExist = False  # True when we successfully open a setting file.
         self.defaultFont = None  # Set in gui.getDefaultConfigFont.
+        
+        ### Experimental.
+        self.defaultsDict = g.TypedDict(
+            name='g.app.config.defaultsDict',
+            keyType=str,
+            valType=g.GeneralSetting,
+        )
+        self.ivarsDict = g.TypedDict(
+            name='g.app.config.ivarsDict',
+            keyType=str,
+            valType=g.GeneralSetting,
+        )
+        self.ivarsData = ()
+        
+        self.default_derived_file_encoding = 'utf-8'
         self.defaultFontFamily = None  # Set in gui.getDefaultConfigFont.
         self.enabledPluginsFileName = None
         self.enabledPluginsString = ''
@@ -1371,24 +1259,11 @@ class GlobalConfigManager:
         self.recentFiles: List[str] = []
         self.sc = None
         self.tree = None
-        self.initDicts()
-        self.initIvarsFromSettings()
+        ### self.initDicts()
+        ### self.initIvarsFromDicts()
         self.initRecentFiles()
-    #@+node:ekr.20041227063801.2: *4* gcm.initDicts
-    def initDicts(self) -> None:
-        # Only the settings parser needs to search all dicts.
-        self.dictList = [self.defaultsDict]
-        for key, kind, val in self.defaultsData:
-            self.defaultsDict[self.munge(key)] = g.GeneralSetting(
-                kind, setting=key, val=val, tag='defaults')
-        for key, kind, val in self.ivarsData:
-            self.ivarsDict[self.munge(key)] = g.GeneralSetting(
-                kind, ivar=key, val=val, tag='ivars')
-        for key, kind, val in self.encodingIvarsData:
-            self.encodingIvarsDict[self.munge(key)] = g.GeneralSetting(
-                kind, encoding=val, ivar=key, tag='encoding')
-    #@+node:ekr.20041117065611.2: *4* gcm.initIvarsFromSettings & helpers
-    def initIvarsFromSettings(self) -> None:
+    #@+node:ekr.20041117065611.2: *4* gcm.initIvarsFromDicts & helpers
+    def initIvarsFromDicts(self) -> None:
         for ivar in sorted(list(self.encodingIvarsDict.keys())):
             self.initEncoding(ivar)
         for ivar in sorted(list(self.ivarsDict.keys())):
@@ -1690,7 +1565,7 @@ class LocalConfigManager:
     """A class to hold config settings for commanders."""
     #@+others
     #@+node:ekr.20120215072959.12472: *3* c.config.Birth
-    #@+node:ekr.20041118104831.2: *4* c.config.ctor
+    #@+node:ekr.20041118104831.2: *4* c.config.ctor (*** changed)
     def __init__(self, c: Cmdr, previousSettings: str=None) -> None:
 
         self.c = c
@@ -1710,20 +1585,29 @@ class LocalConfigManager:
             assert d2 is None or isinstance(
                 d2, g.TypedDict), repr(d2)  # was TypedDictOfLists.
         # Define these explicitly to eliminate a pylint warning.
-        if 0:
+        ### if 0:
             # No longer needed now that c.config.initIvar always sets
             # both c and c.config ivars.
-            self.default_derived_file_encoding = g.app.config.default_derived_file_encoding
+            ### self.default_derived_file_encoding = g.app.config.default_derived_file_encoding
             ### self.redirect_execute_script_output_to_log_pane = \
             ### g.app.config.redirect_execute_script_output_to_log_pane
-        self.defaultBodyFontSize = g.app.config.defaultBodyFontSize
-        self.defaultLogFontSize = g.app.config.defaultLogFontSize
-        self.defaultMenuFontSize = g.app.config.defaultMenuFontSize
-        self.defaultTreeFontSize = g.app.config.defaultTreeFontSize
-        for key in sorted(list(g.app.config.encodingIvarsDict.keys())):
-            self.initEncoding(key)
-        for key in sorted(list(g.app.config.ivarsDict.keys())):
-            self.initIvar(key)
+        
+        # Default encodings.
+        self.default_at_auto_file_encoding = 'utf-8'
+        self.default_derived_file_encoding = 'utf-8'
+        self.new_leo_file_encoding = 'utf-8'
+        
+        # Default fonts.
+        self.defaultBodyFontSize = 12  # 9 if sys.platform == "win32" else 12
+        self.defaultLogFontSize = 12  # 8 if sys.platform == "win32" else 12
+        self.defaultMenuFontSize = 12  # 9 if sys.platform == "win32" else 12
+        self.defaultTreeFontSize = 12  # 9 if sys.platform == "win32" else 12
+
+        ### To be removed???
+            # for key in sorted(list(g.app.config.encodingIvarsDict.keys())):
+                # self.initEncoding(key)
+            # for key in sorted(list(g.app.config.ivarsDict.keys())):
+                # self.initIvar(key)
     #@+node:ekr.20041118104414: *4* c.config.initEncoding
     def initEncoding(self, key: str) -> None:
         # Important: the key is munged.

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1266,19 +1266,22 @@ class GlobalConfigManager:
             # # # ("log_text_font_size", "size", defaultLogFontSize),
             # # # ("log_text_font_slant", "slant", "roman"),
             # # # ("log_text_font_weight", "weight", "normal"),
-        ("initial_window_height", "int", 600),
-        ("initial_window_width", "int", 800),
-        ("initial_window_left", "int", 10),
-        ("initial_window_top", "int", 10),
-        ("initial_split_orientation", "string", "vertical"),  # was initial_splitter_orientation.
-        ("initial_vertical_ratio", "ratio", 0.5),
-        ("initial_horizontal_ratio", "ratio", 0.3),
-        ("initial_horizontal_secondary_ratio", "ratio", 0.5),
-        ("initial_vertical_secondary_ratio", "ratio", 0.7),
+        ###
+            # ("initial_window_height", "int", 600),
+            # ("initial_window_width", "int", 800),
+            # ("initial_window_left", "int", 10),
+            # ("initial_window_top", "int", 10),
+        ###
+            # ("initial_split_orientation", "string", "vertical"),  # was initial_splitter_orientation.
+            # ("initial_vertical_ratio", "ratio", 0.5),
+            # ("initial_horizontal_ratio", "ratio", 0.3),
+            # ("initial_horizontal_secondary_ratio", "ratio", 0.5),
+            # ("initial_vertical_secondary_ratio", "ratio", 0.7),
         # ("outline_pane_scrolls_horizontally","bool",False),
-        ("split_bar_color", "color", "LightSteelBlue2"),
-        ("split_bar_relief", "relief", "groove"),
-        ("split_bar_width", "int", 7),
+        ###
+            # ("split_bar_color", "color", "LightSteelBlue2"),
+            # ("split_bar_relief", "relief", "groove"),
+            # ("split_bar_width", "int", 7),
     )
     #@-<< gcm.defaultsDict >>
     #@+<< gcm.encodingIvarsDict >>

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -432,7 +432,7 @@ class FastRead:
             gnx2body = self.scanJsonTnodes(t_elements)
             hidden_v = self.scanJsonVnodes(gnx2body, self.gnx2vnode, gnx2ua, v_elements)
             # self.handleBits()
-        except:
+        except Exception:
             g.trace(f"Error .leojs JSON is not valid: {path}")
             g.es_exception()
             return None, None

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1405,7 +1405,8 @@ class FileCommands:
                 if not silent:
                     self.putSavedMessage(fileName)
                 c.clearChanged()  # Clears all dirty bits.
-                if c.config.save_clears_undo_buffer:
+                ### if c.config.save_clears_undo_buffer:
+                if c.config.getBool('save-clears-undo-buffer'):
                     g.es("clearing undo")
                     c.undoer.clearUndoState()
             c.redraw_after_icons_changed()

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -18,7 +18,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
-from typing import Dict
+from typing import Dict, Set
 import zipfile
 import xml.etree.ElementTree as ElementTree
 import xml.sax
@@ -427,7 +427,7 @@ class FastRead:
             g_element = d.get('globals', {})
             v_elements = d.get('vnodes')
             t_elements = d.get('tnodes')
-            gnx2ua = defaultdict(dict)
+            gnx2ua: Dict = defaultdict(dict)
             gnx2ua.update(d.get('uas', {})) # User attributes in their own dict for leojs files
             gnx2body = self.scanJsonTnodes(t_elements)
             hidden_v = self.scanJsonVnodes(gnx2body, self.gnx2vnode, gnx2ua, v_elements)
@@ -1768,7 +1768,7 @@ class FileCommands:
         for v in c.all_unique_nodes():
             if hasattr(v, 'unknownAttributes') and len(v.unknownAttributes.keys()):
                 uas[v.gnx] = v.unknownAttributes
-        gnxSet = set() # hods all gnx found so far, to exclude adding headlines of already defined gnx.
+        gnxSet: Set[str] = set() # hods all gnx found so far, to exclude adding headlines of already defined gnx.
         result = {
                 'leoHeader': {'fileFormat': 2},
                 'globals': self.leojs_globals(),

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1405,7 +1405,6 @@ class FileCommands:
                 if not silent:
                     self.putSavedMessage(fileName)
                 c.clearChanged()  # Clears all dirty bits.
-                ### if c.config.save_clears_undo_buffer:
                 if c.config.getBool('save-clears-undo-buffer'):
                     g.es("clearing undo")
                     c.undoer.clearUndoState()

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -786,7 +786,7 @@ class LeoFrame:
     #@+node:ekr.20031218072017.3689: *4* LeoFrame.initialRatios
     def initialRatios(self) -> Tuple[bool, float, float]:
         c = self.c
-        s = c.config.get("initial_split_orientation", "string")
+        s = c.config.getString("initial_split_orientation")
         verticalFlag = s is None or (s != "h" and s != "horizontal")
         if verticalFlag:
             r = c.config.getRatio("initial-vertical-ratio")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3339,10 +3339,8 @@ def getOutputNewline(c: Cmdr=None, name: str=None) -> str:
     if name:
         s = name
     elif c:
-        ### s = c.config.output_newline
         s = c.config.getString('output-newline')
     else:
-        ### s = app.config.output_newline
         s = 'nl'  # Legacy value. Perhaps dubious.
     if not s:
         s = ''
@@ -3782,7 +3780,6 @@ def getBaseDirectory(c: Cmdr) -> str:
     """Convert '!' or '.' to proper directory references."""
     if not c:
         return ''  # No relative base given.
-    ### base = app.config.relative_path_base_directory
     base = c.config.getBool('relative-path-base-directory')
     if base and base == "!":
         base = app.loadDir

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3339,9 +3339,11 @@ def getOutputNewline(c: Cmdr=None, name: str=None) -> str:
     if name:
         s = name
     elif c:
-        s = c.config.output_newline
+        ### s = c.config.output_newline
+        s = c.config.getString('output-newline')
     else:
-        s = app.config.output_newline
+        ### s = app.config.output_newline
+        s = 'nl'  # Legacy value. Perhaps dubious.
     if not s:
         s = ''
     s = s.lower()
@@ -3778,12 +3780,19 @@ def get_files_in_directory(directory: str, kinds: List=None, recursive: bool=Tru
 
 def getBaseDirectory(c: Cmdr) -> str:
     """Convert '!' or '.' to proper directory references."""
-    base = app.config.relative_path_base_directory
+    if not c:
+        return ''  # No relative base given.
+    ### base = app.config.relative_path_base_directory
+    base = c.config.getBool('relative-path-base-directory')
     if base and base == "!":
         base = app.loadDir
     elif base and base == ".":
         base = c.openDirectory
-    if base and g.os_path_isabs(base):
+    else:
+        return ''  # Settings error.
+    if not base:
+        return ''
+    if g.os_path_isabs(base):
         # Set c.chdir_to_relative_path as needed.
         if not hasattr(c, 'chdir_to_relative_path'):
             c.chdir_to_relative_path = c.config.getBool('chdir-to-relative-path')
@@ -3791,7 +3800,7 @@ def getBaseDirectory(c: Cmdr) -> str:
         if c.chdir_to_relative_path:
             os.chdir(base)
         return base  # base need not exist yet.
-    return ""  # No relative base given.
+    return ''  # No relative base given.
 #@+node:ekr.20170223093758.1: *3* g.getEncodingAt
 def getEncodingAt(p: Pos, s: bytes=None) -> str:
     """

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -477,7 +477,7 @@ class NullGui(LeoGui):
         pass
 
     def getFontFromParams(self, family: str, size: str, slant: str, weight: str, defaultSize: int=12) -> Any:
-        return g.app.config.defaultFont
+        return None
 
     def getIconImage(self, name: str) -> None:
         return None

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -356,7 +356,6 @@ class LeoImportCommands:
         c = self.c
         if not v or not c:
             return ""
-        ### startInCode = not c.config.at_root_bodies_start_in_doc_mode
         startInCode = c.config.getBool('at-root-bodies-start-in-doc-mode')
         nl = self.output_newline
         docstart = nl + "@ " if self.webType == "cweb" else nl + "@" + nl
@@ -540,7 +539,6 @@ class LeoImportCommands:
                 line_delim, start_delim = start_delim, None
             #@-<< set delims from the header line >>
             s = self.removeSentinelLines(s, line_delim, start_delim, end_delim)
-            ### ext = c.config.remove_sentinels_extension
             ext = c.config.getString('remove-sentinels-extension')
             if not ext:
                 ext = ".txt"

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -356,7 +356,8 @@ class LeoImportCommands:
         c = self.c
         if not v or not c:
             return ""
-        startInCode = not c.config.at_root_bodies_start_in_doc_mode
+        ### startInCode = not c.config.at_root_bodies_start_in_doc_mode
+        startInCode = c.config.getBool('at-root-bodies-start-in-doc-mode')
         nl = self.output_newline
         docstart = nl + "@ " if self.webType == "cweb" else nl + "@" + nl
         s = v.b
@@ -539,7 +540,8 @@ class LeoImportCommands:
                 line_delim, start_delim = start_delim, None
             #@-<< set delims from the header line >>
             s = self.removeSentinelLines(s, line_delim, start_delim, end_delim)
-            ext = c.config.remove_sentinels_extension
+            ### ext = c.config.remove_sentinels_extension
+            ext = c.config.getString('remove-sentinels-extension')
             if not ext:
                 ext = ".txt"
             if ext[0] == '.':

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -352,7 +352,8 @@ class RstCommands:
         theDir = g.os_path_finalize(theDir)  # 1341
         if g.os_path_exists(theDir):
             return True
-        if c and c.config and c.config.create_nonexistent_directories:
+        ### if c and c.config and c.config.create_nonexistent_directories:
+        if c and c.config and c.config.getBool('create-nonexistent-directories', default=False):
             theDir = c.expand_path_expression(theDir)
             ok = g.makeAllNonExistentDirectories(theDir)  # type:ignore
             if not ok:

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -352,7 +352,6 @@ class RstCommands:
         theDir = g.os_path_finalize(theDir)  # 1341
         if g.os_path_exists(theDir):
             return True
-        ### if c and c.config and c.config.create_nonexistent_directories:
         if c and c.config and c.config.getBool('create-nonexistent-directories', default=False):
             theDir = c.expand_path_expression(theDir)
             ok = g.makeAllNonExistentDirectories(theDir)  # type:ignore

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -131,7 +131,8 @@ def applyFileAction(p, filename, c):
         script += '\n'
         #@+<< redirect output >>
         #@+node:ekr.20040915105758.17: *3* << redirect output >>
-        if c.config.redirect_execute_script_output_to_log_pane:
+        ### if c.config.redirect_execute_script_output_to_log_pane:
+        if c.config.getBool('redirect-execute-script-output-to-log_pane'):
 
             g.redirectStdout()  # Redirect stdout
             g.redirectStderr()  # Redirect stderr

--- a/leo/plugins/leo_pdf.py
+++ b/leo/plugins/leo_pdf.py
@@ -536,7 +536,6 @@ if docutils:
             self.story = []
             # Some of these may be needed, even though they are not referenced directly.
             self.settings = doctree.settings
-            # self.styleSheet = stylesheet and stylesheet.getStyleSheet()
             self.styleSheet = getStyleSheet()
             super().__init__(doctree)  # Init the base class.
             self.language = get_language(doctree)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -945,8 +945,8 @@ class LeoQtGui(leoGui.LeoGui):
         }
         weight_val = d.get(weight.lower(), Weight.Normal)
         italic = slant == 'italic'
-        if not family:
-            family = g.app.config.defaultFontFamily
+        # # # if not family:
+            # # # family = g.app.config.defaultFontFamily
         if not family:
             family = 'DejaVu Sans Mono'
         try:
@@ -963,7 +963,7 @@ class LeoQtGui(leoGui.LeoGui):
                 f" slant: {slant}\n"
                 f"weight: {weight}")
             # g.es_exception() # This just confuses people.
-            return g.app.config.defaultFont
+            return None
     #@+node:ekr.20110605121601.18511: *3* qt_gui.getFullVersion
     def getFullVersion(self, c: Cmdr=None) -> str:
         """Return the PyQt version (for signon)"""

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -945,8 +945,6 @@ class LeoQtGui(leoGui.LeoGui):
         }
         weight_val = d.get(weight.lower(), Weight.Normal)
         italic = slant == 'italic'
-        # # # if not family:
-            # # # family = g.app.config.defaultFontFamily
         if not family:
             family = 'DejaVu Sans Mono'
         try:

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -99,15 +99,6 @@ class TestCommands(LeoUnitTest):
         """)
         result = c.checkPythonCode(event=None, checkOnSave=False, ignoreAtIgnore=True)
         self.assertEqual(result, 'error')
-    #@+node:ekr.20210901140645.7: *3* TestCommands.test_c_config_initIvar_sets_commander_ivars
-    def test_c_config_initIvar_sets_commander_ivars(self):
-        c = self.c
-        for ivar, setting_type, default in g.app.config.ivarsData:
-            assert hasattr(c, ivar), ivar
-            assert hasattr(c.config, ivar), ivar
-            val = getattr(c.config, ivar)
-            val2 = c.config.get(ivar, setting_type)
-            self.assertEqual(val, val2)
     #@+node:ekr.20210906075242.4: *3* TestCommands.test_c_contractAllHeadlines
     def test_c_contractAllHeadlines(self):
         c = self.c

--- a/leo/unittests/core/test_leoConfig.py
+++ b/leo/unittests/core/test_leoConfig.py
@@ -21,11 +21,6 @@ class TestConfig(LeoUnitTest):
     def test_c_config_printSettings(self):
         c = self.c
         c.config.printSettings()
-    #@+node:ekr.20210909194336.22: *3* TestConfig.test_local_settings_c_page_width_
-    def test_local_settings_c_page_width_(self):
-        c = self.c
-        assert c.page_width
-        self.assertEqual(c.page_width, c.config.getInt('page_width'))
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
A grand simplification of the GlobalConfigManager (GCM) class:

The GCM no longer sets ivars or specifies defaults. This eliminates a lot of code and data!  More importantly, the GCM no longer sets policy. Rather than using g.app.config ivars, code throughout Leo calls c.config.get* to get settings.