### PR TITLE
PR for #2791: Improve annotations

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -19,12 +19,13 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Position = Any
     Event = Any
+    Wrapper = Any
 Stroke = Any
-Wrapper = Any
 #@-<< abbrevCommands annotations >>
 
 def cmd(name: Any) -> Callable:

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -28,7 +28,7 @@ else:
 Stroke = Any
 #@-<< abbrevCommands annotations >>
 
-def cmd(name: Any) -> Callable:
+def cmd(name: str) -> Callable:
     """Command decorator for the abbrevCommands class."""
     return g.new_cmd_decorator(name, ['c', 'abbrevCommands',])
 

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -17,12 +17,12 @@ from leo.commands.baseCommands import BaseEditCommandsClass
 #@+node:ekr.20220826065314.1: ** << abbrevCommands annotations >>
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
 else:
     Cmdr = Any
     Position = Any
-
-Event = Any
+    Event = Any
 Stroke = Any
 Wrapper = Any
 #@-<< abbrevCommands annotations >>

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -11,10 +11,10 @@ from leo.core import leoGlobals as g
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
+    ### from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
-
 Wrapper = Any
 #@-<< baseCommands imports and annotations >>
 

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -3,21 +3,20 @@
 #@+node:ekr.20150514035943.1: * @file ../commands/baseCommands.py
 #@@first
 """The base class for all of Leo's user commands."""
-#@+<< baseCommands imports and annotations >>
-#@+node:ekr.20220828071357.1: ** << baseCommands imports and annotations >>
 from typing import Any, Tuple, TYPE_CHECKING
 from leo.core import leoGlobals as g
-
+#@+<< baseCommands annotations >>
+#@+node:ekr.20220828071357.1: ** << baseCommands annotations >>
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
-    ### from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
-Wrapper = Any
-#@-<< baseCommands imports and annotations >>
-
+    Wrapper = Any
+Widget = Any
+#@-<< baseCommands annotations >>
 #@+others
 #@+node:ekr.20160514095639.1: ** class BaseEditCommandsClass
 class BaseEditCommandsClass:
@@ -79,7 +78,7 @@ class BaseEditCommandsClass:
             else:
                 k.resetLabel()
     #@+node:ekr.20150514043714.7: *3* BaseEdit.editWidget
-    def editWidget(self, event: Event, forceFocus: bool=True) -> Wrapper:
+    def editWidget(self, event: Event, forceFocus: bool=True) -> Widget:
         """Return the edit widget for the event. Also sets self.w"""
         c = self.c
         w = event and event.widget

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -275,7 +275,7 @@ def pasteAsTemplate(self: Self, event: Event=None) -> None:
             return gnx
         return g.app.nodeIndices.computeNewIndex()
     #@+node:vitalije.20200529115141.1: *4* viter
-    def viter(parent_gnx: str, xv: Any) -> Generator:  ###
+    def viter(parent_gnx: str, xv: Any) -> Generator:
         """
         iterates <v> nodes generating tuples:
 

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -25,7 +25,7 @@ else:
 Match = re.Match
 #@-<< convertCommands annotations >>
 
-def cmd(name: Any) -> Callable:
+def cmd(name: str) -> Callable:
     """Command decorator for the ConvertCommandsClass class."""
     return g.new_cmd_decorator(name, ['c', 'convertCommands',])
 

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -15,12 +15,13 @@ from leo.commands.baseCommands import BaseEditCommandsClass
 #@+<< convertCommands annotations >>
 #@+node:ekr.20220824202941.1: ** << convertCommands annotations >>
 if TYPE_CHECKING:
-    from leo.core.leoNodes import Position
     from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.core.leoNodes import Position
 else:
     Cmdr = Any
+    Event = Any
     Position = Any
-Event = Any
 Match = re.Match
 #@-<< convertCommands annotations >>
 

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -17,12 +17,13 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     VNode = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< editCommands annotations >>
 
 def cmd(name: str) -> Callable:

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -15,11 +15,12 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< killBufferCommands annotations >>
 
 def cmd(name: str) -> Callable:

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -14,12 +14,9 @@ from leo.commands.baseCommands import BaseEditCommandsClass
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
-    # from leo.core.leoNodes import Position, VNode
 else:
     Cmdr = Any
     Event = Any
-    # Position = Any
-    # VNode = Any
 #@-<< rectangleCommands annotations >>
 
 def cmd(name: str) -> Callable:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -34,8 +34,6 @@ else:
     Event = Any
     Position = Any
     VNode = Any
-
-# Make *sure* all these are Any.
 Widget = Any
 Wrapper = Any
 #@-<< leoApp annotations >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -29,13 +29,14 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     VNode = Any
+    Wrapper = Any
 Widget = Any
-Wrapper = Any
 #@-<< leoApp annotations >>
 #@+others
 #@+node:ekr.20150509193629.1: ** cmd (decorator)

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -16,11 +16,12 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< leoChapters annotations >>
 #@+others
 #@+node:ekr.20150509030349.1: ** cc.cmd (decorator)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from leo.commands.spellCommands import SpellCommandsClass
     # Other objects...
     from leo.plugins.qt_gui import StyleSheetManager
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Event = Any
     Position = Any
@@ -89,12 +90,12 @@ else:
     SpellCommandsClass = Any
     # Special cases...
     StyleSheetManager = Any
+    Wrapper = Any
 
 RegexFlag = Union[int, re.RegexFlag]  # re.RegexFlag does not define 0
 
 # These gui classes are hard to specify...
 Widget = Any
-Wrapper = Any
 #@-<< leoCommands annotations >>
 
 def cmd(name: str) -> Callable:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -33,6 +33,7 @@ else:
     VNode = Any
     Wrapper = Any
 Settings = g.Bunch
+UndoData = g.Bunch
 #@-<< leoFind annotations >>
 #@+<< Theory of operation of find/change >>
 #@+node:ekr.20031218072017.2414: ** << Theory of operation of find/change >>
@@ -105,7 +106,7 @@ class LeoFind:
         self.expert_mode = False  # Set in finishCreate.
         self.ftm: FindTabManager = None  # Created by dw.createFindTab.
         self.k: KeyHandler = c.k
-        self.re_obj: Any = None
+        self.re_obj: re.Pattern = None
         #
         # The work "widget".
         self.work_s = ''  # p.b or p.c.
@@ -148,9 +149,9 @@ class LeoFind:
         # Internal state...
         self.changeAllFlag = False
         self.findAllUniqueFlag = False
-        self.find_def_data: Any = None  # A g.Bunch.
+        self.find_def_data: g.Bunch = None
         self.in_headline = False
-        self.match_obj: Any = None
+        self.match_obj: re.Match = None
         self.reverse = False
         self.root: Position = None  # The start of the search, especially for suboutline-only.
         self.unique_matches: Set = set()
@@ -1683,7 +1684,7 @@ class LeoFind:
     #@+node:ekr.20160422073500.1: *6* find._find_all_helper
     def _find_all_helper(self,
         after: Optional[Position],
-        data: Any,
+        data: UndoData,
         p: Position,
         undoType: str,
     ) -> int:
@@ -2508,7 +2509,7 @@ class LeoFind:
 
         # g.printObj(list(groups), tag=f"groups in {change_text!r}")
 
-        def repl(match_object: Any) -> str:
+        def repl(match_object: re.Match) -> str:
             """re.sub calls this function once per group."""
             # # 1494...
             n = int(match_object.group(1)) - 1
@@ -2606,7 +2607,7 @@ class LeoFind:
             val = w_name.startswith('head')  # pragma: no cover
         return val
     #@+node:ekr.20031218072017.3089: *4* find.restore
-    def restore(self, data: Any) -> None:
+    def restore(self, data: UndoData) -> None:
         """
         Restore Leo's gui and settings from data, a g.Bunch.
         """
@@ -2626,7 +2627,7 @@ class LeoFind:
             w.seeInsertPoint()
             c.widgetWantsFocus(w)
     #@+node:ekr.20031218072017.3090: *4* find.save
-    def save(self) -> Any:
+    def save(self) -> UndoData:
         """Save everything needed to restore after a search fails."""
         c = self.c
         if self.in_headline:  # pragma: no cover

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -17,17 +17,18 @@ from leo.core import leoGlobals as g
 #@+node:ekr.20220415005920.1: ** << leoFind annotations >>
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoGlobals import KeyStroke as Stroke
     from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.core.leoGlobals import KeyStroke as Stroke
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     Stroke = Any
     VNode = Any
+    Wrapper = Any
 Settings = g.Bunch
-Wrapper = Any
 #@-<< leoFind annotations >>
 #@+<< Theory of operation of find/change >>
 #@+node:ekr.20031218072017.2414: ** << Theory of operation of find/change >>
@@ -99,7 +100,6 @@ class LeoFind:
         self.c = c
         self.expert_mode = False  # Set in finishCreate.
         self.ftm: Any = None  # Created by dw.createFindTab.
-        self.frame: Wrapper = None
         self.k: Any = c.k
         self.re_obj: Any = None
         #

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -32,6 +32,7 @@ else:
     Stroke = Any
     VNode = Any
     Wrapper = Any
+MatchGroups = Tuple  # Best we can do so far.
 Settings = g.Bunch
 UndoData = g.Bunch
 #@-<< leoFind annotations >>
@@ -2500,7 +2501,7 @@ class LeoFind:
         self.match_obj = None
         return -1, -1
     #@+node:ekr.20210110073117.48: *4* find.make_regex_subs
-    def make_regex_subs(self, change_text: str, groups: Any) -> str:
+    def make_regex_subs(self, change_text: str, groups: MatchGroups) -> str:
         """
         Substitute group[i-1] for \\i strings in change_text.
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -27,6 +27,7 @@ else:
     Cmdr = Any
     Event = Any
     FindTabManager = Any
+    KeyHandler = Any
     Position = Any
     Stroke = Any
     VNode = Any

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -18,12 +18,15 @@ from leo.core import leoGlobals as g
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.plugins.qt_frame import FindTabManager
+    from leo.core.leoKeys import KeyHandlerClass as KeyHandler
     from leo.core.leoGlobals import KeyStroke as Stroke
     from leo.core.leoNodes import Position, VNode
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
+    FindTabManager = Any
     Position = Any
     Stroke = Any
     VNode = Any
@@ -99,8 +102,8 @@ class LeoFind:
         """Ctor for LeoFind class."""
         self.c = c
         self.expert_mode = False  # Set in finishCreate.
-        self.ftm: Any = None  # Created by dw.createFindTab.
-        self.k: Any = c.k
+        self.ftm: FindTabManager = None  # Created by dw.createFindTab.
+        self.k: KeyHandler = c.k
         self.re_obj: Any = None
         #
         # The work "widget".

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -26,7 +26,7 @@ else:
     Position = Any
     Stroke = Any
     VNode = Any
-Settings = Any
+Settings = g.Bunch
 Wrapper = Any
 #@-<< leoFind annotations >>
 #@+<< Theory of operation of find/change >>
