### PR TITLE
PR for #2957: Rewrite sort-children

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1767,7 +1767,7 @@ def sortChildren(
     reverse: bool=False,  # Not used in Leo's core.
 ) -> None:
 
-    """Sort the siblings of p."""
+    """Sort the children of p."""
     c, u = self, self.undoer
     if not p:
         p = c.p

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1810,8 +1810,7 @@ def sortSiblings(
     c.endEditing()
     parent_v = p._parentVnode()
     oldSiblings = parent_v.children[:]
-    newSiblings: List[VNode] = sorted(
-        parent_v.children, key=key or lowerKey, reverse=reverse)
+    newSiblings: List[VNode] = sorted(parent_v.children, key=key or lowerKey, reverse=reverse)
     if oldSiblings == newSiblings:
         return
     c.setChanged()

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1763,7 +1763,7 @@ def sortChildren(
     self: Self,
     event: Event=None,
     key: Callable=None,  # Not used in Leo's core.
-    p: Position=None,   # Not used in Leo's core.
+    p: Position=None,  # Not used in Leo's core.
     reverse: bool=False,  # Not used in Leo's core.
 ) -> None:
 
@@ -1806,11 +1806,10 @@ def sortSiblings(
     def lowerKey(v: VNode) -> str:
         return v.h.lower()
 
-    oldP = p.copy()
-    old_gnx = p.v.gnx
+    oldP, newP = p.copy(), p.copy()
     c.endEditing()
     parent_v = p._parentVnode()
-    oldSiblings = p.v.children[:]
+    oldSiblings = parent_v.children[:]
     newSiblings: List[VNode] = sorted(
         parent_v.children, key=key or lowerKey, reverse=reverse)
     if oldSiblings == newSiblings:
@@ -1818,17 +1817,14 @@ def sortSiblings(
     c.setChanged()
     parent_v.children = newSiblings
     # Sorting destroys position p, and possibly the root position.
-    # Restore the focus to its pre-sort node
-    for child in p.children():
-        if child.v.gnx == old_gnx:
-            newP = child
-    else:
-        g.trace('Can not happen')
-        newP = p
-    u.afterSort(oldP, newP, oldSiblings)
-    if p.parent():
-        p.parent().setDirty()
-    c.redraw(p)
+    # Only the child index of new position changes!
+    for i, v in enumerate(newSiblings):
+        if v.gnx == oldP.v.gnx:
+            newP._childIndex = i
+            break
+    u.afterSortSiblings(oldP, newP, oldSiblings, newSiblings)
+    newP.setDirty()
+    c.redraw(newP)
 #@+node:ekr.20070420092425: ** def cantMoveMessage
 def cantMoveMessage(c: Cmdr) -> None:
     h = c.rootPosition().h

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3897,26 +3897,6 @@ class Commands:
     # Compatibility, but confusing.
 
     selectVnode = selectPosition
-    #@+node:ekr.20080503055349.1: *5* c.setPositionAfterSort
-    def setPositionAfterSort(self, sortChildren: bool) -> Position:
-        """
-        Return the position to be selected after a sort.
-        """
-        c = self
-        p = c.p
-        p_v = p.v
-        parent = p.parent()
-        parent_v = p._parentVnode()
-        if sortChildren:
-            return parent or c.rootPosition()
-        if parent:
-            p = parent.firstChild()
-        else:
-            p = leoNodes.Position(parent_v.children[0])
-        while p and p.v != p_v:
-            p.moveToNext()
-        p = p or parent
-        return p
     #@+node:ekr.20070226113916: *5* c.treeSelectHelper
     def treeSelectHelper(self, p: Position) -> None:
         c = self

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -178,6 +178,29 @@ class LeoUnitTest(unittest.TestCase):
         # Clone 'child b'
         clone = child_b.clone()
         clone.moveToLastChildOf(p)
+    #@+node:ekr.20220806170537.1: *3* LeoUnitTest.dump_string
+    def dump_string(self, s: str, tag: str=None) -> None:
+        if tag:
+            print(tag)
+        g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
+    #@+node:ekr.20220805071838.1: *3* LeoUnitTest.dump_headlines
+    def dump_headlines(self, root: Position, tag: str=None) -> None:  # pragma: no cover
+        """Dump root's tree just as as Importer.dump_tree."""
+        print('')
+        if tag:
+            print(tag)
+        for p in root.self_and_subtree():
+            print('level:', p.level(), p.h)
+    #@+node:ekr.20211129062220.1: *3* LeoUnitTest.dump_tree
+    def dump_tree(self, root: Position, tag: str=None) -> None:  # pragma: no cover
+        """Dump root's tree just as as Importer.dump_tree."""
+        print('')
+        if tag:
+            print(tag)
+        for p in root.self_and_subtree():
+            print('')
+            print('level:', p.level(), p.h)
+            g.printObj(g.splitLines(p.v.b))
     #@-others
 #@-others
 #@-leo

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -129,6 +129,7 @@ class Undoer:
         self.oldIns = None
         self.oldMarked = None
         self.oldN = None
+        self.oldP = None
         self.oldParent = None
         self.oldParent_v = None
         self.oldRecentFiles = None

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -248,9 +248,6 @@ class Undoer:
             for key in list(bunch.keys()):
                 g.trace(f"{key:20} {bunch.get(key)!r}")
             print('-' * 20)
-        if g.unitTesting:  # #1694: An ever-present unit test.
-            val = bunch.get('oldMarked')
-            assert val in (True, False), f"{val!r} {g.callers()!s}"
         # bunch is not a dict, so bunch.keys() is required.
         for key in list(bunch.keys()):
             val = bunch.get(key)

--- a/leo/plugins/import_cisco_config.py
+++ b/leo/plugins/import_cisco_config.py
@@ -188,11 +188,9 @@ def importCiscoConfig(c):
                     subchild = child.insertAsNthChild(0)
                     subchild.h = value[0]
                     subchild.b = '\n'.join(value)
-            # child.sortChildren()
         else:
             # this should never happen
             g.es("Unknown key: %s" % key)
-    # p.sortChildren()
     current.expand()
     c.redraw()
     #@-<< complete outline >>

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -37,8 +37,8 @@ class TestOutlineCommands(LeoUnitTest):
         for h in table:
             child = p.insertAsLastChild()
             child.h = h
-        
-       
+
+
     #@+node:ekr.20221112051634.1: *3* TestOutlineCommands.test_sort_children
     def test_sort_children(self):
         c, u = self.c, self.c.undoer

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#@+leo-ver=5-thin
+#@+node:ekr.20221113062857.1: * @file ../unittests/commands/test_outlineCommands.py
+#@@first
+"""Tests for Leo's outline commands"""
+### import textwrap
+### from leo.core import leoGlobals as g
+from leo.core.leoTest2 import LeoUnitTest
+#@+others
+#@+node:ekr.20221113062938.1: ** class TestOutlineCommands(LeoUnitTest)
+class TestOutlineCommands(LeoUnitTest):
+    """
+    Unit tests for Leo's outline commands.
+    """
+    #@+others
+    #@+node:ekr.20221112051634.1: *3* TestOutlineCommands.test_sort_children
+    def test_sort_children(self):
+        c = self.c
+        if 0:
+            self.dump_tree(c.p, tag='Initial tree')
+    #@+node:ekr.20221112051650.1: *3* TestOutlineCommands.test_sort_siblings
+    def test_sort_siblings(self):
+        c = self.c
+        if 0:
+            self.dump_tree(c.p, tag='Initial tree')
+    #@-others
+#@-others
+#@-leo

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -2,9 +2,11 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20221113062857.1: * @file ../unittests/commands/test_outlineCommands.py
 #@@first
-"""Tests for Leo's outline commands"""
-### import textwrap
-### from leo.core import leoGlobals as g
+"""
+New unit tests for Leo's outline commands.
+
+Older tests are in unittests/core/test_leoNodes.py
+"""
 from leo.core.leoTest2 import LeoUnitTest
 #@+others
 #@+node:ekr.20221113062938.1: ** class TestOutlineCommands(LeoUnitTest)
@@ -12,17 +14,68 @@ class TestOutlineCommands(LeoUnitTest):
     """
     Unit tests for Leo's outline commands.
     """
+
+    def setUp(self) -> None:
+        super().setUp()
+        c = self.c
+        self.create_test_sort_outline()
+        c.selectPosition(c.rootPosition())
+
     #@+others
+    #@+node:ekr.20221113064908.1: *3* TestOutlineCommands.create_test_sort_outline
+    def create_test_sort_outline(self) -> None:
+        """Create a test outline suitable for sort commands."""
+        p = self.c.p
+        assert p == self.root_p
+        assert p.h == 'root'
+        table = (
+            'child a',
+            'child z',
+            'child b',
+            'child w',
+        )
+        for h in table:
+            child = p.insertAsLastChild()
+            child.h = h
+        
+       
     #@+node:ekr.20221112051634.1: *3* TestOutlineCommands.test_sort_children
     def test_sort_children(self):
-        c = self.c
-        if 0:
-            self.dump_tree(c.p, tag='Initial tree')
+        c, u = self.c, self.c.undoer
+        assert self.root_p.h == 'root'
+        original_children = [z.h for z in self.root_p.v.children]
+        sorted_children = sorted(original_children)
+        c.sortChildren()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, sorted_children)
+        u.undo()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, original_children)
+        u.redo()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, sorted_children)
+        u.undo()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, original_children)
     #@+node:ekr.20221112051650.1: *3* TestOutlineCommands.test_sort_siblings
     def test_sort_siblings(self):
