### PR TITLE
PR: Fully annotate leo.plugins.qt_text

### DIFF
--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -717,7 +717,6 @@ class LeoFrame:
         self.body: Any = None  # A Union
         self.colorPanel: Any = None  # A Union
         self.comparePanel: Any = None  # A Union
-        self.findPanel: Any = None  # A Union.
         self.fontPanel: Any = None  # A Union.
         self.iconBar: Any = None  # A Union.
         self.isNullFrame = False

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -714,21 +714,21 @@ class LeoFrame:
         self.statusLineClass = NullStatusLineClass
         self.title: str = None  # Must be created by subclasses.
         # Objects attached to this frame.
-        self.body = None
-        self.colorPanel = None
-        self.comparePanel = None
-        self.findPanel: Widget = None
-        self.fontPanel: Widget = None
-        self.iconBar: Widget = None
+        self.body: Any = None  # A Union
+        self.colorPanel: Any = None  # A Union
+        self.comparePanel: Any = None  # A Union
+        self.findPanel: Any = None  # A Union.
+        self.fontPanel: Any = None  # A Union.
+        self.iconBar: Any = None  # A Union.
         self.isNullFrame = False
         self.keys = None
-        self.log: Wrapper = None
-        self.menu: Wrapper = None
+        self.log: Any = None  # A Union.
+        self.menu: Any = None  # A Union
         self.miniBufferWidget: Widget = None
-        self.outerFrame: Widget = None
-        self.prefsPanel: Widget = None
-        self.statusLine: Widget = g.NullObject()  # For unit tests.
-        self.tree: Wrapper = None
+        self.outerFrame: Any = None  # A Union
+        self.prefsPanel: Any = None  # A Union
+        self.statusLine: Any = g.NullObject()  # A Union.
+        self.tree: Any = None  # A Union
         self.useMiniBufferWidget = False
         # Gui-independent data
         self.cursorStay = True  # May be overridden in subclass.reloadSettings.

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2187,7 +2187,6 @@ class CoreFrame(leoFrame.LeoFrame):
             # self.bar1 = None
             # self.bar2 = None
             # self.f1 = self.f2 = None
-            # self.findPanel = None # Inited when first opened.
             # self.iconBarComponentName = 'iconBar'
             # self.iconFrame = None
             # self.canvas = None

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2192,7 +2192,6 @@ class CoreFrame(leoFrame.LeoFrame):
             # self.canvas = None
             # self.outerFrame = None
             # self.statusFrame = None
-            # self.statusLineComponentName = 'statusLine'
             # self.statusText = None
             # self.statusLabel = None
             # self.top = None # This will be a class Window object.

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2172,7 +2172,6 @@ class CoreFrame(leoFrame.LeoFrame):
 
         # Official ivars...
             # self.iconBar = None
-            # self.iconBarClass = None # self.QtIconBarClass
             # self.initComplete = False # Set by initCompleteHint().
             # self.minibufferVisible = True
             # self.statusLineClass = None # self.QtStatusLineClass

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2187,7 +2187,6 @@ class CoreFrame(leoFrame.LeoFrame):
             # self.bar1 = None
             # self.bar2 = None
             # self.f1 = self.f2 = None
-            # self.iconBarComponentName = 'iconBar'
             # self.iconFrame = None
             # self.canvas = None
             # self.outerFrame = None
@@ -2197,10 +2196,7 @@ class CoreFrame(leoFrame.LeoFrame):
             # self.top = None # This will be a class Window object.
             # Used by event handlers...
             # self.controlKeyIsDown = False # For control-drags
-            # self.isActive = True
             # self.redrawCount = 0
-            # self.wantedWidget = None
-            # self.wantedCallbackScheduled = False
             # self.scrollWay = None
     #@+node:ekr.20170420163932.1: *5* CFrame.finishCreate
     def finishCreate(self) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1552,7 +1552,7 @@ class LeoQtBody(leoFrame.LeoBody):
     #@+others
     #@+node:ekr.20110605121601.18181: *3* LeoQtBody.Birth
     #@+node:ekr.20110605121601.18182: *4* LeoQtBody.ctor
-    def __init__(self, frame: Widget, parentFrame: Widget) -> None:
+    def __init__(self, frame: "LeoQtFrame", parentFrame: "LeoQtFrame") -> None:
         """Ctor for LeoQtBody class."""
         # Call the base class constructor.
         super().__init__(frame, parentFrame)
@@ -2367,7 +2367,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
                     c.styleSheetManager.mng.update_view(w)  # force appearance update
             w.setText(s)
         #@+node:ekr.20110605121601.18258: *4* QtStatusLineClass.ctor
-        def __init__(self, c: Cmdr, parentFrame: Widget) -> None:
+        def __init__(self, c: Cmdr, parentFrame: "LeoQtFrame") -> None:
             """Ctor for LeoQtFrame class."""
             self.c = c
             self.statusBar = c.frame.top.statusBar
@@ -2922,7 +2922,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         for frame in g.app.windowList:
             self.minimize(frame)
 
-    def minimize(self, frame: Widget) -> None:
+    def minimize(self, frame: "LeoQtFrame") -> None:
         # This unit test will fail when run externally.
         if frame and frame.top:
             w = frame.top.leo_master or frame.top
@@ -3094,7 +3094,7 @@ class LeoQtLog(leoFrame.LeoLog):
     #@+others
     #@+node:ekr.20110605121601.18313: *3* LeoQtLog.Birth
     #@+node:ekr.20110605121601.18314: *4* LeoQtLog.__init__ & reloadSettings
-    def __init__(self, frame: Widget, parentFrame: Widget) -> None:
+    def __init__(self, frame: "LeoQtFrame", parentFrame: "LeoQtFrame") -> None:
         """Ctor for LeoQtLog class."""
         super().__init__(frame, parentFrame)  # Calls createControl.
         # Set in finishCreate.
@@ -3533,7 +3533,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
 
     #@+others
     #@+node:ekr.20110605121601.18341: *3* LeoQtMenu.__init__
-    def __init__(self, c: Cmdr, frame: Widget, label: str) -> None:
+    def __init__(self, c: Cmdr, frame: "LeoQtFrame", label: str) -> None:
         """ctor for LeoQtMenu class."""
         assert frame
         assert frame.c
@@ -3679,7 +3679,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         # realName = realName.replace("&","")
         # menu.entryconfig(realName,accelerator='')
     #@+node:ekr.20110605121601.18356: *5* LeoQtMenu.createMenuBar
