### PR TITLE
Boltex/issue3100

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1242,7 +1242,8 @@ class Commands:
         return None, None
     #@+node:tbrown.20091206142842.10296: *5* c.vnode2allPositions
     def vnode2allPositions(self, v: VNode) -> List[Position]:
-        """Given a VNode v, find all valid positions p such that p.v = v.
+        """
+        Given a VNode v, find all valid positions p such that p.v = v.
 
         Not really all, just all for each of v's distinct immediate parents.
         """
@@ -1271,7 +1272,8 @@ class Commands:
         return positions
     #@+node:ekr.20090107113956.1: *5* c.vnode2position
     def vnode2position(self, v: VNode) -> Position:
-        """Given a VNode v, construct a valid position p such that p.v = v.
+        """
+        Given a VNode v, construct a valid position p such that p.v = v.
         """
         c = self
         context = v.context  # v's commander.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1614,17 +1614,6 @@ class LeoFind:
             # Start an undo-group instead of a single 'InsertNode' undo
             u.beforeChangeGroup(c.p, undoType)
 
-        # ! PLACING THIS HERE MAKES THE FIRST NODE UNDER THE ROOT NOT 'MARK-REDOABLE' !
-        # if self.mark_finds:
-        #     for match in matches_dict:
-        #         p = c.vnode2position(match['v'])
-        #         if not p.isMarked():
-        #             markUndoType = 'Mark Finds'
-        #             bunch = u.beforeMark(p, markUndoType)
-        #             p.setMarked()
-        #             p.setDirty()
-        #             u.afterMark(p, markUndoType, bunch)
-
         # Create the result dict.
         result_string = self.make_result_from_matches(matches_dict)
         # Create the summary node.
@@ -1642,9 +1631,7 @@ class LeoFind:
                     p.setMarked()
                     p.setDirty()
                     u.afterMark(p, markUndoType, bunch)
-
-        if self.mark_finds:
-            # Finish undo group
+            # Finish undo group only if mark_finds is true
             u.afterChangeGroup(found_p, undoType)
 
         c.setChanged()

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1614,7 +1614,7 @@ class LeoFind:
             # Start an undo-group instead of a single 'InsertNode' undo
             u.beforeChangeGroup(c.p, undoType)
             for match in matches_dict:
-                p = c.vnode2position(match.v)
+                p = c.vnode2position(match['v'])
                 if not p.isMarked():
                     markUndoType = 'Mark Finds'
                     bunch = u.beforeMark(p, markUndoType)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1613,6 +1613,27 @@ class LeoFind:
         if self.mark_finds:
             # Start an undo-group instead of a single 'InsertNode' undo
             u.beforeChangeGroup(c.p, undoType)
+
+        # ! PLACING THIS HERE MAKES THE FIRST NODE UNDER THE ROOT NOT 'MARK-REDOABLE' !
+        # if self.mark_finds:
+        #     for match in matches_dict:
+        #         p = c.vnode2position(match['v'])
+        #         if not p.isMarked():
+        #             markUndoType = 'Mark Finds'
+        #             bunch = u.beforeMark(p, markUndoType)
+        #             p.setMarked()
+        #             p.setDirty()
+        #             u.afterMark(p, markUndoType, bunch)
+
+        # Create the result dict.
+        result_string = self.make_result_from_matches(matches_dict)
+        # Create the summary node.
+        undoData = u.beforeInsertNode(c.p)
+        found_p = self.create_find_all_node(result_string)
+        u.afterInsertNode(found_p, undoType, undoData)
+        c.selectPosition(found_p)
+
+        if self.mark_finds:
             for match in matches_dict:
                 p = c.vnode2position(match['v'])
                 if not p.isMarked():
@@ -1622,16 +1643,10 @@ class LeoFind:
                     p.setDirty()
                     u.afterMark(p, markUndoType, bunch)
 
-        # Create the result dict.
-        result_string = self.make_result_from_matches(matches_dict)
-        # Create the summary node.
-        undoData = u.beforeInsertNode(c.p)
-        found_p = self.create_find_all_node(result_string)
-        u.afterInsertNode(found_p, undoType, undoData)
-        c.selectPosition(found_p)
         if self.mark_finds:
-            # Finish undo group if needed
+            # Finish undo group
             u.afterChangeGroup(found_p, undoType)
+
         c.setChanged()
         c.redraw()
         # Return a dict containing the actual results and statistics.


### PR DESCRIPTION
Fixes undo support for find/replace operations so that they take marking into account.

Also makes find-all and replace-all respect the 'Mark Finds' and 'Mark Changes' options

Fixes #3100