### PR TITLE
PR: fix mypy annotations in leoserver.py

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -24,7 +24,7 @@ import sys
 import socket
 import textwrap
 import time
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Set, Tuple, Union, Iterator, Match
+from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
 # Third-party.
 try:
@@ -57,6 +57,15 @@ Param = Dict[str, Any]
 RegexFlag = Union[int, re.RegexFlag]  # re.RegexFlag does not define 0
 Response = str  # See _make_response.
 Socket = Any
+
+# typing.Match is deprecated, so we may as well not use it.
+# EKR always runs mypy with python 3.10+, so falling back to Any makes no real difference.
+try:
+    Match = re.Match
+    Match_Iter = Iterator[Match[str]]
+except AttributeError:
+    Match = Any  # Python < 3.9
+    Match_Iter = Any
 #@-<< leoserver annotations >>
 #@+<< leoserver version >>
 #@+node:ekr.20220820160619.1: ** << leoserver version >>
@@ -485,12 +494,12 @@ class QuickSearchController:
             hm = [match for match in hm if match[0].key() not in bm_keys]
             if self.showParents:
                 # Was: parents = OrderedDefaultDict(list)
-                parents: Dict[str, List[Tuple[Position, Optional[Iterator[Match[str]]]]]] = {}
+                parents: Dict[str, List[Tuple[Position, Optional[Match_Iter]]]] = {}
 
                 for nodeList in [hm, bm]:
                     for node in nodeList:
                         key = 'Root' if node[0].level() == 0 else node[0].parent().gnx
-                        aList: List[Tuple[Position, Optional[Iterator[Match[str]]]]] = parents.get(key, [])
+                        aList: List[Tuple[Position, Optional[Match_Iter]]] = parents.get(key, [])
                         aList.append(node)
                         parents[key] = aList
                 lineMatchHits = self.addParentMatches(parents)
@@ -511,7 +520,7 @@ class QuickSearchController:
         self._search_patterns = ([pat] + self._search_patterns)[:30]
 
     #@+node:felix.20220225003906.5: *5* QSC.addBodyMatches
-    def addBodyMatches(self, positions: List[Tuple[Position, Optional[Iterator[Match[str]]]]]) -> int:
+    def addBodyMatches(self, positions: List[Tuple[Position, Optional[Match_Iter]]]) -> int:
         lineMatchHits = 0
         for p in positions:
             it = {"type": "headline", "label": p[0].h}
@@ -552,7 +561,7 @@ class QuickSearchController:
     def qsc_sort_by_gnx(self) -> None:
         """Return positions by gnx."""
         c = self.c
