### PR TITLE
Update viewrendered3.py

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -64,6 +64,7 @@ Previous Recent Changes
 For Asciidoctor only, new setting to suppress the footer inserted by the
 Asciidoctor by default (``@bool vr3-asciidoctor-nofooter = True``).
 Asciidoctor by default (``@string vr3-asciidoctor-icons=''``).
+Asciidoctor by default (``@string vr3-asciidoctor-imagesdir=''``).
 
 New minibuffer commands *vr3-freeze* and *vr3-unfreeze*.
 Improved detection of the notebook URL in *@jupyter* nodes.  The URL no longer
@@ -186,6 +187,7 @@ All settings are of type @string unless shown as ``@bool``
    "@string vr3-prefer-external", "''", "Name of external asciidoctor processor", "Use Ruby ``asciidoctor`` program"
    "@bool vr3-asciidoctor-nofooter", "False", "True, False", "Whether to suppress footer (``sciidoctor`` only)"   "@bool vr3-insert-headline-from-node", "True", "True, False", "Render node headline as top heading if True"
    "@string vr3-asciidoctor-icons", "", "'', font, image", "Whether to use icons (``asciidoctor`` only)"
+   "@string vr3-asciidoctor-imagesdir", "", "'', absolutePath, relativePath, URL", "Whether to use imagesdir (``asciidoctor`` only)"
 
 .. csv-table:: Int Settings (integer only, do not use any units)
    :header: "Setting", "Default", "Values", "Purpose"
@@ -2301,6 +2303,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.asciidoc_show_proc_fail_msgs = True
         self.asciidoctor_suppress_footer = c.config.getBool('vr3-asciidoctor-nofooter', default=False)
         self.asciidoctor_icons = c.config.getString('vr3-asciidoctor-icons') or ''
+        self.asciidoctor_imagesdir = c.config.getString('vr3-asciidoctor-imagesdir') or ''
 
         self.external_editor = c.config.getString('vr3-ext-editor') or ''
 
@@ -3207,6 +3210,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
             attrs.append('nofooter')
         if self.asciidoctor_icons:  # not ""
             attrs.append(f'icons={self.asciidoctor_icons}')
+        if self.asciidoctor_imagesdir:
+            attrs.append(f'imagesdir={self.asciidoctor_imagesdir}')
         att_str = ''
         for att in attrs:
             att_str += f'-a {att} '


### PR DESCRIPTION
Add `imagesdir` attribute support.

<https://docs.asciidoctor.org/asciidoc/latest/macros/images-directory/#imagesdir-attribute-syntax>

>The value of imagesdir can be an absolute path, relative path or URL. By default, the imagesdir value is empty. That means the images are resolved relative to the document. If an image macro’s target is an absolute path or URL, the value of imagesdir is not added to the target path.