### PR TITLE
PR for #3049: remove encoding lines

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514035236.1: * @file ../commands/abbrevCommands.py
-#@@first
 """Leo's abbreviations commands."""
 #@+<< abbrevCommands imports & abbreviations >>
 #@+node:ekr.20150514045700.1: ** << abbrevCommands imports & abbreviations >>

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514035943.1: * @file ../commands/baseCommands.py
-#@@first
 """The base class for all of Leo's user commands."""
 #@+<< baseCommands imports & abbreviations >>
 #@+node:ekr.20220828071357.1: ** << baseCommands imports & abbreviations >>

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514035559.1: * @file ../commands/bufferCommands.py
-#@@first
 """Leo's buffer commands."""
 #@+<< bufferCommands imports & annotations >>
 #@+node:ekr.20150514045750.1: ** << bufferCommands imports & annotations >>

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20161021090740.1: * @file ../commands/checkerCommands.py
-#@@first
 """Commands that invoke external checkers"""
 #@+<< checkerCommands imports >>
 #@+node:ekr.20161021092038.1: ** << checkerCommands imports >>

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20171123135539.1: * @file ../commands/commanderEditCommands.py
-#@@first
 """Edit commands that used to be defined in leoCommands.py"""
 
 #@+<< commanderEditCommands imports & annotations >>

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20171123095353.1: * @file ../commands/commanderFileCommands.py
-#@@first
 """File commands that used to be defined in leoCommands.py"""
 #@+<< commanderFileCommands imports & annotations >>
 #@+node:ekr.20220826120852.1: ** << commanderFileCommands imports & annotations >>

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20171124073126.1: * @file ../commands/commanderHelpCommands.py
-#@@first
 """Help commands that used to be defined in leoCommands.py"""
 #@+<< commanderHelpCommands imports & annotations >>
 #@+node:ekr.20220826122759.1: ** << commanderHelpCommands imports & annotations >>

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20171124080430.1: * @file ../commands/commanderOutlineCommands.py
-#@@first
 """Outline commands that used to be defined in leoCommands.py"""
 #@+<< commanderOutlineCommands imports & annotations >>
 #@+node:ekr.20220826123551.1: ** << commanderOutlineCommands imports & annotations >>

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040100.1: * @file ../commands/controlCommands.py
-#@@first
 """Leo's control commands."""
 #@+<< controlCommands imports & annotations >>
 #@+node:ekr.20150514050127.1: ** << controlCommands imports & annotations >>

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20160316095222.1: * @file ../commands/convertCommands.py
-#@@first
 """Leo's file-conversion commands."""
 #@+<< convertCommands imports & annotations >>
 #@+node:ekr.20220824202922.1: ** << convertCommands imports & annotations >>
@@ -2187,7 +2185,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
         def pre_pass(self, s: str) -> str:
 
             # Remove the python encoding lines.
-            s = s.replace('@first # -*- coding: utf-8 -*-\n', '')
+            s = s.replace('', '')
 
             # Replace 'self' by 'this' *everywhere*.
             s = re.sub(r'\bself\b', 'this', s)

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040118.1: * @file ../commands/debugCommands.py
-#@@first
 """Per-commander debugging class."""
 #@+<< debugCommands imports & annotations >>
 #@+node:ekr.20181006100818.1: ** << debugCommands imports & annotations >>

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514035813.1: * @file ../commands/editCommands.py
-#@@first
 """Leo's general editing commands."""
 #@+<< editCommands imports & annotations  >>
 #@+node:ekr.20150514050149.1: **  << editCommands imports & annotations >>

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514041209.1: * @file ../commands/editFileCommands.py
-#@@first
 """Leo's file-editing commands."""
 #@+<< editFileCommands imports & annotations >>
 #@+node:ekr.20170806094317.4: ** << editFileCommands imports & annotations >>

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150624112334.1: * @file ../commands/gotoCommands.py
-#@@first
 """Leo's goto commands."""
 #@+<< gotoCommands imports & annotations >>
 #@+node:ekr.20220827065126.1: ** << gotoCommands imports & annotations >>

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040138.1: * @file ../commands/helpCommands.py
-#@@first
 """Leo's help commands."""
 #@+<< helpCommands imports & annotations >>
 #@+node:ekr.20150514050337.1: ** << helpCommands imports & annotations >>
@@ -558,7 +556,6 @@ class HelpCommandsClass(BaseEditCommandsClass):
         external file. For example::
 
             @first #! /usr/bin/env python
-            @first # -*- coding: utf-8 -*-
 
         Similarly, @last forces lines to appear after the last sentinel.
 

--- a/leo/commands/keyCommands.py
+++ b/leo/commands/keyCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040140.1: * @file ../commands/keyCommands.py
-#@@first
 """Leo's key-handling commands."""
 # This file *is* used. Do not delete it!
 

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040142.1: * @file ../commands/killBufferCommands.py
-#@@first
 """Leo's kill-buffer commands."""
 #@+<< killBufferCommands imports & annotations >>
 #@+node:ekr.20150514050411.1: ** << killBufferCommands imports & annotations >>

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040146.1: * @file ../commands/rectangleCommands.py
-#@@first
 """Leo's rectangle commands."""
 #@+<< rectangleCommands imports & annotations >>
 #@+node:ekr.20150514050446.1: ** << rectangleCommands imports & annotations >>

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514040239.1: * @file ../commands/spellCommands.py
-#@@first
 """Leo's spell-checking commands."""
 #@+<< spellCommands imports & annotations >>
 #@+node:ekr.20150514050530.1: ** << spellCommands imports & annotations >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.2608: * @file leoApp.py
