### PR TITLE
PR for #2844: decluttered icons

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3221,15 +3221,16 @@ class Commands:
 
     force_redraw = redraw
     redraw_now = redraw
-    #@+node:ekr.20090110073010.3: *6* c.redraw_after_icons_changed
+    #@+node:ekr.20090110073010.3: *6* c.redraw_after_icons_changed (to be removed)
     def redraw_after_icons_changed(self) -> None:
         """Update the icon for the presently selected node"""
-        c = self
-        if c.enableRedrawFlag:
-            pass
-            # Do not call c.treeFocusHelper here.
-        else:
-            c.requestLaterRedraw = True
+        if 0:
+            c = self
+            if c.enableRedrawFlag:
+                pass
+                # Do not call c.treeFocusHelper here.
+            else:
+                c.requestLaterRedraw = True
     #@+node:ekr.20090110131802.2: *6* c.redraw_after_contract
     def redraw_after_contract(self, p: Position=None) -> None:
         c = self

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2353,12 +2353,11 @@ class VNode:
         try:
             tree = c.frame.tree  # May not exist at startup.
             if not tree:
-                g.trace('No tree')
                 return
-            tree.nodeIconsDict.pop(v.gnx, None)  # Only exists for Qt gui.
+            if not hasattr(tree, 'nodeIconsDict'):  # Only exists for Qt gui.
+                return
         except AttributeError:
             return
-
         # Update all cloned items.
         icon = tree.getCompositeIconImage(v)
         items = tree.vnode2items(v)

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -7802,6 +7802,133 @@ def stripped_args(self, s):
         args.append(arg)
         assert progress < i, (i, repr(s[i:]))
     return ', '.join(args)
+#@+node:ekr.20220913064923.2: ** qtree.drawVisible & helpers (not used)
+def drawVisible(self, p: Position) -> None:
+    """
+    Add only the visible nodes to the outline.
+
+    Not used, as this causes scrolling issues.
+    """
+    t1 = time.process_time()
+    c = self.c
+    parents: List[Any] = []
+    # Clear the widget.
+    w = self.treeWidget
+    w.clear()
+    # Clear the dicts.
+    self.initData()
+    if c.hoistStack:
+        first_p = c.hoistStack[-1].p
+        target_p = first_p.nodeAfterTree().visBack(c)
+    else:
+        first_p = c.rootPosition()
+        target_p = None
+    n = 0
+    for p in self.yieldVisible(first_p, target_p):
+        n += 1
+        level = p.level()
+        parent_item = w if level == 0 else parents[level - 1]
+        item = QtWidgets.QTreeWidgetItem(parent_item)
+        item.setFlags(item.flags() | ItemFlag.ItemIsEditable)
+        item.setChildIndicatorPolicy(
+            item.ShowIndicator if p.hasChildren()
+            else item.DontShowIndicator)
+        item.setExpanded(bool(p.hasChildren() and p.isExpanded()))
+        self.items.append(item)
+        # Update parents.
+        parents = [] if level == 0 else parents[:level]
+        parents.append(item)
+        # Update the dicts.
+        itemHash = self.itemHash(item)
+        self.item2positionDict[itemHash] = p.copy()
+        self.item2vnodeDict[itemHash] = p.v
+        self.position2itemDict[p.key()] = item
+        d = self.vnode2itemsDict
+        v = p.v
+        aList = d.get(v, [])
+        aList.append(item)
+        d[v] = aList
+        # Enter the headline.
+        item.setText(0, p.h)
+        if self.use_declutter:
+            item._real_text = p.h
+        # Draw the icon.
+        icon = self.getCompositeIconImage(p.v)
+        if icon:
+            self.setItemIcon(item, icon)
+        # Set current item.
+        if p == c.p:
+            w.setCurrentItem(item)
+    # Useful, for now.
+    t2 = time.process_time()
+    if t2 - t1 > 0.1:
+        g.trace(f"{n} nodes, {t2 - t1:5.2f} sec")
+#@+node:ekr.20220913064923.3: *3* qtree.yieldVisible (not used)
+def yieldVisible(self, first_p: Position, target_p: Position=None) -> Generator:
+    """
+    A generator yielding positions from first_p to target_p.
+    """
+    c = self.c
+    p = first_p.copy()
+    yield p
+    while p:
+        if p == target_p:
+            return
+        v = p.v
+        if (v.children and (
+            # Use slower test for clones:
+            len(v.parents) > 1 and p in v.expandedPositions or
+            # Use a quick test for non-clones:
+            len(v.parents) <= 1 and (v.statusBits & v.expandedBit) != 0
+        )):
+            # p.moveToFirstChild()
+            p.stack.append((v, p._childIndex),)
+            p.v = v.children[0]
+            p._childIndex = 0
+            yield p
+            continue
+        # if p.hasNext():
+        parent_v = p.stack[-1][0] if p.stack else c.hiddenRootNode
+        if p._childIndex + 1 < len(parent_v.children):
+            # p.moveToNext()
+            p._childIndex += 1
+            p.v = parent_v.children[p._childIndex]
+            yield p
+            continue
+        #
+        # A fast version of p.moveToThreadNext().
+        # We look for a parent with a following sibling.
+        while p.stack:
+            # p.moveToParent()
+            p.v, p._childIndex = p.stack.pop()
+            # if p.hasNext():
+            parent_v = p.stack[-1][0] if p.stack else c.hiddenRootNode
+            if p._childIndex + 1 < len(parent_v.children):
+                # p.moveToNext()
+                p._childIndex += 1
+                p.v = parent_v.children[p._childIndex]
+                break  # Found: moveToThreadNext()
+        else:
+            break  # Not found.
+        # Found moveToThreadNext()
+        yield p
+        continue
+    if target_p:
+        g.trace('NOT FOUND:', target_p.h)
+#@+node:ekr.20220913064923.4: *3* qtree.slowYieldVisible (not used)
+def slowYieldVisible(self, first_p: Position, target_p: Position=None) -> Generator:
+    """
+    A generator yielding positions from first_p to target_p.
+    """
+    c = self.c
+    p = first_p.copy()
+    while p:
+        yield p
+        if p == target_p:
+            return
+        p.moveToVisNext(c)
+    if target_p:
+        g.trace('NOT FOUND:', target_p.h)
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -525,9 +525,6 @@ class LeoQtTree(leoFrame.LeoTree):
                     if self.use_declutter:  # #2844.
                         icon = self.declutter_node(c, p, item)
                         item.setIcon(0, icon)  # 0 is the column number.
