### PR TITLE
PR for #2870: todo.py icons

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1137,7 +1137,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 i['on'] = 'VNode'
         return fromVnode
     #@+node:ekr.20150514063305.234: *5* ec.setIconList & helpers
-    def setIconList(self, p: Position, aList: List[Any]) -> None:  ###, setDirty: bool=True) -> None:
+    def setIconList(self, p: Position, aList: List[Any]) -> None:
         """Set list of icons for position p to aList"""
         current = self.getIconList(p.v)
         if not aList and not current:
@@ -1148,7 +1148,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             # no difference between original and current list of dictionaries
             return
         # set p.u.
-        self._setIconListHelper(p, aList)  ###, setDirty)
+        self._setIconListHelper(p, aList)
     #@+node:ekr.20150514063305.235: *6* ec._setIconListHelper
     def _setIconListHelper(self, p: Position, aList: List[Any]) -> None:
         """Set icon UA for p.v. to the given list of Icons."""

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1171,7 +1171,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList = self.getIconList(c.p.v)
         if aList:
             self.setIconList(p, aList[1:])
-            p.setDirty()  ###
+            p.setDirty()
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.237: *4* ec.deleteIconByName
@@ -1193,7 +1193,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 newList.append(d)
         if len(newList) != len(aList):
             self.setIconList(p, newList)
-            p.setDirty()  ###
+            p.setDirty()
             c.setChanged()
             c.redraw_after_icons_changed()
         else:
@@ -1206,7 +1206,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList = self.getIconList(p.v)
         if aList:
             self.setIconList(c.p, aList[:-1])
-            p.setDirty()  ###
+            p.setDirty()
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.239: *4* ec.deleteNodeIcons
@@ -1218,7 +1218,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         if p.u:
             p.v._p_changed = True
             self.setIconList(p, [])
-            p.setDirty()  ###
+            p.setDirty()
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.240: *4* ec.insertIcon
@@ -1246,7 +1246,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList2 = self.getIconList(p.v)
         aList2.extend(aList)
         self.setIconList(p, aList2)
-        p.setDirty()  ###
+        p.setDirty()
         c.setChanged()
         c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.241: *4* ec.insertIconFromFile
@@ -1262,7 +1262,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             pos = len(aList2)
         aList2.insert(pos, aList[0])
         self.setIconList(p, aList2)
-        p.setDirty()  ###
+        p.setDirty()
         c.setChanged()
         c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.242: *3* ec: indent

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1137,53 +1137,41 @@ class EditCommandsClass(BaseEditCommandsClass):
                 i['on'] = 'VNode'
         return fromVnode
     #@+node:ekr.20150514063305.234: *5* ec.setIconList & helpers
-    def setIconList(self, p: Position, l: List[Any], setDirty: bool=True) -> None:
-        """Set list of icons for position p to l"""
+    def setIconList(self, p: Position, aList: List[Any]) -> None:  ###, setDirty: bool=True) -> None:
+        """Set list of icons for position p to aList"""
         current = self.getIconList(p.v)
-        if not l and not current:
+        if not aList and not current:
             return  # nothing to do
-        lHash = ''.join([self.dHash(i) for i in l])
+        lHash = ''.join([self.dHash(i) for i in aList])
         cHash = ''.join([self.dHash(i) for i in current])
         if lHash == cHash:
             # no difference between original and current list of dictionaries
             return
-        self._setIconListHelper(p, l, p.v, setDirty)
+        # set p.u.
+        self._setIconListHelper(p, aList)  ###, setDirty)
     #@+node:ekr.20150514063305.235: *6* ec._setIconListHelper
-    def _setIconListHelper(self,
-        p: Position,
-        subl: List[Any],
-        uaLoc: VNode,
-        setDirty: bool,
-    ) -> None:
-        """icon setting code common between v and t nodes
-
-        p - position
-        subl - list of icons for the v or t node
-        uaLoc - the v or t node
-        """
-        if subl:  # Update the uA.
-            if not hasattr(uaLoc, 'unknownAttributes'):
-                uaLoc.unknownAttributes = {}
-            uaLoc.unknownAttributes['icons'] = list(subl)
-            # g.es((p.h,uaLoc.unknownAttributes['icons']))
-            uaLoc._p_changed = True
-            if setDirty:
-                p.setDirty()
+    def _setIconListHelper(self, p: Position, aList: List[Any]) -> None:
+        """Set icon UA for p.v. to the given list of Icons."""
+        v = p.v
+        if aList:  # Update the uA.
+            if not hasattr(v, 'unknownAttributes'):
+                v.unknownAttributes = {}
+            v.unknownAttributes['icons'] = list(aList)
+            v._p_changed = True
         else:  # delete the uA.
