### PR TITLE
Annotate LeoFrame ivars as Unions

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -638,15 +638,6 @@ def findMatchingBracket(self: Self, event: Event=None) -> None:
         g.es('match-brackets not supported for', language)
     else:
         g.MatchBrackets(c, p, language).run()
-#@+node:ekr.20171123135625.9: ** c_ec.fontPanel
-@g.commander_command('set-font')
-def fontPanel(self: Self, event: Event=None) -> None:
-    """Open the font dialog."""
-    c = self
-    frame = c.frame
-    if not frame.fontPanel:
-        frame.fontPanel = g.app.gui.createFontPanel(c)
-    frame.fontPanel.bringToFront()
 #@+node:ekr.20110402084740.14490: ** c_ec.goToNext/PrevHistory
 @g.commander_command('goto-next-history-node')
 def goToNextHistory(self: Self, event: Event=None) -> None:

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -100,15 +100,6 @@ def addComments(self: Self, event: Event=None) -> None:
     #
     # "after" snapshot.
     u.afterChangeBody(p, 'Add Comments', bunch)
-#@+node:ekr.20171123135625.3: ** c_ec.colorPanel
-@g.commander_command('set-colors')
-def colorPanel(self: Self, event: Event=None) -> None:
-    """Open the color dialog."""
-    c = self
-    frame = c.frame
-    if not frame.colorPanel:
-        frame.colorPanel = g.app.gui.createColorPanel(c)
-    frame.colorPanel.bringToFront()
 #@+node:ekr.20171123135625.16: ** c_ec.convertAllBlanks
 @g.commander_command('convert-all-blanks')
 def convertAllBlanks(self: Self, event: Event=None) -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -28,7 +28,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoMenu import LeoMenu, NullMenu
     from leo.core.leoNodes import Position, VNode
-    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreMenu, CoreStatusLine, CoreTree
+    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreMenu, CoreStatusLine, CoreTree, TopFrame
+    from leo.plugins.qt_frame import DynamicWindow
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtMenu, LeoQtTree, QtIconBarClass
     from leo.plugins.notebook import NbController
@@ -40,12 +41,14 @@ else:
     CoreMenu = Any
     CoreStatusLine = Any
     CoreTree = Any
+    DynamicWindow = Any
     Event = Any
     LeoMenu = Any
     LeoQtBody = Any
     LeoQtLog = Any
     LeoQtMenu = Any
     LeoQtTree = Any
+    TopFrame = Any
     QtIconBarClass = Any
     NbController = Any
     NullMenu = Any
@@ -726,28 +729,29 @@ class LeoFrame:
     def __init__(self, c: Cmdr, gui: Any) -> None:
         self.c = c
         self.gui = gui
+        # Types...
         self.iconBarClass = NullIconBarClass
-        self.isNullFrame = False
         self.statusLineClass = NullStatusLineClass
-        self.title: str = None  # Must be created by subclasses.
-        # Objects attached to this frame.
+        # Objects attached to this frame...
         self.body: Union[CoreBody, LeoBody, NullBody, LeoQtBody] = None
         self.iconBar: Union[NullIconBarClass, QtIconBarClass] = None
         self.log: Union[CoreLog, LeoLog, NullLog, LeoQtLog] = None
         self.menu: Union[CoreMenu, LeoMenu, LeoQtMenu, NullMenu] = None
         self.miniBufferWidget: Widget = None
         self.statusLine: Union[CoreStatusLine, "NullStatusLineClass", g.NullObject] = g.NullObject()
+        self.top: Union[TopFrame, DynamicWindow] = None
         self.tree: Union[CoreTree, LeoTree, NullTree, LeoQtTree] = None
         self.useMiniBufferWidget = False
-        # Gui-independent data
+        # Other ivars...
         self.cursorStay = True  # May be overridden in subclass.reloadSettings.
