### PR TITLE
PR2 for #2983: support --black-sentinels

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -171,6 +171,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             c.config.getBool('scripting-at-script-nodes') or
             c.config.getBool('scripting-abbreviations'))
         self.globalDynamicAbbrevs = c.config.getBool('globalDynamicAbbrevs')
+#@verbatim
         # @data abbreviations-subst-env must *only* be defined in leoSettings.leo or myLeoSettings.leo!
         if c.config:
             key = 'abbreviations-subst-env'

--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -171,7 +171,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             c.config.getBool('scripting-at-script-nodes') or
             c.config.getBool('scripting-abbreviations'))
         self.globalDynamicAbbrevs = c.config.getBool('globalDynamicAbbrevs')
-#@verbatim
+        #@verbatim
         # @data abbreviations-subst-env must *only* be defined in leoSettings.leo or myLeoSettings.leo!
         if c.config:
             key = 'abbreviations-subst-env'

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1841,7 +1841,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         k.showStateAndMode()
         c.widgetWantsFocus(w)
     #@+node:ekr.20150514063305.268: *4* ec.selfInsertCommand, helpers
-#@verbatim
+    #@verbatim
     # @cmd('self-insert-command')
 
     def selfInsertCommand(self, event: Event, action: str='insert') -> None:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1841,6 +1841,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         k.showStateAndMode()
         c.widgetWantsFocus(w)
     #@+node:ekr.20150514063305.268: *4* ec.selfInsertCommand, helpers
+#@verbatim
     # @cmd('self-insert-command')
 
     def selfInsertCommand(self, event: Event, action: str='insert') -> None:

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -166,10 +166,12 @@ class GoToCommands:
                     gnx, h = self.get_script_node_info(s, delim2)
                 elif s2.startswith('@+others') or s2.startswith('@+<<'):
                     stack.append((gnx, h, offset),)
+#@verbatim
                     # @others is visible in the outline, but *not* in the file.
                     offset += 1
                 elif s2.startswith('@-others') or s2.startswith('@-<<'):
                     gnx, h, offset = stack.pop()
+#@verbatim
                     # @-others is invisible.
                     offset += 1
                 elif s2.startswith('@@'):

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -166,12 +166,12 @@ class GoToCommands:
                     gnx, h = self.get_script_node_info(s, delim2)
                 elif s2.startswith('@+others') or s2.startswith('@+<<'):
                     stack.append((gnx, h, offset),)
-#@verbatim
+                    #@verbatim
                     # @others is visible in the outline, but *not* in the file.
                     offset += 1
                 elif s2.startswith('@-others') or s2.startswith('@-<<'):
                     gnx, h, offset = stack.pop()
-#@verbatim
+                    #@verbatim
                     # @-others is invisible.
                     offset += 1
                 elif s2.startswith('@@'):

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -111,9 +111,8 @@ class GoToCommands:
         stack: List[Tuple[str, str, int]] = []
         for s in g.splitLines(file_s):
             n += 1  # All lines contribute to the file's line count.
-            # g.trace('%4s %4r %40r %s' % (n, node_offset, h, s.rstrip()))
             if self.is_sentinel(delim1, delim2, s):
-                s2 = s.strip()[len(delim1) :]
+                s2 = s.strip()[len(delim1) :]  # Works for blackened sentinels.
                 # Common code for the visible sentinels.
                 if s2.startswith(('@+others', '@+<<', '@@'),):
                     if target_offset == node_offset and gnx == target_gnx:
@@ -159,7 +158,7 @@ class GoToCommands:
         for s in lines:
             is_sentinel = self.is_sentinel(delim1, delim2, s)
             if is_sentinel:
-                s2 = s.strip()[len(delim1) :]
+                s2 = s.strip()[len(delim1) :]  # Works for blackened sentinels.
                 if s2.startswith('@+node'):
                     # Invisible, but resets the offset.
                     offset = 0
@@ -206,7 +205,7 @@ class GoToCommands:
         stack = [(gnx, h, offset),]
         for i, s in enumerate(lines):
             if self.is_sentinel(delim1, delim2, s):
-                s2 = s.strip()[len(delim1) :]
+                s2 = s.strip()[len(delim1) :]  # Works for blackened sentinels.
                 if s2.startswith('@+node'):
                     offset = 0
                     gnx, h = self.get_script_node_info(s, delim2)
@@ -338,14 +337,15 @@ class GoToCommands:
             h = h.rstrip(delim2)
         return gnx, h
     #@+node:ekr.20150625124027.1: *4* goto.is_sentinel
-    def is_sentinel(self, delim1: Any, delim2: Any, s: str) -> bool:
+    def is_sentinel(self, delim1: str, delim2: str, s: str) -> bool:
         """Return True if s is a sentinel line with the given delims."""
-        assert delim1
-        i = s.find(delim1 + '@')
-        if delim2:
-            j = s.find(delim2)
-            return -1 < i < j
-        return -1 < i
+        # Leo 6.7.2: Use g.is_sentinel, which handles blackened sentinels properly.
+        delims: Tuple
+        if delim1 and delim2:
+            delims = (None, delim1, delim2)
+        else:
+            delims = (delim1, None, None)
+        return g.is_sentinel(line=s, delims=delims)
     #@+node:ekr.20100728074713.5843: *4* goto.remove_level_stars
     def remove_level_stars(self, s: str) -> str:
         i = g.skip_ws(s, 0)

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -140,6 +140,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of autocompletion."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.378: *4* << define s >> (helpForAutocompletion)
+#@verbatim
         # @pagewidth 40
         #@@language rest
 
@@ -256,6 +257,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of keyboard bindings."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.380: *4* << define s >> (helpForBindings)
+#@verbatim
         # @pagewidth 40
         #@@language rest
 
@@ -594,6 +596,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of of Leo's debugging commands."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.389: *4* << define s >> (helpForDebuggingCommands)
+#@verbatim
         # @pagewidth 40
         #@@language rest
 
@@ -625,6 +628,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of of Leo's debugging commands."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.391: *4* << define s >> (helpForDragAndDrop
+#@verbatim
         # @pagewidth 40
         #@@language rest
 

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -140,7 +140,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of autocompletion."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.378: *4* << define s >> (helpForAutocompletion)
-#@verbatim
+        #@verbatim
         # @pagewidth 40
         #@@language rest
 
@@ -257,7 +257,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of keyboard bindings."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.380: *4* << define s >> (helpForBindings)
-#@verbatim
+        #@verbatim
         # @pagewidth 40
         #@@language rest
 
@@ -596,7 +596,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of of Leo's debugging commands."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.389: *4* << define s >> (helpForDebuggingCommands)
-#@verbatim
+        #@verbatim
         # @pagewidth 40
         #@@language rest
 
@@ -628,7 +628,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
         """Prints a discussion of of Leo's debugging commands."""
         #@+<< define s >>
         #@+node:ekr.20150514063305.391: *4* << define s >> (helpForDragAndDrop
-#@verbatim
+        #@verbatim
         # @pagewidth 40
         #@@language rest
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -150,6 +150,7 @@ class LeoApp:
         self.translateToUpperCase = False  # Never set to True.
         self.useIpython = False  # True: add support for IPython.
         self.use_splash_screen = True  # True: put up a splash screen.
+        self.write_black_sentinels = False  # True: write a space befor '@' in sentinel lines.
         #@-<< LeoApp: command-line arguments >>
         #@+<< LeoApp: Debugging & statistics >>
         #@+node:ekr.20161028035835.1: *5* << LeoApp: Debugging & statistics >>
