### PR TITLE
Felix-server5

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1554,7 +1554,7 @@ class LeoFind:
             {
                 'body': body,  # List of indices into v.b
                 'head': head,  # List of indices into v.h
-                'v': v,        # The vnode containing the mateches.
+                'v': v,        # The vnode containing the matches.
             }
         """
         self.init_ivars_from_settings(settings)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -583,7 +583,7 @@ class LeoFind:
             self.update_change_list(self.change_text)  # Optional. An edge case.
             # Do the command!
             settings = self._compute_find_def_settings(find_pattern)
-            result = method(settings, word)
+            result = method(settings)
             if result[0]:
                 # Keep the settings that found the match.
                 ftm.set_widgets_from_dict(settings)
@@ -592,9 +592,9 @@ class LeoFind:
         self._restore_after_find_def()
         return None, None, None
 
-    def do_find_def(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
+    def do_find_def(self, settings: Settings) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""
-        return self._fd_helper(settings, word)
+        return self._fd_helper(settings)
     #@+node:ekr.20210114202757.1: *5* find._compute_find_def_settings
     def _compute_find_def_settings(self, find_pattern: str) -> Settings:
 
@@ -638,7 +638,7 @@ class LeoFind:
                 return word[len(tag) :].strip()
         return word
     #@+node:ekr.20150629125733.1: *5* find._fd_helper
-    def _fd_helper(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
+    def _fd_helper(self, settings: Settings) -> Tuple[Position, int, int]:
         """
         Find the definition of the class, def or var under the cursor.
 
@@ -886,7 +886,7 @@ class LeoFind:
         self.update_change_list(self.change_text)  # Optional. An edge case.
         settings = self._compute_find_def_settings(find_pattern)
         # Do the command!
-        result = self.do_find_var(settings, word)
+        result = self.do_find_var(settings)
         if result[0]:
             # Keep the settings that found the match.
             ftm.set_widgets_from_dict(settings)
@@ -894,9 +894,9 @@ class LeoFind:
             # Restore the previous find settings!
             self._restore_after_find_def()
 
-    def do_find_var(self, settings: Settings, word: str) -> Tuple[Position, int, int]:
+    def do_find_var(self, settings: Settings) -> Tuple[Position, int, int]:
         """A standalone helper for unit tests."""
-        return self._fd_helper(settings, word)
+        return self._fd_helper(settings)
     #@+node:ekr.20141113094129.6: *4* find.focus-to-find
     @cmd('focus-to-find')
     def focus_to_find(self, event: Event = None) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1861,31 +1861,6 @@ class LeoServer:
         result = {"found": bool(p), "pos": pos, "range": selRange,
                     "newpos": newpos, "focus": focus}
         return self._make_response(result)
-    #@+node:felix.20230204161448.1: *5* server.find_all_unique_regex
-    def find_all_unique_regex(self, param: Param) -> Response:
-        """Find Unique Regex / Replace All Unique Regex"""
-        tag = 'find_all_unique_regex'
-        c = self._check_c()
-        fc = c.findCommands
-        replace = param.get("replace")
-        findText = param.get("findText")
-        replaceText = param.get("replaceText", "")
-        result = Any
-        try:
-            settings = fc.ftm.get_settings()
-            settings["findText"] = findText
-            settings["replaceText"] = replaceText
-            fc.findAllUniqueFlag = True
-            if replace:
-                result = fc.do_change_all(settings)
-            else:
-                result = fc.do_find_all(settings)
-        except Exception as e:
-            raise ServerError(f"{tag}: Running find_all_unique_regex operation gave exception: {e}")
-        #
-        focus = self._get_focus()
-        return self._make_response({"found": result, "focus": focus})
-
     #@+node:felix.20210621233316.22: *5* server.find_all
     def find_all(self, param: Param) -> Response:
         """Run Leo's find all command and return results."""

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -282,7 +282,7 @@ class TestFind(LeoUnitTest):
         # Test 2.
         init()
         settings.suboutline_only = True
-        count = x.do_find_all(settings)
+        x.do_find_all(settings)
         # Test 3.
         init()
         settings.search_headline = False
@@ -290,7 +290,6 @@ class TestFind(LeoUnitTest):
         x.do_find_all(settings)
         # Test 4.
         init()
-        x.findAllUniqueFlag = True
         settings.pattern_match = True
         settings.find_text = r'^(def)'
         settings.change_text = '*\1*'
@@ -312,14 +311,14 @@ class TestFind(LeoUnitTest):
             # Successful search.
             x.reverse_find_defs = reverse
             settings = x._compute_find_def_settings('def child5')
-            p, pos, newpos = x.do_find_def(settings, word='child5')
+            p, pos, newpos = x.do_find_def(settings)
             self.assertTrue(p)
             self.assertEqual(p.h, 'child 5')
             s = p.b[pos:newpos]
             self.assertEqual(s, 'def child5')
             # Unsuccessful search.
             settings = x._compute_find_def_settings('def xyzzy')
-            p, pos, newpos = x.do_find_def(settings, word='xyzzy')
+            p, pos, newpos = x.do_find_def(settings)
             assert p is None, repr(p)
     #@+node:ekr.20210110073117.64: *4* TestFind.test_find-next
     def test_find_next(self):
@@ -396,7 +395,7 @@ class TestFind(LeoUnitTest):
     def test_find_var(self):
         x = self.x
         settings = x._compute_find_def_settings('v5 =')
-        p, pos, newpos = x.do_find_var(settings, word='v5')
+        p, pos, newpos = x.do_find_var(settings)
         assert p
         self.assertEqual(p.h, 'child 5')
         s = p.b[pos:newpos]
@@ -675,9 +674,9 @@ class TestFind(LeoUnitTest):
             ('ABbabc',  'b',    [1, 2, 4]),
 
             (True, True),
-            ('ax aba ab abc'    'ab', [7]),
-            ('ax aba\nab abc'   'ab', [7]),
-            ('ax aba ab\babc'   'ab', [7]),
+            ('ax aba ab abc',   'ab', [7]),
+            ('ax aba\nab abc',  'ab', [7]),
+            ('ax aba ab\babc',  'ab', [7]),
         )
         for aTuple in table:
             if len(aTuple) == 2:


### PR DESCRIPTION
Fixes 'find' related quirps, syntax errors and details.

(Those were found while transliterating leoFind.py & test_leoFind.py into typescript for leoJS.)

I've run unit tests in windows to make sure they pass prior to making this pull request.