### PR TITLE
PR: Second try to define Match and Match_Iter annotations

### DIFF
--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -8,6 +8,7 @@
 import re
 import time
 from typing import Any, Callable, Dict, List, Tuple, TYPE_CHECKING
+from typing import Match  # Deprecated, but we'll deal with this later.
 from leo.core import leoGlobals as g
 from leo.core import leoBeautify
 from leo.commands.baseCommands import BaseEditCommandsClass
@@ -21,10 +22,6 @@ else:
     Cmdr = Any
     Position = Any
 Event = Any
-try:
-    Match = re.Match
-except AttributeError:
-    Match = Any  # Python 3.6
 #@-<< convertCommands annotations >>
 
 def cmd(name: Any) -> Callable:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -25,6 +25,7 @@ import socket
 import textwrap
 import time
 from typing import Any, Callable, Dict, Generator, Iterable, Iterator, List, Optional, Set, Tuple, Union
+from typing import Match  # Deprecated, but we'll deal with this later.
 
 # Third-party.
 try:
@@ -58,14 +59,8 @@ RegexFlag = Union[int, re.RegexFlag]  # re.RegexFlag does not define 0
 Response = str  # See _make_response.
 Socket = Any
 
-# typing.Match is deprecated, so we may as well not use it.
-# EKR always runs mypy with python 3.10+, so falling back to Any makes no real difference.
-try:
-    Match = re.Match
-    Match_Iter = Iterator[Match[str]]
-except AttributeError:
-    Match = Any  # Python < 3.9
-    Match_Iter = Any
+# typing.Match is deprecated, but it's tricky to do without it at present.
+Match_Iter = Iterator[Match[str]]
 #@-<< leoserver annotations >>
 #@+<< leoserver version >>
 #@+node:ekr.20220820160619.1: ** << leoserver version >>


### PR DESCRIPTION
This is tricky to get right for both Python 3.6 and Python 3.10.

For now, Leo will use typing.Match even though it is deprecated.