### PR TITLE
PR: Revise leoAst.LeoGlobals and leoGlobals

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1801,7 +1801,7 @@ class Commands:
             if g.unitTesting:
                 raise
             g.warning(f"Syntax error in: {h}")
-            g.es_exception(full=False, color="black")
+            g.es_exception()
         except Exception:
             g.es_print('unexpected exception')
             g.es_exception()
@@ -2203,7 +2203,7 @@ class Commands:
                 if g.unitTesting:
                     raise
                 g.es_print("exception executing command")
-                g.es_exception(c=c)
+                g.es_exception()
             if c and c.exists:
                 if c.requestCloseWindow:
                     c.requestCloseWindow = False
@@ -2595,7 +2595,7 @@ class Commands:
                         aList.append(s2)
                     except Exception:
                         g.es(f"Exception evaluating {{{{{exp}}}}} in {s.strip()}")
-                        g.es_exception(full=True, c=c)
+                        g.es_exception()
                 # Prepare to search again after the last '}}'
                 previ = j + 2
             else:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -685,13 +685,13 @@ class FileCommands:
             if self.read_only:
                 g.error("read only")
             g.error("exception deleting backup file:", fileName)
-            g.es_exception(full=False)
+            g.es_exception()
     #@+node:ekr.20100119145629.6108: *4* fc.handleWriteLeoFileException
     def handleWriteLeoFileException(self, fileName: str, backupName: str, f: Any) -> None:
         """Report an exception. f is an open file, or None."""
         # c = self.c
         g.es("exception writing:", fileName)
-        g.es_exception(full=True)
+        g.es_exception()
         if f:
             f.close()
         # Delete fileName.
@@ -706,7 +706,7 @@ class FileCommands:
                 shutil.move(src, dst)
             except Exception:
                 g.error('exception renaming', src, 'to', dst)
-                g.es_exception(full=False)
+                g.es_exception()
         else:
             g.error('backup file does not exist!', repr(backupName))
     #@+node:ekr.20040324080359.1: *4* fc.isReadOnly

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5859,7 +5859,7 @@ def es_event_exception(eventName: str, full: bool = False) -> None:
     if not g.stdErrIsRedirected():  # 2/16/04
         traceback.print_exc()
 #@+node:ekr.20031218072017.3112: *3* g.es_exception
-def es_exception() -> None:
+def es_exception(*args: Sequence, **kwargs: Sequence) -> None:
     """Print the last exception."""
     # val is the second argument to the raise statement.
     typ, val, tb = sys.exc_info()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5859,17 +5859,12 @@ def es_event_exception(eventName: str, full: bool = False) -> None:
     if not g.stdErrIsRedirected():  # 2/16/04
         traceback.print_exc()
 #@+node:ekr.20031218072017.3112: *3* g.es_exception
-def es_exception(full: bool = True, c: Cmdr = None, color: str = "red") -> Tuple[str, int]:
-    typ, val, tb = sys.exc_info()
+def es_exception() -> None:
+    """Print the last exception."""
     # val is the second argument to the raise statement.
-    if full:
-        lines = traceback.format_exception(typ, val, tb)
-    else:
-        lines = traceback.format_exception_only(typ, val)
-    for line in lines:
-        g.es_print_error(line, color=color)
-    fileName, n = g.getLastTracebackFileAndLineNumber()
-    return fileName, n
+    typ, val, tb = sys.exc_info()
+    for line in traceback.format_exception(typ, val, tb):
+        print(line)
 #@+node:ekr.20061015090538: *3* g.es_exception_type
 def es_exception_type(c: Cmdr = None, color: str = "red") -> None:
     # exctype is a Exception class object; value is the error message.

--- a/leo/core/tracing_utils.py
+++ b/leo/core/tracing_utils.py
@@ -77,14 +77,10 @@ def callers_list(n: int = 4) -> List[str]:
         i += 1
     return list(reversed(result))
 #@+node:ekr.20230208054438.1: ** tracing_utils.es_exception