-    def createMenuBar(self, frame: Widget) -> None:
+    def createMenuBar(self, frame: "LeoQtFrame") -> None:
         """
         (LeoQtMenu) Create all top-level menus.
         The menuBar itself has already been created.
@@ -4518,7 +4518,7 @@ class QtTabBarWrapper(QtWidgets.QTabBar):  # type:ignore
 class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     #@+others
     #@+node:ekr.20110605121601.18459: *3* ctor and __repr__(QtMenuWrapper)
-    def __init__(self, c: Cmdr, frame: Widget, parent: Widget, label: str) -> None:
+    def __init__(self, c: Cmdr, frame: "LeoQtFrame", parent: Widget, label: str) -> None:
         """ctor for QtMenuWrapper class."""
         assert c
         assert frame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1090,7 +1090,11 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         # self.setWindowIcon(QtGui.QIcon(g.app.leoDir + "/Icons/leoapp32.png"))
         g.app.gui.attachLeoIcon(self)
     #@+node:ekr.20110605121601.18174: *3* dw.setSplitDirection
-    def setSplitDirection(self, main_splitter: Widget, secondary_splitter: Widget, orientation: Any) -> None:
+    def setSplitDirection(self,
+        main_splitter: "LeoQtFrame",
+        secondary_splitter: "LeoQtFrame",
+        orientation: Orientation,
+    ) -> None:
         """Set the orientations of the splitters in the Leo main window."""
         # c = self.leo_c
         vert = orientation and orientation.lower().startswith('v')
@@ -4617,11 +4621,11 @@ class TabbedFrameFactory:
         # Will be created when first frame appears.
         # Workaround a problem setting the window title when tabs are shown.
         self.alwaysShowTabs = True
-        self.leoFrames: Dict[Any, Widget] = {}  # Keys are DynamicWindows, values are frames.
+        self.leoFrames: Dict["DynamicWindow", "LeoQtFrame"] = {}
         self.masterFrame: Widget = None
         self.createTabCommands()
     #@+node:ekr.20110605121601.18466: *3* frameFactory.createFrame
-    def createFrame(self, leoFrame: Widget) -> Widget:
+    def createFrame(self, leoFrame: "LeoQtFrame") -> "LeoQtFrame":
 
         c = leoFrame.c
         tabw = self.masterFrame
@@ -4670,7 +4674,7 @@ class TabbedFrameFactory:
         if g.app.start_minimized:
             window.showMinimized()
     #@+node:ekr.20110605121601.18472: *3* frameFactory.createTabCommands
-    def detachTab(self, wdg: Widget) -> None:
+    def detachTab(self, wdg: "DynamicWindow") -> None:
         """ Detach specified tab as individual toplevel window """
         del self.leoFrames[wdg]
         wdg.setParent(None)
@@ -4726,7 +4730,7 @@ class TabbedFrameFactory:
             tab_cycle(-1)
         #@-<< Commands for tabs >>
     #@+node:ekr.20110605121601.18467: *3* frameFactory.deleteFrame
-    def deleteFrame(self, wdg: Widget) -> None:
+    def deleteFrame(self, wdg: "DynamicWindow") -> None:
 
         if not wdg:
             return

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -254,7 +254,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         if where:
             self.addToolBar(where, self.iconBar)
     #@+node:ekr.20110605121601.18141: *3* dw.createMainWindow & helpers
-    def createMainWindow(self) -> Tuple[Widget, Widget]:
+    def createMainWindow(self) -> Tuple["LeoQtFrame", "LeoQtFrame"]:
         """
         Create the component ivars of the main window.
         Copied/adapted from qt_main.py.
@@ -285,7 +285,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         return main_splitter, secondary_splitter
     #@+node:ekr.20110605121601.18142: *4* dw.top-level
     #@+node:ekr.20190118150859.10: *5* dw.addNewEditor
-    def addNewEditor(self, name: str) -> Tuple[Widget, Wrapper]:
+    def addNewEditor(self, name: str) -> Tuple["LeoQtFrame", Wrapper]:
         """Create a new body editor."""
         c, p = self.leo_c, self.leo_c.p
         body = c.frame.body
@@ -409,7 +409,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.createFindTab(self.findTab, self.findScrollArea)
         self.findScrollArea.setWidget(self.findTab)
     #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout
-    def createMainLayout(self, parent: "LeoQtFrame") -> Tuple[Widget, Widget]:
+    def createMainLayout(self, parent: "LeoQtFrame") -> Tuple["LeoQtFrame", "LeoQtFrame"]:
         """Create the layout for Leo's main window."""
         # c = self.leo_c
         vLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
@@ -650,7 +650,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     #@+node:ekr.20110605121601.18162: *5* dw.createTabWidget
     def createTabWidget(self,
         parent: "LeoQtFrame", name: str, hPolicy: Policy=None, vPolicy: Policy=None,
-    ) -> Widget:
+    ) -> "LeoQtFrame":
         w = QtWidgets.QTabWidget(parent)
         # tb = w.tabBar()
         # tb.setTabsClosable(True)
@@ -665,7 +665,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         lineWidth: int=0,
         shadow: Shadow=None,
         shape: Shape=None,
-    ) -> Widget:
+    ) -> "LeoQtFrame":
         # Create a text widget.
         c = self.leo_c
         if name == 'richTextEdit' and self.useScintilla and Qsci:
@@ -685,7 +685,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             self.setName(w, name)
         return w
     #@+node:ekr.20110605121601.18164: *5* dw.createTreeWidget
-    def createTreeWidget(self, parent: "LeoQtFrame", name: str) -> Widget:
+    def createTreeWidget(self, parent: "LeoQtFrame", name: str) -> "LeoQtFrame":
         c = self.leo_c
         w = LeoQTreeWidget(c, parent)
         self.setSizePolicy(w)
@@ -748,7 +748,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.leo_spell_listBox = listBox  # Must exist
         self.leo_spell_label = lab  # Must exist (!!)
     #@+node:ekr.20110605121601.18166: *5* dw.createFindTab & helpers
-    def createFindTab(self, parent: "LeoQtFrame", tab_widget: Widget) -> None:
+    def createFindTab(self, parent: "LeoQtFrame", tab_widget: "LeoQtFrame") -> None:
         """Create a Find Tab in the given parent."""
         c, dw = self.leo_c, self
         fc = c.findCommands
@@ -1044,13 +1044,13 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         EventWrapper(c, w=ftm.check_box_mark_changes, next_w=ftm.find_findbox, func=None)
     #@+node:ekr.20110605121601.18168: *4* dw.utils
     #@+node:ekr.20110605121601.18169: *5* dw.setName
-    def setName(self, widget: Widget, name: str) -> None:
+    def setName(self, widget: "LeoQtFrame", name: str) -> None:
         if name:
             # if not name.startswith('leo_'):
                 # name = 'leo_' + name
             widget.setObjectName(name)
     #@+node:ekr.20110605121601.18170: *5* dw.setSizePolicy
-    def setSizePolicy(self, widget: Widget, kind1: Policy=None, kind2: Policy=None) -> None:
+    def setSizePolicy(self, widget: "LeoQtFrame", kind1: Policy=None, kind2: Policy=None) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
         if kind2 is None:
@@ -3407,7 +3407,7 @@ class LeoQtLog(leoFrame.LeoLog):
             w.clear()  # w is a QTextBrowser.
     #@+node:ekr.20110605121601.18326: *4* LeoQtLog.createTab
     def createTab(self,
-        tabName: str, createText: bool=True, widget: Widget=None, wrap: str='none',
+        tabName: str, createText: bool=True, widget: "LeoQtFrame"=None, wrap: str='none',
     ) -> Any:  # Widget or LeoQTextBrowser.
         """
         Create a new tab in tab widget

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2105,7 +2105,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # "Official ivars created in createLeoFrame and its allies.
         self.bar1 = None
         self.bar2 = None
-        self.body: Widget = None
+        self.body: LeoQtBody = None
         self.f1 = self.f2 = None
         self.findPanel: Widget = None  # Inited when first opened.
         self.iconBarComponentName = 'iconBar'
@@ -2142,12 +2142,12 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.createSplitterComponents()
         self.createStatusLine()  # A base class method.
         self.createFirstTreeNode()  # Call the base-class method.
-        self.menu: Widget = LeoQtMenu(c, self, label='top-level-menu')
+        self.menu = LeoQtMenu(c, self, label='top-level-menu')
         g.app.windowList.append(self)
         t2 = time.process_time()
         self.setQtStyle()  # Slow, but only the first time it is called.
         t3 = time.process_time()
-        self.miniBufferWidget: Widget = qt_text.QMinibufferWrapper(c)
+        self.miniBufferWidget = qt_text.QMinibufferWrapper(c)
         c.bodyWantsFocus()
         t4 = time.process_time()
         if 'speed' in g.app.debug:
@@ -4047,7 +4047,7 @@ class LeoTabbedTopLevel(LeoBaseTabWidget):
         self.setMovable(False)
         tb = QtTabBarWrapper(self)
         self.setTabBar(tb)
-#@+node:ekr.20110605121601.18262: ** class QtIconBarClass (moved)
+#@+node:ekr.20110605121601.18262: ** class QtIconBarClass
 class QtIconBarClass:
     """A class representing the singleton Icon bar"""
     #@+others
@@ -4360,7 +4360,7 @@ class QtSearchWidget:
         self.wrapper = self
         self.body = self
         self.text = None
-#@+node:ekr.20110605121601.18257: ** class QtStatusLineClass (moved)
+#@+node:ekr.20110605121601.18257: ** class QtStatusLineClass
 class QtStatusLineClass:
     """A class representing the status line."""
     #@+others

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1566,7 +1566,7 @@ class LeoQtBody(leoFrame.LeoBody):
         assert c.frame == frame and frame.c == c
         self.colorizer: Any = None  # A Union
         self.wrapper: Wrapper = None
-        self.widget: Widget = None
+        self.widget: "LeoQtFrame" = None
         self.reloadSettings()
         self.set_widget()  # Sets self.widget and self.wrapper.
         self.setWrap(c.p)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -30,6 +30,7 @@ from leo.core.leoQt import TextInteractionFlag, ToolBarArea, Type, Weight, Windo
 from leo.plugins import qt_events
 from leo.plugins import qt_text
 from leo.plugins import qt_tree
+from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
 from leo.plugins.nested_splitter import NestedSplitter
 #@-<< qt_frame imports >>
@@ -2105,19 +2106,16 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # "Official ivars created in createLeoFrame and its allies.
         self.bar1 = None
         self.bar2 = None
-        self.body: LeoQtBody = None
+        self.body: "LeoQtBody" = None
         self.f1 = self.f2 = None
         self.iconBarComponentName = 'iconBar'
-        self.iconFrame: Widget = None
-        self.log: Widget = None
+        self.iconFrame: "QtIconBarClass" = None
+        self.log: "LeoQtLog" = None
         self.canvas: Widget = None
-        self.outerFrame: Widget = None
-        self.statusFrame: Widget = None
-        self.statusLineComponentName = 'statusLine'
-        self.statusText: Widget = None
-        self.statusLabel: Widget = None
+        self.outerFrame: "LeoQtFrame" = None
+        self.statusFrame: "LeoQtFrame" = None
         self.top: Widget = None  # This will be a class Window object.
-        self.tree: Widget = None
+        self.tree: LeoQtTree = None
         # Used by event handlers...
         self.controlKeyIsDown = False  # For control-drags
         self.isActive = True

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -149,7 +149,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     """
     #@+others
     #@+node:ekr.20110605121601.18138: *3*  dw.ctor & reloadSettings
-    def __init__(self, c: Cmdr, parent: Widget=None) -> None:
+    def __init__(self, c: Cmdr, parent: "LeoQtFrame"=None) -> None:
         """Ctor for the DynamicWindow class.  The main window is c.frame.top"""
             # Called from LeoQtFrame.finishCreate.
             # parent is a LeoTabbedTopLevel.
@@ -4386,7 +4386,7 @@ class LeoQtTreeTab:
     #@+others
     #@+node:ekr.20110605121601.18439: *3*  Birth & death
     #@+node:ekr.20110605121601.18440: *4*  ctor (LeoQtTreeTab)
-    def __init__(self, c: Cmdr, iconBar: Widget) -> None:
+    def __init__(self, c: Cmdr, iconBar: "LeoQtLog") -> None:
         """Ctor for LeoQtTreeTab class."""
 
         self.c = c

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2481,7 +2481,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         """A class representing the singleton Icon bar"""
         #@+others
         #@+node:ekr.20110605121601.18263: *4*  QtIconBar.ctor & reloadSettings
-        def __init__(self, c: Cmdr, parentFrame: Widget) -> None:
+        def __init__(self, c: Cmdr, parentFrame: "LeoQtFrame") -> None:
             """Ctor for QtIconBarClass."""
             # Copy ivars
             self.c = c
@@ -4405,7 +4405,7 @@ class LeoQtTreeTab:
         class LeoQComboBox(QtWidgets.QComboBox):  # type:ignore
             """Create a subclass in order to handle focusInEvents."""
 
-            def __init__(self, tt: Widget) -> None:
+            def __init__(self, tt: "LeoQtTreeTab") -> None:
                 self.leo_tt = tt
                 super().__init__()
                 # Fix #458: Chapters drop-down list is not automatically resized.
@@ -4418,7 +4418,8 @@ class LeoQtTreeTab:
         tt = self
         frame = QtWidgets.QLabel('Chapters: ')
         ibw = tt.iconBar.w  # "ibw": iconbar widget (a QToolbar)
-        tt.w = w = LeoQComboBox(tt)
+        tt.w = LeoQComboBox(tt)
+        w = tt.w
         tt.setNames()
 
         # Should the "Chapters" group be installed at the left of the toolbar?

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -41,15 +41,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    from leo.core.leoQt import QComboBox
 else:
     Cmdr = Any
     Event = Any
-    QComboBox = Any
     Position = Any
     Wrapper = Any
-QComboBox = Any
-QPushButton = Any
 Widget = Any
 #@-<< qt_frame annotations >>
 #@+<< qt_frame decorators >>
@@ -152,7 +148,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     def construct(self, master: "LeoTabbedTopLevel"=None) -> None:
         """ Factor 'heavy duty' code out from the DynamicWindow ctor """
         c = self.leo_c
-        self.leo_master = master  # A LeoTabbedTopLevel or None for non-tabbed windows.
+        self.leo_master = master
         self.useScintilla = c.config.getBool('qt-use-scintilla')
         self.reloadSettings()
         main_splitter, secondary_splitter = self.createMainWindow()
@@ -2027,7 +2023,7 @@ class LeoQtBody(leoFrame.LeoBody):
                 w.leo_label = None
         self.selectEditor(new_wrapper)
     #@+node:ekr.20110605121601.18220: *4* LeoQtBody.packRenderer
-    def packRenderer(self, f: str, name: str, w: Wrapper) -> Widget:
+    def packRenderer(self, f: str, name: str, w: Wrapper) -> Widget:  # A QLineEdit
         n = max(1, self.numberOfEditors)
         assert isinstance(f, QtWidgets.QFrame), f
         layout = f.layout()