-        self.componentsDict: Dict[str, Any] = {}  # Keys are names, values are componentClass instances.
-        self.es_newlines = 0  # newline count for this log stream
+        self.es_newlines = 0  # newline count for this log stream.
+        self.isNullFrame = False
         self.openDirectory = ""
         self.saved = False  # True if ever saved
         self.splitVerticalFlag = True  # Set by initialRatios later.
         self.stylesheet: str = None  # The contents of <?xml-stylesheet...?> line.
         self.tab_width = 0  # The tab width in effect in this pane.
+        self.title: str = None  # Must be created by subclasses.
     #@+node:ekr.20051009045404: *4* frame.createFirstTreeNode
     def createFirstTreeNode(self) -> VNode:
         c = self.c
@@ -1866,7 +1870,6 @@ class NullFrame(LeoFrame):
         self.ratio = self.secondary_ratio = 0.5
         self.statusLineClass = NullStatusLineClass
         self.title = title
-        ### self.top: Widget = None  # Always None.
         # Create the component objects.
         self.body = NullBody(frame=self, parentFrame=None)
         self.log = NullLog(frame=self, parentFrame=None)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -27,14 +27,17 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
-    from leo.core.cursesGui2 import CoreLog
+    from leo.core.cursesGui2 import CoreBody, CoreLog
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    from leo.plugins.qt_text import LeoQtLog
+    from leo.plugins.qt_text import LeoQtBody, LeoQtLog
     from leo.plugins.notebook import NbController
 else:
     ChapterController = Any
     Cmdr = Any
+    CoreBody = Any
+    CoreLog = Any
     Event = Any
+    LeoQtBody = Any
     LeoQtLog = Any
     NbController = Any
     Position = Any
@@ -718,7 +721,7 @@ class LeoFrame:
         self.statusLineClass = NullStatusLineClass
         self.title: str = None  # Must be created by subclasses.
         # Objects attached to this frame.
-        self.body: Any = None  # A Union
+        self.body: Union[CoreBody, LeoBody, NullBody, LeoQtBody] = None
         self.colorPanel: Any = None  # A Union
         self.comparePanel: Any = None  # A Union
         self.fontPanel: Any = None  # A Union.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position, VNode
     from leo.core.cursesGui2 import CoreBody, CoreLog, CoreMenu, CoreStatusLine, CoreTree
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtMenu, LeoQtTree
+    from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtMenu, LeoQtTree, QtIconBarClass
     from leo.plugins.notebook import NbController
 else:
     ChapterController = Any
@@ -46,6 +46,7 @@ else:
     LeoQtLog = Any
     LeoQtMenu = Any
     LeoQtTree = Any
+    QtIconBarClass = Any
     NbController = Any
     NullMenu = Any
     Position = Any
@@ -731,7 +732,7 @@ class LeoFrame:
         self.title: str = None  # Must be created by subclasses.
         # Objects attached to this frame.
         self.body: Union[CoreBody, LeoBody, NullBody, LeoQtBody] = None
-        self.iconBar: Any = None  # A Union.
+        self.iconBar: Union[NullIconBarClass, QtIconBarClass] = None
         self.log: Union[CoreLog, LeoLog, NullLog, LeoQtLog] = None
         self.menu: Union[CoreMenu, LeoMenu, LeoQtMenu, NullMenu] = None
         self.miniBufferWidget: Widget = None
@@ -884,13 +885,13 @@ class LeoFrame:
             return self.iconBar.clear()
         return None
 
-    def createIconBar(self) -> None:
+    def createIconBar(self) -> Union["NullIconBarClass", QtIconBarClass]:
         c = self.c
         if not self.iconBar:
             self.iconBar = self.iconBarClass(c, None)
         return self.iconBar
 
-    def getIconBar(self) -> None:
+    def getIconBar(self) -> Union["NullIconBarClass", QtIconBarClass]:
         if not self.iconBar:
             self.iconBar = self.iconBarClass(self.c, None)
         return self.iconBar
@@ -1865,7 +1866,7 @@ class NullFrame(LeoFrame):
         self.ratio = self.secondary_ratio = 0.5
         self.statusLineClass = NullStatusLineClass
         self.title = title
-        self.top: Widget = None  # Always None.
+        ### self.top: Widget = None  # Always None.
         # Create the component objects.
         self.body = NullBody(frame=self, parentFrame=None)
         self.log = NullLog(frame=self, parentFrame=None)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoMenu import LeoMenu, NullMenu
     from leo.core.leoNodes import Position, VNode
