### PR TITLE
PR for #2812: retire qt_tree.redraw_after_icons_changed

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -214,7 +214,7 @@ def pasteOutlineRetainingClones(
 def computeCopiedBunchList(
     c: Cmdr,
     pasted: Position,
-    vnodeInfoDict: Dict[VNode, Any],  ###
+    vnodeInfoDict: Dict[VNode, Any],
 ) -> List[Any]:
     """Create a dict containing only copied vnodes."""
     d = {}

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1127,7 +1127,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def dHash(self, d: Dict[str, str]) -> str:
         """Hash a dictionary"""
         return ''.join([f"{str(k)}{str(d[k])}" for k in sorted(d)])
-    #@+node:ekr.20150514063305.233: *5* ec.getIconList (uses VNode)
+    #@+node:ekr.20150514063305.233: *5* ec.getIconList
     def getIconList(self, v: VNode) -> List[Dict]:  ###
         """Return list of icons for v."""
         fromVnode: List[Dict] = []

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1128,7 +1128,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """Hash a dictionary"""
         return ''.join([f"{str(k)}{str(d[k])}" for k in sorted(d)])
     #@+node:ekr.20150514063305.233: *5* ec.getIconList
-    def getIconList(self, v: VNode) -> List[Dict]:  ###
+    def getIconList(self, v: VNode) -> List[Dict]:
         """Return list of icons for v."""
         fromVnode: List[Dict] = []
         if hasattr(v, 'unknownAttributes'):
@@ -1189,7 +1189,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.237: *4* ec.deleteIconByName
-    def deleteIconByName(self, t: Any, name: str, relPath: str) -> None:  ### t not used.
+    def deleteIconByName(self, t: Any, name: str, relPath: str) -> None:  # t not used.
         """for use by the right-click remove icon callback"""
         c, p = self.c, self.c.p
         aList = self.getIconList(p.v)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1148,8 +1148,8 @@ class EditCommandsClass(BaseEditCommandsClass):
             # no difference between original and current list of dictionaries
             return
         self._setIconListHelper(p, l, p.v, setDirty)
-        if g.app.gui.guiName() == 'qt':
-            self.c.frame.tree.updateIcon(p)
+        ### if g.app.gui.guiName() == 'qt':
+        ###    self.c.frame.tree.updateIcon(p)
     #@+node:ekr.20150514063305.235: *6* ec._setIconListHelper
     def _setIconListHelper(self,
         p: Position,

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1127,19 +1127,19 @@ class EditCommandsClass(BaseEditCommandsClass):
     def dHash(self, d: Dict[str, str]) -> str:
         """Hash a dictionary"""
         return ''.join([f"{str(k)}{str(d[k])}" for k in sorted(d)])
-    #@+node:ekr.20150514063305.233: *5* ec.getIconList
-    def getIconList(self, p: Position) -> List[Dict]:  ###
-        """Return list of icons for position p, call setIconList to apply changes"""
+    #@+node:ekr.20150514063305.233: *5* ec.getIconList (uses VNode)
+    def getIconList(self, v: VNode) -> List[Dict]:  ###
+        """Return list of icons for v."""
         fromVnode: List[Dict] = []
-        if hasattr(p.v, 'unknownAttributes'):
-            fromVnode = [dict(i) for i in p.v.u.get('icons', [])]
+        if hasattr(v, 'unknownAttributes'):
+            fromVnode = [dict(i) for i in v.u.get('icons', [])]
             for i in fromVnode:
                 i['on'] = 'VNode'
         return fromVnode
     #@+node:ekr.20150514063305.234: *5* ec.setIconList & helpers
     def setIconList(self, p: Position, l: List[Any], setDirty: bool=True) -> None:
         """Set list of icons for position p to l"""
-        current = self.getIconList(p)
+        current = self.getIconList(p.v)
         if not l and not current:
             return  # nothing to do
         lHash = ''.join([self.dHash(i) for i in l])
@@ -1183,7 +1183,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def deleteFirstIcon(self, event: Event=None) -> None:
         """Delete the first icon in the selected node's icon list."""
         c = self.c
-        aList = self.getIconList(c.p)
+        aList = self.getIconList(c.p.v)
         if aList:
             self.setIconList(c.p, aList[1:])
             c.setChanged()
@@ -1192,7 +1192,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def deleteIconByName(self, t: Any, name: str, relPath: str) -> None:  ### t not used.
         """for use by the right-click remove icon callback"""
         c, p = self.c, self.c.p
-        aList = self.getIconList(p)
+        aList = self.getIconList(p.v)
         if not aList:
             return
         basePath = g.os_path_finalize_join(g.app.loadDir, "..", "Icons")  # #1341.
@@ -1216,7 +1216,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def deleteLastIcon(self, event: Event=None) -> None:
         """Delete the first icon in the selected node's icon list."""
         c = self.c
-        aList = self.getIconList(c.p)
+        aList = self.getIconList(c.p.v)
         if aList:
             self.setIconList(c.p, aList[:-1])
             c.setChanged()
@@ -1255,7 +1255,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         xoffset = 2
         for path in paths:
             xoffset = self.appendImageDictToList(aList, path, xoffset)
-        aList2 = self.getIconList(p)
+        aList2 = self.getIconList(p.v)
         aList2.extend(aList)
         self.setIconList(p, aList2)
         c.setChanged()
@@ -1268,7 +1268,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList: List[Any] = []
         xoffset = 2
         xoffset = self.appendImageDictToList(aList, path, xoffset, **kargs)
-        aList2 = self.getIconList(p)
+        aList2 = self.getIconList(p.v)
         if pos is None:
             pos = len(aList2)
         aList2.insert(pos, aList[0])

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1148,8 +1148,6 @@ class EditCommandsClass(BaseEditCommandsClass):
             # no difference between original and current list of dictionaries
             return
         self._setIconListHelper(p, l, p.v, setDirty)
-        ### if g.app.gui.guiName() == 'qt':
-        ###    self.c.frame.tree.updateIcon(p)
     #@+node:ekr.20150514063305.235: *6* ec._setIconListHelper
     def _setIconListHelper(self,
         p: Position,

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -132,8 +132,6 @@ class AtFile:
         self.rootSeen = False
         self.targetFileName = fileName  # For self.writeError only.
         self.v = None
-        ### self.vStack: List[VNode] = []
-        ### self.thinChildIndexStack: List[int] = []  # number of siblings at this level.
         self.updateWarningGiven = False
     #@+node:ekr.20041005105605.15: *4* at.initWriteIvars
     def initWriteIvars(self, root: Position) -> Optional[str]:
@@ -628,7 +626,6 @@ class AtFile:
         fn = g.fullPath(c, p)  # #1521, #1341, #1914.
         if not g.os_path_exists(fn):
             g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL())
-            ### return p
             return False
         # Delete all the child nodes.
         while p.hasChildren():

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3227,7 +3227,6 @@ class Commands:
         c = self
         if c.enableRedrawFlag:
             pass
-            ### c.frame.tree.redraw_after_icons_changed()
             # Do not call c.treeFocusHelper here.
         else:
             c.requestLaterRedraw = True

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3228,8 +3228,7 @@ class Commands:
         if c.enableRedrawFlag:
             pass
             ### c.frame.tree.redraw_after_icons_changed()
-            # Do not call treeFocusHelper here.
-                # c.treeFocusHelper()
+            # Do not call c.treeFocusHelper here.
         else:
             c.requestLaterRedraw = True
     #@+node:ekr.20090110131802.2: *6* c.redraw_after_contract

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3226,7 +3226,8 @@ class Commands:
         """Update the icon for the presently selected node"""
         c = self
         if c.enableRedrawFlag:
-            c.frame.tree.redraw_after_icons_changed()
+            pass
+            ### c.frame.tree.redraw_after_icons_changed()
             # Do not call treeFocusHelper here.
                 # c.treeFocusHelper()
         else:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2191,7 +2191,6 @@ class LeoFind:
         else:
             p.v.b = gui_w.getAllText()
             u.afterChangeBody(p, 'Change Body', bunch)
-        ### c.frame.tree.updateIcon(p)  # redraw only the icon.
         return True
     #@+node:ekr.20210110073117.31: *4* find.check_args
     def check_args(self, tag: str) -> bool:
@@ -2250,9 +2249,6 @@ class LeoFind:
                 if self.mark_finds:  # pragma: no cover
                     p.setMarked()
                     p.setDirty()
-                    ###
-                        # if not self.changeAllFlag:
-                            # c.frame.tree.updateIcon(p)  # redraw only the icon.
                 return p, pos, newpos
             # Searching the pane failed: switch to another pane or node.
             if self._fnm_should_stay_in_node(p):

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2191,7 +2191,7 @@ class LeoFind:
         else:
             p.v.b = gui_w.getAllText()
             u.afterChangeBody(p, 'Change Body', bunch)
-        c.frame.tree.updateIcon(p)  # redraw only the icon.
+        ### c.frame.tree.updateIcon(p)  # redraw only the icon.
         return True
     #@+node:ekr.20210110073117.31: *4* find.check_args
     def check_args(self, tag: str) -> bool:
@@ -2234,7 +2234,6 @@ class LeoFind:
 
         Return (p, pos, newpos).
         """
-        c = self.c
         if not self.search_headline and not self.search_body:  # pragma: no cover
             return None, None, None
         if not self.find_text:  # pragma: no cover
@@ -2251,8 +2250,9 @@ class LeoFind:
                 if self.mark_finds:  # pragma: no cover
                     p.setMarked()
                     p.setDirty()
-                    if not self.changeAllFlag:
-                        c.frame.tree.updateIcon(p)  # redraw only the icon.
+                    ###
+                        # if not self.changeAllFlag:
+                            # c.frame.tree.updateIcon(p)  # redraw only the icon.
                 return p, pos, newpos
             # Searching the pane failed: switch to another pane or node.
             if self._fnm_should_stay_in_node(p):

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -2278,8 +2278,9 @@ class NullTree(LeoTree):
     def scrollTo(self, p: Position) -> None:
         pass
 
-    def updateIcon(self, p: Position) -> None:
-        pass
+    ###
+    # def updateIcon(self, p: Position) -> None:
+        # pass
     #@+node:ekr.20070228160345: *3* NullTree.setHeadline
     def setHeadline(self, p: Position, s: str) -> None:
         """Set the actual text of the headline widget.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -120,9 +120,6 @@ class TreeAPI:
         pass
     # Must be defined in subclasses.
 
-    def drawIcon(self, p: Position) -> None:
-        pass
-
     def editLabel(self, v: VNode, selectAll: bool=False, selection: Any=None) -> None:
         pass
 
@@ -1581,9 +1578,6 @@ class LeoTree:
     #@+node:ekr.20031218072017.3706: *3* LeoTree.Must be defined in subclasses
     # Drawing & scrolling.
 
-    def drawIcon(self, p: Position) -> None:
-        self.oops()
-
     def redraw(self, p: Position=None) -> None:
         self.oops()
     redraw_now = redraw
@@ -2252,9 +2246,6 @@ class NullTree(LeoTree):
             w = d.get(key)
             g.pr('w', w, 'v.h:', key.headString, 's:', repr(w.s))
     #@+node:ekr.20070228163350.1: *3* NullTree.Drawing & scrolling
-    def drawIcon(self, p: Position) -> None:
-        pass
-
     def redraw(self, p: Position=None) -> None:
         self.redrawCount += 1
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -2268,10 +2268,6 @@ class NullTree(LeoTree):
 
     def scrollTo(self, p: Position) -> None:
         pass
-
-    ###
-    # def updateIcon(self, p: Position) -> None:
-        # pass
     #@+node:ekr.20070228160345: *3* NullTree.setHeadline
     def setHeadline(self, p: Position, s: str) -> None:
         """Set the actual text of the headline widget.

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2338,7 +2338,7 @@ class VNode:
 
     def setIcon(self) -> None:  # pragma: no cover
         pass  # Compatibility routine for old scripts
-    #@+node:ekr.20220905044353.1: *4* v.updateIcon (new)
+    #@+node:ekr.20220905044353.1: *4* v.updateIcon
     def updateIcon(self) -> None:
 
         c, v = self.context, self

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2342,16 +2342,15 @@ class VNode:
     def updateIcon(self) -> None:
 
         c, v = self.context, self
-        tree = c.frame.tree
-        if not tree:
-            g.trace('No tree')
-            return
         try:
-            tree.nodeIconsDict.pop(v.gnx, None)
+            tree = c.frame.tree  # May not exist at startup.
+            if not tree:
+                g.trace('No tree')
+                return
+            tree.nodeIconsDict.pop(v.gnx, None)  # Only exists for Qt gui.
         except AttributeError:
             return
 
-        # icon = self.getIcon(p)  # sets p.v.iconVal
         v.iconVal = v.computeIcon()
         icon = tree.getCompositeIconImage(v)
 
@@ -2427,11 +2426,13 @@ class VNode:
         v = self
         if isinstance(s, str):
             v._bodyString = s
+            v.updateIcon()
             return
         else:  # pragma: no cover
             v._bodyString = g.toUnicode(s, reportErrors=True)
             self.contentModified()  # #1413.
             signal_manager.emit(self.context, 'body_changed', self)
+            v.updateIcon()
 
     def setHeadString(self, s: Any) -> None:
         # pylint: disable=no-else-return
@@ -2440,11 +2441,13 @@ class VNode:
         v = self
         if isinstance(s, str):
             v._headString = s.replace('\n', '')
+            v.updateIcon()
             return
         else:  # pragma: no cover
             s = g.toUnicode(s, reportErrors=True)
             v._headString = s.replace('\n', '')  # type:ignore
             self.contentModified()  # #1413.
+            v.updateIcon()
 
     initBodyString = setBodyString
     initHeadString = setHeadString

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2288,7 +2288,9 @@ class VNode:
         This method is fast, but dangerous. Unlike p.setDirty, this method does
         not call v.setAllAncestorAtFileNodesDirty.
         """
-        self.statusBits |= self.dirtyBit
+        v = self
+        v.statusBits |= v.dirtyBit
+        v.updateIcon()  ### Experimental
     #@+node:ekr.20031218072017.3398: *5* v.setMarked & initMarkedBit
     def setMarked(self) -> None:
         self.statusBits |= self.markedBit
@@ -2331,6 +2333,27 @@ class VNode:
 
     def setIcon(self) -> None:  # pragma: no cover
         pass  # Compatibility routine for old scripts
+    #@+node:ekr.20220905044353.1: *4* v.updateIcon (new)
+    def updateIcon(self) -> None:
+
+        c, v = self.context, self
+        tree = c.frame.tree
+        if not tree:
+            g.trace('No tree')
+            return
+        try:
+            tree.nodeIconsDict.pop(v.gnx, None)
+        except AttributeError:
+            return
+
+        # icon = self.getIcon(p)  # sets p.v.iconVal
+        v.iconVal = v.computeIcon()
+        icon = tree.getCompositeIconImage(v)
+
+        # Update all cloned items.
+        items = tree.vnode2items(v)
+        for item in items:
+            tree.setItemIcon(item, icon)
     #@+node:ville.20120502221057.7498: *4* v.contentModified
     def contentModified(self) -> None:
         g.contentModifiedSet.add(self)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2351,10 +2351,8 @@ class VNode:
         except AttributeError:
             return
 
-        ### v.iconVal = v.computeIcon()
-        icon = tree.getCompositeIconImage(v)
-
         # Update all cloned items.
+        icon = tree.getCompositeIconImage(v)
         items = tree.vnode2items(v)
         for item in items:
             tree.setItemIcon(item, icon)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2249,9 +2249,12 @@ class VNode:
         """Clear the vnode dirty bit."""
         v = self
         v.statusBits &= ~v.dirtyBit
+        v.updateIcon()
     #@+node:ekr.20031218072017.3391: *5* v.clearMarked
     def clearMarked(self) -> None:
-        self.statusBits &= ~self.markedBit
+        v = self
+        self.statusBits &= ~v.markedBit
+        v.updateIcon()
     #@+node:ekr.20031218072017.3392: *5* v.clearOrphan
     def clearOrphan(self) -> None:
         self.statusBits &= ~self.orphanBit
@@ -2290,10 +2293,12 @@ class VNode:
         """
         v = self
         v.statusBits |= v.dirtyBit
-        v.updateIcon()  ### Experimental
+        v.updateIcon()
     #@+node:ekr.20031218072017.3398: *5* v.setMarked & initMarkedBit
     def setMarked(self) -> None:
-        self.statusBits |= self.markedBit
+        v = self
+        v.statusBits |= v.markedBit
+        v.updateIcon()
 
     def initMarkedBit(self) -> None:
         self.statusBits |= self.markedBit

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2253,7 +2253,7 @@ class VNode:
     #@+node:ekr.20031218072017.3391: *5* v.clearMarked
     def clearMarked(self) -> None:
         v = self
-        self.statusBits &= ~v.markedBit
+        v.statusBits &= ~v.markedBit
         v.updateIcon()
     #@+node:ekr.20031218072017.3392: *5* v.clearOrphan
     def clearOrphan(self) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2351,7 +2351,7 @@ class VNode:
         except AttributeError:
             return
 
-        v.iconVal = v.computeIcon()
+        ### v.iconVal = v.computeIcon()
         icon = tree.getCompositeIconImage(v)
 
         # Update all cloned items.

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -4757,7 +4757,7 @@ class LeoServer:
         for p in c.all_unique_positions():
             if p.v.gnx == gnx:
                 return p
-        return None  ### Was False.
+        return None
     #@+node:felix.20210622232409.1: *4* server._send_async_output & helper
     def _send_async_output(self, package: Package, toAll: bool=False) -> None:
         """

--- a/leo/plugins/auto_colorize2_0.py
+++ b/leo/plugins/auto_colorize2_0.py
@@ -97,35 +97,9 @@ def colorize(c, p, item):
                     font.setBold(True)
             except Exception:
                 pass
-            #icon
-            # if f['icon']:
-                # com = c.editCommands
-                # allIcons = com.getIconList(p)
-                # icons = [i for i in allIcons if f['icon'] not in i]
-                # in_list = False
-                # for i in icons:
-                    # print("%s : %s" % (f['icon'], i))
-                    # if f['icon'] in i:
-                        # in_list = True
-                        # break
-
-                # if in_list != True:
-                    # com.appendImageDictToList(icons, f['icon_dir'], f['icon'], 1)
-                    # com.setIconList(p, icons, True)
         if k == p.h:
             format_one(f)
-        # else:
-            # if "++" in p.h:
-                # color = "#999999"
-            # try:
-                # item.setForeground(0, QBrush(QColor(color)))
-            # except:
-                # pass
     item.setFont(0, font)
-
-
-
-
 
 
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -68,7 +68,7 @@ class LeoQtGui(leoGui.LeoGui):
         super().__init__('qt')  # Initialize the base class.
         self.active = True
         self.consoleOnly = False  # Console is separate from the log.
-        self.iconimages: Dict = {}
+        self.iconimages: Dict[str, Any] = {}  # Keys are paths, values are Icons.
         self.globalFindDialog: Widget = None
         self.idleTimeClass: Any = qt_idle_time.IdleTime
         self.insert_char_flag = False  # A flag for eventFilter.

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -633,17 +633,13 @@ class LeoQtTree(leoFrame.LeoTree):
         """Redraw all Qt outline items cloned to c.p."""
         if self.busy:
             return
-        p = self.c.p
+        c, p = self.c, self.c.p
         if p:
             h = p.h  # 2010/02/09: Fix bug 518823.
             for item in self.vnode2items(p.v):
                 if self.isValidItem(item):
                     self.setItemText(item, h)
-        # Bug fix: 2009/10/06
-        self.redraw_after_icons_changed()
-    #@+node:ekr.20110605121601.17883: *4* qtree.redraw_after_icons_changed (Disabled)
-    def redraw_after_icons_changed(self) -> None:
-        """No longer used."""
+        c.redraw_after_icons_changed()
     #@+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
     def redraw_after_select(self, p: Position=None) -> None:
         """Redraw the entire tree when an invisible node is selected."""

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -643,24 +643,9 @@ class LeoQtTree(leoFrame.LeoTree):
                     self.setItemText(item, h)
         # Bug fix: 2009/10/06
         self.redraw_after_icons_changed()
-    #@+node:ekr.20110605121601.17883: *4* qtree.redraw_after_icons_changed
+    #@+node:ekr.20110605121601.17883: *4* qtree.redraw_after_icons_changed (Disabled)
     def redraw_after_icons_changed(self) -> None:
-
-        if 0:  ### Disabled.
-
-            if self.busy:
-                return
-            self.redrawCount += 1  # To keep a unit test happy.
-            c = self.c
-            try:
-                self.busy = True  # Suppress call to setHeadString in onItemChanged!
-                self.getCurrentItem()
-                # 2799: Only c.p and its parents need to be updated.
-                #       This is a *huge* performance improvement.
-                for p in c.p.self_and_parents(copy=False):
-                    self.updateIcon(p)
-            finally:
-                self.busy = False
+        """No longer used."""
     #@+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
     def redraw_after_select(self, p: Position=None) -> None:
         """Redraw the entire tree when an invisible node is selected."""

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -42,7 +42,7 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+others
     #@+node:ekr.20110605121601.18404: *3* qtree.Birth
     #@+node:ekr.20110605121601.18405: *4* qtree.__init__
-    def __init__(self, c: Cmdr, frame: Any) -> None:  ### Frame is a LeoQtFrame.
+    def __init__(self, c: Cmdr, frame: Any) -> None:  # Frame is a LeoQtFrame.
         """Ctor for the LeoQtTree class."""
         super().__init__(frame)
         self.c = c
@@ -212,7 +212,6 @@ class LeoQtTree(leoFrame.LeoTree):
                 item._real_text = p.h
             # Draw the icon.
             v.iconVal = v.computeIcon()
-            ## icon = self.getCompositeIconImage(p, v.iconVal)
             icon = self.getCompositeIconImage(p.v)
             if icon:
                 self.setItemIcon(item, icon)
@@ -567,7 +566,6 @@ class LeoQtTree(leoFrame.LeoTree):
         # Draw the icon.
         v.iconVal = v.computeIcon()
         # **Slow**, but allows per-vnode icons.
-        ### icon = self.getCompositeIconImage(p, v.iconVal)
         icon = self.getCompositeIconImage(p.v)
         if icon:
             item.setIcon(0, icon)
@@ -887,7 +885,6 @@ class LeoQtTree(leoFrame.LeoTree):
             item = self.position2item(p)
             return item and self.declutter_node(self.c, p, item)
         p.v.iconVal = p.v.computeIcon()
-        ### return self.getCompositeIconImage(p.v, iv)
         return self.getCompositeIconImage(p.v)
     #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node
     def icon_filenames_for_node(self, v: VNode, val: int) -> List[str]:
@@ -932,7 +929,6 @@ class LeoQtTree(leoFrame.LeoTree):
         painter.end()
         return QtGui.QIcon(QtGui.QPixmap.fromImage(pix))
     #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage
-    ### def getCompositeIconImage(self, v: VNode, val: int) -> Icon:
     def getCompositeIconImage(self, v: VNode) -> Icon:
         """Get the icon at v."""
         fnames = self.icon_filenames_for_node(v, v.iconVal)
@@ -956,16 +952,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
     #@+node:ekr.20110605121601.17951: *4* qtree.updateIcon (disabled)
     def updateIcon(self, p: Position) -> None:
-
-        if 0:  ###  Use qt_gui.updateIcon instead.
-            if not p:
-                return
-            self.nodeIconsDict.pop(p.gnx, None)
-            icon = self.getIcon(p)  # sets p.v.iconVal
-            # Update all cloned items.
-            items = self.vnode2items(p.v)
-            for item in items:
-                self.setItemIcon(item, icon)
+        pass  ### To be removed.
     #@+node:ekr.20110605121601.18414: *3* qtree.Items
     #@+node:ekr.20110605121601.17943: *4*  qtree.item dict getters
     def itemHash(self, item: Item) -> str:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -211,7 +211,7 @@ class LeoQtTree(leoFrame.LeoTree):
             if self.use_declutter:
                 item._real_text = p.h
             # Draw the icon.
-            v.iconVal = v.computeIcon()
+            ### v.iconVal = v.computeIcon()
             icon = self.getCompositeIconImage(p.v)
             if icon:
                 self.setItemIcon(item, icon)
@@ -563,9 +563,8 @@ class LeoQtTree(leoFrame.LeoTree):
             if icon:
                 item.setIcon(0, icon)
             return item
-        # Draw the icon.
-        v.iconVal = v.computeIcon()
-        # **Slow**, but allows per-vnode icons.
+        # Draw the icon: **Slow**, but allows per-vnode icons.
+        ### v.iconVal = v.computeIcon()
         icon = self.getCompositeIconImage(p.v)
         if icon:
             item.setIcon(0, icon)
@@ -880,12 +879,13 @@ class LeoQtTree(leoFrame.LeoTree):
         if self.use_declutter:
             item = self.position2item(p)
             return item and self.declutter_node(self.c, p, item)
-        p.v.iconVal = p.v.computeIcon()
+        ### p.v.iconVal = p.v.computeIcon()
         return self.getCompositeIconImage(p.v)
     #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node
-    def icon_filenames_for_node(self, v: VNode, val: int) -> List[str]:
+    ### def icon_filenames_for_node(self, v: VNode, val: int) -> List[str]:
+    def icon_filenames_for_node(self, v: VNode) -> List[str]:
         """Returns a list of icon filenames for v."""
-        nicon = f'box{val:02d}.png'
+        nicon = f'box{v.iconVal:02d}.png'
         fnames = self.nodeIconsDict.get(v.gnx)
         if not fnames:
             icons = self.c.editCommands.getIconList(v)
@@ -927,7 +927,8 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage
     def getCompositeIconImage(self, v: VNode) -> Icon:
         """Get the icon at v."""
-        fnames = self.icon_filenames_for_node(v, v.iconVal)
+        v.iconVal = v.computeIcon()
+        fnames = self.icon_filenames_for_node(v)
         h = ':'.join(fnames)
         icon = g.app.gui.iconimages.get(h)
         loaded_images = self.loaded_images

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -904,7 +904,7 @@ class LeoQtTree(leoFrame.LeoTree):
         p.v.iconVal = p.v.computeIcon()
         ### return self.getCompositeIconImage(p.v, iv)
         return self.getCompositeIconImage(p.v)
-    #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node (uses VNode)
+    #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node
     def icon_filenames_for_node(self, v: VNode, val: int) -> List[str]:
         """Returns a list of icon filenames for v."""
         nicon = f'box{val:02d}.png'
@@ -946,7 +946,7 @@ class LeoQtTree(leoFrame.LeoTree):
             x += i.width() + hsep
         painter.end()
         return QtGui.QIcon(QtGui.QPixmap.fromImage(pix))
-    #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage (uses VNode)
+    #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage
     ### def getCompositeIconImage(self, v: VNode, val: int) -> Icon:
     def getCompositeIconImage(self, v: VNode) -> Icon:
         """Get the icon at v."""

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -212,7 +212,8 @@ class LeoQtTree(leoFrame.LeoTree):
                 item._real_text = p.h
             # Draw the icon.
             v.iconVal = v.computeIcon()
-            icon = self.getCompositeIconImage(p, v.iconVal)
+            ## icon = self.getCompositeIconImage(p, v.iconVal)
+            icon = self.getCompositeIconImage(p.v)
             if icon:
                 self.setItemIcon(item, icon)
             # Set current item.
@@ -349,7 +350,7 @@ class LeoQtTree(leoFrame.LeoTree):
             Returns a list of icon filenames for this node.
             The list is sorted to owner the 'where' key of image dicts.
             """
-            icons = c.editCommands.getIconList(p)
+            icons = c.editCommands.getIconList(p.v)
             a = [x['file'] for x in icons if x['where'] == 'beforeIcon']
             a.append(iconName)
             a.extend(x['file'] for x in icons if x['where'] == 'beforeHeadline')
@@ -566,7 +567,8 @@ class LeoQtTree(leoFrame.LeoTree):
         # Draw the icon.
         v.iconVal = v.computeIcon()
         # **Slow**, but allows per-vnode icons.
-        icon = self.getCompositeIconImage(p, v.iconVal)
+        ### icon = self.getCompositeIconImage(p, v.iconVal)
+        icon = self.getCompositeIconImage(p.v)
         if icon:
             item.setIcon(0, icon)
         return item
@@ -644,19 +646,21 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.17883: *4* qtree.redraw_after_icons_changed
     def redraw_after_icons_changed(self) -> None:
 
-        if self.busy:
-            return
-        self.redrawCount += 1  # To keep a unit test happy.
-        c = self.c
-        try:
-            self.busy = True  # Suppress call to setHeadString in onItemChanged!
-            self.getCurrentItem()
-            # 2799: Only c.p and its parents need to be updated.
-            #       This is a *huge* performance improvement.
-            for p in c.p.self_and_parents(copy=False):
-                self.updateIcon(p)
-        finally:
-            self.busy = False
+        if 0:  ### Disabled.
+
+            if self.busy:
+                return
+            self.redrawCount += 1  # To keep a unit test happy.
+            c = self.c
+            try:
+                self.busy = True  # Suppress call to setHeadString in onItemChanged!
+                self.getCurrentItem()
+                # 2799: Only c.p and its parents need to be updated.
+                #       This is a *huge* performance improvement.
+                for p in c.p.self_and_parents(copy=False):
+                    self.updateIcon(p)
+            finally:
+                self.busy = False
     #@+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
     def redraw_after_select(self, p: Position=None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
@@ -897,29 +901,26 @@ class LeoQtTree(leoFrame.LeoTree):
         if self.use_declutter:
             item = self.position2item(p)
             return item and self.declutter_node(self.c, p, item)
-        p.v.iconVal = iv = p.v.computeIcon()
-        return self.getCompositeIconImage(p, iv)
-
-
-    #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node
-    def icon_filenames_for_node(self, p: Position, val: int) -> List[str]:
-        """Prepares and returns a list of icon filenames
-           related to this node.
-        """
+        p.v.iconVal = p.v.computeIcon()
+        ### return self.getCompositeIconImage(p.v, iv)
+        return self.getCompositeIconImage(p.v)
+    #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node (uses VNode)
+    def icon_filenames_for_node(self, v: VNode, val: int) -> List[str]:
+        """Returns a list of icon filenames for v."""
         nicon = f'box{val:02d}.png'
-        fnames = self.nodeIconsDict.get(p.gnx)
+        fnames = self.nodeIconsDict.get(v.gnx)
         if not fnames:
-            icons = self.c.editCommands.getIconList(p)
+            icons = self.c.editCommands.getIconList(v)
             fnames = [x['file'] for x in icons if x['where'] == 'beforeIcon']
             fnames.append(nicon)
             fnames.extend(x['file'] for x in icons if x['where'] == 'beforeHeadline')
-            self.nodeIconsDict[p.gnx] = fnames
+            self.nodeIconsDict[v.gnx] = fnames
         pat = re.compile(r'^box\d\d\.png$')
         loaded_images = self.loaded_images
         for i, f in enumerate(fnames):
             if pat.match(f):
                 fnames[i] = nicon
-                self.nodeIconsDict[p.gnx] = fnames
+                self.nodeIconsDict[v.gnx] = fnames
                 f = nicon
             if f not in loaded_images:
                 loaded_images[f] = g.app.gui.getImageImage(f)
@@ -945,10 +946,11 @@ class LeoQtTree(leoFrame.LeoTree):
             x += i.width() + hsep
         painter.end()
         return QtGui.QIcon(QtGui.QPixmap.fromImage(pix))
-    #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage
-    def getCompositeIconImage(self, p: Position, val: int) -> Icon:
-        """Get the icon at position p."""
-        fnames = self.icon_filenames_for_node(p, val)
+    #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage (uses VNode)
+    ### def getCompositeIconImage(self, v: VNode, val: int) -> Icon:
+    def getCompositeIconImage(self, v: VNode) -> Icon:
+        """Get the icon at v."""
+        fnames = self.icon_filenames_for_node(v, v.iconVal)
         h = ':'.join(fnames)
         icon = g.app.gui.iconimages.get(h)
         loaded_images = self.loaded_images
@@ -967,17 +969,18 @@ class LeoQtTree(leoFrame.LeoTree):
             # but there is no itemChanged event handler.
             item.setIcon(0, icon)
 
-    #@+node:ekr.20110605121601.17951: *4* qtree.updateIcon
+    #@+node:ekr.20110605121601.17951: *4* qtree.updateIcon (disabled)
     def updateIcon(self, p: Position) -> None:
 
-        if not p:
-            return
-        self.nodeIconsDict.pop(p.gnx, None)
-        icon = self.getIcon(p)  # sets p.v.iconVal
-        # Update all cloned items.
-        items = self.vnode2items(p.v)
-        for item in items:
-            self.setItemIcon(item, icon)
+        if 0:  ###  Use qt_gui.updateIcon instead.
+            if not p:
+                return
+            self.nodeIconsDict.pop(p.gnx, None)
+            icon = self.getIcon(p)  # sets p.v.iconVal
+            # Update all cloned items.
+            items = self.vnode2items(p.v)
+            for item in items:
+                self.setItemIcon(item, icon)
     #@+node:ekr.20110605121601.18414: *3* qtree.Items
     #@+node:ekr.20110605121601.17943: *4*  qtree.item dict getters
     def itemHash(self, item: Item) -> str:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -931,10 +931,6 @@ class LeoQtTree(leoFrame.LeoTree):
             # but there is no itemChanged event handler.
             item.setIcon(0, icon)
 
-    #@+node:ekr.20110605121601.17951: *4* qtree.updateIcon (disabled)
-    ##
-    # def updateIcon(self, p: Position) -> None:
-        # pass  ### To be removed.
     #@+node:ekr.20110605121601.18414: *3* qtree.Items
     #@+node:ekr.20110605121601.17943: *4*  qtree.item dict getters
     def itemHash(self, item: Item) -> str:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -211,7 +211,6 @@ class LeoQtTree(leoFrame.LeoTree):
             if self.use_declutter:
                 item._real_text = p.h
             # Draw the icon.
-            ### v.iconVal = v.computeIcon()
             icon = self.getCompositeIconImage(p.v)
             if icon:
                 self.setItemIcon(item, icon)
@@ -564,7 +563,6 @@ class LeoQtTree(leoFrame.LeoTree):
                 item.setIcon(0, icon)
             return item
         # Draw the icon: **Slow**, but allows per-vnode icons.
-        ### v.iconVal = v.computeIcon()
         icon = self.getCompositeIconImage(p.v)
         if icon:
             item.setIcon(0, icon)
@@ -879,10 +877,8 @@ class LeoQtTree(leoFrame.LeoTree):
         if self.use_declutter:
             item = self.position2item(p)
             return item and self.declutter_node(self.c, p, item)
-        ### p.v.iconVal = p.v.computeIcon()
         return self.getCompositeIconImage(p.v)
     #@+node:vitalije.20200329153148.1: *5* qtree.icon_filenames_for_node
-    ### def icon_filenames_for_node(self, v: VNode, val: int) -> List[str]:
     def icon_filenames_for_node(self, v: VNode) -> List[str]:
         """Returns a list of icon filenames for v."""
         nicon = f'box{v.iconVal:02d}.png'

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -859,11 +859,6 @@ class LeoQtTree(leoFrame.LeoTree):
     def setFocus(self) -> None:
         g.app.gui.set_focus(self.c, self.treeWidget)
     #@+node:ekr.20110605121601.18409: *3* qtree.Icons
-    #@+node:ekr.20110605121601.18410: *4* qtree.drawIcon
-    def drawIcon(self, p: Position) -> None:
-        """Redraw the icon at p."""
-        ### self.updateIcon(p)
-       
     #@+node:ekr.20110605121601.18411: *4* qtree.getIcon & helper
     def getIcon(self, p: Position) -> Icon:
         """Return the proper icon for position p."""

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -862,15 +862,8 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.18410: *4* qtree.drawIcon
     def drawIcon(self, p: Position) -> None:
         """Redraw the icon at p."""
-        self.updateIcon(p)
-        # the following code is wrong. It constructs a new item
-        # and assignes the icon to it. However this item is never
-        # added to the treeWidget so it is soon garbage collected
-            # w = self.treeWidget
-            # itemOrTree = self.position2item(p) or w
-            # item = QtWidgets.QTreeWidgetItem(itemOrTree)
-            # icon = self.getIcon(p)
-            # self.setItemIcon(item, icon)
+        ### self.updateIcon(p)
+       
     #@+node:ekr.20110605121601.18411: *4* qtree.getIcon & helper
     def getIcon(self, p: Position) -> Icon:
         """Return the proper icon for position p."""
@@ -944,8 +937,9 @@ class LeoQtTree(leoFrame.LeoTree):
             item.setIcon(0, icon)
 
     #@+node:ekr.20110605121601.17951: *4* qtree.updateIcon (disabled)
-    def updateIcon(self, p: Position) -> None:
-        pass  ### To be removed.
+    ##
+    # def updateIcon(self, p: Position) -> None:
+        # pass  ### To be removed.
     #@+node:ekr.20110605121601.18414: *3* qtree.Items
     #@+node:ekr.20110605121601.17943: *4*  qtree.item dict getters
     def itemHash(self, item: Item) -> str:

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -582,7 +582,7 @@ class todoController:
     def loadIcons(self, p: Position, clear: bool=False) -> None:
 
         com = self.c.editCommands
-        allIcons = com.getIconList(p)
+        allIcons = com.getIconList(p.v)
         icons = [i for i in allIcons if 'cleoIcon' not in i]
         if self.icon_order == 'pri-first':
             iterations = ['priority', 'progress', 'duedate']


### PR DESCRIPTION
PR for #2812.

**Summary**

The old code (qtree.redraw_after_icons_changed) updated all visible nodes in the entire tree, a huge waste of time. Instead, the VNode setters that affect icons call v.updateIcon.  That's all!

- [x] Retire qtree.redraw_after_icons_changed.
- [x] Add v.updateIcon.
- [x] Call v.updateIcon from all vnode setters that could affect icons.
- [x] Use a VNode arg instead of a Position arg in:
    ec.getIconList,
    qtree.getCompositeIconImage,
    qtree.icon_filenames_for_node
- [x] Simplify calls to tree.getCompositeIconImage and qtree.icon_filenames_for_node.
- [x] Retire all tree-related updateIcon methods.
- [x] Retire all drawIcon methods.
- [x] Remove unused vStack and thinChildIndexStack from AtFile class.
- [x] Update annotations as needed.