### PR TITLE
PR: use breakpoint builtin

### DIFF
--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -120,11 +120,6 @@ class DebugCommandsClass(BaseEditCommandsClass):
             g.es_print('killed log listener.')
         else:
             g.es_print('log listener not active.')
-    #@+node:ekr.20150514063305.109: ** debug.pdb
-    @cmd('pdb')
-    def pdb(self, event: Event = None) -> None:
-        """Fall into pdb."""
-        g.pdb()
     #@+node:ekr.20150514063305.110: ** debug.show-focus
     @cmd('show-focus')
     def printFocus(self, event: Event = None) -> None:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -257,11 +257,6 @@ class LeoGlobals:  # pragma: no cover
             result.append(repr(obj))
         result.append('')
         return '\n'.join(result)
-    #@+node:ekr.20220327132500.1: *3* LeoGlobals.pdb
-    def pdb(self) -> None:
-        import pdb as _pdb
-        # pylint: disable=forgotten-debug-statement
-        _pdb.set_trace()
     #@+node:ekr.20191226190425.1: *3* LeoGlobals.plural
     def plural(self, obj: Any) -> str:
         """Return "s" or "" depending on n."""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2693,7 +2693,6 @@ def pause(s: str) -> None:
 #@+node:ekr.20041105091148: *4* g.pdb
 def pdb(message: str = '') -> None:
     """Fall into pdb."""
-    import pdb  # Required: we have just defined pdb as a function!
     if app and not app.useIpython:
         try:
             from leo.core.leoQt import QtCore
@@ -2703,7 +2702,7 @@ def pdb(message: str = '') -> None:
     if message:
         print(message)
     # pylint: disable=forgotten-debug-statement
-    pdb.set_trace()
+    breakpoint()  # New in Python 3.7.
 #@+node:ekr.20050819064157: *4* g.objToString & aliases
 def objToString(obj: Any, indent: int = 0, tag: str = None, width: int = 120) -> str:
     """

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -153,11 +153,11 @@ class InternalIPKernel:
     #@+node:ekr.20160331083020.1: *3* ileo.pdb
     def pdb(self, message: str = '') -> None:
         """Fall into pdb."""
-        import pdb  # Required: we have just defined pdb as a function!
-        pdb = pdb.Pdb(stdout=sys.__stdout__)  # type:ignore # mypy is confused.
         if message:
             self.put_stdout(message)
-        pdb.set_trace()  # This works, but there are no IPython sources.
+        # pylint: disable=forgotten-debug-statement
+        # This works, but there are no IPython sources.
+        breakpoint()  # New in Python 3.7.
     #@+node:ekr.20130930062914.15995: *3* ileo.print_namespace
     def print_namespace(self, event: Event = None) -> None:
         print("\n***Variables in User namespace***")


### PR DESCRIPTION
`g.pdb` wraps this code:
```python
if app and not app.useIpython:
    try:
        from leo.core.leoQt import QtCore
        QtCore.pyqtRemoveInputHook()
    except Exception:
        pass
```
All other code can simply call Python's `breakpoint` builtin, new in Python 3.7.

- [x] Use `breakpoint` builtin in `g.pdb` and `ileo.pdb`.
- [x] Remove `LeoGlobals.pdb` and `debug.pdb`.