-    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreMenu, CoreTree
+    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreMenu, CoreStatusLine, CoreTree
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtMenu, LeoQtTree
     from leo.plugins.notebook import NbController
@@ -38,6 +38,7 @@ else:
     CoreBody = Any
     CoreLog = Any
     CoreMenu = Any
+    CoreStatusLine = Any
     CoreTree = Any
     Event = Any
     LeoMenu = Any
@@ -725,18 +726,17 @@ class LeoFrame:
         self.c = c
         self.gui = gui
         self.iconBarClass = NullIconBarClass
+        self.isNullFrame = False
         self.statusLineClass = NullStatusLineClass
         self.title: str = None  # Must be created by subclasses.
         # Objects attached to this frame.
         self.body: Union[CoreBody, LeoBody, NullBody, LeoQtBody] = None
         self.iconBar: Any = None  # A Union.
-        self.isNullFrame = False
-        self.keys = None
         self.log: Union[CoreLog, LeoLog, NullLog, LeoQtLog] = None
-        self.menu: Union[CoreMenu, LeoMenu, LeoQtMenu, NullMenu] = None  # A Union
+        self.menu: Union[CoreMenu, LeoMenu, LeoQtMenu, NullMenu] = None
         self.miniBufferWidget: Widget = None
-        self.statusLine: Any = g.NullObject()  # A Union.
-        self.tree: Union[CoreTree, LeoTree, NullTree, LeoQtTree] = None  # A Union
+        self.statusLine: Union[CoreStatusLine, "NullStatusLineClass", g.NullObject] = g.NullObject()
+        self.tree: Union[CoreTree, LeoTree, NullTree, LeoQtTree] = None
         self.useMiniBufferWidget = False
         # Gui-independent data
         self.cursorStay = True  # May be overridden in subclass.reloadSettings.
@@ -910,7 +910,7 @@ class LeoFrame:
         if self.iconBar:
             self.iconBar.show()
     #@+node:ekr.20041223105114.1: *4* LeoFrame.Status line convenience methods
-    def createStatusLine(self) -> str:
+    def createStatusLine(self) -> Union[CoreStatusLine, "NullStatusLineClass", g.NullObject]:
         if not self.statusLine:
             self.statusLine = self.statusLineClass(self.c, None)  # type:ignore
         return self.statusLine
@@ -927,7 +927,7 @@ class LeoFrame:
         if self.statusLine:
             self.statusLine.enable(background)
 
-    def getStatusLine(self) -> str:
+    def getStatusLine(self) -> Union[CoreStatusLine, "NullStatusLineClass", g.NullObject]:
         return self.statusLine
 
     getStatusObject = getStatusLine

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -26,22 +26,27 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoChapters import ChapterController
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
+    from leo.core.leoMenu import LeoMenu, NullMenu
     from leo.core.leoNodes import Position, VNode
-    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreTree
+    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreMenu, CoreTree
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtTree
+    from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtMenu, LeoQtTree
     from leo.plugins.notebook import NbController
 else:
     ChapterController = Any
     Cmdr = Any
     CoreBody = Any
     CoreLog = Any
+    CoreMenu = Any
     CoreTree = Any
     Event = Any
+    LeoMenu = Any
     LeoQtBody = Any
     LeoQtLog = Any
+    LeoQtMenu = Any
     LeoQtTree = Any
     NbController = Any
+    NullMenu = Any
     Position = Any
     VNode = Any
     Wrapper = Any
@@ -728,9 +733,8 @@ class LeoFrame:
         self.isNullFrame = False
         self.keys = None
         self.log: Union[CoreLog, LeoLog, NullLog, LeoQtLog] = None
-        self.menu: Any = None  # A Union
+        self.menu: Union[CoreMenu, LeoMenu, LeoQtMenu, NullMenu] = None  # A Union
         self.miniBufferWidget: Widget = None
