### PR TITLE
PR: Improve search for pylint's configuration file

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -511,19 +511,29 @@ class PylintCommand:
     #@+node:ekr.20150514125218.10: *3* 3. pylint.get_rc_file
     def get_rc_file(self) -> Optional[str]:
         """Return the path to the pylint configuration file."""
-        base = 'pylint-leo-rc.txt'
-        table = (
-            # In ~/.leo
-            g.os_path_finalize_join(g.app.homeDir, '.leo', base),
-            # In leo/test
-            g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base),
+        c = self.c
+        bases = (
+            '.pylintrc',
+            'pylint-leo-rc.txt',
         )
-        for fn in table:
-            fn = g.os_path_abspath(fn)
-            if g.os_path_exists(fn):
-                return fn
-        table_s = '\n'.join(table)
-        g.es_print(f"no pylint configuration file found in\n{table_s}")
+        local_dir = g.os_path_dirname(c.fileName())
+        for base in bases:
+            table = (
+                # In the directory containing the outline.
+                g.os_path_finalize_join(local_dir, base),
+                # In ~/.leo
+                g.os_path_finalize_join(g.app.homeDir, '.leo', base),
+                # In leo/test
+                g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base),
+            )
+            for fn in table:
+                print(f"Using {fn}")
+                fn = g.os_path_abspath(fn)
+                if g.os_path_exists(fn):
+                    return fn
+        # table_s = '\n'.join(table)
+        # g.es_print("no pylint configuration file found")
+        g.es_print('Not found: .pylintrc and pylint-leo-rc.txt')
         return None
     #@+node:ekr.20150514125218.9: *3* 4. pylint.get_fn
     def get_fn(self, p: Position) -> Optional[str]:

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -512,28 +512,28 @@ class PylintCommand:
     def get_rc_file(self) -> Optional[str]:
         """Return the path to the pylint configuration file."""
         c = self.c
-        bases = (
-            '.pylintrc',
-            'pylint-leo-rc.txt',
-        )
+        base1 = '.pylintrc'  # Standard name.
+        base2 = 'pylint-leo-rc.txt'  # Leo-centric name
         local_dir = g.os_path_dirname(c.fileName())
-        for base in bases:
-            table = (
-                # In the directory containing the outline.
-                g.os_path_finalize_join(local_dir, base),
-                # In ~/.leo
-                g.os_path_finalize_join(g.app.homeDir, '.leo', base),
-                # In leo/test
-                g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base),
-            )
-            for fn in table:
-                print(f"Using {fn}")
-                fn = g.os_path_abspath(fn)
-                if g.os_path_exists(fn):
-                    return fn
-        # table_s = '\n'.join(table)
-        # g.es_print("no pylint configuration file found")
-        g.es_print('Not found: .pylintrc and pylint-leo-rc.txt')
+        table = (
+            # In the directory containing the outline.
+            g.os_path_finalize_join(local_dir, base1),
+            g.os_path_finalize_join(local_dir, base2),
+            # In ~/.leo
+            g.os_path_finalize_join(g.app.homeDir, '.leo', base1),
+            g.os_path_finalize_join(g.app.homeDir, '.leo', base2),
+            # In leo/test
+            g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base2),
+            g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base2),
+        )
+        for fn in table:
+            fn = g.os_path_abspath(fn)
+            if g.os_path_exists(fn):
+                print(f"pylint: {fn}")
+                return fn
+        table_s = '\n'.join(table)
+        g.es_print(f"no pylint configuration file found in\n{table_s}")
+        # g.es_print('Not found: .pylintrc and pylint-leo-rc.txt')
         return None
     #@+node:ekr.20150514125218.9: *3* 4. pylint.get_fn
     def get_fn(self, p: Position) -> Optional[str]:


### PR DESCRIPTION
Leo's pylint command worked only for Leo itself!

The new search table:
- Looks for `.pylintrc` first.
- Looks first in the directory containing the .leo file.