-#@@first
 #@+<< leoApp imports >>
 #@+node:ekr.20120219194520.10463: ** << leoApp imports >>
 from __future__ import annotations

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20141012064706.18389: * @file leoAst.py
-#@@first
 # This file is part of Leo: https://leoeditor.com
 # Leo's copyright notice is based on the MIT license: http://leoeditor.com/license.html
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150323150718.1: * @file leoAtFile.py
-#@@first
 """Classes to read and write @file nodes."""
 #@+<< leoAtFile imports & annotations >>
 #@+node:ekr.20041005105605.2: ** << leoAtFile imports & annotations >>

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20161026193447.1: * @file leoBackground.py
-#@@first
 """Handling background processes"""
 #@+<< leoBackground imports & annotations >>
 #@+node:ekr.20220410202718.1: ** << leoBackground imports & annotations >>

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150521115018.1: * @file leoBeautify.py
-#@@first
 """Leo's beautification classes."""
 #@+<< leoBeautify imports & annotations >>
 #@+node:ekr.20220822114944.1: ** << leoBeautify imports & annotations >>

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20070227091955.1: * @file leoBridge.py
-#@@first
 #@@first
 """A module to allow full access to Leo commanders from outside Leo."""
 #@@language python

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20100208065621.5894: * @file leoCache.py
-#@@first
 """A module encapsulating Leo's file caching"""
 #@+<< leoCache imports & annotations >>
 #@+node:ekr.20100208223942.10436: ** << leoCache imports & annotations >>

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20070317085508.1: * @file leoChapters.py
-#@@first
 """Classes that manage chapters in Leo's core."""
 #@+<< leoChapters imports & annotations >>
 #@+node:ekr.20220824080606.1: ** << leoChapters imports & annotations >>

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.2794: * @file leoColor.py
-#@@first
 #@+<< leoColor docstring >>
 #@+node:bob.20080115083029: ** << leoColor docstring >>
 """A color database for Leo.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140827092102.18574: * @file leoColorizer.py
-#@@first
 """All colorizing code for Leo."""
 
 # Indicated code are copyright (c) Jupyter Development Team.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.2810: * @file leoCommands.py
-#@@first
 #@+<< leoCommands imports >>
 #@+node:ekr.20040712045933: ** << leoCommands imports >>
 from __future__ import annotations

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180212072657.2: * @file leoCompare.py
-#@@first
 """Leo's base compare class."""
 #@+<< leoCompare imports & annotations >>
 #@+node:ekr.20220901161941.1: ** << leoCompare imports & annotations >>

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20130925160837.11429: * @file leoConfig.py
-#@@first
 """Configuration classes for Leo."""
 # pylint: disable=unsubscriptable-object
 #@+<< leoConfig imports & annotations >>

--- a/leo/core/leoDebugger.py
+++ b/leo/core/leoDebugger.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20130302121602.10208: * @file leoDebugger.py
-#@@first
 
 # Disable all mypy errors.
 # type:ignore

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20160306114544.1: * @file leoExternalFiles.py
-#@@first
 #@+<< leoExternalFiles imports & annotations >>
 #@+node:ekr.20220821202943.1: ** << leoExternalFiles imports & annotations >>
 from __future__ import annotations

--- a/leo/core/leoFastRedraw.py
+++ b/leo/core/leoFastRedraw.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20181202062518.1: * @file leoFastRedraw.py
-#@@first
 """
 Gui-independent fast-redraw code.
 

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3018: * @file leoFileCommands.py
-#@@first
 """Classes relating to reading and writing .leo files."""
 #@+<< leoFileCommands imports >>
 #@+node:ekr.20050405141130: ** << leoFileCommands imports >>

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20060123151617: * @file leoFind.py
-#@@first
 """Leo's gui-independent find classes."""
 #@+<< leoFind imports & annotations >>
 #@+node:ekr.20220415005856.1: ** << leoFind imports & annotations >>

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3655: * @file leoFrame.py
-#@@first
 """
 The base classes for all Leo Windows, their body, log and tree panes,
 key bindings and menus.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3093: * @file leoGlobals.py
-#@@first
 """
 Global constants, variables and utility functions used throughout Leo.
 

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3719: * @file leoGui.py
-#@@first
 """
 A module containing the base gui-related classes.
 

--- a/leo/core/leoHistory.py
+++ b/leo/core/leoHistory.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150514154159.1: * @file leoHistory.py
-#@@first
 #@+<< leoHistory imports & annotations >>
 #@+node:ekr.20221213120137.1: ** << leoHistory imports & annotations >>
 from __future__ import annotations

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20120401063816.10072: * @file leoIPython.py
-#@@first
 #@+<< leoIpython docstring >>
 #@+node:ekr.20180326102140.1: ** << leoIpython docstring >>
 """

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3206: * @file leoImport.py
-#@@first
 #@+<< leoImport imports >>
 #@+node:ekr.20091224155043.6539: ** << leoImport imports >>
 from __future__ import annotations

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20061031131434: * @file leoKeys.py
-#@@first
 """Gui-independent keystroke handling for Leo."""
 # pylint: disable=eval-used
 # pylint: disable=deprecated-method

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20190515070742.1: * @file leoMarkup.py
-#@@first
 """Supports @adoc, @pandoc and @sphinx nodes and related commands."""
 #@+<< leoMarkup imports & annotations >>
 #@+node:ekr.20190515070742.3: ** << leoMarkup imports & annotations >>

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3749: * @file leoMenu.py
-#@@first
 """Gui-independent menu handling for Leo."""
 #@+<< leoMenu imports & annotations >>
 #@+node:ekr.20220414095908.1: ** << leoMenu imports & annotations >>

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3320: * @file leoNodes.py
-#@@first
 """Leo's fundamental data classes."""
 #@+<< leoNodes imports & annotations >>
 #@+node:ekr.20060904165452.1: ** << leoNodes imports & annotations >>

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140821055201.18331: * @file leoPersistence.py
-#@@first
 """Support for persistent clones, gnx's and uA's using @persistence trees."""
 #@+<< leoPersistence imports & annotations >>
 #@+node:ekr.20220901064457.1: ** << leoPersistence imports & annotations >>

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3439: * @file leoPlugins.py
-#@@first
 """Classes relating to Leo's plugin architecture."""
 #@+<< leoPlugins imports & annotations >>
 #@+node:ekr.20220901071118.1: ** << leoPlugins imports & annotations >>

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20150419124739.1: * @file leoPrinting.py
-#@@first
 """
 Support the commands in Leo's File:Print menu.
 Adapted from printing plugin.

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20061024060248.1: * @file leoPymacs.py
-#@@first
 #@+<< leoPymacs docstring>>
 #@+node:ekr.20061024060248.2: ** << leoPymacs docstring >>
 """A module to allow the Pymacs bridge to access Leo data.

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # flake8: noqa
 #@+leo-ver=5-thin
 #@+node:ekr.20140810053602.18074: * @file leoQt.py
