### PR TITLE
PR for #2899: show-bindings

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1876,7 +1876,10 @@ class LoadManager:
                 return letter
         if lm.theme_path and path.endswith(lm.theme_path.lower()):
             return 'T'
-        if path == 'register-command' or path.find('mode') > -1:
+        tag = 'register-command:'
+        if path.startswith(tag):
+            return self.computeBindingLetter(c, path=path[len(tag) :])
+        if path.endswith('-mode'):
             return '@'
         return 'D'
     #@+node:ekr.20120223062418.10421: *4* LM.computeLocalSettings

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -762,7 +762,7 @@ class LeoFrame:
         # Create the first node.
         v = leoNodes.VNode(context=c)
         p = leoNodes.Position(v)
-        v.initHeadString("NewHeadline")
+        v.initHeadString("newHeadline")
         #
         # New in Leo 4.5: p.moveToRoot would be wrong:
         #                 the node hasn't been linked yet.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2560,6 +2560,9 @@ class KeyHandlerClass:
                 assert g.isStroke(stroke), stroke
                 bi = d2.get(stroke)
                 assert isinstance(bi, g.BindingInfo), repr(bi)
+                # #2899: Adjust scope for @command and @button.
+                if bi.commandName.startswith(('@button-', '@command-')):
+                    scope = 'all'
                 data.append((scope, k.prettyPrintKey(stroke), bi.commandName, bi.kind))
         # Print keys by type.
         result = []
@@ -2994,7 +2997,7 @@ class KeyHandlerClass:
         allowBinding: bool=False,
         pane: str='all',
         shortcut: str=None,  # Must be None unless allowBindings is True.
-        **kwargs: Any,
+        **kwargs: Any,  # Used only to warn about deprecated kwargs.
     ) -> None:
         """
         Make the function available as a minibuffer command.
@@ -3066,7 +3069,7 @@ class KeyHandlerClass:
                     pane = bi.pane  # 2015/05/11.
                     break
         if stroke:
-            k.bindKey(pane, stroke, func, commandName, tag='register-command')  # Must be a stroke.
+            k.bindKey(pane, stroke, func, commandName, tag=f"register-command:{c.shortFileName()}")
             k.makeMasterGuiBinding(stroke)  # Must be a stroke.
         # Fixup any previous abbreviation to press-x-button commands.
         if commandName.startswith('press-') and commandName.endswith('-button'):

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -183,7 +183,7 @@ class TextFrame(leoFrame.LeoFrame):
         #
         v = leoNodes.vnode(context=c)
         p = leoNodes.position(v)
-        v.initHeadString("NewHeadline")
+        v.initHeadString("newHeadline")
         # New in Leo 4.5: p.moveToRoot would be wrong:
         # the node hasn't been linked yet.
         p._linkAsRoot()


### PR DESCRIPTION
See #2899.

The fix is a hack that works for `@command` and `@button` nodes.

Alas, the show-bindings commands does not report the scope properly for `@openwith` nodes. An heroic fix would be required. It's not going to happen.