### PR TITLE
PR: Improve style for Leo's (extended) core files

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20150514035236.1: * @file ../commands/abbrevCommands.py
 #@@first
 """Leo's abbreviations commands."""
-#@+<< imports >>
-#@+node:ekr.20150514045700.1: ** << imports >> (abbrevCommands.py)
+#@+<< abbrevCommands imports >>
+#@+node:ekr.20150514045700.1: ** << abbrevCommands imports >>
 import functools
 import re
 import string
@@ -12,7 +12,7 @@ from typing import Dict
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< abbrevCommands imports >>
 
 def cmd(name):
     """Command decorator for the abbrevCommands class."""

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -3,11 +3,11 @@
 #@+node:ekr.20150514035559.1: * @file ../commands/bufferCommands.py
 #@@first
 """Leo's buffer commands."""
-#@+<< imports >>
-#@+node:ekr.20150514045750.1: ** << imports >> (bufferCommands.py)
+#@+<< bufferCommands imports >>
+#@+node:ekr.20150514045750.1: ** << bufferCommands imports >>
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< bufferCommands imports >>
 
 def cmd(name):
     """Command decorator for the BufferCommands class."""

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20161021090740.1: * @file ../commands/checkerCommands.py
 #@@first
 """Commands that invoke external checkers"""
-#@+<< imports >>
-#@+node:ekr.20161021092038.1: ** << imports >> checkerCommands.py
+#@+<< checkerCommands imports >>
+#@+node:ekr.20161021092038.1: ** << checkerCommands imports >>
 import os
 import shlex
 import sys
@@ -38,7 +38,7 @@ except Exception:
 #
 # Leo imports.
 from leo.core import leoGlobals as g
-#@-<< imports >>
+#@-<< checkerCommands imports >>
 #@+others
 #@+node:ekr.20161021091557.1: **  Commands
 #@+node:ekr.20190608084751.1: *3* find-long-lines

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -3,13 +3,13 @@
 #@+node:ekr.20150514040100.1: * @file ../commands/controlCommands.py
 #@@first
 """Leo's control commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050127.1: ** << imports >> (controlCommands.py)
+#@+<< controlCommands imports >>
+#@+node:ekr.20150514050127.1: ** << controlCommands imports >>
 import shlex
 import subprocess
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< controlCommands imports >>
 
 def cmd(name):
     """Command decorator for the ControlCommandsClass class."""

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -3,14 +3,14 @@
 #@+node:ekr.20150514035813.1: * @file ../commands/editCommands.py
 #@@first
 """Leo's general editing commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050149.1: **  << imports >> (editCommands.py)
+#@+<< editCommands imports >>
+#@+node:ekr.20150514050149.1: **  << editCommands imports >>
 import os
 import re
 from typing import Any, List
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< editCommands imports >>
 
 def cmd(name):
     """Command decorator for the EditCommandsClass class."""

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20150514041209.1: * @file ../commands/editFileCommands.py
 #@@first
 """Leo's file-editing commands."""
-#@+<< imports >>
-#@+node:ekr.20170806094317.4: ** << imports >> (editFileCommands.py)
+#@+<< editFileCommands imports >>
+#@+node:ekr.20170806094317.4: ** << editFileCommands imports >>
 import difflib
 import io
 import os
@@ -13,7 +13,7 @@ from typing import Any, List
 from leo.core import leoGlobals as g
 from leo.core import leoCommands
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< editFileCommands imports >>
 
 def cmd(name):
     """Command decorator for the EditFileCommandsClass class."""

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -3,15 +3,15 @@
 #@+node:ekr.20150514040138.1: * @file ../commands/helpCommands.py
 #@@first
 """Leo's help commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050337.1: ** << imports >> (helpCommands.py)
+#@+<< helpCommands imports >>
+#@+node:ekr.20150514050337.1: ** << helpCommands imports >>
 import io
 import re
 import sys
 import textwrap
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< helpCommands imports >>
 
 def cmd(name):
     """Command decorator for the helpCommands class."""

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -3,11 +3,11 @@
 #@+node:ekr.20150514040142.1: * @file ../commands/killBufferCommands.py
 #@@first
 """Leo's kill-buffer commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050411.1: ** << imports >> (killBufferCommands.py)
+#@+<< killBufferCommands imports >>
+#@+node:ekr.20150514050411.1: ** << killBufferCommands imports >>
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< killBufferCommands imports >>
 
 def cmd(name):
     """Command decorator for the KillBufferCommandsClass class."""

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -3,11 +3,11 @@
 #@+node:ekr.20150514040146.1: * @file ../commands/rectangleCommands.py
 #@@first
 """Leo's rectangle commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050446.1: ** << imports >> (rectangleCommands.py)
+#@+<< rectangleCommands imports >>
+#@+node:ekr.20150514050446.1: ** << rectangleCommands imports >>
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
-#@-<< imports >>
+#@-<< rectangleCommands imports >>
 
 def cmd(name):
     """Command decorator for the RectangleCommandsClass class."""

--- a/leo/commands/searchCommands.py
+++ b/leo/commands/searchCommands.py
@@ -3,12 +3,12 @@
 #@+node:ekr.20150514040236.1: * @file ../commands/searchCommands.py
 #@@first
 """Leo's search commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050515.1: ** << imports >> (searchCommands.py)
