### PR TITLE
PR for #3124: improve ctrl-click searches

### DIFF
--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -484,7 +484,7 @@ class SpellCommandsClass(BaseEditCommandsClass):
             self.handler.add()
         else:
             self.openSpellTab()
-    #@+node:ekr.20150514063305.486: *4* find
+    #@+node:ekr.20150514063305.486: *4* spell-find
     @cmd('spell-find')
     def find(self, event: Event = None) -> None:
         """

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -599,7 +599,7 @@ class LeoFind:
             self.init_vim_search(find_pattern)
             self.update_change_list(self.change_text)  # Optional. An edge case.
             # Do the command!
-            settings = self._compute_find_def_settings(find_pattern)
+            settings = self._compute_find_def_settings(find_pattern, use_regex)
             result = method(settings, word)
             if result[0]:
                 # Keep the settings that found the match.
@@ -617,18 +617,18 @@ class LeoFind:
         """A standalone helper for unit tests."""
         return self._fd_helper(settings, word)
     #@+node:ekr.20210114202757.1: *5* find._compute_find_def_settings
-    def _compute_find_def_settings(self, find_pattern: str) -> Settings:
+    def _compute_find_def_settings(self, find_pattern: str, use_regex: bool = False) -> Settings:
 
         settings = self.default_settings()
         table = (
             ('change_text', ''),
             ('find_text', find_pattern),
-            ('ignore_case', True),  ### Was False
-            ('pattern_match', True),  ### Was False
+            ('ignore_case', True),
+            ('pattern_match', use_regex),
             ('reverse', False),
             ('search_body', True),
             ('search_headline', False),
-            ('whole_word', False),  ### Was True.
+            ('whole_word', not use_regex),
         )
         for attr, val in table:
             # Guard against renamings & misspellings.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -541,9 +541,16 @@ class LeoFind:
     def find_def(
         self,
         event: Event = None,
-        strict: bool = False,
+        ### strict: bool = False,
     ) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
         """Find the def or class under the cursor."""
+        
+        # Note: This method is *also* part of the ctrl-click logic:
+        #
+        # QTextEditWrapper.mouseReleaseEvent calls g.openUrlOnClick.
+        # g.openUrlOnClick calls g.openUrlHelper.
+        # g.openUrlHelper calls this method.
+        
         ftm, p = self.ftm, self.c.p
         # Check.
         word = self._compute_find_def_word(event)
@@ -565,7 +572,7 @@ class LeoFind:
             # Do the command!
             settings = self._compute_find_def_settings(find_pattern)
             g.trace(find_pattern, word)
-            p, pos, newpos = self.do_find_def(settings, word, strict)
+            p, pos, newpos = self.do_find_def(settings, word) ###, strict)
             if p:
                 return p, pos, newpos
         # #3124. Finally, try looking for an assignment.
@@ -578,13 +585,16 @@ class LeoFind:
         g.trace(find_pattern, word)
         return self.do_find_var(settings, word)
 
-    def find_def_strict(self, event: Event = None) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
-        """Same as find_def, but don't call _switch_style."""
-        return self.find_def(event=event, strict=True)
+    ###
+    # def find_def_strict(self, event: Event = None) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
+        # """Same as find_def, but don't call _switch_style."""
+        # return self.find_def(event=event, strict=True)
 