-#@@first
 #@@first
 #@@nopyflakes
 """

--- a/leo/core/leoQt5.py
+++ b/leo/core/leoQt5.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210407010914.1: * @file leoQt5.py
-#@@first
 """Import wrapper for pyQt5"""
 
 # For now, suppress all mypy checks

--- a/leo/core/leoQt6.py
+++ b/leo/core/leoQt6.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210407011013.1: * @file leoQt6.py
-#@@first
 """
 Import wrapper for pyQt6.
 

--- a/leo/core/leoRope.py
+++ b/leo/core/leoRope.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140526082700.18440: * @file leoRope.py
-#@@first
 #@+<< leoRope imports >>
 #@+node:ekr.20140525065558.15807: ** << leoRope imports >>
 import time

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20090502071837.3: * @file leoRst.py
-#@@first
 #@+<< leoRst docstring >>
 #@+node:ekr.20090502071837.4: ** << leoRst docstring >>
 """Support for restructured text (rST), adapted from rst3 plugin.

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20120420054855.14241: * @file leoSessions.py
-#@@first
 """Support for sessions in Leo."""
 #@+<< leoSessions imports  & annotations >>
 #@+node:ekr.20120420054855.14344: ** << leoSessions imports & annotations >>

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20080708094444.1: * @file leoShadow.py
-#@@first
 #@+<< leoShadow docstring >>
 #@+node:ekr.20080708094444.78: ** << leoShadow docstring >>
 """

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20201129023817.1: * @file leoTest2.py
-#@@first
 """
 Support for Leo's new unit tests, contained in leo/unittests/test_*.py.
 

--- a/leo/core/leoTips.py
+++ b/leo/core/leoTips.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180121041003.1: * @file leoTips.py
-#@@first
 """Save and show tips to the user."""
 #@+<< leoTips imports & annotations >>
 #@+node:ekr.20220901094023.1: ** << leoTips imports & annotations >>
@@ -479,7 +477,6 @@ Within scripts, use section references only when code must
 be placed exactly. Here is a common pattern for @file nodes
 for python files:
 
-    @first # -*- coding: utf-8 -*-
     {g.angleBrackets('imports')}
     {'@others'}
 

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.3603: * @file leoUndo.py
-#@@first
-
 # Suppress all mypy errors (mypy doesn't like g.Bunch).
 # type: ignore
 """Leo's undo/redo manager."""

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20131109170017.16504: * @file leoVim.py
-#@@first
 #@+<< leoVim docstring >>
 #@+node:ekr.20220824081749.1: ** << leoVim docstring >>
 """

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210202110241.1: * @file leoclient.py
-#@@first
 """
 An example client for leoserver.py, based on work by Félix Malboeuf. Used by permission.
 """

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:felix.20210621233316.1: * @file leoserver.py
-#@@first
 #@@language python
 #@@tabwidth -4
 """

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -1,8 +1,6 @@
 #! /usr/bin/env python
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20031218072017.2605: * @file runLeo.py
-#@@first
 #@@first
 """Entry point for Leo in Python."""
 #@+<< imports and inits >>

--- a/leo/core/signal_manager.py
+++ b/leo/core/signal_manager.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115541.1: * @file signal_manager.py
-#@@first
 #@+<< signal_manager docstring >>
 #@+node:ekr.20220901092728.1: ** << signal_manager docstring >>
 """

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170419092835.1: * @file ../plugins/cursesGui2.py
-#@@first
 #@+<< cursesGui2 docstring >>
 #@+node:ekr.20170608073034.1: ** << cursesGui2 docstring >>
 """

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170128213103.1: * @file ../plugins/demo.py
-#@@first
 """
 A plugin that makes making Leo demos easy. See:
 https://github.com/leo-editor/leo-editor/blob/master/leo/doc/demo.md

--- a/leo/plugins/editpane/clicky_splitter.py
+++ b/leo/plugins/editpane/clicky_splitter.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171029210211.1: * @file ../plugins/editpane/clicky_splitter.py
-#@@first
 #@@language python
 """
 clicky_splitter.py - a QSplitter which allows flipping / rotating of