-            if hasattr(uaLoc, 'unknownAttributes'):
-                if 'icons' in uaLoc.unknownAttributes:
-                    del uaLoc.unknownAttributes['icons']
-                    uaLoc._p_changed = True
-                    if setDirty:
-                        p.setDirty()
+            if hasattr(v, 'unknownAttributes'):
+                if 'icons' in v.unknownAttributes:
+                    del v.unknownAttributes['icons']
+                    v._p_changed = True
     #@+node:ekr.20150514063305.236: *4* ec.deleteFirstIcon
     @cmd('delete-first-icon')
     def deleteFirstIcon(self, event: Event=None) -> None:
         """Delete the first icon in the selected node's icon list."""
-        c = self.c
+        c, p = self.c, self.c.p
         aList = self.getIconList(c.p.v)
         if aList:
-            self.setIconList(c.p, aList[1:])
+            self.setIconList(p, aList[1:])
+            p.setDirty()  ###
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.237: *4* ec.deleteIconByName
@@ -1205,6 +1193,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 newList.append(d)
         if len(newList) != len(aList):
             self.setIconList(p, newList)
+            p.setDirty()  ###
             c.setChanged()
             c.redraw_after_icons_changed()
         else:
@@ -1213,10 +1202,11 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('delete-last-icon')
     def deleteLastIcon(self, event: Event=None) -> None:
         """Delete the first icon in the selected node's icon list."""
-        c = self.c
-        aList = self.getIconList(c.p.v)
+        c, p = self.c, self.c.p
+        aList = self.getIconList(p.v)
         if aList:
             self.setIconList(c.p, aList[:-1])
+            p.setDirty()  ###
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.239: *4* ec.deleteNodeIcons
@@ -1228,7 +1218,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         if p.u:
             p.v._p_changed = True
             self.setIconList(p, [])
-            p.setDirty()
+            p.setDirty()  ###
             c.setChanged()
             c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.240: *4* ec.insertIcon
@@ -1256,6 +1246,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList2 = self.getIconList(p.v)
         aList2.extend(aList)
         self.setIconList(p, aList2)
+        p.setDirty()  ###
         c.setChanged()
         c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.241: *4* ec.insertIconFromFile
@@ -1271,6 +1262,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             pos = len(aList2)
         aList2.insert(pos, aList[0])
         self.setIconList(p, aList2)
+        p.setDirty()  ###
         c.setChanged()
         c.redraw_after_icons_changed()
     #@+node:ekr.20150514063305.242: *3* ec: indent

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2744,10 +2744,10 @@ def objToString(obj: Any, indent: str='', tag: str='', concise: bool=False) -> s
     concise=False: (Legacy) return a detailed string.
     concise=True: Return a summary string.
     """
+    if tag:
+        print(tag.strip())
     if concise:
         r = repr(obj)
-        if tag:
-            print(tag.strip())
         if obj is None:
             return f"{indent}None"
         if isinstance(obj, dict):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2348,7 +2348,7 @@ class VNode:
         pass  # Compatibility routine for old scripts
     #@+node:ekr.20220905044353.1: *4* v.updateIcon
     def updateIcon(self) -> None:
-
+        """Update any user icon."""
         c, v = self.context, self
         try:
             tree = c.frame.tree  # May not exist at startup.
@@ -2358,8 +2358,11 @@ class VNode:
                 return
         except AttributeError:
             return
-        # Update all cloned items.
+
+        ### icon = tree.getIcon(v)  ### Supports declutter, but that's for later.
         icon = tree.getCompositeIconImage(v)
+        if v.h == 'Test':
+            g.trace(v.iconVal, id(icon), g.callers(2))  ###
         items = tree.vnode2items(v)
         for item in items:
             tree.setItemIcon(item, icon)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2359,10 +2359,9 @@ class VNode:
         except AttributeError:
             return
 
-        ### icon = tree.getIcon(v)  ### Supports declutter, but that's for later.
         # #2870: Clear the icon cache (Remove v.gnx from the dict).
         tree.nodeIconsDict.pop(v.gnx, None)
-        icon = tree.getCompositeIconImage(v)
+        icon = tree.getIcon(v)
         items = tree.vnode2items(v)
         for item in items:
             tree.setItemIcon(item, icon)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2360,9 +2360,9 @@ class VNode:
             return
 
         ### icon = tree.getIcon(v)  ### Supports declutter, but that's for later.
+        # #2870: Clear the icon cache (Remove v.gnx from the dict).
+        tree.nodeIconsDict.pop(v.gnx, None)
         icon = tree.getCompositeIconImage(v)
-        if v.h == 'Test':
-            g.trace(v.iconVal, id(icon), g.callers(2))  ###
         items = tree.vnode2items(v)
         for item in items:
             tree.setItemIcon(item, icon)

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -215,7 +215,6 @@ class LeoQtTree(leoFrame.LeoTree):
 
         returns composite icon for this node, containing the icon box and perhaps other icons.
         """