-        self.prefsPanel: Any = None  # A Union
         self.statusLine: Any = g.NullObject()  # A Union.
         self.tree: Union[CoreTree, LeoTree, NullTree, LeoQtTree] = None  # A Union
         self.useMiniBufferWidget = False
@@ -1865,7 +1869,7 @@ class NullFrame(LeoFrame):
         # Create the component objects.
         self.body = NullBody(frame=self, parentFrame=None)
         self.log = NullLog(frame=self, parentFrame=None)
-        self.menu: Widget = leoMenu.NullMenu(frame=self)
+        self.menu = leoMenu.NullMenu(frame=self)
         self.tree = NullTree(frame=self)
         # Default window position.
         self.w = 600

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -27,18 +27,20 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
-    from leo.core.cursesGui2 import CoreBody, CoreLog
+    from leo.core.cursesGui2 import CoreBody, CoreLog, CoreTree
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    from leo.plugins.qt_text import LeoQtBody, LeoQtLog
+    from leo.plugins.qt_text import LeoQtBody, LeoQtLog, LeoQtTree
     from leo.plugins.notebook import NbController
 else:
     ChapterController = Any
     Cmdr = Any
     CoreBody = Any
     CoreLog = Any
+    CoreTree = Any
     Event = Any
     LeoQtBody = Any
     LeoQtLog = Any
+    LeoQtTree = Any
     NbController = Any
     Position = Any
     VNode = Any
@@ -730,7 +732,7 @@ class LeoFrame:
         self.miniBufferWidget: Widget = None
         self.prefsPanel: Any = None  # A Union
         self.statusLine: Any = g.NullObject()  # A Union.
-        self.tree: Any = None  # A Union
+        self.tree: Union[CoreTree, LeoTree, NullTree, LeoQtTree] = None  # A Union
         self.useMiniBufferWidget = False
         # Gui-independent data
         self.cursorStay = True  # May be overridden in subclass.reloadSettings.
@@ -1864,7 +1866,7 @@ class NullFrame(LeoFrame):
         self.body = NullBody(frame=self, parentFrame=None)
         self.log = NullLog(frame=self, parentFrame=None)
         self.menu: Widget = leoMenu.NullMenu(frame=self)
-        self.tree: Widget = NullTree(frame=self)
+        self.tree = NullTree(frame=self)
         # Default window position.
         self.w = 600
         self.h = 500

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1861,8 +1861,8 @@ class NullFrame(LeoFrame):
         self.title = title
         self.top: Widget = None  # Always None.
         # Create the component objects.
-        self.body: Widget = NullBody(frame=self, parentFrame=None)
-        self.log: Widget = NullLog(frame=self, parentFrame=None)
+        self.body = NullBody(frame=self, parentFrame=None)
+        self.log = NullLog(frame=self, parentFrame=None)
         self.menu: Widget = leoMenu.NullMenu(frame=self)
         self.tree: Widget = NullTree(frame=self)
         # Default window position.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
+    from leo.core.cursesGui2 import CoreLog
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     from leo.plugins.qt_text import LeoQtLog
     from leo.plugins.notebook import NbController
@@ -724,7 +725,7 @@ class LeoFrame:
         self.iconBar: Any = None  # A Union.
         self.isNullFrame = False
         self.keys = None
-        self.log: Union[LeoLog, NullLog, LeoQtLog] = None
+        self.log: Union[CoreLog, LeoLog, NullLog, LeoQtLog] = None
         self.menu: Any = None  # A Union
         self.miniBufferWidget: Widget = None
         self.outerFrame: Any = None  # A Union

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -12,7 +12,8 @@ These classes should be overridden to create frames for a particular gui.
 #@+node:ekr.20120219194520.10464: ** << leoFrame imports >>
 import os
 import string
-from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColorizer  # NullColorizer is a subclass of ColorizerMixin
 from leo.core import leoMenu
@@ -27,11 +28,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_text import LeoQtLog
     from leo.plugins.notebook import NbController
 else:
     ChapterController = Any
     Cmdr = Any
     Event = Any
+    LeoQtLog = Any
     NbController = Any
     Position = Any
     VNode = Any
