### PR TITLE
Fix command adoc output path changed

### DIFF
--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -260,7 +260,8 @@ class MarkupCommands:
                 i_path = self.filename(p)
                 # #1398.
                 i_path = c.expand_path_expression(i_path)
-                i_path = g.os_path_finalize(i_path)
+                n_path = c.getNodePath(c.p)  # node path
+                i_path = g.os_path_finalize_join(n_path, i_path)
                 with open(i_path, 'w', encoding='utf-8', errors='replace') as self.output_file:
                     self.write_root(p)
                     i_paths.append(i_path)


### PR DESCRIPTION
The command `adoc` output path is not in a fixed position, perhaps in some condition. Bellow is one output position used to be.

```
adoc: wrote /Users/swot/app/leo-editor/leo/core/xxx.adoc

adoc: wrote /Users/swot/app/leo-editor/xxx.adoc

adoc: wrote /Users/swot/xxx.adoc

adoc: wrote /Users/swot/learning/html/xxx.adoc (in my project directory, wanted)
```

So the xxx.adoc should be found manually, then copy to the project directory because of the asciidoc directive like `include` or `image` needing relative path.