### PR TITLE
PR: Fix crasher in parse-body

### DIFF
--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1190,7 +1190,7 @@ class LeoImportCommands:
         s = p.b
         p.b = ''
         try:
-            parser(c, s, p)  # 2357.
+            parser(c, p, s)
             c.undoer.afterChangeTree(p, 'parse-body', bunch)
             p.expand()
             c.selectPosition(p)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -188,7 +188,7 @@ class Python_Importer(Importer):
 #@+node:vitalije.20211201230203.1: ** function: token_based_python_importer
 SPLIT_THRESHOLD = 10  # Don't split blocks shorter than this threshold.
 
-def token_based_python_importer(c: Cmdr, root: Any, s: str) -> None:
+def token_based_python_importer(c: Cmdr, root: Position, s: str) -> None:
     """
     An importer that uses python's tokenizer module to analyze program structure.
     By Виталије Милошевић, (Vitalije Milosevic).

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -40,6 +40,43 @@ class TestLeoImport(BaseTestImporter):
             (1, 'a1', ''),
             (1, 'a2', ''),
         ))
+    #@+node:ekr.20221104065722.1: *3* TestLeoImport.test_parse_body
+    def test_parse_body(self):
+
+        c = self.c
+        x = c.importCommands
+        target = c.p.insertAfter()
+        target.h = 'target'
+        target.b = textwrap.dedent("""\
+            import os
+
+            def macro(func):
+                def new_func(*args, **kwds):
+                    raise RuntimeError('blah blah blah')
+            return new_func
+        """)
+        x.parse_body(target)
+        
+        # self.dump_tree(target, tag='Actual results...')
+
+        self.check_outline(target, (
+            (0, '',  # check_outline ignores the top-level headline.
+                'import os\n'
+                '\n'
+                '@others\n'
+                'return new_func\n'
+                '@language python\n'
+                '@tabwidth -4\n'
+            ),
+            (1, 'macro',
+                'def macro(func):\n'
+                '    @others\n'
+            ),
+            (2, 'new_func',
+                'def new_func(*args, **kwds):\n'
+                "    raise RuntimeError('blah blah blah')\n"
+            ),
+        ))
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
```console
Traceback (most recent call last):

  File "C:\Repos\leo-editor\leo\core\leoImport.py", line 1193, in parse_body
    parser(c, s, p)  # 2357.

  File "C:\Repos\leo-editor\leo\plugins\importers\python.py", line 507, in do_import
    token_based_python_importer(c, parent, s)

  File "C:\Repos\leo-editor\leo\plugins\importers\python.py", line 209, in token_based_python_importer
    lines: List[str] = s.splitlines(True)

AttributeError: 'Position' object has no attribute 'splitlines'
```