+#@+<< searchCommands imports >>
+#@+node:ekr.20150514050515.1: ** << searchCommands imports >>
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 assert g
-#@-<< imports >>
+#@-<< searchCommands imports >>
 
 class SearchCommandsClass(BaseEditCommandsClass):
     """Delegates all searches to LeoFind.py."""

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20150514040239.1: * @file ../commands/spellCommands.py
 #@@first
 """Leo's spell-checking commands."""
-#@+<< imports >>
-#@+node:ekr.20150514050530.1: ** << imports >> (spellCommands.py)
+#@+<< spellCommands imports >>
+#@+node:ekr.20150514050530.1: ** << spellCommands imports >>
 import re
 try:
     # pylint: disable=import-error
@@ -15,7 +15,7 @@ except Exception:  # May throw WinError(!)
     enchant = None
 from leo.commands.baseCommands import BaseEditCommandsClass
 from leo.core import leoGlobals as g
-#@-<< imports >>
+#@-<< spellCommands imports >>
 
 def cmd(name):
     """Command decorator for the SpellCommandsClass class."""

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20161026193447.1: * @file leoBackground.py
 #@@first
 """Handling background processes"""
-#@+<< leoBackground.py imports >>
-#@+node:ekr.20220410202718.1: ** << leoBackground.py imports >>
+#@+<< leoBackground imports >>
+#@+node:ekr.20220410202718.1: ** << leoBackground imports >>
 import re
 import subprocess
 import _thread as thread
@@ -17,7 +17,7 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoNodes import Position as Pos
 else:
     Cmdr = Pos = Any
-#@-<< leoBackground.py imports >>
+#@-<< leoBackground imports >>
 
 Event = Any
 Pattern = Union[Any, str]

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150521115018.1: * @file leoBeautify.py
+#@@first
 """Leo's beautification classes."""
 #@+<< leoBeautify imports >>
 #@+node:ekr.20220822114944.1: ** << leoBeautify imports >>

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20070227091955.1: * @file leoBridge.py
+#@@first
 #@@first
 """A module to allow full access to Leo commanders from outside Leo."""
 #@@language python

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20100208065621.5894: * @file leoCache.py
+#@@first
 """A module encapsulating Leo's file caching"""
-#@+<< imports >>
-#@+node:ekr.20100208223942.10436: ** << imports >> (leoCache)
+#@+<< leoCache imports >>
+#@+node:ekr.20100208223942.10436: ** << leoCache imports >>
 import fnmatch
 import os
 import pickle
@@ -11,7 +13,7 @@ import stat
 from typing import Any, Dict, Sequence
 import zlib
 from leo.core import leoGlobals as g
-#@-<< imports >>
+#@-<< leoCache imports >>
 # pylint: disable=raise-missing-from
 # Abbreviations used throughout.
 abspath = g.os_path_abspath

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -1,10 +1,15 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20070317085508.1: * @file leoChapters.py
+#@@first
 """Classes that manage chapters in Leo's core."""
+#@+<< leoChapters imports >>
+#@+node:ekr.20220824080606.1: ** << leoChapters imports >>
 import re
 import string
 from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 from leo.core import leoGlobals as g
+#@-<< leoChapters imports >>
 #@+<< leoChapters annotations >>
 #@+node:ekr.20220821201049.1: ** << leoChapters annotations >>
 if TYPE_CHECKING:

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.2794: * @file leoColor.py
-#@+<< docstring >>
-#@+node:bob.20080115083029: ** << docstring >>
+#@@first
+#@+<< leoColor docstring >>
+#@+node:bob.20080115083029: ** << leoColor docstring >>
 """A color database for Leo.
 
 leo_color_database is a dictionary of color names mapped onto the
@@ -30,11 +32,7 @@ Use these functions as follows::
 If neither 'name' nor 'default' can be translated then accessor functions
 will return None.
 """
-#@-<< docstring >>
-from leo.core import leoGlobals as g
-assert g
-# import re
-# import string
+#@-<< leoColor docstring >>
 #@+<< define leo_color_database >>
 #@+node:bob.20080115070511.2: ** << define leo_color_database >>
 #@@language rest
@@ -734,7 +732,7 @@ leo_color_database = {
     "yellowgreen": "#9ACD32"
 }
 #@-<< define leo_color_database >>
-#
+
 # Check that all keys are normalized.
 # This is essential for Leo's jEdit-based colorizers.
 for key in leo_color_database:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -7,8 +7,8 @@
 # Indicated code are copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-#@+<< imports >>
-#@+node:ekr.20140827092102.18575: ** << imports >> (leoColorizer.py)
+#@+<< leoColorizer imports >>
+#@+node:ekr.20140827092102.18575: ** << leoColorizer imports >>
 import re
 import string
 import time
@@ -32,7 +32,7 @@ try:  # #1973
 except Exception:
     Qsci = QtGui = QtWidgets = None
     UnderlineStyle = Weight = None