@@ -262,7 +262,8 @@ class LeoFind:
         """
         #@-<< docstring: find.batch_change >>
         try:
-            self._init_from_dict(settings or {})
+            # self._init_from_dict(settings or {})
+            self._init_from_dict(settings or g.Bunch())
             count = 0
             for find, change in replacements:
                 count += self._batch_change_helper(root, find, change)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -15,17 +15,18 @@ from leo.core import leoGlobals as g
 #@-<< leoFind imports >>
 #@+<< leoFind annotations >>
 #@+node:ekr.20220415005920.1: ** << leoFind annotations >>
-if TYPE_CHECKING:  # Always False at runtime.
-    from leo.core.leoCommands import Commands as Cmdr  # pragma: no cover
-    from leo.core.leoGui import LeoKeyEvent as Event  # pragma: no cover
-    from leo.core.leoNodes import Position, VNode  # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoGlobals import KeyStroke as Stroke
+    from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.core.leoNodes import Position, VNode
 else:
     Cmdr = Any
     Event = Any
     Position = Any
+    Stroke = Any
     VNode = Any
 Settings = Any
-Stroke = Any
 Wrapper = Any
 #@-<< leoFind annotations >>
 #@+<< Theory of operation of find/change >>
@@ -121,7 +122,7 @@ class LeoFind:
         #
         # For isearch commands...
         self.stack: List[Tuple[Position, int, int, bool]] = []
-        self.inverseBindingDict: Dict[str, List[Tuple[str, str]]] = {}
+        self.inverseBindingDict: Dict[str, List[Tuple[str, Stroke]]] = {}
         self.isearch_ignore_case: bool = False
         self.isearch_forward_flag: bool = False
         self.isearch_regexp: bool = False
@@ -2881,7 +2882,7 @@ class LeoFind:
         if len(self.stack) <= 1:
             self.abort_search()
     #@+node:ekr.20131117164142.16952: *5* find.get_strokes
-    def get_strokes(self, commandName: str) -> List[str]:  # pragma: no cover (cmd)
+    def get_strokes(self, commandName: str) -> List[Stroke]:  # pragma: no cover (cmd)
         aList = self.inverseBindingDict.get(commandName, [])
         return [key for pane, key in aList]
     #@+node:ekr.20131117164142.16953: *5* find.push & pop

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1815,7 +1815,7 @@ class NullBody(LeoBody):
     def assignPositionToEditor(self, p: Position) -> None:
         pass
 
-    def createEditorFrame(self, w: Wrapper) -> Wrapper:
+    def createEditorFrame(self, w: Widget) -> Widget:
         return None
 
     def cycleEditorFocus(self, event: Event=None) -> None:
@@ -1824,16 +1824,16 @@ class NullBody(LeoBody):
     def deleteEditor(self, event: Event=None) -> None:
         pass
 
-    def selectEditor(self, w: Wrapper) -> None:
+    def selectEditor(self, w: Widget) -> None:
         pass
 
-    def selectLabel(self, w: Wrapper) -> None:
+    def selectLabel(self, w: Widget) -> None:
         pass
 
     def setEditorColors(self, bg: str, fg: str) -> None:
         pass
 
-    def unselectLabel(self, w: Wrapper) -> None:
+    def unselectLabel(self, w: Widget) -> None:
         pass
 
     def updateEditors(self) -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -26,14 +26,15 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     VNode = Any
+    Wrapper = Any
 Index = Union[int, str]  # A zero-based index or a Tk index.
 Widget = Any
-Wrapper = Any
 #@-<< leoFrame annotations >>
 #@+<< leoFrame: about handling events >>
 #@+node:ekr.20031218072017.2410: ** << leoFrame: about handling events >>
@@ -352,9 +353,11 @@ class LeoBody:
 
     def createEditorFrame(self, w: Wrapper) -> Wrapper:
         self.oops()
+        return None
 
     def createTextWidget(self, parentFrame: Widget, p: Position, name: str) -> Wrapper:
         self.oops()
+        return None
 
     def packEditorLabelWidget(self, w: Wrapper) -> None:
         self.oops()
@@ -507,7 +510,7 @@ class LeoBody:
         finally:
             self.selectEditorLockout = False
     #@+node:ekr.20070423102603: *6* LeoBody.selectEditorHelper
-    def selectEditorHelper(self, wrapper: str) -> None:
+    def selectEditorHelper(self, wrapper: Wrapper) -> None:
         """Select the editor whose widget is given."""
         c = self.c
         if not (hasattr(wrapper, 'leo_p') and wrapper.leo_p):
@@ -783,7 +786,7 @@ class LeoFrame:
     def initCompleteHint(self) -> None:
         pass
     #@+node:ekr.20031218072017.3687: *4* LeoFrame.setTabWidth
-    def setTabWidth(self, w: Wrapper) -> None:
+    def setTabWidth(self, w: int) -> None:
         """Set the tab width in effect for this frame."""
         # Subclasses may override this to affect drawing.
         self.tab_width = w
@@ -1590,11 +1593,13 @@ class LeoTree:
 
     # Headlines.
 
-    def editLabel(self, p: Position, selectAll: bool=False, selection: Any=None) -> Wrapper:
+    def editLabel(self, p: Position, selectAll: bool=False, selection: Any=None) -> Tuple[Any, Any]:  ###
         self.oops()
+        return None, None
 
     def edit_widget(self, p: Position) -> Wrapper:
         self.oops()
+        return None
     #@+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
     tree_select_lockout = False
 
@@ -1765,6 +1770,7 @@ class LeoTreeTab:
     #@+node:ekr.20070317073755: *3* Must be defined in subclasses
     def createControl(self) -> Wrapper:
         self.oops()
+        return None
 
     def createTab(self, tabName: str, createText: bool=True, widget: Widget=None, select: bool=True) -> None:
         self.oops()
@@ -1793,7 +1799,7 @@ class NullBody(LeoBody):
         self.selection = 0, 0
         self.s = ""  # The body text
         self.widget: Widget = None
-        self.wrapper: Wrapper = StringTextWrapper(c=self.c, name='body')
+        self.wrapper: Any = StringTextWrapper(c=self.c, name='body')
         self.editorWrappers['1'] = self.wrapper
         self.colorizer: Any = NullColorizer(self.c)
     #@+node:ekr.20031218072017.2197: *3* NullBody: LeoBody interface
@@ -1862,19 +1868,19 @@ class NullFrame(LeoFrame):
         super().__init__(c, gui)
         assert self.c
         self.wrapper: Wrapper = None
-        self.iconBar: Wrapper = NullIconBarClass(self.c, self)
+        self.iconBar: Widget = NullIconBarClass(self.c, self)
         self.initComplete = True
         self.isNullFrame = True
         self.outerFrame: Wrapper = None
         self.ratio = self.secondary_ratio = 0.5
         self.statusLineClass: Any = NullStatusLineClass
         self.title = title
-        self.top = None  # Always None.
+        self.top: Any = None  # Always None.
         # Create the component objects.
-        self.body: Wrapper = NullBody(frame=self, parentFrame=None)
-        self.log: Wrapper = NullLog(frame=self, parentFrame=None)
-        self.menu: Wrapper = leoMenu.NullMenu(frame=self)
-        self.tree: Wrapper = NullTree(frame=self)
+        self.body: Any = NullBody(frame=self, parentFrame=None)
+        self.log: Any = NullLog(frame=self, parentFrame=None)
+        self.menu: Any = leoMenu.NullMenu(frame=self)
+        self.tree: Any = NullTree(frame=self)
         # Default window position.
         self.w = 600
         self.h = 500
@@ -2100,14 +2106,13 @@ class NullLog(LeoLog):
     def finishCreate(self) -> None:
         pass
     #@+node:ekr.20041012083237.1: *4* NullLog.createControl
-    def createControl(self, parentFrame: Widget) -> Wrapper:
+    def createControl(self, parentFrame: Widget) -> "StringTextWrapper":
         return self.createTextWidget(parentFrame)
     #@+node:ekr.20070302095121: *4* NullLog.createTextWidget
-    def createTextWidget(self, parentFrame: Widget) -> Wrapper:
+    def createTextWidget(self, parentFrame: Widget) -> "StringTextWrapper":
         self.logNumber += 1
         c = self.c
-        log = StringTextWrapper(c=c, name=f"log-{self.logNumber}")
-        return log
+        return StringTextWrapper(c=c, name=f"log-{self.logNumber}")
     #@+node:ekr.20181119135041.1: *3* NullLog.hasSelection
     def hasSelection(self) -> None:
         return self.widget.hasSelection()
@@ -2168,7 +2173,7 @@ class NullStatusLineClass:
         self.c = c
         self.enabled = False
         self.parentFrame = parentFrame
-        self.textWidget: Wrapper = StringTextWrapper(c, name='status-line')
+        self.textWidget: Any = StringTextWrapper(c, name='status-line')
         # Set the official ivars.
         c.frame.statusFrame = None
         c.frame.statusLabel = None
@@ -2231,7 +2236,7 @@ class NullTree(LeoTree):
             w.setAllText(p.h)
         return w
     #@+node:ekr.20070228164730: *3* NullTree.editLabel
-    def editLabel(self, p: Position, selectAll: bool=False, selection: Any=None) -> Tuple[Any, Wrapper]:
+    def editLabel(self, p: Position, selectAll: bool=False, selection: Any=None) -> Tuple[Any, Any]:
         """Start editing p's headline."""
         self.endEditLabel()
         if p:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -12,7 +12,7 @@ These classes should be overridden to create frames for a particular gui.
 #@+node:ekr.20120219194520.10464: ** << leoFrame imports >>
 import os
 import string
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Union
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColorizer  # NullColorizer is a subclass of ColorizerMixin
@@ -31,7 +31,7 @@ else:
     Event = Any
     Position = Any
     VNode = Any
-Index = Any  # For now, really Union[int, str], but that creates type-checking problems.
+Index = Union[int, str]  # A zero-based index or a Tk index.
 Widget = Any
 Wrapper = Any
 #@-<< leoFrame annotations >>

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -353,11 +353,11 @@ class LeoBody:
 
     def createEditorFrame(self, w: Wrapper) -> Wrapper:
         self.oops()
-        return None
+        return None  # pylint: disable=useless-return
 
     def createTextWidget(self, parentFrame: Widget, p: Position, name: str) -> Wrapper:
         self.oops()
-        return None
+        return None  # pylint: disable=useless-return
 
     def packEditorLabelWidget(self, w: Wrapper) -> None:
         self.oops()
@@ -1593,13 +1593,13 @@ class LeoTree:
 
     # Headlines.
 
-    def editLabel(self, p: Position, selectAll: bool=False, selection: Any=None) -> Tuple[Any, Any]:  ###
+    def editLabel(self, p: Position, selectAll: bool=False, selection: Any=None) -> Tuple[Any, Any]:
         self.oops()
-        return None, None
+        return None, None  # pylint: disable=useless-return
 
     def edit_widget(self, p: Position) -> Wrapper:
         self.oops()
-        return None
+        return None  # pylint: disable=useless-return
     #@+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
     tree_select_lockout = False
 