--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20211210102459.1: * @file ../plugins/editpane/csvedit.py
-#@@first
 #@@language python
 #@@tabwidth -4
 #@@language python

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.6: * @file ../plugins/editpane/editpane.py
-#@@first
 """Support for the edit-pane-test-open command and window."""
 #@+<<editpane imports>>
 #@+node:tbrown.20171028115438.1: ** << editpane imports >>

--- a/leo/plugins/editpane/leotextedit.py
+++ b/leo/plugins/editpane/leotextedit.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.5: * @file ../plugins/editpane/leotextedit.py
-#@@first
 #@+<<leotextedit imports >>
 #@+node:tbrown.20171028115508.1: ** <<leotextedit imports >>
 from leo.core import leoGlobals as g

--- a/leo/plugins/editpane/markdownview.py
+++ b/leo/plugins/editpane/markdownview.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.4: * @file ../plugins/editpane/markdownview.py
-#@@first
 #@+<< markdownview imports >>
 #@+node:tbrown.20171028115507.1: ** << markdownview imports >>
 import markdown

--- a/leo/plugins/editpane/pandownview.py
+++ b/leo/plugins/editpane/pandownview.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.3: * @file ../plugins/editpane/pandownview.py
-#@@first
 #@+<< pandownview imports >>
 #@+node:tbrown.20171028115505.1: ** << pandownview imports >>
 """Markdown view using Pandoc.

--- a/leo/plugins/editpane/plaintextedit.py
+++ b/leo/plugins/editpane/plaintextedit.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.2: * @file ../plugins/editpane/plaintextedit.py
-#@@first
 #@+<< plaintextedit imports >>
 #@+node:tbrown.20171028115504.1: ** << plaintextedit imports >>
 import re

--- a/leo/plugins/editpane/plaintextview.py
+++ b/leo/plugins/editpane/plaintextview.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115144.1: * @file ../plugins/editpane/plaintextview.py
-#@@first
 #@+<< plaintextview imports >>
 #@+node:tbrown.20171028115502.1: ** << plaintextview imports >>
 from leo.core import leoGlobals as g

--- a/leo/plugins/editpane/vanillascintilla.py
+++ b/leo/plugins/editpane/vanillascintilla.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115143.3: * @file ../plugins/editpane/vanillascintilla.py
-#@@first
 """
 vanillascintilla.py - a LeoEditPane editor that uses QScintilla
 but does not try to add Leo key handling

--- a/leo/plugins/editpane/webengineview.py
+++ b/leo/plugins/editpane/webengineview.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115143.2: * @file ../plugins/editpane/webengineview.py
-#@@first
 #@+<< webengineview imports >>
 #@+node:tbrown.20171028115459.1: ** << webengineview imports >>
 # EKR: Use QtWebKitWidgets instead of QtWebEngineWidgets

--- a/leo/plugins/editpane/webkitview.py
+++ b/leo/plugins/editpane/webkitview.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20171028115143.1: * @file ../plugins/editpane/webkitview.py
-#@@first
 #@+<< webkitview imports >>
 #@+node:tbrown.20171028115457.1: ** << webkitview imports >>
 import os

--- a/leo/plugins/examples/chinese_menu.py
+++ b/leo/plugins/examples/chinese_menu.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20040828105233: * @file ../plugins/examples/chinese_menu.py
-#@@first
 
 """
 Translate a few menu items into Simplified Chinese

--- a/leo/plugins/examples/french_fm.py
+++ b/leo/plugins/examples/french_fm.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:EKR.20040517080202.3: * @file ../plugins/examples/french_fm.py
-#@@first
 """traduit les menus en Français"""
 
 # French translation completed by Frédéric Momméja, Spring 2003

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20120419093256.10048: * @file ../plugins/free_layout.py
-#@@first
 #@+<< free_layout docstring >>
 #@+node:ekr.20110319161401.14467: ** << free_layout docstring >>
 """

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.17926: * @file ../plugins/importers/c.py
-#@@first
 """The @auto importer for the C language and other related languages."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20160505094722.1: * @file ../plugins/importers/coffeescript.py
-#@@first
 """The @auto importer for coffeescript."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/csharp.py
+++ b/leo/plugins/importers/csharp.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18140: * @file ../plugins/importers/csharp.py
-#@@first
 """The @auto importer for the csharp language."""
 from leo.core.leoCommands import Commands as Cmdr
 from leo.core.leoNodes import Position

--- a/leo/plugins/importers/ctext.py
+++ b/leo/plugins/importers/ctext.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20140801105909.47549: * @file ../plugins/importers/ctext.py
-#@@first
 import re
 from typing import Dict, List
 from leo.core import leoGlobals as g  # Required

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20200619141135.1: * @file ../plugins/importers/cython.py
-#@@first
 """@auto importer for cython."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/dart.py
+++ b/leo/plugins/importers/dart.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20141116100154.1: * @file ../plugins/importers/dart.py
-#@@first
 """The @auto importer for the dart language."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/elisp.py
