### PR TITLE
Update leoMarkup.py

### DIFF
--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -460,7 +460,7 @@ class MarkupCommands:
         else:
             g.es_print(f"bad kind: {self.kind!r}")
             return
-        self.output_file.write(f"{section} {p.h}\n\n")
+        self.output_file.write(f"{section} {p.h}\n")
     #@+node:ekr.20191007054942.1: *4* markup.remove_directives
     def remove_directives(self, s: str) -> str:
         lines = g.splitLines(s)


### PR DESCRIPTION
Fix command adoc add one blank line.

xxx.adoc compare:

Before:
```
= Single Test for asciidoctor-pdf

:source-highlighter: pygments
:icons: font
:scripts: cjk
:toc:
:toc: right
:toc-title: Directory
:toclevels: 4
```

After:
```
= Single Test for asciidoctor-pdf
:source-highlighter: pygments
:icons: font
:scripts: cjk
:toc:
:toc: right
:toc-title: Directory
:toclevels: 4
```

Reference: https://docs.asciidoctor.org/asciidoc/latest/document/header/

> The document header cannot contain empty lines. The first empty line that the processor encounters after the document header begins marks the end of the document header and the beginning of the document body.
