### PR TITLE
PR for #2875: todo.py problems

### DIFF
--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -546,26 +546,20 @@ class todoController:
         return self.menuicons[key]
     #@+node:tbrown.20090119215428.13: *3* redrawer
     # mypy complains about missing 'self' arg.
+    # pylint: disable=no-self-argument
     def redrawer(fn: Callable) -> Callable:  # type:ignore
         """decorator for methods which create the need for a redraw"""
 
-            # pylint: disable=no-self-argument
         def todo_redrawer_callback(self: Any, *args: Any, **kargs: Any) -> Any:
 
-            if 1:  ### All @redrawer decorators *might* be removed.
-                self.redrawLevels += 1
-                try:
-                    # pylint: disable=not-callable
-                    ans = fn(self, *args, **kargs)
-                finally:
-                    self.redrawLevels -= 1
-                    if self.redrawLevels == 0:
-                        g.trace('fn:', fn.__name__, g.callers(3))  ### pylint: disable=no-member
-                        self.redraw()
-                    else:  ###
-                        g.trace('Skip Redraw', 'fn:', fn.__name__, g.callers(3))  ### pylint: disable=no-member
-                return ans
-            return None
+            self.redrawLevels += 1
+            try:
+                ans = fn(self, *args, **kargs)  # pylint: disable=not-callable
+            finally:
+                self.redrawLevels -= 1
+                if self.redrawLevels == 0:
+                    self.updateUI()
+            return ans
 
         return todo_redrawer_callback
     #@+node:tbrown.20090119215428.14: *3* projectChanger
@@ -780,13 +774,6 @@ class todoController:
         if k in d:
             del d[k]
     #@+node:tbrown.20090119215428.27: *3* drawing...
-    #@+node:tbrown.20090119215428.28: *4* redraw (todo.py)
-    def redraw(self) -> None:
-
-        self.updateUI()
-        if not g.app.initing:
-            # This is disabled (converted to redraw_later) during startup.
-            self.c.redraw()
     #@+node:tbrown.20090119215428.29: *4* clear_all
     @redrawer
     def clear_all(self, recurse: bool=False, all: bool=False) -> None:

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -96,6 +96,10 @@ Menu = Any
 Priority = Union[int, str]
 #@-<< todo annotations >>
 
+# Aliases: these should be in leoQt5.py or leoQt6.py.
+Checked = QtConst.CheckState.Checked if isQt6 else QtConst.Checked
+Unchecked = QtConst.CheckState.Unchecked if isQt6 else QtConst.Unchecked
+
 NO_TIME = datetime.date(3000, 1, 1)
 
 #@+others
@@ -545,17 +549,23 @@ class todoController:
     def redrawer(fn: Callable) -> Callable:  # type:ignore
         """decorator for methods which create the need for a redraw"""
 
-        # pylint: disable=no-self-argument
+            # pylint: disable=no-self-argument
         def todo_redrawer_callback(self: Any, *args: Any, **kargs: Any) -> Any:
-            self.redrawLevels += 1
-            try:
-                # pylint: disable=not-callable
-                ans = fn(self, *args, **kargs)
-            finally:
-                self.redrawLevels -= 1
-                if self.redrawLevels == 0:
-                    self.redraw()
-            return ans
+
+            if 1:  ### All @redrawer decorators *might* be removed.
+                self.redrawLevels += 1
+                try:
+                    # pylint: disable=not-callable
+                    ans = fn(self, *args, **kargs)
+                finally:
+                    self.redrawLevels -= 1
+                    if self.redrawLevels == 0:
+                        g.trace('fn:', fn.__name__, g.callers(3))  ### pylint: disable=no-member
+                        self.redraw()
+                    else:  ###
+                        g.trace('Skip Redraw', 'fn:', fn.__name__, g.callers(3))  ### pylint: disable=no-member
+                return ans
+            return None
 
         return todo_redrawer_callback
     #@+node:tbrown.20090119215428.14: *3* projectChanger
@@ -972,12 +982,12 @@ class todoController:
             toggle = self.ui.UI.nxtwkDateToggle
 
         if mode == 'check':
-            if toggle.checkState() == QtConst.Unchecked:
+            if toggle.checkState() == Unchecked:
                 self.setat(v, field, "")
             else:
                 self.setat(v, field, val.toPyDate())
         else:
-            toggle.setCheckState(QtConst.Checked)
+            toggle.setCheckState(Checked)
             self.setat(v, field, val.toPyDate())
 
         self.updateUI()  # if change was made to date with offset selector
@@ -1000,12 +1010,12 @@ class todoController:
             toggle = self.ui.UI.nxtwkTimeToggle
 
         if mode == 'check':
-            if toggle.checkState() == QtConst.Unchecked:
+            if toggle.checkState() == Unchecked:
                 self.setat(v, field, "")
             else:
                 self.setat(v, field, val.toPyTime())
         else:
-            toggle.setCheckState(QtConst.Checked)
+            toggle.setCheckState(Checked)
             self.setat(v, field, val.toPyTime())
         self.loadIcons(p)
 


### PR DESCRIPTION
See #2875.

- [x] Remove todoController.redraw! `@redrawer` decorator just calls updateUI.
- [x] Fix Qt-related crashers.

Traces show no evidence of big performance bugs.

Imo, no further work should be done for Leo 6.7.0.