### PR TITLE
Fixed loop in leoserver, for having the chosen file's document selected, when trying to open an already opened file.

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1215,6 +1215,7 @@ class LeoServer:
             for c in g.app.commanders():
                 if c.fileName() == filename:
                     found = True
+                    break
         if not found:
             c = self.bridge.openLeoFile(filename)
             # Add ftm. This won't happen if opened outside leoserver


### PR DESCRIPTION
(99.999% sure this is my last fix for 6.7.2) Fixed little quirp in the server for when opening an already opened file. 