-#@-<< imports >>
+#@-<< leoColorizer imports >>
 #@+others
 #@+node:ekr.20190323044524.1: ** function: make_colorizer
 def make_colorizer(c, widget):

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180212072657.2: * @file leoCompare.py
+#@@first
 """Leo's base compare class."""
 import difflib
 import filecmp

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20130925160837.11429: * @file leoConfig.py
+#@@first
 """Configuration classes for Leo."""
 # pylint: disable=unsubscriptable-object
 #@+<< leoConfig imports >>

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20060123151617: * @file leoFind.py
+#@@first
 """Leo's gui-independent find classes."""
 #@+<< leoFind imports >>
 #@+node:ekr.20220415005856.1: ** << leoFind imports >>

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1,12 +1,15 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3655: * @file leoFrame.py
+#@@first
 """
-The base classes for all Leo Windows, their body, log and tree panes, key bindings and menus.
+The base classes for all Leo Windows, their body, log and tree panes,
+key bindings and menus.
 
 These classes should be overridden to create frames for a particular gui.
 """
-#@+<< imports >>
-#@+node:ekr.20120219194520.10464: ** << imports >> (leoFrame)
+#@+<< leoFrame imports >>
+#@+node:ekr.20120219194520.10464: ** << leoFrame imports >>
 import os
 import string
 from typing import Any, Callable, Dict, List, Tuple
@@ -16,9 +19,9 @@ from leo.core import leoColorizer  # NullColorizer is a subclass of ColorizerMix
 from leo.core import leoMenu
 from leo.core import leoNodes
 
-#@-<< imports >>
-#@+<< type aliases leoFrame >>
-#@+node:ekr.20220415013957.1: ** << type aliases leoFrame >>
+#@-<< leoFrame imports >>
+#@+<< leoFrame annotations >>
+#@+node:ekr.20220415013957.1: ** << leoFrame annotations >>
 if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position as Pos
@@ -29,9 +32,9 @@ Event = Any
 Index = Any  # For now, really Union[int, str], but that creates type-checking problems.
 Widget = Any
 Wrapper = Any
-#@-<< type aliases leoFrame >>
-#@+<< About handling events >>
-#@+node:ekr.20031218072017.2410: ** << About handling events >>
+#@-<< leoFrame annotations >>
+#@+<< leoFrame: about handling events >>
+#@+node:ekr.20031218072017.2410: ** << leoFrame: about handling events >>
 #@+at Leo must handle events or commands that change the text in the outline
 # or body panes. We must ensure that headline and body text corresponds
 # to the VNode corresponding to presently selected outline, and vice
@@ -57,9 +60,9 @@ Wrapper = Any
 # - body.bodyChanged & tree.headChanged:
 #     Called by commands throughout Leo's core that change the body or headline.
 #     These are thin wrappers for updateBody and updateTree.
-#@-<< About handling events >>
-#@+<< command decorators >>
-#@+node:ekr.20150509054428.1: ** << command decorators >> (leoFrame.py)
+#@-<< leoFrame: about handling events >>
+#@+<< leoFrame command decorators >>
+#@+node:ekr.20150509054428.1: ** << leoFrame command decorators >>
 def log_cmd(name: str) -> Callable:  # Not used.
     """Command decorator for the LeoLog class."""
     return g.new_cmd_decorator(name, ['c', 'frame', 'log'])
@@ -71,7 +74,7 @@ def body_cmd(name: str) -> Callable:
 def frame_cmd(name: str) -> Callable:
     """Command decorator for the LeoFrame class."""
     return g.new_cmd_decorator(name, ['c', 'frame',])
-#@-<< command decorators >>
+#@-<< leoFrame command decorators >>
 #@+others
 #@+node:ekr.20140907201613.18660: ** API classes
 # These classes are for documentation and unit testing.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7,8 +7,8 @@ Global constants, variables and utility functions used throughout Leo.
 
 Important: This module imports no other Leo module.
 """
-#@+<< imports >>
-#@+node:ekr.20050208101229: ** << imports >> (leoGlobals)
+#@+<< leoGlobals imports >>
+#@+node:ekr.20050208101229: ** << leoGlobals imports >>
 import binascii
 import codecs
 import copy
@@ -39,6 +39,9 @@ from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Seq
 import unittest
 import urllib
 import urllib.parse as urlparse
+
+# Leo never imports any other Leo module.
+
 # Third-party tools.
 import webbrowser
 try:
@@ -48,14 +51,16 @@ except Exception:
 #
 # Abbreviations...
 StringIO = io.StringIO
-#@-<< imports >>
-# Leo never imports any other Leo module.
+#@-<< leoGlobals imports >>
+#@+<< leoGlobals annotations >>
+#@+node:ekr.20220824084642.1: ** << leoGlobals annotations >>
 if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position as Pos
     from leo.core.leoNodes import VNode
 else:
     Cmdr = Pos = VNode = Any
+#@-<< leoGlobals annotations >>
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.6'  # #1215.

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -22,8 +22,8 @@ This object, a LeoNameSpace instance, simplifies dealing with multiple open
 Leo commanders.
 """
 #@-<< leoIpython docstring >>
-#@+<< imports >>
-#@+node:ekr.20130930062914.15990: ** << imports >> (leoIpython.py)
+#@+<< leoIPython imports >>
+#@+node:ekr.20130930062914.15990: ** << leoIPython imports >>
 import sys
 from leo.core import leoGlobals as g
 
