### PR TITLE
Add pylint disable statements.

### DIFF
--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -249,7 +249,7 @@ from leo.core import leoColorizer
 from leo.plugins import qt_text
 
 # pylint: disable=ungrouped-imports
-
+#pylint: disable = c-extension-no-member
 try:
     # pylint: disable=import-error
     # this can fix an issue with Qt Web views in Ubuntu
@@ -662,6 +662,7 @@ class ZEditorWin(QtWidgets.QMainWindow):
     #@+node:tom.20210527185804.1: *3* ctor
     def __init__(self, c, title='Z-editor'):
         # pylint: disable=too-many-locals
+        # pylint: disable = too-many-statements
         global TAB2SPACES
         super().__init__()
         QWidget().__init__()


### PR DESCRIPTION
I marked this little PR for 6.7.0, but only because there's nothing later on offer.  It's not urgent. With this PR, pylint reports 10/10.

There is a comment the @Edward added that says the pylint hangs when testing freewin.  One of two things happens, or maybe both, on my system but they are not fatal:

1. pylint finishes but does not release its shell until an <ENTER> is typed in the console;
2. An <ENTER> is not needed, but there is a time delay of perhaps 10 - 20 seconds before pylint returns control to Leo.  On my system, Leo hasn't permanently hung.