### PR TITLE
PR 2 for #2827

### DIFF
--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -46,7 +46,7 @@ class LeoGui:
         self.consoleOnly = True  # True if g.es goes to console.
         self.globalFindTabManager: Any = None
         self.globalFindTab: Widget = None
-        self.idleTimeClass = None
+        self.idleTimeClass: Any = None
         self.isNullGui = False
         self.lastFrame: Any = None
         self.leoIcon = None

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -499,9 +499,6 @@ class NullGui(LeoGui):
 
     def onDeactivateEvent(self, *args: str, **keys: str) -> None:
         pass
-
-    def set_top_geometry(self, w: Widget, h: str, x: str, y: str) -> None:
-        pass
     #@+node:ekr.20070228155807: *3* NullGui.isTextWidget & isTextWrapper
     def isTextWidget(self, w: Any) -> bool:
         return True  # Must be True for unit tests.

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -111,22 +111,25 @@ class LeoUnitTest(unittest.TestCase):
 
     def setUp(self) -> None:
         """
-        Create a commander using a **null** gui, regardless of g.app.gui.
+        Create a commander using g.app.gui.
         Create the nodes in the commander.
         """
         # Do the import here to avoid circular dependencies.
         from leo.core import leoCommands
-        from leo.core.leoGui import NullGui
+
         # Set g.unitTesting *early*, for guards.
         g.unitTesting = True
+
         # Create a new commander for each test.
         # This is fast, because setUpClass has done all the imports.
-        self.c = c = leoCommands.Commands(fileName=None, gui=NullGui())
+        self.c = c = leoCommands.Commands(fileName=None, gui=g.app.gui)
+
         # Init the 'root' and '@settings' nodes.
         self.root_p = c.rootPosition()
         self.root_p.h = 'root'
         self.settings_p = self.root_p.insertAfter()
         self.settings_p.h = '@settings'
