### PR TITLE
Make dialogs use Leo's theme for CSS styling

### DIFF
--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -404,7 +404,14 @@ class ParserBaseClass:
             targetPath, mode, source = parts
             if not targetPath.startswith('/'):
                 targetPath = '/' + targetPath
-            ans = self.patchMenuTree(g.app.config.menusList, targetPath)
+            is_local = 'leosettings' not in self.c.mFileName.lower()
+            if is_local:
+                mlist = g.app.config.menusList[:]
+                self.c.config.set(None, 'menus', 'menus', mlist)
+            else:
+                mlist = g.app.config.menusList
+            # ans = self.patchMenuTree(g.app.config.menusList, targetPath)
+            ans = self.patchMenuTree(mlist, targetPath)
             if ans:
                 # pylint: disable=unpacking-non-sequence
                 list_, idx = ans
@@ -484,7 +491,6 @@ class ParserBaseClass:
         return None
     #@+node:ekr.20070925144337.2: *4* pbc.doMenus & helper
     def doMenus(self, p: Position, kind: str, name: str, val: Any) -> None:
-
         c = self.c
         p = p.copy()
         aList: List[Any] = []  # This entire logic is mysterious, and likely buggy.
@@ -1779,10 +1785,56 @@ class LocalConfigManager:
         return language
     #@+node:ekr.20120215072959.12534: *5* c.config.getMenusList
     def getMenusList(self) -> List:
-        """Return the list of entries for the @menus tree."""
+        """Return the list of entries for the @menus tree.
+        
+        This method gets called twice when an outline is loaded.
+        After the second pass, it deletes all local menu settings
+        to prevent them from getting reused by the next outline.
+        """
         aList = self.get('menus', 'menus')
-        # aList is typically empty.
+        # aList is typically empty, unless there is an @menuat setting.
+
+        if not hasattr(self.c, 'menulist_pass'):
+            self.c.menulist_pass = 0
+        self.c.menulist_pass += 1
+
+        # Remove this outline's "doMenuat" settings so they won't get reused
+        # by later outlines.
+        if self.c.menulist_pass == 2:
+            lm = g.app.loadManager
+            lm.globalSettingsDict['menus'] = None
+            self.set(None, 'menus', 'menus', None)
+            self.c.menulist_pass = 0
+
         return aList or g.app.config.menusList
+
+
+    # def getMenusList(self) -> List:
+        # """Return the list of entries for the @menus tree."""
+        # aList = self.get('menus', 'menus')
+        # # aList is typically empty, unless there was an @menuat setting.
+        # # Remove this outline's "doMenuat" settings so they won't get reused
+        # # by later outlines.
+        # if not hasattr(self.c, 'menulist_pass'):
+            # self.c.menulist_pass = 0
+        # self.c.menulist_pass += 1
+        # fn = g.shortFileName(self.c.mFileName) or '[new outline]'
+        # g.trace(f'----- [local menulist] [pass {self.c.menulist_pass}] {fn}')
+        # print(f'  showing global menus - pass {self.c.menulist_pass}')
+        # self.c.k.simulateCommand('x-show-global-menus')
+        # msg = '\n    '.join([it[0] for it in aList]) if aList else '[no local menuList]'
+        # print('   ', msg)
+        # if not aList:
+            # msg = 'global menus: ' + '\n'.join([it[0] for it in aList])\
+                    # if aList else '[None]'
+            # print('    ', fn, 'pass', self.c.menulist_pass, msg)
+        # if self.c.menulist_pass == 2:
+            # self.set(None, 'menus', 'menus', None)
+            # lm = g.app.loadManager
+            # lm.globalSettingsDict['menus'] = None
+            # self.c.menulist_pass = 0
+        # g.trace('--------- end')
+        # return aList or g.app.config.menusList
     #@+node:ekr.20120215072959.12535: *5* c.config.getOpenWith
     def getOpenWith(self) -> List[Dict[str, Any]]:
         """Return a list of dictionaries corresponding to @openwith nodes."""
@@ -1950,9 +2002,10 @@ class LocalConfigManager:
         if gs:
             assert isinstance(gs, g.GeneralSetting), repr(gs)
             path = gs.path
-            if warn and g.os_path_finalize(
-                c.mFileName) != g.os_path_finalize(path):  # #1341.
-                g.es("over-riding setting:", name, "from", path)
+            if warn and g.os_path_finalize(c.mFileName) \
+                        != g.os_path_finalize(path):  # #1341.
+                g.trace("over-riding setting:", name, "from", path)
+                print('    Comparing', c.mFileName, g.os_path_finalize(path))
         d[key] = g.GeneralSetting(kind, path=c.mFileName, val=val, tag='setting')
     #@+node:ekr.20190905082644.1: *3* c.config.settingIsActiveInPath
     def settingIsActiveInPath(self, gs: str, target_path: str) -> bool:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -220,7 +220,7 @@ class LeoQtGui(leoGui.LeoGui):
             self.globalFindDialog = dialog
             # Fix #516: Do the following only once...
             if c:
-                dialog.setStyleSheet(c.active_stylesheet)
+                # dialog.setStyleSheet(c.active_stylesheet)
                 # Set the commander's FindTabManager.
                 assert g.app.globalFindTabManager
                 c.ftm = g.app.globalFindTabManager
@@ -259,7 +259,7 @@ class LeoQtGui(leoGui.LeoGui):
         self.attachLeoIcon(dialog)
         dialog.setLayout(layout)
         if c:
-            c.styleSheetManager.set_style_sheets(w=dialog)
+            # c.styleSheetManager.set_style_sheets(w=dialog)
             g.app.gui.setFilter(c, dialog, dialog, 'find-dialog')
             # This makes most standard bindings available.
         dialog.setModal(False)
@@ -289,6 +289,12 @@ class LeoQtGui(leoGui.LeoGui):
         if g.unitTesting:
             return
         dialog = QtWidgets.QMessageBox(c and c.frame.top)
+        ssm = g.app.gui.styleSheetManagerClass(c)
+        w = ssm.get_master_widget()
+        sheet = w.styleSheet()
+        if sheet:
+            dialog.setStyleSheet(sheet)
+
         dialog.setText(f"{version}\n{theCopyright}\n{url}\n{email}")
         dialog.setIcon(Icon.Information)
         yes = dialog.addButton('Ok', ButtonRole.YesRole)
@@ -381,6 +387,11 @@ class LeoQtGui(leoGui.LeoGui):
             init = datetime.datetime.now()
         dialog = Calendar(c and c.frame.top, message=message, init=init, step_min=step_min)
         if c:
+            ssm = g.app.gui.styleSheetManagerClass(c)
+            w = ssm.get_master_widget()
+            sheet = w.styleSheet()
+            if sheet:
+                dialog.setStyleSheet(sheet)
             dialog.setStyleSheet(c.active_stylesheet)
             dialog.setWindowTitle(title)
             try:
@@ -411,6 +422,7 @@ class LeoQtGui(leoGui.LeoGui):
         parent = None
         title = 'Enter Leo id'
         s, ok = QtWidgets.QInputDialog.getText(parent, title, message)
+
         return s
     #@+node:ekr.20110605121601.18491: *4* qt_gui.runAskOkCancelNumberDialog
     def runAskOkCancelNumberDialog(self,
@@ -421,8 +433,11 @@ class LeoQtGui(leoGui.LeoGui):
             return None
         # n,ok = QtWidgets.QInputDialog.getDouble(None,title,message)
         dialog = QtWidgets.QInputDialog()
-        if c:
-            dialog.setStyleSheet(c.active_stylesheet)
+        ssm = g.app.gui.styleSheetManagerClass(c)
+        w = ssm.get_master_widget()
+        sheet = w.styleSheet()
+        if sheet:
+            dialog.setStyleSheet(sheet)
         dialog.setWindowTitle(title)
         dialog.setLabelText(message)
         if cancelButtonText:
@@ -456,8 +471,11 @@ class LeoQtGui(leoGui.LeoGui):
         if g.unitTesting:
             return None
         dialog = QtWidgets.QInputDialog()
-        if c:
-            dialog.setStyleSheet(c.active_stylesheet)
+        ssm = g.app.gui.styleSheetManagerClass(c)
+        w = ssm.get_master_widget()
+        sheet = w.styleSheet()
+        if sheet:
+            dialog.setStyleSheet(sheet)
         dialog.setWindowTitle(title)
         dialog.setLabelText(message)
         dialog.setTextValue(default)
@@ -477,9 +495,6 @@ class LeoQtGui(leoGui.LeoGui):
         if g.unitTesting:
             return
         dialog = QtWidgets.QMessageBox(c and c.frame.top)
-        stylesheet = getattr(c, 'active_stylesheet', None)
-        if stylesheet:
-            dialog.setStyleSheet(stylesheet)
         dialog.setWindowTitle(title)
         if message:
             dialog.setText(message)
@@ -512,9 +527,6 @@ class LeoQtGui(leoGui.LeoGui):
         if g.unitTesting:
             return None
         dialog = QtWidgets.QMessageBox(c and c.frame.top)
-        stylesheet = getattr(c, 'active_stylesheet', None)
-        if stylesheet:
-            dialog.setStyleSheet(stylesheet)
         if message:
             dialog.setText(message)
         dialog.setIcon(Information.Warning)
@@ -568,8 +580,6 @@ class LeoQtGui(leoGui.LeoGui):
             dialog.addButton('Yes To All', ButtonRole.YesRole)
         if no_all:
             dialog.addButton('No To All', ButtonRole.NoRole)
-        if c:
-            dialog.setStyleSheet(c.active_stylesheet)
         dialog.setWindowTitle(title)
         if message:
             dialog.setText(message)
@@ -623,8 +633,6 @@ class LeoQtGui(leoGui.LeoGui):
             startpath = g.init_dialog_folder(c, c.p, use_at_path=True)
         filter_ = self.makeFilter(filetypes)
         dialog = QtWidgets.QFileDialog()
-        if c:
-            dialog.setStyleSheet(c.active_stylesheet)
         self.attachLeoIcon(dialog)
         func = dialog.getOpenFileNames if multiple else dialog.getOpenFileName
         if c:
@@ -668,7 +676,7 @@ class LeoQtGui(leoGui.LeoGui):
             return ''
         dialog = QtWidgets.QFileDialog()
         if c:
-            dialog.setStyleSheet(c.active_stylesheet)
+            # dialog.setStyleSheet(c.active_stylesheet)
             self.attachLeoIcon(dialog)
             try:
                 c.in_qt_dialog = True


### PR DESCRIPTION
 Eliminates "can't parse stylesheet" error messages.  [OS dialogs like FileOpen cannot be styled this way.]

Dialogs that are fixed here:

runAboutLeoDialog
runAskOkDialog
runAskOkCancelNumberDialog
runAskOkCancelStringDialog
runAskDateTimeDialog
runAskYesNoDialog
runAskYesNoCancelDialog

Note - some dialog classes automatically use the current theme, others need to have the current stylesheet set.

Fixes Issue https://github.com/leo-editor/leo-editor/issues/2943
