### PR TITLE
PR: remove Any annotations assigned to real objects

### DIFF
--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -37,7 +37,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
         """Ctor for KillBufferCommandsClass class."""
         # pylint: disable=super-init-not-called
         self.c = c
-        self.kbiterator: Any = self.iterateKillBuffer()  # An instance of KillBufferIterClass.
+        self.kbiterator = self.iterateKillBuffer()  # An instance of KillBufferIterClass.
         # For interacting with system clipboard.
         self.last_clipboard: str = None
         # Position of the last item returned by iterateKillBuffer.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -252,8 +252,8 @@ class LeoApp:
         #@+node:ekr.20161028040204.1: *5* << LeoApp: global types >>
         from leo.core import leoFrame
         from leo.core import leoGui
-        self.nullGui: Any = leoGui.NullGui()
-        self.nullLog: Any = leoFrame.NullLog()
+        self.nullGui = leoGui.NullGui()
+        self.nullLog = leoFrame.NullLog()
         #@-<< LeoApp: global types >>
         #@+<< LeoApp: plugins and event handlers >>
         #@+node:ekr.20161028040229.1: *5* << LeoApp: plugins and event handlers >>

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -493,7 +493,6 @@ class SqlitePickleShare:
         if not isdir(self.root) and not g.unitTesting:
             self._makedirs(self.root)
         dbfile = ':memory:' if g.unitTesting else join(root, 'cache.sqlite')
-        ### self.conn: Any = sqlite3.connect(dbfile, isolation_level=None)
         self.conn = sqlite3.connect(dbfile, isolation_level=None)
         self.init_dbtables(self.conn)
         # Keys are normalized file names.

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -493,7 +493,8 @@ class SqlitePickleShare:
         if not isdir(self.root) and not g.unitTesting:
             self._makedirs(self.root)
         dbfile = ':memory:' if g.unitTesting else join(root, 'cache.sqlite')
-        self.conn: Any = sqlite3.connect(dbfile, isolation_level=None)
+        ### self.conn: Any = sqlite3.connect(dbfile, isolation_level=None)
+        self.conn = sqlite3.connect(dbfile, isolation_level=None)
         self.init_dbtables(self.conn)
         # Keys are normalized file names.
         # Values are tuples (obj, orig_mod_time)

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -43,7 +43,7 @@ class ChapterController:
         self.re_chapter: re.Pattern = None  # Set where used.
         self.selectedChapter = None
         self.selectChapterLockout = False  # True: cc.selectChapterForPosition does nothing.
-        self.tt: Any = None  # May be set in finishCreate.
+        self.tt: Any = None  # May be set in createChaptersIcon.
         self.reloadSettings()
 
     def reloadSettings(self) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -271,7 +271,7 @@ class Commands:
     def initOptionsIvars(self) -> None:
         """Init Commander ivars corresponding to user options."""
         self.fixed = False
-        self.fixedWindowPosition: Any = []
+        self.fixedWindowPosition: List[Tuple[int, int, int, int]] = []
         self.forceExecuteEntireBody = False
         self.focus_border_color = 'white'
         self.focus_border_width = 1  # pixels

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -75,7 +75,7 @@ class ParserBaseClass:
     def __init__(self, c: Cmdr, localFlag: bool) -> None:
         """Ctor for the ParserBaseClass class."""
         self.c = c
-        self.clipBoard: Any = []
+        self.clipBoard: List[str] = []
         # True if this is the .leo file being opened,
         # as opposed to myLeoSettings.leo or leoSettings.leo.
         self.localFlag = localFlag

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1856,12 +1856,12 @@ class NullFrame(LeoFrame):
         super().__init__(c, gui)
         assert self.c
         self.wrapper: Wrapper = None
-        self.iconBar: Widget = NullIconBarClass(self.c, self)
+        self.iconBar = NullIconBarClass(self.c, self)
         self.initComplete = True
         self.isNullFrame = True
         self.outerFrame: Wrapper = None
         self.ratio = self.secondary_ratio = 0.5
-        self.statusLineClass: Any = NullStatusLineClass
+        self.statusLineClass = NullStatusLineClass
         self.title = title
         self.top: Any = None  # Always None.
         # Create the component objects.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -22,11 +22,13 @@ from leo.core import leoNodes
 #@+<< leoFrame annotations >>
 #@+node:ekr.20220415013957.1: ** << leoFrame annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from leo.core.leoChapters import ChapterController
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 else:
+    ChapterController = Any
     Cmdr = Any
     Event = Any
     Position = Any
@@ -1748,9 +1750,9 @@ class LeoTreeTab:
     """A class representing a tabbed outline pane."""
     #@+others
     #@+node:ekr.20070317073627.1: *3*  ctor (LeoTreeTab)
-    def __init__(self, c: Cmdr, chapterController: Any, parentFrame: Widget) -> None:
+    def __init__(self, c: Cmdr, chapterController: ChapterController, parentFrame: Widget) -> None:
         self.c = c
