### PR TITLE
PR for #2761: CPrettyPrinter class looks buggy

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -33,12 +33,17 @@ exclude =
     # qt_main.py is generated automatically, so it's pointless to add annotations.
     |qt_main
     
-# The default for all core files: Full annotation...
+# The default for all core files: full annotation.
 [mypy-leo.core.*]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
-# Importer and writer plugins should be fully annotated...
+# The default for specific leo.commands files: full annotation.
+[mypy-leo.commands.convertCommands]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
+# All importer and writer plugins: full annotation.
 [mypy-leo.plugins.importers.*,leo.plugins.writers.*]
 disallow_untyped_defs = True
 disallow_incomplete_defs = True

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -3,12 +3,22 @@
 #@+node:ekr.20160316095222.1: * @file ../commands/convertCommands.py
 #@@first
 """Leo's file-conversion commands."""
-
+#@+<< convertCommands imports >>
+#@+node:ekr.20220824202922.1: ** << convertCommands imports >>
 import re
-from typing import Any, Dict, List
+import time
+from typing import Any, Dict, List, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoBeautify
 from leo.commands.baseCommands import BaseEditCommandsClass
+#@-<< convertCommands imports >>
+#@+<< convertCommands annotations >>
+#@+node:ekr.20220824202941.1: ** << convertCommands annotations >>
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+else:
+    Cmdr = Any
+#@-<< convertCommands annotations >>
 
 def cmd(name):
     """Command decorator for the ConvertCommandsClass class."""
@@ -18,17 +28,17 @@ def cmd(name):
 #@+node:ekr.20150514063305.123: ** << class To_Python >>
 class To_Python:  # pragma: no cover
     """The base class for x-to-python commands."""
-    #@+others
-    #@+node:ekr.20150514063305.125: *3* To_Python.ctor
+
     def __init__(self, c):
         """Ctor for To_Python class."""
         self.c = c
         self.p = self.c.p.copy()
         aList = g.get_directives_dict_list(self.p)
         self.tab_width = g.scanAtTabwidthDirectives(aList) or 4
+
+    #@+others
     #@+node:ekr.20150514063305.126: *3* To_Python.go
-    def go(self):
-        import time
+    def go(self) -> None:
         t1 = time.time()
         c = self.c
         u, undoType = c.undoer, 'typescript-to-python'
@@ -63,7 +73,7 @@ class To_Python:  # pragma: no cover
         t2 = time.time()
         g.es_print(f"done! {n_files} files, {n_nodes} nodes, {t2 - t1:2.2f} sec")
     #@+node:ekr.20150514063305.127: *3* To_Python.convertCodeList
-    def convertCodeList(self, aList):
+    def convertCodeList(self, aList: List[str]) -> None:
         """The main search/replace method."""
         g.trace('must be defined in subclasses.')
     #@+node:ekr.20150514063305.128: *3* To_Python.Utils
@@ -747,7 +757,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
     class C_To_Python(To_Python):  # pragma: no cover
         #@+others
         #@+node:ekr.20150514063305.161: *5* ctor & helpers (C_To_Python)
-        def __init__(self, c):
+        def __init__(self, c: Cmdr) -> None:
             """Ctor for C_To_Python class."""
             super().__init__(c)
             #
@@ -755,7 +765,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             # The class name for the present function.  Used to modify ivars.
             self.class_name = ''
             # List of ivars to be converted to self.ivar
-            self.ivars = []
+            self.ivars: List[str] = []
             self.get_user_types()
         #@+node:ekr.20150514063305.162: *6* get_user_types (C_To_Python)
         def get_user_types(self):
@@ -788,7 +798,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     return {}
             return d
         #@+node:ekr.20150514063305.164: *5* convertCodeList (C_To_Python) & helpers
-        def convertCodeList(self, aList):
+        def convertCodeList(self, aList: List[str]) -> None:
             r, sr = self.replace, self.safe_replace
             # First...
             r(aList, "\r", '')
@@ -848,8 +858,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             self.replaceComments(aList)  # should follow all calls to safe_replace
             self.removeTrailingWs(aList)
             r(aList, "\t ", "\t")  # happens when deleting declarations.
+            ### g.printObj(aList, tag='C_To_Python.convertCodeList')
         #@+node:ekr.20150514063305.165: *6* handle_all_keywords
-        def handle_all_keywords(self, aList):
+        def handle_all_keywords(self, aList: List[str]) -> None:
             """
             converts if ( x ) to if x:
             converts while ( x ) to while x:
@@ -905,7 +916,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 return j
             return i
         #@+node:ekr.20150514063305.167: *6* mungeAllFunctions
-        def mungeAllFunctions(self, aList):
+        def mungeAllFunctions(self, aList: List[str]) -> None:
             """Scan for a '{' at the top level that is preceeded by ')' """
             prevSemi = 0  # Previous semicolon: header contains all previous text
             i = 0
@@ -2209,6 +2220,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 self.class_name = ''
             #@+node:ekr.20150514063305.178: *5* convertCodeList (TS_To_Python) & helpers
             def convertCodeList(self, aList):
+                g.pdb()
                 r, sr = self.replace, self.safe_replace
                 # First...
                 r(aList, '\r', '')

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -76,7 +76,7 @@ class To_Python:  # pragma: no cover
         t2 = time.time()
         g.es_print(f"done! {n_files} files, {n_nodes} nodes, {t2 - t1:2.2f} sec")
     #@+node:ekr.20150514063305.127: *3* To_Python.convertCodeList
-    def convertCodeList(self, aList: List[str]) -> None:
+    def convertCodeList(self, lines: List[str]) -> None:
         """The main search/replace method."""
         g.trace('must be defined in subclasses.')
     #@+node:ekr.20150514063305.128: *3* To_Python.Utils
@@ -110,14 +110,14 @@ class To_Python:  # pragma: no cover
             return not ch.isalnum() and ch != '_'
         return False
     #@+node:ekr.20150514063305.132: *4* insert_not
-    def insert_not(self, aList: List[str]) -> None:
+    def insert_not(self, lines: List[str]) -> None:
         """Change "!" to "not" except before an equal sign."""
         i = 0
-        while i < len(aList):
-            if self.is_string_or_comment(aList, i):
-                i = self.skip_string_or_comment(aList, i)
-            elif aList[i] == '!' and not self.match(aList, i + 1, '='):
-                aList[i : i + 1] = list('not ')
+        while i < len(lines):
+            if self.is_string_or_comment(lines, i):
+                i = self.skip_string_or_comment(lines, i)
+            elif lines[i] == '!' and not self.match(lines, i + 1, '='):
+                lines[i : i + 1] = list('not ')
                 i += 4
             else:
                 i += 1
@@ -155,90 +155,90 @@ class To_Python:  # pragma: no cover
         return i
     #@+node:ekr.20150514063305.138: *4* remove...
     #@+node:ekr.20150514063305.139: *5* removeBlankLines
-    def removeBlankLines(self, aList: List[str]) -> None:
+    def removeBlankLines(self, lines: List[str]) -> None:
         i = 0
-        while i < len(aList):
+        while i < len(lines):
             j = i
-            while j < len(aList) and aList[j] in " \t":
+            while j < len(lines) and lines[j] in " \t":
                 j += 1
-            if j == len(aList) or aList[j] == '\n':
-                del aList[i : j + 1]
+            if j == len(lines) or lines[j] == '\n':
+                del lines[i : j + 1]
             else:
-                i = self.skip_past_line(aList, i)
+                i = self.skip_past_line(lines, i)
     #@+node:ekr.20150514063305.140: *5* removeExcessWs
-    def removeExcessWs(self, aList: List[str]) -> None:
+    def removeExcessWs(self, lines: List[str]) -> None:
         i = 0
-        i = self.removeExcessWsFromLine(aList, i)
-        while i < len(aList):
-            if self.is_string_or_comment(aList, i):
-                i = self.skip_string_or_comment(aList, i)
-            elif self.match(aList, i, '\n'):
+        i = self.removeExcessWsFromLine(lines, i)
+        while i < len(lines):
+            if self.is_string_or_comment(lines, i):
+                i = self.skip_string_or_comment(lines, i)
+            elif self.match(lines, i, '\n'):
                 i += 1
-                i = self.removeExcessWsFromLine(aList, i)
+                i = self.removeExcessWsFromLine(lines, i)
             else: i += 1
     #@+node:ekr.20150514063305.141: *5* removeExessWsFromLine
-    def removeExcessWsFromLine(self, aList: List[str], i: int) -> int:
-        assert(i == 0 or aList[i - 1] == '\n')
-        i = self.skip_ws(aList, i)  # Retain the leading whitespace.
-        while i < len(aList):
-            if self.is_string_or_comment(aList, i):
+    def removeExcessWsFromLine(self, lines: List[str], i: int) -> int:
+        assert(i == 0 or lines[i - 1] == '\n')
+        i = self.skip_ws(lines, i)  # Retain the leading whitespace.
+        while i < len(lines):
+            if self.is_string_or_comment(lines, i):
                 break  # safe
-            elif self.match(aList, i, '\n'):
+            elif self.match(lines, i, '\n'):
                 break
-            elif self.match(aList, i, ' ') or self.match(aList, i, '\t'):
+            elif self.match(lines, i, ' ') or self.match(lines, i, '\t'):
                 # Replace all whitespace by one blank.
-                j = self.skip_ws(aList, i)
+                j = self.skip_ws(lines, i)
                 assert j > i
-                aList[i:j] = [' ']
+                lines[i:j] = [' ']
                 i += 1  # make sure we don't go past a newline!
             else: i += 1
         return i
     #@+node:ekr.20150514063305.142: *5* removeMatchingBrackets
-    def removeMatchingBrackets(self, aList: List[str], i: int) -> int:
-        j = self.skip_to_matching_bracket(aList, i)
-        if i < j < len(aList):
-            c = aList[j]
+    def removeMatchingBrackets(self, lines: List[str], i: int) -> int:
+        j = self.skip_to_matching_bracket(lines, i)
+        if i < j < len(lines):
+            c = lines[j]
             if c == ')' or c == ']' or c == '}':
-                del aList[j : j + 1]
-                del aList[i : i + 1]
+                del lines[j : j + 1]
+                del lines[i : i + 1]
                 return j - 1
             return j + 1
         return j
     #@+node:ekr.20150514063305.143: *5* removeSemicolonsAtEndOfLines
-    def removeSemicolonsAtEndOfLines(self, aList: List[str]) -> None:
+    def removeSemicolonsAtEndOfLines(self, lines: List[str]) -> None:
         i = 0
-        while i < len(aList):
-            if self.is_string_or_comment(aList, i):
-                i = self.skip_string_or_comment(aList, i)
-            elif aList[i] == ';':
-                j = self.skip_ws(aList, i + 1)
+        while i < len(lines):
+            if self.is_string_or_comment(lines, i):
+                i = self.skip_string_or_comment(lines, i)
+            elif lines[i] == ';':
+                j = self.skip_ws(lines, i + 1)
                 if (
-                    j >= len(aList) or
-                    self.match(aList, j, '\n') or
-                    self.match(aList, j, '#') or
-                    self.match(aList, j, "//")
+                    j >= len(lines) or
+                    self.match(lines, j, '\n') or
+                    self.match(lines, j, '#') or
+                    self.match(lines, j, "//")
                 ):
-                    del aList[i]
+                    del lines[i]
                 else:
                     i += 1
             else:
                 i += 1
     #@+node:ekr.20150514063305.144: *5* removeTrailingWs
-    def removeTrailingWs(self, aList: List[str]) -> None:
+    def removeTrailingWs(self, lines: List[str]) -> None:
         i = 0
-        while i < len(aList):
-            if self.is_ws(aList[i]):
+        while i < len(lines):
+            if self.is_ws(lines[i]):
                 j = i
-                i = self.skip_ws(aList, i)
+                i = self.skip_ws(lines, i)
                 assert j < i
-                if i >= len(aList) or aList[i] == '\n':
-                    # print "removing trailing ws:", `i-j`
-                    del aList[j:i]
+                if i >= len(lines) or lines[i] == '\n':
+                    del lines[j:i]
                     i = j
-            else: i += 1
+            else:
+                i += 1
     #@+node:ekr.20150514063305.145: *4* replace... & safe_replace
     #@+node:ekr.20150514063305.146: *5* replace
-    def replace(self, aList: List[str], findString: str, changeString: str) -> None:
+    def replace(self, lines: List[str], findString: str, changeString: str) -> None:
         """
         Replaces all occurances of findString by changeString.
         changeString may be the empty string, but not None.