-        timeline: List[Tuple[Position, Optional[Iterator[Match[str]]]]] = [
+        timeline: List[Tuple[Position, Optional[Match_Iter]]] = [
             (p.copy(), None) for p in c.all_unique_positions()
         ]
         timeline.sort(key=lambda x: x[0].gnx, reverse=True)
@@ -560,7 +569,7 @@ class QuickSearchController:
         self.addHeadlineMatches(timeline)
     #@+node:felix.20220225003906.15: *4* QSC.qsc_background_search
     def qsc_background_search(self, pat: str) -> Tuple[
-        List[Tuple[Position, Optional[Iterator[Match[str]]]]],
+        List[Tuple[Position, Optional[Match_Iter]]],
         List[Position]
     ]:
 
@@ -588,7 +597,7 @@ class QuickSearchController:
     #@+node:felix.20220225003906.13: *4* QSC.qsc_find_changed
     def qsc_find_changed(self) -> None:
         c = self.c
-        changed: List[Tuple[Position, Optional[Iterator[Match[str]]]]] = [
+        changed: List[Tuple[Position, Optional[Match_Iter]]] = [
             (p.copy(), None) for p in c.all_unique_positions() if p.isDirty()
         ]
         self.clear()
@@ -628,7 +637,7 @@ class QuickSearchController:
         return it
 
     #@+node:felix.20220313185430.1: *5* QSC.find_tag
-    def find_tag(self, pat: str) -> List[Tuple[Position, Optional[Iterator[Match[str]]]]]:
+    def find_tag(self, pat: str) -> List[Tuple[Position, Optional[Match_Iter]]]:
         """
         Return list of all positions that have matching tags
         """
@@ -669,7 +678,7 @@ class QuickSearchController:
             elif op == '^':
                 resultset ^= nodes
 
-        aList: List[Tuple[Position, Optional[Iterator[Match[str]]]]] = []
+        aList: List[Tuple[Position, Optional[Match_Iter]]] = []
         for gnx in resultset:
             n = gnxDict.get(gnx)
             if n is not None:
@@ -678,7 +687,7 @@ class QuickSearchController:
         return aList
     #@+node:felix.20220225003906.10: *4* QSC.qsc_get_history
     def qsc_get_history(self) -> None:
-        headlines: List[Tuple[Position, Optional[Iterator[Match[str]]]]] = [
+        headlines: List[Tuple[Position, Optional[Match_Iter]]] = [
             (po[0].copy(), None) for po in self.c.nodeHistory.beadList
         ]
         headlines.reverse()
@@ -694,7 +703,7 @@ class QuickSearchController:
     #@+node:ekr.20220818083228.1: *3* QSC: helpers
     #@+node:felix.20220225003906.8: *4* QSC.addHeadlineMatches
     def addHeadlineMatches(self,
-        position_list: List[Tuple[Position, Optional[Iterator[Match[str]]]]]
+        position_list: List[Tuple[Position, Optional[Match_Iter]]]
     ) -> None:
         for p in position_list:
             it = {"type": "headline", "label": p[0].h}
@@ -707,7 +716,7 @@ class QuickSearchController:
         return len(self.its) > 999  # Limit to 999 for now
     #@+node:felix.20220225003906.6: *4* QSC.addParentMatches
     def addParentMatches(self,
-        parent_list: Dict[str, List[Tuple[Position, Optional[Iterator[Match[str]]]]]],
+        parent_list: Dict[str, List[Tuple[Position, Optional[Match_Iter]]]],
     ) -> int:
         lineMatchHits = 0
         for parent_key, parent_value in parent_list.items():
@@ -743,7 +752,7 @@ class QuickSearchController:
         regex: str,
         positions: List[Position],
         flags: RegexFlag=re.IGNORECASE | re.MULTILINE,
-    ) -> List[Tuple[Position, Optional[Iterator[Match[str]]]]]:
+    ) -> List[Tuple[Position, Optional[Match_Iter]]]:
         """
         Return list of all tuple (Position, matchiter/None) whose body matches regex one or more times.
         """
@@ -751,7 +760,7 @@ class QuickSearchController:
             pat = re.compile(regex, flags)
         except Exception:
             return []
-        aList: List[Tuple[Position, Optional[Iterator[Match[str]]]]] = []
+        aList: List[Tuple[Position, Optional[Match_Iter]]] = []
 
         for p in positions:
             m = re.finditer(pat, p.b)
@@ -769,7 +778,7 @@ class QuickSearchController:
         regex: str,
         positions: List[Position],
         flags: RegexFlag=re.IGNORECASE,
-    ) -> List[Tuple[Position, Optional[Iterator[Match[str]]]]]:
+    ) -> List[Tuple[Position, Optional[Match_Iter]]]:
         """
         Return the list of all tuple (Position, matchiter/None) whose headline matches the given pattern.
         """
@@ -779,7 +788,7 @@ class QuickSearchController:
             return []
         return [(p.copy(), None) for p in positions if re.match(pat, p.h)]
     #@+node:felix.20220225224130.1: *4* QSC.matchlines
-    def matchlines(self, b: str, miter: Iterator[Match[str]]) -> List[Tuple[str, Tuple[int, int]]]:
+    def matchlines(self, b: str, miter: Match_Iter) -> List[Tuple[str, Tuple[int, int]]]:
         aList = []
         for m in miter:
             st, en = g.getLine(b, m.start())


### PR DESCRIPTION
This PR allows leoserver.py (and the corresponding unit tests) to work with Python 3.6

*Note*: Just assigning `Match = Any` doesn't work.