### PR TITLE
PR for #2914: Retire old window code

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1459,7 +1459,6 @@
 </v>
 </v>
 <v t="ekr.20131213135427.22320"><vh>@menu &amp;Window</vh>
-<v t="ekr.20131213135427.22341"><vh>@item &amp;cascade-windows</vh></v>
 <v t="ekr.20131213135427.22321"><vh>@item &amp;equal-sized-panes</vh></v>
 <v t="ekr.20131213135427.22342"><vh>@item &amp;minimize-all</vh></v>
 <v t="ekr.20131213135427.22340"><vh>@item &amp;resize-to-screen</vh></v>
@@ -5823,7 +5822,6 @@ minibuffer-find-mode    use-find-dialog     mode: Ctrl-F puts focus in
 <t tx="ekr.20131213135427.22322"></t>
 <t tx="ekr.20131213135427.22323"></t>
 <t tx="ekr.20131213135427.22340"></t>
-<t tx="ekr.20131213135427.22341"></t>
 <t tx="ekr.20131213135427.22342"></t>
 <t tx="ekr.20131213135427.22343"></t>
 <t tx="ekr.20131213135427.22344"></t>

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -7930,6 +7930,51 @@ def slowYieldVisible(self, first_p: Position, target_p: Position=None) -> Genera
         p.moveToVisNext(c)
     if target_p:
         g.trace('NOT FOUND:', target_p.h)
+#@+node:ekr.20221017070902.1: *3* Old non-tabbed gui commands
+#@+node:ekr.20110605121601.18303: *4* qtFrame.cascade
+@frame_cmd('cascade-windows')
+def cascade(self, event: Event=None) -> None:
+    """Cascade all Leo windows."""
+    x, y, delta = 50, 50, 50
+    for frame in g.app.windowList:
+        w = frame and frame.top
+        if w:
+            r = w.geometry()  # a Qt.Rect
+            # 2011/10/26: Fix bug 823601: cascade-windows fails.
+            w.setGeometry(QtCore.QRect(x, y, r.width(), r.height()))
+            # Compute the new offsets.
+            x += 30
+            y += 30
+            if x > 200:
+                x = 10 + delta
+                y = 40 + delta
+                delta += 10
+#@+node:ekr.20131115120119.17392: *4* qt_base_tab.tile
+def tile(self, index: int, orientation: str='V') -> None:
+    """detach tab and tile with parent window"""
+    w = self.widget(index)
+    window = w.window()
+    # window.showMaximized()
+    # this doesn't happen until we've returned to main even loop
+    # user needs to do it before using this function
+    fg = window.frameGeometry()
+    geom = window.geometry()
+    x, y, fw, fh = fg.x(), fg.y(), fg.width(), fg.height()
+    ww, wh = geom.width(), geom.height()
+    w = self.detach(index)
+    if window.isMaximized():
+        window.showNormal()
+    if orientation == 'V':
+        # follow MS Windows convention for which way is horizontal/vertical
+        window.resize(ww / 2, wh)
+        window.move(x, y)
+        w.resize(ww / 2, wh)
+        w.move(x + fw / 2, y)
+    else:
+        window.resize(ww, wh / 2)
+        window.move(x, y)
+        w.resize(ww, wh / 2)
+        w.move(x, y + fh / 2)
 #@+node:ekr.20220917052540.1: ** Old commands
 #@+node:ekr.20210907103011.1: *3* leo/commands/testCommands.py
 @first # -*- coding: utf-8 -*-

--- a/leo/plugins/leo_babel/babel_lib.py
+++ b/leo/plugins/leo_babel/babel_lib.py
@@ -300,7 +300,7 @@ class MenuPopUp(QtWidgets.QMenu):
     def _info(self, what):
         QtWidgets.QMessageBox.information(self, 'Information Only', what)
         self.exec_(QtWidgets.QApplication.desktop().screen().rect().center() -
-            self.rect().center())
+            self.rect().center())  # type:ignore
     #@-others
 
 #@+node:bob.20170726143458.15: ** babelMenu()

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1363,18 +1363,16 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):  # type:ignore
                 return
             menu = QtWidgets.QMenu()
             # #310: Create new file on right-click in file tab in UI.
