### PR TITLE
PR for # 3161: exception in g.handleScriptException

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -716,7 +716,7 @@ class Commands:
         except KeyboardInterrupt:
             g.es('interrupted')
         except Exception:
-            g.handleScriptException(c, p, script, script)
+            g.handleScriptException(c, p)
         finally:
             del sys.path[:2]
     #@+node:ekr.20171123135625.4: *3* @cmd execute-script & public helpers
@@ -749,7 +749,8 @@ class Commands:
         raiseFlag=False         True: reraise any exceptions.
         runPyflakes=True        True: run pyflakes if allowed by setting.
         """
-        c, script1 = self, script
+        ### c, script1 = self, script
+        c = self
         if runPyflakes:
             run_pyflakes = c.config.getBool('run-pyflakes-on-write', default=False)
         else:
@@ -785,7 +786,7 @@ class Commands:
                 except Exception:
                     if raiseFlag:
                         raise
-                    g.handleScriptException(c, script_p, script, script1)
+                    g.handleScriptException(c, script_p)
                 finally:
                     del sys.path[0]
                     del sys.path[0]

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -749,7 +749,6 @@ class Commands:
         raiseFlag=False         True: reraise any exceptions.
         runPyflakes=True        True: run pyflakes if allowed by setting.
         """
-        ### c, script1 = self, script
         c = self
         if runPyflakes:
             run_pyflakes = c.config.getBool('run-pyflakes-on-write', default=False)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7026,35 +7026,41 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
             result.append(line)
     return ''.join(result)
 #@+node:ekr.20060624085200: *3* g.handleScriptException
-def handleScriptException(c: Cmdr, p: Position, script: str, script1: str) -> None:
+def handleScriptException(
+    c: Cmdr,
+    p: Position,
+    script: str = None,  # No longer used.
+    script1: str = None,  # No longer used.
+) -> None:
     g.warning("exception executing script")
     g.es_exception()
     # Careful: this test is no longer guaranteed.
-    if p.v.context == c:
-        fileName, n = g.getLastTracebackFileAndLineNumber()
-        try:
-            c.goToScriptLineNumber(n, p)
-            #@+<< dump the lines near the error >>
-            #@+node:EKR.20040612215018: *4* << dump the lines near the error >>
-            if g.os_path_exists(fileName):
-                with open(fileName) as f:
-                    lines = f.readlines()
-            else:
-                lines = g.splitLines(script)
-            s = '-' * 20
-            g.es_print('', s)
-            # Print surrounding lines.
-            i = max(0, n - 2)
-            j = min(n + 2, len(lines))
-            while i < j:
-                ch = '*' if i == n - 1 else ' '
-                s = f"{ch} line {i+1:d}: {lines[i]}"
-                g.es('', s, newline=False)
-                i += 1
-            #@-<< dump the lines near the error >>
-        except Exception:
-            g.es_print('Unexpected exception in g.handleScriptException')
-            g.es_exception()
+    if p.v.context != c:
+        return
+    fileName, n = g.getLastTracebackFileAndLineNumber()
+    try:
+        c.goToScriptLineNumber(n, p)
+        #@+<< dump the lines near the error >>
+        #@+node:EKR.20040612215018: *4* << dump the lines near the error >>
+        if g.os_path_exists(fileName):
+            with open(fileName) as f:
+                lines = f.readlines()
+        else:
+            lines = g.splitLines(script)
+        s = '-' * 20
+        g.es_print('', s)
+        # Print surrounding lines.
+        i = max(0, n - 2)
+        j = min(n + 2, len(lines))
+        while i < j:
+            ch = '*' if i == n - 1 else ' '
+            s = f"{ch} line {i+1:d}: {lines[i]}"
+            g.es('', s, newline=False)
+            i += 1
+        #@-<< dump the lines near the error >>
+    except Exception:
+        g.es_print('Unexpected exception in g.handleScriptException')
+        g.es_exception()
 #@+node:ekr.20140209065845.16767: *3* g.insertCodingLine
 def insertCodingLine(encoding: str, script: str) -> str:
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7028,9 +7028,10 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
 #@+node:ekr.20060624085200: *3* g.handleScriptException
 def handleScriptException(c: Cmdr, p: Position, script: str, script1: str) -> None:
     g.warning("exception executing script")
-    fileName, n = g.es_exception()
+    g.es_exception()
     # Careful: this test is no longer guaranteed.
     if p.v.context == c:
+        fileName, n = g.getLastTracebackFileAndLineNumber()
         try:
             c.goToScriptLineNumber(n, p)
             #@+<< dump the lines near the error >>

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -5,5 +5,8 @@ cd c:\Repos\leo-editor
 rem echo test-one-leo: TestHtml.test_brython
 rem call python -m unittest leo.unittests.test_importers.TestHtml.test_brython
 
+rem echo test-one-leo: test_leoFind.TestFind
+rem call python -m unittest leo.unittests.core.test_leoFind.TestFind
+
 echo test-one-leo: test_leoFind.TestFind
-call python -m unittest leo.unittests.core.test_leoFind.TestFind
+call python -m unittest leo.unittests.core.test_leoGlobals.TestGlobals.test_g_handleScriptException

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -2,6 +2,7 @@
 #@+node:ekr.20210902164946.1: * @file ../unittests/core/test_leoGlobals.py
 """Tests for leo.core.leoGlobals"""
 
+import io
 import os
 import stat
 import sys
@@ -264,6 +265,29 @@ class TestGlobals(LeoUnitTest):
             )
             for url, aList in table2:
                 g.handleUrl(c=c, p=c.p, url=url)
+    #@+node:ekr.20230221153849.1: *3* TestGlobals.test_g_handleScriptException
+    def test_g_handleScriptException(self):
+
+        c = self.c
+        table = (
+            'test_leoGlobals.py", line',
+            'in test_g_handleScriptException',
+            'print(1/0)',
+            'ZeroDivisionError: division by zero'
+        )
+        with self.assertRaises(ZeroDivisionError):
+            try:
+                print(1/0)
+            except ZeroDivisionError:
+                old_stdout = sys.stdout
+                sys.stdout = io.StringIO()
+                g.handleScriptException(c, c.p)
+                report = sys.stdout.getvalue()
+                for s in table:
+                    assert s in report, repr(s)
+                sys.stdout = old_stdout
+                # print(report)
+                raise
     #@+node:ekr.20210905203541.23: *3* TestGlobals.test_g_import_module
     def test_g_import_module(self):
         assert g.import_module('leo.core.leoAst')


### PR DESCRIPTION
See #3161.

- [x] Call `g.getLastTracebackFileAndLineNumber` in `g.handleScriptException`.
- [x] Convert `script` and `script1` args to optional kwargs: they are no longer used.
- [x] Remove 'script' and 'script1' args from all calls to `g.handleScriptException`.
- [x] Create a strong new unit test.