### PR TITLE
VR3 - Add trailing space after Markdown headline string introducer ("##"). …

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3481,7 +3481,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
                         headline = ' '.join(fields[1:]) if len(fields) > 1 else header[1:]
                     else:
                         headline = header
-                    headline_str = '##' + headline
+                    headline_str = '## ' + headline
                     s = headline_str + '\n' + s
                 lines = s.split('\n')
 


### PR DESCRIPTION
…Some external MD processors require the space.

A user has requested this fix as soon as possible -  see [Problem: markdown export now without blank between hash and section title](https://groups.google.com/g/leo-editor/c/gd3yDOpfxtc)