### PR TITLE
Add Declutter DOCICON command

### DIFF
--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -401,6 +401,11 @@ class LeoQtTree(leoFrame.LeoTree):
                     # wrap list 'new_icons' in a saved argument as
                     # the list is recreated before each call.
                     new_icons.append(param)
+            elif cmd == 'DOCICON':
+                param = g.os_path_join(g.os_path_dirname(c.fileName()), param)
+                def modifier(item: Item, param: str) -> None:
+                    # As above, but for document relative icons
+                    new_icons.append(param)
             elif cmd == 'BG':
                 def modifier(item: Item, param: str) -> None:
                     item.setBackground(0, QtGui.QBrush(QtGui.QColor(param)))


### PR DESCRIPTION
Add document relative icons to Declutter.

Works like the existing ICON command except that relative paths are document relative instead of theme relative.

Example:
RULE some rule
DOCICON relative/path/to/icon.png

Compatibilty: Older versions of Leo will display a warning and won't load the icon but are otherwise unaffected.

If you'd prefer I can continue working on a more general solution that would make this PR redundant.