### PR TITLE
PR: Simplify g.trace by removing all kwargs

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6159,65 +6159,11 @@ def printStack() -> None:
     traceback.print_stack()
 #@+node:ekr.20031218072017.2317: *3* g.trace
 def trace(*args: Any, **keys: Any) -> None:
-    """Print a tracing message."""
-    # Don't use g here: in standalone mode g is a NullObject!
-    # Compute the effective args.
-    d: Dict[str, Any] = {'align': 0, 'before': '', 'newline': True, 'caller_level': 1, 'noname': False}
-    d = doKeywordArgs(keys, d)
-    newline = d.get('newline')
-    align = d.get('align', 0)
-    caller_level = d.get('caller_level', 1)
-    noname = d.get('noname')
-    # Compute the caller name.
-    if noname:
-        name = ''
-    else:
-        try:  # get the function name from the call stack.
-            f1 = sys._getframe(caller_level)  # The stack frame, one level up.
-            code1 = f1.f_code  # The code object
-            name = code1.co_name  # The code name
-        except Exception:
-            name = g.shortFileName(__file__)
-        if name == '<module>':
-            name = g.shortFileName(__file__)
-        if name.endswith('.pyc'):
-            name = name[:-1]
-    # Pad the caller name.
-    if align != 0 and len(name) < abs(align):
-        pad = ' ' * (abs(align) - len(name))
-        if align > 0:
-            name = name + pad
-        else:
-            name = pad + name
-    # Munge *args into s.
-    result = [name] if name else []
-    #
-    # Put leading newlines into the prefix.
-    if isinstance(args, tuple):
-        args = list(args)  # type:ignore
-    if args and isinstance(args[0], str):
-        prefix = ''
-        while args[0].startswith('\n'):
-            prefix += '\n'
-            args[0] = args[0][1:]  # type:ignore
-    else:
-        prefix = ''
-    for arg in args:
-        if isinstance(arg, str):
-            pass
-        elif isinstance(arg, bytes):
-            arg = toUnicode(arg)
-        else:
-            arg = repr(arg)
-        if result:
-            result.append(" " + arg)
-        else:
-            result.append(arg)
-    s = d.get('before') + ''.join(result)
-    if prefix:
-        prefix = prefix[1:]  # One less newline.
-        pr(prefix)
-    pr(s, newline=newline)
+    """Print the name of the calling function followed by all the args."""
+    name = g._callerName(2)
+    if name.endswith(".pyc"):
+        name = name[:-1]
+    pr(name, args)
 #@+node:ekr.20080220111323: *3* g.translateArgs
 console_encoding = None
 


### PR DESCRIPTION
I never used the old kwargs and anyway f-strings do a better job of formatting.