+
         # Select the 'root' node.
         c.selectPosition(self.root_p)
 

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -44,12 +44,11 @@ def create_app(gui_name: str='null') -> Cmdr:
     """
     trace = False
     t1 = time.process_time()
-    #
     # Set g.unitTesting *early*, for guards, to suppress the splash screen, etc.
     g.unitTesting = True
     # Create g.app now, to avoid circular dependencies.
     g.app = leoApp.LeoApp()
-    # Late imports.
+    # Do late imports.
     warnings.simplefilter("ignore")
     from leo.core import leoConfig
     from leo.core import leoNodes
@@ -61,9 +60,10 @@ def create_app(gui_name: str='null') -> Cmdr:
     g.app.recentFilesManager = leoApp.RecentFilesManager()
     g.app.loadManager = lm = leoApp.LoadManager()
     lm.computeStandardDirectories()
-    g.app.leoID = 'TestLeoId'  # 2022/03/06: Use a standard user id for all tests.
+    g.app.leoID = 'TestLeoId'  # Use a standard user id for all tests.
     g.app.nodeIndices = leoNodes.NodeIndices(g.app.leoID)
     g.app.config = leoConfig.GlobalConfigManager()
+    # Disable dangerous code.
     g.app.db = g.NullObject('g.app.db')  # type:ignore
     g.app.pluginsController = g.NullObject('g.app.pluginsController')  # type:ignore
     g.app.commander_cacher = g.NullObject('g.app.commander_cacher')  # type:ignore
@@ -74,9 +74,7 @@ def create_app(gui_name: str='null') -> Cmdr:
     else:  # pragma: no cover
         raise TypeError(f"create_gui: unknown gui_name: {gui_name!r}")
     t3 = time.process_time()
-    # Create a dummy commander, to do the imports in c.initObjects.
-    # Always use a null gui to avoid screen flash.
-    # setUp will create another commander.
+    # Create the commander, for c.initObjects.
     c = leoCommands.Commands(fileName=None, gui=g.app.gui)
     # Create minimal config dictionaries.
     settings_d, bindings_d = lm.createDefaultSettingsDicts()

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -70,11 +70,10 @@ class LeoQtGui(leoGui.LeoGui):
         self.consoleOnly = False  # Console is separate from the log.
         self.iconimages: Dict[str, Any] = {}  # Keys are paths, values are Icons.
         self.globalFindDialog: Widget = None
-        self.idleTimeClass: Any = qt_idle_time.IdleTime
+        self.idleTimeClass: qt_idle_time.IdleTime
         self.insert_char_flag = False  # A flag for eventFilter.
         self.mGuiName = 'qt'
-        self.main_window = None  # The *singleton* QMainWindow.
-        self.plainTextWidget: Any = qt_text.PlainTextWrapper
+        self.plainTextWidget: qt_text.PlainTextWrapper
         self.show_tips_flag = False  # #2390: Can't be inited in reload_settings.
         self.styleSheetManagerClass = StyleSheetManager
         # Be aware of the systems native colors, fonts, etc.
@@ -1096,28 +1095,6 @@ class LeoQtGui(leoGui.LeoGui):
                 # return False, indicating that the widget must handle
                 # qevent, which *presumably* is the best that can be done.
                 g.app.gui.insert_char_flag = True
-    #@+node:ekr.20190819072045.1: *3* qt_gui.make_main_window
-    def make_main_window(self) -> None:
-        """Make the *singleton* QMainWindow."""
-        window = QtWidgets.QMainWindow()
-        window.setObjectName('LeoGlobalMainWindow')
-        # Calling window.show() here causes flash.
-        self.attachLeoIcon(window)
-        # Monkey-patch
-        window.closeEvent = self.close_event  # Use self: g.app.gui does not exist yet.
-        self.runAtIdle(self.set_main_window_style_sheet)  # No StyleSheetManager exists yet.
-        return window
-
-    def set_main_window_style_sheet(self) -> None:
-        """Style the main window, using the first .leo file."""
-        commanders = g.app.commanders()
-        if commanders:
-            c = commanders[0]
-            ssm = c.styleSheetManager
-            ssm.set_style_sheets(w=self.main_window)
-            self.main_window.setWindowTitle(c.frame.title)  # #1506.
-        else:
-            g.trace("No open commanders!")
     #@+node:ekr.20110605121601.18528: *3* qt_gui.makeScriptButton
     def makeScriptButton(
         self,
@@ -1298,16 +1275,6 @@ class LeoQtGui(leoGui.LeoGui):
             g.es_exception()
             print('can not init leo.core.leoIPython.py')
             sys.exit(1)
-    #@+node:ekr.20190822174038.1: *3* qt_gui.set_top_geometry
-    already_sized = False
-
-    def set_top_geometry(self, w: int, h: int, x: int, y: int) -> None:
-        """Set the geometry of the main window."""
-        if 'size' in g.app.debug:
-            g.trace('(qt_gui) already_sized', self.already_sized, w, h, x, y)
-        if not self.already_sized:
-            self.already_sized = True
-            self.main_window.setGeometry(QtCore.QRect(x, y, w, h))
     #@+node:ekr.20180117053546.1: *3* qt_gui.show_tips & helpers
     @g.command('show-tips')
     def show_next_tip(self, event: Event=None) -> None:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -70,10 +70,10 @@ class LeoQtGui(leoGui.LeoGui):
         self.consoleOnly = False  # Console is separate from the log.
         self.iconimages: Dict[str, Any] = {}  # Keys are paths, values are Icons.
         self.globalFindDialog: Widget = None
-        self.idleTimeClass: qt_idle_time.IdleTime
+        self.idleTimeClass = qt_idle_time.IdleTime
         self.insert_char_flag = False  # A flag for eventFilter.
         self.mGuiName = 'qt'
-        self.plainTextWidget: qt_text.PlainTextWrapper
+        self.plainTextWidget = qt_text.PlainTextWrapper
         self.show_tips_flag = False  # #2390: Can't be inited in reload_settings.
         self.styleSheetManagerClass = StyleSheetManager
         # Be aware of the systems native colors, fonts, etc.

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -133,6 +133,14 @@ class TestQtGui(LeoUnitTest):
             s = s.replace('\\', os.sep).rstrip() + '\n'
             result = c.frame.log.put_html_links(s)
             self.assertEqual(result, expected, msg=repr(s))
+    #@+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_text
+    def test_qt_text(self):
+
+        # g.printObj([z for z in dir(g.app.gui) if not z.startswith('__')])
+        if 0:
+            print('')
+            g.trace('g.app', g.app)
+        ### g.trace('g.app.gui.main_window', g.app.gui.main_window)
     #@-others
 #@+node:ekr.20220911100525.1: ** class TestAPIClasses(LeoUnitTest)
 class TestAPIClasses(LeoUnitTest):

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -136,7 +136,7 @@ class TestQtGui(LeoUnitTest):
             self.assertEqual(result, expected, msg=repr(s))
     #@+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_attributes
     def test_qt_attributes(self):
-
+        # Various preliminary tests.
         c = self.c
         if 0:
             print('')
@@ -148,7 +148,6 @@ class TestQtGui(LeoUnitTest):
             print('')
             g.trace(g.app.gui)
             g.trace(c.frame.body)
-
         if 0:
             g.trace(c.frame.body.wrapper)
             for method in ('delete', 'insert', 'toPythonIndexRowCol'):

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -136,30 +136,15 @@ class TestQtGui(LeoUnitTest):
     #@+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_text
     def test_qt_text(self):
 
-        # g.printObj([z for z in dir(g.app.gui) if not z.startswith('__')])
-        if 1:
+        # g.trace(self.c)
+
+        if 0:
             print('')
             for z in dir(g.app.gui):
                 if not z.startswith('__'):
                     obj = getattr(g.app.gui, z, None)
-                    if 0:  # Poor.
-                        print(f"{z:>30} {g.objToString(obj)}")
-                    else:
-                        # Maybe this should be model for g.objToString.
-                        if 'method' in repr(obj):
-                            print(f"{z:>30} method: {obj.__name__}")
-                        elif 'module' in repr(obj):
-                            print(f"{z:>30} module")
-                        elif 'class' in repr(obj):
-                            print(f"{z:>30} class")
-                        elif isinstance(obj, list):
-                            print(f"{z:>30} list: {len(obj)} items")
-                        elif isinstance(obj, dict):
-                            print(f"{z:>30} dict: {len(obj.keys())} keys")
-                        elif obj is None:
-                            print(f"{z:>30} None")
-                        else:
-                            print(f"{z:>30} object: {obj!r}")
+                    print(f"{z:>30} {g.objToString(obj)}")
+
         ### To do: test various g.app.gui (LeoQtGui) methods
     #@-others
 #@+node:ekr.20220911100525.1: ** class TestAPIClasses(LeoUnitTest)

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -137,10 +137,30 @@ class TestQtGui(LeoUnitTest):
     def test_qt_text(self):
 
         # g.printObj([z for z in dir(g.app.gui) if not z.startswith('__')])
-        if 0:
+        if 1:
             print('')
-            g.trace('g.app', g.app)
-        ### g.trace('g.app.gui.main_window', g.app.gui.main_window)
+            for z in dir(g.app.gui):
+                if not z.startswith('__'):
+                    obj = getattr(g.app.gui, z, None)
+                    if 0:  # Poor.
+                        print(f"{z:>30} {g.objToString(obj)}")
+                    else:
+                        # Maybe this should be model for g.objToString.
+                        if 'method' in repr(obj):
+                            print(f"{z:>30} method: {obj.__name__}")
+                        elif 'module' in repr(obj):
+                            print(f"{z:>30} module")
+                        elif 'class' in repr(obj):
+                            print(f"{z:>30} class")
+                        elif isinstance(obj, list):
+                            print(f"{z:>30} list: {len(obj)} items")
+                        elif isinstance(obj, dict):
+                            print(f"{z:>30} dict: {len(obj.keys())} keys")
+                        elif obj is None:
+                            print(f"{z:>30} None")
+                        else:
+                            print(f"{z:>30} object: {obj!r}")
+        ### To do: test various g.app.gui (LeoQtGui) methods
     #@-others
 #@+node:ekr.20220911100525.1: ** class TestAPIClasses(LeoUnitTest)
 class TestAPIClasses(LeoUnitTest):

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -155,7 +155,7 @@ class TestQtGui(LeoUnitTest):
                 print(repr(f))
     #@+node:ekr.20220912140743.1: *3* TestQtGui.test_QTextEditWrapper_delete
     def test_QTextEditWrapper_delete(self):
-        
+
         c = self.c
         wrapper = c.frame.body.wrapper
         widget = wrapper.widget

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -14,6 +14,7 @@ from leo.core.leoFrame import StatusLineAPI, TreeAPI, WrapperAPI
 from leo.core.leoFrame import LeoTree, NullStatusLineClass, NullTree, StringTextWrapper
 from leo.plugins.qt_frame import LeoQtFrame
 from leo.plugins.qt_text import QLineEditWrapper, QScintillaWrapper, QTextEditWrapper
+from leo.plugins.qt_text import LeoQTextBrowser
 from leo.plugins.qt_tree import LeoQtTree
 #@-<< test_gui imports >>
 
@@ -133,8 +134,8 @@ class TestQtGui(LeoUnitTest):
             s = s.replace('\\', os.sep).rstrip() + '\n'
             result = c.frame.log.put_html_links(s)
             self.assertEqual(result, expected, msg=repr(s))
-    #@+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_text
-    def test_qt_text(self):
+    #@+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_attributes
+    def test_qt_attributes(self):
 
         c = self.c
         if 0:
@@ -148,7 +149,27 @@ class TestQtGui(LeoUnitTest):
             g.trace(g.app.gui)
             g.trace(c.frame.body)
 
-        ### To do: test various g.app.gui (LeoQtGui) methods
+        if 0:
+            g.trace(c.frame.body.wrapper)
+            for method in ('delete', 'insert', 'toPythonIndexRowCol'):
+                f = getattr(c.frame.body.wrapper, method, None)
+                print(repr(f))
+    #@+node:ekr.20220912140743.1: *3* TestQtGui.test_QTextEditWrapper_delete
+    def test_QTextEditWrapper_delete(self):
+        
+        c = self.c
+        wrapper = c.frame.body.wrapper
+        widget = wrapper.widget
+        self.assertTrue(isinstance(wrapper, QTextEditWrapper))
+        self.assertTrue(isinstance(widget, LeoQTextBrowser))
+        widget.setText('line1\nline2')
+        # g.trace(wrapper.getAllText())
+        wrapper.delete(0, 6)
+        # g.trace(wrapper.getAllText())
+        widget.setText('line1\nline2')
+        # g.trace(wrapper.getAllText())
+        wrapper.delete(6, 0)
+        # g.trace(wrapper.getAllText())
     #@-others
 #@+node:ekr.20220911100525.1: ** class TestAPIClasses(LeoUnitTest)
 class TestAPIClasses(LeoUnitTest):

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -41,12 +41,12 @@ class TestNullGui(LeoUnitTest):
 class TestQtGui(LeoUnitTest):
     """Test cases for gui base classes."""
 
-    #@+others
-    #@+node:ekr.20210912143315.1: *3*  TestQtGui.setUpClass
     # Override LeoUnitTest setUpClass.
     @classmethod
     def setUpClass(cls):
         create_app(gui_name='qt')
+
+    #@+others
     #@+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
     def test_bug_2164(self):
         # show-invisibles crashes with PyQt6.
@@ -136,14 +136,17 @@ class TestQtGui(LeoUnitTest):
     #@+node:ekr.20220912093438.1: *3* TestQtGui.test_qt_text
     def test_qt_text(self):
 
-        # g.trace(self.c)
-
+        c = self.c
         if 0:
             print('')
             for z in dir(g.app.gui):
                 if not z.startswith('__'):
                     obj = getattr(g.app.gui, z, None)
                     print(f"{z:>30} {g.objToString(obj)}")
+        if 0:
+            print('')
+            g.trace(g.app.gui)
+            g.trace(c.frame.body)
 
         ### To do: test various g.app.gui (LeoQtGui) methods
     #@-others


### PR DESCRIPTION
#2827 contains Ahas and ground rules.

- [x] LeoUnitTest.setUp uses g.app.gui rather than NullGui.
    **This was the only changed needed to enable unit tests of Qt code!**
- [x] Add two new TestQtGui tests: test_qt_attributes and test_QTextEditWrapper_delete.
- [x] Correct misleading comments in create_app function in leoTest2.py.

mypy revealed, and cffs confirmed, that the following methods were no longer used:

- [x] Remove LeoQtGui.main_window.
- [x] Remove LeoGui/LeoQtGui.set_top_geometry.
- [x] Remove LeoQtGui.make_main_window
- [x] Remove LeoQtGui.set_main_window_style_sheet.