### PR TITLE
gnx UUID support

### DIFF
--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -85,7 +85,11 @@ class NodeIndices:
         c = v.context
         fc = c.fileCommands
         t_s = self.update()  # Updates self.lastTime and self.lastIndex.
-        gnx = g.toUnicode(f"{self.userId}.{t_s}.{self.lastIndex:d}")
+        if c.config.getBool('gnxisuuid'):
+            import uuid
+            gnx = g.toUnicode(str(uuid.uuid4()))
+        else:
+            gnx = g.toUnicode(f"{self.userId}.{t_s}.{self.lastIndex:d}")
         v.fileIndex = gnx
         self.check_gnx(c, gnx, v)
         fc.gnxDict[gnx] = v


### PR DESCRIPTION
This patch enables UUID based gnx strings. The feature is gated by a new @settings option '@bool gnx-is-uuid'. If the option is disabled (default) then nothing happens, but if it is enabled then all new gnx IDs will be created as UUID4 (random) strings instead of the current "username.timestamp.sequence" format. The option may be set in myLeoSettings.leo or in a document's @settings node, as usual.

Compatibility notes:
Existing vnodes are not affected by this option, and both timestamp and UUID based gnx strings may safely coexist in the same document.

Older versions of Leo (as far back as 4.1 when the current gnx format was introduced) can read and write such files without difficulty and will simply ignore the new setting. AFAICT the only impact is to the ToDo plugin, which will be unable to determine when a UUID node was created. It handles this situation gracefully but the "sort by creation date" feature won't work with UUID nodes.

User written code that depends on the format of gnx strings may misbehave if used with this feature, but code that treats gnx strings as blind data should be unaffected.

UUID based gnx is slightly less version control friendly than timestamp based since newly created nodes will be distributed at random instead of as contiguous blocks, but UUIDs are sort-stable so spurious changes will still be avoided.