### PR TITLE
fix crash on declutter REPLACE error

### DIFF
--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -367,7 +367,10 @@ class LeoQtTree(leoFrame.LeoTree):
             replacement, s = None, None
 
             if cmd == 'REPLACE':
-                s = pattern.sub(arg, text)
+                try:
+                    s = pattern.sub(arg, text)
+                except re.error as e:
+                    g.log(f'Error in declutter REPLACE "{e!s}"\n  RULE:{pattern.pattern!r}\n  REPLACE:{arg!r}\n  HEADLINE:{text!r}', color='error')
             elif cmd == 'REPLACE-HEAD':
                 s = text[: m.start()].rstrip()
             elif cmd == 'REPLACE-TAIL':


### PR DESCRIPTION
There is a crash bug when a declutter REPLACE pattern is invalid. This patch prevents the crash and provides a detailed report to help the user find the bad rule and the headline triggering the error.