-def es_exception(full: bool = True) -> None:
-    typ, val, tb = sys.exc_info()
+def es_exception() -> None:
     # val is the second argument to the raise statement.
-    if full:
-        lines = traceback.format_exception(typ, val, tb)
-    else:
-        lines = traceback.format_exception_only(typ, val)
-    for line in lines:
+    typ, val, tb = sys.exc_info()
+    for line in traceback.format_exception(typ, val, tb):
         print(line)
 #@+node:ekr.20230203163544.6: ** tracing_utils.get_ctor_name
 def get_ctor_name(self: Any, file_name: str, width: int = 25) -> str:

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -142,7 +142,7 @@ def applyFileAction(p, filename, c):
             exec(script, namespace)
         except Exception:
             g.es("exception in FileAction plugin")
-            g.es_exception(full=False, c=c)
+            g.es_exception()
         finally:
             if redirect:
                 g.restoreStderr()

--- a/leo/plugins/leo_to_html.py
+++ b/leo/plugins/leo_to_html.py
@@ -643,7 +643,7 @@ class Leo_to_HTML:
             f = open(filepath, 'wb')
         except Exception:
             g.error('can not open: %s' % (filepath))
-            g.es_exception(full=False, c=self.c)
+            # g.es_exception()
             return False
         try:
             try:
@@ -653,7 +653,7 @@ class Leo_to_HTML:
                 ok = True
             except Exception:
                 g.error('write failed: %s' % (filepath))
-                g.es_exception(full=False, c=self.c)
+                g.es_exception()
                 ok = False
         finally:
             f.close()

--- a/leo/plugins/md_docer.py
+++ b/leo/plugins/md_docer.py
@@ -167,7 +167,7 @@ def sync_transformations(event):
             gnxDict[dst].b = out.getvalue()
             count += 1
         except Exception:
-            g.es_exception(True, c)
+            g.es_exception()
     if count:
         g.es('%d node(s) transformed' % count)
 #@-others

--- a/leo/plugins/nodeActions.py
+++ b/leo/plugins/nodeActions.py
@@ -391,7 +391,7 @@ def applyNodeAction(pScript, pClicked, c):
             exec(script, namespace)
         except Exception:
             g.es("exception in NodeAction plugin")
-            g.es_exception(full=False, c=c)
+            g.es_exception()
         finally:
             # Unredirect output
             if redirect:

--- a/leo/scripts/leoScripts.txt
+++ b/leo/scripts/leoScripts.txt
@@ -16266,7 +16266,7 @@ def htmlize(c,p):
         g.es(lang, p.h)
     except Exception:
         g.es('htmlize malfunction?', color='tomato')
-        g.es_exception(full= True)
+        g.es_exception()
 #@+node:ekr.20041229163210.7: *6* << colorize with silvercity >>
 if lang in [ # Leo may not have all of these yet
     'csharp', 'c', 'c++', 'cpp', # (C and C++)


### PR DESCRIPTION
**Summary**

- This PR should have no effect on existing scripts or plugins.
- Change signature for `g.es_exception`, retaining compatibility.
- Simplify `LeoGlobals` class in `leoAst.py` and use pep8 names throughout `leoAst.py`.

**Changes to leoAst.py**

- [x] Use Pep8 names for all members of `LeoGlobals` class.
- [x] Use `pprint.pformat` in `LeoGlobals.to_string`.
- [x] Simplify `LeoGlobals.es_exception`.
- [x] Simplify `LeoGlobals.trace`.

**Changes to leoGlobals.py**

- [x] Remove all kwargs from `g.es_exception`.
- [x] `g.es_exception` returns None.

**Changes to tracing_utils.py**

- [x] Simplify `ex_exception` function, as in `g.es_exception`.
- [x] Simplify `trace` function as in `LeoGlobals.trace`.
- [x] Add `to_encoded_string` and `to_unicode` functions.

**All other files**

- [x] Remove all kwargs in calls to `g.es_exception`.
- [x] No change needed to `LeoDocs.leo`, 'CheatSheet.leo`, or 'quickstart.leo`.
- [x] Update one script in `scripts.Leo`.