@@ -1770,7 +1770,7 @@ class LeoTreeTab:
     #@+node:ekr.20070317073755: *3* Must be defined in subclasses
     def createControl(self) -> Wrapper:
         self.oops()
-        return None
+        return None  # pylint: disable=useless-return
 
     def createTab(self, tabName: str, createText: bool=True, widget: Widget=None, select: bool=True) -> None:
         self.oops()

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -351,13 +351,13 @@ class LeoBody:
         """Say that a required method in a subclass is missing."""
         g.trace("(LeoBody) %s should be overridden in a subclass", g.callers())
 
-    def createEditorFrame(self, w: Wrapper) -> Wrapper:
+    def createEditorFrame(self, w: Wrapper) -> Wrapper:  # pylint: disable=useless-return
         self.oops()
-        return None  # pylint: disable=useless-return
+        return None
 
-    def createTextWidget(self, parentFrame: Widget, p: Position, name: str) -> Wrapper:
+    def createTextWidget(self, parentFrame: Widget, p: Position, name: str) -> Wrapper:  # pylint: disable=useless-return
         self.oops()
-        return None  # pylint: disable=useless-return
+        return None
 
     def packEditorLabelWidget(self, w: Wrapper) -> None:
         self.oops()
@@ -1597,9 +1597,9 @@ class LeoTree:
         self.oops()
         return None, None  # pylint: disable=useless-return
 
-    def edit_widget(self, p: Position) -> Wrapper:
+    def edit_widget(self, p: Position) -> Wrapper:  # pylint: disable=useless-return
         self.oops()
-        return None  # pylint: disable=useless-return
+        return None
     #@+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
     tree_select_lockout = False
 
@@ -1768,9 +1768,9 @@ class LeoTreeTab:
         self.nb: Any = None  # Created in createControl.
         self.parentFrame: Widget = parentFrame
     #@+node:ekr.20070317073755: *3* Must be defined in subclasses
-    def createControl(self) -> Wrapper:
+    def createControl(self) -> Wrapper:  # pylint: disable=useless-return
         self.oops()
-        return None  # pylint: disable=useless-return
+        return None
 
     def createTab(self, tabName: str, createText: bool=True, widget: Widget=None, select: bool=True) -> None:
         self.oops()

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1507,7 +1507,7 @@ class LeoTree:
         self.redrawCount = 0  # For traces
         self.use_chapters = False  # May be overridden in subclasses.
         # Define these here to keep pylint happy.
-        self.canvas = None
+        self.canvas: Any = None
     #@+node:ekr.20061109165848: *3* LeoTree.Must be defined in base class
     #@+node:ekr.20040803072955.126: *4* LeoTree.endEditLabel
     def endEditLabel(self) -> None:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2391,7 +2391,7 @@ class SettingsDict(dict):
         # The result is a g.SettingsDict.
         return copy.deepcopy(self)
     #@+node:ekr.20190904052828.1: *4* td.add_to_list
-    def add_to_list(self, key: Any, val: Any) -> None:
+    def add_to_list(self, key: str, val: Any) -> None:
         """Update the *list*, self.d [key]"""
         if key is None:
             g.trace('TypeDict: None is not a valid key', g.callers())

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -23,13 +23,13 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event  # pylint: disable=import-self
     from leo.core.leoNodes import Position
-    # from leo.core.leoQt import QtWidgets
+    # from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Widget = Any
 Wrapper = Any
+Widget = Any
 #@-<< leoGui annotations >>
 #@+others
 #@+node:ekr.20031218072017.3720: ** class LeoGui

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -23,12 +23,12 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event  # pylint: disable=import-self
     from leo.core.leoNodes import Position
-    # from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Wrapper = Any
+    Wrapper = Any
 Widget = Any
 #@-<< leoGui annotations >>
 #@+others
@@ -48,7 +48,7 @@ class LeoGui:
         self.globalFindTab: Widget = None
         self.idleTimeClass = None
         self.isNullGui = False
-        self.lastFrame: Wrapper = None
+        self.lastFrame: Any = None
         self.leoIcon = None
         self.mGuiName = guiName
         self.mainLoop = None
@@ -298,7 +298,7 @@ class LeoGui:
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         pass
     #@+node:ekr.20051206103652: *4* LeoGui.widget_name (LeoGui)
-    def widget_name(self, w: Wrapper) -> str:
+    def widget_name(self, w: Widget) -> str:
         # First try the widget's getName method.
         if not 'w':
             return '<no widget>'
@@ -319,7 +319,7 @@ class LeoKeyEvent:
         char: str,
         event: Event,
         binding: Any,
-        w: Wrapper,
+        w: Any,
         x: int=None,
         y: int=None,
         x_root: int=None,
@@ -377,7 +377,7 @@ class NullGui(LeoGui):
         self.clipboardContents = ''
         self.focusWidget: Widget = None
         self.script = None
-        self.lastFrame: Wrapper = None  # The outer frame, to set g.app.log in runMainLoop.
+        self.lastFrame: Any = None  # The outer frame, to set g.app.log in runMainLoop.
         self.isNullGui = True
         self.idleTimeClass: Any = g.NullObject
     #@+node:ekr.20031218072017.3744: *3* NullGui.dialogs
@@ -500,13 +500,13 @@ class NullGui(LeoGui):
     def onDeactivateEvent(self, *args: str, **keys: str) -> None:
         pass
 
-    def set_top_geometry(self, w: Wrapper, h: str, x: str, y: str) -> None:
+    def set_top_geometry(self, w: Widget, h: str, x: str, y: str) -> None:
         pass
     #@+node:ekr.20070228155807: *3* NullGui.isTextWidget & isTextWrapper
-    def isTextWidget(self, w: Wrapper) -> bool:
+    def isTextWidget(self, w: Any) -> bool:
         return True  # Must be True for unit tests.
 
-    def isTextWrapper(self, w: Wrapper) -> bool:
+    def isTextWrapper(self, w: Any) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and getattr(w, 'supportsHighLevelInterface', None)
     #@+node:ekr.20031218072017.2230: *3* NullGui.oops

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -109,7 +109,7 @@ class FreeMindImporter:
         else:
             g.error(f"file not found: {sfn}")
     #@+node:ekr.20160503145113.1: *3* freemind.import_files
-    def import_files(self, files: Any) -> None:
+    def import_files(self, files: List[str]) -> None:
         """Import a list of FreeMind (.mmap) files."""
         c = self.c
         if files:
@@ -158,7 +158,7 @@ class JSON_Import_Helper:
 
     #@+others
     #@+node:ekr.20160504144353.1: *3* json.create_nodes (generalize)
-    def create_nodes(self, parent: Any, parent_d: Dict[str, str]) -> None:
+    def create_nodes(self, parent: Position, parent_d: Dict[str, str]) -> None:
         """Create the tree of nodes rooted in parent."""
         d = self.gnx_dict
         for child_gnx in parent_d.get('children'):
@@ -195,7 +195,7 @@ class JSON_Import_Helper:
         c.undoer.afterInsertNode(p, 'Import', undoData)
         return p
     #@+node:ekr.20160504144314.1: *3* json.scan (generalize)
-    def scan(self, s: str, parent: Any) -> bool:
+    def scan(self, s: str, parent: Position) -> bool:
         """Create an outline from a MindMap (.csv) file."""
         c, d, self.gnx_dict = self.c, json.loads(s), {}
         for d2 in d.get('nodes', []):
@@ -491,7 +491,7 @@ class LeoImportCommands:
                 theFile.write(s)
         theFile.close()
     #@+node:ekr.20031218072017.1148: *4* ic.outlineToWeb
-    def outlineToWeb(self, fileName: str, webType: Any) -> None:
+    def outlineToWeb(self, fileName: str, webType: str) -> None:
         c = self.c
         nl = self.output_newline
         current = c.p
@@ -636,7 +636,7 @@ class LeoImportCommands:
             g.print_exception()
     #@+node:ekr.20031218072017.3209: *3* ic.Import
     #@+node:ekr.20031218072017.3210: *4* ic.createOutline & helpers
-    def createOutline(self, parent: Any, ext: Any=None, s: str=None) -> Position:
+    def createOutline(self, parent: Position, ext: str=None, s: str=None) -> Position:
         """
         Create an outline by importing a file, reading the file with the
         given encoding if string s is None.
@@ -686,13 +686,13 @@ class LeoImportCommands:
         w.seeInsertPoint()
         return p
     #@+node:ekr.20140724064952.18038: *5* ic.dispatch & helpers
-    def dispatch(self, ext: Any, p: Position) -> Optional[Callable]:
+    def dispatch(self, ext: str, p: Position) -> Optional[Callable]:
         """Return the correct scanner function for p, an @auto node."""
         # Match the @auto type first, then the file extension.
         c = self.c
         return g.app.scanner_for_at_auto(c, p) or g.app.scanner_for_ext(c, ext)
     #@+node:ekr.20170405191106.1: *5* ic.import_binary_file
-    def import_binary_file(self, fileName: str, parent: Any) -> Position:
+    def import_binary_file(self, fileName: str, parent: Position) -> Position:
 
         # Fix bug 1185409 importing binary files puts binary content in body editor.
         # Create an @url node.
@@ -822,10 +822,10 @@ class LeoImportCommands:
     #@+node:ekr.20031218072017.3212: *4* ic.importFilesCommand
     def importFilesCommand(
         self,
-        files: Any=None,
-        parent: Any=None,
+        files: List[str]=None,
+        parent: Position=None,
         shortFn: bool=False,
-        treeType: Any=None,
+        treeType: str=None,
         verbose: bool=True,  # Legacy value.
     ) -> None:
         # Not a command.  It must *not* have an event arg.
@@ -1326,7 +1326,7 @@ class LeoImportCommands:
         s = s.rstrip()
         return s
     #@+node:ekr.20031218072017.1463: *4* ic.setEncoding
-    def setEncoding(self, p: Position=None, default: Any=None) -> None:
+    def setEncoding(self, p: Position=None, default: str=None) -> None:
         c = self.c
         encoding = g.getEncodingAt(p or c.p) or default
         if encoding and g.isValidEncoding(encoding):
@@ -1365,7 +1365,7 @@ class MindMapImporter:
         c.undoer.afterInsertNode(p, 'Import', undoData)
         return p
     #@+node:ekr.20160503144647.1: *3* mindmap.import_files
-    def import_files(self, files: Any) -> None:
+    def import_files(self, files: List[str]) -> None:
         """Import a list of MindMap (.csv) files."""
         c = self.c
         if files:
@@ -1657,12 +1657,12 @@ class RecursiveImportController:
         c: Cmdr,
         kind: str,
         add_context: bool=None,  # Override setting only if True/False
-        add_file_context: Any=None,  # Override setting only if True/False
+        add_file_context: bool=None,  # Override setting only if True/False
         add_path: bool=True,
         recursive: bool=True,
         safe_at_file: bool=True,
-        theTypes: Any=None,
-        ignore_pattern: Any=None,
+        theTypes: List[str]=None,
+        ignore_pattern: re.Pattern=None,
         verbose: bool=True,  # legacy value.
     ) -> None:
         """Ctor for RecursiveImportController class."""
@@ -2331,7 +2331,7 @@ class ZimImportController:
         rstNode.h = name
         return rstNode
     #@+node:davy.20141212140940.1: *3* zic.clean
-    def clean(self, zimNode: Position, rstType: Any) -> None:
+    def clean(self, zimNode: Position, rstType: str) -> None:
         """Clean useless nodes"""
         warning = 'Warning: this node is ignored when writing this file'
         for p in zimNode.subtree_iter():
@@ -2423,7 +2423,7 @@ class LegacyExternalFileImporter:
             self.level = level
             self.lines: List[str] = []
     #@+node:ekr.20200424092652.1: *3* legacy.add
-    def add(self, line: Any, stack: List[Any]) -> None:
+    def add(self, line: str, stack: List[Any]) -> None:
         """Add a line to the present node."""
         if stack:
             node = stack[-1]

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2051,7 +2051,7 @@ class TabImporter:
             parent.b = parent.b + self.undent(level, s)
         return level
     #@+node:ekr.20161006071801.7: *3* tabbed.undent
-    def undent(self, level: Any, s: str) -> str:
+    def undent(self, level: int, s: str) -> str:
         """Unindent all lines of p.b by level."""
         if level <= 0:
             return s
@@ -2092,7 +2092,7 @@ class ToDoImporter:
             g.es_exception()
             return []
     #@+node:ekr.20200310101028.1: *3* todo_i.import_files
-    def import_files(self, files: Any) -> Dict[str, List[Any]]:
+    def import_files(self, files: List[str]) -> Dict[str, List[Any]]:
         """
         Import all todo.txt files in the given list of file names.
 

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -31,12 +31,13 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     # from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Position = Any
+    Wrapper = Any
 Event = Any  # Several kinds of events?
 Stroke = Any