@@ -45,7 +45,7 @@ except ImportError:
     import_fail('IPKernelApp')
 
 g.app.ipython_inited = IPKernelApp is not None
-#@-<< imports >>
+#@-<< leoIPython imports >>
 #@+others
 #@+node:ekr.20190927110149.1: ** @g.command("ipython-new")
 @g.command("ipython-new")

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -1,13 +1,18 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3749: * @file leoMenu.py
+#@@first
 """Gui-independent menu handling for Leo."""
-#@+<< imports leoMenu.py >>
-#@+node:ekr.20220414095908.1: ** << imports leoMenu.py >>
+#@+<< leoMenu imports >>
+#@+node:ekr.20220414095908.1: ** << leoMenu imports >>
 from typing import Any, Callable, Dict, List, Tuple
 from leo.core import leoGlobals as g
-#@-<< imports leoMenu.py >>
+#@-<< leoMenu imports >>
+#@+<< leoMenu annotations >>
+#@+node:ekr.20220824085300.1: ** << leoMenu annotations >>
 Event = Any
 Widget = Any
+#@-<< leoMenu annotations >>
 #@+others
 #@+node:ekr.20031218072017.3750: ** class LeoMenu
 class LeoMenu:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20031218072017.3320: * @file leoNodes.py
 #@@first
 """Leo's fundamental data classes."""
-#@+<< imports >>
-#@+node:ekr.20060904165452.1: ** << imports >> (leoNodes.py)
+#@+<< leoNodes imports >>
+#@+node:ekr.20060904165452.1: ** << leoNodes imports >>
 #Transcrypt does not support Python's copy module.
 import copy
 import time
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # Always False at runtime. # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
 else:
     Cmdr = Any
-#@-<< imports >>
+#@-<< leoNodes imports >>
 #@+others
 #@+node:ekr.20031218072017.1991: ** class NodeIndices
 class NodeIndices:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3439: * @file leoPlugins.py
+#@@first
 """Classes relating to Leo's plugin architecture."""
 import sys
 from typing import List

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150419124739.1: * @file leoPrinting.py
+#@@first
 """
 Support the commands in Leo's File:Print menu.
 Adapted from printing plugin.

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -2,8 +2,8 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20061024060248.1: * @file leoPymacs.py
 #@@first
-#@+<< docstring>>
-#@+node:ekr.20061024060248.2: ** << docstring >> (leoPymacs.py)
+#@+<< leoPymacs docstring>>
+#@+node:ekr.20061024060248.2: ** << leoPymacs docstring >>
 """A module to allow the Pymacs bridge to access Leo data.
 
 All code in this module must be called *from* Emacs:
@@ -24,13 +24,14 @@ Notes:
   Note that full path names are required in each case.
 
 """
-#@-<< docstring>>
+#@-<< leoPymacs docstring>>
+
 # As in leo.py we must be very careful about imports.
 # pylint: disable = global-variable-not-assigned
+
 g = None  # set by init: do *not* import it here!
 inited = False
 pymacsFile = __file__
-# print('leoPymacs:pymacsFile',pymacsFile)
 #@+others
 #@+node:ekr.20061024131236: ** dump (pymacs)
 def dump(anObject):

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140810053602.18074: * @file leoQt.py
+#@@first
 #@@nopyflakes
 """
 General import wrapper for PyQt5 and PyQt6.

--- a/leo/core/leoQt5.py
+++ b/leo/core/leoQt5.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210407010914.1: * @file leoQt5.py
+#@@first
 """Import wrapper for pyQt5"""
 
 # For now, suppress all mypy checks

--- a/leo/core/leoQt6.py
+++ b/leo/core/leoQt6.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210407011013.1: * @file leoQt6.py
+#@@first
 """
 Import wrapper for pyQt6.
 

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -2,8 +2,8 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20090502071837.3: * @file leoRst.py
 #@@first
-#@+<< docstring >>
-#@+node:ekr.20090502071837.4: ** << docstring >>
+#@+<< leoRst docstring >>
+#@+node:ekr.20090502071837.4: ** << leoRst docstring >>
 """Support for restructured text (rST), adapted from rst3 plugin.
 
 For full documentation, see: http://leoeditor.com/rstplugin3.html
