### PR TITLE
Fix user attributes

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -2164,7 +2164,7 @@ class FileCommands:
         if key.startswith('str_'):
             if isinstance(val, (str, bytes)):
                 val = g.toUnicode(val)
-                attr = f' {key}="{xml.sax.saxutils.escape(val)}"'
+                attr = f' {key}={xml.sax.saxutils.quoteattr(val)}'
                 return attr
             g.trace(type(val), repr(val))
             g.warning("ignoring non-string attribute", key, "in", torv)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -2179,7 +2179,7 @@ class FileCommands:
         if isinstance(attrDict, dict):
             val = ''.join(
                 [self.putUaHelper(v, key, val)
-                    for key, val in attrDict.items()])
+                    for key, val in sorted(attrDict.items())])
             return val
         g.warning("ignoring non-dictionary unknownAttributes for", v)
         return ''


### PR DESCRIPTION
Leo supports storing plain strings as user attributes if the key starts with 'str_', but there is a quoting bug that results in a corrupted file if the value contains the '"' character. This patch causes Leo to use correct quoting for such values.

Compatibility note: Affected files will be readable by unpatched versions of Leo but won't be writable. Users not using this feature are unaffected.

This patch also sorts user attributes by key name, otherwise the order isn't stable from one save to another and causes noise when using version control. This change is fully backward compatible.