-        g.trace(v.h) ### 
         dd = self.declutter_data
         iconVal = v.computeIcon()
         iconName = f'box{iconVal:02d}.png'
@@ -783,7 +782,6 @@ class LeoQtTree(leoFrame.LeoTree):
                 f = nicon
             if f not in loaded_images:
                 loaded_images[f] = g.app.gui.getImageImage(f)
-        if v.h == 'Test': g.trace(fnames, g.callers(2))
         return fnames
     #@+node:vitalije.20200329153154.1: *5* qtree.make_composite_icon
     def make_composite_icon(self, images: List[Any]) -> Icon:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -205,7 +205,6 @@ class LeoQtTree(leoFrame.LeoTree):
     redraw_now = full_redraw  #type:ignore
     #@+node:vitalije.20200329160945.1: *5* tree declutter code
     #@+node:tbrown.20150807090639.1: *6* qtree.declutter_node & helpers
-    ### def declutter_node(self, c: Cmdr, p: Position, item: Item) -> Icon:
     def declutter_node(self, c: Cmdr, v: VNode, item: Item) -> Icon:
         """declutter_node - change the appearance of a node
 
@@ -221,7 +220,6 @@ class LeoQtTree(leoFrame.LeoTree):
         loaded_images = self.loaded_images
         #@+others
         #@+node:vitalije.20200329153544.1: *7* sorted_icons
-        ### def sorted_icons(p: Position) -> List[str]:
         def sorted_icons(v: VNode) -> List[str]:
             """
             Returns a list of icon filenames for this node.
@@ -753,11 +751,9 @@ class LeoQtTree(leoFrame.LeoTree):
         g.app.gui.set_focus(self.c, self.treeWidget)
     #@+node:ekr.20110605121601.18409: *3* qtree.Icons
     #@+node:ekr.20110605121601.18411: *4* qtree.getIcon & helpers
-    ### def getIcon(self, p: Position) -> Icon:
     def getIcon(self, v: VNode) -> Icon:
         """Return the proper icon for position p."""
         if self.use_declutter:
-            ### item = self.position2item(p)
             items = self.vnode2items(v)
             if items:
                 return self.declutter_node(self.c, v, items[0])
@@ -813,7 +809,6 @@ class LeoQtTree(leoFrame.LeoTree):
         if not icon:
             icon = self.make_composite_icon(images)
             g.app.gui.iconimages[h] = icon
-        ### if v.h == 'Test':  g.trace(v.iconVal, id(icon), g.callers(2))  ###
         return icon
     #@+node:ekr.20110605121601.17950: *4* qtree.setItemIcon
     def setItemIcon(self, item: Item, icon: str) -> None:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -753,7 +753,7 @@ class LeoQtTree(leoFrame.LeoTree):
     def setFocus(self) -> None:
         g.app.gui.set_focus(self.c, self.treeWidget)
     #@+node:ekr.20110605121601.18409: *3* qtree.Icons
-    #@+node:ekr.20110605121601.18411: *4* qtree.getIcon & helper
+    #@+node:ekr.20110605121601.18411: *4* qtree.getIcon & helpers
     ### def getIcon(self, p: Position) -> Icon:
     def getIcon(self, v: VNode) -> Icon:
         """Return the proper icon for position p."""
@@ -783,6 +783,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 f = nicon
             if f not in loaded_images:
                 loaded_images[f] = g.app.gui.getImageImage(f)
+        if v.h == 'Test': g.trace(fnames, g.callers(2))
         return fnames
     #@+node:vitalije.20200329153154.1: *5* qtree.make_composite_icon
     def make_composite_icon(self, images: List[Any]) -> Icon:
@@ -814,8 +815,7 @@ class LeoQtTree(leoFrame.LeoTree):
         if not icon:
             icon = self.make_composite_icon(images)
             g.app.gui.iconimages[h] = icon