@@ -3936,7 +3932,7 @@ class LeoQtTreeTab:
         self.iconBar = iconBar
         self.lockout = False  # True: do not redraw.
         self.tabNames: List[str] = []  # The list of tab names. Changes when tabs are renamed.
-        self.w: QComboBox = None  # The QComboBox, not a QWidget.
+        self.w: Widget = None  # A QComboBox
         # self.reloadSettings()
         self.createControl()
     #@+node:ekr.20110605121601.18441: *4* tt.createControl (defines class LeoQComboBox)
@@ -4091,7 +4087,7 @@ class QtIconBarClass:
 
             def __init__(self, parent: "LeoQtFrame", text: str, toolbar: "QtIconBarClass") -> None:
                 super().__init__(parent)
-                self.button: QPushButton = None  # set below
+                self.button: Widget = None  # A QPushButton
                 self.text = text
                 self.toolbar = toolbar
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1390,7 +1390,7 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):  # type:ignore
         c = w.leo_c
         c.new()
     #@+node:ekr.20131115120119.17391: *3* qt_base_tab.detach
-    def detach(self, index: int) -> Widget:
+    def detach(self, index: int) -> Widget:  # A QIcon.
         """detach tab (from tab's context menu)"""
         w = self.widget(index)
         name = self.tabText(index)
@@ -1509,10 +1509,10 @@ class LeoQtBody(leoFrame.LeoBody):
         self.totalNumberOfEditors = 1
         # For renderer panes.
         self.canvasRenderer = None
-        self.canvasRendererLabel: Widget = None
+        self.canvasRendererLabel: Widget = None  # A QLineEdit.
         self.canvasRendererVisible = False
-        self.textRenderer: Widget = None
-        self.textRendererLabel: Widget = None
+        self.textRenderer: Widget = None  # A QFrame
+        self.textRendererLabel: Widget = None  # A QLineEdit.
         self.textRendererVisible = False
         self.textRendererWrapper: Wrapper = None
     #@+node:ekr.20110605121601.18185: *5* LeoQtBody.get_name
@@ -2084,11 +2084,11 @@ class LeoQtFrame(leoFrame.LeoFrame):
         assert self.c == c
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
         # Official ivars...
-        self.iconBar: Widget = None
-        self.iconBarClass: Widget = QtIconBarClass  # A Union
+        self.iconBar: QtIconBarClass = None
+        self.iconBarClass: Any = QtIconBarClass  # A Union
         self.initComplete = False  # Set by initCompleteHint().
         self.minibufferVisible = True
-        self.statusLineClass: Widget = QtStatusLineClass  # A Union
+        self.statusLineClass: Any = QtStatusLineClass  # A Union
         self.title = title
         self.setIvars()
         self.reloadSettings()
@@ -2639,13 +2639,13 @@ class LeoQtLog(leoFrame.LeoLog):
         # logCtrl may be either a wrapper or a widget.
         assert self.logCtrl is None, self.logCtrl  # type:ignore
         self.c = c = frame.c  # Also set in the base constructor, but we need it here.
-        self.contentsDict: Dict[str, Widget] = {}  # Keys are tab names.  Values are widgets.
+        self.contentsDict: Dict[str, Widget] = {}  # Keys are tab names.  Values are Qt widgets.
         self.eventFilters: List = []  # Apparently needed to make filters work!
         self.logCtrl: Wrapper = None
         self.logDict: Dict[str, Widget] = {}  # Keys are tab names; values are the widgets.
-        self.logWidget: Widget = None  # Set in finishCreate.
-        self.menu: Widget = None  # A menu that pops up on right clicks in the hull or in tabs.
-        self.tabWidget: Widget = c.frame.top.tabWidget  # The Qt.QTabWidget that holds all the tabs.
+        self.logWidget: "LeoQtLog" = None  # Set in finishCreate.
+        self.menu: Widget = None  # A Qt menu that pops up on right clicks in the hull or in tabs.
+        self.tabWidget: Widget = c.frame.top.tabWidget  # A QTabWidget that holds all the tabs.
         tw = self.tabWidget
 
         # Bug 917814: Switching Log Pane tabs is done incompletely.
@@ -3097,7 +3097,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
     # See the Tk docs for what these routines are to do
     #@+node:ekr.20110605121601.18343: *4* LeoQtMenu.Methods with Tk spellings
     #@+node:ekr.20110605121601.18344: *5* LeoQtMenu.add_cascade
-    def add_cascade(self, parent: "LeoQtFrame", label: str, menu: Widget, underline: int) -> Widget:
+    def add_cascade(self,
+        parent: "LeoQtFrame", label: str, menu: Widget, underline: int,
+    ) -> Widget:  # A QMenu.
         """Wrapper for the Tkinter add_cascade menu method.
 
         Adds a submenu to the parent menu, or the menubar."""
@@ -3114,8 +3116,13 @@ class LeoQtMenu(leoMenu.LeoMenu):
         menu.leo_menu_label = label
         return menu
     #@+node:ekr.20110605121601.18345: *5* LeoQtMenu.add_command (Called by createMenuEntries)
-    def add_command(self, menu: Widget,
-        accelerator: str='', command: Callable=None, commandName: str=None, label: str=None, underline: int=0,
+    def add_command(self,
+        menu: Widget,  # A QMenu.
+        accelerator: str='',
+        command: Callable=None,
+        commandName: str=None,
+        label: str=None,
+        underline: int=0,
     ) -> None:
         """Wrapper for the Tkinter add_command menu method."""
         if not label:
@@ -3182,9 +3189,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         parent: "LeoQtFrame",
         index: int,
         label: str,
-        menu: Widget,
+        menu: Widget,  # A QMenu.
         underline: int,  # Not used
-    ) -> Widget:
+    ) -> Widget:  # A QMenu.
         """Wrapper for the Tkinter insert_cascade menu method."""
         menu.setTitle(label)
         label.replace('&', '').lower()

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -311,7 +311,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             body.recolorWidget(p, wrapper)
         return parent_frame, wrapper
     #@+node:ekr.20110605121601.18143: *5* dw.createBodyPane
-    def createBodyPane(self, parent: Widget) -> Widget:
+    def createBodyPane(self, parent: "LeoQtFrame") -> Widget:
         """
         Create the *pane* for the body, not the actual QTextBrowser.
         """
@@ -409,7 +409,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.createFindTab(self.findTab, self.findScrollArea)
         self.findScrollArea.setWidget(self.findTab)
     #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout
-    def createMainLayout(self, parent: Widget) -> Tuple[Widget, Widget]:
+    def createMainLayout(self, parent: "LeoQtFrame") -> Tuple[Widget, Widget]:
         """Create the layout for Leo's main window."""
         # c = self.leo_c
         vLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
@@ -436,7 +436,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         # Official ivars.
         self.leo_menubar = w
     #@+node:ekr.20110605121601.18148: *5* dw.createMiniBuffer (class VisLineEdit)
