### PR TITLE
PR: clarify python importer

### DIFF
--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -40,7 +40,7 @@ def split_root(root, lines):
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
     def_tuple = namedtuple('def_tuple', [
-        'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
+        'name', 'kind', 'col', 'h1', 'h2', 'start_b',  'c_ind', 'end_b',
     ])
 
     def getdefn(start):
@@ -128,13 +128,12 @@ def split_root(root, lines):
             else:
                 break
 
-        return def_tuple(
+        # This is the only instantiation of def_tuple.
+        return def_tuple(name, kind,
             col=col,
             h1=a - get_intro(a, col),
             h2=end_h,
             start_b=start_b,
-            kind=kind,
-            name=name,
             c_ind=c_ind,
             end_b=end_b,
         )

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -248,8 +248,7 @@ def split_root(root, lines):
         last = start
 
         # Calculate b1, the lines preceding the @others.
-        _inner_indent2, h1, _, _, _, _, _, _ = inner_defs[0]
-        assert _inner_indent2 == inner_indent
+        _, h1, _, _, _, _, _, _ = inner_defs[0]
         b1 = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
@@ -260,8 +259,7 @@ def split_root(root, lines):
 
         # Add a child for each inner definition.
         last = h1
-        for _inner_indent3, h1, _, _, _, name, c_ind, end_b in inner_defs:
-            assert _inner_indent3 == inner_indent
+        for _, h1, _, _, _, name, c_ind, end_b in inner_defs:
             if h1 > last:
                 # There are declaration lines between two inner definitions.
                 new_body = body(last, h1, inner_indent)  # #2500.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -55,7 +55,7 @@ def split_root(root: Any, lines: List[str]) -> None:
         Look for a def or class found at rawtokens[start].
         Return None or a def_tuple.
         """
-        nonlocal lines
+        nonlocal lines  # 'lines' is a kwarg to split_root.
 
         # pylint: disable=undefined-loop-variable
         # tok will never be empty, but pylint is not to know that.
@@ -266,12 +266,14 @@ def split_root(root: Any, lines: List[str]) -> None:
             last = body_line1
     #@+node:vitalije.20211208101750.1: *4* body & bodyLine
     def bodyLine(s: str, i: int) -> str:
+        """Massage line s."""
         if i == 0 or s[:i].isspace():
             return s[i:] or '\n'
         n = len(s) - len(s.lstrip())
         return f'\\\\-{i-n}.{s[n:]}'
 
     def body(a: int, b: int, i: int) -> str:
+        """Return the (massaged) concatentation of lines[a: b]"""
         nonlocal lines  # 'lines' is a kwarg to split_root.
         xlines = (bodyLine(s, i) for s in lines[a - 1 : b and (b - 1)])
         return ''.join(xlines)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -211,53 +211,52 @@ def split_root(root, lines):
             if t.type == k:
                 yield j, t
     #@+node:vitalije.20211208104408.1: *3* mknode & helpers
-    def mknode(p, start, start_b, end, l_ind, indent, xdefs):
+    def mknode(p, start, start_b, end, others_indent, inner_indent, xdefs):
         """
         Set p.b and add children recursively using the arguments.
 
-              p: The current node.
-          start: The line number of the first line of this node
-        start_b: The line number of first line of this node's function/class body
-            end: The line number of the first line after this node.
-          l_ind: The amount of white space to strip from left.
-                 This is the acccumated at-others indentation.
-         indent: The column at which start all of the inner definitions.
-          xdefs: The list of the definitions covering p.
+                    p: The current node.
+                start: The line number of the first line of this node
+              start_b: The line number of first line of this node's function/class body
+                  end: The line number of the first line after this node.
+        others_indent: The amount of white space to strip from left.
+         inner_indent: The column at which start all of the inner definitions.
+                xdefs: The list of the definitions covering p.
         """
 
         # Find all defs with the same indentation as our function/method/class body.
-        tdefs = [x for x in xdefs if x[0] == indent]
+        tdefs = [x for x in xdefs if x[0] == inner_indent]
 
         if not tdefs or end - start < SPLIT_THRESHOLD:
             # Don't split the body.
-            p.b = body(start, end, l_ind)
+            p.b = body(start, end, others_indent)
             return
 
         # last keeps track of the last used line
         last = start
 
         # Calculate b1, the lines preceding the @others.
-        indent, h1, h2, start_b, kind, name, c_ind, end_b = tdefs[0]
+        inner_indent, h1, h2, start_b, kind, name, c_ind, end_b = tdefs[0]
         if h1 > start:
             # The first inner definition starts later.
-            b1 = body(start, h1, l_ind)
+            b1 = body(start, h1, others_indent)
         else:
             # The inner definitions start at the beginning of our body.
             b1 = ''
-        others_line = calculate_indent('@others\n', indent - l_ind)
+        others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
         # Calculate b2, the lines following the @others line.
         if tdefs[-1][-1] < end:
-            b2 = body(tdefs[-1][-1], end, l_ind)
+            b2 = body(tdefs[-1][-1], end, others_indent)
         else:
             b2 = ''
         p.b = f'{b1}{others_line}{b2}'
 
         # Add children for each inner definition.
         last = h1
-        for indent, h1, h2, start_b, kind, name, c_ind, end_b in tdefs:
+        for inner_indent, h1, h2, start_b, kind, name, c_ind, end_b in tdefs:
             if h1 > last:
-                new_body = body(last, h1, indent)  # #2500.
+                new_body = body(last, h1, inner_indent)  # #2500.
                 # there are some declaration lines in between two inner definitions
                 p1 = p.insertAsLastChild()
                 p1.h = declaration_headline(new_body)  # #2500
@@ -276,13 +275,13 @@ def split_root(root, lines):
                     start=h1,
                     start_b=start_b,
                     end=end_b,
-                    l_ind=l_ind + indent,  # increase indentation for at-others
-                    indent=c_ind,
+                    others_indent=others_indent + inner_indent,  # increase indentation for at-others
+                    inner_indent=c_ind,
                     xdefs=subdefs,
                 )
             else:
                 # Just set the body.
-                p1.b = body(h1, end_b, indent)
+                p1.b = body(h1, end_b, inner_indent)
             last = end_b
     #@+node:vitalije.20211208101750.1: *4* body & bodyLine
     def bodyLine(x, ind):
@@ -309,7 +308,7 @@ def split_root(root, lines):
                 return s
         # Return legacy headline.
         return "...some declarations"  # pragma: no cover
-    #@+node:vitalije.20211208110301.1: *4* indent
+    #@+node:vitalije.20211208110301.1: *4* calculate_indent
     def calculate_indent(x, n):
         return x.rjust(len(x) + n)
     #@-others
@@ -329,8 +328,9 @@ def split_root(root, lines):
 
     # Start the recursion.
     root.deleteAllChildren()
-    mknode(p=root, start=1, start_b=1, end=len(lines)+1, l_ind=0, indent=0, xdefs=xdefs)
-
+    mknode(
+        p=root, start=1, start_b=1, end=len(lines)+1,
+        others_indent=0, inner_indent=0, xdefs=xdefs)
 #@-others
 importer_dict = {
     'func': do_import,

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -34,7 +34,7 @@ def_tuple = namedtuple('def_tuple', [
     'name',  # name of the function, class or method.
 ])
 
-def split_root(root, lines):
+def split_root(root: Any, lines: List[str]):
     """
     Create direct children of root for all top level function definitions and class definitions.
 
@@ -198,7 +198,7 @@ def split_root(root, lines):
 
         return nextline
     #@+node:vitalije.20211208104408.1: *3* mknode & helpers
-    def mknode(p,
+    def mknode(p: Any,
         start: int,
         start_b: int,
         end: int,

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -235,7 +235,8 @@ def split_root(root, lines):
         last = start
 
         # Calculate head, the lines preceding the @others.
-        _, h1, _, _, _, _, _, _ = inner_defs[0]
+        ### _, h1, _, _, _, _, _, _ = inner_defs[0]
+        h1 = inner_defs[0].h1
         head = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
@@ -246,7 +247,12 @@ def split_root(root, lines):
 
         # Add a child for each inner definition.
         last = h1
-        for _, h1, _, _, _, name, c_ind, end_b in inner_defs:
+        # for _, h1, _, _, _, name, c_ind, end_b in inner_defs:
+        for inner_def in inner_defs:
+            c_ind = inner_def.c_ind
+            h1 = inner_def.h1
+            end_b = inner_def.end_b
+            
             if h1 > last:
                 # There are declaration lines between two inner definitions.
                 new_body = body(last, h1, inner_indent)  # #2500.
@@ -255,7 +261,7 @@ def split_root(root, lines):
                 p1.b = new_body
                 last = h1
             child = p.insertAsLastChild()
-            child.h = name
+            child.h = inner_def.name
 
             # Next-level inner definitions are definitions whose
             # starting and end line contained in this node.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -259,8 +259,9 @@ def split_root(root, lines):
 
         # Calculate b2, the lines following the @others line.
         ### if inner_defs[-1][-1] < end:
-        if inner_defs[-1][end_b_offset] < end:
-            b2 = body(inner_defs[-1][end_b_offset], end, others_indent)
+        last_offset = inner_defs[-1][end_b_offset]
+        if last_offset < end:
+            b2 = body(last_offset, end, others_indent)
         else:
             b2 = ''
         p.b = f'{b1}{others_line}{b2}'

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -40,8 +40,7 @@ def split_root(root, lines):
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
     def_tuple = namedtuple('def_tuple', [
-        'name', 'kind', 'body_indent', 'body_line1', 'decl_indent', 'decl_line1',
-    ])
+        'body_indent', 'body_line1', 'decl_indent', 'decl_line1', 'kind', 'name'])
 
     def getdefn(start):
         """
@@ -115,11 +114,13 @@ def split_root(root, lines):
                 break
 
         # This is the only instantiation of def_tuple.
-        return def_tuple(name, kind,
-            body_indent=body_indent,
+        return def_tuple(
+            body_indent = body_indent,
             body_line1 = body_line1,
-            decl_indent=decl_indent,
-            decl_line1=decl_line - get_intro(decl_line, decl_indent),
+            decl_indent = decl_indent,
+            decl_line1 = decl_line - get_intro(decl_line, decl_indent),
+            kind = kind,
+            name = name,
         )
     #@+node:vitalije.20211208084231.1: *4* get_intro & helper
     def get_intro(row, col):

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -83,10 +83,15 @@ def split_root(root, lines):
             break
 
         # Look ahead to see if we have a one-line definition (INDENT comes after the NEWLINE).
-        oneliner = True
-        for (i1, t), (i2, t2) in zip(search(i + 1, token.INDENT), search(i + 1, token.NEWLINE)):
-            oneliner = i1 > i2
-            break
+        if 1:
+            i1, t = find(i + 1, token.INDENT)
+            i2, t2 = find(i + 1, token.NEWLINE)
+            oneliner = i1 > i2 if t and t2 else False
+        else:
+            oneliner = True
+            for (i1, t), (i2, t2) in zip(search(i + 1, token.INDENT), search(i + 1, token.NEWLINE)):
+                oneliner = i1 > i2
+                break
 
         # Find the end of this definition
         if oneliner:
@@ -122,6 +127,12 @@ def split_root(root, lines):
             name = name,
         )
     #@+node:vitalije.20211208092833.1: *4* find and search
+    def find(i, k):
+        for j, t in itoks(i):
+            if t.type == k:
+                return j, t
+        return None, None
+
     def search(i, k):
         """Generate (n, rawtokens[n]), starting with i, for all tokens with type k."""
         for j, t in itoks(i):

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -224,7 +224,7 @@ def split_root(root, lines):
         """
 
         # Find all defs with the given inner indentation.
-        inner_defs = [x for x in definitions if x[0] == inner_indent]
+        inner_defs = [x for x in definitions if x.col == inner_indent]
 
         if not inner_defs or end - start < SPLIT_THRESHOLD:
             # Don't split the body.
@@ -260,10 +260,8 @@ def split_root(root, lines):
             child = p.insertAsLastChild()
             child.h = inner_def.name
 
-            # Next-level inner definitions are definitions whose
-            # starting and end lines are contained in this node.
-            ### inner_definitions = [x for x in definitions if x[1] > h1 and x[-1] <= end_b]
-            inner_definitions = [x for x in definitions if x.h1 > h1 and x.end_b <= end_b]
+            # Compute inner definitions.
+            inner_definitions = [z for z in definitions if z.h1 > h1 and z.end_b <= end_b]
             if inner_definitions:
                 # Recursively split this node.
                 mknode(

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -40,7 +40,7 @@ def split_root(root, lines):
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
     def_tuple = namedtuple('def_tuple', [
-        'name', 'kind', 'decl_indent', 'decl_line1', 'h2', 'start_b',  'c_ind', 'end_b',
+        'name', 'kind', 'decl_indent', 'decl_line1', 'decl_line2', 'start_b',  'c_ind', 'end_b',
     ])
 
     def getdefn(start):
@@ -52,8 +52,7 @@ def split_root(root, lines):
         decl_indent: Indentation of the class or def.
          decl_line1: Line number of the first line of this node.
                      This line may be a comment or decorator.
-        h2      line number of the last line of the declaration
-                (the line number containing the colon).
+         decl_line2: The line number of the last line of the declaration (contains ':').
         start_b line number of the first indented line of the function/class body.
         kind    'def' or 'class'
         name    name of the function, class or method
@@ -86,11 +85,11 @@ def split_root(root, lines):
             # The last of the `header lines`.
             # These lines should not be indented in the node body.
             # The body lines *will* be indented.
-            end_h = t.start[0]
+            decl_line2 = t.start[0]
             # In case we have a oneliner, let's define end_b here
-            end_b = end_h
+            end_b = decl_line2
             # indented body starts on the next line
-            start_b = end_h + 1
+            start_b = decl_line2 + 1
             break
 
         # Look ahead to check if we have a oneline definition or not.
@@ -130,10 +129,9 @@ def split_root(root, lines):
                 break
 
         # This is the only instantiation of def_tuple.
+        decl_line1 = decl_line - get_intro(decl_line, decl_indent)
         return def_tuple(name, kind,
-            decl_indent=decl_indent,
-            decl_line1=decl_line - get_intro(decl_line, decl_indent),
-            h2=end_h,
+            decl_indent=decl_indent, decl_line1=decl_line1, decl_line2=decl_line2,
             start_b=start_b,
             c_ind=c_ind,
             end_b=end_b,

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -24,6 +24,7 @@ def do_import(c, s, parent):
 #@+node:vitalije.20211201230203.1: ** split_root & helpers
 SPLIT_THRESHOLD = 10
 
+# This named tuple contains all data relating to one declaration of a class or def.
 def_tuple = namedtuple('def_tuple', [
     'body_indent',  # Indentation of body.
     'body_line1',  # Line number of the first line after the definition.
@@ -47,7 +48,8 @@ def split_root(root: Any, lines: List[str]) -> None:
     t.string: the token string;
     t.start:  a tuple (srow, scol) of starting row/column numbers.
     """
-
+    
+    rawtokens: List
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helper
     def getdefn(start: int) -> def_tuple:
@@ -58,7 +60,7 @@ def split_root(root: Any, lines: List[str]) -> None:
         nonlocal lines  # 'lines' is a kwarg to split_root.
 
         # pylint: disable=undefined-loop-variable
-        # tok will never be empty, but pylint is not to know that.
+        # tok will never be empty, but pylint doesn't know that.
 
         # Ignore all tokens except 'async', 'def', 'class'
         tok = rawtokens[start]

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -248,9 +248,7 @@ def split_root(root, lines):
         last = start
 
         # Calculate b1, the lines preceding the @others.
-        # inner_indent, h1, h2, start_b, kind, name, c_ind, end_b = inner_defs[0]
-        inner_def0 = inner_defs[0]
-        inner_indent, h1 = inner_def0[0], inner_def0[1]
+        inner_indent, h1, _, _, _, _, _, _ = inner_defs[0]
         b1 = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
@@ -261,7 +259,7 @@ def split_root(root, lines):
 
         # Add children for each inner definition.
         last = h1
-        for inner_indent, h1, h2, start_b, kind, name, c_ind, end_b in inner_defs:
+        for inner_indent, h1, _, _, _, name, c_ind, end_b in inner_defs:
             if h1 > last:
                 new_body = body(last, h1, inner_indent)  # #2500.
                 # there are some declaration lines in between two inner definitions

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -40,7 +40,8 @@ def split_root(root, lines):
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
     def_tuple = namedtuple('def_tuple', [
-        'name', 'kind', 'decl_indent', 'decl_line1',  'start_b',  'c_ind', 'end_b',
+        'name', 'kind', 'decl_indent', 'decl_line1', 'c_ind', 'end_b',
+        #'body_line1',
     ])
 
     def getdefn(start):
@@ -49,12 +50,11 @@ def split_root(root, lines):
 
         Return None or named tuple with the following fields:
 
+               kind: 'def' or 'class'
+               name: name of the function, class or method
         decl_indent: Indentation of the class or def.
          decl_line1: Line number of the first line of this node.
                      This line may be a comment or decorator.
-        start_b line number of the first indented line of the function/class body.
-        kind    'def' or 'class'
-        name    name of the function, class or method
         c_ind   column of the indented body
         end_b   line number of the first line after the definition
         """
@@ -79,7 +79,7 @@ def split_root(root, lines):
         # This one logical line may span several physical lines.
         for i, t in search(start + 1, token.NEWLINE):
             end_b = t.start[0]
-            start_b = end_b + 1
+            body_line1 = end_b + 1
             break
 
         # Look ahead to check if we have a oneline definition or not.
@@ -96,7 +96,7 @@ def split_root(root, lines):
             # because the definition was in the same line.
             c_ind = decl_indent
             # The end of the body is the same as the start of the body
-            end_b = start_b
+            end_b = body_line1
         else:
             # We have some body lines. Presumably the next token is INDENT.
             i += 1
@@ -122,7 +122,6 @@ def split_root(root, lines):
         return def_tuple(name, kind,
             decl_indent=decl_indent,
             decl_line1=decl_line - get_intro(decl_line, decl_indent),
-            start_b=start_b,
             c_ind=c_ind,
             end_b=end_b,
         )

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -127,7 +127,7 @@ def split_root(root: Any, lines: List[str]) -> None:
                 return j, t
         return None, None
 
-    def search(i: int, k: int) -> Generator:
+    def search(i: int, k: int) -> Generator:  # Not used at present.
         """Generate (n, rawtokens[n]), starting with i, for all tokens with type k."""
         for j, t in itoks(i):
             if t.type == k:
@@ -135,8 +135,7 @@ def split_root(root: Any, lines: List[str]) -> None:
     #@+node:vitalije.20211208084231.1: *4* get_intro & helper
     def get_intro(row: int, col: int) -> int:
         """
-        Returns the number of preceeding lines that can be considered as an `intro`
-        to this funciton/class/method definition.
+        Return the number of preceeding lines that should be added to this class or def.
         """
         last = row
         for i in range(row - 1, 0, -1):
@@ -144,8 +143,8 @@ def split_root(root: Any, lines: List[str]) -> None:
                 last = i
             else:
                 break
-        # we don't want `intro` to start with the bunch of blank lines
-        # they better be added to the end of the preceeding node.
+        # Remove blank lines from the start of the intro.
+        # Leading blank lines should be added to the end of the preceeding node.
         for i in range(last, row):
             if lines[i - 1].isspace():
                 last = i + 1
@@ -157,29 +156,20 @@ def split_root(root: Any, lines: List[str]) -> None:
         - a comment line that starts at the same column as the def/class line,
         - a decorator line
         """
-        # first we filter list of all tokens in the line n. We don't want white space tokens
-        # we are interested only in the tokens containing some text.
+        # Filter out all whitespace tokens.
         xs = [z for z in lntokens[n] if z[0] not in (token.DEDENT, token.INDENT, token.NL)]
-
-        if not xs:
-            # all tokens in this line are white space, therefore we
-            # have a blank line. We want to allow a blank line in the
-            # block of comments, so we return True
-            return True
-
-        t = xs[0]  # this is the first non blank token in the line n
+        if not xs:  # A blank line.
+            return True  # Allow blank lines in a block of comments.
+        t = xs[0]  # The first non blank token in line n.
         if t.start[1] != col:
-            # if it isn't at the same column as the definition, it can't be
-            # considered as a `intro` line
+            # Not the same indentation as the definition.
             return False
         if t.type == token.OP and t.string == '@':
-            # this lines starts with `@`, which means it is the decorator
+            # A decorator.
             return True
         if t.type == token.COMMENT:
-            # this line starts with the comment at the same column as the definition
+            # A comment at the same indentation as the definition.
             return True
-
-        # in all other cases this isn't an `intro` line
         return False
     #@+node:vitalije.20211208092828.1: *4* itoks
     def itoks(i: int) -> Generator:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -78,20 +78,13 @@ def split_root(root, lines):
 
         # Find the end of the definition line, ending in a NEWLINE token.
         # This one logical line may span several physical lines.
-        for i, t in search(start + 1, token.NEWLINE):
-            body_line1 = t.start[0] + 1
-            break
+        i, t = find(start + 1, token.NEWLINE)
+        body_line1 = t.start[0] + 1
 
         # Look ahead to see if we have a one-line definition (INDENT comes after the NEWLINE).
-        if 1:
-            i1, t = find(i + 1, token.INDENT)
-            i2, t2 = find(i + 1, token.NEWLINE)
-            oneliner = i1 > i2 if t and t2 else False
-        else:
-            oneliner = True
-            for (i1, t), (i2, t2) in zip(search(i + 1, token.INDENT), search(i + 1, token.NEWLINE)):
-                oneliner = i1 > i2
-                break
+        i1, t = find(i + 1, token.INDENT)
+        i2, t2 = find(i + 1, token.NEWLINE)
+        oneliner = i1 > i2 if t and t2 else False
 
         # Find the end of this definition
         if oneliner:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -249,12 +249,7 @@ def split_root(root, lines):
 
         # Calculate b1, the lines preceding the @others.
         inner_indent, h1, h2, start_b, kind, name, c_ind, end_b = inner_defs[0]
-        if h1 > start:
-            # The first inner definition starts later.
-            b1 = body(start, h1, others_indent)
-        else:
-            # The inner definitions start at the beginning of our body.
-            b1 = ''
+        b1 = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
         # Calculate b2, the lines following the @others line.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -40,7 +40,7 @@ def split_root(root, lines):
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
     def_tuple = namedtuple('def_tuple', [
-        'name', 'kind', 'decl_indent', 'decl_line1', 'decl_line2', 'start_b',  'c_ind', 'end_b',
+        'name', 'kind', 'decl_indent', 'decl_line1',  'start_b',  'c_ind', 'end_b',
     ])
 
     def getdefn(start):
@@ -52,7 +52,6 @@ def split_root(root, lines):
         decl_indent: Indentation of the class or def.
          decl_line1: Line number of the first line of this node.
                      This line may be a comment or decorator.
-         decl_line2: The line number of the last line of the declaration (contains ':').
         start_b line number of the first indented line of the function/class body.
         kind    'def' or 'class'
         name    name of the function, class or method
@@ -74,22 +73,13 @@ def split_root(root, lines):
         if kind == 'def' and rawtokens[start - 1][1] == 'async':
             return None
 
-        #
         decl_line, decl_indent = tok.start
 
-        # now we are searching for the end of the definition line
-        # this one logical line may be divided in several physical
-        # lines. At the end of this logical line, there will be a
-        # NEWLINE token
+        # Find the end of the definition line, ending in a NEWLINE token.
+        # This one logical line may span several physical lines.
         for i, t in search(start + 1, token.NEWLINE):
-            # The last of the `header lines`.
-            # These lines should not be indented in the node body.
-            # The body lines *will* be indented.
-            decl_line2 = t.start[0]
-            # In case we have a oneliner, let's define end_b here
-            end_b = decl_line2
-            # indented body starts on the next line
-            start_b = decl_line2 + 1
+            end_b = t.start[0]
+            start_b = end_b + 1
             break
 
         # Look ahead to check if we have a oneline definition or not.
@@ -129,9 +119,9 @@ def split_root(root, lines):
                 break
 
         # This is the only instantiation of def_tuple.
-        decl_line1 = decl_line - get_intro(decl_line, decl_indent)
         return def_tuple(name, kind,
-            decl_indent=decl_indent, decl_line1=decl_line1, decl_line2=decl_line2,
+            decl_indent=decl_indent,
+            decl_line1=decl_line - get_intro(decl_line, decl_indent),
             start_b=start_b,
             c_ind=c_ind,
             end_b=end_b,

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -248,12 +248,13 @@ def split_root(root, lines):
         last = start
 
         # Calculate b1, the lines preceding the @others.
-        inner_indent, h1, h2, start_b, kind, name, c_ind, end_b = inner_defs[0]
+        # inner_indent, h1, h2, start_b, kind, name, c_ind, end_b = inner_defs[0]
+        inner_def0 = inner_defs[0]
+        inner_indent, h1 = inner_def0[0], inner_def0[1]
         b1 = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
         # Calculate b2, the lines following the @others line.
-        ### if inner_defs[-1][-1] < end:
         last_offset = inner_defs[-1][end_b_offset]
         b2 = body(last_offset, end, others_indent) if last_offset < end else ''
         p.b = f'{b1}{others_line}{b2}'

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -5,7 +5,7 @@ import sys
 import tokenize
 import token
 from typing import Any, Dict
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 import leo.core.leoGlobals as g
 #@+others
 #@+node:ekr.20211209052710.1: ** do_import
@@ -39,9 +39,9 @@ def split_root(root, lines):
 
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
-    # def_tuple = namedtuple('def_tuple', [
-        # 'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
-    # ])
+    def_tuple = namedtuple('def_tuple', [
+        'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
+    ])
 
     end_b_offset = 7  ### Temp.
 
@@ -130,27 +130,16 @@ def split_root(root, lines):
             else:
                 break
 
-        return (
-            col,
-            a - get_intro(a, col),
-            end_h,
-            start_b,
-            kind,
-            name,
-            c_ind,
-            end_b,
+        return def_tuple(
+            col=col,
+            h1=a - get_intro(a, col),
+            h2=end_h,
+            start_b=start_b,
+            kind=kind,
+            name=name,
+            c_ind=c_ind,
+            end_b=end_b,
         )
-
-        # return def_tuple(
-            # col=col,
-            # h1=a - get_intro(a, col),
-            # h2=end_h,
-            # start_b=start_b,
-            # kind=kind,
-            # name=name,
-            # c_ind=c_ind,
-            # end_b=end_b,
-        # )
     #@+node:vitalije.20211208084231.1: *4* get_intro & helper
     def get_intro(row, col):
         """

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -235,7 +235,6 @@ def split_root(root, lines):
         last = start
 
         # Calculate head, the lines preceding the @others.
-        ### _, h1, _, _, _, _, _, _ = inner_defs[0]
         h1 = inner_defs[0].h1
         head = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
@@ -247,12 +246,10 @@ def split_root(root, lines):
 
         # Add a child for each inner definition.
         last = h1
-        # for _, h1, _, _, _, name, c_ind, end_b in inner_defs:
         for inner_def in inner_defs:
-            c_ind = inner_def.c_ind
-            h1 = inner_def.h1
-            end_b = inner_def.end_b
-            
+
+            c_ind, end_b, h1 = inner_def.c_ind, inner_def.end_b, inner_def.h1
+
             if h1 > last:
                 # There are declaration lines between two inner definitions.
                 new_body = body(last, h1, inner_indent)  # #2500.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -270,7 +270,7 @@ def split_root(root: Any, lines: List[str]) -> None:
         if i == 0 or s[:i].isspace():
             return s[i:] or '\n'
         n = len(s) - len(s.lstrip())
-        return f'\\\\-{i-n}.{s[n:]}'  # Return the representation of an underindented strings.
+        return f'\\\\-{i-n}.{s[n:]}'  # Return the representation of an underindented string.
 
     def body(a: int, b: Optional[int], i: int) -> str:
         """Return the (massaged) concatentation of lines[a: b]"""

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -261,8 +261,9 @@ def split_root(root, lines):
             child.h = inner_def.name
 
             # Next-level inner definitions are definitions whose
-            # starting and end line contained in this node.
-            inner_definitions = [x for x in definitions if x[1] > h1 and x[-1] <= end_b]
+            # starting and end lines are contained in this node.
+            ### inner_definitions = [x for x in definitions if x[1] > h1 and x[-1] <= end_b]
+            inner_definitions = [x for x in definitions if x.h1 > h1 and x.end_b <= end_b]
             if inner_definitions:
                 # Recursively split this node.
                 mknode(

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -40,8 +40,7 @@ def split_root(root, lines):
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
     def_tuple = namedtuple('def_tuple', [
-        'name', 'kind', 'decl_indent', 'decl_line1', 'c_ind', 'end_b',
-        #'body_line1',
+        'name', 'kind', 'body_indent', 'decl_indent', 'decl_line1', 'end_b',
     ])
 
     def getdefn(start):
@@ -52,10 +51,10 @@ def split_root(root, lines):
 
                kind: 'def' or 'class'
                name: name of the function, class or method
+         body_line1: Indentation of body.
         decl_indent: Indentation of the class or def.
          decl_line1: Line number of the first line of this node.
                      This line may be a comment or decorator.
-        c_ind   column of the indented body
         end_b   line number of the first line after the definition
         """
         # pylint: disable=undefined-loop-variable
@@ -94,14 +93,14 @@ def split_root(root, lines):
         if oneliner:
             # The following lines will not be indented
             # because the definition was in the same line.
-            c_ind = decl_indent
+            body_indent = decl_indent
             # The end of the body is the same as the start of the body
             end_b = body_line1
         else:
             # We have some body lines. Presumably the next token is INDENT.
             i += 1
             # This is the indentation of the first function/method/class body line
-            c_ind = len(t.string) + decl_indent
+            body_indent = len(t.string) + decl_indent
             # Now search to find the end of this function/method/body
             for i, t in itoks(i + 1):
                 col2 = t.start[1]
@@ -120,9 +119,9 @@ def split_root(root, lines):
 
         # This is the only instantiation of def_tuple.
         return def_tuple(name, kind,
+            body_indent=body_indent,
             decl_indent=decl_indent,
             decl_line1=decl_line - get_intro(decl_line, decl_indent),
-            c_ind=c_ind,
             end_b=end_b,
         )
     #@+node:vitalije.20211208084231.1: *4* get_intro & helper
@@ -235,7 +234,7 @@ def split_root(root, lines):
         last = decl_line1
         for inner_def in inner_defs:
 
-            c_ind, end_b, decl_line1 = inner_def.c_ind, inner_def.end_b, inner_def.decl_line1
+            body_indent, end_b, decl_line1 = inner_def.body_indent, inner_def.end_b, inner_def.decl_line1
 
             if decl_line1 > last:
                 # There are declaration lines between two inner definitions.
@@ -257,7 +256,7 @@ def split_root(root, lines):
                     start_b=start_b,
                     end=end_b,
                     others_indent=others_indent + inner_indent,
-                    inner_indent=c_ind,
+                    inner_indent=body_indent,
                     definitions=inner_definitions,
                 )
             else:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -55,6 +55,8 @@ def split_root(root: Any, lines: List[str]) -> None:
         Look for a def or class found at rawtokens[start].
         Return None or a def_tuple.
         """
+        nonlocal lines
+
         # pylint: disable=undefined-loop-variable
         # tok will never be empty, but pylint is not to know that.
 
@@ -270,6 +272,7 @@ def split_root(root: Any, lines: List[str]) -> None:
         return f'\\\\-{i-n}.{s[n:]}'
 
     def body(a: int, b: int, i: int) -> str:
+        nonlocal lines  # 'lines' is a kwarg to split_root.
         xlines = (bodyLine(s, i) for s in lines[a - 1 : b and (b - 1)])
         return ''.join(xlines)
     #@+node:ekr.20220320055103.1: *4* declaration_headline

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -96,10 +96,11 @@ def split_root(root: Any, lines: List[str]) -> None:
             # The entire decl is on the same line.
             body_indent = decl_indent
         else:
-            # We have some body lines. Presumably the next token is INDENT.
             body_indent = len(t.string) + decl_indent
+            # Skip the INDENT token.
+            assert t.type == token.INDENT, t.type
             i += 1
-            # Find the end of the body.
+            # The body ends at the next DEDENT or COMMENT token with less indentation.
             for i, t in itoks(i + 1):
                 col2 = t.start[1]
                 if col2 > decl_indent:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -43,6 +43,8 @@ def split_root(root, lines):
         # 'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
     # ])
 
+    end_b_offset = 7  ### Temp.
+
     def getdefn(start):
         """
         Look for a def or class found at rawtokens[start].
@@ -61,7 +63,6 @@ def split_root(root, lines):
         c_ind   column of the indented body
         end_b   line number of the first line after the definition
         """
-        #  b_ind   minimal number of leading spaces in each line of the function, method or class body
         # pylint: disable=undefined-loop-variable
         tok = rawtokens[start]
         if tok.type != token.NAME or tok.string not in ('async', 'def', 'class'):
@@ -257,8 +258,9 @@ def split_root(root, lines):
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
         # Calculate b2, the lines following the @others line.
-        if inner_defs[-1][-1] < end:
-            b2 = body(inner_defs[-1][-1], end, others_indent)
+        ### if inner_defs[-1][-1] < end:
+        if inner_defs[-1][end_b_offset] < end:
+            b2 = body(inner_defs[-1][end_b_offset], end, others_indent)
         else:
             b2 = ''
         p.b = f'{b1}{others_line}{b2}'

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -260,10 +260,7 @@ def split_root(root, lines):
         # Calculate b2, the lines following the @others line.
         ### if inner_defs[-1][-1] < end:
         last_offset = inner_defs[-1][end_b_offset]
-        if last_offset < end:
-            b2 = body(last_offset, end, others_indent)
-        else:
-            b2 = ''
+        b2 = body(last_offset, end, others_indent) if last_offset < end else ''
         p.b = f'{b1}{others_line}{b2}'
 
         # Add children for each inner definition.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -41,7 +41,7 @@ def split_root(root: Any, lines: List[str]) -> None:
 
     For longer class nodes, create separate child nodes for each method.
 
-    This function uses a token-oriented "parse" of the lines.
+    Helpers use a token-oriented "parse" of the lines.
     Tokens are named 5-tuples, but this code uses only three fields:
 
     t.type:   token type
@@ -56,7 +56,7 @@ def split_root(root: Any, lines: List[str]) -> None:
     def getdefn(start: int) -> def_tuple:
         """
         Look for a def or class found at rawtokens[start].
-        Return None or a def_tuple.
+        Return None or a def_tuple describing the def or class.
         """
         nonlocal lines  # 'lines' is a kwarg to split_root.
         nonlocal rawtokens
@@ -174,7 +174,7 @@ def split_root(root: Any, lines: List[str]) -> None:
         definitions: List[def_tuple],
     ) -> None:
         """
-        Set p.b and add children recursively using the arguments.
+        Set p.b and add children recursively using the tokens described by the arguments.
 
                     p: The current node.
                 start: The line number of the first line of this node

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -5,7 +5,7 @@ import sys
 import tokenize
 import token
 from typing import Any, Dict
-from collections import defaultdict, namedtuple
+from collections import defaultdict
 import leo.core.leoGlobals as g
 #@+others
 #@+node:ekr.20211209052710.1: ** do_import
@@ -39,9 +39,9 @@ def split_root(root, lines):
 
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helpers
-    def_tuple = namedtuple('def_tuple', [
-        'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
-    ])
+    # def_tuple = namedtuple('def_tuple', [
+        # 'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
+    # ])
 
     def getdefn(start):
         """
@@ -129,16 +129,27 @@ def split_root(root, lines):
             else:
                 break
 
-        return def_tuple(
-            col=col,
-            h1=a - get_intro(a, col),
-            h2=end_h,
-            start_b=start_b,
-            kind=kind,
-            name=name,
-            c_ind=c_ind,
-            end_b=end_b,
+        return (
+            col,
+            a - get_intro(a, col),
+            end_h,
+            start_b,
+            kind,
+            name,
+            c_ind,
+            end_b,
         )
+
+        # return def_tuple(
+            # col=col,
+            # h1=a - get_intro(a, col),
+            # h2=end_h,
+            # start_b=start_b,
+            # kind=kind,
+            # name=name,
+            # c_ind=c_ind,
+            # end_b=end_b,
+        # )
     #@+node:vitalije.20211208084231.1: *4* get_intro & helper
     def get_intro(row, col):
         """

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -4,7 +4,7 @@
 import sys
 import tokenize
 import token
-from typing import Any, Callable, Dict, Generator, List, Tuple
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
 from collections import defaultdict, namedtuple
 import leo.core.leoGlobals as g
 #@+others
@@ -270,9 +270,9 @@ def split_root(root: Any, lines: List[str]) -> None:
         if i == 0 or s[:i].isspace():
             return s[i:] or '\n'
         n = len(s) - len(s.lstrip())
-        return f'\\\\-{i-n}.{s[n:]}'
+        return f'\\\\-{i-n}.{s[n:]}'  # Return the representation of an underindented strings.
 
-    def body(a: int, b: int, i: int) -> str:
+    def body(a: int, b: Optional[int], i: int) -> str:
         """Return the (massaged) concatentation of lines[a: b]"""
         nonlocal lines  # 'lines' is a kwarg to split_root.
         xlines = (bodyLine(s, i) for s in lines[a - 1 : b and (b - 1)])

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -247,15 +247,15 @@ def split_root(root, lines):
         # last keeps track of the last used line
         last = start
 
-        # Calculate b1, the lines preceding the @others.
+        # Calculate head, the lines preceding the @others.
         _, h1, _, _, _, _, _, _ = inner_defs[0]
-        b1 = body(start, h1, others_indent) if h1 > start else ''
+        head = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
-        # Calculate b2, the lines following the @others line.
+        # Calculate tail, the lines following the @others line.
         last_offset = inner_defs[-1][end_b_offset]
-        b2 = body(last_offset, end, others_indent) if last_offset < end else ''
-        p.b = f'{b1}{others_line}{b2}'
+        tail = body(last_offset, end, others_indent) if last_offset < end else ''
+        p.b = f'{head}{others_line}{tail}'
 
         # Add a child for each inner definition.
         last = h1

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -50,6 +50,7 @@ def split_root(root: Any, lines: List[str]) -> None:
     """
     
     rawtokens: List
+
     #@+others
     #@+node:vitalije.20211208092910.1: *3* getdefn & helper
     def getdefn(start: int) -> def_tuple:
@@ -58,6 +59,7 @@ def split_root(root: Any, lines: List[str]) -> None:
         Return None or a def_tuple.
         """
         nonlocal lines  # 'lines' is a kwarg to split_root.
+        nonlocal rawtokens
 
         # pylint: disable=undefined-loop-variable
         # tok will never be empty, but pylint doesn't know that.
@@ -103,9 +105,7 @@ def split_root(root: Any, lines: List[str]) -> None:
             # The body ends at the next DEDENT or COMMENT token with less indentation.
             for i, t in itoks(i + 1):
                 col2 = t.start[1]
-                if col2 > decl_indent:
-                    continue
-                if t.type in (token.DEDENT, token.COMMENT):
+                if col2 <= decl_indent and t.type in (token.DEDENT, token.COMMENT):
                     body_line1 = t.start[0]
                     break
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -43,8 +43,6 @@ def split_root(root, lines):
         'col', 'h1', 'h2', 'start_b', 'kind', 'name', 'c_ind', 'end_b',
     ])
 
-    end_b_offset = 7  ### Temp.
-
     def getdefn(start):
         """
         Look for a def or class found at rawtokens[start].
@@ -242,7 +240,7 @@ def split_root(root, lines):
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
         # Calculate tail, the lines following the @others line.
-        last_offset = inner_defs[-1][end_b_offset]
+        last_offset = inner_defs[-1].end_b
         tail = body(last_offset, end, others_indent) if last_offset < end else ''
         p.b = f'{head}{others_line}{tail}'
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -236,7 +236,7 @@ def split_root(root, lines):
                 xdefs: The list of the definitions covering p.
         """
 
-        # Find all defs with the inner indentation.
+        # Find all defs with the given inner indentation.
         inner_defs = [x for x in definitions if x[0] == inner_indent]
 
         if not inner_defs or end - start < SPLIT_THRESHOLD:
@@ -248,7 +248,8 @@ def split_root(root, lines):
         last = start
 
         # Calculate b1, the lines preceding the @others.
-        inner_indent, h1, _, _, _, _, _, _ = inner_defs[0]
+        _inner_indent2, h1, _, _, _, _, _, _ = inner_defs[0]
+        assert _inner_indent2 == inner_indent
         b1 = body(start, h1, others_indent) if h1 > start else ''
         others_line = calculate_indent('@others\n', inner_indent - others_indent)
 
@@ -259,7 +260,8 @@ def split_root(root, lines):
 
         # Add a child for each inner definition.
         last = h1
-        for inner_indent, h1, _, _, _, name, c_ind, end_b in inner_defs:
+        for _inner_indent3, h1, _, _, _, name, c_ind, end_b in inner_defs:
+            assert _inner_indent3 == inner_indent
             if h1 > last:
                 # There are declaration lines between two inner definitions.
                 new_body = body(last, h1, inner_indent)  # #2500.
@@ -267,8 +269,8 @@ def split_root(root, lines):
                 p1.h = declaration_headline(new_body)  # #2500
                 p1.b = new_body
                 last = h1
-            p1 = p.insertAsLastChild()
-            p1.h = name
+            child = p.insertAsLastChild()
+            child.h = name
 
             # Next-level inner definitions are definitions whose
             # starting and end line contained in this node.
@@ -276,7 +278,7 @@ def split_root(root, lines):
             if inner_definitions:
                 # Recursively split this node.
                 mknode(
-                    p=p1,
+                    p=child,
                     start=h1,
                     start_b=start_b,
                     end=end_b,
@@ -286,7 +288,7 @@ def split_root(root, lines):
                 )
             else:
                 # Just set the body.
-                p1.b = body(h1, end_b, inner_indent)
+                child.b = body(h1, end_b, inner_indent)
             last = end_b
     #@+node:vitalije.20211208101750.1: *4* body & bodyLine
     def bodyLine(x, ind):


### PR DESCRIPTION
This is important code, and I wanted to understand every line.

This PR contains the following improvements to leo/importers/python.py:

- [x] getdefn now returns a namedtuple, with longer, clearer, names.
      This renaming was tricky. At each stage I ran all unit tests.
      All client functions use these longer names.
      The named tuple has 6 fields, not 8. Two of the original tuple were never used.
- [x] Remove all tuple unpacking statements.
- [x] Except for t.start, replace all tuple indices by field names.
- [x] Improve *all* comments and docstrings. All functions have docstrings.
- [x] Replace search with find_token.
- [x] The itoks generator no longer creates substrings.
- [x] Add mypy annotations for all functions.
- [x] Add "nonlocal" statements as a form of comment.
- [x] In mknode, replace "indent" function by a direct calculation of `@others` indentation.