### PR TITLE
PR 3 for g.objToString

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2719,7 +2719,7 @@ def objToString(obj: Any, indent: int = 0, tag: str = None, width: int = 120) ->
             f"  {i:4}: {z!r}\n" for i, z in enumerate(g.splitLines(obj))
         ])
         result = f"[\n{lines}]\n"
-    return f"{tag.strip()}: {result}" if tag else result
+    return f"{tag.strip()}: {result}" if tag.strip() else result
 
 toString = objToString
 dictToString = objToString

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2704,7 +2704,7 @@ def pdb(message: str = '') -> None:
         print(message)
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
-#@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
+#@+node:ekr.20050819064157: *4* g.objToString & g.toString
 def objToString(obj: Any, indent: int = 0, tag: str = None, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2704,7 +2704,7 @@ def pdb(message: str = '') -> None:
         print(message)
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
-#@+node:ekr.20050819064157: *4* g.objToString & g.toString
+#@+node:ekr.20050819064157: *4* g.objToString & aliases
 def objToString(obj: Any, indent: int = 0, tag: str = None, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.
@@ -2719,7 +2719,7 @@ def objToString(obj: Any, indent: int = 0, tag: str = None, width: int = 120) ->
             f"  {i:4}: {z!r}\n" for i, z in enumerate(g.splitLines(obj))
         ])
         result = f"[\n{lines}]\n"
-    return f"{tag.strip()}: {result}" if tag.strip() else result
+    return f"{tag.strip()}: {result}" if tag and tag.strip() else result
 
 toString = objToString
 dictToString = objToString