@@ -721,7 +724,7 @@ class LeoFrame:
         self.iconBar: Any = None  # A Union.
         self.isNullFrame = False
         self.keys = None
-        self.log: Any = None  # A Union.
+        self.log: Union[LeoLog, NullLog, LeoQtLog] = None
         self.menu: Any = None  # A Union
         self.miniBufferWidget: Widget = None
         self.outerFrame: Any = None  # A Union
@@ -764,23 +767,15 @@ class LeoFrame:
 
     def setTitle(self, title: str) -> None:
         self.title = title
-    #@+node:ekr.20081005065934.3: *4* LeoFrame.initAfterLoad  & initCompleteHint
-    def initAfterLoad(self) -> None:
-        """Provide official hooks for late inits of components of Leo frames."""
-        frame = self
-        frame.body.initAfterLoad()
-        frame.log.initAfterLoad()
-        frame.menu.initAfterLoad()
-        # if frame.miniBufferWidget: frame.miniBufferWidget.initAfterLoad()
-        frame.tree.initAfterLoad()
-
-    def initCompleteHint(self) -> None:
-        pass
     #@+node:ekr.20031218072017.3687: *4* LeoFrame.setTabWidth
     def setTabWidth(self, w: int) -> None:
         """Set the tab width in effect for this frame."""
         # Subclasses may override this to affect drawing.
         self.tab_width = w
+    #@+node:ekr.20220916041432.1: *4* LeoFrame.initCompleteHint
+    def initCompleteHint(self) -> None:
+        """A hook for Qt."""
+        pass
     #@+node:ekr.20061109125528.1: *3* LeoFrame.Must be defined in base class
     #@+node:ekr.20031218072017.3689: *4* LeoFrame.initialRatios
     def initialRatios(self) -> Tuple[bool, float, float]:
@@ -1214,6 +1209,7 @@ class LeoLog:
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
         self.textDict: Dict[str, Widget] = {}  # Keys are page names. Values are logCtrl's (text widgets).
+        self.wrapper: Any = None  # For cursesGui2.py.
     #@+node:ekr.20070302094848.1: *3* LeoLog.clearTab
     def clearTab(self, tabName: str, wrap: str='none') -> None:
         self.selectTab(tabName, wrap=wrap)
@@ -2091,6 +2087,7 @@ class NullLog(LeoLog):
         # self.logCtrl is now a property of the base LeoLog class.
         self.logNumber = 0
         self.widget: Widget = self.createControl(parentFrame)
+        self.wrapper: Any = None  # For cursesGui2.py.
     #@+node:ekr.20120216123546.10951: *4* NullLog.finishCreate
     def finishCreate(self) -> None:
         pass

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -722,7 +722,6 @@ class LeoFrame:
         self.title: str = None  # Must be created by subclasses.
         # Objects attached to this frame.
         self.body: Union[CoreBody, LeoBody, NullBody, LeoQtBody] = None
-        self.colorPanel: Any = None  # A Union
         self.comparePanel: Any = None  # A Union
         self.fontPanel: Any = None  # A Union.
         self.iconBar: Any = None  # A Union.
@@ -743,7 +742,7 @@ class LeoFrame:
         self.openDirectory = ""
         self.saved = False  # True if ever saved
         self.splitVerticalFlag = True  # Set by initialRatios later.
-        self.stylesheet = None  # The contents of <?xml-stylesheet...?> line.
+        self.stylesheet: str = None  # The contents of <?xml-stylesheet...?> line.
         self.tab_width = 0  # The tab width in effect in this pane.
     #@+node:ekr.20051009045404: *4* frame.createFirstTreeNode
     def createFirstTreeNode(self) -> VNode:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -728,7 +728,6 @@ class LeoFrame:
         self.log: Union[CoreLog, LeoLog, NullLog, LeoQtLog] = None
         self.menu: Any = None  # A Union
         self.miniBufferWidget: Widget = None
-        self.outerFrame: Any = None  # A Union
         self.prefsPanel: Any = None  # A Union
         self.statusLine: Any = g.NullObject()  # A Union.
         self.tree: Any = None  # A Union