-    def createMiniBuffer(self, parent: Widget) -> Widget:
+    def createMiniBuffer(self, parent: "LeoQtFrame") -> Widget:
         """Create the widgets for Leo's minibuffer area."""
         # Create widgets.
         frame = self.createFrame(parent, 'minibufferFrame',
@@ -498,7 +498,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         # self.leo_minibuffer_layout = layout
         return frame
     #@+node:ekr.20110605121601.18149: *5* dw.createOutlinePane
-    def createOutlinePane(self, parent: Widget) -> Widget:
+    def createOutlinePane(self, parent: "LeoQtFrame") -> Widget:
         """Create the widgets and ivars for Leo's outline."""
         # Create widgets.
         treeFrame = self.createFrame(parent, 'outlineFrame', vPolicy=Policy.Expanding)
@@ -512,7 +512,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.treeWidget = treeWidget
         return treeFrame
     #@+node:ekr.20110605121601.18150: *5* dw.createStatusBar
-    def createStatusBar(self, parent: Widget) -> None:
+    def createStatusBar(self, parent: "LeoQtFrame") -> None:
         """Create the widgets and ivars for Leo's status area."""
         w = QtWidgets.QStatusBar(parent)
         w.setObjectName("statusbar")
@@ -553,13 +553,13 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         dw.resize(691, 635)
     #@+node:ekr.20110605121601.18152: *4* dw.widgets
     #@+node:ekr.20110605121601.18153: *5* dw.createButton
-    def createButton(self, parent: Widget, name: str, label: str) -> Widget:
+    def createButton(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
         w = QtWidgets.QPushButton(parent)
         w.setObjectName(name)
         w.setText(self.tr(label))
         return w
     #@+node:ekr.20110605121601.18154: *5* dw.createCheckBox
-    def createCheckBox(self, parent: Widget, name: str, label: str) -> Widget:
+    def createCheckBox(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
         w = QtWidgets.QCheckBox(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
@@ -567,7 +567,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     #@+node:ekr.20110605121601.18155: *5* dw.createFrame
     def createFrame(
         self,
-        parent: Widget,
+        parent: "LeoQtFrame",
         name: str,
         hPolicy: Policy=None,
         vPolicy: Policy=None,
@@ -589,41 +589,41 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.setName(w, name)
         return w
     #@+node:ekr.20110605121601.18156: *5* dw.createGrid
-    def createGrid(self, parent: Widget, name: str, margin: int=0, spacing: int=0) -> Widget:
+    def createGrid(self, parent: "LeoQtFrame", name: str, margin: int=0, spacing: int=0) -> Widget:
         w = QtWidgets.QGridLayout(parent)
         w.setContentsMargins(QtCore.QMargins(margin, margin, margin, margin))
         w.setSpacing(spacing)
         self.setName(w, name)
         return w
     #@+node:ekr.20110605121601.18157: *5* dw.createHLayout & createVLayout
-    def createHLayout(self, parent: Widget, name: str, margin: int=0, spacing: int=0) -> Any:
+    def createHLayout(self, parent: "LeoQtFrame", name: str, margin: int=0, spacing: int=0) -> Any:
         hLayout = QtWidgets.QHBoxLayout(parent)
         hLayout.setSpacing(spacing)
         hLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
         self.setName(hLayout, name)
         return hLayout
 
-    def createVLayout(self, parent: Widget, name: str, margin: int=0, spacing: int=0) -> Any:
+    def createVLayout(self, parent: "LeoQtFrame", name: str, margin: int=0, spacing: int=0) -> Any:
         vLayout = QtWidgets.QVBoxLayout(parent)
         vLayout.setSpacing(spacing)
         vLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
         self.setName(vLayout, name)
         return vLayout
     #@+node:ekr.20110605121601.18158: *5* dw.createLabel
-    def createLabel(self, parent: Widget, name: str, label: str) -> Widget:
+    def createLabel(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
         w = QtWidgets.QLabel(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
         return w
     #@+node:ekr.20110605121601.18159: *5* dw.createLineEdit
-    def createLineEdit(self, parent: Widget, name: str, disabled: bool=True) -> Widget:
+    def createLineEdit(self, parent: "LeoQtFrame", name: str, disabled: bool=True) -> Widget:
 
         w = QtWidgets.QLineEdit(parent)
         w.setObjectName(name)
         w.leo_disabled = disabled  # Inject the ivar.
         return w
     #@+node:ekr.20110605121601.18160: *5* dw.createRadioButton
-    def createRadioButton(self, parent: Widget, name: str, label: str) -> Widget:
+    def createRadioButton(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
         w = QtWidgets.QRadioButton(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
@@ -631,7 +631,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     #@+node:ekr.20110605121601.18161: *5* dw.createStackedWidget
     def createStackedWidget(
         self,
-        parent: Widget,
+        parent: "LeoQtFrame",
         name: str,
         lineWidth: int=1,
         hPolicy: Policy=None,
@@ -645,7 +645,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         return w
     #@+node:ekr.20110605121601.18162: *5* dw.createTabWidget
     def createTabWidget(self,
-        parent: Widget, name: str, hPolicy: Policy=None, vPolicy: Policy=None,
+        parent: "LeoQtFrame", name: str, hPolicy: Policy=None, vPolicy: Policy=None,
     ) -> Widget:
         w = QtWidgets.QTabWidget(parent)
         # tb = w.tabBar()
@@ -656,7 +656,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     #@+node:ekr.20110605121601.18163: *5* dw.createText (creates QTextBrowser)
     def createText(
         self,
-        parent: Widget,
+        parent: "LeoQtFrame",
         name: str,
         lineWidth: int=0,
         shadow: Shadow=None,
@@ -681,7 +681,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             self.setName(w, name)
         return w
     #@+node:ekr.20110605121601.18164: *5* dw.createTreeWidget
-    def createTreeWidget(self, parent: Widget, name: str) -> Widget:
+    def createTreeWidget(self, parent: "LeoQtFrame", name: str) -> Widget:
         c = self.leo_c
         w = LeoQTreeWidget(c, parent)
         self.setSizePolicy(w)
@@ -699,7 +699,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         return w
     #@+node:ekr.20110605121601.18165: *4* dw.log tabs
     #@+node:ekr.20110605121601.18167: *5* dw.createSpellTab
-    def createSpellTab(self, parent: Widget) -> None:
+    def createSpellTab(self, parent: "LeoQtFrame") -> None:
         # dw = self
         vLayout = self.createVLayout(parent, 'spellVLayout', margin=2)
         spellFrame = self.createFrame(parent, 'spellFrame')
@@ -744,7 +744,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.leo_spell_listBox = listBox  # Must exist
         self.leo_spell_label = lab  # Must exist (!!)
     #@+node:ekr.20110605121601.18166: *5* dw.createFindTab & helpers
-    def createFindTab(self, parent: Widget, tab_widget: Widget) -> None:
+    def createFindTab(self, parent: "LeoQtFrame", tab_widget: Widget) -> None:
         """Create a Find Tab in the given parent."""
         c, dw = self.leo_c, self
         fc = c.findCommands
@@ -770,7 +770,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.leo_find_widget = tab_widget  # A scrollArea.
         ftm.init_widgets()
     #@+node:ekr.20131118152731.16847: *6* dw.create_find_grid
-    def create_find_grid(self, parent: Widget) -> Any:
+    def create_find_grid(self, parent: "LeoQtFrame") -> Any:
         grid = self.createGrid(parent, 'findGrid', margin=10, spacing=10)
         grid.setColumnStretch(0, 100)
         grid.setColumnStretch(1, 100)
@@ -779,7 +779,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         grid.setColumnMinimumWidth(2, 175)
         return grid
     #@+node:ekr.20131118152731.16849: *6* dw.create_find_header
-    def create_find_header(self, grid: Any, parent: Widget, row: int) -> int:
+    def create_find_header(self, grid: Any, parent: "LeoQtFrame", row: int) -> int:
         if False:
             dw = self
             lab1 = dw.createLabel(parent, 'findHeading', 'Find/Change Settings...')
@@ -787,7 +787,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             row += 1
         return row
     #@+node:ekr.20131118152731.16848: *6* dw.create_find_findbox
-    def create_find_findbox(self, grid: Any, parent: Widget, row: int) -> int:
+    def create_find_findbox(self, grid: Any, parent: "LeoQtFrame", row: int) -> int:
         """Create the Find: label and text area."""
         c, dw = self.leo_c, self
         fc = c.findCommands
@@ -801,7 +801,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         row += 1
         return row
     #@+node:ekr.20131118152731.16850: *6* dw.create_find_replacebox
-    def create_find_replacebox(self, grid: Any, parent: Widget, row: int) -> int:
+    def create_find_replacebox(self, grid: Any, parent: "LeoQtFrame", row: int) -> int:
         """Create the Replace: label and text area."""
         c, dw = self.leo_c, self
         fc = c.findCommands
@@ -815,7 +815,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         row += 1
         return row
     #@+node:ekr.20131118152731.16851: *6* dw.create_find_checkboxes
-    def create_find_checkboxes(self, grid: Any, parent: Widget, max_row2: int, row: int) -> int:
+    def create_find_checkboxes(self, grid: Any, parent: "LeoQtFrame", max_row2: int, row: int) -> int:
         """Create check boxes and radio buttons."""
         c, dw = self.leo_c, self
         fc = c.findCommands
@@ -882,7 +882,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             setattr(ftm, name, w)
         return max_row2
     #@+node:ekr.20131118152731.16853: *6* dw.create_help_row
-    def create_help_row(self, grid: Any, parent: Widget, row: int) -> int:
+    def create_help_row(self, grid: Any, parent: "LeoQtFrame", row: int) -> int:
         # Help row.
         if False:
             w = self.createLabel(parent,
@@ -891,7 +891,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             row += 1
         return row
     #@+node:ekr.20131118152731.16852: *6* dw.create_find_buttons
-    def create_find_buttons(self, grid: Any, parent: Widget, max_row2: int, row: int) -> int:
+    def create_find_buttons(self, grid: Any, parent: "LeoQtFrame", max_row2: int, row: int) -> int:
         """
         Per #1342, this method now creates labels, not real buttons.
         """
@@ -922,7 +922,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     #@+node:ekr.20150618072619.1: *6* dw.create_find_status
     if 0:
 
-        def create_find_status(self, grid: Any, parent: Widget, row: int) -> None:
+        def create_find_status(self, grid: Any, parent: "LeoQtFrame", row: int) -> None:
             """Create the status line."""
             dw = self
             status_label = dw.createLabel(parent, 'status-label', 'Status')
@@ -2526,13 +2526,13 @@ class LeoQtFrame(leoFrame.LeoFrame):
             class leoIconBarButton(QtWidgets.QWidgetAction):  # type:ignore
 
                 # toolbar is a QtIconBarClass object, not a QWidget.
-                def __init__(self, parent: Widget, text: str, toolbar: Any) -> None:
+                def __init__(self, parent: "LeoQtFrame", text: str, toolbar: Any) -> None:
                     super().__init__(parent)
                     self.button: Widget = None  # set below
                     self.text = text
                     self.toolbar = toolbar
 
-                def createWidget(self, parent: Widget) -> None:
+                def createWidget(self, parent: "LeoQtFrame") -> None:
                     self.button = b = QtWidgets.QPushButton(self.text, parent)
                     self.button.setProperty('button_kind', kind)  # for styling
                     return b
@@ -3560,7 +3560,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
     # See the Tk docs for what these routines are to do
     #@+node:ekr.20110605121601.18343: *4* LeoQtMenu.Methods with Tk spellings
     #@+node:ekr.20110605121601.18344: *5* LeoQtMenu.add_cascade
-    def add_cascade(self, parent: Widget, label: str, menu: Widget, underline: int) -> Widget:
+    def add_cascade(self, parent: "LeoQtFrame", label: str, menu: Widget, underline: int) -> Widget:
         """Wrapper for the Tkinter add_cascade menu method.
 
         Adds a submenu to the parent menu, or the menubar."""
@@ -3642,7 +3642,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
                 action.triggered.connect(insert_callback)
     #@+node:ekr.20110605121601.18352: *5* LeoQtMenu.insert_cascade
     def insert_cascade(self,
-        parent: Widget,
+        parent: "LeoQtFrame",
         index: int,
         label: str,
         menu: Widget,
@@ -3663,7 +3663,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             g.trace('no action for menu', label)
         return menu
     #@+node:ekr.20110605121601.18353: *5* LeoQtMenu.new_menu
-    def new_menu(self, parent: Widget, tearoff: int=0, label: str='') -> Any:  # label is for debugging.
+    def new_menu(self, parent: "LeoQtFrame", tearoff: int=0, label: str='') -> Any:  # label is for debugging.
         """Wrapper for the Tkinter new_menu menu method."""
         c, leoFrame = self.c, self.frame
         # Parent can be None, in which case it will be added to the menuBar.
@@ -3770,7 +3770,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
 #@+node:ekr.20110605121601.18363: ** class LeoQTreeWidget (QTreeWidget)
 class LeoQTreeWidget(QtWidgets.QTreeWidget):  # type:ignore
 
-    def __init__(self, c: Cmdr, parent: Widget) -> None:
+    def __init__(self, c: Cmdr, parent: "LeoQtFrame") -> None:
         super().__init__(parent)
         self.setAcceptDrops(True)
         enable_drag = c.config.getBool('enable-tree-dragging')
@@ -4503,7 +4503,7 @@ class LeoTabbedTopLevel(LeoBaseTabWidget):
 class QtTabBarWrapper(QtWidgets.QTabBar):  # type:ignore
     #@+others
     #@+node:peckj.20140516114832.10108: *3* __init__
-    def __init__(self, parent: Widget=None) -> None:
+    def __init__(self, parent: "LeoQtFrame"=None) -> None:
         super().__init__(parent)
         self.setMovable(True)
     #@+node:peckj.20140516114832.10109: *3* mouseReleaseEvent (QtTabBarWrapper)
@@ -4518,7 +4518,7 @@ class QtTabBarWrapper(QtWidgets.QTabBar):  # type:ignore
 class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
     #@+others
     #@+node:ekr.20110605121601.18459: *3* ctor and __repr__(QtMenuWrapper)
-    def __init__(self, c: Cmdr, frame: "LeoQtFrame", parent: Widget, label: str) -> None:
+    def __init__(self, c: Cmdr, frame: "LeoQtFrame", parent: "LeoQtFrame", label: str) -> None:
         """ctor for QtMenuWrapper class."""
         assert c
         assert frame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2107,7 +2107,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.bar2 = None
         self.body: LeoQtBody = None
         self.f1 = self.f2 = None
-        self.findPanel: Widget = None  # Inited when first opened.
         self.iconBarComponentName = 'iconBar'
         self.iconFrame: Widget = None
         self.log: Widget = None

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -311,7 +311,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             body.recolorWidget(p, wrapper)
         return parent_frame, wrapper
     #@+node:ekr.20110605121601.18143: *5* dw.createBodyPane
-    def createBodyPane(self, parent: "LeoQtFrame") -> Widget:
+    def createBodyPane(self, parent: "LeoQtFrame") -> "LeoQtFrame":
         """
         Create the *pane* for the body, not the actual QTextBrowser.
         """
@@ -349,7 +349,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         return bodyFrame
 
     #@+node:ekr.20110605121601.18144: *5* dw.createCentralWidget
-    def createCentralWidget(self) -> Widget:
+    def createCentralWidget(self) -> "LeoQtFrame":
         """Create the central widget."""
         dw = self
         w = QtWidgets.QWidget(dw)
@@ -436,7 +436,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         # Official ivars.
         self.leo_menubar = w
     #@+node:ekr.20110605121601.18148: *5* dw.createMiniBuffer (class VisLineEdit)
-    def createMiniBuffer(self, parent: "LeoQtFrame") -> Widget:
+    def createMiniBuffer(self, parent: "LeoQtFrame") -> "LeoQtFrame":
         """Create the widgets for Leo's minibuffer area."""
         # Create widgets.
         frame = self.createFrame(parent, 'minibufferFrame',
@@ -498,7 +498,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         # self.leo_minibuffer_layout = layout
         return frame
     #@+node:ekr.20110605121601.18149: *5* dw.createOutlinePane
-    def createOutlinePane(self, parent: "LeoQtFrame") -> Widget:
+    def createOutlinePane(self, parent: "LeoQtFrame") -> "LeoQtFrame":
         """Create the widgets and ivars for Leo's outline."""
         # Create widgets.
         treeFrame = self.createFrame(parent, 'outlineFrame', vPolicy=Policy.Expanding)
@@ -553,13 +553,13 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         dw.resize(691, 635)
     #@+node:ekr.20110605121601.18152: *4* dw.widgets
     #@+node:ekr.20110605121601.18153: *5* dw.createButton
-    def createButton(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
+    def createButton(self, parent: "LeoQtFrame", name: str, label: str) -> "LeoQtFrame":
         w = QtWidgets.QPushButton(parent)
         w.setObjectName(name)
         w.setText(self.tr(label))
         return w
     #@+node:ekr.20110605121601.18154: *5* dw.createCheckBox
-    def createCheckBox(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
+    def createCheckBox(self, parent: "LeoQtFrame", name: str, label: str) -> "LeoQtFrame":
         w = QtWidgets.QCheckBox(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
@@ -574,7 +574,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         lineWidth: int=1,
         shadow: Shadow=None,
         shape: Shape=None,
-    ) -> Widget:
+    ) -> "LeoQtFrame":
         """Create a Qt Frame."""
         if shadow is None:
             shadow = Shadow.Plain
@@ -589,7 +589,9 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.setName(w, name)
         return w
     #@+node:ekr.20110605121601.18156: *5* dw.createGrid
-    def createGrid(self, parent: "LeoQtFrame", name: str, margin: int=0, spacing: int=0) -> Widget:
+    def createGrid(self,
+        parent: "LeoQtFrame", name: str, margin: int=0, spacing: int=0,
+    ) -> "LeoQtFrame":
         w = QtWidgets.QGridLayout(parent)
         w.setContentsMargins(QtCore.QMargins(margin, margin, margin, margin))
         w.setSpacing(spacing)
@@ -610,20 +612,22 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.setName(vLayout, name)
         return vLayout
     #@+node:ekr.20110605121601.18158: *5* dw.createLabel
-    def createLabel(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
+    def createLabel(self, parent: "LeoQtFrame", name: str, label: str) -> "LeoQtFrame":
         w = QtWidgets.QLabel(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
         return w
     #@+node:ekr.20110605121601.18159: *5* dw.createLineEdit
-    def createLineEdit(self, parent: "LeoQtFrame", name: str, disabled: bool=True) -> Widget:
+    def createLineEdit(self, parent: "LeoQtFrame", name: str, disabled: bool=True) -> "LeoQtFrame":
 
         w = QtWidgets.QLineEdit(parent)
         w.setObjectName(name)
         w.leo_disabled = disabled  # Inject the ivar.
         return w
     #@+node:ekr.20110605121601.18160: *5* dw.createRadioButton
-    def createRadioButton(self, parent: "LeoQtFrame", name: str, label: str) -> Widget:
+    def createRadioButton(self,
+        parent: "LeoQtFrame", name: str, label: str,
+    ) -> Widget:  # QtWidgets.QRadioButton:
         w = QtWidgets.QRadioButton(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
@@ -636,7 +640,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         lineWidth: int=1,
         hPolicy: Policy=None,
         vPolicy: Policy=None,
-    ) -> Widget:
+    ) -> Widget:  # QtWidgets.QStackedWidget
         w = QtWidgets.QStackedWidget(parent)
         self.setSizePolicy(w, kind1=hPolicy, kind2=vPolicy)
         w.setAcceptDrops(True)
@@ -793,7 +797,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         fc = c.findCommands
         ftm = fc.ftm
         assert ftm.find_findbox is None
-        ftm.find_findbox = w = dw.createLineEdit(
+        ftm.find_findbox = w = dw.createLineEdit(  # type:ignore
             parent, 'findPattern', disabled=fc.expert_mode)
         lab2 = self.createLabel(parent, 'findLabel', 'Find:')
         grid.addWidget(lab2, row, 0)
@@ -807,7 +811,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         fc = c.findCommands
         ftm = fc.ftm
         assert ftm.find_replacebox is None
-        ftm.find_replacebox = w = dw.createLineEdit(
+        ftm.find_replacebox = w = dw.createLineEdit(  # type:ignore
             parent, 'findChange', disabled=fc.expert_mode)
         lab3 = dw.createLabel(parent, 'changeLabel', 'Replace:')  # Leo 4.11.1.
         grid.addWidget(lab3, row, 0)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -49,6 +49,7 @@ else:
     Position = Any
     Wrapper = Any
 QComboBox = Any
+QPushButton = Any
 Widget = Any
 #@-<< qt_frame annotations >>
 #@+<< qt_frame decorators >>
@@ -4088,17 +4089,16 @@ class QtIconBarClass:
 
         class leoIconBarButton(QtWidgets.QWidgetAction):  # type:ignore
 
-            # toolbar is a QtIconBarClass object, not a QWidget.
-            def __init__(self, parent: "LeoQtFrame", text: str, toolbar: Any) -> None:
+            def __init__(self, parent: "LeoQtFrame", text: str, toolbar: "QtIconBarClass") -> None:
                 super().__init__(parent)
-                self.button: Widget = None  # set below
+                self.button: QPushButton = None  # set below
                 self.text = text
                 self.toolbar = toolbar
 
             def createWidget(self, parent: "LeoQtFrame") -> None:
-                self.button = b = QtWidgets.QPushButton(self.text, parent)
+                self.button = QtWidgets.QPushButton(self.text, parent)
                 self.button.setProperty('button_kind', kind)  # for styling
-                return b
+                return self.button
 
         action: Any
         if qaction is None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2104,23 +2104,18 @@ class LeoQtFrame(leoFrame.LeoFrame):
     #@+node:ekr.20110605121601.18248: *5* qtFrame.setIvars
     def setIvars(self) -> None:
         # "Official ivars created in createLeoFrame and its allies.
-        self.bar1 = None
-        self.bar2 = None
+        self.bar1: "LeoQtFrame" = None
+        self.bar2: "LeoQtFrame"= None
         self.body: "LeoQtBody" = None
-        self.f1 = self.f2 = None
-        self.iconBarComponentName = 'iconBar'
         self.iconFrame: "QtIconBarClass" = None
         self.log: "LeoQtLog" = None
-        self.canvas: Widget = None
         self.outerFrame: "LeoQtFrame" = None
         self.statusFrame: "LeoQtFrame" = None
-        self.top: Widget = None  # This will be a class Window object.
+        self.top: "DynamicWindow" = None
         self.tree: LeoQtTree = None
         # Used by event handlers...
         self.controlKeyIsDown = False  # For control-drags
-        self.isActive = True
         self.redrawCount = 0
-        self.wantedCallbackScheduled = False
     #@+node:ekr.20110605121601.18249: *4* qtFrame.__repr__
     def __repr__(self) -> str:
         return f"<LeoQtFrame: {self.title}>"

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -87,7 +87,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
             # parent is a LeoTabbedTopLevel.
         super().__init__(parent)
         self.leo_c = c
-        self.leo_master = None  # Set in construct.
+        self.leo_master: "LeoTabbedTopLevel" = None  # Set in construct.
         self.leo_menubar = None  # Set in createMenuBar.
         c._style_deltas = defaultdict(lambda: 0)  # for adjusting styles dynamically
         self.reloadSettings()
@@ -149,7 +149,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         else:
             event.ignore()
     #@+node:ekr.20110605121601.18139: *3* dw.construct & helpers
-    def construct(self, master: Widget=None) -> None:
+    def construct(self, master: "LeoTabbedTopLevel"=None) -> None:
         """ Factor 'heavy duty' code out from the DynamicWindow ctor """
         c = self.leo_c
         self.leo_master = master  # A LeoTabbedTopLevel or None for non-tabbed windows.
@@ -4544,7 +4544,7 @@ class TabbedFrameFactory:
         # Workaround a problem setting the window title when tabs are shown.
         self.alwaysShowTabs = True
         self.leoFrames: Dict["DynamicWindow", "LeoQtFrame"] = {}
-        self.masterFrame: Widget = None
+        self.masterFrame: "LeoTabbedTopLevel" = None
         self.createTabCommands()
     #@+node:ekr.20110605121601.18466: *3* frameFactory.createFrame
     def createFrame(self, leoFrame: "LeoQtFrame") -> "LeoQtFrame":

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -943,7 +943,9 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         #@+node:ekr.20131118172620.16892: *7* class EventWrapper
         class EventWrapper:
 
-            def __init__(self, c: Cmdr, w: Widget, next_w: Widget, func: Callable) -> None:
+            def __init__(self,
+                c: Cmdr, w: "LeoQtFrame", next_w: "LeoQtFrame", func: Callable,
+            ) -> None:
                 self.c = c
                 self.d = self.create_d()  # Keys: stroke.s; values: command-names.
                 self.w = w
@@ -2334,7 +2336,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # Keys are widgets, values are stylesheets.
         styleSheetCache: Dict[Any, str] = {}
 
-        def put_helper(self, s: str, w: Widget, bg: str=None, fg: str=None) -> None:
+        def put_helper(self, s: str, w: "LeoQtFrame", bg: str=None, fg: str=None) -> None:
             """Put string s in the indicated widget, with proper colors."""
             c = self.c
             bg = bg or c.config.getColor('status-bg') or 'white'
@@ -2580,7 +2582,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 # self.addRow()
             # g.app.iconWidgetCount += 1
         #@+node:ekr.20110605121601.18267: *4* QtIconBar.addWidget
-        def addWidget(self, w: Widget) -> None:
+        def addWidget(self, w: "LeoQtFrame") -> None:
             self.w.addWidget(w)
         #@+node:ekr.20110605121601.18268: *4* QtIconBar.clear
         def clear(self) -> None:
@@ -2597,7 +2599,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 return LeoQtTreeTab(c, f.iconBar)
             return None
         #@+node:ekr.20110605121601.18270: *4* QtIconBar.deleteButton
-        def deleteButton(self, w: Widget) -> None:
+        def deleteButton(self, w: "LeoQtFrame") -> None:
             """ w is button """
             self.w.removeAction(w)
             self.c.bodyWantsFocus()
@@ -3240,7 +3242,7 @@ class LeoQtLog(leoFrame.LeoLog):
         c.frame.log.selectTab('Log')
         c.bodyWantsFocus()
     #@+node:ekr.20111120124732.10184: *3* LeoQtLog.isLogWidget
-    def isLogWidget(self, w: Widget) -> bool:
+    def isLogWidget(self, w: "LeoQtFrame") -> bool:
         val = w == self or w in list(self.contentsDict.values())
         return val
     #@+node:tbnorth.20171220123648.1: *3* LeoQtLog.linkClicked

--- a/leo/unittests/core/test_leoFrame.py
+++ b/leo/unittests/core/test_leoFrame.py
@@ -21,9 +21,6 @@ class TestFrame(LeoUnitTest):
             assert hasattr(f, ivar), 'missing frame ivar: %s' % ivar
             val = getattr(f, ivar)
             self.assertTrue(val is not None, msg=ivar)
-        # These do not have to be initied.
-        for ivar in ('findPanel',):
-            self.assertTrue(hasattr(f, ivar), msg=ivar)
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -12,7 +12,7 @@ from leo.core.leoTest2 import LeoUnitTest, create_app
 from leo.core.leoQt import QtCore
 from leo.core.leoFrame import StatusLineAPI, TreeAPI, WrapperAPI
 from leo.core.leoFrame import LeoTree, NullStatusLineClass, NullTree, StringTextWrapper
-from leo.plugins.qt_frame import LeoQtFrame
+from leo.plugins.qt_frame import QtStatusLineClass
 from leo.plugins.qt_text import QLineEditWrapper, QScintillaWrapper, QTextEditWrapper
 from leo.plugins.qt_text import LeoQTextBrowser
 from leo.plugins.qt_tree import LeoQtTree
@@ -184,7 +184,7 @@ class TestAPIClasses(LeoUnitTest):
         def get_missing(cls):
             return [z for z in get_methods(StatusLineAPI) if z not in get_methods(cls)]
 
-        for cls in (LeoQtFrame.QtStatusLineClass, NullStatusLineClass):
+        for cls in (QtStatusLineClass, NullStatusLineClass):
             self.assertFalse(get_missing(cls), msg=f"Missing {cls.__class__.__name__} methods")
     #@+node:ekr.20220911101329.1: *3* test_tree_api
     def test_tree_api(self):


### PR DESCRIPTION
- [x] Fully annotate qt_text.py.
    - Remove unused ivars!
    - Keep the 'Widget' annotation for Qt classes, but add comments about the actual types.
    - Move two classes out of the LeoQtFrame class. This makes them available for annotations.
 - [x] Generalize annotations in LeoFrame.py.
 - [x] Remove comment in cursesGui2.py re removed ivars.
 - [x] Update unit tests.
     - Use 'Any' for the annotations of gui-specific widgets.
     - This simplifies type checking in qt_text.py.