### PR TITLE
Reintroduce type:ignore to handle tricky type (and fix a crash!)

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -520,10 +520,10 @@ class PylintCommand:
         args = ','.join([f"'--rcfile={rc_fn}'", f"'{fn}'"])
         if is_win:
             args = args.replace('\\', '\\\\')
-        command_s = (
+        command = (
             f'{sys.executable} -c "from pylint import lint; args=[{args}]; lint.Run(args)"')
         if not is_win:
-            command = shlex.split(command_s)
+            command = shlex.split(command)  # type:ignore
         #
         # Run the command using the BPM.
         bpm = g.app.backgroundProcessManager


### PR DESCRIPTION
Sometimes code is just too tricky...