@@ -11,9 +11,9 @@ For full documentation, see: http://leoeditor.com/rstplugin3.html
 To generate documents from rST files, Python's docutils_ module must be
 installed. The code will use the SilverCity_ syntax coloring package if is is
 available."""
-#@-<< docstring >>
-#@+<< imports >>
-#@+node:ekr.20100908120927.5971: ** << imports >> (leoRst)
+#@-<< leoRst docstring >>
+#@+<< leoRst imports >>
+#@+node:ekr.20100908120927.5971: ** << leoRst imports >>
 import io
 import os
 import re
@@ -34,7 +34,7 @@ if 'plugins' in getattr(g.app, 'debug', []):
     print('leoRst.py: docutils:', bool(docutils))
     print('leoRst.py:  parsers:', bool(parsers))
     print('leoRst.py:      rst:', bool(rst))
-#@-<< imports >>
+#@-<< leoRst imports >>
 #@+others
 #@+node:ekr.20150509035745.1: ** cmd (decorator)
 def cmd(name):

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -1,21 +1,19 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20120420054855.14241: * @file leoSessions.py
+#@@first
 """Support for sessions in Leo."""
-#@+<< imports >>
-#@+node:ekr.20120420054855.14344: ** <<imports>> (leoSessions.py)
+#@+<< leoSessions imports >>
+#@+node:ekr.20120420054855.14344: ** << leoSessions imports >>
 import json
 from typing import List
 from leo.core import leoGlobals as g
-#@-<< imports >>
-#@+<< exception classes>>
-#@+node:ekr.20120420054855.14357: ** <<exception classes>>
-# class LeoNodeNotFoundException(Exception):
-    # pass
-
-
+#@-<< leoSessions imports >>
+#@+<< leoSessions exception classes>>
+#@+node:ekr.20120420054855.14357: ** << leoSessions exception classes >>
 class LeoSessionException(Exception):
     pass
-#@-<< exception classes>>
+#@-<< leoSessions exception classes>>
 #@+others
 #@+node:ekr.20120420054855.14349: ** class SessionManager
 # These were top-level nodes of leotools.py

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -1,5 +1,8 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3603: * @file leoUndo.py
+#@@first
+
 # Suppress all mypy errors (mypy doesn't like g.Bunch).
 # type: ignore
 """Leo's undo/redo manager."""

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -2,6 +2,8 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20131109170017.16504: * @file leoVim.py
 #@@first
+#@+<< leoVim docstring >>
+#@+node:ekr.20220824081749.1: ** << leoVim docstring >>
 """
 Leo's vim mode.
 
@@ -15,6 +17,7 @@ Vim *mode* is independent of vim *emulation* because
 k.masterKeyHandler dispatches keys to vim mode before
 doing the normal key handling that vim emulation uses.
 """
+#@-<< leoVim docstring >>
 import os
 import string
 from leo.core import leoGlobals as g

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210202110241.1: * @file leoclient.py
+#@@first
 """
 An example client for leoserver.py, based on work by Félix Malboeuf. Used by permission.
 """

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.2605: * @file runLeo.py
+#@@first
 #@@first
 """Entry point for Leo in Python."""
 #@+<< imports and inits >>

--- a/leo/core/signal_manager.py
+++ b/leo/core/signal_manager.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115541.1: * @file signal_manager.py
+#@@first
 """
 signal_manager.py - SignalManager - light weight signal management
 

--- a/leo/plugins/editpane/clicky_splitter.py
+++ b/leo/plugins/editpane/clicky_splitter.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171029210211.1: * @file ../plugins/editpane/clicky_splitter.py
+#@@first
 #@@language python
 """
 clicky_splitter.py - a QSplitter which allows flipping / rotating of

--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20211210102459.1: * @file ../plugins/editpane/csvedit.py
+#@@first
 #@@language python
 #@@tabwidth -4
 #@@language python

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.6: * @file ../plugins/editpane/editpane.py
+#@@first
 """Support for the edit-pane-test-open command and window."""
-#@+<<editpane.py imports>>
-#@+node:tbrown.20171028115438.1: ** << editpane.py imports >>
+#@+<<editpane imports>>
+#@+node:tbrown.20171028115438.1: ** << editpane imports >>
 from collections import defaultdict
 from importlib import import_module
 import os
@@ -21,7 +23,7 @@ from leo.core import leoGlobals as g
 from leo.core import signal_manager
 if QtCore is not None:
     from leo.plugins.editpane.clicky_splitter import ClickySplitter
-#@-<<editpane.py imports>>
+#@-<<editpane imports>>
 #@+others
 #@+node:tbrown.20171028115438.2: ** DBG
 def DBG(text):

--- a/leo/plugins/editpane/leotextedit.py
+++ b/leo/plugins/editpane/leotextedit.py
@@ -1,14 +1,16 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.5: * @file ../plugins/editpane/leotextedit.py
-#@+<<leotextedit.py imports >>
-#@+node:tbrown.20171028115508.1: ** <<leotextedit.py imports >>
+#@@first
+#@+<<leotextedit imports >>
+#@+node:tbrown.20171028115508.1: ** <<leotextedit imports >>
 from leo.core import leoGlobals as g
 assert g
 from leo.core.leoQt import QtWidgets  #  QtConst, QtCore, QtGui
 from leo.core.leoColorizer import JEditColorizer  # LeoHighlighter
 
 
-#@-<<leotextedit.py imports >>
+#@-<<leotextedit imports >>
 #@+others
 #@+node:tbrown.20171028115508.2: ** DBG
 def DBG(text):

--- a/leo/plugins/editpane/markdownview.py
+++ b/leo/plugins/editpane/markdownview.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.4: * @file ../plugins/editpane/markdownview.py
-#@+<< markdownview.py imports >>
-#@+node:tbrown.20171028115507.1: ** << markdownview.py imports >>
+#@@first
+#@+<< markdownview imports >>
+#@+node:tbrown.20171028115507.1: ** << markdownview imports >>
 import markdown
 from leo.core import leoGlobals as g
 assert g