-        if v.h == 'Test':
-            g.trace(v.iconVal, id(icon), g.callers(2))  ###
+        ### if v.h == 'Test':  g.trace(v.iconVal, id(icon), g.callers(2))  ###
         return icon
     #@+node:ekr.20110605121601.17950: *4* qtree.setItemIcon
     def setItemIcon(self, item: Item, icon: str) -> None:

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -631,7 +631,7 @@ class todoController:
                         where=self.prog_location)
         # Set the p.v.u for the icons.
         com.setIconList(p, icons)
-        p.v.updateIcon()
+        p.v.updateIcon()  # #2870.
     #@+node:tbrown.20090119215428.17: *3* close
     def close(self, tag: str, key: Any) -> None:
         "unregister handlers on closing commander"

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -629,30 +629,9 @@ class todoController:
                         on='vnode',
                         cleoIcon='1',
                         where=self.prog_location)
-
-        if icons:
-            ### g.trace('Icons for', p.h)
-            g.printObj(icons, tag=p.h)
-        
         # Set the p.v.u for the icons.
         com.setIconList(p, icons)
-        d = p.v.u.get('icons')
-        if d:
-            ### g.trace(p.h)
-            g.printObj(d, tag=p.h)
-        
-        # Update the vnode's icon.
-        
-        ### Add guard??? 
-        # tree = c.frame.tree
-
-        # # Like v.updateIcons:
-        # items = tree.vnode2items(p.v)
-        # for item in items:
-            # for icon in icons:
-                # tree.setItemIcon(item, icon)
-        ### v.updateIcon()
-        # c.redraw_after_icons_changed()
+        p.v.updateIcon()
     #@+node:tbrown.20090119215428.17: *3* close
     def close(self, tag: str, key: Any) -> None:
         "unregister handlers on closing commander"

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -577,11 +577,12 @@ class todoController:
         """Load icons to represent cleo state"""
         for p in self.c.all_positions():
             self.loadIcons(p, clear=clear)
-    #@+node:tbrown.20090119215428.16: *3* loadIcons
+    #@+node:tbrown.20090119215428.16: *3* loadIcons (todo.py)
     @redrawer
     def loadIcons(self, p: Position, clear: bool=False) -> None:
 
-        com = self.c.editCommands
+        c = self.c
+        com = c.editCommands
         allIcons = com.getIconList(p.v)
         icons = [i for i in allIcons if 'cleoIcon' not in i]
         if self.icon_order == 'pri-first':
@@ -621,10 +622,37 @@ class todoController:
                         icon = "date_today.png"
                     else:
                         icon = "date_future.png"
-                    com.appendImageDictToList(icons, g.os_path_join('cleo', icon),
-                        2, on='vnode', cleoIcon='1', where=self.prog_location)
+                    # Append the icon to the icons list.
+                    com.appendImageDictToList(icons,
+                        g.os_path_join('cleo', icon),
+                        2,
+                        on='vnode',
+                        cleoIcon='1',
+                        where=self.prog_location)
 
-        com.setIconList(p, icons, setDirty=False)
+        if icons:
+            ### g.trace('Icons for', p.h)
+            g.printObj(icons, tag=p.h)
+        
+        # Set the p.v.u for the icons.
+        com.setIconList(p, icons)
+        d = p.v.u.get('icons')
+        if d:
+            ### g.trace(p.h)
+            g.printObj(d, tag=p.h)
+        
+        # Update the vnode's icon.
+        
+        ### Add guard??? 
+        # tree = c.frame.tree
+
+        # # Like v.updateIcons:
+        # items = tree.vnode2items(p.v)
+        # for item in items:
+            # for icon in icons:
+                # tree.setItemIcon(item, icon)
+        ### v.updateIcon()
+        # c.redraw_after_icons_changed()
     #@+node:tbrown.20090119215428.17: *3* close
     def close(self, tag: str, key: Any) -> None:
         "unregister handlers on closing commander"


### PR DESCRIPTION
See #2870.

**High-level summary**

- [x] todo.py: loadIcons calls v.updateIcon.
- [x] leoNodes.py: **Aha!** v.updateIcon must clear the icon cache!
- [x] editCommands.py: _setIconListHelper takes a VNode arg instead of a Position arg.
- [x] qt_tree.py:  The following methods use a VNode arg instead of a Position arg:
    - declutter_node and its helper functions.
    - getIcon.

**Other changes**

- [x] editCommands.py: 
    - setIconList: Remove evil 'setDirty' kwarg. Change 'l' to 'aList'.
    - _setIconListHelper: Replace 'uaLoc' with 'v'.
    - Call p.setDirty after calls to setIconList.
- [x] leoGlobals.py: fix recent regression in g.objToString.