### PR TITLE
Fix typos that disabled two guards

### DIFF
--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -300,7 +300,7 @@ class LeoGui:
     #@+node:ekr.20051206103652: *4* LeoGui.widget_name (LeoGui)
     def widget_name(self, w: Widget) -> str:
         # First try the widget's getName method.
-        if not 'w':
+        if not w:
             return '<no widget>'
         if hasattr(w, 'getName'):
             return w.getName()

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1403,7 +1403,7 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20110605121601.18527: *4* qt_gui.widget_name
     def widget_name(self, w: Wrapper) -> str:
         # First try the widget's getName method.
-        if not 'w':
+        if not w:
             name = '<no widget>'
         elif hasattr(w, 'getName'):
             name = w.getName()


### PR DESCRIPTION
The legacy code ruined a minor guard in two places.