@@ -247,38 +247,38 @@ class To_Python:  # pragma: no cover
             return
         changeList = list(changeString)
         i = 0
-        while i < len(aList):
-            if self.match(aList, i, findString):
-                aList[i : i + len(findString)] = changeList
+        while i < len(lines):
+            if self.match(lines, i, findString):
+                lines[i : i + len(findString)] = changeList
                 i += len(changeList)
             else:
                 i += 1
     #@+node:ekr.20150514063305.147: *5* replaceComments
-    def replaceComments(self, aList: List[str]) -> None:
+    def replaceComments(self, lines: List[str]) -> None:
         i = 0
-        while i < len(aList):
+        while i < len(lines):
             # Loop invariant: j > progress at end.
             progress = i
-            if self.match(aList, i, "//"):
-                aList[i : i + 2] = ['#']
-                j = self.skip_past_line(aList, i)
-            elif self.match(aList, i, "/*"):
-                j = self.skip_c_block_comment(aList, i)
+            if self.match(lines, i, "//"):
+                lines[i : i + 2] = ['#']
+                j = self.skip_past_line(lines, i)
+            elif self.match(lines, i, "/*"):
+                j = self.skip_c_block_comment(lines, i)
                 k = i
-                while k - 1 >= 0 and aList[k - 1] in ' \t':
+                while k - 1 >= 0 and lines[k - 1] in ' \t':
                     k -= 1
-                assert k == 0 or aList[k - 1] not in ' \t'
-                lws = ''.join(aList[k:i])
-                comment_body = ''.join(aList[i + 2 : j - 2])
+                assert k == 0 or lines[k - 1] not in ' \t'
+                lws = ''.join(lines[k:i])
+                comment_body = ''.join(lines[i + 2 : j - 2])
                 comment_lines = g.splitLines(lws + comment_body)
                 comment_lines = self.munge_block_comment(comment_lines)
                 comment = '\n'.join(comment_lines)  # A list of lines.
                 comment_list = list(comment)  # A list of characters.
-                aList[k:j] = comment_list
+                lines[k:j] = comment_list
                 j = k + len(comment_list)
                 progress = j - 1  # Disable the check below.
-            elif self.match(aList, i, '"') or self.match(aList, i, "'"):
-                j = self.skip_string(aList, i)
+            elif self.match(lines, i, '"') or self.match(lines, i, "'"):
+                j = self.skip_string(lines, i)
             else:
                 j = i + 1
             # Defensive programming.
@@ -306,26 +306,26 @@ class To_Python:  # pragma: no cover
                 result.append('')  # Add a blank line
         return result
     #@+node:ekr.20150514063305.149: *5* replaceSectionDefs
-    def replaceSectionDefs(self, aList: List[str]) -> None:
+    def replaceSectionDefs(self, lines: List[str]) -> None:
         """Replaces < < x > > = by @c (at the start of lines)."""
-        if not aList:
+        if not lines:
             return
         i = 0
-        j = self.is_section_def(aList[i])
+        j = self.is_section_def(lines[i])
         if j > 0:
-            aList[i:j] = list("@c ")
-        while i < len(aList):
-            if self.is_string_or_comment(aList, i):
-                i = self.skip_string_or_comment(aList, i)
-            elif self.match(aList, i, "\n"):
+            lines[i:j] = list("@c ")
+        while i < len(lines):
+            if self.is_string_or_comment(lines, i):
+                i = self.skip_string_or_comment(lines, i)
+            elif self.match(lines, i, "\n"):
                 i += 1
-                j = self.is_section_def(aList[i])
+                j = self.is_section_def(lines[i])
                 if j > i:
-                    aList[i:j] = list("@c ")
+                    lines[i:j] = list("@c ")
             else:
                 i += 1
     #@+node:ekr.20150514063305.150: *5* safe_replace