-    def do_find_def(self, settings: Settings, word: str, strict: bool) -> Tuple[Position, int, int]:
+    ### def do_find_def(self, settings: Settings, word: str, strict: bool) -> Tuple[Position, int, int]:
+    def do_find_def(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""
-        return self._fd_helper(settings, word, def_flag=True, strict=strict)
+        ### return self._fd_helper(settings, word, def_flag=True, strict=strict)
+        return self._fd_helper(settings, word)
     #@+node:ekr.20210114202757.1: *5* find._compute_find_def_settings
     def _compute_find_def_settings(self, find_pattern: str) -> Settings:
 
@@ -631,22 +641,25 @@ class LeoFind:
     def _fd_helper(self,
         settings: Settings,
         word: str,
-        def_flag: bool,
-        strict: bool,
+        ### def_flag: bool,
+        ### strict: bool,
     ) -> Tuple[Position, int, int]:
         """
         Find the definition of the class, def or var under the cursor.
 
         return p, pos, newpos for unit tests.
         """
-        c, find, ftm = self.c, self, self.ftm
-        # Recompute find_text for unit tests.
-        if def_flag:
-            prefix = 'class' if word[0].isupper() else 'def'
-            self.find_text = settings.find_text = prefix + ' ' + word
-        else:
-            prefix = ''
-            self.find_text = settings.find_text = word + ' ='
+        ### c, find, ftm = self.c, self, self.ftm
+        c = self.c
+        self.find_text = settings.find_text  ###
+        ###
+            # # Recompute find_text for unit tests.
+            # if def_flag:
+                # prefix = 'class' if word[0].isupper() else 'def'
+                # self.find_text = settings.find_text = prefix + ' ' + word
+            # else:
+                # prefix = ''
+                # self.find_text = settings.find_text = word + ' ='
         # Just search body text.
         self.search_headline = False
         self.search_body = True
@@ -683,24 +696,25 @@ class LeoFind:
                 found = pos is not None
                 if found or not g.inAtNosearch(p):  # do *not* use c.p.
                     break
-            if not found and def_flag and not strict:
-                # Leo 5.7.3: Look for an alternative definition of function/methods.
-                word2 = self._switch_style(word)
-                if self.reverse_find_defs:
-                    # #2161: start at the last position.
-                    p = c.lastPosition()
-                else:
-                    p = c.rootPosition()
-                if word2:
-                    find_pattern = prefix + ' ' + word2
-                    find.find_text = find_pattern
-                    ftm.set_find_text(find_pattern)
-                    # #1592.  Ignore hits under control of @nosearch
-                    while True:
-                        p, pos, newpos = self.find_next_match(p)
-                        found = pos is not None
-                        if not found or not g.inAtNosearch(p):
-                            break
+            ###
+                # if not found and def_flag and not strict:
+                    # # Leo 5.7.3: Look for an alternative definition of function/methods.
+                    # word2 = self._switch_style(word)
+                    # if self.reverse_find_defs:
+                        # # #2161: start at the last position.
+                        # p = c.lastPosition()
+                    # else:
+                        # p = c.rootPosition()
+                    # if word2:
+                        # find_pattern = prefix + ' ' + word2
+                        # find.find_text = find_pattern
+                        # ftm.set_find_text(find_pattern)
+                        # # #1592.  Ignore hits under control of @nosearch
+                        # while True:
+                            # p, pos, newpos = self.find_next_match(p)
+                            # found = pos is not None
+                            # if not found or not g.inAtNosearch(p):
+                                # break
         finally:
             self.reverse = old_reverse
         if found:
@@ -909,7 +923,8 @@ class LeoFind:
 
     def do_find_var(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""
-        return self._fd_helper(settings, word, def_flag=False, strict=False)
+        ### return self._fd_helper(settings, word, def_flag=False, strict=False)
+        return self._fd_helper(settings, word)
     #@+node:ekr.20141113094129.6: *4* find.focus-to-find
     @cmd('focus-to-find')
     def focus_to_find(self, event: Event = None) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -538,12 +538,8 @@ class LeoFind:
         return True
     #@+node:ekr.20150629084204.1: *4* find.find-def, do_find_def & helpers
     @cmd('find-def')
-    def find_def(
-        self,
-        event: Event = None,
-        ### strict: bool = False,
-    ) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
-        """Find the def or class under the cursor."""
+    def find_def(self, event: Event = None) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
+        """Find the class, def or assignment to var of the word under the cursor."""
 
         # Note: This method is *also* part of the ctrl-click logic:
         #
@@ -557,43 +553,26 @@ class LeoFind:
         if not word:
             return None, None, None
         # Settings...
-        i = 1 if word[0] == '_' else 0
-        if i <= len(word):
-            return None, None, None
-        # #3124. Try both possibilities.
-        prefix1 = 'class' if word[i].isupper() else 'def'
-        prefix2 = 'def' if word[i].isupper() else 'class'
-        for prefix in (prefix1, prefix2):
-            find_pattern = prefix + ' ' + word
+        # #3124. Try all possibilities, regardless of case.
+        table = (
+            (f"class {word}", self.do_find_def),
+            (f"def {word}", self.do_find_def),
+            (f"{word} =", self.do_find_var),
+        )
+        for find_pattern, method in table:
             ftm.set_find_text(find_pattern)
             self._save_before_find_def(p)  # Save previous settings.
             self.init_vim_search(find_pattern)
             self.update_change_list(self.change_text)  # Optional. An edge case.
             # Do the command!
             settings = self._compute_find_def_settings(find_pattern)
-            g.trace(find_pattern, word)
-            p, pos, newpos = self.do_find_def(settings, word)  ###, strict)
-            if p:
-                return p, pos, newpos
-        # #3124. Finally, try looking for an assignment.
-        find_pattern = word + ' ='
-        ftm.set_find_text(find_pattern)
-        self._save_before_find_def(p)  # Save previous settings.
-        self.init_vim_search(find_pattern)
-        self.update_change_list(self.change_text)  # Optional. An edge case.
-        settings = self._compute_find_def_settings(find_pattern)
-        g.trace(find_pattern, word)
-        return self.do_find_var(settings, word)
+            result = method(settings, word)
+            if result[0]:
+                return result
+        return None, None, None
 
-    ###
-    # def find_def_strict(self, event: Event = None) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
-        # """Same as find_def, but don't call _switch_style."""
-        # return self.find_def(event=event, strict=True)
-
-    ### def do_find_def(self, settings: Settings, word: str, strict: bool) -> Tuple[Position, int, int]:
     def do_find_def(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""
-        ### return self._fd_helper(settings, word, def_flag=True, strict=strict)
         return self._fd_helper(settings, word)
     #@+node:ekr.20210114202757.1: *5* find._compute_find_def_settings
     def _compute_find_def_settings(self, find_pattern: str) -> Settings:
@@ -638,28 +617,14 @@ class LeoFind:
                 return word[len(tag) :].strip()
         return word
     #@+node:ekr.20150629125733.1: *5* find._fd_helper
-    def _fd_helper(self,
-        settings: Settings,
-        word: str,
-        ### def_flag: bool,
-        ### strict: bool,
-    ) -> Tuple[Position, int, int]:
+    def _fd_helper(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
         """
         Find the definition of the class, def or var under the cursor.
 
         return p, pos, newpos for unit tests.
         """
-        ### c, find, ftm = self.c, self, self.ftm
         c = self.c
-        self.find_text = settings.find_text  ###
-        ###
-            # # Recompute find_text for unit tests.
-            # if def_flag:
-                # prefix = 'class' if word[0].isupper() else 'def'
-                # self.find_text = settings.find_text = prefix + ' ' + word
-            # else:
-                # prefix = ''
-                # self.find_text = settings.find_text = word + ' ='
+        self.find_text = settings.find_text
         # Just search body text.
         self.search_headline = False
         self.search_body = True
@@ -696,25 +661,6 @@ class LeoFind:
                 found = pos is not None
                 if found or not g.inAtNosearch(p):  # do *not* use c.p.
                     break
-            ###
-                # if not found and def_flag and not strict:
-                    # # Leo 5.7.3: Look for an alternative definition of function/methods.
-                    # word2 = self._switch_style(word)
-                    # if self.reverse_find_defs:
-                        # # #2161: start at the last position.
-                        # p = c.lastPosition()
-                    # else:
-                        # p = c.rootPosition()
-                    # if word2:
-                        # find_pattern = prefix + ' ' + word2
-                        # find.find_text = find_pattern
-                        # ftm.set_find_text(find_pattern)
-                        # # #1592.  Ignore hits under control of @nosearch
-                        # while True:
-                            # p, pos, newpos = self.find_next_match(p)
-                            # found = pos is not None
-                            # if not found or not g.inAtNosearch(p):
-                                # break
         finally:
             self.reverse = old_reverse
         if found:
@@ -923,7 +869,6 @@ class LeoFind:
 
     def do_find_var(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""
-        ### return self._fd_helper(settings, word, def_flag=False, strict=False)
         return self._fd_helper(settings, word)
     #@+node:ekr.20141113094129.6: *4* find.focus-to-find
     @cmd('focus-to-find')

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -554,11 +554,22 @@ class LeoFind:
             return None, None, None
         # Settings...
         # #3124. Try all possibilities, regardless of case.
-        table = (
-            (f"class {word}", self.do_find_def),
-            (f"def {word}", self.do_find_def),
-            (f"{word} =", self.do_find_var),
-        )
+        alt_word = self._switch_style(word)
+        if alt_word:
+            table = (
+                (f"^\s*class {word}\b", self.do_find_def),
+                (f"^\s*class {alt_word}\b", self.do_find_def),
+                (f"^\s*def {word}\b", self.do_find_def),
+                (f"^\s*def {alt_word}\b", self.do_find_def),
+                (f"^\s*{word} =", self.do_find_var),
+                (f"^\s*{alt_word} =", self.do_find_var),
+            )
+        else:
+            table = (
+                (f"^\s*class {word}\b", self.do_find_def),
+                (f"^\s*def {word}\b", self.do_find_def),
+                (f"{word} =", self.do_find_var),
+            )
         for find_pattern, method in table:
             ftm.set_find_text(find_pattern)
             self._save_before_find_def(p)  # Save previous settings.
@@ -582,11 +593,11 @@ class LeoFind:
             ('change_text', ''),
             ('find_text', find_pattern),
             ('ignore_case', False),
-            ('pattern_match', False),
+            ('pattern_match', True),  ### Was False
             ('reverse', False),
             ('search_body', True),
             ('search_headline', False),
-            ('whole_word', True),
+            ('whole_word', False),  ### Was False.
         )
         for attr, val in table:
             # Guard against renamings & misspellings.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -544,13 +544,13 @@ class LeoFind:
         ### strict: bool = False,
     ) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)
         """Find the def or class under the cursor."""
-        
+
         # Note: This method is *also* part of the ctrl-click logic:
         #
         # QTextEditWrapper.mouseReleaseEvent calls g.openUrlOnClick.
         # g.openUrlOnClick calls g.openUrlHelper.
         # g.openUrlHelper calls this method.
-        
+
         ftm, p = self.ftm, self.c.p
         # Check.
         word = self._compute_find_def_word(event)
@@ -572,7 +572,7 @@ class LeoFind:
             # Do the command!
             settings = self._compute_find_def_settings(find_pattern)
             g.trace(find_pattern, word)
-            p, pos, newpos = self.do_find_def(settings, word) ###, strict)
+            p, pos, newpos = self.do_find_def(settings, word)  ###, strict)
             if p:
                 return p, pos, newpos
         # #3124. Finally, try looking for an assignment.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -603,13 +603,9 @@ class LeoFind:
             result = method(settings, word)
             if result[0]:
                 # Keep the settings that found the match.
-                d = self.find_def_data
-                d.find_text = find_pattern
-                d.pattern_match = use_regex
-                d.whole_word = not use_regex
-                ftm.set_widgets_from_dict(self.find_def_data)
+                ftm.set_widgets_from_dict(settings)
                 return result
-        # Restore the previous find settings.
+        # Restore the previous find settings!
         self._restore_after_find_def()
         return None, None, None
 
@@ -908,8 +904,12 @@ class LeoFind:
         settings = self._compute_find_def_settings(find_pattern)
         # Do the command!
         result = self.do_find_var(settings, word)
-        if not result[0]:
-            self._restore_after_find_def()  # Avoid massive confusion!
+        if result[0]:
+            # Keep the settings that found the match.
+            ftm.set_widgets_from_dict(settings)
+        else:
+            # Restore the previous find settings!
+            self._restore_after_find_def()
 
     def do_find_var(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -564,6 +564,7 @@ class LeoFind:
             self.update_change_list(self.change_text)  # Optional. An edge case.
             # Do the command!
             settings = self._compute_find_def_settings(find_pattern)
+            g.trace(find_pattern, word)
             p, pos, newpos = self.do_find_def(settings, word, strict)
             if p:
                 return p, pos, newpos
@@ -574,6 +575,7 @@ class LeoFind:
         self.init_vim_search(find_pattern)
         self.update_change_list(self.change_text)  # Optional. An edge case.
         settings = self._compute_find_def_settings(find_pattern)
+        g.trace(find_pattern, word)
         return self.do_find_var(settings, word)
 
     def find_def_strict(self, event: Event = None) -> Tuple[Position, int, int]:  # pragma: no cover (cmd)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -548,7 +548,6 @@ class LeoFind:
         # g.openUrlHelper calls this method.
 
         # re searches are more accurate, but not enough to be worth changing the user's settings.
-        use_regex = False  # This is not going to be a user option!
         ftm, p = self.ftm, self.c.p
         # Check.
         word = self._compute_find_def_word(event)
@@ -562,23 +561,7 @@ class LeoFind:
         #@+<< compute the search table >>
         #@+node:ekr.20230203092333.1: *5* << compute the search table >>
         table: Tuple
-
-        if use_regex and alt_word:
-            table = (
-                (fr"^\s*class {word}\b", self.do_find_def),
-                # (fr"^\s*class {alt_word}\b", self.do_find_def),
-                (fr"^\s*def {word}\b", self.do_find_def),
-                (fr"^\s*def {alt_word}\b", self.do_find_def),
-                (fr"^\s*{word} =", self.do_find_var),
-                (fr"^\s*{alt_word} =", self.do_find_var),
-            )
-        elif use_regex:
-            table = (
-                (fr"^\s*class {word}\b", self.do_find_def),
-                (fr"^\s*def {word}\b", self.do_find_def),
-                (fr"{word} =", self.do_find_var),
-            )
-        elif alt_word:
+        if alt_word:
             table = (
                 (f"class {word}", self.do_find_def),
                 # (fr"^\s*class {alt_word}\b", self.do_find_def),
@@ -599,7 +582,7 @@ class LeoFind:
             self.init_vim_search(find_pattern)
             self.update_change_list(self.change_text)  # Optional. An edge case.
             # Do the command!
-            settings = self._compute_find_def_settings(find_pattern, use_regex)
+            settings = self._compute_find_def_settings(find_pattern)
             result = method(settings, word)
             if result[0]:
                 # Keep the settings that found the match.
@@ -613,18 +596,18 @@ class LeoFind:
         """A standalone helper for unit tests."""
         return self._fd_helper(settings, word)
     #@+node:ekr.20210114202757.1: *5* find._compute_find_def_settings
-    def _compute_find_def_settings(self, find_pattern: str, use_regex: bool = False) -> Settings:
+    def _compute_find_def_settings(self, find_pattern: str) -> Settings:
 
         settings = self.default_settings()
         table = (
             ('change_text', ''),
             ('find_text', find_pattern),
             ('ignore_case', True),
-            ('pattern_match', use_regex),
+            ('pattern_match', False),
             ('reverse', False),
             ('search_body', True),
             ('search_headline', False),
-            ('whole_word', not use_regex),
+            ('whole_word', True),
         )
         for attr, val in table:
             # Guard against renamings & misspellings.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5336,13 +5336,14 @@ def checkUnicode(s: str, encoding: str = None) -> str:
         return s
     if not isinstance(s, bytes):
         g.error(f"{tag}: unexpected argument: {s!r}")
+        g.trace('callers:', g.callers())
         return ''
     #
     # Report the unexpected conversion.
     callers = g.callers(1)
     if callers not in checkUnicode_dict:
-        g.trace(g.callers())
         g.error(f"\n{tag}: expected unicode. got: {s!r}\n")
+        g.trace(g.callers())
         checkUnicode_dict[callers] = True
     #
     # Convert to unicode, reporting all errors.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7585,7 +7585,6 @@ def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
     word = w.getSelectedText().strip()
     if not word:
         return None
-    ### p, pos, newpos = c.findCommands.find_def_strict(event)
     p, pos, newpos = c.findCommands.find_def(event)
     if p:
         return None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7480,13 +7480,14 @@ def openUrl(p: Position) -> None:
 #@+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
 def openUrlOnClick(event: Any, url: str = None) -> Optional[str]:
     """Open the URL under the cursor.  Return it for unit testing."""
-    # This can be called outside Leo's command logic, so catch all exceptions.
+    # QTextEditWrapper.mouseReleaseEvent calls this outside Leo's command logic.
+    # Make sure to catch all exceptions!
     try:
         return openUrlHelper(event, url)
     except Exception:
         g.es_exception()
         return None
-#@+node:ekr.20170216091704.1: *4* g.openUrlHelper
+#@+node:ekr.20170216091704.1: *4* g.openUrlHelper (changed)
 def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     c = getattr(event, 'c', None)
@@ -7584,7 +7585,8 @@ def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
     word = w.getSelectedText().strip()
     if not word:
         return None
-    p, pos, newpos = c.findCommands.find_def_strict(event)
+    ### p, pos, newpos = c.findCommands.find_def_strict(event)
+    p, pos, newpos = c.findCommands.find_def(event)
     if p:
         return None
     #@+<< look for filename or import>>

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1297,13 +1297,13 @@ class FindTabManager:
 
     def set_find_text(self, s: str) -> None:
         w = self.find_findbox
-        s = g.checkUnicode(s)
+        s = g.checkUnicode(s or '')
         w.clear()
         w.insert(s)
 
     def set_change_text(self, s: str) -> None:
         w = self.find_replacebox
-        s = g.checkUnicode(s)
+        s = g.checkUnicode(s or '')
         w.clear()
         w.insert(s)
     #@+node:ekr.20131117120458.16791: *3* ftm.toggle_checkbox

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1527,7 +1527,7 @@ class QScintillaWrapper(QTextMixin):
 class QTextEditWrapper(QTextMixin):
     """A wrapper for a QTextEdit/QTextBrowser supporting the high-level interface."""
     #@+others
-    #@+node:ekr.20110605121601.18073: *3* qtew.ctor & helpers
+    #@+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
     def __init__(self, widget: Widget, name: str, c: Cmdr=None) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
@@ -1543,7 +1543,7 @@ class QTextEditWrapper(QTextMixin):
             self.set_config()
             self.set_signals()
 
-    #@+node:ekr.20110605121601.18076: *4* qtew.set_config
+    #@+node:ekr.20110605121601.18076: *4* QTextEditWrapper.set_config
     def set_config(self) -> None:
         """Set configuration options for QTextEdit."""
         w = self.widget
@@ -1553,7 +1553,7 @@ class QTextEditWrapper(QTextMixin):
             w.setTabStopDistance(24)
         else:
             w.setTabStopWidth(24)
-    #@+node:ekr.20140901062324.18566: *4* qtew.set_signals (should be distributed?)
+    #@+node:ekr.20140901062324.18566: *4* QTextEditWrapper.set_signals (should be distributed?)
     def set_signals(self) -> None:
         """Set up signals."""
         c, name = self.c, self.name
@@ -1567,7 +1567,7 @@ class QTextEditWrapper(QTextMixin):
         if name in ('body', 'log'):
             # Monkey patch the event handler.
             #@+others
-            #@+node:ekr.20140901062324.18565: *5* mouseReleaseEvent (monkey-patch) QTextEditWrapper
+            #@+node:ekr.20140901062324.18565: *5* QTextEditWrapper.mouseReleaseEvent (monkey-patch)
             def mouseReleaseEvent(event: Event, self: Any=self) -> None:
                 """
                 Monkey patch for self.widget (QTextEditWrapper) mouseReleaseEvent.
@@ -1589,13 +1589,13 @@ class QTextEditWrapper(QTextMixin):
                     c.k.keyboardQuit(setFocus=False)
             #@-others
             self.widget.mouseReleaseEvent = mouseReleaseEvent
-    #@+node:ekr.20200312052821.1: *3* qtew.repr
+    #@+node:ekr.20200312052821.1: *3* QTextEditWrapper.repr
     def __repr__(self) -> str:
         # Add a leading space to align with StringTextWrapper.
         return f" <QTextEditWrapper: {id(self)} {self.name}>"
 
     __str__ = __repr__
-    #@+node:ekr.20110605121601.18078: *3* qtew.High-level interface
+    #@+node:ekr.20110605121601.18078: *3* QTextEditWrapper.High-level interface
     # These are all widget-dependent
     #@+node:ekr.20110605121601.18079: *4* qtew.delete (avoid call to setAllText)
     def delete(self, i: int, j: int=None) -> None:

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -5,6 +5,5 @@ cd c:\Repos\leo-editor
 rem echo test-one-leo: TestHtml.test_brython
 rem call python -m unittest leo.unittests.test_importers.TestHtml.test_brython
 
-echo test-one-leo: test_leoFind.TestFind.test_find_def and test_find_var
-call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_def
-call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_var
+echo test-one-leo: test_leoFind.TestFind
+call python -m unittest leo.unittests.core.test_leoFind.TestFind

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -2,17 +2,9 @@ echo off
 cls
 cd c:\Repos\leo-editor
 
-rem echo test-one-leo: test_leoFind.TestFind
-rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
+rem echo test-one-leo: TestHtml.test_brython
+rem call python -m unittest leo.unittests.test_importers.TestHtml.test_brython
 
-echo test-one-leo: TestHtml.test_brython
-call python -m unittest leo.unittests.test_importers.TestHtml.test_brython
-
-
-
-
-
-
-
-
-
+echo test-one-leo: test_leoFind.TestFind.test_find_def and test_find_var
+call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_def
+call python -m unittest leo.unittests.core.test_leoFind.TestFind.test_find_var

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -314,17 +314,20 @@ class TestFind(LeoUnitTest):
         # Test 1.
         for bool_val in (True, False):
             x.reverse_find_defs = bool_val
-            p, pos, newpos = x.do_find_def(settings, word='child5', strict=True)
+            ### p, pos, newpos = x.do_find_def(settings, word='child5', strict=True)
+            p, pos, newpos = x.do_find_def(settings, word='child5')
             assert p
             self.assertEqual(p.h, 'child 5')
             s = p.b[pos:newpos]
             self.assertEqual(s, 'def child5')
-            # Test 2: switch style.
-            p, pos, newpos = x.do_find_def(settings, word='child_5', strict=False)
-            assert p
-            self.assertEqual(p.h, 'child 5')
-            # Test 3: not found after switching style.
-            p, pos, newpos = x.do_find_def(settings, word='xyzzy', strict=False)
+            ###
+                # # Test 2: switch style.
+                # p, pos, newpos = x.do_find_def(settings, word='child_5', strict=False)
+                # assert p
+                # self.assertEqual(p.h, 'child 5')
+            ### # Test 3: not found after switching style.
+            # Test 2: not found
+            p, pos, newpos = x.do_find_def(settings, word='xyzzy')
             assert p is None, repr(p)
     #@+node:ekr.20210110073117.64: *4* TestFind.test_find-next
     def test_find_next(self):

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -302,7 +302,7 @@ class TestFind(LeoUnitTest):
         settings.find_text = 'not-found-xyzzy'
         x.do_find_all(settings)
 
-    #@+node:ekr.20210110073117.65: *4* TestFind.test_find_def
+    #@+node:ekr.20210110073117.65: *4* TestFind.test_find-def
     def test_find_def(self):
         # settings, x = self.settings, self.x
         x = self.x

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -304,26 +304,26 @@ class TestFind(LeoUnitTest):
 
     #@+node:ekr.20210110073117.65: *4* TestFind.test_find-def
     def test_find_def(self):
-        # settings, x = self.settings, self.x
         x = self.x
 
         # Test 1: Test methods called by x.find_def.
         x._save_before_find_def(x.c.rootPosition())  # Also tests _restore_after_find_def.
 
         # Test 2:
-        for reverse in (True, False):
-            # Successful search.
-            x.reverse_find_defs = reverse
-            settings = x._compute_find_def_settings('def child5')
-            p, pos, newpos = x.do_find_def(settings, word='child5')
-            self.assertTrue(p)
-            self.assertEqual(p.h, 'child 5')
-            s = p.b[pos:newpos]
-            self.assertEqual(s, 'def child5')
-            # Unsuccessful search.
-            settings = x._compute_find_def_settings('def xyzzy')
-            p, pos, newpos = x.do_find_def(settings, word='xyzzy')
-            assert p is None, repr(p)
+        for use_regex in (True, False):
+            for reverse in (True, False):
+                # Successful search.
+                x.reverse_find_defs = reverse
+                settings = x._compute_find_def_settings('def child5', use_regex)
+                p, pos, newpos = x.do_find_def(settings, word='child5')
+                self.assertTrue(p)
+                self.assertEqual(p.h, 'child 5')
+                s = p.b[pos:newpos]
+                self.assertEqual(s, 'def child5')
+                # Unsuccessful search.
+                settings = x._compute_find_def_settings('def xyzzy', use_regex)
+                p, pos, newpos = x.do_find_def(settings, word='xyzzy')
+                assert p is None, repr(p)
     #@+node:ekr.20210110073117.64: *4* TestFind.test_find-next
     def test_find_next(self):
         settings, x = self.settings, self.x
@@ -397,14 +397,14 @@ class TestFind(LeoUnitTest):
         self.assertEqual(s, settings.find_text)
     #@+node:ekr.20210110073117.66: *4* TestFind.test_find-var
     def test_find_var(self):
-        # settings, x = self.settings, self.x
         x = self.x
-        settings = x._compute_find_def_settings('v5 =')
-        p, pos, newpos = x.do_find_var(settings, word='v5')
-        assert p
-        self.assertEqual(p.h, 'child 5')
-        s = p.b[pos:newpos]
-        self.assertEqual(s, 'v5 =')
+        for use_regex in (True, False):
+            settings = x._compute_find_def_settings('v5 =', use_regex)
+            p, pos, newpos = x.do_find_var(settings, word='v5')
+            assert p
+            self.assertEqual(p.h, 'child 5')
+            s = p.b[pos:newpos]
+            self.assertEqual(s, 'v5 =')
     #@+node:ekr.20210110073117.68: *4* TestFind.test_replace-then-find
     def test_replace_then_find(self):
         settings, w, x = self.settings, self.c.frame.body.wrapper, self.x

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -309,7 +309,7 @@ class TestFind(LeoUnitTest):
 
         # Test 1: Test methods called by x.find_def.
         x._save_before_find_def(x.c.rootPosition())  # Also tests _restore_after_find_def.
-      
+
         # Test 2:
         for reverse in (True, False):
             # Successful search.

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -302,31 +302,26 @@ class TestFind(LeoUnitTest):
         settings.find_text = 'not-found-xyzzy'
         x.do_find_all(settings)
 
-    #@+node:ekr.20210110073117.65: *4* TestFind.test_find-def
+    #@+node:ekr.20210110073117.65: *4* TestFind.test_find_def
     def test_find_def(self):
-        settings, x = self.settings, self.x
-        # Test methods called by x.find_def.
-        # It would be wrong to call these methods from x.do_find_def.
+        # settings, x = self.settings, self.x
+        x = self.x
+
+        # Test 1: Test methods called by x.find_def.
         x._save_before_find_def(x.c.rootPosition())  # Also tests _restore_after_find_def.
-        x._compute_find_def_settings('my-find-pattern')
-        #
-        # Now the main tests...
-        # Test 1.
-        for bool_val in (True, False):
-            x.reverse_find_defs = bool_val
-            ### p, pos, newpos = x.do_find_def(settings, word='child5', strict=True)
+      
+        # Test 2:
+        for reverse in (True, False):
+            # Successful search.
+            x.reverse_find_defs = reverse
+            settings = x._compute_find_def_settings('def child5')
             p, pos, newpos = x.do_find_def(settings, word='child5')
-            assert p
+            self.assertTrue(p)
             self.assertEqual(p.h, 'child 5')
             s = p.b[pos:newpos]
             self.assertEqual(s, 'def child5')
-            ###
-                # # Test 2: switch style.
-                # p, pos, newpos = x.do_find_def(settings, word='child_5', strict=False)
-                # assert p
-                # self.assertEqual(p.h, 'child 5')
-            ### # Test 3: not found after switching style.
-            # Test 2: not found
+            # Unsuccessful search.
+            settings = x._compute_find_def_settings('def xyzzy')
             p, pos, newpos = x.do_find_def(settings, word='xyzzy')
             assert p is None, repr(p)
     #@+node:ekr.20210110073117.64: *4* TestFind.test_find-next
@@ -402,7 +397,9 @@ class TestFind(LeoUnitTest):
         self.assertEqual(s, settings.find_text)
     #@+node:ekr.20210110073117.66: *4* TestFind.test_find-var
     def test_find_var(self):
-        settings, x = self.settings, self.x
+        # settings, x = self.settings, self.x
+        x = self.x
+        settings = x._compute_find_def_settings('v5 =')
         p, pos, newpos = x.do_find_var(settings, word='v5')
         assert p
         self.assertEqual(p.h, 'child 5')

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -310,20 +310,19 @@ class TestFind(LeoUnitTest):
         x._save_before_find_def(x.c.rootPosition())  # Also tests _restore_after_find_def.
 
         # Test 2:
-        for use_regex in (True, False):
-            for reverse in (True, False):
-                # Successful search.
-                x.reverse_find_defs = reverse
-                settings = x._compute_find_def_settings('def child5', use_regex)
-                p, pos, newpos = x.do_find_def(settings, word='child5')
-                self.assertTrue(p)
-                self.assertEqual(p.h, 'child 5')
-                s = p.b[pos:newpos]
-                self.assertEqual(s, 'def child5')
-                # Unsuccessful search.
-                settings = x._compute_find_def_settings('def xyzzy', use_regex)
-                p, pos, newpos = x.do_find_def(settings, word='xyzzy')
-                assert p is None, repr(p)
+        for reverse in (True, False):
+            # Successful search.
+            x.reverse_find_defs = reverse
+            settings = x._compute_find_def_settings('def child5')
+            p, pos, newpos = x.do_find_def(settings, word='child5')
+            self.assertTrue(p)
+            self.assertEqual(p.h, 'child 5')
+            s = p.b[pos:newpos]
+            self.assertEqual(s, 'def child5')
+            # Unsuccessful search.
+            settings = x._compute_find_def_settings('def xyzzy')
+            p, pos, newpos = x.do_find_def(settings, word='xyzzy')
+            assert p is None, repr(p)
     #@+node:ekr.20210110073117.64: *4* TestFind.test_find-next
     def test_find_next(self):
         settings, x = self.settings, self.x
@@ -398,13 +397,12 @@ class TestFind(LeoUnitTest):
     #@+node:ekr.20210110073117.66: *4* TestFind.test_find-var
     def test_find_var(self):
         x = self.x
-        for use_regex in (True, False):
-            settings = x._compute_find_def_settings('v5 =', use_regex)
-            p, pos, newpos = x.do_find_var(settings, word='v5')
-            assert p
-            self.assertEqual(p.h, 'child 5')
-            s = p.b[pos:newpos]
-            self.assertEqual(s, 'v5 =')
+        settings = x._compute_find_def_settings('v5 =')
+        p, pos, newpos = x.do_find_var(settings, word='v5')
+        assert p
+        self.assertEqual(p.h, 'child 5')
+        s = p.b[pos:newpos]
+        self.assertEqual(s, 'v5 =')
     #@+node:ekr.20210110073117.68: *4* TestFind.test_replace-then-find
     def test_replace_then_find(self):
         settings, w, x = self.settings, self.c.frame.body.wrapper, self.x


### PR DESCRIPTION
See #3124.

**Summary**

The `find-def` command (and ctrl-clicks):
- searches for `class`, `def` and assignments using whole-word searches.
- *restores* previous search settings only if the search fails.
- *retains* the whole-word search settings that resulted in the match.
- Experiments show that using regex searches would not be worthwhile.
  The gain in accuracy is not worth the extra complexity of the patterns shown to the user.

**Details**

- [x] `find.find_def` searches for `class`, `def` and assignments, using alternative names if the original searches fail.
- [x] Add comment in `find.find_def` about calling sequence.
- [x] Add comment in `g.openUrlOnClick` about calling sequence.
- [x] Remove evil 'do_def' and 'strict' kwargs.
- [x] Remove `find.find_def_strict`. `g.openUrlOnClick now calls `find.find_def`.
- [x] Revise the unit test.