### PR TITLE
PR for #3107: broken clickable links

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7257,10 +7257,10 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
                         pass
             # Finally, just add the whole UNL.
             result.append(s)
-        return list(set(result))
+        return result
     #@+node:ekr.20220213142735.1: *4* function: full_match
     def full_match(p: Position) -> bool:
-        """Return True if the headlines of p and all p's parents match unlList."""
+        """Return True if the stripped headlines of p and all p's parents match unlList."""
         # Careful: make copies.
         aList, p1 = unlList[:], p.copy()
         while aList and p1:
@@ -7281,10 +7281,12 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
     targets = []
     m = new_pat.match(unlList[-1])
     target = m and m.group(1) or unlList[-1]
-    targets.append(target)
+    targets.append(target.strip())  ###
     targets.extend(unlList[:-1])
     # Find all target positions. Prefer later positions.
     positions = list(reversed(list(z for z in c.all_positions() if z.h.strip() in targets)))
+    g.printObj(targets,tag='g.findUNL: targets')
+    g.printObj([z.h for z in positions],tag='g.findUNL: positions')
     while unlList:
         for p in positions:
             p1 = p.copy()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7257,7 +7257,7 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
                         pass
             # Finally, just add the whole UNL.
             result.append(s)
-        # Do *not* return duplicates!
+        # Do *not* remove duplicates!
         return result
     #@+node:ekr.20220213142735.1: *4* function: full_match
     def full_match(p: Position) -> bool:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7231,7 +7231,6 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
     Find and move to the unl given by the unlList in the commander c.
     Return the found position, or None.
     """
-
     # Define the unl patterns.
     old_pat = re.compile(r'^(.*):(\d+),?(\d+)?,?([-\d]+)?,?(\d+)?$')  # ':' is the separator.
     new_pat = re.compile(r'^(.*?)(::)([-\d]+)?$')  # '::' is the separator.
@@ -7282,9 +7281,8 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
     targets = []
     m = new_pat.match(unlList[-1])
     target = m and m.group(1) or unlList[-1]
-    targets.append(target.strip())
+    targets.append(target)
     targets.extend(unlList[:-1])
-
     # Find all target positions. Prefer later positions.
     positions = list(reversed(list(z for z in c.all_positions() if z.h.strip() in targets)))
     while unlList:
@@ -7301,14 +7299,15 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
                         n = int(line)
                     except(TypeError, ValueError):
                         g.trace('bad line number', line)
-                if n < 0:
+                if n == 0:
+                    c.redraw(p)
+                elif n < 0:
                     p, offset, ok = c.gotoCommands.find_file_line(-n, p)  # Calls c.redraw().
-                    if not ok:
-                        g.trace(f"Not found: global line {n} in {p.h}")
                     return p if ok else None
-                insert_point = sum(len(z) for z in g.splitLines(p.b)[:n])
-                c.redraw(p)
-                c.frame.body.wrapper.setInsertPoint(insert_point)
+                elif n > 0:
+                    insert_point = sum(len(i) + 1 for i in p.b.split('\n')[: n - 1])
+                    c.redraw(p)
+                    c.frame.body.wrapper.setInsertPoint(insert_point)
                 c.frame.bringToFront()
                 c.bodyWantsFocusNow()
                 return p

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7257,6 +7257,7 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
                         pass
             # Finally, just add the whole UNL.
             result.append(s)
+        # Do *not* return duplicates!
         return result
     #@+node:ekr.20220213142735.1: *4* function: full_match
     def full_match(p: Position) -> bool:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7281,12 +7281,10 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
     targets = []
     m = new_pat.match(unlList[-1])
     target = m and m.group(1) or unlList[-1]
-    targets.append(target.strip())  ###
+    targets.append(target.strip())
     targets.extend(unlList[:-1])
     # Find all target positions. Prefer later positions.
     positions = list(reversed(list(z for z in c.all_positions() if z.h.strip() in targets)))
-    g.printObj(targets,tag='g.findUNL: targets')
-    g.printObj([z.h for z in positions],tag='g.findUNL: positions')
     while unlList:
         for p in positions:
             p1 = p.copy()
@@ -7301,15 +7299,14 @@ def findUNL(unlList1: List[str], c: Cmdr) -> Optional[Position]:
                         n = int(line)
                     except(TypeError, ValueError):
                         g.trace('bad line number', line)
-                if n == 0:
-                    c.redraw(p)
-                elif n < 0:
+                if n < 0:
                     p, offset, ok = c.gotoCommands.find_file_line(-n, p)  # Calls c.redraw().
+                    if not ok:
+                        g.trace(f"Not found: global line {n} in {p.h}")
                     return p if ok else None
-                elif n > 0:
-                    insert_point = sum(len(i) + 1 for i in p.b.split('\n')[: n - 1])
-                    c.redraw(p)
-                    c.frame.body.wrapper.setInsertPoint(insert_point)
+                insert_point = sum(len(z) for z in g.splitLines(p.b)[:n])
+                c.redraw(p)
+                c.frame.body.wrapper.setInsertPoint(insert_point)
                 c.frame.bringToFront()
                 c.bodyWantsFocusNow()
                 return p


### PR DESCRIPTION
See #3107.

The change to the `convert_unl_list` helper function in PR #3103 (find-all) was the culprit.

Rev 5e279ed3 was the first *bad* commit.

- [x] Don't remove duplicates in  `convert_unl_list`.