@@ -15,7 +17,7 @@ except ImportError:
     from leo.plugins.editpane.webengineview import LEP_WebEngineView as HtmlView
 
 from leo.plugins.editpane.plaintextview import LEP_PlainTextView as TextView
-#@-<< markdownview.py imports >>
+#@-<< markdownview imports >>
 #@+others
 #@+node:tbrown.20171028115507.2: ** to_html
 def to_html(text):

--- a/leo/plugins/editpane/pandownview.py
+++ b/leo/plugins/editpane/pandownview.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.3: * @file ../plugins/editpane/pandownview.py
-#@+<< pandownview.py imports >>
-#@+node:tbrown.20171028115505.1: ** << pandownview.py imports >>
+#@@first
+#@+<< pandownview imports >>
+#@+node:tbrown.20171028115505.1: ** << pandownview imports >>
 """Markdown view using Pandoc.
 
 There could also be a more generic Pandoc view that handles more input
@@ -23,7 +25,7 @@ except ImportError:
 
 from leo.plugins.editpane.plaintextview import LEP_PlainTextView as TextView
 
-#@-<< pandownview.py imports >>
+#@-<< pandownview imports >>
 #@+others
 #@+node:tbrown.20171028115505.2: ** to_html
 def to_html(text, from_='markdown'):

--- a/leo/plugins/editpane/plaintextedit.py
+++ b/leo/plugins/editpane/plaintextedit.py
@@ -1,13 +1,15 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.2: * @file ../plugins/editpane/plaintextedit.py
-#@+<< plaintextedit.py imports >>
-#@+node:tbrown.20171028115504.1: ** << plaintextedit.py imports >>
+#@@first
+#@+<< plaintextedit imports >>
+#@+node:tbrown.20171028115504.1: ** << plaintextedit imports >>
 import re
 from leo.core import leoGlobals as g
 assert g
 from leo.core.leoQt import QtGui, QtWidgets
 from leo.core.leoQt import GlobalColor, Weight
-#@-<< plaintextedit.py imports >>
+#@-<< plaintextedit imports >>
 #@+others
 #@+node:tbrown.20171028115504.2: ** DBG
 def DBG(text):

--- a/leo/plugins/editpane/plaintextview.py
+++ b/leo/plugins/editpane/plaintextview.py
@@ -1,11 +1,13 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.1: * @file ../plugins/editpane/plaintextview.py
-#@+<< plaintextview.py declarations >>
-#@+node:tbrown.20171028115502.1: ** << plaintextview.py declarations >>
+#@@first
+#@+<< plaintextview imports >>
+#@+node:tbrown.20171028115502.1: ** << plaintextview imports >>
 from leo.core import leoGlobals as g
 assert g
 from leo.core.leoQt import QtWidgets  # QtCore, QtGui, QtConst
-#@-<< plaintextview.py declarations >>
+#@-<< plaintextview imports >>
 #@+others
 #@+node:tbrown.20171028115502.2: ** class LEP_PlainTextView
 class LEP_PlainTextView(QtWidgets.QTextBrowser):

--- a/leo/plugins/editpane/vanillascintilla.py
+++ b/leo/plugins/editpane/vanillascintilla.py
@@ -1,20 +1,22 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115143.3: * @file ../plugins/editpane/vanillascintilla.py
+#@@first
 """
 vanillascintilla.py - a LeoEditPane editor that uses QScintilla
 but does not try to add Leo key handling
 
 Terry Brown, Terry_N_Brown@yahoo.com, Sat Feb  4 12:38:26 2017
 """
-#@+<< vanillascintilla.py imports >>
-#@+node:tbrown.20171028115501.1: ** << vanillascintilla.py imports >>
+#@+<< vanillascintilla imports >>
+#@+node:tbrown.20171028115501.1: ** << vanillascintilla imports >>
 from leo.core import leoGlobals as g
 assert g
 from leo.core.leoQt import QtGui, QtWidgets, Qsci
 
 if Qsci is None:  # leo.core.leoQt eats ImportErrors
     raise ImportError
-#@-<< vanillascintilla.py imports >>
+#@-<< vanillascintilla imports >>
 #@+others
 #@+node:tbrown.20171028115501.2: ** DBG
 def DBG(text):

--- a/leo/plugins/editpane/webengineview.py
+++ b/leo/plugins/editpane/webengineview.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115143.2: * @file ../plugins/editpane/webengineview.py
-#@+<< webengineview.py imports >>
-#@+node:tbrown.20171028115459.1: ** << webengineview.py imports >>
+#@@first
+#@+<< webengineview imports >>
+#@+node:tbrown.20171028115459.1: ** << webengineview imports >>
 # EKR: Use QtWebKitWidgets instead of QtWebEngineWidgets
 # TNB: No, there are two HTML viewers, this one must be QtWebEngineWidgets
 #      it's ok if it fails to load
@@ -9,7 +11,7 @@
 from PyQt5 import QtWebEngineWidgets
 from leo.core import leoGlobals as g
 assert g
-#@-<< webengineview.py imports >>
+#@-<< webengineview imports >>
 #@+others
 #@+node:tbrown.20171028115459.2: ** class LEP_WebEngineView
 class LEP_WebEngineView(QtWebEngineWidgets.QWebEngineView):

--- a/leo/plugins/editpane/webkitview.py
+++ b/leo/plugins/editpane/webkitview.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115143.1: * @file ../plugins/editpane/webkitview.py
-#@+<< webkitview.py imports >>
-#@+node:tbrown.20171028115457.1: ** << webkitview.py imports >>
+#@@first
+#@+<< webkitview imports >>
+#@+node:tbrown.20171028115457.1: ** << webkitview imports >>
 import os
 from leo.core import leoGlobals as g
 assert g
@@ -10,7 +12,7 @@ if not QtWebKitWidgets or 'engine' in g.os_path_basename(
     QtWebKitWidgets.__file__).lower():
     # not loading webkit view, webengine masquerading as webkit
     raise ImportError
-#@-<< webkitview.py imports >>
+#@-<< webkitview imports >>
 #@+others
 #@+node:tbrown.20171028115457.2: ** _path_from_pos
 def _path_from_pos(c, p):

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20120419093256.10048: * @file ../plugins/free_layout.py
-#@+<< docstring >>
-#@+node:ekr.20110319161401.14467: ** << docstring >> (free_layout.py)
+#@@first
+#@+<< free_layout docstring >>
+#@+node:ekr.20110319161401.14467: ** << free_layout docstring >>
 """
 Free layout
 ===========
