### PR TITLE
PR for #3079: improve html importer

### DIFF
--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -179,20 +179,26 @@ class LeoUnitTest(unittest.TestCase):
             print(tag)
         g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
     #@+node:ekr.20220805071838.1: *3* LeoUnitTest.dump_headlines
-    def dump_headlines(self, root: Position, tag: str = None) -> None:  # pragma: no cover
-        """Dump root's tree just as as Importer.dump_tree."""
+    def dump_headlines(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
+        """
+        Dump root's headlines, or all headlines if root is None.
+        """
         print('')
         if tag:
             print(tag)
-        for p in root.self_and_subtree():
+        _iter = root.self_and_subtree if root else self.c.all_positions
+        for p in _iter():
             print('level:', p.level(), p.h)
     #@+node:ekr.20211129062220.1: *3* LeoUnitTest.dump_tree
-    def dump_tree(self, root: Position, tag: str = None) -> None:  # pragma: no cover
-        """Dump root's tree just as as Importer.dump_tree."""
+    def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
+        """
+        Dump root's tree, or the entire tree if root is None.
+        """
         print('')
         if tag:
             print(tag)
-        for p in root.self_and_subtree():
+        _iter = root.self_and_subtree if root else self.c.all_positions
+        for p in _iter():
             print('')
             print('level:', p.level(), p.h)
             g.printObj(g.splitLines(p.v.b))

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -127,6 +127,9 @@ class Importer:
         if not ws_ok:
             lines = self.regularize_whitespace(lines)
 
+        # A hook for xml importer: preprocess lines.
+        lines = self.preprocess_lines(lines)
+
         # New: just call gen_lines.
         self.gen_lines(lines, parent)
 
@@ -134,6 +137,14 @@ class Importer:
         # #1451: Do not change the outline's change status.
         for p in root.self_and_subtree():
             p.clearDirty()
+    #@+node:ekr.20230126034143.1: *4* i.preprocess_lines
+    def preprocess_lines(self, lines: List[str]) -> List[str]:
+        """
+        A hook for the xml/html importers.
+
+        These importers ensure that closing tags are followed by a newline.
+        """
+        return lines
     #@+node:ekr.20161108131153.14: *4* i.regularize_whitespace
     def regularize_whitespace(self, lines: List[str]) -> List[str]:  # pragma: no cover (missing test)
         """

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -78,7 +78,7 @@ class Xml_Importer(Importer):
             tag_name3 = m3 and m3.group(1) or ''
             # Separate the elements only if their tag names are different and the second tag is an open tag.
             # make_sub = tag_name2 != tag_name3 and not m.group(3).startswith('</')
-            
+
             # *Don't* separate tags if the tags open and close the same element.
             make_sub = not (
                 tag_name2 == tag_name3

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -85,7 +85,7 @@ class Xml_Importer(Importer):
                 and not m.group(2).startswith('</')
                 and m.group(3).startswith('</')
             )
-            if True and make_sub:  ###
+            if False and make_sub:  ###
                 print('')
                 g.trace(m.group(2), m.group(3))
                 g.trace(repr(tag_name2), repr(tag_name3))

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -76,11 +76,16 @@ class Xml_Importer(Importer):
             m3 = self.tag_name_pat.match(m.group(3))
             tag_name2 = m2 and m2.group(1) or ''
             tag_name3 = m3 and m3.group(1) or ''
-            # Separate the elements only if:
-            # - their tag names are different and
-            # - The second tag is an open tag.
-            make_sub = tag_name2 != tag_name3 and not m.group(3).startswith('</')
-            if False and make_sub:  ###
+            # Separate the elements only if their tag names are different and the second tag is an open tag.
+            # make_sub = tag_name2 != tag_name3 and not m.group(3).startswith('</')
+            
+            # *Don't* separate tags if the tags open and close the same element.
+            make_sub = not (
+                tag_name2 == tag_name3
+                and not m.group(2).startswith('</')
+                and m.group(3).startswith('</')
+            )
+            if True and make_sub:  ###
                 print('')
                 g.trace(m.group(2), m.group(3))
                 g.trace(repr(tag_name2), repr(tag_name3))

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -56,6 +56,26 @@ class Xml_Importer(Importer):
         if this_state.level > prev_state.level:
             return i + 1
         return None
+    #@+node:ekr.20230126034427.1: *3* xml.preprocess_lines
+    # Match an end tag followed by an open tag.
+    adjacent_tags_pat = re.compile(r'^(.*?</.*?>)\s*(<[^/!].*?>.*)$')
+
+    def preprocess_lines(self, lines: List[str]) -> List[str]:
+        """
+        Xml_Importer.preprocess_lines.
+
+        Ensure that closing tags are followed by a newline.
+        """
+        result_lines = []
+        for i, line in enumerate(lines):
+            m = self.adjacent_tags_pat.match(line)
+            if m:
+                # print(f"preprocess {i:<4}: {line.rstrip()}")
+                result_lines.append(m.group(1).rstrip() + '\n')
+                result_lines.append(m.group(2).rstrip() + '\n')
+            else:
+                result_lines.append(line)
+        return result_lines
     #@+node:ekr.20220815111538.1: *3* xml_i.update_level
     ch_pattern = re.compile(r'([\!\?]?[\w\_\.\:\-]+)', re.UNICODE)
 

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -44,9 +44,9 @@ class Xml_Importer(Importer):
     #@+node:ekr.20220801082146.1: *3* xml_i.new_starts_block
     def new_starts_block(self, i: int) -> Optional[int]:
         """
-        Return None if lines[i] does not start a class, function or method.
+        Return None if lines[i] does not start a tag.
 
-        Otherwise, return the index of the first line of the body.
+        Otherwise, return the index of the first line tag.
         """
         lines, states = self.lines, self.line_states
         prev_state = states[i - 1] if i > 0 else self.state_class()

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -72,25 +72,21 @@ class Xml_Importer(Importer):
         """
 
         def repl(m: re.Match) -> str:
+            """
+                Split lines, adding leading whitespace to the second line.
+                *Don't* separate tags if the tags open and close the same element.
+            """
             m2 = self.tag_name_pat.match(m.group(2))
             m3 = self.tag_name_pat.match(m.group(3))
             tag_name2 = m2 and m2.group(1) or ''
             tag_name3 = m3 and m3.group(1) or ''
-            # Separate the elements only if their tag names are different and the second tag is an open tag.
-            # make_sub = tag_name2 != tag_name3 and not m.group(3).startswith('</')
-
-            # *Don't* separate tags if the tags open and close the same element.
-            make_sub = not (
+            same_element = (
                 tag_name2 == tag_name3
                 and not m.group(2).startswith('</')
                 and m.group(3).startswith('</')
             )
-            if False and make_sub:  ###
-                print('')
-                g.trace(m.group(2), m.group(3))
-                g.trace(repr(tag_name2), repr(tag_name3))
             lws = g.get_leading_ws(m.group(1))
-            sep = '\n' + lws if make_sub else ''
+            sep = '' if same_element else '\n' + lws
             return m.group(1) + m.group(2).rstrip() + sep + m.group(3)
 
         result_lines = []

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -5,9 +5,8 @@ cd c:\Repos\leo-editor
 rem echo test-one-leo: test_leoFind.TestFind
 rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
 
-echo test-one-leo: TestHtml.test_slideshow_slide
-rem call python -m unittest leo.unittests.test_importers.TestXML.test_xml_1
-call python -m unittest leo.unittests.test_importers.TestHtml.test_slideshow_slide
+echo test-one-leo: TestHtml.test_brython
+call python -m unittest leo.unittests.test_importers.TestHtml.test_brython
 
 
 

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -7,7 +7,7 @@ rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
 
 echo test-one-leo: TestHtml.test_slideshow_slide
 rem call python -m unittest leo.unittests.test_importers.TestXML.test_xml_1
-call python -m unittest leo.unittests.test_importers.TestHtml.test_multiple_tags_on_a_line
+call python -m unittest leo.unittests.test_importers.TestHtml.test_slideshow_slide
 
 
 

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -2,26 +2,14 @@ echo off
 cls
 cd c:\Repos\leo-editor
 
-rem echo test-one-leo: TestPlugins.test_cursesGui2
-rem call python -m unittest leo.unittests.test_plugins.TestPlugins.test_cursesGui2 %*
+rem echo test-one-leo: test_leoFind.TestFind
+rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
 
-rem echo test-one-leo: test_leoAst.TestFstringify
-rem call python -m unittest leo.unittests.core.test_leoAst.TestFstringify
+echo test-one-leo: TestHtml.test_slideshow_slide
+call python -m unittest leo.unittests.test_importers.TestHtml.test_slideshow_slide
 
-rem echo test-one-leo: test_leoAst.TestOrange
-rem call python -m unittest leo.unittests.core.test_leoAst.TestOrange
 
-rem echo test-one-leo: test_importers.TestHtml.test_structure
-rem call python -m unittest leo.unittests.test_importers.TestHtml.test_structure
 
-rem echo test-one-leo: test_leoFind.TestFind.test_find_all
-rem call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_all
-
-REM  echo test-one-leo: test_leoFind.TestFind.test_find_all_regex
-REM  call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_all_regex
-
-echo test-one-leo: test_leoFind.TestFind
-call python -m unittest leo.unittests.core.test_leoFind.TestFind
 
 
 

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -6,8 +6,8 @@ rem echo test-one-leo: test_leoFind.TestFind
 rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
 
 echo test-one-leo: TestHtml.test_slideshow_slide
-call python -m unittest leo.unittests.test_importers.TestHtml.test_multple_node_completed_on_a_line
-
+rem call python -m unittest leo.unittests.test_importers.TestXML.test_xml_1
+call python -m unittest leo.unittests.test_importers.TestHtml.test_multiple_tags_on_a_line
 
 
 

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -6,7 +6,7 @@ rem echo test-one-leo: test_leoFind.TestFind
 rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
 
 echo test-one-leo: TestHtml.test_slideshow_slide
-call python -m unittest leo.unittests.test_importers.TestHtml.test_slideshow_slide
+call python -m unittest leo.unittests.test_importers.TestHtml.test_multple_node_completed_on_a_line
 
 
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -925,6 +925,8 @@ class TestHtml(BaseTestImporter):
     def test_brython(self):
 
         # https://github.com/leo-editor/leo-editor/issues/479
+        #@+<< define s >>
+        #@+node:ekr.20230126081859.1: *4* << define s >>
         s = '''
             <!DOCTYPE html>
             <html>
@@ -1063,8 +1065,11 @@ class TestHtml(BaseTestImporter):
             </body>
             </html>
         '''
+        #@-<< define s >>
         p = self.run_test(s)
         self.check_outline(p, (
+            #@+<< define comparison tuples >>
+            #@+node:ekr.20230126082712.1: *4* << define comparison tuples >>
             (0, '',  # check_outline ignores the first headline.
                     '<!DOCTYPE html>\n'
                     '@others\n'
@@ -1214,6 +1219,7 @@ class TestHtml(BaseTestImporter):
                     '</html>\n'
                     '\n'
             ),
+            #@-<< define comparison tuples >>
         ))
     #@+node:ekr.20210904065459.25: *3* TestHtml.test_improperly_nested_tags
     def test_improperly_nested_tags(self):
@@ -1454,7 +1460,8 @@ class TestHtml(BaseTestImporter):
         # Don't run the standard round-trip test.
         p = self.run_test(s, check_flag=False)
 
-        # xml.preprocess_lines should insert two newlines.
+        # xml.preprocess_lines inserts several newlines.
+        # Modify the expected result accordingly.
         expected_s = (s
             .replace('Form 25 Filings</a></td>\n', 'Form 25 Filings</a>\n</td>\n')
             .replace('</tr><tr>\n', '</tr>\n<tr>\n')
@@ -1475,6 +1482,8 @@ class TestHtml(BaseTestImporter):
             <html><head>headline</head><body>body</body></html>
         """
 
+        # xml.preprocess_lines inserts several newlines.
+        # Modify the expected result accordingly.
         expected_s = textwrap.dedent("""\
             <!-- tags that start nodes: html,body,head,div,table,nodeA,nodeB -->
             <html>
@@ -1672,12 +1681,13 @@ class TestHtml(BaseTestImporter):
         # Don't run the standard round-trip test.
         p = self.run_test(s, check_flag=False)
 
-        # xml.preprocess_lines should insert a newline.
+        # xml.preprocess_lines inserts several newlines.
+        # Modify the expected result accordingly.
         expected_s = (s
             .replace('</head><body>', '</head>\n<body>')
             .replace('><meta', '>\n<meta')
             .replace('index</a></li>', 'index</a>\n</li>')
-            # .replace('"><a', '">\n<a')  # Too many matches.
+            # .replace('"><a', '">\n<a')  # This replacement would affect too many lines.
             .replace('m-0"><a', 'm-0">\n<a')
             .replace('m-1"><a', 'm-1">\n<a')
             .replace('item-2"><a', 'item-2">\n<a')

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1649,8 +1649,7 @@ class TestHtml(BaseTestImporter):
                   <a href="slide-003.html" title="Editing headlines"
                      >next</a> |</li>
                 <li class="right" >
-                  <a href="basics.html" title="Leoâ€™s Basics"
-                     >previous</a> |</li>
+                  <a href="basics.html" title="Leoâ€™s Basics">previous</a> |</li>
                 <li class="nav-item nav-item-0"><a href="../../leo_toc.html">Leo 6.7.2 documentation</a> &#187;</li>
                   <li class="nav-item nav-item-1"><a href="../../toc-more-links.html" >More Leo Links</a> &#187;</li>
                   <li class="nav-item nav-item-2"><a href="../../slides.html" >Slides</a> &#187;</li>
@@ -1672,7 +1671,21 @@ class TestHtml(BaseTestImporter):
         p = self.run_test(s, check_flag=False)
 
         # xml.preprocess_lines should insert a newline.
-        expected_s = s.replace('</head><body>', '</head>\n<body>')
+        expected_s = (s
+            .replace('</head><body>', '</head>\n<body>')
+            .replace('><meta', '>\n<meta')
+            .replace('index</a></li>', 'index</a>\n</li>')
+            # .replace('"><a', '">\n<a')  # Too many matches.
+            .replace('m-0"><a', 'm-0">\n<a')
+            .replace('m-1"><a', 'm-1">\n<a')
+            .replace('item-2"><a', 'item-2">\n<a')
+            .replace('m-3"><a', 'm-3">\n<a')
+            .replace('nav-item-this"><a', 'nav-item-this">\n<a')
+            .replace('<p class="logo"><a', '<p class="logo">\n<a')
+            .replace('</a></li>', '</a>\n</li>')
+            .replace('<p><strong>', '<p>\n<strong>')
+            .replace('</a></p>', '</a>\n</p>')
+        )
         self.check_round_trip(p, expected_s)
 
         # This dump now looks good!

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1557,7 +1557,7 @@ class TestHtml(BaseTestImporter):
     #@+node:ekr.20230126023536.1: *3* TestHtml.test_slideshow_slide
     def test_slideshow_slide(self):
 
-        # s is the contents of slides/basics/slide-002.html 
+        # s is the contents of slides/basics/slide-002.html
         #@+<< define s >>
         #@+node:ekr.20230126031120.1: *4* << define s >>
         s = '''\
@@ -1572,20 +1572,22 @@ class TestHtml(BaseTestImporter):
             <link rel="stylesheet" type="text/css" href="../../_static/pygments.css" />
             <link rel="stylesheet" type="text/css" href="../../_static/classic.css" />
             <link rel="stylesheet" type="text/css" href="../../_static/custom.css" />
-            
+
             <script data-url_root="../../" id="documentation_options" src="../../_static/documentation_options.js"></script>
             <script src="../../_static/doctools.js"></script>
             <script src="../../_static/sphinx_highlight.js"></script>
-            
+
             <script src="../../_static/sidebar.js"></script>
-            
+
             <link rel="index" title="Index" href="../../genindex.html" />
             <link rel="search" title="Search" href="../../search.html" />
             <link rel="next" title="Editing headlines" href="slide-003.html" />
-            <link rel="prev" title="Leoâ€™s Basics" href="basics.html" /> 
-          </head>
-          <!-- EKR: Inserted newline here -->
-          <body>
+            <link rel="prev" title="Leoâ€™s Basics" href="basics.html" />
+          <!--
+            EKR: Xml_Importer.preprocess_lines should insert put </head> and <body> on separate lines.
+            As with this comment, there is a risk that preprocessing might affect comments...
+          -->
+          </head><body>
             <div class="related" role="navigation" aria-label="related navigation">
               <h3>Navigation</h3>
               <ul>
@@ -1602,15 +1604,15 @@ class TestHtml(BaseTestImporter):
                   <li class="nav-item nav-item-1"><a href="../../toc-more-links.html" >More Leo Links</a> &#187;</li>
                   <li class="nav-item nav-item-2"><a href="../../slides.html" >Slides</a> &#187;</li>
                   <li class="nav-item nav-item-3"><a href="basics.html" accesskey="U">Leoâ€™s Basics</a> &#187;</li>
-                <li class="nav-item nav-item-this"><a href="">The workbook file</a></li> 
+                <li class="nav-item nav-item-this"><a href="">The workbook file</a></li>
               </ul>
-            </div>  
+            </div>
 
             <div class="document">
               <div class="documentwrapper">
                 <div class="bodywrapper">
                   <div class="body" role="main">
-                    
+
           <section id="the-workbook-file">
         <h1>The workbook file<a class="headerlink" href="#the-workbook-file" title="Permalink to this heading">Â¶</a></h1>
         <p>Leo opens the <strong>workbook file</strong> when you start
@@ -1677,7 +1679,7 @@ class TestHtml(BaseTestImporter):
                   <li class="nav-item nav-item-1"><a href="../../toc-more-links.html" >More Leo Links</a> &#187;</li>
                   <li class="nav-item nav-item-2"><a href="../../slides.html" >Slides</a> &#187;</li>
                   <li class="nav-item nav-item-3"><a href="basics.html" >Leoâ€™s Basics</a> &#187;</li>
-                <li class="nav-item nav-item-this"><a href="">The workbook file</a></li> 
+                <li class="nav-item nav-item-this"><a href="">The workbook file</a></li>
               </ul>
             </div>
             <div class="footer" role="contentinfo">
@@ -1689,14 +1691,16 @@ class TestHtml(BaseTestImporter):
         </html>
         '''
         #@-<< define s >>
-        
-        # run_test calls check_round_trip with strict_flag=False
-        self.run_test(s)
-        
+
+        # Don't run the standard round-trip test.
+        p = self.run_test(s, check_flag=False)
+
+        # We expect that xml.preprocess_lines will insert a newline.
+        expected_s = s.replace('</head><body>', '</head>\n<body>')
+        self.check_round_trip(p, expected_s)
+
         # This dump looks good when </head> and <body> are on separate lines.
         # self.dump_tree()
-        
-
     #@+node:ekr.20230123162321.1: *3* TestHtml.test_structure
     def test_structure(self):
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1554,6 +1554,58 @@ class TestHtml(BaseTestImporter):
                     '\n'
             ),
         ))
+    #@+node:ekr.20230126023536.1: *3* TestHtml.test_slideshow_slide
+    def test_slideshow_slide(self):
+
+        s = '''
+            <html>
+            <head>
+                <meta charset="utf-8" />
+            </head>
+            <body>
+                <div class="a">
+                    <div class="a-1">
+                        some text
+                    </div>
+                </div>
+            </body>
+            </html>
+        '''
+        p = self.run_test(s)
+        self.check_outline(p, (
+            (0, '',  # check_outline ignores the first headline.
+                    '@others\n'
+                    '@language html\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, '<html>',
+                    '<html>\n'
+                    '@others\n'
+                    '</html>\n'
+                    '\n'
+            ),
+            (2, '<head>',
+                    '<head>\n'
+                    '    <meta charset="utf-8" />\n'
+                    '</head>\n'
+            ),
+            (2, '<body>',
+                     '<body>\n'
+                     '    @others\n'
+                     '</body>\n'
+            ),
+            (3, '<div class="a">',
+                     '<div class="a">\n'
+                     '    @others\n'
+                     '</div>\n'
+            ),
+            (4, '<div class="a-1">',
+
+                     '<div class="a-1">\n'
+                     '    some text\n'
+                     '</div>\n'
+            ),
+        ))
     #@+node:ekr.20230123162321.1: *3* TestHtml.test_structure
     def test_structure(self):
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1386,11 +1386,12 @@ class TestHtml(BaseTestImporter):
                     '</body>\n'
             ),
         ))