-    def safe_replace(self, aList: List[str], findString: str, changeString: str) -> None:
+    def safe_replace(self, lines: List[str], findString: str, changeString: str) -> None:
         """
         Replaces occurances of findString by changeString,
         but only outside of C comments and strings.
@@ -336,18 +336,18 @@ class To_Python:  # pragma: no cover
         changeList = list(changeString)
         i = 0
         if findString[0].isalpha():  # use self.match_word
-            while i < len(aList):
-                if self.is_string_or_comment(aList, i):
-                    i = self.skip_string_or_comment(aList, i)
-                elif self.match_word(aList, i, findString):
-                    aList[i : i + len(findString)] = changeList
+            while i < len(lines):
+                if self.is_string_or_comment(lines, i):
+                    i = self.skip_string_or_comment(lines, i)
+                elif self.match_word(lines, i, findString):
+                    lines[i : i + len(findString)] = changeList
                     i += len(changeList)
                 else:
                     i += 1
         else:  #use self.match
-            while i < len(aList):
-                if self.match(aList, i, findString):
-                    aList[i : i + len(findString)] = changeList
+            while i < len(lines):
+                if self.match(lines, i, findString):
+                    lines[i : i + len(findString)] = changeList
                     i += len(changeList)
                 else:
                     i += 1
@@ -434,17 +434,17 @@ class To_Python:  # pragma: no cover
             else: i += 1
         return i
     #@+node:ekr.20150514063305.159: *5* skip_ws and skip_ws_and_nl
-    def skip_ws(self, aList: List[str], i: int) -> int:
-        while i < len(aList):
-            c = aList[i]
+    def skip_ws(self, lines: List[str], i: int) -> int:
+        while i < len(lines):
+            c = lines[i]
             if c == ' ' or c == '\t':
                 i += 1
             else: break
         return i
 
-    def skip_ws_and_nl(self, aList: List[str], i: int) -> int:
-        while i < len(aList):
-            c = aList[i]
+    def skip_ws_and_nl(self, lines: List[str], i: int) -> int:
+        while i < len(lines):
+            c = lines[i]
             if c == ' ' or c == '\t' or c == '\n':
                 i += 1
             else: break
@@ -802,146 +802,146 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     return {}
             return d
         #@+node:ekr.20150514063305.164: *5* convertCodeList (C_To_Python) & helpers
-        def convertCodeList(self, aList: List[str]) -> None:
+        def convertCodeList(self, lines: List[str]) -> None:
             r, sr = self.replace, self.safe_replace
             # First...
-            r(aList, "\r", '')
-            # self.convertLeadingBlanks(aList) # Now done by indent.
-            # if leoFlag: replaceSectionDefs(aList)
-            self.mungeAllFunctions(aList)
+            r(lines, "\r", '')
+            # self.convertLeadingBlanks(lines) # Now done by indent.
+            # if leoFlag: replaceSectionDefs(lines)
+            self.mungeAllFunctions(lines)
             # Next...
             if 1:
                 # CC2 stuff:
-                sr(aList, "TRACEPB", "if trace: g.trace")
-                sr(aList, "TRACEPN", "if trace: g.trace")
-                sr(aList, "TRACEPX", "if trace: g.trace")
-                sr(aList, "TICKB", "if trace: g.trace")
-                sr(aList, "TICKN", "if trace: g.trace")
-                sr(aList, "TICKX", "if trace: g.trace")
-                sr(aList, "g.trace(ftag,", "g.trace(")
-                sr(aList, "ASSERT_TRACE", "assert")
-            sr(aList, "ASSERT", "assert")
-            sr(aList, " -> ", '.')
-            sr(aList, "->", '.')
-            sr(aList, " . ", '.')
-            sr(aList, "this.self", "self")
-            sr(aList, "{", '')
-            sr(aList, "}", '')
-            sr(aList, "#if", "if")
-            sr(aList, "#else", "else")
-            sr(aList, "#endif", '')
-            sr(aList, "else if", "elif")
-            sr(aList, "else", "else:")
-            sr(aList, "&&", " and ")
-            sr(aList, "||", " or ")
-            sr(aList, "TRUE", "True")
-            sr(aList, "FALSE", "False")
-            sr(aList, "NULL", "None")
-            sr(aList, "this", "self")
-            sr(aList, "try", "try:")
-            sr(aList, "catch", "except:")
-            # if leoFlag: sr(aList, "@code", "@c")
+                sr(lines, "TRACEPB", "if trace: g.trace")
+                sr(lines, "TRACEPN", "if trace: g.trace")
+                sr(lines, "TRACEPX", "if trace: g.trace")
+                sr(lines, "TICKB", "if trace: g.trace")
+                sr(lines, "TICKN", "if trace: g.trace")
+                sr(lines, "TICKX", "if trace: g.trace")
+                sr(lines, "g.trace(ftag,", "g.trace(")
+                sr(lines, "ASSERT_TRACE", "assert")
+            sr(lines, "ASSERT", "assert")
+            sr(lines, " -> ", '.')
+            sr(lines, "->", '.')
+            sr(lines, " . ", '.')
+            sr(lines, "this.self", "self")
+            sr(lines, "{", '')
+            sr(lines, "}", '')
+            sr(lines, "#if", "if")
+            sr(lines, "#else", "else")
+            sr(lines, "#endif", '')
+            sr(lines, "else if", "elif")
+            sr(lines, "else", "else:")
+            sr(lines, "&&", " and ")
+            sr(lines, "||", " or ")
+            sr(lines, "TRUE", "True")
+            sr(lines, "FALSE", "False")
+            sr(lines, "NULL", "None")
+            sr(lines, "this", "self")
+            sr(lines, "try", "try:")
+            sr(lines, "catch", "except:")
+            # if leoFlag: sr(lines, "@code", "@c")
             # Next...
-            self.handle_all_keywords(aList)
-            self.insert_not(aList)
+            self.handle_all_keywords(lines)
+            self.insert_not(lines)
             # after processing for keywords
-            self.removeSemicolonsAtEndOfLines(aList)
+            self.removeSemicolonsAtEndOfLines(lines)
             # Last...
-            # if firstPart and leoFlag: removeLeadingAtCode(aList)
-            self.removeBlankLines(aList)
-            self.removeExcessWs(aList)
+            # if firstPart and leoFlag: removeLeadingAtCode(lines)
+            self.removeBlankLines(lines)
+            self.removeExcessWs(lines)
             # your taste may vary: in Python I don't like extra whitespace
-            sr(aList, " :", ":")
-            sr(aList, ", ", ",")
-            sr(aList, " ,", ",")
-            sr(aList, " (", "(")
-            sr(aList, "( ", "(")
-            sr(aList, " )", ")")
-            sr(aList, ") ", ")")
-            sr(aList, "@language c", "@language python")
-            self.replaceComments(aList)  # should follow all calls to safe_replace
-            self.removeTrailingWs(aList)
-            r(aList, "\t ", "\t")  # happens when deleting declarations.
+            sr(lines, " :", ":")
+            sr(lines, ", ", ",")
+            sr(lines, " ,", ",")
+            sr(lines, " (", "(")
+            sr(lines, "( ", "(")
+            sr(lines, " )", ")")
+            sr(lines, ") ", ")")
+            sr(lines, "@language c", "@language python")
+            self.replaceComments(lines)  # should follow all calls to safe_replace
+            self.removeTrailingWs(lines)
+            r(lines, "\t ", "\t")  # happens when deleting declarations.
         #@+node:ekr.20150514063305.165: *6* handle_all_keywords
-        def handle_all_keywords(self, aList: List[str]) -> None:
+        def handle_all_keywords(self, lines: List[str]) -> None:
             """
             converts if ( x ) to if x:
             converts while ( x ) to while x:
             """
             i = 0
-            while i < len(aList):
-                if self.is_string_or_comment(aList, i):
-                    i = self.skip_string_or_comment(aList, i)
+            while i < len(lines):
+                if self.is_string_or_comment(lines, i):
+                    i = self.skip_string_or_comment(lines, i)
                 elif (
-                    self.match_word(aList, i, "if") or
-                    self.match_word(aList, i, "while") or
-                    self.match_word(aList, i, "for") or
-                    self.match_word(aList, i, "elif")
+                    self.match_word(lines, i, "if") or
+                    self.match_word(lines, i, "while") or
+                    self.match_word(lines, i, "for") or
+                    self.match_word(lines, i, "elif")
                 ):
-                    i = self.handle_keyword(aList, i)
+                    i = self.handle_keyword(lines, i)
                 else:
                     i += 1
-            # print "handAllKeywords2:", ''.join(aList)
+
         #@+node:ekr.20150514063305.166: *7* handle_keyword
-        def handle_keyword(self, aList: List[str], i: int) -> int:
-            if self.match_word(aList, i, "if"):
+        def handle_keyword(self, lines: List[str], i: int) -> int:
+            if self.match_word(lines, i, "if"):
                 i += 2
-            elif self.match_word(aList, i, "elif"):
+            elif self.match_word(lines, i, "elif"):
                 i += 4
-            elif self.match_word(aList, i, "while"):
+            elif self.match_word(lines, i, "while"):
                 i += 5
-            elif self.match_word(aList, i, "for"):
+            elif self.match_word(lines, i, "for"):
                 i += 3
             else:
                 assert False
             # Make sure one space follows the keyword.
             k = i
-            i = self.skip_ws(aList, i)
+            i = self.skip_ws(lines, i)
             if k == i:
-                c = aList[i]
-                aList[i : i + 1] = [' ', c]
+                c = lines[i]
+                lines[i : i + 1] = [' ', c]
                 i += 1
             # Remove '(' and matching ')' and add a ':'
-            if aList[i] == "(":
+            if lines[i] == "(":
                 # Look ahead.  Don't remove if we span a line.
-                j = self.skip_to_matching_bracket(aList, i)
+                j = self.skip_to_matching_bracket(lines, i)
                 k = i
                 found = False
                 while k < j and not found:
-                    found = aList[k] == '\n'
+                    found = lines[k] == '\n'
                     k += 1
                 if not found:
-                    j = self.removeMatchingBrackets(aList, i)
-                if i < j < len(aList):
-                    ch = aList[j]
-                    aList[j : j + 1] = [ch, ":", " "]
+                    j = self.removeMatchingBrackets(lines, i)
+                if i < j < len(lines):
+                    ch = lines[j]
+                    lines[j : j + 1] = [ch, ":", " "]
                     j = j + 2
                 return j
             return i
         #@+node:ekr.20150514063305.167: *6* mungeAllFunctions
-        def mungeAllFunctions(self, aList: List[str]) -> None:
+        def mungeAllFunctions(self, lines: List[str]) -> None:
             """Scan for a '{' at the top level that is preceeded by ')' """
             prevSemi = 0  # Previous semicolon: header contains all previous text
             i = 0
             firstOpen = None
-            while i < len(aList):
+            while i < len(lines):
                 progress = i
-                if self.is_string_or_comment(aList, i):
-                    j = self.skip_string_or_comment(aList, i)
+                if self.is_string_or_comment(lines, i):
+                    j = self.skip_string_or_comment(lines, i)
                     prevSemi = j
-                elif self.match(aList, i, '('):
+                elif self.match(lines, i, '('):
                     if not firstOpen:
                         firstOpen = i
                     j = i + 1
-                elif self.match(aList, i, '#'):
+                elif self.match(lines, i, '#'):
                     # At this point, it is a preprocessor directive.
-                    j = self.skip_past_line(aList, i)
+                    j = self.skip_past_line(lines, i)
                     prevSemi = j
-                elif self.match(aList, i, ';'):
+                elif self.match(lines, i, ';'):
                     j = i + 1
                     prevSemi = j
-                elif self.match(aList, i, "{"):
-                    j = self.handlePossibleFunctionHeader(aList, i, prevSemi, firstOpen)
+                elif self.match(lines, i, "{"):
+                    j = self.handlePossibleFunctionHeader(lines, i, prevSemi, firstOpen)
                     prevSemi = j
                     firstOpen = None  # restart the scan
                 else:
@@ -952,7 +952,12 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 assert j > progress
                 i = j
         #@+node:ekr.20150514063305.168: *7* handlePossibleFunctionHeader
-        def handlePossibleFunctionHeader(self, aList: List[str], i: int, prevSemi: int, firstOpen: int) -> int:
+        def handlePossibleFunctionHeader(self,
+            lines: List[str],
+            i: int,
+            prevSemi: int,
+            firstOpen: int,
+        ) -> int:
             """
             Converts function header lines from c++ format to python format.
             That is, converts