+++ b/leo/plugins/importers/elisp.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18141: * @file ../plugins/importers/elisp.py
-#@@first
 """The @auto importer for the elisp language."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/html.py
+++ b/leo/plugins/importers/html.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18138: * @file ../plugins/importers/html.py
-#@@first
 """The @auto importer for HTML."""
 from leo.core.leoCommands import Commands as Cmdr
 from leo.core.leoNodes import Position

--- a/leo/plugins/importers/ini.py
+++ b/leo/plugins/importers/ini.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18142: * @file ../plugins/importers/ini.py
-#@@first
 """The @auto importer for .ini files."""
 import re
 from typing import Dict, List, Optional

--- a/leo/plugins/importers/java.py
+++ b/leo/plugins/importers/java.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18143: * @file ../plugins/importers/java.py
-#@@first
 """The @auto importer for the java language."""
 import re
 from typing import Optional

--- a/leo/plugins/importers/javascript.py
+++ b/leo/plugins/importers/javascript.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18144: * @file ../plugins/importers/javascript.py
-#@@first
 """The @auto importer for JavaScript."""
 import re
 from typing import Any, Dict, Generator

--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18151: * @file ../plugins/importers/leo_rst.py
-#@@first
 """
 The @auto importer for restructured text.
 

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20161108125620.1: * @file ../plugins/importers/linescanner.py
-#@@first
 """linescanner.py: The base Importer class used by some importers."""
 import io
 import re

--- a/leo/plugins/importers/lua.py
+++ b/leo/plugins/importers/lua.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170530024520.2: * @file ../plugins/importers/lua.py
-#@@first
 """
 The @auto importer for the lua language.
 

--- a/leo/plugins/importers/markdown.py
+++ b/leo/plugins/importers/markdown.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140725190808.18066: * @file ../plugins/importers/markdown.py
-#@@first
 """The @auto importer for the markdown language."""
 import re
 from typing import Dict, List, Tuple

--- a/leo/plugins/importers/org.py
+++ b/leo/plugins/importers/org.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18146: * @file ../plugins/importers/org.py
-#@@first
 """The @auto importer for the org language."""
 import re
 from typing import Dict, List

--- a/leo/plugins/importers/otl.py
+++ b/leo/plugins/importers/otl.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18150: * @file ../plugins/importers/otl.py
-#@@first
 """The @auto importer for vim-outline files."""
 import re
 from typing import Dict, List

--- a/leo/plugins/importers/pascal.py
+++ b/leo/plugins/importers/pascal.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18147: * @file ../plugins/importers/pascal.py
-#@@first
 """The @auto importer for the pascal language."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/perl.py
+++ b/leo/plugins/importers/perl.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20161027100313.1: * @file ../plugins/importers/perl.py
-#@@first
 """The @auto importer for Perl."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/php.py
+++ b/leo/plugins/importers/php.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18148: * @file ../plugins/importers/php.py
-#@@first
 """The @auto importer for the php language."""
 import re
 from leo.core import leoGlobals as g  # required

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20211209153303.1: * @file ../plugins/importers/python.py
-#@@first
 """The new, tokenize based, @auto importer for Python."""
 import re
 import tokenize

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20200316100818.1: * @file ../plugins/importers/rust.py
-#@@first
 """The @auto importer for rust."""
 import re
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/importers/tcl.py
+++ b/leo/plugins/importers/tcl.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170615153639.2: * @file ../plugins/importers/tcl.py
-#@@first
 """
 The @auto importer for the tcl language.
 

--- a/leo/plugins/importers/treepad.py
+++ b/leo/plugins/importers/treepad.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180201203240.2: * @file ../plugins/importers/treepad.py
-#@@first
 """The @auto importer for the TreePad file format."""
 import re
 from typing import Dict, List

--- a/leo/plugins/importers/typescript.py
+++ b/leo/plugins/importers/typescript.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18152: * @file ../plugins/importers/typescript.py
-#@@first
 """The @auto importer for TypeScript."""
 import re
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140723122936.18137: * @file ../plugins/importers/xml.py
-#@@first
 """The @auto importer for the xml language."""
 import re
 from typing import List, Optional, Tuple

--- a/leo/plugins/leo_pdf.py
+++ b/leo/plugins/leo_pdf.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 #! /usr/bin/env python
 #@+leo-ver=5-thin
 #@+node:ekr.20090704103932.5160: * @file ../plugins/leo_pdf.py
-#@@first
 #@@first
 
 """

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20181103094900.1: * @file ../plugins/leoflexx.py
-#@@first
 
 # Disable mypy checking.
 # type:ignore

--- a/leo/plugins/leofts.py
+++ b/leo/plugins/leofts.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20220823200700.1: * @file ../plugins/leofts.py
-#@@first
 import os
 from whoosh.index import create_in, open_dir
 from whoosh.fields import ID, TEXT, Schema

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:EKR.20040517080250.1: * @file ../plugins/mod_http.py
-#@@first
 # pylint: disable=line-too-long
 #@+<< docstring >>
 #@+node:ekr.20050111111238: ** << docstring >>

--- a/leo/plugins/mod_read_dir_outline.py
+++ b/leo/plugins/mod_read_dir_outline.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20050301083306: * @file ../plugins/mod_read_dir_outline.py
-#@@first
 
 #@+<< docstring >>
 #@+node:ekr.20050301084207: ** << docstring >>

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20110605121601.17954: * @file ../plugins/nested_splitter.py
-#@@first
 """Nested splitter classes."""
 from leo.core import leoGlobals as g
 from leo.core.leoQt import isQt6, Qt, QtCore, QtGui, QtWidgets

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:peckj.20140804114520.9427: * @file ../plugins/nodetags.py
-#@@first
 #@+<< nodetags docstring >>
 #@+node:peckj.20140804103733.9242: ** << nodetags docstring >>
 """Provides node tagging capabilities to Leo