-    #@+node:ekr.20210904065459.20: *3* TestHtml.test_multiple_tags_on_a_line (poor)
+    #@+node:ekr.20210904065459.20: *3* TestHtml.test_multiple_tags_on_a_line
     def test_multiple_tags_on_a_line(self):
 
         # pylint: disable=line-too-long
-
+        #@+<< define s >>
+        #@+node:ekr.20230126042723.1: *4* << define s >>
         # tags that cause nodes: html, head, body, div, table, nodeA, nodeB
         # NOT: tr, td, tbody, etc.
         s = """
@@ -1438,81 +1439,18 @@ class TestHtml(BaseTestImporter):
             </body>
             </html>
         """
-        p = self.run_test(s)
-        # The importer doesn't do a good job.
-        self.check_outline(p, (
-            (0, '',  # check_outline ignores the first headline.
-                    '@others\n'
-                    '@language html\n'
-                    '@tabwidth -4\n'
-            ),
-            (1, '<html>',
-                    '<html>\n'
-                    '@others\n'
-            ),
-            (2, '<body>',
-                    '<body>\n'
-                    '    @others\n'
-                    '</html>\n'
-                    '\n'
-            ),
-            (3, '<table id="0">',
-                    '<table id="0">\n'
-                    '    <tr valign="top">\n'
-                    '    <td width="619">\n'
-                    '    @others\n'
-                    '</td>\n'
-                    '</tr>\n'
-                    '<script language="JavaScript1.1">var SA_ID="nyse;nyse";</script>\n'
-                    '<script language="JavaScript1.1" src="/scripts/stats/track.js"></script>\n'
-                    '<noscript><img src="/scripts/stats/track.js" height="1" width="1" alt="" border="0"></noscript>\n'
-                    '</body>\n'
-            ),
-            (4, '<table id="2">',
-                    '<table id="2"> <tr valign="top"> <td width="377">\n'
-                    '@others\n'
-                    '<!-- View First part --> </td> <td width="242"> <!-- View Second part -->\n'
-                    '<!-- View Second part --> </td> </tr></table>\n'
-            ),
-            (5, '<table id="3">',
-                    '<table id="3">\n'
-                    '<tr>\n'
-                    '<td width="368">\n'
-                    '@others\n'
-                    '</td>\n'
-                    '</tr>\n'
-                    '</table>\n'
-            ),
-            (6, '<table id="4">',
-                    '<table id="4">\n'
-                    '<tbody id="5">\n'
-                    '<tr valign="top">\n'
-                    '<td width="550">\n'
-                    '@others\n'
-                    '</td>\n'
-                    '</tr><tr>\n'
-                    '<td width="100%" colspan="2">\n'
-                    '<br />\n'
-                    '</td>\n'
-                    '</tr>\n'
-                    '</tbody>\n'
-                    '</table>\n'
-            ),
-            (7, '<table id="6">',
-                    '<table id="6">\n'
-                    '    <tbody id="6">\n'
-                    '    <tr>\n'
-                    '    <td class="blutopgrabot"><a href="href1">Listing Standards</a> | <a href="href2">Fees</a> | <strong>Non-compliant Issuers</strong> | <a href="href3">Form 25 Filings</a> </td>\n'
-                    '    </tr>\n'
-                    '    </tbody>\n'
-                    '</table>\n'
-            ),
-            (4, '<DIV class="webonly">',
-                    '<DIV class="webonly">\n'
-                    '<script src="/scripts/footer.js"></script>\n'
-                    '</DIV>\n'
-            ),
-        ))
+        #@-<< define s >>
+
+        # Don't run the standard round-trip test.
+        p = self.run_test(s, check_flag=False)
+
+        # xml.preprocess_lines should insert two newlines.
+        expected_s = s.replace('</tr><tr>', '</tr>\n<tr>').replace('</td> <td', '</td>\n<td')
+        self.check_round_trip(p, expected_s)
+
+        # This dump now looks good!
+        # self.dump_tree()
+
     #@+node:ekr.20210904065459.21: *3* TestHtml.test_multple_node_completed_on_a_line
     def test_multple_node_completed_on_a_line(self):
 