@@ -960,24 +965,24 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             to
                 def y (z1,..zn): {
             """
-            assert self.match(aList, i, "{")
-            prevSemi = self.skip_ws_and_nl(aList, prevSemi)
-            close = self.prevNonWsOrNlChar(aList, i)
-            if close < 0 or aList[close] != ')':
+            assert self.match(lines, i, "{")
+            prevSemi = self.skip_ws_and_nl(lines, prevSemi)
+            close = self.prevNonWsOrNlChar(lines, i)
+            if close < 0 or lines[close] != ')':
                 # Should not increase *Python* indent.
-                return 1 + self.skip_to_matching_bracket(aList, i)
+                return 1 + self.skip_to_matching_bracket(lines, i)
             if not firstOpen:
-                return 1 + self.skip_to_matching_bracket(aList, i)
-            close2 = self.skip_to_matching_bracket(aList, firstOpen)
+                return 1 + self.skip_to_matching_bracket(lines, i)
+            close2 = self.skip_to_matching_bracket(lines, firstOpen)
             if close2 != close:
-                return 1 + self.skip_to_matching_bracket(aList, i)
+                return 1 + self.skip_to_matching_bracket(lines, i)
             open_paren = firstOpen
-            assert aList[open_paren] == '('
-            head = aList[prevSemi:open_paren]
+            assert lines[open_paren] == '('
+            head = lines[prevSemi:open_paren]
             # do nothing if the head starts with "if", "for" or "while"
             k = self.skip_ws(head, 0)
             if k >= len(head) or not head[k].isalpha():
-                return 1 + self.skip_to_matching_bracket(aList, i)
+                return 1 + self.skip_to_matching_bracket(lines, i)
             kk = self.skip_past_word(head, k)
             if kk > k:
                 headString = ''.join(head[k:kk])
@@ -985,10 +990,10 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 # print "headString:", headString
                 if headString in [
                     "class", "do", "for", "if", "struct", "switch", "while"]:
-                    return 1 + self.skip_to_matching_bracket(aList, i)
-            args = aList[open_paren : close + 1]
-            k = 1 + self.skip_to_matching_bracket(aList, i)
-            body = aList[close + 1 : k]
+                    return 1 + self.skip_to_matching_bracket(lines, i)
+            args = lines[open_paren : close + 1]
+            k = 1 + self.skip_to_matching_bracket(lines, i)
+            body = lines[close + 1 : k]
             head = self.massageFunctionHead(head)
             args = self.massageFunctionArgs(args)
             body = self.massageFunctionBody(body)
@@ -999,7 +1004,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 result.extend(args)
             if body:
                 result.extend(body)
-            aList[prevSemi:k] = result
+            lines[prevSemi:k] = result
             return prevSemi + len(result)
         #@+node:ekr.20150514063305.170: *7* massageFunctionHead (sets .class_name)
         def massageFunctionHead(self, head: List[str]) -> List[str]:
@@ -2222,181 +2227,173 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 # The class name for the present function.  Used to modify ivars.
                 self.class_name = ''
             #@+node:ekr.20150514063305.178: *5* convertCodeList (TS_To_Python) & helpers
-            def convertCodeList(self, aList: List[str]) -> None:
+            def convertCodeList(self, lines: List[str]) -> None:
                 r, sr = self.replace, self.safe_replace
                 # First...
-                r(aList, '\r', '')
-                self.mungeAllFunctions(aList)
-                self.mungeAllClasses(aList)
+                r(lines, '\r', '')
+                self.mungeAllFunctions(lines)
+                self.mungeAllClasses(lines)
                 # Second...
-                sr(aList, ' -> ', '.')
-                sr(aList, '->', '.')
-                sr(aList, ' . ', '.')
-                # sr(aList, 'this.self', 'self')
-                sr(aList, '{', '')
-                sr(aList, '}', '')
-                sr(aList, 'else if', 'elif')
-                sr(aList, 'else', 'else:')
-                sr(aList, '&&', ' and ')
-                sr(aList, '||', ' or ')
-                sr(aList, 'true', 'True')
-                sr(aList, 'false', 'False')
-                sr(aList, 'null', 'None')
-                sr(aList, 'this', 'self')
-                sr(aList, 'try', 'try:')
-                sr(aList, 'catch', 'except:')
-                sr(aList, 'constructor', '__init__')
-                sr(aList, 'new ', '')
-                # sr(aList, 'var ','')
+                sr(lines, ' -> ', '.')
+                sr(lines, '->', '.')
+                sr(lines, ' . ', '.')
+                # sr(lines, 'this.self', 'self')
+                sr(lines, '{', '')
+                sr(lines, '}', '')
+                sr(lines, 'else if', 'elif')
+                sr(lines, 'else', 'else:')
+                sr(lines, '&&', ' and ')
+                sr(lines, '||', ' or ')
+                sr(lines, 'true', 'True')
+                sr(lines, 'false', 'False')
+                sr(lines, 'null', 'None')
+                sr(lines, 'this', 'self')
+                sr(lines, 'try', 'try:')
+                sr(lines, 'catch', 'except:')
+                sr(lines, 'constructor', '__init__')
+                sr(lines, 'new ', '')
+                # sr(lines, 'var ','')
                     # var usually indicates something weird, or an uninited var,
                     # so it may be good to retain as a marker.
                 # Third...
-                self.handle_all_keywords(aList)
-                self.insert_not(aList)
+                self.handle_all_keywords(lines)
+                self.insert_not(lines)
                 # after processing for keywords
-                self.removeSemicolonsAtEndOfLines(aList)
-                self.comment_scope_ids(aList)
+                self.removeSemicolonsAtEndOfLines(lines)
+                self.comment_scope_ids(lines)
                 # Last...
-                self.removeBlankLines(aList)
-                self.removeExcessWs(aList)
+                self.removeBlankLines(lines)
+                self.removeExcessWs(lines)
                 # I usually don't like extra whitespace. YMMV.
-                sr(aList, '  and ', ' and ')
-                sr(aList, '  not ', ' not ')
-                sr(aList, '  or ', ' or ')
-                sr(aList, ' and  ', ' and ')
-                sr(aList, ' not  ', ' not ')
-                sr(aList, ' or  ', ' or ')
-                sr(aList, ' :', ':')
-                sr(aList, ', ', ',')
-                sr(aList, ' ,', ',')
-                sr(aList, ' (', '(')
-                sr(aList, '( ', '(')
-                sr(aList, ' )', ')')
-                sr(aList, ') ', ')')
-                sr(aList, ' and(', ' and (')
-                sr(aList, ' not(', ' not (')
-                sr(aList, ' or(', ' or (')
-                sr(aList, ')and ', ') and ')
-                sr(aList, ')not ', ') not ')
-                sr(aList, ')or ', ') or ')
-                sr(aList, ')and(', ') and (')
-                sr(aList, ')not(', ') not (')
-                sr(aList, ')or(', ') or (')
-                sr(aList, '@language javascript', '@language python')
-                self.replaceComments(aList)  # should follow all calls to safe_replace
-                self.removeTrailingWs(aList)
-                r(aList, '\t ', '\t')  # happens when deleting declarations.
+                sr(lines, '  and ', ' and ')
+                sr(lines, '  not ', ' not ')
+                sr(lines, '  or ', ' or ')
+                sr(lines, ' and  ', ' and ')
+                sr(lines, ' not  ', ' not ')
+                sr(lines, ' or  ', ' or ')
+                sr(lines, ' :', ':')
+                sr(lines, ', ', ',')
+                sr(lines, ' ,', ',')
+                sr(lines, ' (', '(')
+                sr(lines, '( ', '(')
+                sr(lines, ' )', ')')
+                sr(lines, ') ', ')')
+                sr(lines, ' and(', ' and (')
+                sr(lines, ' not(', ' not (')
+                sr(lines, ' or(', ' or (')
+                sr(lines, ')and ', ') and ')
+                sr(lines, ')not ', ') not ')
+                sr(lines, ')or ', ') or ')
+                sr(lines, ')and(', ') and (')
+                sr(lines, ')not(', ') not (')
+                sr(lines, ')or(', ') or (')
+                sr(lines, '@language javascript', '@language python')
+                self.replaceComments(lines)  # should follow all calls to safe_replace
+                self.removeTrailingWs(lines)
+                r(lines, '\t ', '\t')  # happens when deleting declarations.
             #@+node:ekr.20150514063305.179: *6* comment_scope_ids
-            def comment_scope_ids(self, aList: List[str]) -> None:
+            def comment_scope_ids(self, lines: List[str]) -> None:
                 """convert (public|private|export) aLine to aLine # (public|private|export)"""
                 scope_ids = ('public', 'private', 'export',)
                 i = 0
-                if any(self.match_word(aList, i, z) for z in scope_ids):
-                    i = self.handle_scope_keyword(aList, i)
-                while i < len(aList):
+                if any(self.match_word(lines, i, z) for z in scope_ids):
+                    i = self.handle_scope_keyword(lines, i)
+                while i < len(lines):
                     progress = i
-                    if self.is_string_or_comment(aList, i):
-                        i = self.skip_string_or_comment(aList, i)
-                    elif aList[i] == '\n':
+                    if self.is_string_or_comment(lines, i):
+                        i = self.skip_string_or_comment(lines, i)
+                    elif lines[i] == '\n':
                         i += 1
-                        i = self.skip_ws(aList, i)
-                        if any(self.match_word(aList, i, z) for z in scope_ids):
-                            i = self.handle_scope_keyword(aList, i)
+                        i = self.skip_ws(lines, i)
+                        if any(self.match_word(lines, i, z) for z in scope_ids):
+                            i = self.handle_scope_keyword(lines, i)
                     else:
                         i += 1
                     assert i > progress
-                # print "handAllKeywords2:", ''.join(aList)
+
             #@+node:ekr.20150514063305.180: *7* handle_scope_keyword
-            def handle_scope_keyword(self, aList: List[str], i: int) -> int:
+            def handle_scope_keyword(self, lines: List[str], i: int) -> int:
                 i1 = i
                 # pylint: disable=undefined-loop-variable
                 for word in ('public', 'private', 'export'):
-                    if self.match_word(aList, i, word):
+                    if self.match_word(lines, i, word):
                         i += len(word)
                         break
                 else:
                     return None
                 # Skip any following spaces.
-                i2 = self.skip_ws(aList, i)
+                i2 = self.skip_ws(lines, i)
                 # Scan to the next newline:
-                i3 = self.skip_line(aList, i)
+                i3 = self.skip_line(lines, i)
                 # Optional: move the word to a trailing comment.
                 comment: List[str] = list(f" # {word}") if False else []
                 # Change the list in place.
-                aList[i1:i3] = aList[i2:i3] + comment
+                lines[i1:i3] = lines[i2:i3] + comment
                 i = i1 + (i3 - i2) + len(comment)
                 return i
             #@+node:ekr.20150514063305.181: *6* handle_all_keywords
-            def handle_all_keywords(self, aList: List[str]) -> None:
+            def handle_all_keywords(self, lines: List[str]) -> None:
                 """
                 converts if ( x ) to if x:
                 converts while ( x ) to while x:
                 """
                 statements = ('elif', 'for', 'if', 'while',)
                 i = 0
-                while i < len(aList):
-                    if self.is_string_or_comment(aList, i):
-                        i = self.skip_string_or_comment(aList, i)
-                    elif any(self.match_word(aList, i, z) for z in statements):
-                        i = self.handle_keyword(aList, i)
-                    # elif (
-                        # self.match_word(aList,i,"if") or
-                        # self.match_word(aList,i,"while") or
-                        # self.match_word(aList,i,"for") or
-                        # self.match_word(aList,i,"elif")
-                    # ):
-                        # i = self.handle_keyword(aList,i)
+                while i < len(lines):
+                    if self.is_string_or_comment(lines, i):
+                        i = self.skip_string_or_comment(lines, i)
+                    elif any(self.match_word(lines, i, z) for z in statements):
+                        i = self.handle_keyword(lines, i)
                     else:
                         i += 1
-                # print "handAllKeywords2:", ''.join(aList)
             #@+node:ekr.20150514063305.182: *7* handle_keyword
-            def handle_keyword(self, aList: List[str], i: int) -> int:
-                if self.match_word(aList, i, "if"):
+            def handle_keyword(self, lines: List[str], i: int) -> int:
+                if self.match_word(lines, i, "if"):
                     i += 2
-                elif self.match_word(aList, i, "elif"):
+                elif self.match_word(lines, i, "elif"):
                     i += 4
-                elif self.match_word(aList, i, "while"):
+                elif self.match_word(lines, i, "while"):
                     i += 5
-                elif self.match_word(aList, i, "for"):
+                elif self.match_word(lines, i, "for"):
                     i += 3
                 else: assert False, 'not a keyword'
                 # Make sure one space follows the keyword.
                 k = i
-                i = self.skip_ws(aList, i)
+                i = self.skip_ws(lines, i)
                 if k == i:
-                    c = aList[i]
-                    aList[i : i + 1] = [' ', c]
+                    c = lines[i]
+                    lines[i : i + 1] = [' ', c]
                     i += 1
                 # Remove '(' and matching ')' and add a ':'
-                if aList[i] == "(":
+                if lines[i] == "(":
                     # Look ahead.  Don't remove if we span a line.
-                    j = self.skip_to_matching_bracket(aList, i)
+                    j = self.skip_to_matching_bracket(lines, i)
                     k = i
                     found = False
                     while k < j and not found:
-                        found = aList[k] == '\n'
+                        found = lines[k] == '\n'
                         k += 1
                     if not found:
-                        j = self.removeMatchingBrackets(aList, i)
-                    if i < j < len(aList):
-                        ch = aList[j]
-                        aList[j : j + 1] = [ch, ":", " "]
+                        j = self.removeMatchingBrackets(lines, i)
+                    if i < j < len(lines):
+                        ch = lines[j]
+                        lines[j : j + 1] = [ch, ":", " "]
                         j = j + 2
                     return j
                 return i
             #@+node:ekr.20150514063305.183: *6* mungeAllClasses
-            def mungeAllClasses(self, aList: List[str]) -> None:
+            def mungeAllClasses(self, lines: List[str]) -> None:
                 """Scan for a '{' at the top level that is preceded by ')' """
                 i = 0
-                while i < len(aList):
+                while i < len(lines):
                     progress = i
-                    if self.is_string_or_comment(aList, i):
-                        i = self.skip_string_or_comment(aList, i)
-                    elif self.match_word(aList, i, 'class'):
+                    if self.is_string_or_comment(lines, i):
+                        i = self.skip_string_or_comment(lines, i)
+                    elif self.match_word(lines, i, 'class'):
                         i1 = i
-                        i = self.skip_line(aList, i)
-                        aList[i - 1 : i] = list(f"{aList[i - 1]}:")
-                        s = ''.join(aList[i1:i])
+                        i = self.skip_line(lines, i)
+                        lines[i - 1 : i] = list(f"{lines[i - 1]}:")
+                        s = ''.join(lines[i1:i])
                         k = s.find(' extends ')
                         if k > -1:
                             k1 = k
@@ -2405,36 +2402,36 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                             if k < len(s) and g.is_c_id(s[k]):
                                 k2 = g.skip_id(s, k)
                                 word = s[k:k2]
-                                aList[i1:i] = list(f"{s[:k1]} ({word})")
-                    elif self.match_word(aList, i, 'interface'):
-                        aList[i : i + len('interface')] = list('class')
-                        i = self.skip_line(aList, i)
-                        aList[i - 1 : i] = list(f"{aList[i - 1]}: # interface")
-                        i = self.skip_line(aList, i)  # Essential.
+                                lines[i1:i] = list(f"{s[:k1]} ({word})")
+                    elif self.match_word(lines, i, 'interface'):
+                        lines[i : i + len('interface')] = list('class')
+                        i = self.skip_line(lines, i)
+                        lines[i - 1 : i] = list(f"{lines[i - 1]}: # interface")
+                        i = self.skip_line(lines, i)  # Essential.
                     else:
                         i += 1
                     assert i > progress
             #@+node:ekr.20150514063305.184: *6* mungeAllFunctions & helpers
-            def mungeAllFunctions(self, aList: List[str]) -> None:
+            def mungeAllFunctions(self, lines: List[str]) -> None:
                 """Scan for a '{' at the top level that is preceded by ')' """
                 prevSemi = 0  # Previous semicolon: header contains all previous text
                 i = 0
                 firstOpen = None
-                while i < len(aList):
+                while i < len(lines):
                     progress = i
-                    if self.is_string_or_comment(aList, i):
-                        j = self.skip_string_or_comment(aList, i)
+                    if self.is_string_or_comment(lines, i):
+                        j = self.skip_string_or_comment(lines, i)
                         prevSemi = j
-                    elif self.match(aList, i, '('):
+                    elif self.match(lines, i, '('):
                         if not firstOpen:
                             firstOpen = i
                         j = i + 1
-                    elif self.match(aList, i, ';'):
+                    elif self.match(lines, i, ';'):
                         j = i + 1
                         prevSemi = j
-                    elif self.match(aList, i, "{"):
+                    elif self.match(lines, i, "{"):
                         j = self.handlePossibleFunctionHeader(
-                            aList, i, prevSemi, firstOpen)
+                            lines, i, prevSemi, firstOpen)
                         prevSemi = j
                         firstOpen = None  # restart the scan
                     else:
@@ -2445,7 +2442,12 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     assert j > progress
                     i = j
             #@+node:ekr.20150514063305.185: *7* handlePossibleFunctionHeader
-            def handlePossibleFunctionHeader(self, aList: List[str], i: int, prevSemi: int, firstOpen: int) -> int:
+            def handlePossibleFunctionHeader(self,
+                lines: List[str],
+                i: int,
+                prevSemi: int,
+                firstOpen: int,
+            ) -> int:
                 """
                 converts function header lines from typescript format to python format.
                 That is, converts
@@ -2454,34 +2456,34 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 to
                     def y (z1,..zn): { # (public|private|export)
                 """
-                assert self.match(aList, i, "{")
-                prevSemi = self.skip_ws_and_nl(aList, prevSemi)
-                close = self.prevNonWsOrNlChar(aList, i)
-                if close < 0 or aList[close] != ')':
+                assert self.match(lines, i, "{")
+                prevSemi = self.skip_ws_and_nl(lines, prevSemi)
+                close = self.prevNonWsOrNlChar(lines, i)
+                if close < 0 or lines[close] != ')':
                     # Should not increase *Python* indent.
-                    return 1 + self.skip_to_matching_bracket(aList, i)
+                    return 1 + self.skip_to_matching_bracket(lines, i)
                 if not firstOpen:
-                    return 1 + self.skip_to_matching_bracket(aList, i)
-                close2 = self.skip_to_matching_bracket(aList, firstOpen)
+                    return 1 + self.skip_to_matching_bracket(lines, i)
+                close2 = self.skip_to_matching_bracket(lines, firstOpen)
                 if close2 != close:
-                    return 1 + self.skip_to_matching_bracket(aList, i)
+                    return 1 + self.skip_to_matching_bracket(lines, i)
                 open_paren = firstOpen
-                assert aList[open_paren] == '('
-                head = aList[prevSemi:open_paren]
+                assert lines[open_paren] == '('
+                head = lines[prevSemi:open_paren]
                 # do nothing if the head starts with "if", "for" or "while"
                 k = self.skip_ws(head, 0)
                 if k >= len(head) or not head[k].isalpha():
-                    return 1 + self.skip_to_matching_bracket(aList, i)
+                    return 1 + self.skip_to_matching_bracket(lines, i)
                 kk = self.skip_past_word(head, k)
                 if kk > k:
                     headString = ''.join(head[k:kk])
                     # C keywords that might be followed by '{'
                     # print "headString:", headString
                     if headString in ["do", "for", "if", "struct", "switch", "while"]:
-                        return 1 + self.skip_to_matching_bracket(aList, i)
-                args = aList[open_paren : close + 1]
-                k = 1 + self.skip_to_matching_bracket(aList, i)
-                body = aList[close + 1 : k]
+                        return 1 + self.skip_to_matching_bracket(lines, i)
+                args = lines[open_paren : close + 1]
+                k = 1 + self.skip_to_matching_bracket(lines, i)
+                body = lines[close + 1 : k]
                 head = self.massageFunctionHead(head)
                 args = self.massageFunctionArgs(args)
                 body = self.massageFunctionBody(body)
@@ -2492,7 +2494,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     result.extend(args)
                 if body:
                     result.extend(body)
-                aList[prevSemi:k] = result
+                lines[prevSemi:k] = result
                 return prevSemi + len(result)
             #@+node:ekr.20150514063305.186: *7* massageFunctionArgs
             def massageFunctionArgs(self, args: List[str]) -> List[str]:

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -82,13 +82,14 @@ class To_Python:  # pragma: no cover
     #@+node:ekr.20150514063305.128: *3* To_Python.Utils
     #@+node:ekr.20150514063305.129: *4* match...
     #@+node:ekr.20150514063305.130: *5* match
-    def match(self, s: str, i: int, pat: str) -> bool:
+    def match(self, s: List[str], i: int, pat: str) -> bool:
         """
         Return True if s[i:] matches the pat string.
 
         We can't use g.match because s is usually a list.
         """
         assert pat
+        assert isinstance(s, list), g.callers() ###
         j = 0
         while i + j < len(s) and j < len(pat):
             if s[i + j] == pat[j]:
@@ -99,13 +100,14 @@ class To_Python:  # pragma: no cover
                 return False
         return False
     #@+node:ekr.20150514063305.131: *5* match_word
-    def match_word(self, s: str, i: int, pat: str) -> bool:
+    def match_word(self, s: List[str], i: int, pat: str) -> bool:
         """
         Return True if s[i:] word matches the pat string.
 
         We can't use g.match_word because s is usually a list
         and g.match_word uses s.find.
         """
+        assert isinstance(s, list), g.callers() ###
         if self.match(s, i, pat):
             j = i + len(pat)
             if j >= len(s):
@@ -130,16 +132,18 @@ class To_Python:  # pragma: no cover
                 i += 1
     #@+node:ekr.20150514063305.133: *4* is...
     #@+node:ekr.20150514063305.134: *5* is_section_def/ref
-    def is_section_def(self, p: Position) -> bool:
-        return self.is_section_ref(p.h)
+    def is_section_def(self, s: str) -> bool:
+        ### return self.is_section_ref(p.h)
+        return self.is_section_def(s)
 
     def is_section_ref(self, s: str) -> bool:
         n1 = s.find("<<", 0)
         n2 = s.find(">>", 0)
         return -1 < n1 < n2 and bool(s[n1 + 2 : n2].strip())
     #@+node:ekr.20150514063305.135: *5* is_string_or_comment
-    def is_string_or_comment(self, s: str, i: int) -> bool:
+    def is_string_or_comment(self, s: List[str], i: int) -> bool:
         # Does range checking.
+        assert isinstance(s, list), g.callers() ###
         m = self.match
         return m(s, i, "'") or m(s, i, '"') or m(s, i, "//") or m(s, i, "/*")
     #@+node:ekr.20150514063305.136: *5* is_ws and is_ws_or_nl
@@ -155,7 +159,8 @@ class To_Python:  # pragma: no cover
             i -= 1
         return i
 
-    def prevNonWsOrNlChar(self, s: str, i: int) -> int:
+    def prevNonWsOrNlChar(self, s: List[str], i: int) -> int:
+        assert isinstance(s, list), g.callers() ###
         i -= 1
         while i >= 0 and self.is_ws_or_nl(s[i]):
             i -= 1
@@ -231,7 +236,7 @@ class To_Python:  # pragma: no cover
             else:
                 i += 1
     #@+node:ekr.20150514063305.144: *5* removeTrailingWs
-    def removeTrailingWs(self, aList: List[List]) -> None:
+    def removeTrailingWs(self, aList: List[str]) -> None:
         i = 0
         while i < len(aList):
             if self.is_ws(aList[i]):
@@ -360,7 +365,8 @@ class To_Python:  # pragma: no cover
                     i += 1
     #@+node:ekr.20150514063305.151: *4* skip
     #@+node:ekr.20150514063305.152: *5* skip_c_block_comment
-    def skip_c_block_comment(self, s: str, i: int) -> int:
+    def skip_c_block_comment(self, s: List[str], i: int) -> int:
+        assert isinstance(s, list), g.callers() ###
         assert self.match(s, i, "/*")
         i += 2
         while i < len(s):
@@ -369,12 +375,14 @@ class To_Python:  # pragma: no cover
             i += 1
         return i
     #@+node:ekr.20150514063305.153: *5* skip_line
-    def skip_line(self, s: str, i: int) -> int:
+    def skip_line(self, s: List[str], i: int) -> int:
+        assert isinstance(s, list), g.callers() ###
         while i < len(s) and s[i] != '\n':
             i += 1
         return i
     #@+node:ekr.20150514063305.154: *5* skip_past_line