@@ -882,19 +881,19 @@ class LeoFrame:
     def createIconBar(self) -> None:
         c = self.c
         if not self.iconBar:
-            self.iconBar = self.iconBarClass(c, self.outerFrame)
+            self.iconBar = self.iconBarClass(c, None)
         return self.iconBar
 
     def getIconBar(self) -> None:
         if not self.iconBar:
-            self.iconBar = self.iconBarClass(self.c, self.outerFrame)
+            self.iconBar = self.iconBarClass(self.c, None)
         return self.iconBar
 
     getIconBarObject = getIconBar
 
     def getNewIconFrame(self) -> None:
         if not self.iconBar:
-            self.iconBar = self.iconBarClass(self.c, self.outerFrame)
+            self.iconBar = self.iconBarClass(self.c, None)
         return self.iconBar.getNewFrame()
 
     def hideIconBar(self) -> None:
@@ -907,7 +906,7 @@ class LeoFrame:
     #@+node:ekr.20041223105114.1: *4* LeoFrame.Status line convenience methods
     def createStatusLine(self) -> str:
         if not self.statusLine:
-            self.statusLine = self.statusLineClass(self.c, self.outerFrame)  # type:ignore
+            self.statusLine = self.statusLineClass(self.c, None)  # type:ignore
         return self.statusLine
 
     def clearStatusLine(self) -> None:
@@ -1857,7 +1856,6 @@ class NullFrame(LeoFrame):
         self.iconBar = NullIconBarClass(self.c, self)
         self.initComplete = True
         self.isNullFrame = True
-        self.outerFrame: Wrapper = None
         self.ratio = self.secondary_ratio = 0.5
         self.statusLineClass = NullStatusLineClass
         self.title = title

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -722,8 +722,6 @@ class LeoFrame:
         self.title: str = None  # Must be created by subclasses.
         # Objects attached to this frame.
         self.body: Union[CoreBody, LeoBody, NullBody, LeoQtBody] = None
-        self.comparePanel: Any = None  # A Union
-        self.fontPanel: Any = None  # A Union.
         self.iconBar: Any = None  # A Union.
         self.isNullFrame = False
         self.keys = None

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -189,10 +189,6 @@ class LeoGui:
         self.oops()
         return 'no'
     #@+node:ekr.20031218072017.3732: *4* LeoGui.panels
-    def createColorPanel(self, c: Cmdr) -> None:
-        """Create a color panel"""
-        self.oops()
-
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
         self.oops()

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
 else:
     Event = Any
 Widget = Any
+Wrapper = Any
 #@-<< leoMenu annotations >>
 #@+others
 #@+node:ekr.20031218072017.3750: ** class LeoMenu
@@ -28,6 +29,7 @@ class LeoMenu:
         self.frame = frame
         self.isNull = False
         self.menus: Dict[str, Any] = {}  # Menu dictionary.
+        self.wrapper: Wrapper = None
 
     def finishCreate(self) -> None:
         self.define_enable_dict()
@@ -682,7 +684,7 @@ class LeoMenu:
     def setMenuLabel(self, menu: str, name: str, label: str, underline: int=-1) -> None:
         self.oops()
     #@-others
-#@+node:ekr.20031218072017.3811: ** class NullMenu
+#@+node:ekr.20031218072017.3811: ** class NullMenu(LeoMenu)
 class NullMenu(LeoMenu):
     """A null menu class for testing and batch execution."""
     #@+others

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2152,50 +2152,20 @@ class CoreFrame(leoFrame.LeoFrame):
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
         super().__init__(c, gui=g.app.gui)  # Init the base class.
         assert c and self.c == c
-        #
-        # These type mismatches arise from declared types in leoFrame.py.
-        #
-        c.frame = self  # type:ignore
-        self.log = CoreLog(c)  # type:ignore
+        c.frame = self
+        self.log = CoreLog(c)
         g.app.gui.log = self.log
         self.title: str = title
         # Standard ivars.
         self.ratio = self.secondary_ratio = 0.5
         # Widgets
         self.top = TopFrame(c)