-Wrapper = Any
 #@-<< leoKeys annotations >>
 #@+<< Key bindings, an overview >>
 #@+node:ekr.20130920121326.11281: ** << Key bindings, an overview >>
@@ -1095,7 +1096,7 @@ class FileNameChooser:
         self.c = c
         self.k = c.k
         assert c and c.k
-        self.log: Wrapper = c.frame.log or g.NullObject()
+        self.log: Any = c.frame.log or g.NullObject()
         self.callback: Callable = None
         self.filterExt: List[str] = None
         self.prompt: str = None

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -15,13 +15,15 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
+    Wrapper = Any
+
 # mypy doesn't seem to handle this.
 Tag_List = Any  # Union[str, Sequence[str]]
-Wrapper = Any
 #@-<< leoPlugins annotations >>
 # Define modules that may be enabled by default
 # but that mignt not load because imports may fail.

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -56,12 +56,13 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     VNode = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< leoUndo annotations >>
 # pylint: disable=unpacking-non-sequence
 #@+others

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -63,13 +63,15 @@ else:
     Position = Any
     VNode = Any
     Wrapper = Any
+UndoData = g.Bunch
 #@-<< leoUndo annotations >>
 # pylint: disable=unpacking-non-sequence
-#@+others
-#@+node:ekr.20150509193222.1: ** u.cmd (decorator)
-def cmd(name: Any) -> Callable:
+
+def cmd(name: str) -> Callable:
     """Command decorator for the Undoer class."""
     return g.new_cmd_decorator(name, ['c', 'undoer',])
+
+#@+others
 #@+node:ekr.20031218072017.3605: ** class Undoer
 class Undoer:
     """A class that implements unlimited undo and redo."""
@@ -191,7 +193,7 @@ class Undoer:
             return self.dumpBead(n - 1)
         return '<no top bead>'
     #@+node:EKR.20040526150818: *4* u.getBead
-    def getBead(self, n: int) -> Any:
+    def getBead(self, n: int) -> UndoData:
         """Set Undoer ivars from the bunch at the top of the undo stack."""
         u = self
         if n < 0 or n >= len(u.beads):
@@ -202,7 +204,7 @@ class Undoer:
             print(f" u.getBead: {n:3} of {len(u.beads)}")
         return bunch
     #@+node:EKR.20040526150818.1: *4* u.peekBead
-    def peekBead(self, n: int) -> Any:
+    def peekBead(self, n: int) -> UndoData:
 
         u = self
         if n < 0 or n >= len(u.beads):
@@ -384,7 +386,7 @@ class Undoer:
             child = child.next()
         return treeInfo
     #@+node:ekr.20050415170737.1: *5* u.createVnodeUndoInfo