-    def skip_past_line(self, s: str, i: int) -> int:
+    def skip_past_line(self, s: List[str], i: int) -> int:
+        assert isinstance(s, list), g.callers() ###
         while i < len(s) and s[i] != '\n':
             i += 1
         if i < len(s) and s[i] == '\n':
@@ -394,7 +402,9 @@ class To_Python:  # pragma: no cover
                 break
         return i
     #@+node:ekr.20150514063305.156: *5* skip_string
-    def skip_string(self, s: str, i: int) -> int:
+    def skip_string(self, s: List[str], i: int) -> int:
+        assert isinstance(s, list), g.callers() ###
+        ### Huh???
         delim = s[i]  # handle either single or double-quoted strings
         assert delim == '"' or delim == "'"
         i += 1
@@ -407,7 +417,8 @@ class To_Python:  # pragma: no cover
                 i += 1
         return i
     #@+node:ekr.20150514063305.157: *5* skip_string_or_comment
-    def skip_string_or_comment(self, s: str, i: int) -> int:
+    def skip_string_or_comment(self, s: List[str], i: int) -> int:
+        assert isinstance(s, list), g.callers() ###
         if self.match(s, i, "'") or self.match(s, i, '"'):
             j = self.skip_string(s, i)
         elif self.match(s, i, "//"):
@@ -442,6 +453,7 @@ class To_Python:  # pragma: no cover
         return i
     #@+node:ekr.20150514063305.159: *5* skip_ws and skip_ws_and_nl
     def skip_ws(self, aList: List[str], i: int) -> int:
+        assert isinstance(aList, list), g.callers() ###
         while i < len(aList):
             c = aList[i]
             if c == ' ' or c == '\t':
@@ -1243,7 +1255,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 self.files: List[str] = []  # May also be set in the config file.
                 self.output_directory = self.finalize(
                     c.config.getString('stub-output-directory') or '.')
-                self.output_fn = None
+                self.output_fn: str = None
                 self.overwrite = c.config.getBool('stub-overwrite', default=False)
                 self.trace_matches = c.config.getBool(
                     'stub-trace-matches', default=False)

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1503,7 +1503,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         #@+others
         #@+node:ekr.20211020162251.1: *5* py2ts.ctor
-        def __init__(self, c: Cmdr, alias: Any=None) -> None:
+        def __init__(self, c: Cmdr, alias: str=None) -> None:
             self.c = c
             self.alias = alias  # For scripts. An alias for 'self'.
             data = c.config.getData('python-to-typescript-types') or []

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -435,7 +435,6 @@ class To_Python:  # pragma: no cover
         return i
     #@+node:ekr.20150514063305.159: *5* skip_ws and skip_ws_and_nl
     def skip_ws(self, aList: List[str], i: int) -> int:
-        assert isinstance(aList, list), g.callers() ###
         while i < len(aList):
             c = aList[i]
             if c == ' ' or c == '\t':
@@ -863,7 +862,6 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             self.replaceComments(aList)  # should follow all calls to safe_replace
             self.removeTrailingWs(aList)
             r(aList, "\t ", "\t")  # happens when deleting declarations.
-            ### g.printObj(aList, tag='C_To_Python.convertCodeList')
         #@+node:ekr.20150514063305.165: *6* handle_all_keywords
         def handle_all_keywords(self, aList: List[str]) -> None:
             """

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -637,7 +637,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         arg_pat = re.compile(r'(\s*[\*\w]+\s*)([:,=])?')
         comment_pat = re.compile(r'(\s*#.*?\n)')
 
-        def do_args(self, args: Any) -> str:
+        def do_args(self, args: str) -> str:
             """Add type annotations for all arguments."""
             multiline = '\n' in args.strip()
             comma = ',\n' if multiline else ', '

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -374,13 +374,13 @@ class To_Python:  # pragma: no cover
             i += 1
         return i
     #@+node:ekr.20150514063305.155: *5* skip_past_word
-    def skip_past_word(self, s: Any, i: int) -> int:  ###
-        assert s[i].isalpha() or s[i] == '~'
+    def skip_past_word(self, lines: List[str], i: int) -> int:
+        assert lines[i].isalpha() or lines[i] == '~'
         # Kludge: this helps recognize dtors.
-        if s[i] == '~':
+        if lines[i] == '~':
             i += 1
-        while i < len(s):
-            ch = s[i]
+        while i < len(lines):
+            ch = lines[i]
             if ch.isalnum() or ch == '_':
                 i += 1
             else:
@@ -411,8 +411,8 @@ class To_Python:  # pragma: no cover
             assert False
         return j
     #@+node:ekr.20150514063305.158: *5* skip_to_matching_bracket
-    def skip_to_matching_bracket(self, s: Any, i: int) -> int:  ###
-        ch = s[i]
+    def skip_to_matching_bracket(self, lines: List[str], i: int) -> int:
+        ch = lines[i]
         if ch == '(':
             delim = ')'
         elif ch == '{':
@@ -422,14 +422,14 @@ class To_Python:  # pragma: no cover
         else:
             assert False
         i += 1
-        while i < len(s):
-            ch = s[i]
-            if self.is_string_or_comment(s, i):
-                i = self.skip_string_or_comment(s, i)
+        while i < len(lines):
+            ch = lines[i]
+            if self.is_string_or_comment(lines, i):
+                i = self.skip_string_or_comment(lines, i)
             elif ch == delim:
                 return i
             elif ch == '(' or ch == '[' or ch == '{':
-                i = self.skip_to_matching_bracket(s, i)
+                i = self.skip_to_matching_bracket(lines, i)
                 i += 1  # skip the closing bracket.
             else: i += 1
         return i

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1272,7 +1272,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     g.trace(f"warning: no @data {kind} node")
                 return aList
             #@+node:ekr.20160213070235.4: *6* msf.scan_d
-            def scan_d(self, kind: Any) -> Dict[str, List[str]]:
+            def scan_d(self, kind: str) -> Dict[str, List[str]]:
                 """Return a dict created from an @data node of the given kind."""
                 c = self.c
                 aList = c.config.getData(kind, strip_comments=True, strip_data=True)
@@ -1560,7 +1560,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             except Exception:
                 g.es_exception()
         #@+node:ekr.20211013101327.1: *5* py2ts.convert_node
-        def convert_node(self, p: Position, parent: Any) -> None:
+        def convert_node(self, p: Position, parent: Position) -> None:
             # Create a copy of p as the last child of parent.
             target = parent.insertAsLastChild()
             target.h = p.h  # The caller will rename this node.
@@ -1570,7 +1570,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             for child in p.children():
                 self.convert_node(child, target)
         #@+node:ekr.20211013102209.1: *5* py2ts.convert_body, handlers &helpers
-        def convert_body(self, p: Position, target: Any) -> None:
+        def convert_body(self, p: Position, target: Position) -> None:
             """
             Convert p.b into target.b.
 
@@ -2495,7 +2495,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 aList[prevSemi:k] = result
                 return prevSemi + len(result)
             #@+node:ekr.20150514063305.186: *7* massageFunctionArgs
-            def massageFunctionArgs(self, args: Any) -> List[str]:
+            def massageFunctionArgs(self, args: List[str]) -> List[str]:
                 assert args[0] == '('
                 assert args[-1] == ')'
                 result: List[str] = ['(']
@@ -2526,7 +2526,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 return result
             #@+node:ekr.20150514063305.187: *7* massageFunctionHead (sets .class_name)
             def massageFunctionHead(self, head: List[str]) -> List[str]:
-                result: List[Any] = []
+                result: List[str] = []
                 prevWord = []
                 self.class_name = ''
                 i = 0

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -82,17 +82,12 @@ class To_Python:  # pragma: no cover
     #@+node:ekr.20150514063305.128: *3* To_Python.Utils
     #@+node:ekr.20150514063305.129: *4* match...
     #@+node:ekr.20150514063305.130: *5* match
-    def match(self, s: List[str], i: int, pat: str) -> bool:
-        """
-        Return True if s[i:] matches the pat string.
-
-        We can't use g.match because s is usually a list.
-        """
+    def match(self, lines: List[str], i: int, pat: str) -> bool:
+        """Return True if lines[i:] matches the pat string."""
         assert pat
-        assert isinstance(s, list), g.callers() ###
         j = 0
-        while i + j < len(s) and j < len(pat):
-            if s[i + j] == pat[j]:
+        while i + j < len(lines) and j < len(pat):
+            if lines[i + j] == pat[j]:
                 j += 1
                 if j == len(pat):
                     return True
@@ -100,22 +95,18 @@ class To_Python:  # pragma: no cover
                 return False
         return False
     #@+node:ekr.20150514063305.131: *5* match_word
-    def match_word(self, s: List[str], i: int, pat: str) -> bool:
+    def match_word(self, lines: List[str], i: int, pat: str) -> bool:
         """
-        Return True if s[i:] word matches the pat string.
-
-        We can't use g.match_word because s is usually a list
-        and g.match_word uses s.find.
+        Return True if lines[i:] word matches the pat string.
         """
