### PR TITLE
PR for #3096: fix find-all

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1648,7 +1648,7 @@ class LeoFind:
         c = self.c
         log = c.frame.log
         # Find the first position with the given vnode.
-        for p in c.all_positions():
+        for p in c.all_unique_positions():
             if p.v == v:
                 break
         else:

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1533,7 +1533,7 @@ class LeoFind:
         self.root = None
         self.node_only = self.suboutline_only = False
         return n
-    #@+node:ekr.20160422073500.1: *6* find._find_all_helper & helpers (test)
+    #@+node:ekr.20160422073500.1: *6* find._find_all_helper & helpers
     def _find_all_helper(self, settings: Settings) -> int:
         """
         Handle the find-all command from p to after.
@@ -1560,7 +1560,7 @@ class LeoFind:
         for v in vnodes:
             body, head = [], []
             if self.search_body:
-                body =self.find_all_matches_in_string(v.b)
+                body = self.find_all_matches_in_string(v.b)
                 number_of_matches += len(body)
             if self.search_headline:
                 head = self.find_all_matches_in_string(v.h)
@@ -1591,27 +1591,41 @@ class LeoFind:
         status = status.strip().lstrip('(').rstrip(')').strip()
         found.b = f"# {status}\n{result}"
         return found
-    #@+node:ekr.20230124103253.1: *7* find._make_result_from_matches (to do)
+    #@+node:ekr.20230124103253.1: *7* find.make_result_from_matches
     def make_result_from_matches(self, matches: List[Dict]) -> str:
 
-        both = self.search_headline and self.search_body
+        def index_to_line_info(index: int, s: str) -> Tuple[int, str]:
+            i, j = g.getLine(s, index)
+            line = s[i:j]
+            row, col = g.convertPythonIndexToRowCol(s, i)
+            return row + 1, line
 
         results: List[str] = []
         for d in matches:
-            if both:
-                pass
-            else:
-                pass
+            body, head, v = d['body'], d['head'], d['v']
+            if head:
+                results.append(f"head: found {len(head)} match: {v.h}")
+            if body:
+                results.append(f"body: found {len(body)} match{g.plural(len(body))}")
+                for i in body:
+                    n, line = index_to_line_info(i, v.b)
+                    line_col_s = f"line {n}, col {i}"
+                    results.append(f"{line_col_s:>20}: {line.rstrip()}")
+                    self.put_link(line, n, v)
         return ''.join(results)
     #@+node:ekr.20230124102225.1: *7* find.put_link
-    def put_link(self, line: str, line_number: int, p: Position) -> None:  # pragma: no cover  # #2023
-        """Put a link to the given line at the given line_number in p.h."""
-        if g.unitTesting:
+    def put_link(self, line: str, line_number: int, v: VNode) -> None:  # pragma: no cover  # #2023
+        """Put a link to the given line at the given line_number in v.h."""
+        c = self.c
+        log = c.frame.log
+        # Find the first position with the given vnode.
+        for p in c.all_positions():
+            if p.v == v:
+                break
+        else:
+            g.trace(f"Can not happen: no position for {v}")
             return
-        log = self.c.frame.log
         unl = p.get_UNL()
-        if self.in_headline:
-            line_number = 1
         log.put(line.strip() + '\n', nodeLink=f"{unl}::{line_number}")  # Local line.
     #@+node:ekr.20230124101551.1: *7* find.find_all_matches_in_string & helpers
     def find_all_matches_in_string(self, s: str) -> List[int]:
@@ -1627,7 +1641,7 @@ class LeoFind:
             s = s.replace('\r', '')
         if not s.strip():
             return []
-        find_s= self.replace_back_slashes(self.find_text)
+        find_s = self.replace_back_slashes(self.find_text)
         f = self.find_all_regex if self.pattern_match else self.find_all_plain
         return f(find_s, s)
     #@+node:ekr.20230124130028.2: *8* find.find_all_plain

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1658,7 +1658,7 @@ class LeoFind:
         flags = re.MULTILINE
         if self.ignore_case:
             flags |= re.IGNORECASE
-        return [m.start() for m in re.finditer(self.find_text, s, flags)]
+        return [m.start() for m in re.finditer(find_s, s, flags)]
     #@+node:ekr.20171226140643.1: *4* find.find-all-unique-regex
     @cmd('find-all-unique-regex')
     def interactive_find_all_unique_regex(self, event: Event = None) -> None:  # pragma: no cover (interactive)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1606,7 +1606,7 @@ class LeoFind:
         c = self.c
         found = c.lastTopLevel().insertAfter()
         assert found
-        found.h = f"Found All:{self.find_text}"
+        found.h = f"find-all:{self.find_text}"
         status = self.compute_result_status(find_all_flag=True)
         status = status.strip().lstrip('(').rstrip(')').strip()
         found.b = f"@nosearch\n# {status}\n{result}"

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -11,8 +11,13 @@ rem call python -m unittest leo.unittests.core.test_leoAst.TestFstringify
 rem echo test-one-leo: test_leoAst.TestOrange
 rem call python -m unittest leo.unittests.core.test_leoAst.TestOrange
 
-echo test-one-leo: test_importers.TestHtml.test_structure
-call python -m unittest leo.unittests.test_importers.TestHtml.test_structure
+rem echo test-one-leo: test_importers.TestHtml.test_structure
+rem call python -m unittest leo.unittests.test_importers.TestHtml.test_structure
+
+echo test-one-leo: test_leoFind.TestFind.test_find_all
+call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_all
+
+
 
 
 

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -14,8 +14,15 @@ rem call python -m unittest leo.unittests.core.test_leoAst.TestOrange
 rem echo test-one-leo: test_importers.TestHtml.test_structure
 rem call python -m unittest leo.unittests.test_importers.TestHtml.test_structure
 
-echo test-one-leo: test_leoFind.TestFind.test_find_all
-call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_all
+rem echo test-one-leo: test_leoFind.TestFind.test_find_all
+rem call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_all
+
+REM  echo test-one-leo: test_leoFind.TestFind.test_find_all_regex
+REM  call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_all_regex
+
+echo test-one-leo: test_leoFind.TestFind
+call python -m unittest leo.unittests.core.test_leoFind.TestFind
+
 
 
 

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -71,7 +71,7 @@ class TestFind(LeoUnitTest):
         # Always start with the root selected.
         c.selectPosition(c.rootPosition())
     #@+node:ekr.20210110073117.59: *3* Tests of Commands...
-    #@+node:ekr.20210110073117.67: *4* TestFind.change-all
+    #@+node:ekr.20210110073117.67: *4* TestFind.test_change-all
     def test_change_all(self):
         c, settings, x = self.c, self.settings, self.x
         root = c.rootPosition()
@@ -136,7 +136,7 @@ class TestFind(LeoUnitTest):
         root.h = '@file xyzzy'
         settings.find_text = settings.change_text = 'child1'
         x.do_change_all(settings)
-    #@+node:ekr.20210220091434.1: *4* TestFind.change-all (@file node)
+    #@+node:ekr.20210220091434.1: *4* TestFind.test_change-all (@file node)
     def test_change_all_with_at_file_node(self):
         c, settings, x = self.c, self.settings, self.x
         root = c.rootPosition().next()  # Must have children.
@@ -154,7 +154,7 @@ class TestFind(LeoUnitTest):
         x.do_change_all(settings)
         assert root.v.isDirty(), root.h
 
-    #@+node:ekr.20210220091434.2: *4* TestFind.change-all (headline)
+    #@+node:ekr.20210220091434.2: *4* TestFind.test_change-all (headline)
     def test_change_all_headline(self):
         settings, x = self.settings, self.x
         settings.find_text = 'child'
@@ -165,7 +165,7 @@ class TestFind(LeoUnitTest):
         settings.pattern_match = False
         settings.suboutline_only = False
         x.do_change_all(settings)
-    #@+node:ekr.20210110073117.60: *4* TestFind.clone-find-all
+    #@+node:ekr.20210110073117.60: *4* TestFind.test_clone-find-all
     def test_clone_find_all(self):
         settings, x = self.settings, self.x
         # Regex find.
@@ -181,7 +181,7 @@ class TestFind(LeoUnitTest):
         # Suboutline only.
         settings.suboutline_only = True
         x.do_clone_find_all(settings)
-    #@+node:ekr.20210110073117.61: *4* TestFind.clone-find-all-flattened
+    #@+node:ekr.20210110073117.61: *4* TestFind.test_clone-find-all-flattened
     def test_clone_find_all_flattened(self):
         settings, x = self.settings, self.x
         # regex find.
@@ -196,7 +196,7 @@ class TestFind(LeoUnitTest):
         # Suboutline only.
         settings.suboutline_only = True
         x.do_clone_find_all_flattened(settings)
-    #@+node:ekr.20210617072622.1: *4* TestFind.clone-find-marked
+    #@+node:ekr.20210617072622.1: *4* TestFind.test_clone-find-marked
     def test_clone_find_marked(self):
         c, x = self.c, self.x
         root = c.rootPosition()
@@ -204,7 +204,7 @@ class TestFind(LeoUnitTest):
         x.cloneFindAllMarked()
         x.cloneFindAllFlattenedMarked()
         root.setMarked()
-    #@+node:ekr.20210615084049.1: *4* TestFind.clone-find-parents
+    #@+node:ekr.20210615084049.1: *4* TestFind.test_clone-find-parents
     def test_clone_find_parents(self):
 
         c, x = self.c, self.x
@@ -214,7 +214,7 @@ class TestFind(LeoUnitTest):
         c.selectPosition(p)
         x.cloneFindParents()
 
-    #@+node:ekr.20210110073117.62: *4* TestFind.clone-find-tag
+    #@+node:ekr.20210110073117.62: *4* TestFind.test_clone-find-tag
     def test_clone_find_tag(self):
         c, x = self.c, self.x
 
@@ -235,7 +235,7 @@ class TestFind(LeoUnitTest):
         x.do_clone_find_tag('test')
         c.theTagController = None
         x.do_clone_find_tag('test')
-    #@+node:ekr.20210110073117.63: *4* TestFind.find-all
+    #@+node:ekr.20210110073117.63: *4* TestFind.test_find-all
     def test_find_all(self):
         settings, x = self.settings, self.x
 
@@ -260,16 +260,23 @@ class TestFind(LeoUnitTest):
                 g.printObj(g.splitLines(p.b), tag=f"node {i}: {p.h}")
 
         # Test 1.
-        for find_text, pattern_match, expected_count in (
-            ('def', False, 7),
-            ('bla', False, 6),
+        for aTuple in (
+            ('settings', (True, False, False)),
+            ('def', 7),
+            ('bla', 40),
         ):
-            init()
-            self.assertTrue(self.c, self.c.rootPosition())
-            settings.find_text = find_text
-            settings.pattern_match = pattern_match
-            count = x.do_find_all(settings)
-            self.assertEqual(count, expected_count, msg=find_text)
+            if aTuple[0] == 'settings':
+                case, regex, word = aTuple[1]
+            else:
+                find_text, expected_count = aTuple
+                init()
+                settings.find_text = find_text
+                settings.ignore_case = case
+                settings.pattern_match = regex
+                settings.whole_word = word
+                self.assertTrue(self.c, self.c.rootPosition())
+                count = x.do_find_all(settings)
+                self.assertEqual(count, expected_count, msg=find_text)
             
         ### return
 
@@ -294,7 +301,7 @@ class TestFind(LeoUnitTest):
         settings.find_text = 'not-found-xyzzy'
         x.do_find_all(settings)
 
-    #@+node:ekr.20210110073117.65: *4* TestFind.find-def
+    #@+node:ekr.20210110073117.65: *4* TestFind.test_find-def
     def test_find_def(self):
         settings, x = self.settings, self.x
         # Test methods called by x.find_def.
@@ -318,7 +325,7 @@ class TestFind(LeoUnitTest):
             # Test 3: not found after switching style.
             p, pos, newpos = x.do_find_def(settings, word='xyzzy', strict=False)
             assert p is None, repr(p)
-    #@+node:ekr.20210110073117.64: *4* TestFind.find-next
+    #@+node:ekr.20210110073117.64: *4* TestFind.test_find-next
     def test_find_next(self):
         settings, x = self.settings, self.x
         settings.find_text = 'def top1'
@@ -327,7 +334,7 @@ class TestFind(LeoUnitTest):
         self.assertEqual(p.h, 'Node 1')
         s = p.b[pos:newpos]
         self.assertEqual(s, settings.find_text)
-    #@+node:ekr.20220525100840.1: *4* TestFind.find-next (file-only)
+    #@+node:ekr.20220525100840.1: *4* TestFind.test_find-next (file-only)
     def test_find_next_file_only(self):
         settings, x = self.settings, self.x
         settings.file_only = True  # init_ivars_from_settings will set the ivar.
@@ -337,7 +344,7 @@ class TestFind(LeoUnitTest):
         self.assertEqual(p.h, '@file test.py')
         s = p.b[pos:newpos]
         self.assertEqual(s, settings.find_text)
-    #@+node:ekr.20210220072631.1: *4* TestFind.find-next (suboutline-only)
+    #@+node:ekr.20210220072631.1: *4* TestFind.test_find-next (suboutline-only)
     def test_find_next_suboutline_only(self):
         settings, x = self.settings, self.x
         settings.find_text = 'def root()'
@@ -347,7 +354,7 @@ class TestFind(LeoUnitTest):
         self.assertEqual(p.h, '@file test.py')
         s = p.b[pos:newpos]
         self.assertEqual(s, settings.find_text)
-    #@+node:ekr.20210924032146.1: *4* TestFind.change-then-find (headline)
+    #@+node:ekr.20210924032146.1: *4* TestFind.test_change-then-find (headline)
     def test_change_then_find_in_headline(self):
         # Test #2220:
         # https://github.com/leo-editor/leo-editor/issues/2220
@@ -373,7 +380,7 @@ class TestFind(LeoUnitTest):
         p = c.p
         self.assertEqual(p, test_p)
         self.assertEqual(p.h, 'XX1 Test2 Test3')
-    #@+node:ekr.20210216094444.1: *4* TestFind.find-prev
+    #@+node:ekr.20210216094444.1: *4* TestFind.test_find-prev
     def test_find_prev(self):
         c, settings, x = self.c, self.settings, self.x
         settings.find_text = 'def top1'
@@ -389,7 +396,7 @@ class TestFind(LeoUnitTest):
         self.assertEqual(p.h, 'child 2')
         s = p.b[pos:newpos]
         self.assertEqual(s, settings.find_text)
-    #@+node:ekr.20210110073117.66: *4* TestFind.find-var
+    #@+node:ekr.20210110073117.66: *4* TestFind.test_find-var
     def test_find_var(self):
         settings, x = self.settings, self.x
         p, pos, newpos = x.do_find_var(settings, word='v5')
@@ -397,7 +404,7 @@ class TestFind(LeoUnitTest):
         self.assertEqual(p.h, 'child 5')
         s = p.b[pos:newpos]
         self.assertEqual(s, 'v5 =')
-    #@+node:ekr.20210110073117.68: *4* TestFind.replace-then-find
+    #@+node:ekr.20210110073117.68: *4* TestFind.test_replace-then-find
     def test_replace_then_find(self):
         settings, w, x = self.settings, self.c.frame.body.wrapper, self.x
         settings.find_text = 'def top1'
@@ -442,7 +449,7 @@ class TestFind(LeoUnitTest):
         assert w
         s = p.h[pos:newpos]
         self.assertEqual(s, settings.find_text)
-    #@+node:ekr.20210110073117.69: *4* TestFind.tag-children
+    #@+node:ekr.20210110073117.69: *4* TestFind.test_tag-children
     def test_tag_children(self):
 
         c, x = self.c, self.x
@@ -516,7 +523,7 @@ class TestFind(LeoUnitTest):
             settings=settings)
         assert n > 0
 
-    #@+node:ekr.20210110073117.58: *4* TestFind.test_tree
+    #@+node:ekr.20210110073117.58: *4* TestFind.test_test_tree
     def test_tree(self):
         c = self.c
         table = (

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -275,7 +275,8 @@ class TestFind(LeoUnitTest):
                 settings.pattern_match = regex
                 settings.whole_word = word
                 self.assertTrue(self.c, self.c.rootPosition())
-                count = x.do_find_all(settings)
+                result_dict = x.do_find_all(settings)
+                count = result_dict['total_matches']
                 self.assertEqual(count, expected_count, msg=find_text)
 
         ### return

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -26,7 +26,7 @@ class TestFind(LeoUnitTest):
     def make_test_tree(self):
         """Make a test tree for other tests"""
         c = self.c
-        
+
         # 2023/01/24: Remove any previous tree.
         root = c.rootPosition()
         while root.hasChildren():
@@ -250,7 +250,7 @@ class TestFind(LeoUnitTest):
             settings.pattern_match = False
             settings.suboutline_only = False
             settings.whole_word = True
-            
+
         # Debugging.
         if 0:
             init()
@@ -277,7 +277,7 @@ class TestFind(LeoUnitTest):
                 self.assertTrue(self.c, self.c.rootPosition())
                 count = x.do_find_all(settings)
                 self.assertEqual(count, expected_count, msg=find_text)
-            
+
         ### return
 
         # Test 2.
@@ -676,7 +676,7 @@ class TestFind(LeoUnitTest):
             ('axA',     'a',    [0, 2]),
             ('aAa',     'A',    [0, 1, 2]),
             ('ABbabc',  'b',    [1, 2, 4]),
-            
+
             (True, True),
             ('ax aba ab abc'    'ab', [7]),
             ('ax aba\nab abc'   'ab', [7]),

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -653,6 +653,51 @@ class TestFind(LeoUnitTest):
         partial_settings.wrapping = True
         x.init_ivars_from_settings(partial_settings)
         x.compute_result_status(find_all_flag=False)
+    #@+node:ekr.20230124162455.1: *4* TestFind.test_find_all_plain
+    #@@nobeautify
+    def test_find_all_plain(self):
+        c = self.c
+        fc = c.findCommands
+        table = (
+            (False, False),
+            # s         find    expected
+            ('aA',      'a',    [0]),
+            ('aAa',     'A',    [1]),
+            ('AAbabc',  'b',    [2, 4]),
+
+            (True, False),
+            ('axA',     'a',    [0, 2]),
+            ('aAa',     'A',    [0, 1, 2]),
+            ('ABbabc',  'b',    [1, 2, 4]),
+            
+            (True, True),
+            ('ax aba ab abc'    'ab', [7]),
+            ('ax aba\nab abc'   'ab', [7]),
+            ('ax aba ab\babc'   'ab', [7]),
+        )
+        for aTuple in table:
+            if len(aTuple) == 2:
+                fc.ignore_case, fc.whole_word = aTuple
+            else:
+                s, find, expected = aTuple
+                aList = fc.find_all_plain(find, s)
+                self.assertEqual(aList, expected, msg=s)
+    #@+node:ekr.20230124162609.1: *4* TestFind.test_find_all_regex
+    #@@nobeautify
+    def test_find_all_regex(self):
+        c = self.c
+        fc = c.findCommands
+        regex_table = (
+            # s                  find        expected
+            ('a ba aa a ab a',   r'\b\w+\b', [0, 2, 5, 8, 10, 13]),
+            ('a AA aa aab ab a', r'\baa\b',  [5]),
+            # Multi-line
+            ('aaa AA\naa aab',   r'\baa\b',  [7]),
+        )
+        for s, find, expected in regex_table:
+            fc.ignore_case = False
+            aList = fc.find_all_regex(find, s)
+            self.assertEqual(aList, expected, msg=s)
     #@+node:ekr.20210829203927.12: *4* TestFind.test_inner_search_backward
     def test_inner_search_backward(self):
         c = self.c


### PR DESCRIPTION
See #3096.

- [x] Fix bug in testing infrastructure: remove old test nodes in `TestFind.make_test_tree`.
- [x] Add new tests to `TestFind.test_find_all`.
- [x] Rewrite `find._find_all_helper`.
- [x] 'find-all' returns a description dict, including stats and an inner dict describing matches in detail.
- [x] Improve report in the created `find-all` node.
- [x] Remove the "unique node" logic. The new report probably renders that moot.
  
**Acknowledgement**

This PR owes much to Vitalije.
Years ago now he suggested that sometimes it is better to duplicate code rather than trying to reuse code.
This suggestion/pattern applies here. Replacing faux-helpers with separate code simplified everything.