-        self.body = CoreBody(c)  # type:ignore
-        self.menu = CoreMenu(c)  # type:ignore
-        self.miniBufferWidget: Wrapper = None  # Set later.
+        self.body = CoreBody(c)
+        self.menu = CoreMenu(c)
+        self.miniBufferWidget: MiniBufferWrapper = None
         self.statusLine: Wrapper = g.NullObject()  # For unit tests.
         assert self.tree is None, self.tree
-        self.tree = CoreTree(c)  # type:ignore
-
-        # Official ivars...
-            # self.iconBar = None
-            # self.minibufferVisible = True
-            # self.statusLineClass = None # self.QtStatusLineClass
-            #
-            # Config settings.
-            # self.trace_status_line = c.config.getBool('trace_status_line')
-            # self.use_chapters = c.config.getBool('use_chapters')
-            # self.use_chapter_tabs = c.config.getBool('use_chapter_tabs')
-            #
-            # self.set_ivars()
-            #
-            # "Official ivars created in createLeoFrame and its allies.
-            # self.bar1 = None
-            # self.bar2 = None
-            # self.f1 = self.f2 = None
-            # self.iconFrame = None
-            # self.canvas = None
-            # self.statusFrame = None
-            # self.statusText = None
-            # self.statusLabel = None
-            # self.top = None # This will be a class Window object.
-            # Used by event handlers...
-            # self.controlKeyIsDown = False # For control-drags
-            # self.redrawCount = 0
-            # self.scrollWay = None
+        self.tree = CoreTree(c)
     #@+node:ekr.20170420163932.1: *5* CFrame.finishCreate
     def finishCreate(self) -> None:
 

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2188,7 +2188,6 @@ class CoreFrame(leoFrame.LeoFrame):
             # self.f1 = self.f2 = None
             # self.iconFrame = None
             # self.canvas = None
-            # self.outerFrame = None
             # self.statusFrame = None
             # self.statusText = None
             # self.statusLabel = None

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2172,7 +2172,6 @@ class CoreFrame(leoFrame.LeoFrame):
 
         # Official ivars...
             # self.iconBar = None
-            # self.initComplete = False # Set by initCompleteHint().
             # self.minibufferVisible = True
             # self.statusLineClass = None # self.QtStatusLineClass
             #

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2085,7 +2085,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
         # Official ivars...
         self.iconBar: QtIconBarClass = None
-        self.iconBarClass: Any = QtIconBarClass  # A Union
+        self.iconBarClass: Any = QtIconBarClass  # A Union. Can't easily be removed.
         self.initComplete = False  # Set by initCompleteHint().
         self.minibufferVisible = True
         self.statusLineClass: Any = QtStatusLineClass  # A Union

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2106,7 +2106,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.body: "LeoQtBody" = None
         self.iconFrame: "QtIconBarClass" = None
         self.log: "LeoQtLog" = None
-        self.outerFrame: "LeoQtFrame" = None
         self.statusFrame: "LeoQtFrame" = None
         self.top: "DynamicWindow" = None
         self.tree: LeoQtTree = None

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2085,10 +2085,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         leoFrame.LeoFrame.instances += 1  # Increment the class var.
         # Official ivars...
         self.iconBar: QtIconBarClass = None
-        self.iconBarClass: Any = QtIconBarClass  # A Union. Can't easily be removed.
+        self.iconBarClass: Any = QtIconBarClass  # A Union. 'Any' can't easily be removed.
         self.initComplete = False  # Set by initCompleteHint().
         self.minibufferVisible = True
-        self.statusLineClass: Any = QtStatusLineClass  # A Union
+        self.statusLineClass: Any = QtStatusLineClass  # A Union. 'Any' can't easily be removed.
         self.title = title
         self.setIvars()
         self.reloadSettings()


### PR DESCRIPTION
Replacing 'Any' with `Union[<list of subclasses>]` is good documentation and helps mypy considerably.

- [x] Remove LeoFrame.initAfterLoad.
- [x] Remove set-colors and set-font commands, and related c.frame ivars.
- [x] LeoFrame ctor correctly annotates all objects.
- [x] Return 'type-ignore' statements from CoreFrame ctor in cursesGui2.py.