@@ -2675,6 +2676,8 @@ class LoadManager:
         add = parser.add_argument
         add('PATHS', nargs='*', metavar='FILES',
             help='list of files')
+        add('--black-sentinels', dest='black_sentinels', action='store_true',
+            help='write black-compatible sentinel comments')
         add('--diff', dest='diff', action='store_true',
             help='use Leo as an external git diff')
         add('--fail-fast', dest='fail_fast', action='store_true',
@@ -2793,6 +2796,8 @@ class LoadManager:
     #@+node:ekr.20210927034148.8: *6* LM.doSimpleOptions
     def doSimpleOptions(self, args: Any, trace_m: str) -> None:
         """These args just set g.app ivars."""
+        # --black-sentinels
+        g.app.write_black_sentinels = args.black_sentinels
         # --fail-fast
         g.app.failFast = args.fail_fast
         # --fullscreen

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2676,7 +2676,7 @@ class LoadManager:
         add = parser.add_argument
         add('PATHS', nargs='*', metavar='FILES',
             help='list of files')
-        add('--black-sentinels', dest='black_sentinels', action='store_true',
+        add('-b', '--black-sentinels', dest='black_sentinels', action='store_true',
             help='write black-compatible sentinel comments')
         add('--diff', dest='diff', action='store_true',
             help='use Leo as an external git diff')

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2129,7 +2129,7 @@ class IterativeTokenGenerator:
         returns = getattr(node, 'returns', None)
         result: ActionList = []
         # Decorators...
-#@verbatim
+            #@verbatim
             # @{z}\n
         for z in node.decorator_list or []:
             result.extend([
@@ -2163,7 +2163,7 @@ class IterativeTokenGenerator:
 
         result: ActionList = []
         for z in node.decorator_list or []:
-#@verbatim
+            #@verbatim
             # @{z}\n
             result.extend([
                 (self.op, '@'),
@@ -2198,7 +2198,7 @@ class IterativeTokenGenerator:
         returns = getattr(node, 'returns', None)
         result: ActionList = []
         # Decorators...
-#@verbatim
+            #@verbatim
             # @{z}\n
         for z in node.decorator_list or []:
             result.extend([
@@ -3635,7 +3635,7 @@ class Orange:
                 tail.insert(0, t)
             elif t.kind == 'comment':
                 # Only underindented single-line comments belong in the tail.
-#@verbatim
+                #@verbatim
                 # @+node comments must never be in the tail.
                 single_line = self.code_list[i].kind in ('line-end', 'line-indent')
                 lws = len(t.value) - len(t.value.lstrip())
@@ -4916,7 +4916,7 @@ class TokenOrderGenerator:
     def do_ClassDef(self, node: Node) -> None:
 
         for z in node.decorator_list or []:
-#@verbatim
+            #@verbatim
             # @{z}\n
             self.op('@')
             self.visit(z)
@@ -4945,7 +4945,7 @@ class TokenOrderGenerator:
         # Guards...
         returns = getattr(node, 'returns', None)
         # Decorators...
-#@verbatim
+            #@verbatim
             # @{z}\n
         for z in node.decorator_list or []:
             self.op('@')

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2129,6 +2129,7 @@ class IterativeTokenGenerator:
         returns = getattr(node, 'returns', None)
         result: ActionList = []
         # Decorators...
+#@verbatim
             # @{z}\n
         for z in node.decorator_list or []:
             result.extend([
@@ -2162,6 +2163,7 @@ class IterativeTokenGenerator:
 
         result: ActionList = []
         for z in node.decorator_list or []:
+#@verbatim
             # @{z}\n
             result.extend([
                 (self.op, '@'),
@@ -2196,6 +2198,7 @@ class IterativeTokenGenerator:
         returns = getattr(node, 'returns', None)
         result: ActionList = []
         # Decorators...
+#@verbatim
             # @{z}\n
         for z in node.decorator_list or []:
             result.extend([
@@ -3632,6 +3635,7 @@ class Orange:
                 tail.insert(0, t)
             elif t.kind == 'comment':
                 # Only underindented single-line comments belong in the tail.
+#@verbatim
                 # @+node comments must never be in the tail.
                 single_line = self.code_list[i].kind in ('line-end', 'line-indent')
                 lws = len(t.value) - len(t.value.lstrip())
@@ -4912,6 +4916,7 @@ class TokenOrderGenerator:
     def do_ClassDef(self, node: Node) -> None:
 
         for z in node.decorator_list or []:
+#@verbatim
             # @{z}\n
             self.op('@')
             self.visit(z)
@@ -4940,6 +4945,7 @@ class TokenOrderGenerator:
         # Guards...
         returns = getattr(node, 'returns', None)
         # Decorators...
+#@verbatim
             # @{z}\n
         for z in node.decorator_list or []:
             self.op('@')

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1839,7 +1839,7 @@ class AtFile:
         if isSection:
             return False  # A section definition node.
         if at.sentinels:
-#@verbatim
+            #@verbatim
             # @ignore must not stop expansion here!
             return True
         if p.isAtIgnoreNode():  # pragma: no cover
@@ -1888,18 +1888,12 @@ class AtFile:
         line = s[i:j]
 
         def put_verbatim_sentinel() -> None:
-            """Put an @verbatim sentinel with or without indentation."""
-            if g.app.write_black_sentinels:
-                ws = s[i:k]
-                self.putIndent(len(ws))
-                self.putSentinel("@verbatim")
-            else:
-                old_indent = at.indent
-                try:
-                    at.indent = 0
-                    self.putSentinel("@verbatim")
-                finally:
-                    at.indent = old_indent
+            """
+            Put an @verbatim sentinel. *Always* use black-compatible indentation.
+            """
+            ws = s[i:k]
+            self.putIndent(len(ws))
+            self.putSentinel("@verbatim")
 
         # Put an @verbatim sentinel if the next line looks like another sentinel.
         if at.language == 'python':  # New in Leo 6.7.2.
@@ -3016,12 +3010,12 @@ class FastAtRead:
             ('doc',         fr'^\s*{delim1}@\+(at|doc)?(\s.*?)?{delim2}\n'), # @doc or @
             ('first',       fr'^\s*{delim1}@@first{delim2}$'),               # @first
             ('last',        fr'^\s*{delim1}@@last{delim2}$'),                # @last
-#@verbatim
+            #@verbatim
             # @node
             ('node_start',  fr'^(\s*){delim1}@\+node:([^:]+): \*(\d+)?(\*?) (.*){delim2}$'),
             ('others',      fr'^(\s*){delim1}@(\+|-)others\b(.*){delim2}$'), # @others
             ('ref',         fr'^(\s*){delim1}@(\+|-){ref}\s*{delim2}$'),     # section ref
-#@verbatim
+            #@verbatim
             # @section-delims
             ('section_delims', fr'^\s*{delim1}@@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*{delim2}$'),
         )
@@ -3289,7 +3283,7 @@ class FastAtRead:
                 #@+node:ekr.20211031033754.1: *4* << handle @ or @doc >>
                 m = self.doc_pat.match(line)
                 if m:
-#@verbatim
+                    #@verbatim
                     # @+at or @+doc?
                     doc = '@doc' if m.group(1) == 'doc' else '@'
                     doc2 = m.group(2) or ''  # Trailing text.
@@ -3310,7 +3304,7 @@ class FastAtRead:
             #@+node:ekr.20180602103135.13: *4* << handle @all >>
             m = self.all_pat.match(line)
             if m:
-#@verbatim
+                #@verbatim
                 # @all tells Leo's *write* code not to check for undefined sections.
                 # Here, in the read code, we merely need to add it to the body.
                 # Pushing and popping the stack may not be necessary, but it can't hurt.
@@ -3437,7 +3431,7 @@ class FastAtRead:
             # These sections must be last, in this order.
             #@+<< handle remaining @@ lines >>
             #@+node:ekr.20180603135602.1: *4* << handle remaining @@ lines >>
-#@verbatim
+            #@verbatim
             # @first, @last, @delims and @comment generate @@ sentinels,
             # So this must follow all of those.
             if line.startswith(comment_delim1 + '@@'):

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3002,22 +3002,22 @@ class FastAtRead:
         ref = g.angleBrackets(r'(.*)')
         table = (
             # These patterns must be mutually exclusive.
-            ('after',       fr'^\s*{delim1}@afterref{delim2}$'),             # @afterref
-            ('all',         fr'^(\s*){delim1}@(\+|-)all\b(.*){delim2}$'),    # @all
-            ('code',        fr'^\s*{delim1}@@c(ode)?{delim2}$'),             # @c and @code
-            ('comment',     fr'^\s*{delim1}@@comment(.*){delim2}'),          # @comment
-            ('delims',      fr'^\s*{delim1}@delims(.*){delim2}'),            # @delims
-            ('doc',         fr'^\s*{delim1}@\+(at|doc)?(\s.*?)?{delim2}\n'), # @doc or @
-            ('first',       fr'^\s*{delim1}@@first{delim2}$'),               # @first
-            ('last',        fr'^\s*{delim1}@@last{delim2}$'),                # @last
+            ('after',       fr'^\s*{delim1}\s?@afterref{delim2}$'),             # @afterref
+            ('all',         fr'^(\s*){delim1}\s?@(\+|-)all\b(.*){delim2}$'),    # @all
+            ('code',        fr'^\s*{delim1}\s?@@c(ode)?{delim2}$'),             # @c and @code
+            ('comment',     fr'^\s*{delim1}\s?@@comment(.*){delim2}'),          # @comment
+            ('delims',      fr'^\s*{delim1}\s?@delims(.*){delim2}'),            # @delims
+            ('doc',         fr'^\s*{delim1}\s?@\+(at|doc)?(\s.*?)?{delim2}\n'), # @doc or @
+            ('first',       fr'^\s*{delim1}\s?@@first{delim2}$'),               # @first
+            ('last',        fr'^\s*{delim1}\s?@@last{delim2}$'),                # @last
             #@verbatim
             # @node
-            ('node_start',  fr'^(\s*){delim1}@\+node:([^:]+): \*(\d+)?(\*?) (.*){delim2}$'),
-            ('others',      fr'^(\s*){delim1}@(\+|-)others\b(.*){delim2}$'), # @others
-            ('ref',         fr'^(\s*){delim1}@(\+|-){ref}\s*{delim2}$'),     # section ref
+            ('node_start',  fr'^(\s*){delim1}\s?@\+node:([^:]+): \*(\d+)?(\*?) (.*){delim2}$'),
+            ('others',      fr'^(\s*){delim1}\s?@(\+|-)others\b(.*){delim2}$'), # @others
+            ('ref',         fr'^(\s*){delim1}\s?@(\+|-){ref}\s*{delim2}$'),     # section ref
             #@verbatim
             # @section-delims
-            ('section_delims', fr'^\s*{delim1}@@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*{delim2}$'),
+            ('section_delims', fr'^\s*{delim1}\s?@@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*{delim2}$'),
         )
         # Set the ivars.
         for (name, pattern) in table:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1886,7 +1886,7 @@ class AtFile:
         j = g.skip_line(s, i)
         k = g.skip_ws(s, i)
         line = s[i:j]
-        
+
         def put_verbatim_sentinel() -> None:
             """Put an @verbatim sentinel without indentation."""
             old_indent = at.indent
@@ -1903,8 +1903,8 @@ class AtFile:
                 put_verbatim_sentinel()
         elif g.match(s, k, self.startSentinelComment + "@"):
             put_verbatim_sentinel()
-            
-        if False: ### line.strip() == '# @ignore must not stop expansion here!':
+
+        if False:  ### line.strip() == '# @ignore must not stop expansion here!':
             g.pdb()
 
         # Don't put any whitespace in otherwise blank lines.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1839,7 +1839,7 @@ class AtFile:
         if isSection:
             return False  # A section definition node.
         if at.sentinels:
-            #@verbatim
+    #@verbatim
             # @ignore must not stop expansion here!
             return True
         if p.isAtIgnoreNode():  # pragma: no cover
@@ -1885,16 +1885,13 @@ class AtFile:
         at = self
         j = g.skip_line(s, i)
         k = g.skip_ws(s, i)
-        ws = s[i:k]
         line = s[i:j]
 
-        # Put and @verbatim sentinel if the next line looks like another sentinel.
+        # Put an @verbatim sentinel if the next line looks like another sentinel.
         if at.language == 'python':  # New in Leo 6.7.2.
             # Python sentinels *only* may contain a splace between '#' and '@'
             assert self.startSentinelComment == '#'
             if g.match(s, k, '#@') or g.match(s, k, '# @'):
-                # For compatiblility with Black, match the indentation of the *next* line.
-                at.os(ws)
                 self.putSentinel("@verbatim")
         elif g.match(s, k, self.startSentinelComment + "@"):
             self.putSentinel("@verbatim")
@@ -3006,12 +3003,12 @@ class FastAtRead:
             ('doc',         fr'^\s*{delim1}@\+(at|doc)?(\s.*?)?{delim2}\n'), # @doc or @
             ('first',       fr'^\s*{delim1}@@first{delim2}$'),               # @first
             ('last',        fr'^\s*{delim1}@@last{delim2}$'),                # @last
-            #@verbatim
+    #@verbatim
             # @node
             ('node_start',  fr'^(\s*){delim1}@\+node:([^:]+): \*(\d+)?(\*?) (.*){delim2}$'),
             ('others',      fr'^(\s*){delim1}@(\+|-)others\b(.*){delim2}$'), # @others
             ('ref',         fr'^(\s*){delim1}@(\+|-){ref}\s*{delim2}$'),     # section ref
-            #@verbatim
+    #@verbatim
             # @section-delims
             ('section_delims', fr'^\s*{delim1}@@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*{delim2}$'),
         )
@@ -3270,7 +3267,7 @@ class FastAtRead:
                 #@+node:ekr.20211031033754.1: *4* << handle @ or @doc >>
                 m = self.doc_pat.match(line)
                 if m:
-                    #@verbatim
+                #@verbatim
                     # @+at or @+doc?
                     doc = '@doc' if m.group(1) == 'doc' else '@'
                     doc2 = m.group(2) or ''  # Trailing text.
@@ -3291,7 +3288,7 @@ class FastAtRead:
             #@+node:ekr.20180602103135.13: *4* << handle @all >>
             m = self.all_pat.match(line)
             if m:
-                #@verbatim
+            #@verbatim
                 # @all tells Leo's *write* code not to check for undefined sections.
                 # Here, in the read code, we merely need to add it to the body.
                 # Pushing and popping the stack may not be necessary, but it can't hurt.
@@ -3451,7 +3448,7 @@ class FastAtRead:
 
                 # This assert verifies the short-circuit test.
                 assert strip_line.startswith((sentinel, sentinel2)), repr(line)
-                
+
                 # Defensive: make *sure* we ignore verbatim lines.
                 if strip_line in (verbatim_line, verbatim_line2):
                     g.trace('Ignore bad @verbatim sentinel', repr(line))

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1839,8 +1839,8 @@ class AtFile:
         if isSection:
             return False  # A section definition node.
         if at.sentinels:
-                #@verbatim
-                # @ignore must not stop expansion here!
+            #@verbatim
+            # @ignore must not stop expansion here!
             return True
         if p.isAtIgnoreNode():  # pragma: no cover
             g.error('did not write @ignore node', p.v.h)
@@ -3006,13 +3006,13 @@ class FastAtRead:
             ('doc',         fr'^\s*{delim1}@\+(at|doc)?(\s.*?)?{delim2}\n'), # @doc or @
             ('first',       fr'^\s*{delim1}@@first{delim2}$'),               # @first
             ('last',        fr'^\s*{delim1}@@last{delim2}$'),                # @last
-                #@verbatim
-                # @node
+            #@verbatim
+            # @node
             ('node_start',  fr'^(\s*){delim1}@\+node:([^:]+): \*(\d+)?(\*?) (.*){delim2}$'),
             ('others',      fr'^(\s*){delim1}@(\+|-)others\b(.*){delim2}$'), # @others
             ('ref',         fr'^(\s*){delim1}@(\+|-){ref}\s*{delim2}$'),     # section ref
-                #@verbatim
-                # @section-delims
+            #@verbatim
+            # @section-delims
             ('section_delims', fr'^\s*{delim1}@@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*{delim2}$'),
         )
         # Set the ivars.
@@ -3270,8 +3270,8 @@ class FastAtRead:
                 #@+node:ekr.20211031033754.1: *4* << handle @ or @doc >>
                 m = self.doc_pat.match(line)
                 if m:
-                                    #@verbatim
-                                    # @+at or @+doc?
+                    #@verbatim
+                    # @+at or @+doc?
                     doc = '@doc' if m.group(1) == 'doc' else '@'
                     doc2 = m.group(2) or ''  # Trailing text.
                     if doc2:
@@ -3291,8 +3291,8 @@ class FastAtRead:
             #@+node:ekr.20180602103135.13: *4* << handle @all >>
             m = self.all_pat.match(line)
             if m:
-                            #@verbatim
-                            # @all tells Leo's *write* code not to check for undefined sections.
+                #@verbatim
+                # @all tells Leo's *write* code not to check for undefined sections.
                 # Here, in the read code, we merely need to add it to the body.
                 # Pushing and popping the stack may not be necessary, but it can't hurt.
                 if m.group(2) == '+':  # opening sentinel
@@ -3416,8 +3416,8 @@ class FastAtRead:
             # These sections must be last, in this order.
             #@+<< handle remaining @@ lines >>
             #@+node:ekr.20180603135602.1: *4* << handle remaining @@ lines >>
-                        #@verbatim
-                        # @first, @last, @delims and @comment generate @@ sentinels,
+            #@verbatim
+            # @first, @last, @delims and @comment generate @@ sentinels,
             # So this must follow all of those.
             if line.startswith(comment_delim1 + '@@'):
                 ii = len(comment_delim1) + 1  # on second '@'

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3042,6 +3042,9 @@ class FastAtRead:
         """
         Scan for the header line, which follows any @first lines.
         Return (delims, first_lines, i+1) or None
+        
+        Important: delims[0] will end with a blank when reading a file with blackened sentinels!
+                   This fact eliminates all special cases in scan_lines!
         """
         first_lines: List[str] = []
         i = 0  # To keep some versions of pylint happy.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3444,10 +3444,11 @@ class FastAtRead:
                     # doc lines are unchanged.
                     body.append(line)
                     continue
-                # Doc lines start with start_delim + one blank.
-                # #1496: Retire the @doc convention.
-                # #2194: Strip lws.
-                tail = line.lstrip()[len(comment_delim1) + 1 :]
+
+                #    with --black-sentinels: comment_delim1 ends with a blank.
+                # without --black-sentinels: comment_delim1 does *not* end with a blank.
+
+                tail = line.lstrip()[len(comment_delim1.rstrip()) + 1 :]
                 if tail.strip():
                     body.append(tail)
                 else:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3042,7 +3042,7 @@ class FastAtRead:
         """
         Scan for the header line, which follows any @first lines.
         Return (delims, first_lines, i+1) or None
-        
+
         Important: delims[0] will end with a blank when reading a file with blackened sentinels!
                    This fact eliminates all special cases in scan_lines!
         """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1890,6 +1890,8 @@ class AtFile:
         def put_verbatim_sentinel() -> None:
             """Put an @verbatim sentinel with or without indentation."""
             if g.app.write_black_sentinels:
+                ws = s[i:k]
+                self.putIndent(len(ws))
                 self.putSentinel("@verbatim")
             else:
                 old_indent = at.indent

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3136,9 +3136,8 @@ class FastAtRead:
             #@+<< finalize line >>
             #@+node:ekr.20180602103135.10: *4* << finalize line >>
             # Undo the cweb hack.
-            if is_cweb:
-                if line.startswith(sentinel):
-                    line = line[: len(sentinel)] + line[len(sentinel) :].replace('@@', '@')
+            if is_cweb and line.startswith(sentinel):
+                line = line[: len(sentinel)] + line[len(sentinel) :].replace('@@', '@')
             # Adjust indentation.
             if indent and line[:indent].isspace() and len(line) > indent:
                 line = line[indent:]

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3142,13 +3142,17 @@ class FastAtRead:
             #@+<< finalize line >>
             #@+node:ekr.20180602103135.10: *4* << finalize line >>
             # Undo the cweb hack.
-            if is_cweb and line.startswith(sentinel):
-                line = line[: len(sentinel)] + line[len(sentinel) :].replace('@@', '@')
+            if is_cweb:
+                if line.startswith(sentinel):
+                    line = line[: len(sentinel)] + line[len(sentinel) :].replace('@@', '@')
+                elif line.startswith(sentinel2):
+                    line = line[: len(sentinel2)] + line[len(sentinel2) :].replace('@@', '@')
+
             # Adjust indentation.
             if indent and line[:indent].isspace() and len(line) > indent:
                 line = line[indent:]
             #@-<< finalize line >>
-            if not in_doc and not strip_line.startswith(sentinel):  # Faster than a regex!
+            if not in_doc and not strip_line.startswith((sentinel, sentinel2)):  # Faster than a regex!
                 body.append(line)
                 continue
             # These three sections might clear in_doc.
@@ -3373,6 +3377,7 @@ class FastAtRead:
                 doc_skip = (comment_delim1 + '\n', comment_delim2 + '\n')
                 is_cweb = comment_delim1 == '@q@' and comment_delim2 == '@>'
                 sentinel = comment_delim1 + '@'
+                sentinel2 = comment_delim1 + ' @'
                 #
                 # Recalculate the patterns.
                 comment_delims = comment_delim1, comment_delim2
@@ -3406,6 +3411,7 @@ class FastAtRead:
                 doc_skip = (comment_delim1 + '\n', comment_delim2 + '\n')
                 is_cweb = comment_delim1 == '@q@' and comment_delim2 == '@>'
                 sentinel = comment_delim1 + '@'
+                sentinel2 = comment_delim1 + ' @'
                 #
                 # Recalculate the patterns
                 comment_delims = comment_delim1, comment_delim2

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1888,13 +1888,16 @@ class AtFile:
         line = s[i:j]
 
         def put_verbatim_sentinel() -> None:
-            """Put an @verbatim sentinel without indentation."""
-            old_indent = at.indent
-            try:
-                at.indent = 0
+            """Put an @verbatim sentinel with or without indentation."""
+            if g.app.write_black_sentinels:
                 self.putSentinel("@verbatim")
-            finally:
-                at.indent = old_indent
+            else:
+                old_indent = at.indent
+                try:
+                    at.indent = 0
+                    self.putSentinel("@verbatim")
+                finally:
+                    at.indent = old_indent
 
         # Put an @verbatim sentinel if the next line looks like another sentinel.
         if at.language == 'python':  # New in Leo 6.7.2.
@@ -1903,9 +1906,6 @@ class AtFile:
                 put_verbatim_sentinel()
         elif g.match(s, k, self.startSentinelComment + "@"):
             put_verbatim_sentinel()
-
-        if False:  ### line.strip() == '# @ignore must not stop expansion here!':
-            g.pdb()
 
         # Don't put any whitespace in otherwise blank lines.
         if len(line) > 1:  # Preserve *anything* the user puts on the line!!!
@@ -2093,8 +2093,8 @@ class AtFile:
         if at.sentinels or g.app.force_at_auto_sentinels:
             at.putIndent(at.indent)
             at.os(at.startSentinelComment)
-            # #2194. #2983: Put Black sentinels if --put-black-sentinels is in effect.
-            if 0:  ### Not yet.
+            # #2194. #2983: Put Black sentinels if --black-sentinels is in effect.
+            if g.app.write_black_sentinels:
                 at.os(' ')
             # Apply the cweb hack to s:
             #   If the opening comment delim ends in '@',

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -267,7 +267,7 @@ class ChapterController:
         if not self.re_chapter:
             self.re_chapter = re.compile(
                 r'^@chapter\s+([^@]+)\s*(@key\s*=\s*(.+)\s*)?')
-#@verbatim
+                #@verbatim
                 # @chapter (all up to @) (@key=(binding))?
                 # name=group(1), binding=group(3)
         m = self.re_chapter.search(p.h)

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -267,6 +267,7 @@ class ChapterController:
         if not self.re_chapter:
             self.re_chapter = re.compile(
                 r'^@chapter\s+([^@]+)\s*(@key\s*=\s*(.+)\s*)?')
+#@verbatim
                 # @chapter (all up to @) (@key=(binding))?
                 # name=group(1), binding=group(3)
         m = self.re_chapter.search(p.h)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -732,6 +732,7 @@ class BaseColorizer:
         # Now look at the parents.
         for p in p.parents():
             d = self.findColorDirectives(p)
+#@verbatim
             # @killcolor anywhere disables coloring.
             if 'killcolor' in d:
                 return False

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -732,7 +732,7 @@ class BaseColorizer:
         # Now look at the parents.
         for p in p.parents():
             d = self.findColorDirectives(p)
-#@verbatim
+            #@verbatim
             # @killcolor anywhere disables coloring.
             if 'killcolor' in d:
                 return False

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -159,11 +159,13 @@ class ExternalFilesController:
                 self.idle_check_open_with_file(c, ef)
         elif self.unchecked_commanders:
             # Check the next commander for which
+#@verbatim
             # @bool check_for_changed_external_file is True.
             c = self.unchecked_commanders.pop()
             self.idle_check_commander(c)
         else:
             # Add all commanders for which
+#@verbatim
             # @bool check_for_changed_external_file is True.
             self.unchecked_commanders = [
                 z for z in g.app.commanders() if self.is_enabled(z)

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -159,13 +159,13 @@ class ExternalFilesController:
                 self.idle_check_open_with_file(c, ef)
         elif self.unchecked_commanders:
             # Check the next commander for which
-#@verbatim
+            #@verbatim
             # @bool check_for_changed_external_file is True.
             c = self.unchecked_commanders.pop()
             self.idle_check_commander(c)
         else:
             # Add all commanders for which
-#@verbatim
+            #@verbatim
             # @bool check_for_changed_external_file is True.
             self.unchecked_commanders = [
                 z for z in g.app.commanders() if self.is_enabled(z)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1023,6 +1023,7 @@ class LeoFind:
         """Toggle the 'Whole Word' checkbox in the Find tab."""
         self.toggle_option('whole_word')
 
+#@verbatim
     # @cmd('toggle-find-wrap-around-option')
     # def toggleWrapSearchOption(self, event):
         # """Toggle the 'Wrap Around' checkbox in the Find tab."""
@@ -1335,6 +1336,7 @@ class LeoFind:
         return self._cf_helper(settings, flatten=False)
     #@+node:ekr.20131117164142.16996: *4* find.clone-find-all-flattened & helper
     @cmd('clone-find-all-flattened')
+#@verbatim
     # @cmd('find-clone-all-flattened')
     @cmd('cff')
     def interactive_cff(self, event: Event=None, preloaded: bool=False) -> None:  # pragma: no cover (interactive)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1023,7 +1023,7 @@ class LeoFind:
         """Toggle the 'Whole Word' checkbox in the Find tab."""
         self.toggle_option('whole_word')
 
-#@verbatim
+    #@verbatim
     # @cmd('toggle-find-wrap-around-option')
     # def toggleWrapSearchOption(self, event):
         # """Toggle the 'Wrap Around' checkbox in the Find tab."""
@@ -1336,7 +1336,7 @@ class LeoFind:
         return self._cf_helper(settings, flatten=False)
     #@+node:ekr.20131117164142.16996: *4* find.clone-find-all-flattened & helper
     @cmd('clone-find-all-flattened')
-#@verbatim
+    #@verbatim
     # @cmd('find-clone-all-flattened')
     @cmd('cff')
     def interactive_cff(self, event: Event=None, preloaded: bool=False) -> None:  # pragma: no cover (interactive)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3747,6 +3747,9 @@ def is_sentinel(line: str, delims: Sequence) -> bool:
     Leo 6.7.2: Support blackened sentinels.
     """
     delim1, delim2, delim3 = delims
+    # Defensive code. Make *sure* delim has no trailing space.
+    if delim1:
+        delim1 = delim1.rstrip()
     line = line.lstrip()
     if delim1:
         sentinel1 = delim1 + '@'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3743,7 +3743,7 @@ def is_binary_string(s: str) -> bool:
 def is_sentinel(line: str, delims: Sequence) -> bool:
     """
     Return True if line starts with a sentinel comment.
-    
+
     Leo 6.7.2: Support blackened sentinels.
     """
     delim1, delim2, delim3 = delims

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3754,7 +3754,7 @@ def is_sentinel(line: str, delims: Sequence) -> bool:
     if delim1:
         sentinel1 = delim1 + '@'
         sentinel2 = delim1 + ' @'
-        return line.startswith(sentinel1, sentinel2)
+        return line.startswith((sentinel1, sentinel2))
     if delim2 and delim3:
         sentinel1 = delim2 + '@'
         sentinel2 = delim2 + ' @'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2431,7 +2431,7 @@ def assertUi(uitype: Any) -> None:
 class TestLeoGlobals(unittest.TestCase):
     """Tests for leoGlobals.py."""
     #@+others
-    #@+node:ekr.20200219071958.1: *4* test_comment_delims_from_extension
+    #@+node:ekr.20200219071958.1: *4* TestLeoGlobals.test_comment_delims_from_extension
     def test_comment_delims_from_extension(self) -> None:
 
         # pylint: disable=import-self
@@ -2441,15 +2441,17 @@ class TestLeoGlobals(unittest.TestCase):
         assert leo_g.comment_delims_from_extension(".py") == ('#', '', '')
         assert leo_g.comment_delims_from_extension(".c") == ('//', '/*', '*/')
         assert leo_g.comment_delims_from_extension(".html") == ('', '<!--', '-->')
-    #@+node:ekr.20200219072957.1: *4* test_is_sentinel
+    #@+node:ekr.20200219072957.1: *4* TestLeoGlobals.test_is_sentinel
     def test_is_sentinel(self) -> None:
 
         # pylint: disable=import-self
         from leo.core import leoGlobals as leo_g
-        # Python.
+        # Python. Test regular and blackened sentinels.
         py_delims = leo_g.comment_delims_from_extension('.py')
         assert leo_g.is_sentinel("#@+node", py_delims)
+        assert leo_g.is_sentinel("# @+node", py_delims)
         assert not leo_g.is_sentinel("#comment", py_delims)
+        assert not leo_g.is_sentinel("# comment", py_delims)
         # C.
         c_delims = leo_g.comment_delims_from_extension('.c')
         assert leo_g.is_sentinel("//@+node", c_delims)
@@ -3739,15 +3741,28 @@ def is_binary_string(s: str) -> bool:
     return bool(s.translate(None, bytes(aList)))  # type:ignore
 #@+node:EKR.20040504154039: *3* g.is_sentinel
 def is_sentinel(line: str, delims: Sequence) -> bool:
-    """Return True if line starts with a sentinel comment."""
+    """
+    Return True if line starts with a sentinel comment.
+    
+    Leo 6.7.2: Support blackened sentinels.
+    """
     delim1, delim2, delim3 = delims
     line = line.lstrip()
     if delim1:
-        return line.startswith(delim1 + '@')
+        sentinel1 = delim1 + '@'
+        sentinel2 = delim1 + ' @'
+        return line.startswith(sentinel1, sentinel2)
     if delim2 and delim3:
-        i = line.find(delim2 + '@')
-        j = line.find(delim3)
-        return 0 == i < j
+        sentinel1 = delim2 + '@'
+        sentinel2 = delim2 + ' @'
+        if sentinel1 in line:
+            i = line.find(sentinel1)
+            j = line.find(delim3)
+            return 0 == i < j
+        if sentinel2 in line:
+            i = line.find(sentinel2)
+            j = line.find(delim3)
+            return 0 == i < j
     g.error(f"is_sentinel: can not happen. delims: {repr(delims)}")
     return False
 #@+node:ekr.20031218072017.3119: *3* g.makeAllNonExistentDirectories

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -42,7 +42,7 @@ except ImportError:
 try:
     from ipykernel.kernelapp import IPKernelApp
 except ImportError:
-    IPKernelApp = None
+    IPKernelApp = None  # type:ignore
     import_fail('IPKernelApp')
 
 g.app.ipython_inited = IPKernelApp is not None

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -900,7 +900,7 @@ class AutoCompleterClass:
                 if self.forbid_invalid:
                     # Delete the character we just inserted.
                     self.do_backspace()
-#@verbatim
+            #@verbatim
             # @bool auto_tab_complete is deprecated.
             # Auto-completion makes no sense if it is False.
             elif self.auto_tab and len(common_prefix) > len(prefix):

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -900,6 +900,7 @@ class AutoCompleterClass:
                 if self.forbid_invalid:
                     # Delete the character we just inserted.
                     self.do_backspace()
+#@verbatim
             # @bool auto_tab_complete is deprecated.
             # Auto-completion makes no sense if it is False.
             elif self.auto_tab and len(common_prefix) > len(prefix):

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -119,6 +119,9 @@ class LeoUnitTest(unittest.TestCase):
 
         # Set g.unitTesting *early*, for guards.
         g.unitTesting = True
+        
+        # Default.
+        g.app.write_black_sentinels = False
 
         # Create a new commander for each test.
         # This is fast, because setUpClass has done all the imports.

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -119,7 +119,7 @@ class LeoUnitTest(unittest.TestCase):
 
         # Set g.unitTesting *early*, for guards.
         g.unitTesting = True
-        
+
         # Default.
         g.app.write_black_sentinels = False
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -210,7 +210,7 @@ class ServerExternalFilesController(ExternalFilesController):
 
         if self.unchecked_commanders:
             # Check the next commander for which
-#@verbatim
+            #@verbatim
             # @bool check_for_changed_external_file is True.
             c = self.unchecked_commanders.pop()
             self.lastCommander = c
@@ -218,7 +218,7 @@ class ServerExternalFilesController(ExternalFilesController):
             self.idle_check_commander(c)
         else:
             # Add all commanders for which
-#@verbatim
+            #@verbatim
             # @bool check_for_changed_external_file is True.
             self.unchecked_commanders = [
                 z for z in g.app.commanders() if self.is_enabled(z)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -210,6 +210,7 @@ class ServerExternalFilesController(ExternalFilesController):
 
         if self.unchecked_commanders:
             # Check the next commander for which
+#@verbatim
             # @bool check_for_changed_external_file is True.
             c = self.unchecked_commanders.pop()
             self.lastCommander = c
@@ -217,6 +218,7 @@ class ServerExternalFilesController(ExternalFilesController):
             self.idle_check_commander(c)
         else:
             # Add all commanders for which
+#@verbatim
             # @bool check_for_changed_external_file is True.
             self.unchecked_commanders = [
                 z for z in g.app.commanders() if self.is_enabled(z)

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -1389,7 +1389,7 @@ class LeoBrowserMenu(leoMenu.NullMenu):
         # self.root = get_root()
         # self.tag = '(py.menu.wrap)'
 
-#@verbatim
+    #@verbatim
     # @others
 #@+node:ekr.20181115120317.1: *3* class LeoBrowserMinibuffer (StringTextWrapper)
 # Leo's core doesn't define a NullMinibuffer class.

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -1389,6 +1389,7 @@ class LeoBrowserMenu(leoMenu.NullMenu):
         # self.root = get_root()
         # self.tag = '(py.menu.wrap)'
 
+#@verbatim
     # @others
 #@+node:ekr.20181115120317.1: *3* class LeoBrowserMinibuffer (StringTextWrapper)
 # Leo's core doesn't define a NullMinibuffer class.

--- a/leo/plugins/screen_capture.py
+++ b/leo/plugins/screen_capture.py
@@ -94,7 +94,7 @@ class Recorder:
             # not capture the pointer in the image, which is quite
             # typical for screen captures - this code draws a pointer
             # in the right place, and may be need to be enabled by a
-#@verbatim
+            #@verbatim
             # @setting in future, if pointer capture does not occur in
             # all environments - pointer is captured in
             # Leo Log Window

--- a/leo/plugins/screen_capture.py
+++ b/leo/plugins/screen_capture.py
@@ -94,6 +94,7 @@ class Recorder:
             # not capture the pointer in the image, which is quite
             # typical for screen captures - this code draws a pointer
             # in the right place, and may be need to be enabled by a
+#@verbatim
             # @setting in future, if pointer capture does not occur in
             # all environments - pointer is captured in
             # Leo Log Window

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -34,7 +34,7 @@ class TestPythonToTypeScript(LeoUnitTest):
             contents = f.read()
         # Set the gnx of the @file nodes in the contents to root.gnx.
         # This is necessary because of a check in fast_at.scan_lines.
-        pat = re.compile(r'^\s*#@\+node:([^:]+): \* @file leoNodes\.py$')
+        pat = re.compile(r'^\s*#\s?@\+node:([^:]+): \* @file leoNodes\.py$')
         line3 = g.splitLines(contents)[2]
         m = pat.match(line3)
         assert m, "Can not replace gnx"

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2586,7 +2586,7 @@ class TestOrange(BaseTest):
     def test_verbatim(self):
 
         line_length = 40  # For testing.
-        contents = """\
+        contents = textwrap.dedent("""\
     #@@nobeautify
 
     def addOptionsToParser(self, parser, trace_m):
@@ -2610,7 +2610,7 @@ class TestOrange(BaseTest):
     docDirective    =  3 # @doc.
 
     #@@beautify
-    """
+    """)
         contents, tokens, tree = self.make_data(contents)
         expected = contents
         results = self.beautify(contents, tokens, tree,

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -619,9 +619,35 @@ class TestFastAtRead(LeoUnitTest):
         #AT-leo
         ''').replace('AT', '@').replace('LB', '<<')
         #@-<< define contents >>
+        #@+<< define expected >>
+        #@+node:ekr.20221203083459.1: *4* << define expected >> (test_at_all)
+        # Be careful: no line should look like a Leo sentinel!
+        expected = textwrap.dedent(f'''\
+        #AT+leo-ver=5-thin
+        #AT+node:{root.gnx}: * {h}
+        # This is Leo's final resting place for dead code.
+        # Much easier to access than a git repo.
+
+        #AT@language python
+        #AT@killbeautify
+        #AT+all
+        #AT+node:ekr.20211103093559.1: ** node 1
+        Section references can be undefined.
+
+        LB missing reference >>
+        #AT+node:ekr.20211103093633.1: ** node 2
+        #ATverbatim
+        # ATothers doesn't matter
+
+        ATothers
+        #AT-all
+        #AT@nosearch
+        #AT-leo
+        ''').replace('AT', '@').replace('LB', '<<')
+        #@-<< define expected >>
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
-        self.assertEqual(contents, s)
+        self.assertEqual(expected, s)
     #@+node:ekr.20211101085019.1: *3* TestFast.test_at_comment (and @first)
     def test_at_comment(self):
 

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -1044,14 +1044,14 @@ class TestFastAtRead(LeoUnitTest):
         #AT+node (should be protected by verbatim)
         ''').replace('AT', '@')
         #@-<< define expected_body >>
-        
+
         # Test 1: without black delims.
         g.app.write_black_sentinels = False
         x.read_into_root(contents, path='test', root=root)
         self.assertEqual(root.b, expected_body)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
-        
+
         # Test 2: with black delims.
         g.app.write_black_sentinels = True
         contents = contents.replace('#@', '# @')

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -528,7 +528,7 @@ class TestFastAtRead(LeoUnitTest):
         self.x = leoAtFile.FastAtRead(self.c, gnx2vnode={})
 
     #@+others
-    #@+node:ekr.20211104162514.1: *3* TestFast.test_afterref
+    #@+node:ekr.20211104162514.1: *3* TestFastAtRead.test_afterref
     def test_afterref(self):
 
         c, x = self.c, self.x
@@ -587,7 +587,7 @@ class TestFastAtRead(LeoUnitTest):
         # Leo has *never* round-tripped the contents without change!
         self.assertEqual(s, expected_contents, msg='mismatch in contents')
 
-    #@+node:ekr.20211103093332.1: *3* TestFast.test_at_all
+    #@+node:ekr.20211103093332.1: *3* TestFastAtRead.test_at_all
     def test_at_all(self):
 
         c, x = self.c, self.x
@@ -623,7 +623,7 @@ class TestFastAtRead(LeoUnitTest):
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
-    #@+node:ekr.20211101085019.1: *3* TestFast.test_at_comment (and @first)
+    #@+node:ekr.20211101085019.1: *3* TestFastAtRead.test_at_comment (and @first)
     def test_at_comment(self):
 
         c, x = self.c, self.x
@@ -675,7 +675,7 @@ class TestFastAtRead(LeoUnitTest):
         )
         for child, h in table:
             self.assertEqual(child.h, h)
-    #@+node:ekr.20211101111636.1: *3* TestFast.test_at_delims
+    #@+node:ekr.20211101111636.1: *3* TestFastAtRead.test_at_delims
     def test_at_delims(self):
         c, x = self.c, self.x
         h = '@file /test/test_at_delims.txt'
@@ -724,7 +724,7 @@ class TestFastAtRead(LeoUnitTest):
         )
         for child, h in table:
             self.assertEqual(child.h, h)
-    #@+node:ekr.20211103095616.1: *3* TestFast.test_at_last
+    #@+node:ekr.20211103095616.1: *3* TestFastAtRead.test_at_last
     def test_at_last(self):
 
         c, x = self.c, self.x
@@ -762,7 +762,7 @@ class TestFastAtRead(LeoUnitTest):
         self.assertEqual(root.b, expected_body)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
-    #@+node:ekr.20211103092228.1: *3* TestFast.test_at_others
+    #@+node:ekr.20211103092228.1: *3* TestFastAtRead.test_at_others
     def test_at_others(self):
 
         # In particular, we want to test indented @others.
@@ -790,7 +790,7 @@ class TestFastAtRead(LeoUnitTest):
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
-    #@+node:ekr.20211031093209.1: *3* TestFast.test_at_section_delim
+    #@+node:ekr.20211031093209.1: *3* TestFastAtRead.test_at_section_delim
     def test_at_section_delim(self):
 
         c, x = self.c, self.x
@@ -842,7 +842,7 @@ class TestFastAtRead(LeoUnitTest):
         )
         for child, h in table:
             self.assertEqual(child.h, h)
-    #@+node:ekr.20211101155930.1: *3* TestFast.test_clones
+    #@+node:ekr.20211101155930.1: *3* TestFastAtRead.test_clones
     def test_clones(self):
 
         c, x = self.c, self.x
@@ -892,7 +892,7 @@ class TestFastAtRead(LeoUnitTest):
         self.assertEqual(child1.v, child2.v)
         self.assertFalse(grand_child1.isCloned())
         self.assertFalse(grand_child2.isCloned())
-    #@+node:ekr.20211103080718.1: *3* TestFast.test_cweb
+    #@+node:ekr.20211103080718.1: *3* TestFastAtRead.test_cweb
     #@@language python
 
     def test_cweb(self):
@@ -941,13 +941,14 @@ class TestFastAtRead(LeoUnitTest):
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
-    #@+node:ekr.20211101152817.1: *3* TestFast.test_doc_parts
+    #@+node:ekr.20211101152817.1: *3* TestFastAtRead.test_doc_parts
     def test_doc_parts(self):
 
         c, x = self.c, self.x
         h = '@file /test/test_directives.py'
         root = c.rootPosition()
         root.h = h  # To match contents.
+
         #@+<< define contents >>
         #@+node:ekr.20211101152843.1: *4* << define contents >> (test_doc_parts)
         # Be careful: no line should look like a Leo sentinel!
@@ -971,10 +972,21 @@ class TestFastAtRead(LeoUnitTest):
         #AT-leo
         ''').replace('AT', '@').replace('LB', '<<')
         #@-<< define contents >>
+
+        # Test 1: without black delims.
+        g.app.write_black_sentinels = False
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
-        self.assertEqual(contents, s)
-    #@+node:ekr.20211101154632.1: *3* TestFast.test_html_doc_part
+        self.assertEqual(contents, s, msg='Test 1')
+
+        # Test 2: with black delims.
+        g.app.write_black_sentinels = True
+        contents = contents.replace('#@', '# @')
+        x.read_into_root(contents, path='test', root=root)
+        s = c.atFileCommands.atFileToString(root, sentinels=True)
+        ### g.printObj(contents2, tag='contents2')
+        self.assertEqual(contents, s, 'Test 2: -b')
+    #@+node:ekr.20211101154632.1: *3* TestFastAtRead.test_html_doc_part
     def test_html_doc_part(self):
 
         c, x = self.c, self.x
@@ -1002,7 +1014,7 @@ class TestFastAtRead(LeoUnitTest):
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
-    #@+node:ekr.20211101180354.1: *3* TestFast.test_verbatim
+    #@+node:ekr.20211101180354.1: *3* TestFastAtRead.test_verbatim
     def test_verbatim(self):
 
         c, x = self.c, self.x
@@ -1013,15 +1025,15 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101180404.1: *4* << define contents >> (test_verbatim)
         # Be careful: no line should look like a Leo sentinel!
         contents = textwrap.dedent(f'''\
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        #AT@language python
-        # Test of @verbatim
-        print('hi')
-        #ATverbatim
-        #AT+node (should be protected by verbatim)
-        #AT-leo
-        ''').replace('AT', '@').replace('LB', '<<')
+            #AT+leo-ver=5-thin
+            #AT+node:{root.gnx}: * {h}
+            #AT@language python
+            # Test of @verbatim
+            print('hi')
+            #ATverbatim
+            #AT+node (should be protected by verbatim)
+            #AT-leo
+        ''').replace('AT', '@') ### .replace('LB', '<<')
         #@-<< define contents >>
         #@+<< define expected_body >>
         #@+node:ekr.20211106070035.1: *4* << define expected_body >> (test_verbatim)
@@ -1032,10 +1044,23 @@ class TestFastAtRead(LeoUnitTest):
         #AT+node (should be protected by verbatim)
         ''').replace('AT', '@')
         #@-<< define expected_body >>
+        
+        # Test 1: without black delims.
+        g.app.write_black_sentinels = False
         x.read_into_root(contents, path='test', root=root)
         self.assertEqual(root.b, expected_body)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
         self.assertEqual(contents, s)
+        
+        # Test 2: with black delims.
+        g.app.write_black_sentinels = True
+        contents = contents.replace('#@', '# @')
+        expected_body = expected_body.replace('#@', '# @')
+        x.read_into_root(contents, path='test', root=root)
+        self.assertEqual(root.b, expected_body)
+        s = c.atFileCommands.atFileToString(root, sentinels=True)
+        self.assertEqual(contents, s)
+
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -611,31 +611,6 @@ class TestFastAtRead(LeoUnitTest):
 
         LB missing reference >>
         #AT+node:ekr.20211103093633.1: ** node 2
-        # ATothers doesn't matter
-
-        ATothers
-        #AT-all
-        #AT@nosearch
-        #AT-leo
-        ''').replace('AT', '@').replace('LB', '<<')
-        #@-<< define contents >>
-        #@+<< define expected >>
-        #@+node:ekr.20221203083459.1: *4* << define expected >> (test_at_all)
-        # Be careful: no line should look like a Leo sentinel!
-        expected = textwrap.dedent(f'''\
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        # This is Leo's final resting place for dead code.
-        # Much easier to access than a git repo.
-
-        #AT@language python
-        #AT@killbeautify
-        #AT+all
-        #AT+node:ekr.20211103093559.1: ** node 1
-        Section references can be undefined.
-
-        LB missing reference >>
-        #AT+node:ekr.20211103093633.1: ** node 2
         #ATverbatim
         # ATothers doesn't matter
 
@@ -644,10 +619,11 @@ class TestFastAtRead(LeoUnitTest):
         #AT@nosearch
         #AT-leo
         ''').replace('AT', '@').replace('LB', '<<')
-        #@-<< define expected >>
+        #@-<< define contents >>
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
-        self.assertEqual(expected, s)
+        # self.assertEqual(expected, s)
+        self.assertEqual(contents, s)
     #@+node:ekr.20211101085019.1: *3* TestFast.test_at_comment (and @first)
     def test_at_comment(self):
 

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -622,7 +622,6 @@ class TestFastAtRead(LeoUnitTest):
         #@-<< define contents >>
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
-        # self.assertEqual(expected, s)
         self.assertEqual(contents, s)
     #@+node:ekr.20211101085019.1: *3* TestFast.test_at_comment (and @first)
     def test_at_comment(self):

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -81,7 +81,7 @@ class TestColorizer(LeoUnitTest):
             # Unambiguous child.
             (False, '', '@killcolor\n'),
             (True, '', '@color\n'),
-#@verbatim
+            #@verbatim
             # @nocolor-node rules node.
             (False, '', '@nocolor-node\n'),
             (False, '', '@color\n@nocolor-node\n'),

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -81,6 +81,7 @@ class TestColorizer(LeoUnitTest):
             # Unambiguous child.
             (False, '', '@killcolor\n'),
             (True, '', '@color\n'),
+#@verbatim
             # @nocolor-node rules node.
             (False, '', '@nocolor-node\n'),
             (False, '', '@color\n@nocolor-node\n'),

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -167,14 +167,13 @@ class TestGlobals(LeoUnitTest):
         c = self.c
         p = c.p
         p.b = textwrap.dedent("""\
-            @language python
-            @comment a b c
-#@verbatim
-                # @comment must follow @language.
-            @tabwidth -8
-            @pagewidth 72
-            @encoding utf-8
-    """)
+            ATlanguage python
+            ATcomment a b c
+                # ATcomment must follow @language.
+            ATtabwidth -8
+            ATpagewidth 72
+            ATencoding utf-8
+    """).replace('AT', '@')
         d = g.get_directives_dict(p)
         self.assertEqual(d.get('language'), 'python')
         self.assertEqual(d.get('tabwidth'), '-8')

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -166,10 +166,10 @@ class TestGlobals(LeoUnitTest):
     def test_g_get_directives_dict(self):
         c = self.c
         p = c.p
+        # Note: @comment must follow @language.
         p.b = textwrap.dedent("""\
             ATlanguage python
             ATcomment a b c
-                # ATcomment must follow @language.
             ATtabwidth -8
             ATpagewidth 72
             ATencoding utf-8

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -169,6 +169,7 @@ class TestGlobals(LeoUnitTest):
         p.b = textwrap.dedent("""\
             @language python
             @comment a b c
+#@verbatim
                 # @comment must follow @language.
             @tabwidth -8
             @pagewidth 72

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -201,7 +201,7 @@ class TestNodes(LeoUnitTest):
                 aList.append(p)
     #@+node:ekr.20210828075915.1: *5* TestNodes.test_all_nodes_coverage
     def test_all_nodes_coverage(self):
-#@verbatim
+        #@verbatim
         # @test c iters: <coverage tests>
         c = self.c
         v1 = [p.v for p in c.all_positions()]

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -201,6 +201,7 @@ class TestNodes(LeoUnitTest):
                 aList.append(p)
     #@+node:ekr.20210828075915.1: *5* TestNodes.test_all_nodes_coverage
     def test_all_nodes_coverage(self):
+#@verbatim
         # @test c iters: <coverage tests>
         c = self.c
         v1 = [p.v for p in c.all_positions()]

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -201,8 +201,6 @@ class TestNodes(LeoUnitTest):
                 aList.append(p)
     #@+node:ekr.20210828075915.1: *5* TestNodes.test_all_nodes_coverage
     def test_all_nodes_coverage(self):
-        #@verbatim
-        # @test c iters: <coverage tests>
         c = self.c
         v1 = [p.v for p in c.all_positions()]
         v2 = [v for v in c.all_nodes()]

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -27,6 +27,7 @@ class BaseTestImporter(LeoUnitTest):
     def setUp(self):
         super().setUp()
         g.app.loadManager.createAllImporterData()
+        g.app.write_black_sentinels = False
 
     #@+others
     #@+node:vitalije.20211206180043.1: *3* BaseTestImporter.check_outline (best trace)


### PR DESCRIPTION
See #2983.

- [x] Recognize `--black-sentinels` command-line option.
- [x] Put a space between '#' and '@' (Python files only) when `--black-sentinels` is in effect.
- [x] Fix one bug, improve support for blackened sentinels, and add defensive code in FastRead.scan_lines.
- [x] Add support for blackened sentinels to g.is_sentinel.