--- a/leo/plugins/pane_commands.py
+++ b/leo/plugins/pane_commands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20221019064053.1: * @file ../plugins/pane_commands.py
-#@@first
 """A plugin that adds top-of-pane and bottom-of-pane commands."""
 # https://github.com/leo-editor/leo-editor/issues/2910
 # Original code by jknGH. Plugin by EKR.

--- a/leo/plugins/paste_as_headlines.py
+++ b/leo/plugins/paste_as_headlines.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:danr7.20060912105041.1: * @file ../plugins/paste_as_headlines.py
-#@@first
 #@+<< docstring >>
 #@+node:danr7.20060912105041.2: ** << docstring >>
 """ Creates new headlines from clipboard text.

--- a/leo/plugins/qtGui.py
+++ b/leo/plugins/qtGui.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20110605121601.18002: * @file ../plugins/qtGui.py
-#@@first
 """qt gui plugin."""
 #@@language python
 #@@tabwidth -4

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20110605121601.17996: * @file ../plugins/qt_commands.py
-#@@first
 """Leo's Qt-related commands defined by @g.command."""
 from typing import List
 from leo.core import leoGlobals as g

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907103315.18766: * @file ../plugins/qt_events.py
-#@@first
 """Leo's Qt event handling code."""
 #@+<< about internal bindings >>
 #@+node:ekr.20110605121601.18538: ** << about internal bindings >>

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907123524.18774: * @file ../plugins/qt_frame.py
-#@@first
 """Leo's qt frame classes."""
 #@+<< qt_frame imports >>
 #@+node:ekr.20110605121601.18003: **  << qt_frame imports >>

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907085654.18699: * @file ../plugins/qt_gui.py
-#@@first
 """This file contains the gui wrapper for Qt: g.app.gui."""
 # pylint: disable=import-error
 #@+<< qt_gui imports  >>

--- a/leo/plugins/qt_idle_time.py
+++ b/leo/plugins/qt_idle_time.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907103315.18777: * @file ../plugins/qt_idle_time.py
-#@@first
 """Leo's Qt idle-time code."""
 import time
 from leo.core import leoGlobals as g

--- a/leo/plugins/qt_quickheadlines.py
+++ b/leo/plugins/qt_quickheadlines.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907123524.18777: * @file ../plugins/qt_quickheadlines.py
-#@@first
 """qt_quickheadlines plugin."""
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets

--- a/leo/plugins/qt_quicksearch.py
+++ b/leo/plugins/qt_quicksearch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Form implementation generated from reading ui file 'qt_quicksearch.ui'
 #
 # Created: Sat Mar 14 22:38:41 2009

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140831085423.18598: * @file ../plugins/qt_text.py
-#@@first
 """Text classes for the Qt version of Leo"""
 #@+<< qt_text imports & annotations>>
 #@+node:ekr.20220416085845.1: ** << qt_text imports & annotations >>

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140907131341.18707: * @file ../plugins/qt_tree.py
-#@@first
 """Leo's Qt tree class."""
 #@+<< qt_tree imports >>
 #@+node:ekr.20140907131341.18709: ** << qt_tree imports >>

--- a/leo/plugins/tables.py
+++ b/leo/plugins/tables.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20170217164004.1: * @file ../plugins/tables.py
-#@@first
 """
 A plugin that inserts tables, inspired by org mode tables:
 

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20090119215428.2: * @file ../plugins/todo.py
-#@@first
 #@+<< todo docstring >>
 #@+node:tbrown.20090119215428.3: ** << todo docstring >>
 """ Provides to-do list and simple task management.

--- a/leo/plugins/writers/basewriter.py
+++ b/leo/plugins/writers/basewriter.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18143: * @file ../plugins/writers/basewriter.py
-#@@first
 """A module defining the base class for all writers in leo.plugins.writers."""
 
 from leo.core.leoCommands import Commands as Cmdr

--- a/leo/plugins/writers/ctext.py
+++ b/leo/plugins/writers/ctext.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:tbrown.20140804103545.29975: * @file ../plugins/writers/ctext.py
-#@@first
 #@@language python
 #@@tabwidth -4
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/writers/dart.py
+++ b/leo/plugins/writers/dart.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20141116100154.2: * @file ../plugins/writers/dart.py
-#@@first
 """The @auto write code for Emacs org-mode (.org) files."""
 from leo.core import leoGlobals as g  # Required
 from leo.core.leoNodes import Position