@@ -1520,14 +1458,28 @@ class TestHtml(BaseTestImporter):
             <!-- tags that start nodes: html,body,head,div,table,nodeA,nodeB -->
             <html><head>headline</head><body>body</body></html>
         """
-        p = self.run_test(s)
+
+        # Don't run the standard round-trip test.
+        p = self.run_test(s, check_flag=False)
+
+        # xml.preprocess_lines should one newlines.
+        expected_s = s.replace('</head><body>','</head>\n<body>')
+        self.check_round_trip(p, expected_s)
+
+        # This dump now looks good!
+        # self.dump_tree()
+
         self.check_outline(p, (
             (0, '',  # check_outline ignores the first headline.
                     '<!-- tags that start nodes: html,body,head,div,table,nodeA,nodeB -->\n'
-                    '<html><head>headline</head><body>body</body></html>\n'
-                    '\n'
+                    '@others\n'
                     '@language html\n'
                     '@tabwidth -4\n'
+            ),
+            (1, '<html>',
+                    '<html><head>headline</head>\n'
+                    '<body>body</body></html>\n'
+                    '\n'
             ),
         ))
     #@+node:ekr.20210904065459.22: *3* TestHtml.test_multple_node_starts_on_a_line
@@ -1695,11 +1647,11 @@ class TestHtml(BaseTestImporter):
         # Don't run the standard round-trip test.
         p = self.run_test(s, check_flag=False)
 
-        # We expect that xml.preprocess_lines will insert a newline.
+        # xml.preprocess_lines should insert a newline.
         expected_s = s.replace('</head><body>', '</head>\n<body>')
         self.check_round_trip(p, expected_s)
 
-        # This dump looks good when </head> and <body> are on separate lines.
+        # This dump now looks good!
         # self.dump_tree()
     #@+node:ekr.20230123162321.1: *3* TestHtml.test_structure
     def test_structure(self):

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1557,8 +1557,9 @@ class TestHtml(BaseTestImporter):
     #@+node:ekr.20230126023536.1: *3* TestHtml.test_slideshow_slide
     def test_slideshow_slide(self):
 
-        #@+<< define s, the contents of slides/basics/slide-002.html >>
-        #@+node:ekr.20230126024859.1: *4* << define s, the contents of slides/basics/slide-002.html >>
+        # s is the contents of slides/basics/slide-002.html 
+        #@+<< define s >>
+        #@+node:ekr.20230126031120.1: *4* << define s >>
         s = '''\
         <!DOCTYPE html>
 
@@ -1582,7 +1583,9 @@ class TestHtml(BaseTestImporter):
             <link rel="search" title="Search" href="../../search.html" />
             <link rel="next" title="Editing headlines" href="slide-003.html" />
             <link rel="prev" title="Leoâ€™s Basics" href="basics.html" /> 
-          </head><body>
+          </head>
+          <!-- EKR: Inserted newline here -->
+          <body>
             <div class="related" role="navigation" aria-label="related navigation">
               <h3>Navigation</h3>
               <ul>
@@ -1685,43 +1688,15 @@ class TestHtml(BaseTestImporter):
           </body>
         </html>
         '''
-        #@-<< define s, the contents of slides/basics/slide-002.html >>
-        p = self.run_test(s)
-        self.dump_headlines()
-        if 0: self.check_outline(p, (
-            (0, '',  # check_outline ignores the first headline.
-                    '@others\n'
-                    '@language html\n'
-                    '@tabwidth -4\n'
-            ),
-            (1, '<html>',
-                    '<html>\n'
-                    '@others\n'
-                    '</html>\n'
-                    '\n'
-            ),
-            (2, '<head>',
-                    '<head>\n'
-                    '    <meta charset="utf-8" />\n'
-                    '</head>\n'
-            ),
-            (2, '<body>',
-                     '<body>\n'
-                     '    @others\n'
-                     '</body>\n'
-            ),
-            (3, '<div class="a">',
-                     '<div class="a">\n'
-                     '    @others\n'
-                     '</div>\n'
-            ),
-            (4, '<div class="a-1">',
+        #@-<< define s >>
+        
+        # run_test calls check_round_trip with strict_flag=False
+        self.run_test(s)
+        
+        # This dump looks good when </head> and <body> are on separate lines.
+        # self.dump_tree()
+        
 
-                     '<div class="a-1">\n'
-                     '    some text\n'
-                     '</div>\n'
-            ),
-        ))
     #@+node:ekr.20230123162321.1: *3* TestHtml.test_structure
     def test_structure(self):
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1060,7 +1060,8 @@ class TestHtml(BaseTestImporter):
             <link rel="stylesheet" href="Brython_files/doc_brython.css">
             </head>
             <body onload="brython({debug:1, cache:'none'})">
-            </body></html>
+            </body>
+            </html>
         '''
         p = self.run_test(s)
         self.check_outline(p, (
@@ -1209,7 +1210,8 @@ class TestHtml(BaseTestImporter):
             ),
             (2, '<body onload="brython({debug:1, cache:\'none\'})">',
                     '<body onload="brython({debug:1, cache:\'none\'})">\n'
-                    '</body></html>\n'
+                    '</body>\n'
+                    '</html>\n'
                     '\n'
             ),
         ))
@@ -1400,7 +1402,7 @@ class TestHtml(BaseTestImporter):
                 <table id="0">
                     <tr valign="top">
                     <td width="619">
-                    
+
 
                         <table id="3">
                         <tr>
@@ -1412,7 +1414,7 @@ class TestHtml(BaseTestImporter):
                             <table id="6">
                                 <tbody id="6">
                                 <tr>
-                                <td class="blutopgrabot"><a href="href1">Listing Standards</a> | 
+                                <td class="blutopgrabot"><a href="href1">Listing Standards</a> |
                                     <a href="href2">Fees</a> |
                                     <strong>Non-compliant Issuers</strong> |
                                     <a href="href3">Form 25 Filings</a></td>
@@ -1472,7 +1474,7 @@ class TestHtml(BaseTestImporter):
             <!-- tags that start nodes: html,body,head,div,table,nodeA,nodeB -->
             <html><head>headline</head><body>body</body></html>
         """