@@ -2733,7 +2733,7 @@ def sleep(n: float) -> None:
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
 def printObj(obj: Any, tag: str = None, indent: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
-    print(objToString(obj, indent=indent, tag=tag))
+    g.pr(objToString(obj, indent=indent, tag=tag))
 
 printDict = printObj
 printList = printObj

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2705,20 +2705,21 @@ def pdb(message: str = '') -> None:
     # pylint: disable=forgotten-debug-statement
     pdb.set_trace()
 #@+node:ekr.20050819064157: *4* g.objToSTring & g.toString
-def objToString(obj: Any, indent: int = 0, width: int = 120) -> str:
+def objToString(obj: Any, indent: int = 0, tag: str = None, width: int = 120) -> str:
     """
     Pretty print any Python object to a string.
     """
     if not isinstance(obj, str):
-        s = pprint.pformat(obj, indent=indent, width=width)
-        return f"{obj.__class__.__name__}: {pprint.saferepr(s)}"
-    if '\n' not in obj:
-        return f"str: {obj!r}"
-    # Return the enumerated lines of the string.
-    lines = ''.join([
-        f"  {i:4}: {z!r}\n" for i, z in enumerate(g.splitLines(obj))
-    ])
-    return f"str: [\n{lines}]\n"
+        result = pprint.pformat(obj, indent=indent, width=width)
+    elif '\n' not in obj:
+        result = repr(obj)
+    else:
+        # Return the enumerated lines of the string.
+        lines = ''.join([
+            f"  {i:4}: {z!r}\n" for i, z in enumerate(g.splitLines(obj))
+        ])
+        result = f"[\n{lines}]\n"
+    return f"{tag.strip()}: {result}" if tag else result
 
 toString = objToString
 dictToString = objToString
@@ -2732,9 +2733,7 @@ def sleep(n: float) -> None:
 #@+node:ekr.20171023140544.1: *4* g.printObj & aliases
 def printObj(obj: Any, tag: str = None, indent: int = 0) -> None:
     """Pretty print any Python object using g.pr."""
-    if tag:
-        print(tag.strip())
-    print(objToString(obj, indent=indent))
+    print(objToString(obj, indent=indent, tag=tag))
 
 printDict = printObj
 printList = printObj

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -10000,6 +10000,104 @@ def do_qcompleter_tab(self, prefix: str, options: List[str]) -> str:
     matches, common_prefix = g.itemsMatchingPrefixInList(
         prefix, options, matchEmptyPrefix=False)
     return common_prefix
+#@+node:ekr.20230131132752.1: *3* LEGACY: g.objToString & helpers
+def objToString(obj: Any, indent: str='', tag: str='', concise: bool=False) -> str:
+    """
+    Pretty print any Python object to a string.
+
+    concise=False: (Legacy) return a detailed string.
+    concise=True: Return a summary string.
+    """
+    if tag:
+        print(tag.strip())  ### Print ???
+    if concise:
+        r = repr(obj)
+        if obj is None:
+            return f"{indent}None"
+        if isinstance(obj, dict):
+            return f"{indent}dict: {len(obj.keys())} keys"
+        if isinstance(obj, list):
+            return f"{indent}list: {len(obj)} itemg.plural(len(obj))"
+        if isinstance(obj, tuple):
+            return f"{indent}tuple: {len(obj)} item{g.plural(len(obj))}"
+        if 'method' in r:
+            return f"{indent}method: {obj.__name__}"
+        if 'class' in r:
+            return f"{indent}class"
+        if 'module' in r:
+            return f"{indent}module"
+        return f"{indent}object: {obj!r}"
+
+    # concise = False
+    if isinstance(obj, dict):
+        return dictToString(obj, indent=indent)
+    if isinstance(obj, list):
+        return listToString(obj, indent=indent)
+    if isinstance(obj, tuple):
+        return tupleToString(obj, indent=indent)
+    if isinstance(obj, str):
+        # Print multi-line strings as lists.
+        lines = g.splitLines(obj)
+        if len(lines) > 1:
+            return listToString(lines, indent=indent)
+    return f"{indent} {obj!r}"
+
+toString = objToString
+#@+node:ekr.20230131132837.2: *4* LEGACY: g.dictToString
+def dictToString(d: Dict[str, str], indent: str='', tag: str=None) -> str:
+    """Pretty print a Python dict to a string."""
+    # pylint: disable=unnecessary-lambda
+    if not d:
+        return '{}'
+    result = ['{\n']
+    indent2 = indent + ' ' * 4
+    n = 2 + len(indent) + max([len(repr(z)) for z in d.keys()])
+    for i, key in enumerate(sorted(d, key=lambda z: repr(z))):
+        pad = ' ' * max(0, (n - len(repr(key))))
+        result.append(f"{pad}{key}:")
+        result.append(objToString(d.get(key), indent=indent2))
+        if i + 1 < len(d.keys()):
+            result.append(',')
+        result.append('\n')
+    result.append(indent + '}')
+    s = ''.join(result)
+    return f"{tag}...\n{s}\n" if tag else s
+#@+node:ekr.20230131132837.3: *4* LEGACY: g.listToString
+def listToString(obj: Any, indent: str='', tag: str=None) -> str:
+    """Pretty print a Python list to a string."""
+    if not obj:
+        return indent + '[]'
+    result = [indent, '[']
+    indent2 = indent + ' ' * 4
+    # I prefer not to compress lists.
+    for i, obj2 in enumerate(obj):
+        result.append('\n' + indent2)
+        result.append(objToString(obj2, indent=indent2))
+        if i + 1 < len(obj) > 1:
+            result.append(',')
+        else:
+            result.append('\n' + indent)
+    result.append(']')
+    s = ''.join(result)
+    return f"{tag}...\n{s}\n" if tag else s
+#@+node:ekr.20230131132837.4: *4* LEGACY: g.tupleToString
+def tupleToString(obj: Any, indent: str='', tag: str=None) -> str:
+    """Pretty print a Python tuple to a string."""
+    if not obj:
+        return '(),'
+    result = ['(']
+    indent2 = indent + ' ' * 4
+    for i, obj2 in enumerate(obj):
+        if len(obj) > 1:
+            result.append('\n' + indent2)
+        result.append(objToString(obj2, indent=indent2))
+        if len(obj) == 1 or i + 1 < len(obj):
+            result.append(',')
+        elif len(obj) > 1:
+            result.append('\n' + indent)
+    result.append(')')
+    s = ''.join(result)
+    return f"{tag}...\n{s}\n" if tag else s
 #@+node:ekr.20220917052540.1: ** Old commands
 #@+node:ekr.20210907103011.1: *3* leo/commands/testCommands.py
 @first # -*- coding: utf-8 -*-

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -300,6 +300,70 @@ class TestGlobals(LeoUnitTest):
             expected, i, word, line = data
             got = g.match_word(line + '\n', i, word)
             self.assertEqual(expected, got)
+    #@+node:ekr.20230131234527.1: *3* TestGlobals.test_g_objToString
+    def test_g_objToString(self):
+
+        #@+<< define s >>
+        #@+node:ekr.20230131234637.1: *4* << define s >>
+        s = """g.cls()
+
+        def f1():
+            g.trace(g.callers(1))
+            g.trace(g.callers_list(1))
+            f2()
+
+        def f2():
+            print('')
+            g.trace(g.callers(2))
+            g.trace(g.callers_list(2))
+            f3()
+
+        def f3():
+            print('')
+            g.trace(g.callers(2))
+            g.trace(g.callers_list(2))
+            t = TestClass()
+            assert t
+
+        def f4():
+            print('')
+            g.trace(g.callers())
+            g.trace(g.callers_list())
+
+        class TestClass:
+            def __init__(self):
+                print('')
+                g.trace('(TestClass)')
+                f4()
+
+        f1()
+        """
+        #@-<< define s >>
+        #@+<< define class TestClass >>
+        #@+node:ekr.20230131234648.1: *4* << define class TestClass >>
+        class TestClass:
+
+            def test_function(self):
+                pass
+        #@-<< define class TestClass >>
+        table = (
+            (s, 'String1'),
+            ('This is a test', "String2"),
+            ({'a': 1, 'b': 2}, 'Dict'),
+            (['one', 'two', 'three'], 'List'),
+            (('x', 'y'), 'Tuple'),
+            (g.printObj, 'Function'),
+            (TestClass, "Class"),
+            (TestClass(), "Instance"),
+            (TestClass.test_function, 'unbound method'),
+            (TestClass().test_function,'bound method')
+        )
+        for data, tag in table:
+            result = g.objToString(data, tag=tag)
+            self.assertTrue(tag in result, msg=data)
+            self.assertTrue(isinstance(result, str))
+            result2 = g.objToString(data)
+            self.assertTrue(isinstance(result2, str))
     #@+node:ekr.20210905203541.26: *3* TestGlobals.test_g_os_path_finalize_join_with_thumb_drive
     def test_g_os_path_finalize_join_with_thumb_drive(self):
         path1 = r'C:\Python32\Lib\site-packages\leo-editor\leo\core'


### PR DESCRIPTION
`g.objToString` should have no impact on leoInteg, and is irrelevant to leoJS.

The recent work on `g.objToString` came about because I was embarrassed to embed the legacy code in Rope, even semi-privately. The code in this PR is good enough for now. I'll tweak it later only if necessary.

- [x] Simplify g.objToString.
- [x] Simplify g.printObj.
- [x] Add unit test for g.objToString.