### PR TITLE
PR: use pprint in g.objToString

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1039,9 +1039,7 @@ class Commands:
         g.es_print('dump-expanded...')
         for p in c.all_positions():
             if p.v.expandedPositions:
-                indent = ' ' * p.level()
-                print(f"{indent}{p.h}")
-                g.printObj(p.v.expandedPositions, indent=indent)
+                g.printObj(p.v.expandedPositions, indent=p.level(), tag=p.h)
     #@+node:ekr.20040306220230.1: *5* c.edit_widget
     def edit_widget(self, p: Position) -> Widget:
         c = self

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1250,7 +1250,7 @@ class GlobalConfigManager:
                     elif limit == 0 or len(aList) < limit:
                         val = '\n    [\n' + '\n'.join(aList) + '\n    ]'
                         # The following doesn't work well.
-                        # val = g.objToString(aList, indent=' '*4)
+                        # val = g.objToString(aList, indent=4)
                     else:
                         val = f"<{len(aList)} non-comment lines>"
                 elif isinstance(val, str) and val.startswith('<?xml'):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1696,7 +1696,7 @@ class SherlockTracer:
             args_s2 = f"({args_s})"
             if len(args_s2) > 100:
                 print(f"{path}:{indent}{leadin}{full_name}")
-                g.printObj(args_list, indent=indent + ' ' * 22)
+                g.printObj(args_list, indent=len(indent) + 22)
             else:
                 print(f"{path}:{indent}{leadin}{full_name}{args_s2}")
         else:
@@ -1799,7 +1799,7 @@ class SherlockTracer:
             elif isinstance(arg, (tuple, list)):
                 ret_s = ','.join([self.show(z) for z in arg])
                 if len(ret_s) > 40:
-                    g.printObj(arg, indent=indent)
+                    g.printObj(arg, indent=len(indent))
                     ret = ''
                 else:
                     ret = f"[{ret_s}]"
@@ -2716,7 +2716,7 @@ def dictToString(d: Dict[str, str], indent: str = '', tag: str = None) -> str:
     for i, key in enumerate(sorted(d, key=lambda z: repr(z))):
         pad = ' ' * max(0, (n - len(repr(key))))
         result.append(f"{pad}{key}:")
-        result.append(objToString(d.get(key), indent=indent2))
+        result.append(objToString(d.get(key), indent=len(indent2)))
         if i + 1 < len(d.keys()):
             result.append(',')
         result.append('\n')
@@ -2733,7 +2733,7 @@ def listToString(obj: Any, indent: str = '', tag: str = None) -> str:
     # I prefer not to compress lists.
     for i, obj2 in enumerate(obj):
         result.append('\n' + indent2)
-        result.append(objToString(obj2, indent=indent2))
+        result.append(objToString(obj2, indent=len(indent2)))
         if i + 1 < len(obj) > 1:
             result.append(',')
         else:
@@ -2742,11 +2742,7 @@ def listToString(obj: Any, indent: str = '', tag: str = None) -> str:
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
-def objToString(obj: Any, *,
-    concise: bool = True,  # Not used.
-    indent: Union[int, str] = 0,
-    width: int = 120,
-) -> str:
+def objToString(obj: Any, *, indent: int = 0, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.
 
@@ -2757,7 +2753,8 @@ def objToString(obj: Any, *,
     s = pprint.pformat(obj,
         compact=False,
         depth=None,
-        indent=len(indent) if isinstance(indent, str) else indent,
+        # indent=len(indent) if isinstance(indent, str) else indent,
+        indent=indent,
         sort_dicts=True,
         # underscore_numbers=False,
         width=width,
@@ -2782,11 +2779,7 @@ def sleep(n: float) -> None:
     from time import sleep  # type:ignore
     sleep(n)  # type:ignore
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: Any, *,
-    concise: bool = False,
-    indent: Union[int, str] = 0,
-    tag: str = None,
-) -> None:
+def printObj(obj: Any, *, tag: str = None, indent: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     if tag:
         print(tag.strip())
@@ -2805,7 +2798,7 @@ def tupleToString(obj: Any, indent: str = '', tag: str = None) -> str:
     for i, obj2 in enumerate(obj):
         if len(obj) > 1:
             result.append('\n' + indent2)
-        result.append(objToString(obj2, indent=indent2))
+        result.append(objToString(obj2, indent=len(indent2)))
         if len(obj) == 1 or i + 1 < len(obj):
             result.append(',')
         elif len(obj) > 1:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2708,9 +2708,6 @@ def pdb(message: str = '') -> None:
 def objToString(obj: Any, indent: int = 0, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.
-
-    concise=False: return a detailed string.
-    concise=True:  return a summary string.
     """
 
     s = pprint.pformat(obj,

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2704,45 +2704,8 @@ def pdb(message: str = '') -> None:
         print(message)
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
-#@+node:ekr.20041224080039: *4* g.dictToString
-def dictToString(d: Dict[str, str], indent: str = '', tag: str = None) -> str:
-    """Pretty print a Python dict to a string."""
-    # pylint: disable=unnecessary-lambda
-    if not d:
-        return '{}'
-    result = ['{\n']
-    indent2 = indent + ' ' * 4
-    n = 2 + len(indent) + max([len(repr(z)) for z in d.keys()])
-    for i, key in enumerate(sorted(d, key=lambda z: repr(z))):
-        pad = ' ' * max(0, (n - len(repr(key))))
-        result.append(f"{pad}{key}:")
-        result.append(objToString(d.get(key), indent=len(indent2)))
-        if i + 1 < len(d.keys()):
-            result.append(',')
-        result.append('\n')
-    result.append(indent + '}')
-    s = ''.join(result)
-    return f"{tag}...\n{s}\n" if tag else s
-#@+node:ekr.20041126060136: *4* g.listToString
-def listToString(obj: Any, indent: str = '', tag: str = None) -> str:
-    """Pretty print a Python list to a string."""
-    if not obj:
-        return indent + '[]'
-    result = [indent, '[']
-    indent2 = indent + ' ' * 4
-    # I prefer not to compress lists.
-    for i, obj2 in enumerate(obj):
-        result.append('\n' + indent2)
-        result.append(objToString(obj2, indent=len(indent2)))
-        if i + 1 < len(obj) > 1:
-            result.append(',')
-        else:
-            result.append('\n' + indent)
-    result.append(']')
-    s = ''.join(result)
-    return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
-def objToString(obj: Any, *, indent: int = 0, width: int = 120) -> str:
+def objToString(obj: Any, indent: int = 0, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.
 
@@ -2773,13 +2736,16 @@ def objToString(obj: Any, *, indent: int = 0, width: int = 120) -> str:
     return s
 
 toString = objToString
+dictToString = objToString
+listToString = objToString
+tupleToString = objToString
 #@+node:ekr.20120912153732.10597: *4* g.wait
 def sleep(n: float) -> None:
     """Wait about n milliseconds."""
     from time import sleep  # type:ignore
     sleep(n)  # type:ignore
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
-def printObj(obj: Any, *, tag: str = None, indent: int = 0) -> None:
+def printObj(obj: Any, tag: str = None, indent: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
     if tag:
         print(tag.strip())
@@ -2788,24 +2754,6 @@ def printObj(obj: Any, *, tag: str = None, indent: int = 0) -> None:
 printDict = printObj
 printList = printObj
 printTuple = printObj
-#@+node:ekr.20171023110057.1: *4* g.tupleToString
-def tupleToString(obj: Any, indent: str = '', tag: str = None) -> str:
-    """Pretty print a Python tuple to a string."""
-    if not obj:
-        return '(),'
-    result = ['(']
-    indent2 = indent + ' ' * 4
-    for i, obj2 in enumerate(obj):
-        if len(obj) > 1:
-            result.append('\n' + indent2)
-        result.append(objToString(obj2, indent=len(indent2)))
-        if len(obj) == 1 or i + 1 < len(obj):
-            result.append(',')
-        elif len(obj) > 1:
-            result.append('\n' + indent)
-    result.append(')')
-    s = ''.join(result)
-    return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20031218072017.1588: *3* g.Garbage Collection
 #@+node:ekr.20031218072017.1589: *4* g.clearAllIvars
 def clearAllIvars(o: Any) -> None:

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -493,7 +493,7 @@ class PutToOPML:
                 self.putOPMLNode(p2)
                 closed = True
         if closed:
-            self.put('\n%s</outline>' % indent)
+            self.put(f"\n{indent}</outline>")
         else:
             self.put(' />')
     #@+node:ekr.20060919172012.7: *4* attributeEscape

--- a/leo/unittests/test_gui.py
+++ b/leo/unittests/test_gui.py
@@ -141,7 +141,7 @@ class TestQtGui(LeoUnitTest):
             for z in dir(g.app.gui):
                 if not z.startswith('__'):
                     obj = getattr(g.app.gui, z, None)
-                    print(f"{z:>30} {g.objToString(obj, concise=True)}")
+                    print(f"{z:>30} {g.objToString(obj)}")
         if 0:
             print('')
             g.trace(g.app.gui)


### PR DESCRIPTION
More fallout from work on Rope. It's embarrassing not to use python's pprint module.

- [x] Rewrite g.objToString, removing several seldom (or never) used kwargs.
- [x] Require `int` type for `length` kwargs.
- [x] Replace g.dict/list/tuple/ToString with aliases.