-        self.cc: Any = chapterController
+        self.cc: ChapterController
         self.nb: Any = None  # Created in createControl.
         self.parentFrame: Widget = parentFrame
     #@+node:ekr.20070317073755: *3* Must be defined in subclasses

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7680,7 +7680,7 @@ def unquoteUrl(url: str) -> str:
     return urllib.parse.unquote(url)
 #@-others
 # set g when the import is about to complete.
-g: Any = sys.modules.get('leo.core.leoGlobals')
+g = sys.modules.get('leo.core.leoGlobals')
 assert g, sorted(sys.modules.keys())
 if __name__ == '__main__':
     unittest.main()

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -276,7 +276,7 @@ class LeoNameSpace:
         """LeoNameSpace ctor."""
         self.commander: Cmdr = None  # The commander returned by the c property.
         self.commanders_list: List[Cmdr] = []  # The list of commanders returned by the commanders property.
-        self.g: Any = g
+        self.g = g
         self.update()
     #@+others
     #@+node:ekr.20130930062914.16006: *3* LeoNS.c property

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1726,7 +1726,7 @@ class KeyHandlerClass:
         self.reloadSettings()
         self.defineSingleLineCommands()
         self.defineMultiLineCommands()
-        self.autoCompleter: Any = AutoCompleterClass(self)
+        self.autoCompleter = AutoCompleterClass(self)
         self.qcompleter = None  # Set by AutoCompleter.start.
         self.setDefaultUnboundKeyAction()
         self.setDefaultEditingAction()

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1739,7 +1739,7 @@ class KeyHandlerClass:
         self.getArgEscapes: List[str] = []
         self.inputModeName = ''  # The name of the input mode, or None.
         self.modePrompt = ''  # The mode prompt.
-        self.state: Any = g.bunch(kind=None, n=None, handler=None)
+        self.state = g.bunch(kind=None, n=None, handler=None)
 
         # Remove ???
         self.givenArgs: List[str] = []  # Args specified after the command name in k.simulateCommand.

--- a/leo/plugins/importers/org.py
+++ b/leo/plugins/importers/org.py
@@ -4,10 +4,11 @@
 #@@first
 """The @auto importer for the org language."""
 import re
-from typing import Any, Dict, List
+from typing import Dict, List
 from leo.core.leoCommands import Commands as Cmdr
 from leo.core.leoNodes import Position, VNode
 from leo.plugins.importers.linescanner import Importer
+from leo.plugins.nodetags import TagController
 #@+others
 #@+node:ekr.20140723122936.18072: ** class Org_Importer(Importer)
 class Org_Importer(Importer):
@@ -69,7 +70,7 @@ class Org_Importer(Importer):
         Call tag_controller.add_tag for all tags at the end of the headline s.
         """
         c = self.c
-        tag_controller: Any = getattr(c, 'theTagController', None)
+        tag_controller: TagController = getattr(c, 'theTagController', None)
         if not tag_controller:
             # It would be useless to load the nodetags plugin.
             return  # pragma: no cover

--- a/leo/plugins/markup_inline.py
+++ b/leo/plugins/markup_inline.py
@@ -33,7 +33,6 @@ def markup_inline(c, kind='unknown'):
         'italic': ('*', '*'),
         'underline': (':ul:`', '`'),
     }[kind]
-    text: Any
 
     if c.frame.body.bodyCtrl.hasSelection():
         c.user_dict['markup_inline']['last'] = 'close'

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -226,7 +226,7 @@ import select
 import shutil
 import socket
 import time
-from typing import Any
+from typing import List
 import urllib.parse as urlparse
 from xml.sax.saxutils import quoteattr
 from leo.core import leoGlobals as g
@@ -1228,9 +1228,9 @@ def poll(timeout=0.0):
     map = asyncore.socket_map
     if not map:
         return False
-    e: Any
-    r: Any = []
-    w: Any
+    e: List
+    r: List = []
+    w: List
     while 1:
         e = w = []
         for fd, obj in map.items():

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -355,7 +355,7 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
 class QuickSearchController:
 
     #@+others
-    #@+node:ekr.20111015194452.15685: *3* __init__
+    #@+node:ekr.20111015194452.15685: *3* QuickSearchController.__init__
     def __init__(self, c: Cmdr, listWidget: Widget, ui: Any) -> None:
         self.c = c
         self.lw: Widget = listWidget  # A QListWidget.
@@ -396,7 +396,7 @@ class QuickSearchController:
             self.addHeadlineMatches(hm)
             self.addBodyMatches(bm)
 
-        self.throttler: Any = threadutil.NowOrLater(throttledDump)
+        self.throttler = threadutil.NowOrLater(throttledDump)
         self.worker.set_worker(searcher)
         #self.worker.set_output_f(dumper)
         self.worker.resultReady.connect(dumper)


### PR DESCRIPTION
When feasible, removing these Any annotations allows mypy to do better checking.

This PR fixes only the easy cases. That's enough for Leo 6.7.0!