### PR TITLE
Make sure Markdown writers insert just a single space after the headline

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3481,7 +3481,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
                         headline = ' '.join(fields[1:]) if len(fields) > 1 else header[1:]
                     else:
                         headline = header
-                    headline_str = '## ' + headline
+                    headline_str = '## ' + headline.lstrip()
                     s = headline_str + '\n' + s
                 lines = s.split('\n')
 

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -44,7 +44,7 @@ class MarkdownWriter(basewriter.BaseWriter):
         if kind == '!':
             pass  # The signal for a declaration node.
         else:
-            self.put(f"{'#' * level}{p.h}")  # Leo 6.6.4: preserve spacing.
+            self.put(f"{'#' * level} {p.h.lstrip()}")  # Leo 6.6.4: preserve spacing.
     #@+node:ekr.20171230170642.1: *3* mdw.write_root
     def write_root(self, root: Position) -> None:
         """Write the root @auto-org node."""


### PR DESCRIPTION
level introducer (e.g., '### ').