--- a/leo/plugins/writers/leo_rst.py
+++ b/leo/plugins/writers/leo_rst.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18080: * @file ../plugins/writers/leo_rst.py
-#@@first
 """
 The write code for @auto-rst and other reStructuredText nodes.
 This is very different from rst3's write code.

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18073: * @file ../plugins/writers/markdown.py
-#@@first
 """The @auto write code for markdown."""
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position

--- a/leo/plugins/writers/org.py
+++ b/leo/plugins/writers/org.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18079: * @file ../plugins/writers/org.py
-#@@first
 """The @auto write code for Emacs org-mode (.org) files."""
 from typing import Callable
 from leo.core import leoGlobals as g  # Required.

--- a/leo/plugins/writers/otl.py
+++ b/leo/plugins/writers/otl.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18078: * @file ../plugins/writers/otl.py
-#@@first
 """The @auto write code for vimoutline (.otl) files."""
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position

--- a/leo/plugins/writers/treepad.py
+++ b/leo/plugins/writers/treepad.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20180202053206.1: * @file ../plugins/writers/treepad.py
-#@@first
 """The @auto write code for TreePad (.hjt) files."""
 from leo.core import leoGlobals as g
 from leo.core.leoNodes import Position

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210904022712.2: * @file ../unittests/commands/test_checkerCommands.py
-#@@first
 """Tests of leo.commands.leoCheckerCommands."""
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20211013081056.1: * @file ../unittests/commands/test_convertCommands.py
-#@@first
 """Tests of leo.commands.leoConvertCommands."""
 import os
 import re
@@ -35,8 +33,10 @@ class TestPythonToTypeScript(LeoUnitTest):
         # Set the gnx of the @file nodes in the contents to root.gnx.
         # This is necessary because of a check in fast_at.scan_lines.
         pat = re.compile(r'^\s*#\s?@\+node:([^:]+): \* @file leoNodes\.py$')
-        line3 = g.splitLines(contents)[2]
-        m = pat.match(line3)
+        # line 1: #@+leo-ver=5-thin
+        # line 2: #@+node:ekr.20031218072017.3320: * @file leoNodes.py
+        line2 = g.splitLines(contents)[1]
+        m = pat.match(line2)
         assert m, "Can not replace gnx"
         contents = contents.replace(m.group(1), root.gnx)
         # Replace c's outline with leoNodes.py.
@@ -260,36 +260,6 @@ class Test_To_Python(BaseTestImporter):
     """Test cases for commands using To_Python class."""
 
     #@+others
-    #@+node:ekr.20220824194104.1: *3*  TestTo_Python.setUp
-    # def setUp(self):
-        # super().setUp()
-        # c = self.c
-
-        ###
-            # self.assertTrue(hasattr(self.x, 'convert'))
-            # root = self.root_p
-            # # Delete all children
-            # root.deleteAllChildren()
-            # # Read leo.core.leoNodes into contents.
-            # unittest_dir = os.path.dirname(__file__)
-            # core_dir = os.path.abspath(os.path.join(unittest_dir, '..', '..', 'core'))
-            # path = os.path.join(core_dir, 'leoNodes.py')
-            # with open(path) as f:
-                # contents = f.read()
-            # # Set the gnx of the @file nodes in the contents to root.gnx.
-            # # This is necessary because of a check in fast_at.scan_lines.
-            # pat = re.compile(r'^\s*#@\+node:([^:]+): \* @file leoNodes\.py$')
-            # line3 = g.splitLines(contents)[2]
-            # m = pat.match(line3)
-            # assert m, "Can not replace gnx"
-            # contents = contents.replace(m.group(1), root.gnx)
-            # # Replace c's outline with leoNodes.py.
-            # gnx2vnode = {}
-            # ok = c.atFileCommands.fast_read_into_root(c, contents, gnx2vnode, path, root)
-            # self.assertTrue(ok)
-            # root.h = 'leoNodes.py'
-            # self.p = root
-            # c.selectPosition(self.p)
     #@+node:ekr.20220824193932.1: *3* test_c_to_python
     def test_c_to_python(self):
 

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20201202144422.1: * @file ../unittests/commands/test_editCommands.py
-#@@first
 """Tests for leo.commands.editCommands."""
 import textwrap
 from leo.core import leoGlobals as g

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20221113062857.1: * @file ../unittests/commands/test_outlineCommands.py
-#@@first
 """
 New unit tests for Leo's outline commands.
 

--- a/leo/unittests/core/test_leoApp.py
+++ b/leo/unittests/core/test_leoApp.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210901170451.1: * @file ../unittests/core/test_leoApp.py
-#@@first
 """Tests of leoApp.py"""
 import os
 import zipfile

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210902073413.1: * @file ../unittests/core/test_leoAst.py
-#@@first
 """Tests of leoAst.py"""
 #@+<< test_leoAst imports >>
 #@+node:ekr.20210902074548.1: ** << test_leoAst imports >>

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210901172411.1: * @file ../unittests/core/test_leoAtFile.py
-#@@first
 """Tests of leoAtFile.py"""
 import os
 import tempfile
