### PR TITLE
PR Add support for @bool rst3-remove-leo-directives

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -612,6 +612,7 @@
 <v t="ekr.20071213061504"><vh>@string rst3-default-path = None</vh></v>
 <v t="ekr.20090430075506.7"><vh>@bool rst3-generate-rst-header-comment = True</vh></v>
 <v t="ekr.20071213061811.1"><vh>@string rst3-underline-characters = #=+*^~-:&gt;&lt;</vh></v>
+<v t="ekr.20230205102733.1"><vh>@bool rst3-remove-leo-directives = False</vh></v>
 <v t="ekr.20071213061811.3"><vh>@bool rst3-write-intermediate-file = True</vh></v>
 <v t="ekr.20131027064821.18683"><vh>@string rst3-write-intermediate-extension = .txt</vh></v>
 </v>
@@ -11738,6 +11739,9 @@ Compatibility notes:
 - The "sort by creation date" of the todo plugin will not work with UUIDs or KSUIDs.
 
 For more details, see https://github.com/leo-editor/leo-editor/issues/3047
+</t>
+<t tx="ekr.20230205102733.1">False (legacy): Don't filter body text.
+True:           Remove unindented @language, @others and @wrap directives.
 </t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 


### PR DESCRIPTION
This PR allows the default body filter (for the rst3 command) to remove `@language`, `@others`, and  `@wrap` directives if they start a line.

The body filter won't remove these directives if they are (for example) in an indented code block.

- [x] `@bool rst3-remove-leo-directives = False`.
   The default value retains the legacy operation.
- [x] Support the new setting in the rst3 command.
- [x] Remove a redundant default underlining character.