@@ -23,7 +25,7 @@ free-layout-zoom
     Zoom or unzoom the current pane
 
 """
-#@-<< docstring >>
+#@-<< free_layout docstring >>
 # Written by Terry Brown.
 #@+<< imports >>
 #@+node:tbrown.20110203111907.5520: ** << imports >> (free_layout.py)

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.17926: * @file ../plugins/importers/c.py
+#@@first
 """The @auto importer for the C language and other related languages."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20160505094722.1: * @file ../plugins/importers/coffeescript.py
+#@@first
 """The @auto importer for coffeescript."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/csharp.py
+++ b/leo/plugins/importers/csharp.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18140: * @file ../plugins/importers/csharp.py
+#@@first
 """The @auto importer for the csharp language."""
 from leo.core.leoCommands import Commands as Cmdr
 from leo.core.leoNodes import Position

--- a/leo/plugins/importers/ctext.py
+++ b/leo/plugins/importers/ctext.py
@@ -1,7 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20140801105909.47549: * @file ../plugins/importers/ctext.py
-#@@language python
-#@@tabwidth -4
+#@@first
 import re
 from typing import Dict, List
 from leo.core import leoGlobals as g  # Required

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20200619141135.1: * @file ../plugins/importers/cython.py
+#@@first
 """@auto importer for cython."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/dart.py
+++ b/leo/plugins/importers/dart.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20141116100154.1: * @file ../plugins/importers/dart.py
+#@@first
 """The @auto importer for the dart language."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/elisp.py
+++ b/leo/plugins/importers/elisp.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18141: * @file ../plugins/importers/elisp.py
+#@@first
 """The @auto importer for the elisp language."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/html.py
+++ b/leo/plugins/importers/html.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18138: * @file ../plugins/importers/html.py
+#@@first
 """The @auto importer for HTML."""
 from leo.core.leoCommands import Commands as Cmdr
 from leo.core.leoNodes import Position

--- a/leo/plugins/importers/ini.py
+++ b/leo/plugins/importers/ini.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18142: * @file ../plugins/importers/ini.py
+#@@first
 """The @auto importer for .ini files."""
 import re
 from typing import Dict, List, Optional

--- a/leo/plugins/importers/java.py
+++ b/leo/plugins/importers/java.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18143: * @file ../plugins/importers/java.py
+#@@first
 """The @auto importer for the java language."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/javascript.py
+++ b/leo/plugins/importers/javascript.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18144: * @file ../plugins/importers/javascript.py
+#@@first
 """The @auto importer for JavaScript."""
 import re
 from typing import Any, Dict, Generator

--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18151: * @file ../plugins/importers/leo_rst.py
+#@@first
 """
 The @auto importer for restructured text.
 

--- a/leo/plugins/importers/lua.py
+++ b/leo/plugins/importers/lua.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170530024520.2: * @file ../plugins/importers/lua.py
+#@@first
 """
 The @auto importer for the lua language.
 

--- a/leo/plugins/importers/markdown.py
+++ b/leo/plugins/importers/markdown.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140725190808.18066: * @file ../plugins/importers/markdown.py
+#@@first
 """The @auto importer for the markdown language."""
 import re
 from typing import Dict, List, Tuple

--- a/leo/plugins/importers/org.py
+++ b/leo/plugins/importers/org.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18146: * @file ../plugins/importers/org.py
+#@@first
 """The @auto importer for the org language."""
 import re
 from typing import Any, Dict, List

--- a/leo/plugins/importers/otl.py
+++ b/leo/plugins/importers/otl.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18150: * @file ../plugins/importers/otl.py
+#@@first
 """The @auto importer for vim-outline files."""
 import re
 from typing import Dict, List

--- a/leo/plugins/importers/pascal.py
+++ b/leo/plugins/importers/pascal.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18147: * @file ../plugins/importers/pascal.py
+#@@first
 """The @auto importer for the pascal language."""
 import re
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/importers/perl.py
+++ b/leo/plugins/importers/perl.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20161027100313.1: * @file ../plugins/importers/perl.py
+#@@first
 """The @auto importer for Perl."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/php.py
