### PR TITLE
PR: improve check-nodes command

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -385,7 +385,7 @@ class CheckNodes:
             p.h not in self.suppressions
             and not p.h.startswith('class') and '@others' not in p.b
             and not any(z.match(p.h) for z in self.ok_head_patterns)
-            and sum(1 for s in g.splitLines(p.b) if self.def_pattern.match(s)) > 1
+            and sum(1 for s in lines if self.def_pattern.match(s)) > 1
         )
         leading_blank_line = p.b.strip() and not lines[0].strip()
         empty_body = (

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4345,6 +4345,7 @@ def splitLines(s: str) -> List[str]:
     Split s into lines, preserving the number of lines and
     the endings of all lines, including the last line.
     """
+    # The guard protects only against s == None.
     return s.splitlines(True) if s else []  # This is a Python string function!
 
 splitlines = splitLines

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -5,5 +5,8 @@ cd c:\Repos\leo-editor
 rem echo test-one-leo: TestHtml.test_brython
 rem call python -m unittest leo.unittests.test_importers.TestHtml.test_brython
 
-echo test-one-leo: test_leoFind.TestFind
-call python -m unittest leo.unittests.core.test_leoFind.TestFind
+rem echo test-one-leo: test_leoFind.TestFind
+rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
+
+echo test-one-leo: test_CheckerCommands.TestFind.test_check_nodes
+call python -m unittest leo.unittests.commands.test_checkerCommands.TestChecker.test_check_nodes

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -1,6 +1,7 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20210904022712.2: * @file ../unittests/commands/test_checkerCommands.py
 """Tests of leo.commands.leoCheckerCommands."""
+import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 #@+others
@@ -24,6 +25,30 @@ class TestChecker(LeoUnitTest):
             message = message.replace('\\', '/')
             m = pattern.match(message)
             self.assertTrue(m, msg=message)
+    #@+node:ekr.20230221104054.1: *3* test_check_nodes
+    def test_check_nodes(self):
+        c = self.c
+        from leo.commands import checkerCommands
+        x = checkerCommands.CheckNodes()
+        x.c = c
+        x.ok_head_patterns = []
+        table = (
+            textwrap.dedent("""\
+                def spam():
+                    pass
+                def eggs():
+                    pass
+            """),  # Too many defs.
+            "   ",  # Empty body.
+            "\ntest\n",  # Leading blank line.
+            "\n\nclass MyClass\n",  # Trailing class line.
+            "\n\ndef spam():",  # Trailing def line.
+        )
+        p = c.rootPosition()
+        for s in table:
+            p.b = s
+            x.get_data()
+            assert x.is_dubious_node(p)
     #@-others
 #@-others
 


### PR DESCRIPTION
- [x] Add `CheckNodes` class for unit testing.
- [x] Improve `CheckNodes.is_dubious_node` so that it tests for trailing `class` or `def` statement.
- [x] Add `test_checkerCommands.TestChecker.test_check_nodes`.
- [x] Add a comment in `g.splitLines`: `s.splitLines(True)` works better than I knew.