### PR TITLE
In the body, when moving/selecting with Down/Shift-Down, if the

### DIFF
--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1793,6 +1793,17 @@ class QTextEditWrapper(QTextMixin):
                 cursor.clearSelection()
                 w.setTextCursor(cursor)
             w.moveCursor(op, mode)
+            if kind == 'down':
+                # If cursor is at start of last row of body,
+                # extend selection to end of that row.
+                cursor = w.textCursor()
+                lastrow = w.document().blockCount() - 1
+                block = w.toPlainText()
+                ins = self.getInsertPoint()
+                row, col = g.convertPythonIndexToRowCol(block, ins)
+                if row == lastrow and col == 0:
+                    w.moveCursor(MoveOperation.EndOfLine, mode)
+
         self.seeInsertPoint()
         self.rememberSelectionAndScroll()
         # #218.


### PR DESCRIPTION
cursor is located at the start of the last line, move/select to end of that last line.