-        
+
         expected_s = textwrap.dedent("""\
             <!-- tags that start nodes: html,body,head,div,table,nodeA,nodeB -->
             <html>
@@ -1489,7 +1491,7 @@ class TestHtml(BaseTestImporter):
 
         # This dump now looks good!
         # self.dump_tree(p)
-        
+
         self.check_outline(p, (
             (0, '',  # check_outline ignores the first headline.
                     '<!-- tags that start nodes: html,body,head,div,table,nodeA,nodeB -->\n'
@@ -1505,7 +1507,7 @@ class TestHtml(BaseTestImporter):
                     '\n'
             ),
         ))
-                   
+
     #@+node:ekr.20210904065459.22: *3* TestHtml.test_multple_node_starts_on_a_line
     def test_multple_node_starts_on_a_line(self):
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1557,22 +1557,138 @@ class TestHtml(BaseTestImporter):
     #@+node:ekr.20230126023536.1: *3* TestHtml.test_slideshow_slide
     def test_slideshow_slide(self):
 
-        s = '''
-            <html>
-            <head>
-                <meta charset="utf-8" />
-            </head>
-            <body>
-                <div class="a">
-                    <div class="a-1">
-                        some text
-                    </div>
+        #@+<< define s, the contents of slides/basics/slide-002.html >>
+        #@+node:ekr.20230126024859.1: *4* << define s, the contents of slides/basics/slide-002.html >>
+        s = '''\
+        <!DOCTYPE html>
+
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.19: https://docutils.sourceforge.io/" />
+
+            <title>The workbook file &#8212; Leo 6.7.2 documentation</title>
+            <link rel="stylesheet" type="text/css" href="../../_static/pygments.css" />
+            <link rel="stylesheet" type="text/css" href="../../_static/classic.css" />
+            <link rel="stylesheet" type="text/css" href="../../_static/custom.css" />
+            
+            <script data-url_root="../../" id="documentation_options" src="../../_static/documentation_options.js"></script>
+            <script src="../../_static/doctools.js"></script>
+            <script src="../../_static/sphinx_highlight.js"></script>
+            
+            <script src="../../_static/sidebar.js"></script>
+            
+            <link rel="index" title="Index" href="../../genindex.html" />
+            <link rel="search" title="Search" href="../../search.html" />
+            <link rel="next" title="Editing headlines" href="slide-003.html" />
+            <link rel="prev" title="Leoâ€™s Basics" href="basics.html" /> 
+          </head><body>
+            <div class="related" role="navigation" aria-label="related navigation">
+              <h3>Navigation</h3>
+              <ul>
+                <li class="right" style="margin-right: 10px">
+                  <a href="../../genindex.html" title="General Index"
+                     accesskey="I">index</a></li>
+                <li class="right" >
+                  <a href="slide-003.html" title="Editing headlines"
+                     accesskey="N">next</a> |</li>
+                <li class="right" >
+                  <a href="basics.html" title="Leoâ€™s Basics"
+                     accesskey="P">previous</a> |</li>
+                <li class="nav-item nav-item-0"><a href="../../leo_toc.html">Leo 6.7.2 documentation</a> &#187;</li>
+                  <li class="nav-item nav-item-1"><a href="../../toc-more-links.html" >More Leo Links</a> &#187;</li>
+                  <li class="nav-item nav-item-2"><a href="../../slides.html" >Slides</a> &#187;</li>
+                  <li class="nav-item nav-item-3"><a href="basics.html" accesskey="U">Leoâ€™s Basics</a> &#187;</li>
+                <li class="nav-item nav-item-this"><a href="">The workbook file</a></li> 
+              </ul>
+            </div>  
+
+            <div class="document">
+              <div class="documentwrapper">
+                <div class="bodywrapper">
+                  <div class="body" role="main">
+                    
+          <section id="the-workbook-file">
+        <h1>The workbook file<a class="headerlink" href="#the-workbook-file" title="Permalink to this heading">Â¶</a></h1>
+        <p>Leo opens the <strong>workbook file</strong> when you start
+        Leo without a filename.</p>
+        <p>The body has focusâ€“it is colored a pale pink, and
+        contains a blinking cursor.</p>
+        <p><strong>Note</strong>: on some monitors the colors will be almost
+        invisible.  You can choose such colors to suit your
+        taste.</p>
+        <img alt="../../_images/slide-002.png" src="../../_images/slide-002.png" />
+        </section>
+
+
+                    <div class="clearer"></div>
+                  </div>
                 </div>
-            </body>
-            </html>
+              </div>
+              <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
+                <div class="sphinxsidebarwrapper">
+                    <p class="logo"><a href="../../leo_toc.html">
+                      <img class="logo" src="../../_static/LeoLogo.svg" alt="Logo"/>
+                    </a></p>
+          <div>
+            <h4>Previous topic</h4>
+            <p class="topless"><a href="basics.html"
+                                  title="previous chapter">Leoâ€™s Basics</a></p>
+          </div>
+          <div>
+            <h4>Next topic</h4>
+            <p class="topless"><a href="slide-003.html"
+                                  title="next chapter">Editing headlines</a></p>
+          </div>
+        <div id="searchbox" style="display: none" role="search">
+          <h3 id="searchlabel">Quick search</h3>
+            <div class="searchformwrapper">
+            <form class="search" action="../../search.html" method="get">
+              <input type="text" name="q" aria-labelledby="searchlabel" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"/>
+              <input type="submit" value="Go" />
+            </form>
+            </div>
+        </div>
+        <script>document.getElementById('searchbox').style.display = "block"</script>
+                </div>
+        <div id="sidebarbutton" title="Collapse sidebar">
+        <span>Â«</span>
+        </div>
+
+              </div>
+              <div class="clearer"></div>
+            </div>
+            <div class="related" role="navigation" aria-label="related navigation">
+              <h3>Navigation</h3>
+              <ul>
+                <li class="right" style="margin-right: 10px">
+                  <a href="../../genindex.html" title="General Index"
+                     >index</a></li>
+                <li class="right" >
+                  <a href="slide-003.html" title="Editing headlines"
+                     >next</a> |</li>
+                <li class="right" >
+                  <a href="basics.html" title="Leoâ€™s Basics"
+                     >previous</a> |</li>
+                <li class="nav-item nav-item-0"><a href="../../leo_toc.html">Leo 6.7.2 documentation</a> &#187;</li>
+                  <li class="nav-item nav-item-1"><a href="../../toc-more-links.html" >More Leo Links</a> &#187;</li>
+                  <li class="nav-item nav-item-2"><a href="../../slides.html" >Slides</a> &#187;</li>
+                  <li class="nav-item nav-item-3"><a href="basics.html" >Leoâ€™s Basics</a> &#187;</li>
+                <li class="nav-item nav-item-this"><a href="">The workbook file</a></li> 
+              </ul>
+            </div>
+            <div class="footer" role="contentinfo">
+                &#169; Copyright 1997-2023, Edward K. Ream.
+              Last updated on January 24, 2023.
+              Created using <a href="https://www.sphinx-doc.org/">Sphinx</a> 6.1.2.
+            </div>
+          </body>
+        </html>
         '''
+        #@-<< define s, the contents of slides/basics/slide-002.html >>
         p = self.run_test(s)
-        self.check_outline(p, (
+        self.dump_headlines()
+        if 0: self.check_outline(p, (
             (0, '',  # check_outline ignores the first headline.
                     '@others\n'
                     '@language html\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1454,6 +1454,9 @@ class TestHtml(BaseTestImporter):
 
         # xml.preprocess_lines should insert two newlines.
         expected_s = (s
+            .replace('Form 25 Filings</a></td>\n', 'Form 25 Filings</a>\n</td>\n')
+            .replace('</tr><tr>\n', '</tr>\n<tr>\n')
+            .replace('</tr></table>\n', '</tr>\n</table>\n')
             .replace('<td class="blutopgrabot"><a', '<td class="blutopgrabot">\n<a')
             .replace('<noscript><img', '<noscript>\n<img')
         )


### PR DESCRIPTION
See #3079.

**Improve testing infrastructure**

- [x] Improve LeoUnitTest.dump_headlines and dump_tree. They now dump the entire tree if no root is given.
- [x] Improve BaseTestImporter.check_round_trip: it now reports line numbers.

**Improve xml/html importers**

- [x] Add Importer.preprocess_lines as a hook for xml.preprocess_lines.
- [x] xml.preprocess_lines inserts line breaks between *different* tags on the same line.
   Separating elements helps the xml/html importers considerably.

**Adjust unit tests**

- [x] Add TestHtml.test_slideshow_slide.
- [x] Adjust several unit tests to account for the new line breaks.