-    def createVnodeUndoInfo(self, v: VNode) -> Any:
+    def createVnodeUndoInfo(self, v: VNode) -> UndoData:
         """Create a bunch containing all info needed to recreate a VNode for undo."""
         bunch = g.Bunch(
             v=v,
@@ -634,7 +636,7 @@ class Undoer:
         bunch.newMarked = p.isMarked()
         u.pushBead(bunch)
     #@+node:ekr.20111005152227.15555: *5* u.afterDeleteMarkedNodes
-    def afterDeleteMarkedNodes(self, data: Any, p: Position) -> None:
+    def afterDeleteMarkedNodes(self, data: UndoData, p: Position) -> None:
         u = self
         if u.redoing or u.undoing:
             return
@@ -855,7 +857,7 @@ class Undoer:
         bunch.oldParent_v = p._parentVnode()
         return bunch
     #@+node:ekr.20080425060424.3: *5* u.beforeSort
-    def beforeSort(self, p: Position, undoType: Any, oldChildren: Any, newChildren: Any, sortChildren: Any) -> None:
+    def beforeSort(self, p: Position, undoType: str, oldChildren: Any, newChildren: Any, sortChildren: Any) -> None:
         """Create an undo node for sort operations."""
         u = self
         bunch = u.createCommonBunch(p)
@@ -908,9 +910,9 @@ class Undoer:
     def doTyping(
         self,
         p: Position,
-        undo_type: Any,
-        oldText: Any,
-        newText: Any,
+        undo_type: str,
+        oldText: str,
+        newText: str,
         newInsert: Any=None,
         oldSel: Any=None,
         newSel: Any=None,
@@ -1200,7 +1202,7 @@ class Undoer:
             frame.menu.enableMenu(menu, u.redoMenuLabel, u.canRedo())
             frame.menu.enableMenu(menu, u.undoMenuLabel, u.canUndo())
     #@+node:ekr.20110519074734.6094: *4* u.onSelect & helpers
-    def onSelect(self, old_p: Any, p: Position) -> None:
+    def onSelect(self, old_p: Position, p: Position) -> None:
 
         u = self
         if u.per_node_undo:
@@ -1972,7 +1974,7 @@ class Undoer:
         c.frame.body.recolor(p)
         w.seeInsertPoint()  # 2009/12/21
     #@+node:ekr.20050408100042: *4* u.undoRedoTree
-    def undoRedoTree(self, new_data: Any, old_data: Any) -> None:
+    def undoRedoTree(self, new_data: Any, old_data: Any) -> Position:
         """Replace p and its subtree using old_data during undo."""
         # Same as undoReplace except uses g.Bunch.
         c, p, u = self.c, self.c.p, self

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -209,7 +209,7 @@ class Undoer:
             return None
         return u.beads[n]
     #@+node:ekr.20060127113243: *4* u.pushBead
-    def pushBead(self, bunch: Any) -> None:
+    def pushBead(self, bunch: g.Bunch) -> None:
         u = self
         # New in 4.4b2:  Add this to the group if it is being accumulated.
         bunch2 = u.bead >= 0 and u.bead < len(u.beads) and u.beads[u.bead]
@@ -235,7 +235,7 @@ class Undoer:
             return name
         return "Undo " + name
     #@+node:ekr.20060127070008: *4* u.setIvarsFromBunch
-    def setIvarsFromBunch(self, bunch: Any) -> None:
+    def setIvarsFromBunch(self, bunch: g.Bunch) -> None:
         u = self
         u.clearOptionalIvars()
         if False and not g.unitTesting:  # Debugging. # pragma: no cover
@@ -327,7 +327,7 @@ class Undoer:
         for v, vInfo in treeInfo:
             u.restoreVnodeUndoInfo(vInfo)
     #@+node:ekr.20050415170737.2: *5* u.restoreVnodeUndoInfo
-    def restoreVnodeUndoInfo(self, bunch: Any) -> None:
+    def restoreVnodeUndoInfo(self, bunch: g.Bunch) -> None:
         """Restore all ivars saved in the bunch."""
         v = bunch.v
         v.statusBits = bunch.statusBits
@@ -338,7 +338,7 @@ class Undoer:
             v.unknownAttributes = uA
             v._p_changed = True
     #@+node:ekr.20050415170812.2: *5* u.restoreTnodeUndoInfo
-    def restoreTnodeUndoInfo(self, bunch: Any) -> None:
+    def restoreTnodeUndoInfo(self, bunch: g.Bunch) -> None:
         v = bunch.v
         v.h = bunch.headString
         v.b = bunch.bodyString
@@ -421,7 +421,7 @@ class Undoer:
     #@+node:ekr.20031218072017.3608: *3* u.Externally visible entries
     #@+node:ekr.20050318085432.4: *4* u.afterX...
     #@+node:ekr.20201109075104.1: *5* u.afterChangeBody
-    def afterChangeBody(self, p: Position, command: str, bunch: Any) -> None:
+    def afterChangeBody(self, p: Position, command: str, bunch: g.Bunch) -> None:
         """
         Create an undo node using d created by beforeChangeNode.
 
@@ -498,7 +498,7 @@ class Undoer:
         # Recalculate the menu labels.
         u.setUndoTypes()
     #@+node:ekr.20050315134017.2: *5* u.afterChangeNodeContents
-    def afterChangeNodeContents(self, p: Position, command: str, bunch: Any) -> None:
+    def afterChangeNodeContents(self, p: Position, command: str, bunch: g.Bunch) -> None:
         """Create an undo node using d created by beforeChangeNode."""
         u = self
         c = self.c
@@ -522,7 +522,7 @@ class Undoer:
         bunch.newYScroll = w.getYScrollPosition() if w else 0
         u.pushBead(bunch)
     #@+node:ekr.20201107145642.1: *5* u.afterChangeHeadline
-    def afterChangeHeadline(self, p: Position, command: str, bunch: Any) -> None:
+    def afterChangeHeadline(self, p: Position, command: str, bunch: g.Bunch) -> None:
         """Create an undo node using d created by beforeChangeHeadline."""
         u = self
         if u.redoing or u.undoing:
@@ -537,7 +537,7 @@ class Undoer:
 
     afterChangeHead = afterChangeHeadline
     #@+node:ekr.20050315134017.3: *5* u.afterChangeTree
-    def afterChangeTree(self, p: Position, command: str, bunch: Any) -> None:
+    def afterChangeTree(self, p: Position, command: str, bunch: g.Bunch) -> None:
         """Create an undo node for general tree operations using d created by beforeChangeTree"""
         u = self
         c = self.c
@@ -555,7 +555,7 @@ class Undoer:
         bunch.newTree = u.saveTree(p)
         u.pushBead(bunch)
     #@+node:ekr.20050424161505: *5* u.afterClearRecentFiles
-    def afterClearRecentFiles(self, bunch: Any) -> None:
+    def afterClearRecentFiles(self, bunch: g.Bunch) -> None:
         u = self
         bunch.newRecentFiles = g.app.config.recentFiles[:]
         bunch.undoType = 'Clear Recent Files'
@@ -604,7 +604,7 @@ class Undoer:
         bunch.newMarked = p.isMarked()
         u.pushBead(bunch)
     #@+node:ekr.20050411193627.5: *5* u.afterCloneNode
-    def afterCloneNode(self, p: Position, command: str, bunch: Any) -> None:
+    def afterCloneNode(self, p: Position, command: str, bunch: g.Bunch) -> None:
         u = self
         if u.redoing or u.undoing:
             return  # pragma: no cover
@@ -620,7 +620,7 @@ class Undoer:
         bunch.newMarked = p.isMarked()
         u.pushBead(bunch)
     #@+node:ekr.20050411193627.8: *5* u.afterDeleteNode
-    def afterDeleteNode(self, p: Position, command: str, bunch: Any) -> None:
+    def afterDeleteNode(self, p: Position, command: str, bunch: g.Bunch) -> None:
         u = self
         if u.redoing or u.undoing:
             return
@@ -666,7 +666,7 @@ class Undoer:
         # Recalculate the menu labels.
         u.setUndoTypes()
     #@+node:ekr.20050411193627.9: *5* u.afterInsertNode
-    def afterInsertNode(self, p: Position, command: str, bunch: Any) -> None:
+    def afterInsertNode(self, p: Position, command: str, bunch: g.Bunch) -> None:
         u = self
         if u.redoing or u.undoing:
             return
@@ -689,7 +689,7 @@ class Undoer:
             bunch.afterTree = afterTree
         u.pushBead(bunch)
     #@+node:ekr.20050526124257: *5* u.afterMark
-    def afterMark(self, p: Position, command: str, bunch: Any) -> None:
+    def afterMark(self, p: Position, command: str, bunch: g.Bunch) -> None:
         """Create an undo node for mark and unmark commands."""
         # 'command' unused, but present for compatibility with similar methods.
         u = self
@@ -701,7 +701,7 @@ class Undoer:
         bunch.newMarked = p.isMarked()
         u.pushBead(bunch)
     #@+node:ekr.20050410110343: *5* u.afterMoveNode
-    def afterMoveNode(self, p: Position, command: str, bunch: Any) -> None:
+    def afterMoveNode(self, p: Position, command: str, bunch: g.Bunch) -> None:
         u = self
         if u.redoing or u.undoing:
             return
@@ -734,7 +734,7 @@ class Undoer:
         # Recalculate the menu labels.
         u.setUndoTypes()
     #@+node:ekr.20080425060424.2: *5* u.afterSort
-    def afterSort(self, p: Position, bunch: Any) -> None:
+    def afterSort(self, p: Position, bunch: g.Bunch) -> None:
         """Create an undo node for sort operations"""
         u = self
         # c = self.c

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -103,7 +103,7 @@ class Undoer:
         self.afterTree = None
         self.beforeTree = None
         self.children = None
-        self.deleteMarkedNodesData: Any = None
+        self.deleteMarkedNodesData: g.Bunch = None
         self.followingSibs: List[VNode] = None
         self.inHead: bool = None
         self.kind: str = None
@@ -919,7 +919,7 @@ class Undoer:
         undo_type: str,
         oldText: str,
         newText: str,
-        newInsert: Any=None,
+        newInsert: int=None,
         oldSel: Any=None,
         newSel: Any=None,
         oldYview: Any=None,
@@ -1168,16 +1168,16 @@ class Undoer:
     #@+node:ekr.20050126081529: *5* u.recognizeStartOfTypingWord
     def recognizeStartOfTypingWord(
         self,
-        old_lines: Any,
-        old_row: Any,
-        old_col: Any,
-        old_ch: Any,
-        new_lines: Any,
-        new_row: Any,
-        new_col: Any,
-        new_ch: Any,
-        prev_row: Any,
-        prev_col: Any,
+        old_lines: List[str],
+        old_row: int,
+        old_col: int,
+        old_ch: str,
+        new_lines: List[str],
+        new_row: int,
+        new_col: int,
+        new_ch: str,
+        prev_row: int,
+        prev_col: int,
     ) -> None:
         """
         A potentially user-modifiable method that should return True if the
@@ -1934,12 +1934,12 @@ class Undoer:
     def undoRedoText(
         self,
         p: Position,
-        leading: Any,
-        trailing: Any,  # Number of matching leading & trailing lines.
-        oldMidLines: Any,
-        newMidLines: Any,  # Lists of unmatched lines.
-        oldNewlines: Any,
-        newNewlines: Any,  # Number of trailing newlines.
+        leading: int,
+        trailing: int,  # Number of matching leading & trailing lines.
+        oldMidLines: List[str],
+        newMidLines: List[str],  # Lists of unmatched lines.
+        oldNewlines: List[str],
+        newNewlines: List[str],  # Number of trailing newlines.
         tag: str="undo",  # "undo" or "redo"
         undoType: str=None,
     ) -> None:

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -47,7 +47,7 @@
 #@-<< How Leo implements unlimited undo >>
 #@+<< leoUndo imports >>
 #@+node:ekr.20220821074023.1: ** << leoUndo imports >>
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, List, TYPE_CHECKING
 from leo.core import leoGlobals as g
 #@-<< leoUndo imports >>
 #@+<< leoUndo annotations >>
@@ -103,10 +103,10 @@ class Undoer:
         self.afterTree = None
         self.beforeTree = None
         self.children = None
-        self.deleteMarkedNodesData = None
-        self.followingSibs = None
-        self.inHead = None
-        self.kind = None
+        self.deleteMarkedNodesData: Any = None
+        self.followingSibs: List[VNode] = None
+        self.inHead: bool = None
+        self.kind: str = None
         self.newBack = None
         self.newBody = None
         self.newChildren = None
@@ -652,7 +652,7 @@ class Undoer:
         bunch.newMarked = p.isMarked()
         u.pushBead(bunch)
     #@+node:ekr.20080425060424.8: *5* u.afterDemote
-    def afterDemote(self, p: Position, followingSibs: Any) -> None:
+    def afterDemote(self, p: Position, followingSibs: List[VNode]) -> None:
         """Create an undo node for demote operations."""
         u = self
         bunch = u.createCommonBunch(p)
@@ -720,7 +720,7 @@ class Undoer:
         bunch.newP = p.copy()
         u.pushBead(bunch)
     #@+node:ekr.20080425060424.12: *5* u.afterPromote
-    def afterPromote(self, p: Position, children: Any) -> None:
+    def afterPromote(self, p: Position, children: List[VNode]) -> None:
         """Create an undo node for demote operations."""
         u = self
         bunch = u.createCommonBunch(p)
@@ -832,7 +832,7 @@ class Undoer:
         bunch.oldParent = p.parent()
         return bunch
     #@+node:ekr.20050411193627.4: *5* u.beforeInsertNode
-    def beforeInsertNode(self, p: Position, pasteAsClone: bool=False, copiedBunchList: Any=None) -> None:
+    def beforeInsertNode(self, p: Position, pasteAsClone: bool=False, copiedBunchList: List[g.Bunch]=None) -> None:
         u = self
         if copiedBunchList is None:
             copiedBunchList = []
@@ -857,7 +857,13 @@ class Undoer:
         bunch.oldParent_v = p._parentVnode()
         return bunch
     #@+node:ekr.20080425060424.3: *5* u.beforeSort
-    def beforeSort(self, p: Position, undoType: str, oldChildren: Any, newChildren: Any, sortChildren: Any) -> None:
+    def beforeSort(self,
+        p: Position,
+        undoType: str,
+        oldChildren: List[VNode],
+        newChildren: List[VNode],
+        sortChildren: List[VNode],
+    ) -> None:
         """Create an undo node for sort operations."""
         u = self
         bunch = u.createCommonBunch(p)
@@ -1935,7 +1941,7 @@ class Undoer:
         oldNewlines: Any,
         newNewlines: Any,  # Number of trailing newlines.
         tag: str="undo",  # "undo" or "redo"
-        undoType: Any=None,
+        undoType: str=None,
     ) -> None:
         """Handle text undo and redo: converts _new_ text into _old_ text."""
         # newNewlines is unused, but it has symmetry.

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -31,13 +31,14 @@ from leo.core.leoGui import LeoKeyEvent
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Position = Any
+    Wrapper = Any
 Event = Any  # More than one kind of event.
 Stroke = Any
 Widget = Any
-Wrapper = Any
 #@-<< leoVim annotations >>
 
 def cmd(name: str) -> Callable:
@@ -429,7 +430,7 @@ class VimCommands:
     def init_state_ivars(self) -> None:
         """Init all ivars related to command state."""
         self.ch = None  # The incoming character.
-        self.command_i = None  # The offset into the text at the start of a command.
+        self.command_i: int = None  # The offset into the text at the start of a command.
         self.command_list: List[Any] = []  # The list of all characters seen in this command.
         self.command_n: int = None  # The repeat count in effect at the start of a command.
         self.command_w: Widget = None  # The widget in effect at the start of a command.

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -439,7 +439,7 @@ class VimCommands:
         self.handler: Callable = self.do_normal_mode  # Use the handler for normal mode.
         self.in_command = False  # True: we have seen some command characters.
         self.in_motion = False  # True if parsing an *inner* motion, the 2j in d2j.
-        self.motion_func = None  # The callback handler to execute after executing an inner motion.
+        self.motion_func: Callable = None  # The callback handler to execute after executing an inner motion.
         self.motion_i: int = None  # The offset into the text at the start of a motion.
         self.n1 = 1  # The first repeat count.
         self.n = 1  # The second repeat count.
@@ -621,7 +621,7 @@ class VimCommands:
         else:
             self.accept(handler=self.do_insert_mode, add_to_dot=True)
     #@+node:ekr.20140222064735.16706: *5* vc.begin_motion
-    def begin_motion(self, motion_func: Any) -> None:
+    def begin_motion(self, motion_func: Callable) -> None:
         """Start an inner motion."""
         self.do_trace()
         w = self.w
@@ -2402,7 +2402,7 @@ class VimCommands:
                 p.v.b = newText
                 u.afterChangeBody(p, 'vc-save-body', bunch)
     #@+node:ekr.20140804123147.18929: *4* vc.set_border & helper
-    def set_border(self, kind: str=None, w: Wrapper=None, activeFlag: Any=None) -> None:
+    def set_border(self, kind: str=None, w: Wrapper=None, activeFlag: bool=None) -> None:
         """
         Set the border color of self.w, depending on state.
         Called from qtBody.onFocusColorHelper and self.show_status.
@@ -2424,7 +2424,7 @@ class VimCommands:
             except Exception:
                 pass
     #@+node:ekr.20140807070500.18161: *5* vc.set_property
-    def set_property(self, w: Wrapper, focus_flag: Any) -> None:
+    def set_property(self, w: Wrapper, focus_flag: bool) -> None:
         """Set the property of w, depending on focus and state."""
         c, state = self.c, self.state
         #

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -56,11 +56,12 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@+node:ekr.20220828123840.1: ** << contextmenu annotations >>
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
 else:
     Cmdr = Any
+    Event = Any
     Position = Any
-Event = LeoKeyEvent
 Wrapper = Any
 #@-<< contextmenu annotations >>
 

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -56,7 +56,7 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@+node:ekr.20220828123840.1: ** << contextmenu annotations >>
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.core.leoGui import LeoKeyEvent as Event # pylint: disable=reimported
     from leo.core.leoNodes import Position
 else:
     Cmdr = Any

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -58,11 +58,12 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event # pylint: disable=reimported
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< contextmenu annotations >>
 
 # Globals

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -30,7 +30,8 @@ free-layout-zoom
 #@+<< free_layout imports >>
 #@+node:tbrown.20110203111907.5520: ** << free_layout imports >>
 import json
-from typing import Any, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 #
 # Qt imports. May fail from the bridge.
@@ -50,10 +51,11 @@ except Exception:
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< free_layout annotations >>
 #@+others
 #@+node:tbrown.20110203111907.5521: ** free_layout:init
@@ -368,7 +370,7 @@ class FreeLayoutController:
             return True
         return False
     #@+node:tbrown.20110628083641.11724: *3* flc.ns_provide
-    def ns_provide(self, id_: str) -> Optional[Wrapper]:
+    def ns_provide(self, id_: str) -> Union[str, Wrapper, None]:
         if id_.startswith('_leo_tab:'):
             id_ = id_.split(':', 1)[1]
             top = self.get_top_splitter()

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -238,11 +238,12 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< mod_scripting annotations >>
 #@+others
 #@+node:ekr.20210228135810.1: ** cmd decorator

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -68,14 +68,15 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
+    Wrapper = Any
 Item = Any
 Group = Any
 Menu = Any
-Wrapper = Any
 #@-<< plugins_menu annotations >>
 
 __plugin_name__ = "Plugins Menu"

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -39,14 +39,14 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
-    # from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
+    Wrapper = Any
 QComboBox = Any
 Widget = Any
-Wrapper = Any
 #@-<< qt_frame annotations >>
 #@+others
 #@+node:ekr.20200303082457.1: ** top-level commands (qt_frame.py)
@@ -939,7 +939,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         #@+node:ekr.20131118172620.16892: *7* class EventWrapper
         class EventWrapper:
 
-            def __init__(self, c: Cmdr, w: Wrapper, next_w: Wrapper, func: Callable) -> None:
+            def __init__(self, c: Cmdr, w: Widget, next_w: Widget, func: Callable) -> None:
                 self.c = c
                 self.d = self.create_d()  # Keys: stroke.s; values: command-names.
                 self.w = w
@@ -1546,10 +1546,9 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):  # type:ignore
 class LeoQtBody(leoFrame.LeoBody):
     """A class that represents the body pane of a Qt window."""
     #@+others
-    #@+node:ekr.20150521061618.1: *3* LeoQtBody.body_cmd (decorator)
     #@+node:ekr.20110605121601.18181: *3* LeoQtBody.Birth
     #@+node:ekr.20110605121601.18182: *4* LeoQtBody.ctor
-    def __init__(self, frame: Wrapper, parentFrame: Widget) -> None:
+    def __init__(self, frame: Widget, parentFrame: Widget) -> None:
         """Ctor for LeoQtBody class."""
         # Call the base class constructor.
         super().__init__(frame, parentFrame)
@@ -2148,7 +2147,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         assert self.c == c
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
         # Official ivars...
-        self.iconBar = None
+        self.iconBar: Widget = None
         self.iconBarClass = self.QtIconBarClass  # type:ignore
         self.initComplete = False  # Set by initCompleteHint().
         self.minibufferVisible = True
@@ -2167,27 +2166,25 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # "Official ivars created in createLeoFrame and its allies.
         self.bar1 = None
         self.bar2 = None
-        self.body: Wrapper = None
+        self.body: Widget = None
         self.f1 = self.f2 = None
-        self.findPanel = None  # Inited when first opened.
+        self.findPanel: Widget = None  # Inited when first opened.
         self.iconBarComponentName = 'iconBar'
-        self.iconFrame = None
-        self.log: Wrapper = None
-        self.canvas = None
-        self.outerFrame = None
-        self.statusFrame = None
+        self.iconFrame: Widget = None
+        self.log: Widget = None
+        self.canvas: Widget = None
+        self.outerFrame: Widget = None
+        self.statusFrame: Widget = None
         self.statusLineComponentName = 'statusLine'
-        self.statusText = None
-        self.statusLabel = None
-        self.top = None  # This will be a class Window object.
-        self.tree: Wrapper = None
+        self.statusText: Widget = None
+        self.statusLabel: Widget = None
+        self.top: Widget = None  # This will be a class Window object.
+        self.tree: Widget = None
         # Used by event handlers...
         self.controlKeyIsDown = False  # For control-drags
         self.isActive = True
         self.redrawCount = 0
-        self.wantedWidget = None
         self.wantedCallbackScheduled = False
-        self.scrollWay = None
     #@+node:ekr.20110605121601.18249: *4* qtFrame.__repr__
     def __repr__(self) -> str:
         return f"<LeoQtFrame: {self.title}>"
@@ -2206,12 +2203,12 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.createSplitterComponents()
         self.createStatusLine()  # A base class method.
         self.createFirstTreeNode()  # Call the base-class method.
-        self.menu: Wrapper = LeoQtMenu(c, self, label='top-level-menu')
+        self.menu: Widget = LeoQtMenu(c, self, label='top-level-menu')
         g.app.windowList.append(self)
         t2 = time.process_time()
         self.setQtStyle()  # Slow, but only the first time it is called.
         t3 = time.process_time()
-        self.miniBufferWidget: Wrapper = qt_text.QMinibufferWrapper(c)
+        self.miniBufferWidget: Widget = qt_text.QMinibufferWrapper(c)
         c.bodyWantsFocus()
         t4 = time.process_time()
         if 'speed' in g.app.debug:
@@ -2367,7 +2364,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # Keys are widgets, values are stylesheets.
         styleSheetCache: Dict[Any, str] = {}
 
-        def put_helper(self, s: str, w: Wrapper, bg: str=None, fg: str=None) -> None:
+        def put_helper(self, s: str, w: Widget, bg: str=None, fg: str=None) -> None:
             """Put string s in the indicated widget, with proper colors."""
             c = self.c
             bg = bg or c.config.getColor('status-bg') or 'white'
@@ -2572,7 +2569,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 # self.addRow()
             # g.app.iconWidgetCount += 1
         #@+node:ekr.20110605121601.18267: *4* QtIconBar.addWidget
-        def addWidget(self, w: Wrapper) -> None:
+        def addWidget(self, w: Widget) -> None:
             self.w.addWidget(w)
         #@+node:ekr.20110605121601.18268: *4* QtIconBar.clear
         def clear(self) -> None:
@@ -2581,7 +2578,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
             self.actions = []
             g.app.iconWidgetCount = 0
         #@+node:ekr.20110605121601.18269: *4* QtIconBar.createChaptersIcon
-        def createChaptersIcon(self) -> Optional[Wrapper]:
+        def createChaptersIcon(self) -> "LeoQtTreeTab":
 
             c = self.c
             f = c.frame
@@ -2589,7 +2586,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 return LeoQtTreeTab(c, f.iconBar)
             return None
         #@+node:ekr.20110605121601.18270: *4* QtIconBar.deleteButton
-        def deleteButton(self, w: Wrapper) -> None:
+        def deleteButton(self, w: Widget) -> None:
             """ w is button """
             self.w.removeAction(w)
             self.c.bodyWantsFocus()
@@ -2774,7 +2771,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 g.trace(w, h, x, y)
             self.setTopGeometry(w, h, x, y)
     #@+node:ekr.20110605121601.18279: *4* qtFrame.setTabWidth
-    def setTabWidth(self, w: Wrapper) -> None:
+    def setTabWidth(self, w: int) -> None:
         # A do-nothing because tab width is set automatically.
         # It *is* called from Leo's core.
         pass
@@ -3087,7 +3084,7 @@ class LeoQtLog(leoFrame.LeoLog):
     #@+others
     #@+node:ekr.20110605121601.18313: *3* LeoQtLog.Birth
     #@+node:ekr.20110605121601.18314: *4* LeoQtLog.__init__ & reloadSettings
-    def __init__(self, frame: Wrapper, parentFrame: Widget) -> None:
+    def __init__(self, frame: Widget, parentFrame: Widget) -> None:
         """Ctor for LeoQtLog class."""
         super().__init__(frame, parentFrame)  # Calls createControl.
         # Set in finishCreate.
@@ -3233,7 +3230,7 @@ class LeoQtLog(leoFrame.LeoLog):
         c.frame.log.selectTab('Log')
         c.bodyWantsFocus()
     #@+node:ekr.20111120124732.10184: *3* LeoQtLog.isLogWidget
-    def isLogWidget(self, w: Wrapper) -> bool:
+    def isLogWidget(self, w: Widget) -> bool:
         val = w == self or w in list(self.contentsDict.values())
         return val
     #@+node:tbnorth.20171220123648.1: *3* LeoQtLog.linkClicked
@@ -3526,7 +3523,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
 
     #@+others
     #@+node:ekr.20110605121601.18341: *3* LeoQtMenu.__init__
-    def __init__(self, c: Cmdr, frame: Wrapper, label: str) -> None:
+    def __init__(self, c: Cmdr, frame: Widget, label: str) -> None:
         """ctor for LeoQtMenu class."""
         assert frame
         assert frame.c
@@ -3553,7 +3550,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
     # See the Tk docs for what these routines are to do
     #@+node:ekr.20110605121601.18343: *4* LeoQtMenu.Methods with Tk spellings
     #@+node:ekr.20110605121601.18344: *5* LeoQtMenu.add_cascade
-    def add_cascade(self, parent: Widget, label: str, menu: Wrapper, underline: int) -> Wrapper:
+    def add_cascade(self, parent: Widget, label: str, menu: Widget, underline: int) -> Widget:
         """Wrapper for the Tkinter add_cascade menu method.
 
         Adds a submenu to the parent menu, or the menubar."""
@@ -3590,7 +3587,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
 
             action.triggered.connect(qt_add_command_callback)
     #@+node:ekr.20110605121601.18346: *5* LeoQtMenu.add_separator
-    def add_separator(self, menu: Wrapper) -> None:
+    def add_separator(self, menu: Widget) -> None:
         """Wrapper for the Tkinter add_separator menu method."""
         if menu:
             action = menu.addSeparator()
@@ -3664,7 +3661,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         return menu
     #@+node:ekr.20110605121601.18354: *4* LeoQtMenu.Methods with other spellings
     #@+node:ekr.20110605121601.18355: *5* LeoQtMenu.clearAccel
-    def clearAccel(self, menu: Wrapper, name: str) -> None:
+    def clearAccel(self, menu: Widget, name: str) -> None:
         pass
         # if not menu:
             # return
@@ -3692,7 +3689,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             menu.insert_cascade(parent, index, label, menu, underline=amp_index)
         return menu
     #@+node:ekr.20110605121601.18358: *5* LeoQtMenu.disable/enableMenu (not used)
-    def disableMenu(self, menu: Wrapper, name: str) -> None:
+    def disableMenu(self, menu: Widget, name: str) -> None:
         self.enableMenu(menu, name, False)
 
     def enableMenu(self, menu: Wrapper, name: str, val: bool) -> None:
@@ -3704,12 +3701,12 @@ class LeoQtMenu(leoMenu.LeoMenu):
                     action.setEnabled(val)
                     break
     #@+node:ekr.20110605121601.18359: *5* LeoQtMenu.getMenuLabel
-    def getMenuLabel(self, menu: Wrapper, name: str) -> None:
+    def getMenuLabel(self, menu: Widget, name: str) -> None:
         """Return the index of the menu item whose name (or offset) is given.
         Return None if there is no such menu item."""
         # At present, it is valid to always return None.
     #@+node:ekr.20110605121601.18360: *5* LeoQtMenu.setMenuLabel
-    def setMenuLabel(self, menu: Wrapper, name: str, label: str, underline: int=-1) -> None:
+    def setMenuLabel(self, menu: Widget, name: str, label: str, underline: int=-1) -> None:
 
         def munge(s: str) -> str:
             return (s or '').replace('&', '')
@@ -4398,7 +4395,7 @@ class LeoQtTreeTab:
         class LeoQComboBox(QtWidgets.QComboBox):  # type:ignore
             """Create a subclass in order to handle focusInEvents."""
 
-            def __init__(self, tt: Wrapper) -> None:
+            def __init__(self, tt: Widget) -> None:
                 self.leo_tt = tt
                 super().__init__()
                 # Fix #458: Chapters drop-down list is not automatically resized.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    # from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1754,7 +1754,7 @@ class LeoQtBody(leoFrame.LeoBody):
         pass
         # self.createChapterIvar(wrapper)
 
-    def selectLabel(self, wrapper: str) -> None:
+    def selectLabel(self, wrapper: Wrapper) -> None:
         # pylint: disable=arguments-differ
         c = self.c
         w = wrapper.widget

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1256,7 +1256,7 @@ class FindTabManager:
             w = self.radio_button_entire_outline
             w.toggle()
     #@+node:ekr.20210923060904.1: *3* ftm.init_widgets_from_dict (new)
-    def set_widgets_from_dict(self, d: Dict[str, str]) -> None:
+    def set_widgets_from_dict(self, d: g.Bunch) -> None:
         """Set all settings from d."""
         # Similar to ftm.init_widgets, which has already been called.
         c = self.c

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -36,12 +36,12 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
-    # from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Wrapper = Any
+    Wrapper = Any
 Widget = Any
 #@-<< qt_gui annotations >>
 #@+others
@@ -278,11 +278,11 @@ class LeoQtGui(leoGui.LeoGui):
         """Create a qt find tab in the indicated frame."""
         pass  # Now done in dw.createFindTab.
 
-    def createLeoFrame(self, c: Cmdr, title: str) -> Wrapper:
+    def createLeoFrame(self, c: Cmdr, title: str) -> Widget:
         """Create a new Leo frame."""
         return qt_frame.LeoQtFrame(c, title, gui=self)
 
-    def createSpellTab(self, c: Cmdr, spellHandler: Any, tabName: str) -> Wrapper:
+    def createSpellTab(self, c: Cmdr, spellHandler: Any, tabName: str) -> Widget:
         if g.unitTesting:
             return None
         return qt_frame.LeoQtSpellTab(c, spellHandler, tabName)
@@ -358,7 +358,7 @@ class LeoQtGui(leoGui.LeoGui):
 
             def __init__(
                 self,
-                parent: Wrapper=None,
+                parent: Widget=None,
                 message: str='Select Date/Time',
                 init: Any=None,
                 step_min: Dict=None,
@@ -1639,62 +1639,6 @@ class StyleClassManager:
             props = [i for i in props if i not in prop]
 
         self.set_sclasses(w, props)
-    #@+node:tbrown.20150724090431.7: *3* sclass_tests
-    def sclass_tests(self) -> None:
-        """Test style class property manipulation functions"""
-        # pylint: disable=len-as-condition
-
-        class Test_W:
-            """simple standin for QWidget for testing"""
-
-            def __init__(self) -> None:
-                self.x = ''
-
-            def property(self, name: str, default: str=None) -> Any:
-                return self.x or default
-
-            def setProperty(self, name: str, value: Any) -> None:
-                self.x = value
-
-        w = Test_W()
-
-        assert not self.has_sclass(w, 'nonesuch')
-        assert not self.has_sclass(w, ['nonesuch'])
-        assert not self.has_sclass(w, ['nonesuch', 'either'])
-        assert len(self.sclasses(w)) == 0
-
-        self.add_sclass(w, 'test')
-
-        assert not self.has_sclass(w, 'nonesuch')
-        assert self.has_sclass(w, 'test')
-        assert self.has_sclass(w, ['test'])
-        assert not self.has_sclass(w, ['test', 'either'])
-        assert len(self.sclasses(w)) == 1
-
-        self.add_sclass(w, 'test')
-        assert len(self.sclasses(w)) == 1
-        self.add_sclass(w, ['test', 'test', 'other'])
-        assert len(self.sclasses(w)) == 2
-        assert self.has_sclass(w, 'test')
-        assert self.has_sclass(w, 'other')
-        assert self.has_sclass(w, ['test', 'other', 'test'])
-        assert not self.has_sclass(w, ['test', 'other', 'nonesuch'])
-
-        self.remove_sclass(w, ['other', 'nothere'])
-        assert self.has_sclass(w, 'test')
-        assert not self.has_sclass(w, 'other')
-        assert len(self.sclasses(w)) == 1
-
-        self.toggle_sclass(w, 'third')
-        assert len(self.sclasses(w)) == 2
-        assert self.has_sclass(w, ['test', 'third'])
-        self.toggle_sclass(w, 'third')
-        assert len(self.sclasses(w)) == 1
-        assert not self.has_sclass(w, ['test', 'third'])
-
-        self.clear_sclasses(w)
-        assert len(self.sclasses(w)) == 0
-        assert not self.has_sclass(w, 'test')
     #@+node:tbrown.20150724090431.8: *3* sclasses
     def sclasses(self, w: Wrapper) -> List[str]:
         """return list of style classes for QWidget w"""
@@ -1849,7 +1793,7 @@ class StyleSheetManager:
         sheet = w.styleSheet()
         print(f"style sheet for: {w}...\n\n{sheet}")
     #@+node:ekr.20110605121601.18175: *4* ssm.set_style_sheets
-    def set_style_sheets(self, all: bool=True, top: Widget=None, w: Wrapper=None) -> None:
+    def set_style_sheets(self, all: bool=True, top: Widget=None, w: Widget=None) -> None:
         """Set the master style sheet for all widgets using config settings."""
         if g.app.loadedThemes:
             return

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -36,13 +36,13 @@ if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    # from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
-Widget = Any
 Wrapper = Any
-
+Widget = Any
 #@-<< qt_gui annotations >>
 #@+others
 #@+node:ekr.20110605121601.18134: ** init (qt_gui.py)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20140831085423.18598: * @file ../plugins/qt_text.py
 #@@first
 """Text classes for the Qt version of Leo"""
-#@+<< imports qt_text.py >>
-#@+node:ekr.20220416085845.1: ** << imports qt_text.py >>
+#@+<< qt_text imports >>
+#@+node:ekr.20220416085845.1: ** << qt_text imports >>
 import time
 assert time
 from typing import Any, Callable, Dict, List, Tuple
@@ -15,9 +15,9 @@ from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier, Modifier
 from leo.core.leoQt import MouseButton, MoveMode, MoveOperation
 from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, WrapMode
 
-#@-<< imports qt_text.py >>
-#@+<< type aliases qt_text.py >>
-#@+node:ekr.20220416085945.1: ** << type aliases qt_text.py >>
+#@-<< qt_text imports >>
+#@+<< qt_text annotations >>
+#@+node:ekr.20220416085945.1: ** << qt_text annotations >>
 if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
@@ -29,7 +29,7 @@ Index = Any  # For now, really Union[int, str], but that creates type-checking p
 MousePressEvent = Any
 Widget = Any
 Wrapper = Any
-#@-<< type aliases qt_text.py >>
+#@-<< qt_text annotations >>
 
 FullWidthSelection = 0x06000  # works for both Qt5 and Qt6
 QColor = QtGui.QColor

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -285,7 +285,7 @@ class QTextMixin:
     #@+node:ekr.20140901062324.18705: *5* qtm.getSelectedText
     def getSelectedText(self) -> str:
         """QTextMixin"""
-        i, j = self.getSelectionRange()
+        i, j = self.getSelectionRange()  # Returns (int, int)
         if i == j:
             return ''
         s = self.getAllText()
@@ -327,7 +327,7 @@ class QTextMixin:
         w = self
         v = self.c.p.v  # Always accurate.
         v.insertSpot = w.getInsertPoint()
-        i, j = w.getSelectionRange()
+        i, j = w.getSelectionRange()  # Returns (int, int)
         if i > j:
             i, j = j, i
         assert i <= j
@@ -444,8 +444,6 @@ class QLineEditWrapper(QTextMixin):
         if s is None:
             s = w.text()
         n = len(s)
-        # i = self.toPythonIndex(i)
-        # j = self.toPythonIndex(j)
         int_i = max(0, min(int_i, n))
         int_j = max(0, min(int_j, n))
         if insert is None:
@@ -1950,7 +1948,7 @@ class QTextEditWrapper(QTextMixin):
         if int_i == int_j:
             tc.setPosition(int_i)
         elif int_ins == int_j:
-            # Put the insert point at j
+            # Put the insert point at int_j
             tc.setPosition(int_i)
             tc.setPosition(int_j, MoveMode.KeepAnchor)
         elif int_ins == int_i:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1936,7 +1936,7 @@ class QTextEditWrapper(QTextMixin):
         int_i = max(0, min(int_i, n))
         int_j = max(0, min(int_j, n))
         if insert is None:
-            ins = max(int_i, int_j)
+            int_ins = max(int_i, int_j)
         else:
             int_ins = self.toPythonIndex(insert)
             int_ins = max(0, min(int_ins, n))
@@ -1952,7 +1952,7 @@ class QTextEditWrapper(QTextMixin):
             tc.setPosition(int_i)
             tc.setPosition(int_j, MoveMode.KeepAnchor)
         elif int_ins == int_i:
-            # Put the insert point at i
+            # Put the insert point at int_i
             tc.setPosition(int_j)
             tc.setPosition(int_i, MoveMode.KeepAnchor)
         else:
@@ -1967,7 +1967,7 @@ class QTextEditWrapper(QTextMixin):
         #
         # Remember the values for v.restoreCursorAndScroll.
         v = self.c.p.v  # Always accurate.
-        v.insertSpot = ins
+        v.insertSpot = int_ins
         if int_i > int_j:
             int_i, int_j = int_j, int_i
         assert int_i <= int_j

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -21,7 +21,7 @@ from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, W
 if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
-    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper  # pylint: disable=import-self
 else:
     Cmdr = Any
     Event = Any

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -21,14 +21,15 @@ from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, W
 if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
+    Wrapper = Any
+Widget = Any
 
 Index = Union[int, str]  # A zero-based index or a Tk index.
 MousePressEvent = Any
-Widget = Any
-Wrapper = Any
 #@-<< qt_text annotations >>
 
 FullWidthSelection = 0x06000  # works for both Qt5 and Qt6
@@ -508,7 +509,7 @@ if QtWidgets:
         """A subclass of QTextBrowser that overrides the mouse event handlers."""
         #@+others
         #@+node:ekr.20110605121601.18006: *3*  lqtb.ctor
-        def __init__(self, parent: Widget, c: Cmdr, wrapper: Wrapper) -> None:
+        def __init__(self, parent: Widget, c: Cmdr, wrapper: Any) -> None:  # wrapper is a LeoQtBody.
             """ctor for LeoQTextBrowser class."""
             for attr in ('leo_c', 'leo_wrapper',):
                 assert not hasattr(QtWidgets.QTextBrowser, attr), attr

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -3,8 +3,8 @@
 #@+node:ekr.20140907131341.18707: * @file ../plugins/qt_tree.py
 #@@first
 """Leo's Qt tree class."""
-#@+<< imports: qt_tree.py >>
-#@+node:ekr.20140907131341.18709: ** << imports: qt_tree.py >>
+#@+<< qt_tree imports >>
+#@+node:ekr.20140907131341.18709: ** << qt_tree imports >>
 import re
 import time
 from typing import Any, Callable, Dict, Generator, List, Tuple
@@ -15,25 +15,26 @@ from leo.core import leoGlobals as g
 from leo.core import leoFrame
 from leo.core import leoPlugins  # Uses leoPlugins.TryNext.
 from leo.plugins import qt_text
-#@-<< imports: qt_tree.py >>
-#@+<< type aliases: qt_tree.py >>
-#@+node:ekr.20220417193741.1: ** << type aliases: qt_tree.py >>
+#@-<< qt_tree imports >>
+#@+<< qt_tree annotations >>
+#@+node:ekr.20220417193741.1: ** << qt_tree annotations >>
 if TYPE_CHECKING:  # Always False at runtime.
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     VNode = Any
+    Wrapper = Any
 Editor = Any
 Icon = Any
 Item = Any
 Selection = Tuple[int, int, int]
 Widget = Any
-Wrapper = Any
-#@-<< type aliases: qt_tree.py >>
+#@-<< qt_tree annotations >>
 #@+others
 #@+node:ekr.20160514120051.1: ** class LeoQtTree
 class LeoQtTree(leoFrame.LeoTree):
@@ -41,7 +42,7 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+others
     #@+node:ekr.20110605121601.18404: *3* qtree.Birth
     #@+node:ekr.20110605121601.18405: *4* qtree.__init__
-    def __init__(self, c: Cmdr, frame: Wrapper) -> None:
+    def __init__(self, c: Cmdr, frame: Any) -> None:  ### Frame is a LeoQtFrame.
         """Ctor for the LeoQtTree class."""
         super().__init__(frame)
         self.c = c
@@ -62,8 +63,8 @@ class LeoQtTree(leoFrame.LeoTree):
         self.editWidgetsDict: Dict[Editor, Wrapper] = {}  # keys are native edit widgets, values are wrappers.
         self.reloadSettings()
         # Components.
-        self.canvas: Wrapper = self  # An official ivar used by Leo's core.
-        self.headlineWrapper: Wrapper = qt_text.QHeadlineWrapper  # This is a class.
+        self.canvas: Any = self  # An official ivar used by Leo's core.
+        self.headlineWrapper: Any = qt_text.QHeadlineWrapper  # This is a class.
         # w is a LeoQTreeWidget, a subclass of QTreeWidget.
         self.treeWidget: Widget = frame.top.treeWidget  # An internal ivar.
         w = self.treeWidget

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -1278,7 +1278,7 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.17909: *4* qtree.editLabel and helper
     def editLabel(self,
         p: Position, selectAll: bool=False, selection: Selection=None,
-    ) -> Tuple[Editor, Wrapper]:
+    ) -> Tuple[Editor, Any]:
         """Start editing p's headline."""
         if self.busy:
             return None