-        c = self.c
-        if 0:
-            self.dump_tree(c.p, tag='Initial tree')
+        c, u = self.c, self.c.undoer
+        assert self.root_p.h == 'root'
+        original_children = [z.h for z in self.root_p.v.children]
+        sorted_children = sorted(original_children)
+        c.selectPosition(self.root_p.firstChild())
+        c.sortSiblings()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, sorted_children)
+        u.undo()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, original_children)
+        u.redo()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, sorted_children)
+        u.undo()
+        result_children = [z.h for z in self.root_p.v.children]
+        self.assertEqual(result_children, original_children)
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -333,6 +333,8 @@ class TestUndo(LeoUnitTest):
             u.redo()
             self.assertEqual(p.b, newText)
             self.assertEqual(p.isMarked(), oldMarked)
+    #@+node:ekr.20221112051634.1: *3* TestUndo.test_sort_children
+    #@+node:ekr.20221112051650.1: *3* TestUndo.test_sort_siblings
     #@+node:ekr.20210906172626.17: *3* TestUndo.test_undo_group
     def test_undo_group(self):
         # Test an off-by-one error in c.undoer.bead.

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -333,8 +333,6 @@ class TestUndo(LeoUnitTest):
             u.redo()
             self.assertEqual(p.b, newText)
             self.assertEqual(p.isMarked(), oldMarked)