@@ -801,10 +799,8 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101050923.1: *4* << define contents >> (test_at_section_delim)
         # The contents of a personal test file, slightly altered.
         contents = textwrap.dedent(f'''\
-        # -*- coding: utf-8 -*-
         #AT+leo-ver=5-thin
         #AT+node:{root.gnx}: * {h}
-        #AT@first
 
         """Classes to read and write @file nodes."""
 

--- a/leo/unittests/core/test_leoBridge.py
+++ b/leo/unittests/core/test_leoBridge.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210903153138.1: * @file ../unittests/core/test_leoBridge.py
-#@@first
 """Tests of leoBridge.py"""
 
 import os

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210905151702.1: * @file ../unittests/core/test_leoColorizer.py
-#@@first
 """Tests of leoColorizer.py"""
 
 import textwrap

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210903162431.1: * @file ../unittests/core/test_leoCommands.py
-#@@first
 """Tests of leoCommands.py"""
 # pylint: disable=no-member
 import textwrap

--- a/leo/unittests/core/test_leoConfig.py
+++ b/leo/unittests/core/test_leoConfig.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210910073303.1: * @file ../unittests/core/test_leoConfig.py
-#@@first
 """Tests of leoConfig.py"""
 
 from leo.core import leoGlobals as g

--- a/leo/unittests/core/test_leoExternalFiles.py
+++ b/leo/unittests/core/test_leoExternalFiles.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210911052754.1: * @file ../unittests/core/test_leoExternalFiles.py
-#@@first
 """Tests of leoExternalFiles.py"""
 
 from leo.core import leoGlobals as g

--- a/leo/unittests/core/test_leoFileCommands.py
+++ b/leo/unittests/core/test_leoFileCommands.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210910065135.1: * @file ../unittests/core/test_leoFileCommands.py
-#@@first
 """
 Tests of leoFileCommands.py.
 

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210829124658.1: * @file ../unittests/core/test_leoFind.py
-#@@first
 """Tests for leo.core.leoFind"""
 
 import re

--- a/leo/unittests/core/test_leoFrame.py
+++ b/leo/unittests/core/test_leoFrame.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210903161742.1: * @file ../unittests/core/test_leoFrame.py
-#@@first
 """Tests of leoFrame.py"""
 
 from leo.core.leoTest2 import LeoUnitTest

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210902164946.1: * @file ../unittests/core/test_leoGlobals.py
-#@@first
 """Tests for leo.core.leoGlobals"""
 
 import os

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20220822082042.1: * @file ../unittests/core/test_leoImport.py
-#@@first
 """Tests of leoImport.py"""
 
 import io

--- a/leo/unittests/core/test_leoKeys.py
+++ b/leo/unittests/core/test_leoKeys.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210903155556.1: * @file ../unittests/core/test_leoKeys.py
-#@@first
 """Tests of leoKeys.py"""
 
 import string

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20201203042030.1: * @file ../unittests/core/test_leoNodes.py
-#@@first
 """Tests for leo.core.leoNodes"""
 
 # pylint has troubles finding Commands methods.

--- a/leo/unittests/core/test_leoPersistence.py
+++ b/leo/unittests/core/test_leoPersistence.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210908171733.1: * @file ../unittests/core/test_leoPersistence.py
-#@@first
 """Tests for leo.core.leoPersistence"""
 
 from leo.core import leoGlobals as g

--- a/leo/unittests/core/test_leoRst.py
+++ b/leo/unittests/core/test_leoRst.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210902055206.1: * @file ../unittests/core/test_leoRst.py
-#@@first
 """Tests of leo/core/leoRst.py"""
 
 import textwrap

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210902092024.1: * @file ../unittests/core/test_leoShadow.py
-#@@first
 """Tests of leoShadow.py"""
 
 import glob

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210906141410.1: * @file ../unittests/core/test_leoUndo.py
-#@@first
 """Tests of leoUndo.py"""
 
 import textwrap

--- a/leo/unittests/core/test_leoVim.py
+++ b/leo/unittests/core/test_leoVim.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210910072917.1: * @file ../unittests/core/test_leoVim.py
-#@@first
 """Tests of leoVim.py"""
 
 import textwrap

--- a/leo/unittests/test_doctests.py
+++ b/leo/unittests/test_doctests.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210926044012.1: * @file ../unittests/test_doctests.py
-#@@first
 """Run all doctests."""
 import doctest
 import glob

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210910084607.1: * @file ../unittests/test_gui.py
-#@@first
 """Tests of gui base classes"""
 #@+<< test_gui imports >>
 #@+node:ekr.20220911102700.1: ** << test_gui imports >>

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210904064440.2: * @file ../unittests/test_importers.py
-#@@first
 """Tests of leo/plugins/importers"""
 import glob
 import importlib

--- a/leo/unittests/test_plugins.py
+++ b/leo/unittests/test_plugins.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210907081548.1: * @file ../unittests/test_plugins.py
-#@@first
 """General tests of plugins."""
 
 import glob

--- a/leo/unittests/test_syntax.py
+++ b/leo/unittests/test_syntax.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20210901140718.1: * @file ../unittests/test_syntax.py
-#@@first
 """Syntax tests, including a check that Leo will continue to load!"""
 # pylint: disable=no-member
 import glob

--- a/leo/unittests/test_writers.py
+++ b/leo/unittests/test_writers.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:ekr.20220812224747.1: * @file ../unittests/test_writers.py
-#@@first
 """Tests of leo/plugins/writers"""
 import textwrap
 from leo.core.leoTest2 import LeoUnitTest

--- a/run_travis_unit_tests.py
+++ b/run_travis_unit_tests.py
@@ -1,6 +1,5 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20181009072707.1: * @file ../../run_travis_unit_tests.py
-# -*- coding: utf-8 -*-
 import os
 import sys
 import traceback

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 #@+leo-ver=5-thin
 #@+node:maphew.20180224170853.1: * @file ../../setup.py
-#@@first
 """
 setup.py for leo.
 


### PR DESCRIPTION
See #3049.

- [x] Remove all `# -*- coding:` lines.
   [Python's Unicode How-to](https://docs.python.org/3/howto/unicode.html#unicode-literals-in-python-source-code) states that utf-8 is the default encoding, so there is no need for encoding lines in Leo's sources.
- [x] Remove references to such lines in Leo's documentation.
- [x] Adjust `TestTo_Python.setUp` so all unit tests pass.