@@ -1302,7 +1302,7 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.18422: *5* qtree.editLabelHelper
     def editLabelHelper(self,
         item: Any, selectAll: bool=False, selection: Selection=None,
-    ) -> Tuple[Item, Wrapper]:
+    ) -> Tuple[Item, Any]:
         """Helper for qtree.editLabel."""
         c, vc = self.c, self.c.vimCommands
         w = self.treeWidget

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -98,17 +98,18 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
+    Wrapper = Any
 
 Match = re.Match
 Match_Iter = Iterator[re.Match[str]]
 Match_List = List[Tuple[Position, Match_Iter]]
 RegexFlag = Union[int, re.RegexFlag]  # re.RegexFlag does not define 0
 Widget = Any
-Wrapper = Any
 #@-<< quicksearch annotations >>
 #@+others
 #@+node:ekr.20190210123045.1: ** top level

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     # from QtGui import QIcon
 else:
     Cmdr = Any
@@ -88,9 +89,9 @@ else:
     # QIcon = Any
     Position = Any
     VNode = Any
+    Wrapper = Any
 Icon = Any # QtGui.QIcon
 Menu = Any
-Wrapper = Any
 #@-<< todo annotations >>
 
 NO_TIME = datetime.date(3000, 1, 1)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -642,7 +642,7 @@ class ViewRenderedProvider:
             if splitter:
                 splitter.register_provider(self)
     #@+node:tbrown.20110629084915.35151: *3* vr.ns_provide