-        assert isinstance(s, list), g.callers() ###
-        if self.match(s, i, pat):
+        if self.match(lines, i, pat):
             j = i + len(pat)
-            if j >= len(s):
+            if j >= len(lines):
                 return True
             if not pat[-1].isalnum():
                 # Bug fix 10/16/2012: The pattern terminates the word.
                 return True
-            ch = s[j]
+            ch = lines[j]
             return not ch.isalnum() and ch != '_'
         return False
     #@+node:ekr.20150514063305.132: *4* insert_not
@@ -133,7 +124,6 @@ class To_Python:  # pragma: no cover
     #@+node:ekr.20150514063305.133: *4* is...
     #@+node:ekr.20150514063305.134: *5* is_section_def/ref
     def is_section_def(self, s: str) -> bool:
-        ### return self.is_section_ref(p.h)
         return self.is_section_def(s)
 
     def is_section_ref(self, s: str) -> bool:
@@ -141,11 +131,10 @@ class To_Python:  # pragma: no cover
         n2 = s.find(">>", 0)
         return -1 < n1 < n2 and bool(s[n1 + 2 : n2].strip())
     #@+node:ekr.20150514063305.135: *5* is_string_or_comment
-    def is_string_or_comment(self, s: List[str], i: int) -> bool:
+    def is_string_or_comment(self, lines: List[str], i: int) -> bool:
         # Does range checking.
-        assert isinstance(s, list), g.callers() ###
         m = self.match
-        return m(s, i, "'") or m(s, i, '"') or m(s, i, "//") or m(s, i, "/*")
+        return m(lines, i, "'") or m(lines, i, '"') or m(lines, i, "//") or m(lines, i, "/*")
     #@+node:ekr.20150514063305.136: *5* is_ws and is_ws_or_nl
     def is_ws(self, ch: str) -> bool:
         return ch in ' \t'
@@ -159,10 +148,9 @@ class To_Python:  # pragma: no cover
             i -= 1
         return i
 
-    def prevNonWsOrNlChar(self, s: List[str], i: int) -> int:
-        assert isinstance(s, list), g.callers() ###
+    def prevNonWsOrNlChar(self, lines: List[str], i: int) -> int:
         i -= 1
-        while i >= 0 and self.is_ws_or_nl(s[i]):
+        while i >= 0 and self.is_ws_or_nl(lines[i]):
             i -= 1
         return i
     #@+node:ekr.20150514063305.138: *4* remove...
@@ -365,27 +353,24 @@ class To_Python:  # pragma: no cover
                     i += 1
     #@+node:ekr.20150514063305.151: *4* skip
     #@+node:ekr.20150514063305.152: *5* skip_c_block_comment
-    def skip_c_block_comment(self, s: List[str], i: int) -> int:
-        assert isinstance(s, list), g.callers() ###
-        assert self.match(s, i, "/*")
+    def skip_c_block_comment(self, lines: List[str], i: int) -> int:
+        assert self.match(lines, i, "/*")
         i += 2
-        while i < len(s):
-            if self.match(s, i, "*/"):
+        while i < len(lines):
+            if self.match(lines, i, "*/"):
                 return i + 2
             i += 1
         return i
     #@+node:ekr.20150514063305.153: *5* skip_line
-    def skip_line(self, s: List[str], i: int) -> int:
-        assert isinstance(s, list), g.callers() ###
-        while i < len(s) and s[i] != '\n':
+    def skip_line(self, lines: List[str], i: int) -> int:
+        while i < len(lines) and lines[i] != '\n':
             i += 1
         return i
     #@+node:ekr.20150514063305.154: *5* skip_past_line
-    def skip_past_line(self, s: List[str], i: int) -> int:
-        assert isinstance(s, list), g.callers() ###
-        while i < len(s) and s[i] != '\n':
+    def skip_past_line(self, lines: List[str], i: int) -> int:
+        while i < len(lines) and lines[i] != '\n':
             i += 1
-        if i < len(s) and s[i] == '\n':
+        if i < len(lines) and lines[i] == '\n':
             i += 1
         return i
     #@+node:ekr.20150514063305.155: *5* skip_past_word
@@ -402,29 +387,26 @@ class To_Python:  # pragma: no cover
                 break
         return i
     #@+node:ekr.20150514063305.156: *5* skip_string
-    def skip_string(self, s: List[str], i: int) -> int:
-        assert isinstance(s, list), g.callers() ###
-        ### Huh???
-        delim = s[i]  # handle either single or double-quoted strings
+    def skip_string(self, lines: List[str], i: int) -> int:
+        delim = lines[i]  # handle either single or double-quoted strings
         assert delim == '"' or delim == "'"
         i += 1
-        while i < len(s):
-            if s[i] == delim:
+        while i < len(lines):
+            if lines[i] == delim:
                 return i + 1
-            if s[i] == '\\':
+            if lines[i] == '\\':
                 i += 2
             else:
                 i += 1
         return i
     #@+node:ekr.20150514063305.157: *5* skip_string_or_comment
-    def skip_string_or_comment(self, s: List[str], i: int) -> int:
-        assert isinstance(s, list), g.callers() ###
-        if self.match(s, i, "'") or self.match(s, i, '"'):
-            j = self.skip_string(s, i)
-        elif self.match(s, i, "//"):
-            j = self.skip_past_line(s, i)
-        elif self.match(s, i, "/*"):
-            j = self.skip_c_block_comment(s, i)
+    def skip_string_or_comment(self, lines: List[str], i: int) -> int:
+        if self.match(lines, i, "'") or self.match(lines, i, '"'):
+            j = self.skip_string(lines, i)
+        elif self.match(lines, i, "//"):
+            j = self.skip_past_line(lines, i)
+        elif self.match(lines, i, "/*"):
+            j = self.skip_c_block_comment(lines, i)
         else:
             assert False
         return j

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -8,6 +8,8 @@ import re
 import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
+from leo.commands.convertCommands import ConvertCommandsClass
+from leo.unittests.test_importers import BaseTestImporter
 
 #@+others
 #@+node:ekr.20211013081200.1: ** class TestPythonToTypeScript(LeoUnitTest):
@@ -253,7 +255,58 @@ class TestAddMypyAnnotations(LeoUnitTest):
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
     #@-others
+#@+node:ekr.20220824193803.1: ** class Test_To_Python(BaseTestImporter):
+class Test_To_Python(BaseTestImporter):
+    """Test cases for commands using To_Python class."""
+
+    #@+others
+    #@+node:ekr.20220824194104.1: *3*  TestTo_Python.setUp
+    # def setUp(self):
+        # super().setUp()
+        # c = self.c
+
+        ###
+            # self.assertTrue(hasattr(self.x, 'convert'))
+            # root = self.root_p
+            # # Delete all children
+            # root.deleteAllChildren()
+            # # Read leo.core.leoNodes into contents.
+            # unittest_dir = os.path.dirname(__file__)
+            # core_dir = os.path.abspath(os.path.join(unittest_dir, '..', '..', 'core'))
+            # path = os.path.join(core_dir, 'leoNodes.py')
+            # with open(path) as f:
+                # contents = f.read()
+            # # Set the gnx of the @file nodes in the contents to root.gnx.
+            # # This is necessary because of a check in fast_at.scan_lines.
+            # pat = re.compile(r'^\s*#@\+node:([^:]+): \* @file leoNodes\.py$')
+            # line3 = g.splitLines(contents)[2]
+            # m = pat.match(line3)
+            # assert m, "Can not replace gnx"
+            # contents = contents.replace(m.group(1), root.gnx)
+            # # Replace c's outline with leoNodes.py.
+            # gnx2vnode = {}
+            # ok = c.atFileCommands.fast_read_into_root(c, contents, gnx2vnode, path, root)
+            # self.assertTrue(ok)
+            # root.h = 'leoNodes.py'
+            # self.p = root
+            # c.selectPosition(self.p)
+    #@+node:ekr.20220824193932.1: *3* test_c_to_python
+    def test_c_to_python(self):
+
+        c = self.c
+        x1 = ConvertCommandsClass(c)
+        x = x1.C_To_Python(c)
+        s = textwrap.dedent("""\
+        void hello_world()
+        {
+            print('hi')
+            if a == 2 {
+                print('2')
+            }
+        }
+        """)
+        lines = g.splitLines(s)
+        x.convertCodeList(lines)
+    #@-others
 #@-others
-
-
 #@-leo


### PR DESCRIPTION
See #2761.

- [x] Require full mypy annotations for leo.commands.convertCommands.
- [x] Change 's' to 'list' where the actual type of 's' was List[str].
    These misnamings were the source of my confusion (bad annotations).
- [x] mypy passes leo.commands.convertCommands.

**Resolution**

- leo/commands/convertCommands is now properly annotated.
- The changes in this PR consist *only* of added annotations, renamed vars, and one new unit test.
- There is still no guarantees (unit tests) that show the code works properly!