-            if True:
-                a = menu.addAction("New Outline")
-                a.triggered.connect(lambda checked: self.new_outline(index))
+            a = menu.addAction("New Outline")
+            a.triggered.connect(lambda checked: self.new_outline(index))
             if self.count() > 1:
                 a = menu.addAction("Detach")
                 a.triggered.connect(lambda checked: self.detach(index))
-                a = menu.addAction("Horizontal tile")
-                a.triggered.connect(
-                    lambda checked: self.tile(index, orientation='H'))
-                a = menu.addAction("Vertical tile")
-                a.triggered.connect(
-                    lambda checked: self.tile(index, orientation='V'))
+                # #2914: These no longer make sense.
+                    # a = menu.addAction("Horizontal tile")
+                    # a.triggered.connect(lambda checked: self.tile(index, orientation='H'))
+                    # a = menu.addAction("Vertical tile")
+                    # a.triggered.connect(lambda checked: self.tile(index, orientation='V'))
             if self.detached:
                 a = menu.addAction("Re-attach All")
                 a.triggered.connect(lambda checked: self.reattach_all())
@@ -1407,32 +1405,6 @@ class LeoBaseTabWidget(QtWidgets.QTabWidget):  # type:ignore
             # Windows (XP and 7) put the windows title bar off screen.
             w.move(20, 20)
         return w
-    #@+node:ekr.20131115120119.17392: *3* qt_base_tab.tile
-    def tile(self, index: int, orientation: str='V') -> None:
-        """detach tab and tile with parent window"""
-        w = self.widget(index)
-        window = w.window()
-        # window.showMaximized()
-        # this doesn't happen until we've returned to main even loop
-        # user needs to do it before using this function
-        fg = window.frameGeometry()
-        geom = window.geometry()
-        x, y, fw, fh = fg.x(), fg.y(), fg.width(), fg.height()
-        ww, wh = geom.width(), geom.height()
-        w = self.detach(index)
-        if window.isMaximized():
-            window.showNormal()
-        if orientation == 'V':
-            # follow MS Windows convention for which way is horizontal/vertical
-            window.resize(ww / 2, wh)
-            window.move(x, y)
-            w.resize(ww / 2, wh)
-            w.move(x + fw / 2, y)
-        else:
-            window.resize(ww, wh / 2)
-            window.move(x, y)
-            w.resize(ww, wh / 2)
-            w.move(x, y + fh / 2)
     #@+node:ekr.20131115120119.17393: *3* qt_base_tab.reattach_all
     def reattach_all(self) -> None:
         """reattach all detached tabs"""
@@ -2424,24 +2396,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
             c.bodyWantsFocus()
         else:
             c.treeWantsFocus()
-    #@+node:ekr.20110605121601.18303: *5* qtFrame.cascade
-    @frame_cmd('cascade-windows')
-    def cascade(self, event: Event=None) -> None:
-        """Cascade all Leo windows."""
-        x, y, delta = 50, 50, 50
-        for frame in g.app.windowList:
-            w = frame and frame.top
-            if w:
-                r = w.geometry()  # a Qt.Rect
-                # 2011/10/26: Fix bug 823601: cascade-windows fails.
-                w.setGeometry(QtCore.QRect(x, y, r.width(), r.height()))
-                # Compute the new offsets.
-                x += 30
-                y += 30
-                if x > 200:
-                    x = 10 + delta
-                    y = 40 + delta
-                    delta += 10
     #@+node:ekr.20110605121601.18304: *5* qtFrame.equalSizedPanes
     @frame_cmd('equal-sized-panes')
     def equalSizedPanes(self, event: Event=None) -> None:


### PR DESCRIPTION
See #2914.

- [x] Move cascade-windows and tiling popup code to attic.
- [x] Remove cascade-windows from menu.
- [x] Disable a new mypy warning.