-    def ns_provide(self, id_: str) -> Optional[Any]:
+    def ns_provide(self, id_: str) -> Optional[Widget]:
         global controllers, layouts
         # #1678: duplicates in Open Window list
         if id_ == self.ns_provider_id():
@@ -1635,7 +1635,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             w.setPlainText('')
     #@+node:ekr.20110322031455.5765: *4* vr.utils for update helpers...
     #@+node:ekr.20110322031455.5764: *5* vr.ensure_text_widget
-    def ensure_text_widget(self) -> Wrapper:
+    def ensure_text_widget(self) -> Widget:
         """Swap a text widget into the rendering pane if necessary."""
         c, pc = self.c, self
         if pc.must_change_widget(QtWidgets.QTextBrowser):

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -286,12 +286,13 @@ if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
     Cmdr = Any
     Event = Any
     Position = Any
     VNode = Any
-Wrapper = Any
+    Wrapper = Any
 #@-<< vr annotations >>
 # pylint: disable=no-member
 trace = False  # This global trace is convenient.
@@ -683,12 +684,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Set the ivars.
         self.active = False
         self.badColors: List[str] = []
-        self.delete_callback = None
-        self.gnx = None
+        self.delete_callback: Callable = None
+        self.gnx: str = None
         self.graphics_class = QtWidgets.QGraphicsWidget  # type:ignore