-            p.v.updateIcon()  # #2844.
-
-        ### c.redraw_after_icons_changed()
     #@+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
     def redraw_after_select(self, p: Position=None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
@@ -788,19 +785,14 @@ class LeoQtTree(leoFrame.LeoTree):
         width = sum([i.width() for i in images]) + hsep * (len(images) - 1)
         pix = QtGui.QImage(width, height, Format.Format_ARGB32_Premultiplied)
         pix.fill(QtGui.QColor(0, 0, 0, 0))
-        ### pix.fill(QtGui.QColor(0, 0, 0, 0).rgba())  # transparent fill, rgbA
-        ### .rgba() call required for Qt4.7, later versions work with straight color
         painter = QtGui.QPainter()
-        painter.begin(pix)
-        ### if not painter.begin(pix):
-            ### print("Failed to init. painter for icon")
-            # don't return, the code still makes an icon for the cache
-            # which stops this being called again and again
+        ok = painter.begin(pix)
         x = 0
         for i in images:
             painter.drawPixmap(x, 0, i)
             x += i.width() + hsep
-        painter.end()
+        if ok:
+            painter.end()
         return QtGui.QIcon(QtGui.QPixmap.fromImage(pix))
     #@+node:ekr.20110605121601.18412: *5* qtree.getCompositeIconImage
     def getCompositeIconImage(self, v: VNode) -> Icon:


### PR DESCRIPTION
See #2844.

- [x] **The essential change**: Add declutter logic to qtree.redraw_after_icons_changed.
- [x] Simplify guards in v.updateIcon.
- [x] qtree.redraw_after_select *always* returns an icon.
- [x] Remove qt4 code from qtree.make_composite_icon.
- [x] Disable c.redraw_after_icons_changed. Retain it for legacy scripts.
- [x] Move qtree.drawVisible & helpers to the attic.

**Note**: The same icon can be added multiple times, depending on which rules file. This was confusing, but I'm not going to mess with this mess :-)