-    #@+node:ekr.20221112051634.1: *3* TestUndo.test_sort_children
-    #@+node:ekr.20221112051650.1: *3* TestUndo.test_sort_siblings
     #@+node:ekr.20210906172626.17: *3* TestUndo.test_undo_group
     def test_undo_group(self):
         # Test an off-by-one error in c.undoer.bead.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -107,29 +107,6 @@ class BaseTestImporter(LeoUnitTest):
     def dedent(self, s):
         """Remove common leading whitespace from all lines of s."""
         return textwrap.dedent(s)
-    #@+node:ekr.20220806170537.1: *3* BaseTestImporter.dump_string
-    def dump_string(self, s, tag=None):
-        if tag:
-            print(tag)
-        g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
-    #@+node:ekr.20220805071838.1: *3* BaseTestImporter.dump_headlines
-    def dump_headlines(self, root, tag=None):  # pragma: no cover
-        """Dump root's tree just as as Importer.dump_tree."""
-        print('')
-        if tag:
-            print(tag)
-        for p in root.self_and_subtree():
-            print('level:', p.level(), p.h)
-    #@+node:ekr.20211129062220.1: *3* BaseTestImporter.dump_tree
-    def dump_tree(self, root, tag=None):  # pragma: no cover
-        """Dump root's tree just as as Importer.dump_tree."""
-        print('')
-        if tag:
-            print(tag)
-        for p in root.self_and_subtree():
-            print('')
-            print('level:', p.level(), p.h)
-            g.printObj(g.splitLines(p.v.b))
     #@+node:ekr.20211127042843.1: *3* BaseTestImporter.run_test
     def run_test(self, s: str, check_flag: bool=True, strict_flag: bool=False) -> Position:
         """


### PR DESCRIPTION
See #2957.

- [x] Split the two sort commands into entirely separate pieces, eliminating the evil 'sortChildren' kwarg.
- [x] Rewrite sort-children.
- [x] Rewrite sort-siblings.
- [x] Retire beforeSort* methods.
- [x] Revise undo/redo/Sort* methods.
- [x] Retire setPositionAfterSort.
- [x] Move dump methods into LeoUnitTest class.
- [x] Create leo/unittests/commands/test_outlineCommands.py.
- [x] Remove strange unit-test-related assertion in undo code.
- [x] Create unit tests for sort-children and sort-siblings.