-        self.pyplot_canvas = None
-        self.gs = None  # For @graphics-script: a QGraphicsScene
-        self.gv = None  # For @graphics-script: a QGraphicsView
+        self.pyplot_canvas: Any = None
+        self.gs: Any = None  # For @graphics-script: a QGraphicsScene
+        self.gv: Any = None  # For @graphics-script: a QGraphicsView
         self.inited = False
         self.length = 0  # The length of previous p.b.
         self.locked = False
@@ -696,10 +697,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.scrollbar_pos_dict: Dict[VNode, Position] = {}  # Keys are vnodes, values are positions.
         self.sizes: List[int] = []  # Saved splitter sizes.
         self.splitter = None
-        self.splitter_index = None  # The index of the rendering pane in the splitter.
-        self.title = None
-        self.vp = None  # The present video player.
-        self.w = None  # The present widget in the rendering pane.
+        self.splitter_index: int = None  # The index of the rendering pane in the splitter.
+        self.title: str = None
+        self.vp: Any = None  # The present video player.
+        self.w: Wrapper = None  # The present widget in the rendering pane.
         # User settings.
         self.reloadSettings()
         self.node_changed = True

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -293,6 +293,7 @@ else:
     Position = Any
     VNode = Any
     Wrapper = Any
+Widget = Any
 #@-<< vr annotations >>
 # pylint: disable=no-member
 trace = False  # This global trace is convenient.
@@ -397,7 +398,7 @@ def show_scrolled_message(tag: str, kw: Any) -> bool:
     )
     return True
 #@+node:vitalije.20170713082256.1: *3* vr.split_last_sizes
-def split_last_sizes(sizes: Any) -> List[int]:
+def split_last_sizes(sizes: List[int]) -> List[int]:
     result = [2 * x for x in sizes[:-1]]
     result.append(sizes[-1])
     result.append(sizes[-1])
@@ -664,7 +665,7 @@ class ViewRenderedProvider:
         # #1678: duplicates in Open Window list
         return [('Viewrendered', self.ns_provider_id())]
     #@+node:ekr.20200917063221.1: *3* vr.ns_title
-    def ns_title(self, id_: Any) -> Optional[str]:
+    def ns_title(self, id_: str) -> Optional[str]:
         if id_ != self.ns_provider_id():
             return None
         filename = self.c.shortFileName() or 'Unnamed file'
@@ -687,9 +688,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.delete_callback: Callable = None
         self.gnx: str = None
         self.graphics_class = QtWidgets.QGraphicsWidget  # type:ignore
-        self.pyplot_canvas: Any = None
-        self.gs: Any = None  # For @graphics-script: a QGraphicsScene
-        self.gv: Any = None  # For @graphics-script: a QGraphicsView
+        self.pyplot_canvas: Widget = None
+        self.gs: Widget = None  # For @graphics-script: a QGraphicsScene
+        self.gv: Widget = None  # For @graphics-script: a QGraphicsView
         self.inited = False
         self.length = 0  # The length of previous p.b.
         self.locked = False
@@ -699,7 +700,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.splitter = None
         self.splitter_index: int = None  # The index of the rendering pane in the splitter.
         self.title: str = None
-        self.vp: Any = None  # The present video player.
+        self.vp: Widget = None  # The present video player.
         self.w: Wrapper = None  # The present widget in the rendering pane.
         # User settings.
         self.reloadSettings()


### PR DESCRIPTION
See #2791.

- [x] Annotate Event as LeoKeyEvent in most cases.
    The remaining cases are a mixture of events. To be disentangled.
- [x] Annotate Wrapper as QTextEditWrapper everywhere.
    This is a big milestone: Wrappers and Widgets have been disentangled.
- [x] Remove the never-used sclass_tests function. It confused mypy.