+++ b/leo/plugins/importers/php.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18148: * @file ../plugins/importers/php.py
+#@@first
 """The @auto importer for the php language."""
 import re
 from leo.core import leoGlobals as g  # required

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20211209153303.1: * @file ../plugins/importers/python.py
+#@@first
 """The new, tokenize based, @auto importer for Python."""
 import re
 import sys

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20200316100818.1: * @file ../plugins/importers/rust.py
+#@@first
 """The @auto importer for rust."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/tcl.py
+++ b/leo/plugins/importers/tcl.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170615153639.2: * @file ../plugins/importers/tcl.py
+#@@first
 """
 The @auto importer for the tcl language.
 

--- a/leo/plugins/importers/treepad.py
+++ b/leo/plugins/importers/treepad.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180201203240.2: * @file ../plugins/importers/treepad.py
+#@@first
 """The @auto importer for the TreePad file format."""
 import re
 from typing import Dict, List

--- a/leo/plugins/importers/typescript.py
+++ b/leo/plugins/importers/typescript.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18152: * @file ../plugins/importers/typescript.py
+#@@first
 """The @auto importer for TypeScript."""
 import re
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18137: * @file ../plugins/importers/xml.py
+#@@first
 """The @auto importer for the xml language."""
 import re
 from typing import List, Optional, Tuple

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20110605121601.17954: * @file ../plugins/nested_splitter.py
+#@@first
 """Nested splitter classes."""
 from leo.core import leoGlobals as g
 from leo.core.leoQt import isQt6, Qt, QtCore, QtGui, QtWidgets

--- a/leo/plugins/qtGui.py
+++ b/leo/plugins/qtGui.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20110605121601.18002: * @file ../plugins/qtGui.py
+#@@first
 """qt gui plugin."""
 #@@language python
 #@@tabwidth -4

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20110605121601.17996: * @file ../plugins/qt_commands.py
+#@@first
 """Leo's Qt-related commands defined by @g.command."""
 from typing import List
 from leo.core import leoGlobals as g

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907085654.18699: * @file ../plugins/qt_gui.py
+#@@first
 """This file contains the gui wrapper for Qt: g.app.gui."""
 # pylint: disable=import-error
 #@+<< imports qt_gui.py >>

--- a/leo/plugins/writers/basewriter.py
+++ b/leo/plugins/writers/basewriter.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18143: * @file ../plugins/writers/basewriter.py
+#@@first
 """A module defining the base class for all writers in leo.plugins.writers."""
 
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/writers/ctext.py
+++ b/leo/plugins/writers/ctext.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20140804103545.29975: * @file ../plugins/writers/ctext.py
+#@@first
 #@@language python
 #@@tabwidth -4
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/writers/dart.py
+++ b/leo/plugins/writers/dart.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20141116100154.2: * @file ../plugins/writers/dart.py
+#@@first
 """The @auto write code for Emacs org-mode (.org) files."""
 from leo.core import leoGlobals as g  # Required
 from leo.core.leoNodes import Position

--- a/leo/plugins/writers/leo_rst.py
+++ b/leo/plugins/writers/leo_rst.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18080: * @file ../plugins/writers/leo_rst.py
+#@@first
 """
 The write code for @auto-rst and other reStructuredText nodes.
 This is very different from rst3's write code.

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18073: * @file ../plugins/writers/markdown.py
+#@@first
 """The @auto write code for markdown."""
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position

--- a/leo/plugins/writers/org.py
+++ b/leo/plugins/writers/org.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18079: * @file ../plugins/writers/org.py
+#@@first
 """The @auto write code for Emacs org-mode (.org) files."""
 from typing import Callable
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/writers/otl.py
+++ b/leo/plugins/writers/otl.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18078: * @file ../plugins/writers/otl.py
+#@@first
 """The @auto write code for vimoutline (.otl) files."""
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position

--- a/leo/plugins/writers/treepad.py
+++ b/leo/plugins/writers/treepad.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180202053206.1: * @file ../plugins/writers/treepad.py
+#@@first
 """The @auto write code for TreePad (.hjt) files."""
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position

--- a/leo/scripts/wax_off.py
+++ b/leo/scripts/wax_off.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210709045755.1: * @file ../scripts/wax_off.py
+#@@first
 #@+<< docstring >>
 #@+node:ekr.20210710050822.1: ** << docstring >>
 """

--- a/leo/unittests/core/test_leoFrame.py
+++ b/leo/unittests/core/test_leoFrame.py
@@ -4,7 +4,6 @@
 #@@first
 """Tests of leoFrame.py"""
 
-import textwrap
 from leo.core.leoTest2 import LeoUnitTest
 
 #@+others


### PR DESCRIPTION
**Note**: This PR should change *only* comments: rearranging code is not allowed!

- Ensure all .py files start with `@first # -*- coding: utf-8 -*-`.
- Specify module name in standard sections: especially useful for cff results.

Regularize all:
- [x] leo/core files.
- [x] leo/commands files.
- [x] leo/plugins/importers files.
- [x] leo/plugins/writers files.

I'll defer work on other plugins indefinitely.