### PR TITLE
PR: Remove unnecesssary arguments-differ suppressions

### DIFF
--- a/leo/core/leoDebugger.py
+++ b/leo/core/leoDebugger.py
@@ -180,9 +180,7 @@ class Xdb(pdb.Pdb, threading.Thread):
         self.saved_traceback = None
     #@+node:ekr.20181002053718.1: *3* Overrides
     #@+node:ekr.20190108040329.1: *4* xdb.checkline (overrides Pdb)
-    def checkline(self, path, n):
-        # pylint: disable=arguments-differ
-            # filename, lineno
+    def checkline(self, path: str, n: int):
         try:
             return pdb.Pdb.checkline(self, path, n)
         except AttributeError:

--- a/leo/plugins/importers/javascript.py
+++ b/leo/plugins/importers/javascript.py
@@ -44,7 +44,6 @@ class JS_Importer(Importer):
 
     def compute_headline(self, s: str) -> str:
         """Return a cleaned up headline s."""
-        # pylint: disable=arguments-differ
         s = s.strip()
         # Don't clean a headline twice.
         if s.endswith('>>') and s.startswith('<<'):  # pragma: no cover (missing test)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1749,12 +1749,9 @@ class LeoQtBody(leoFrame.LeoBody):
         return c.frame.body.wrapper
     #@+node:ekr.20110605121601.18201: *5* LeoQtBody.select/unselectLabel
     def unselectLabel(self, wrapper: Wrapper) -> None:
-        # pylint: disable=arguments-differ
         pass
-        # self.createChapterIvar(wrapper)
 
     def selectLabel(self, wrapper: Wrapper) -> None:
-        # pylint: disable=arguments-differ
         c = self.c
         w = wrapper.widget
         label = getattr(w, 'leo_label', None)
@@ -1767,7 +1764,6 @@ class LeoQtBody(leoFrame.LeoBody):
 
     def selectEditor(self, wrapper: Wrapper) -> None:
         """Select editor w and node w.leo_p."""
-        # pylint: disable=arguments-differ
         trace = 'select' in g.app.debug and not g.unitTesting
         tag = 'qt_body.selectEditor'
         c = self.c
@@ -1928,7 +1924,6 @@ class LeoQtBody(leoFrame.LeoBody):
     #@+node:ekr.20110605121601.18213: *5* LeoQtBody.recolorWidget (QScintilla only)
     def recolorWidget(self, p: Position, wrapper: Wrapper) -> None:
         """Support QScintillaColorizer.colorize."""
-        # pylint: disable=arguments-differ
         c = self.c
         colorizer = c.frame.body.colorizer
         if p and colorizer and hasattr(colorizer, 'colorize'):
@@ -2814,7 +2809,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
     #@+node:ekr.20110605121601.18282: *4* qtFrame.resizePanesToRatio
     def resizePanesToRatio(self, ratio: float, ratio2: float) -> None:
         """Resize splitter1 and splitter2 using the given ratios."""
-        # pylint: disable=arguments-differ
+        # py--lint: disable=arguments-differ
         self.divideLeoSplitter1(ratio)
         self.divideLeoSplitter2(ratio2)
     #@+node:ekr.20110605121601.18283: *4* qtFrame.divideLeoSplitter1/2
@@ -3071,7 +3066,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.top.raise_()
     #@+node:ekr.20190611053431.8: *4* qtFrame.setTitle
     def setTitle(self, s: str) -> None:
-        # pylint: disable=arguments-differ
         if self.top:
             # Fix https://bugs.launchpad.net/leo-editor/+bug/1194209
             # When using tabs, leo_master (a LeoTabbedTopLevel) contains the QMainWindow.

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -617,7 +617,6 @@ class LeoQtGui(leoGui.LeoGui):
         """
         Create and run an Qt open file dialog.
         """
-        # pylint: disable=arguments-differ
         if g.unitTesting:
             return ''
 
@@ -874,7 +873,6 @@ class LeoQtGui(leoGui.LeoGui):
         Check to see if c.frame is in a tabbed ui, and if so, make sure
         the tab is visible
         """
-        # pylint: disable=arguments-differ
         if 'focus' in g.app.debug:
             g.trace(c1)
         if hasattr(g.app.gui, 'frameFactory'):
@@ -886,7 +884,6 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20190601054958.1: *4* qt_gui.get_focus (no longer used)
     def get_focus(self, c: Cmdr=None, raw: bool=False, at_idle: bool=False) -> Widget:
         """Returns the widget that has focus."""
-        # pylint: disable=arguments-differ
         trace = 'focus' in g.app.debug
         trace_idle = False
         trace = trace and (trace_idle or not at_idle)
@@ -908,7 +905,6 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20190601054959.1: *4* qt_gui.set_focus
     def set_focus(self, c: Cmdr, w: Wrapper) -> None:
         """Put the focus on the widget."""
-        # pylint: disable=arguments-differ
         if not w:
             return
         if getattr(w, 'widget', None):


### PR DESCRIPTION
Recent simplifications render pylint's arguments-differ suppressions unnecessary in most places.  Hurray!