### PR TITLE
PR: Replace most 'oops' methods with NotImplementedError

### DIFF
--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -95,9 +95,7 @@ class BaseEditCommandsClass:
     #@+node:ekr.20150514043714.9: *3* BaseEdit.oops
     def oops(self) -> None:  # pragma: no cover
         """Return a "must be overridden" message"""
-        g.pr("BaseEditCommandsClass oops:",
-            g.callers(),
-            "must be overridden in subclass")
+        raise NotImplementedError
     #@+node:ekr.20150514043714.10: *3* BaseEdit.Helpers
     #@+node:ekr.20150514043714.11: *4* BaseEdit._chckSel
     def _chckSel(self, event: Event, warning: str = 'no selection') -> bool:

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -92,10 +92,6 @@ class BaseEditCommandsClass:
     def getWSString(self, s: str) -> str:  # pragma: no cover
         """Return s with all characters replaced by tab or space."""
         return ''.join([ch if ch == '\t' else ' ' for ch in s])
-    #@+node:ekr.20150514043714.9: *3* BaseEdit.oops
-    # def oops(self) -> None:  # pragma: no cover
-        # """Return a "must be overridden" message"""
-        # raise NotImplementedError
     #@+node:ekr.20150514043714.10: *3* BaseEdit.Helpers
     #@+node:ekr.20150514043714.11: *4* BaseEdit._chckSel
     def _chckSel(self, event: Event, warning: str = 'no selection') -> bool:

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -93,9 +93,9 @@ class BaseEditCommandsClass:
         """Return s with all characters replaced by tab or space."""
         return ''.join([ch if ch == '\t' else ' ' for ch in s])
     #@+node:ekr.20150514043714.9: *3* BaseEdit.oops
-    def oops(self) -> None:  # pragma: no cover
-        """Return a "must be overridden" message"""
-        raise NotImplementedError
+    # def oops(self) -> None:  # pragma: no cover
+        # """Return a "must be overridden" message"""
+        # raise NotImplementedError
     #@+node:ekr.20150514043714.10: *3* BaseEdit.Helpers
     #@+node:ekr.20150514043714.11: *4* BaseEdit._chckSel
     def _chckSel(self, event: Event, warning: str = 'no selection') -> bool:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -688,9 +688,6 @@ class ParserBaseClass:
     #@+node:ekr.20041124063257: *3* pbc.munge
     def munge(self, s: str) -> str:
         return g.app.config.canonicalizeSettingName(s)
-    #@+node:ekr.20041119204700.2: *3* pbc.oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
     #@+node:ekr.20041213082558: *3* pbc.parsers
     #@+node:ekr.20041213082558.1: *4* pbc.parseFont & helper
     def parseFont(self, p: Position) -> Dict[str, Any]:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -689,11 +689,8 @@ class ParserBaseClass:
     def munge(self, s: str) -> str:
         return g.app.config.canonicalizeSettingName(s)
     #@+node:ekr.20041119204700.2: *3* pbc.oops
-    def oops(self) -> None:
-        raise NotImplementedError
-        # g.pr("ParserBaseClass oops:",
-            # g.callers(),
-            # "must be overridden in subclass")
+    # def oops(self) -> None:
+        # raise NotImplementedError
     #@+node:ekr.20041213082558: *3* pbc.parsers
     #@+node:ekr.20041213082558.1: *4* pbc.parseFont & helper
     def parseFont(self, p: Position) -> Dict[str, Any]:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -690,9 +690,10 @@ class ParserBaseClass:
         return g.app.config.canonicalizeSettingName(s)
     #@+node:ekr.20041119204700.2: *3* pbc.oops
     def oops(self) -> None:
-        g.pr("ParserBaseClass oops:",
-            g.callers(),
-            "must be overridden in subclass")
+        raise NotImplementedError
+        # g.pr("ParserBaseClass oops:",
+            # g.callers(),
+            # "must be overridden in subclass")
     #@+node:ekr.20041213082558: *3* pbc.parsers
     #@+node:ekr.20041213082558.1: *4* pbc.parseFont & helper
     def parseFont(self, p: Position) -> Dict[str, Any]:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -917,8 +917,8 @@ class ParserBaseClass:
         self.error(f"{val} is not a valid {kind} for {name}")
     #@+node:ekr.20041119204700.3: *3* pbc.visitNode (must be overwritten in subclasses)
     def visitNode(self, p: Position) -> str:
-        self.oops()
-        return ''
+        raise NotImplementedError
+        ### return ''
     #@-others
 #@-<< class ParserBaseClass >>
 #@+others

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -912,7 +912,6 @@ class ParserBaseClass:
     #@+node:ekr.20041119204700.3: *3* pbc.visitNode (must be overwritten in subclasses)
     def visitNode(self, p: Position) -> str:
         raise NotImplementedError
-        ### return ''
     #@-others
 #@-<< class ParserBaseClass >>
 #@+others

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -328,12 +328,7 @@ class LeoBody:
 
     recolor_now = recolor
     #@+node:ekr.20140903103455.18574: *3* LeoBody.Defined in subclasses
-    # Methods of this class call the following methods of subclasses (LeoQtBody)
-    # Fail loudly if these methods are not defined.
-
-    # def oops(self) -> None:
-        # """Say that a required method in a subclass is missing."""
-        # raise NotImplementedError
+    # LeoBody methods that must be defined in subclasses.
 
     def createEditorFrame(self, w: Wrapper) -> Wrapper:
         raise NotImplementedError
@@ -787,9 +782,6 @@ class LeoFrame:
 
     def shortFileName(self) -> str:
         return g.shortFileName(self.c.mFileName)
-    #@+node:ekr.20031218072017.3691: *4* LeoFrame.oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
     #@+node:ekr.20031218072017.3692: *4* LeoFrame.promptForSave
     def promptForSave(self) -> bool:
         """
@@ -1734,10 +1726,6 @@ class LeoTree:
         c.frame.clearStatusLine()
         if p and p.v:
             c.frame.putStatusLine(p.get_UNL())
-    #@+node:ekr.20031218072017.3718: *3* LeoTree.oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
-
     #@-others
 #@+node:ekr.20070317073627: ** class LeoTreeTab
 class LeoTreeTab:
@@ -1765,9 +1753,6 @@ class LeoTreeTab:
 
     def setTabLabel(self, tabName: str) -> None:
         raise NotImplementedError
-    #@+node:ekr.20070317083104: *3* LeoTreeTab.oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
     #@-others
 #@+node:ekr.20031218072017.2191: ** class NullBody (LeoBody)
 class NullBody(LeoBody):

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1933,9 +1933,6 @@ class NullFrame(LeoFrame):
     def minimizeAll(self, event: Event = None) -> None:
         pass
 
-    # def oops(self) -> None:
-        # raise NotImplementedError
-
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         pass
 
@@ -2086,8 +2083,8 @@ class NullLog(LeoLog):
     def isLogWidget(self, w: Wrapper) -> bool:
         return False
     #@+node:ekr.20041012083237.2: *3* NullLog.oops
-    def oops(self) -> None:
-        pass
+    # def oops(self) -> None:
+        # pass
     #@+node:ekr.20041012083237.3: *3* NullLog.put and putnl
     def put(self,
         s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False, nodeLink: str = None,

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1117,7 +1117,6 @@ class LeoFrame:
 
     def get_window_info(self) -> Tuple[int, int, int, int]:
         raise NotImplementedError
-        ### return 0, 0, 0, 0
 
     def hideBodyPane(self, event: Event = None) -> None:
         raise NotImplementedError
@@ -1567,12 +1566,9 @@ class LeoTree:
 
     def editLabel(self, p: Position, selectAll: bool = False, selection: Tuple = None) -> Tuple[Any, Any]:
         raise NotImplementedError
-        ### return None, None  # pylint: disable=useless-return
 
-    def edit_widget(self, p: Position) -> Wrapper:  # pylint: disable=useless-return
+    def edit_widget(self, p: Position) -> Wrapper:
         raise NotImplementedError
-        return None
-
     #@+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
     tree_select_lockout = False
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -2082,9 +2082,6 @@ class NullLog(LeoLog):
     #@+node:ekr.20111119145033.10186: *3* NullLog.isLogWidget
     def isLogWidget(self, w: Wrapper) -> bool:
         return False
-    #@+node:ekr.20041012083237.2: *3* NullLog.oops
-    # def oops(self) -> None:
-        # pass
     #@+node:ekr.20041012083237.3: *3* NullLog.put and putnl
     def put(self,
         s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False, nodeLink: str = None,

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -331,9 +331,9 @@ class LeoBody:
     # Methods of this class call the following methods of subclasses (LeoQtBody)
     # Fail loudly if these methods are not defined.
 
-    def oops(self) -> None:
-        """Say that a required method in a subclass is missing."""
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # """Say that a required method in a subclass is missing."""
+        # raise NotImplementedError
 
     def createEditorFrame(self, w: Wrapper) -> Wrapper:
         raise NotImplementedError
@@ -788,8 +788,8 @@ class LeoFrame:
     def shortFileName(self) -> str:
         return g.shortFileName(self.c.mFileName)
     #@+node:ekr.20031218072017.3691: *4* LeoFrame.oops
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
     #@+node:ekr.20031218072017.3692: *4* LeoFrame.promptForSave
     def promptForSave(self) -> bool:
         """
@@ -1735,8 +1735,8 @@ class LeoTree:
         if p and p.v:
             c.frame.putStatusLine(p.get_UNL())
     #@+node:ekr.20031218072017.3718: *3* LeoTree.oops
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
 
     #@-others
 #@+node:ekr.20070317073627: ** class LeoTreeTab
@@ -1766,8 +1766,8 @@ class LeoTreeTab:
     def setTabLabel(self, tabName: str) -> None:
         raise NotImplementedError
     #@+node:ekr.20070317083104: *3* LeoTreeTab.oops
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
     #@-others
 #@+node:ekr.20031218072017.2191: ** class NullBody (LeoBody)
 class NullBody(LeoBody):
@@ -1948,8 +1948,8 @@ class NullFrame(LeoFrame):
     def minimizeAll(self, event: Event = None) -> None:
         pass
 
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         pass

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1076,98 +1076,98 @@ class LeoFrame:
             k.showStateAndMode(w=c.frame.body.wrapper)
     #@+node:ekr.20031218072017.3680: *3* LeoFrame.Must be defined in subclasses
     def bringToFront(self) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def cascade(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def contractBodyPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def contractLogPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def contractOutlinePane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def contractPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def deiconify(self) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def equalSizedPanes(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def expandBodyPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def expandLogPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def expandOutlinePane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def expandPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def fullyExpandBodyPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def fullyExpandLogPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def fullyExpandOutlinePane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def fullyExpandPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def get_window_info(self) -> Tuple[int, int, int, int]:
-        self.oops()
-        return 0, 0, 0, 0
+        raise NotImplementedError
+        ### return 0, 0, 0, 0
 
     def hideBodyPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def hideLogPane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def hideLogWindow(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def hideOutlinePane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def hidePane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def leoHelp(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def lift(self) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def minimizeAll(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def resizeToScreen(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def setInitialWindowGeometry(self) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def setTopGeometry(self, w: int, h: int, x: int, y: int) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def toggleActivePane(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def toggleSplitDirection(self, event: Event = None) -> None:
-        self.oops()
+        raise NotImplementedError
     #@-others
 #@+node:ekr.20031218072017.3694: ** class LeoLog
 class LeoLog:
@@ -1565,20 +1565,20 @@ class LeoTree:
     # Drawing & scrolling.
 
     def redraw(self, p: Position = None) -> None:
-        self.oops()
+        raise NotImplementedError
     redraw_now = redraw
 
     def scrollTo(self, p: Position) -> None:
-        self.oops()
+        raise NotImplementedError
 
     # Headlines.
 
     def editLabel(self, p: Position, selectAll: bool = False, selection: Tuple = None) -> Tuple[Any, Any]:
-        self.oops()
-        return None, None  # pylint: disable=useless-return
+        raise NotImplementedError
+        ### return None, None  # pylint: disable=useless-return
 
     def edit_widget(self, p: Position) -> Wrapper:  # pylint: disable=useless-return
-        self.oops()
+        raise NotImplementedError
         return None
 
     #@+node:ekr.20040803072955.128: *3* LeoTree.select & helpers
@@ -1751,20 +1751,20 @@ class LeoTreeTab:
         self.parentFrame: Widget = parentFrame
     #@+node:ekr.20070317073755: *3* LeoTreeTab: Must be defined in subclasses
     def createControl(self) -> Wrapper:  # pylint: disable=useless-return
-        self.oops()
+        raise NotImplementedError
         return None
 
     def createTab(self, tabName: str, createText: bool = True, widget: Widget = None, select: bool = True) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def destroyTab(self, tabName: str) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
-        self.oops()
+        raise NotImplementedError
 
     def setTabLabel(self, tabName: str) -> None:
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20070317083104: *3* LeoTreeTab.oops
     def oops(self) -> None:
         raise NotImplementedError
@@ -2102,7 +2102,7 @@ class NullLog(LeoLog):
         return False
     #@+node:ekr.20041012083237.2: *3* NullLog.oops
     def oops(self) -> None:
-        raise NotImplementedError
+        pass
     #@+node:ekr.20041012083237.3: *3* NullLog.put and putnl
     def put(self,
         s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False, nodeLink: str = None,

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -333,18 +333,16 @@ class LeoBody:
 
     def oops(self) -> None:
         """Say that a required method in a subclass is missing."""
-        g.trace("(LeoBody) %s should be overridden in a subclass", g.callers())
+        raise NotImplementedError
 
-    def createEditorFrame(self, w: Wrapper) -> Wrapper:  # pylint: disable=useless-return
-        self.oops()
-        return None
+    def createEditorFrame(self, w: Wrapper) -> Wrapper:
+        raise NotImplementedError
 
-    def createTextWidget(self, parentFrame: Widget, p: Position, name: str) -> Wrapper:  # pylint: disable=useless-return
-        self.oops()
-        return None
+    def createTextWidget(self, parentFrame: Widget, p: Position, name: str) -> Wrapper:
+        raise NotImplementedError
 
     def packEditorLabelWidget(self, w: Wrapper) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def onFocusOut(self, obj: Any) -> None:
         pass
@@ -791,7 +789,7 @@ class LeoFrame:
         return g.shortFileName(self.c.mFileName)
     #@+node:ekr.20031218072017.3691: *4* LeoFrame.oops
     def oops(self) -> None:
-        g.pr("LeoFrame oops:", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
     #@+node:ekr.20031218072017.3692: *4* LeoFrame.promptForSave
     def promptForSave(self) -> bool:
         """
@@ -1738,19 +1736,20 @@ class LeoTree:
             c.frame.putStatusLine(p.get_UNL())
     #@+node:ekr.20031218072017.3718: *3* LeoTree.oops
     def oops(self) -> None:
-        g.pr("LeoTree oops:", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
+
     #@-others
 #@+node:ekr.20070317073627: ** class LeoTreeTab
 class LeoTreeTab:
     """A class representing a tabbed outline pane."""
     #@+others
-    #@+node:ekr.20070317073627.1: *3*  ctor (LeoTreeTab)
+    #@+node:ekr.20070317073627.1: *3* LeoTreeTab.ctor (LeoTreeTab)
     def __init__(self, c: Cmdr, chapterController: ChapterController, parentFrame: Widget) -> None:
         self.c = c
         self.cc: ChapterController
         self.nb: NbController = None  # Created in createControl.
         self.parentFrame: Widget = parentFrame
-    #@+node:ekr.20070317073755: *3* Must be defined in subclasses
+    #@+node:ekr.20070317073755: *3* LeoTreeTab: Must be defined in subclasses
     def createControl(self) -> Wrapper:  # pylint: disable=useless-return
         self.oops()
         return None
@@ -1766,9 +1765,9 @@ class LeoTreeTab:
 
     def setTabLabel(self, tabName: str) -> None:
         self.oops()
-    #@+node:ekr.20070317083104: *3* oops
+    #@+node:ekr.20070317083104: *3* LeoTreeTab.oops
     def oops(self) -> None:
-        g.pr("LeoTreeTree oops:", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
     #@-others
 #@+node:ekr.20031218072017.2191: ** class NullBody (LeoBody)
 class NullBody(LeoBody):
@@ -1950,7 +1949,7 @@ class NullFrame(LeoFrame):
         pass
 
     def oops(self) -> None:
-        g.trace("NullFrame", g.callers(4))
+        raise NotImplementedError
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         pass
@@ -2103,7 +2102,7 @@ class NullLog(LeoLog):
         return False
     #@+node:ekr.20041012083237.2: *3* NullLog.oops
     def oops(self) -> None:
-        g.trace("NullLog:", g.callers(4))
+        raise NotImplementedError
     #@+node:ekr.20041012083237.3: *3* NullLog.put and putnl
     def put(self,
         s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False, nodeLink: str = None,

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -491,8 +491,8 @@ class NullGui(LeoGui):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and getattr(w, 'supportsHighLevelInterface', None)
     #@+node:ekr.20031218072017.2230: *3* NullGui.oops
-    def oops(self) -> None:
-        pass
+    # def oops(self) -> None:
+        # pass
     #@+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -490,9 +490,6 @@ class NullGui(LeoGui):
     def isTextWrapper(self, w: Any) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and getattr(w, 'supportsHighLevelInterface', None)
-    #@+node:ekr.20031218072017.2230: *3* NullGui.oops
-    # def oops(self) -> None:
-        # pass
     #@+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -279,8 +279,8 @@ class LeoGui:
     def postPopupMenu(self, *args: str, **keys: str) -> None:
         pass
     #@+node:ekr.20031218072017.3741: *4* LeoGui.oops
-    def oops(self) -> Any:
-        raise NotImplementedError
+    # def oops(self) -> Any:
+        # raise NotImplementedError
     #@+node:ekr.20170612065049.1: *4* LeoGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         pass
@@ -745,8 +745,8 @@ class StringGui(LeoGui):
     """
     #@+others
     #@+node:ekr.20170613095422.7: *3* StringGui.oops
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
 
     #@+node:ekr.20170613114120.1: *3* StringGui.runMainLoop
     def runMainLoop(self) -> None:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -175,12 +175,10 @@ class LeoGui:
     ) -> Union[List[str], str]:  # Return type depends on the evil multiple keyword.
         """Create and run an open file dialog ."""
         raise NotImplementedError
-        ### return 'no'
 
     def runSaveFileDialog(self, c: Cmdr, title: str, filetypes: List[str], defaultextension: str) -> str:
         """Create and run a save file dialog ."""
         raise NotImplementedError
-        ### return 'no'
     #@+node:ekr.20031218072017.3732: *4* LeoGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
@@ -214,7 +212,6 @@ class LeoGui:
 
     def getTextFromClipboard(self) -> str:
         raise NotImplementedError
-        ### return ''
     #@+node:ekr.20031218072017.3735: *5* LeoGui.Dialog utils
     def attachLeoIcon(self, window: Any) -> None:
         """Attach the Leo icon to a window."""
@@ -238,7 +235,6 @@ class LeoGui:
     def get_window_info(self, window: str) -> Tuple[int, int, int, int]:
         """Return the window information."""
         raise NotImplementedError
-        ### return 0, 0, 0, 0
     #@+node:ekr.20031218072017.3736: *5* LeoGui.Font
     def getFontFromParams(self, family: str, size: str, slant: str, weight: str, defaultSize: int = 12) -> Any:
         raise NotImplementedError

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -278,9 +278,6 @@ class LeoGui:
 
     def postPopupMenu(self, *args: str, **keys: str) -> None:
         pass
-    #@+node:ekr.20031218072017.3741: *4* LeoGui.oops
-    # def oops(self) -> Any:
-        # raise NotImplementedError
     #@+node:ekr.20170612065049.1: *4* LeoGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         pass
@@ -744,10 +741,6 @@ class StringGui(LeoGui):
     leoFrame.StringTextWrapper class.
     """
     #@+others
-    #@+node:ekr.20170613095422.7: *3* StringGui.oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
-
     #@+node:ekr.20170613114120.1: *3* StringGui.runMainLoop
     def runMainLoop(self) -> None:
         raise NotImplementedError

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -93,21 +93,21 @@ class LeoGui:
     #@+node:ekr.20061109212618: *3* LeoGu: Must be defined in subclasses
     #@+node:ekr.20031218072017.3725: *4* LeoGui.destroySelf
     def destroySelf(self) -> None:
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20031218072017.3730: *4* LeoGui.dialogs
     def runAboutLeoDialog(self,
         c: Cmdr, version: str, theCopyright: str, url: str, email: str,
     ) -> Any:  # Must be any, for compatibility with testing subclass.
         """Create and run Leo's About Leo dialog."""
-        self.oops()
+        raise NotImplementedError
 
     def runAskLeoIDDialog(self) -> Any:
         """Create and run a dialog to get g.app.LeoID."""
-        self.oops()
+        raise NotImplementedError
 
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> Any:
         """Create and run an askOK dialog ."""
-        self.oops()
+        raise NotImplementedError
 
     def runAskOkCancelNumberDialog(self,
         c: Cmdr,
@@ -117,7 +117,7 @@ class LeoGui:
         okButtonText: str = None,
     ) -> Any:
         """Create and run askOkCancelNumber dialog ."""
-        self.oops()
+        raise NotImplementedError
 
     def runAskOkCancelStringDialog(
         self,
@@ -130,7 +130,7 @@ class LeoGui:
         wide: bool = False,
     ) -> Any:
         """Create and run askOkCancelString dialog ."""
-        self.oops()
+        raise NotImplementedError
 
     def runAskYesNoDialog(self,
         c: Cmdr,
@@ -140,7 +140,7 @@ class LeoGui:
         no_all: bool = False,
     ) -> Any:
         """Create and run an askYesNo dialog."""
-        self.oops()
+        raise NotImplementedError
 
     def runAskYesNoCancelDialog(
         self,
@@ -154,7 +154,7 @@ class LeoGui:
         cancelMessage: str = None,
     ) -> Any:
         """Create and run an askYesNoCancel dialog ."""
-        self.oops()
+        raise NotImplementedError
 
     def runPropertiesDialog(self,
         title: str = 'Properties',
@@ -163,7 +163,7 @@ class LeoGui:
         buttons: List[str] = None,
     ) -> Any:
         """Display a modal TkPropertiesDialog"""
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20031218072017.3731: *4* LeoGui.file dialogs
     def runOpenFileDialog(self,
         c: Cmdr,
@@ -174,33 +174,33 @@ class LeoGui:
         startpath: str = None,
     ) -> Union[List[str], str]:  # Return type depends on the evil multiple keyword.
         """Create and run an open file dialog ."""
-        self.oops()
-        return 'no'
+        raise NotImplementedError
+        ### return 'no'
 
     def runSaveFileDialog(self, c: Cmdr, title: str, filetypes: List[str], defaultextension: str) -> str:
         """Create and run a save file dialog ."""
-        self.oops()
-        return 'no'
+        raise NotImplementedError
+        ### return 'no'
     #@+node:ekr.20031218072017.3732: *4* LeoGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
-        self.oops()
+        raise NotImplementedError
 
     def createFindTab(self, c: Cmdr, parentFrame: Widget) -> None:
         """Create a find tab in the indicated frame."""
-        self.oops()
+        raise NotImplementedError
 
     def createFontPanel(self, c: Cmdr) -> None:
         """Create a hidden Font panel."""
-        self.oops()
+        raise NotImplementedError
 
     def createLeoFrame(self, c: Cmdr, title: str) -> Widget:
         """Create a new Leo frame."""
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20031218072017.3729: *4* LeoGui.runMainLoop
     def runMainLoop(self) -> None:
         """Run the gui's main loop."""
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20031218072017.3733: *4* LeoGui.utils
     #@+at Subclasses are expected to subclass all of the following methods.
     # These are all do-nothing methods: callers are expected to check for
@@ -210,19 +210,19 @@ class LeoGui:
     # one of its subcommanders.
     #@+node:ekr.20031218072017.3734: *5* LeoGui.Clipboard
     def replaceClipboardWith(self, s: str) -> None:
-        self.oops()
+        raise NotImplementedError
 
     def getTextFromClipboard(self) -> str:
-        self.oops()
-        return ''
+        raise NotImplementedError
+        ### return ''
     #@+node:ekr.20031218072017.3735: *5* LeoGui.Dialog utils
     def attachLeoIcon(self, window: Any) -> None:
         """Attach the Leo icon to a window."""
-        self.oops()
+        raise NotImplementedError
 
     def center_dialog(self, dialog: str) -> None:
         """Center a dialog."""
-        self.oops()
+        raise NotImplementedError
 
     def create_labeled_frame(self,
         parent: str,
@@ -233,16 +233,15 @@ class LeoGui:
         pady: int = 0,
     ) -> None:
         """Create a labeled frame."""
-        self.oops()
+        raise NotImplementedError
 
     def get_window_info(self, window: str) -> Tuple[int, int, int, int]:
         """Return the window information."""
-        self.oops()
-        return 0, 0, 0, 0
+        raise NotImplementedError
+        ### return 0, 0, 0, 0
     #@+node:ekr.20031218072017.3736: *5* LeoGui.Font
     def getFontFromParams(self, family: str, size: str, slant: str, weight: str, defaultSize: int = 12) -> Any:
-
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20070212145124: *5* LeoGui.getFullVersion
     def getFullVersion(self, c: Cmdr = None) -> str:
         return 'LeoGui: dummy version'
@@ -261,7 +260,7 @@ class LeoGui:
         define_name: str = '__main__',
         silent: bool = False,
     ) -> None:
-        self.oops()
+        raise NotImplementedError
     #@+node:ekr.20070228154059: *3* LeoGui: May be defined in subclasses
     #@+node:ekr.20110613103140.16423: *4* LeoGui.dismiss_spash_screen
     def dismiss_splash_screen(self) -> None:
@@ -496,15 +495,13 @@ class NullGui(LeoGui):
         return w and getattr(w, 'supportsHighLevelInterface', None)
     #@+node:ekr.20031218072017.2230: *3* NullGui.oops
     def oops(self) -> None:
-        raise NotImplementedError
+        pass
     #@+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
-        self.oops()
 
     def createFindTab(self, c: Cmdr, parentFrame: Widget) -> None:
         """Create a find tab in the indicated frame."""
-        pass  # Now always done during startup.
 
     def createLeoFrame(self, c: Cmdr, title: str) -> Widget:
         """Create a null Leo Frame."""
@@ -753,7 +750,7 @@ class StringGui(LeoGui):
 
     #@+node:ekr.20170613114120.1: *3* StringGui.runMainLoop
     def runMainLoop(self) -> None:
-        self.oops()
+        raise NotImplementedError
     #@-others
 #@+node:ekr.20171128093503.1: ** class StringLineEdit (leoGui)
 class StringLineEdit:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -281,10 +281,7 @@ class LeoGui:
         pass
     #@+node:ekr.20031218072017.3741: *4* LeoGui.oops
     def oops(self) -> Any:
-        # It is not usually an error to call methods of this class.
-        # However, this message is useful when writing gui plugins.
-        if 1:
-            g.pr("LeoGui oops", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
     #@+node:ekr.20170612065049.1: *4* LeoGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         pass
@@ -499,7 +496,7 @@ class NullGui(LeoGui):
         return w and getattr(w, 'supportsHighLevelInterface', None)
     #@+node:ekr.20031218072017.2230: *3* NullGui.oops
     def oops(self) -> None:
-        g.trace("NullGui", g.callers(4))
+        raise NotImplementedError
     #@+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:
         """Create Compare panel."""
@@ -752,8 +749,8 @@ class StringGui(LeoGui):
     #@+others
     #@+node:ekr.20170613095422.7: *3* StringGui.oops
     def oops(self) -> None:
+        raise NotImplementedError
 
-        g.trace("StringGui", g.callers(4))
     #@+node:ekr.20170613114120.1: *3* StringGui.runMainLoop
     def runMainLoop(self) -> None:
         self.oops()

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1978,8 +1978,7 @@ class KeyHandlerClass:
         k.resetLabel()
     #@+node:ekr.20061101071425: *4* k.oops
     def oops(self) -> None:
-
-        g.trace('Should be defined in subclass:', g.callers(4))
+        raise NotImplementedError
     #@+node:ekr.20120217070122.10479: *4* k.reloadSettings
     def reloadSettings(self) -> None:
         # Part 1: These were in the ctor.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1976,9 +1976,6 @@ class KeyHandlerClass:
         k.inited = True
         k.setDefaultInputState()
         k.resetLabel()
-    #@+node:ekr.20061101071425: *4* k.oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
     #@+node:ekr.20120217070122.10479: *4* k.reloadSettings
     def reloadSettings(self) -> None:
         # Part 1: These were in the ctor.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -512,7 +512,6 @@ class AutoCompleterClass:
                 return key, []
             options = d.get(key)
             if options:
-                ### g.trace(len(options), repr(key))
                 return key, options
         return None, []
     #@+node:ekr.20061031131434.29: *4* ac.do_backspace

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1977,8 +1977,8 @@ class KeyHandlerClass:
         k.setDefaultInputState()
         k.resetLabel()
     #@+node:ekr.20061101071425: *4* k.oops
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
     #@+node:ekr.20120217070122.10479: *4* k.reloadSettings
     def reloadSettings(self) -> None:
         # Part 1: These were in the ctor.

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -680,15 +680,9 @@ class LeoMenu:
 #@+node:ekr.20031218072017.3811: ** class NullMenu(LeoMenu)
 class NullMenu(LeoMenu):
     """A null menu class for testing and batch execution."""
-    #@+others
-    #@+node:ekr.20050104094308: *3* NullMenu.ctor
     def __init__(self, frame: Widget) -> None:
         super().__init__(frame)
         self.isNull = True
-    #@+node:ekr.20050104094029: *3* NullMenu.oops (do-nothing oops)
-    # def oops(self) -> None:
-        # pass
-    #@-others
 #@-others
 #@@language python
 #@@tabwidth -4

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -110,7 +110,7 @@ class LeoMenu:
                     g.trace(f"*** bad entry for {key}")
     #@+node:ekr.20031218072017.3775: *3* LeoMenu.error and oops
     def oops(self) -> None:
-        g.pr("LeoMenu oops:", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
 
     def error(self, s: str) -> None:
         g.error('', s)
@@ -689,11 +689,11 @@ class LeoMenu:
 class NullMenu(LeoMenu):
     """A null menu class for testing and batch execution."""
     #@+others
-    #@+node:ekr.20050104094308: *3* ctor (NullMenu)
+    #@+node:ekr.20050104094308: *3* NullMenu.ctor
     def __init__(self, frame: Widget) -> None:
         super().__init__(frame)
         self.isNull = True
-    #@+node:ekr.20050104094029: *3* oops
+    #@+node:ekr.20050104094029: *3* NullMenu.oops (do-nothing oops)
     def oops(self) -> None:
         pass
     #@-others

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -625,65 +625,60 @@ class LeoMenu:
     #@+node:ekr.20031218072017.3808: *3* LeoMenu.Must be overridden in menu subclasses
     #@+node:ekr.20031218072017.3809: *4* LeoMenu.9 Routines with Tk spellings
     def add_cascade(self, parent: Any, label: str, menu: Any, underline: int) -> None:
-        self.oops()
+        pass
 
     def add_command(self, menu: Widget,
         accelerator: str = '', command: Callable = None, commandName: str = None, label: str = None, underline: int = 0,
     ) -> None:
-        self.oops()
+        pass
 
     def add_separator(self, menu: str) -> None:
-        self.oops()
-
-    # def bind (self,bind_shortcut,callback):
-    #     self.oops()
+        pass
 
     def delete(self, menu: Any, realItemName: str) -> None:
-        self.oops()
+        pass
 
     def delete_range(self, menu: Any, n1: int, n2: int) -> None:
-        self.oops()
+        pass
 
     def destroy(self, menu: Any) -> None:
-        self.oops()
+        pass
 
     def insert(self, menuName: str, position: int, label: str, command: Callable, underline: int = None) -> None:
-        self.oops()
+        pass
 
     def insert_cascade(self, parent: Widget, index: int, label: str, menu: Any, underline: int) -> Widget:
-        self.oops()
+        pass
 
     def new_menu(self, parent: Widget, tearoff: int = 0, label: str = '') -> Any:
-        # 2010: added label arg for pylint.
-        self.oops()
+        pass
     #@+node:ekr.20031218072017.3810: *4* LeoMenu.9 Routines with new spellings
     def activateMenu(self, menuName: str) -> None:  # New in Leo 4.4b2.
-        self.oops()
+        pass
 
     def clearAccel(self, menu: str, name: str) -> None:
-        self.oops()
+        pass
 
     def createMenuBar(self, frame: Widget) -> None:
-        self.oops()
+        pass
 
     def createOpenWithMenu(self, parent: Any, label: str, index: int, amp_index: int) -> Any:
-        self.oops()
+        pass
 
     def disableMenu(self, menu: str, name: str) -> None:
-        self.oops()
+        pass
 
     def enableMenu(self, menu: Widget, name: str, val: bool) -> None:
-        self.oops()
+        pass
 
     def getMacHelpMenu(self, table: List) -> Any:
-        self.oops()
+        pass
 
     def getMenuLabel(self, menu: str, name: str) -> str:
-        self.oops()
         return ''
 
     def setMenuLabel(self, menu: str, name: str, label: str, underline: int = -1) -> None:
-        self.oops()
+        pass
     #@-others
 #@+node:ekr.20031218072017.3811: ** class NullMenu(LeoMenu)
 class NullMenu(LeoMenu):

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -108,10 +108,7 @@ class LeoMenu:
             for key in sorted(d.keys()):
                 if key not in commandKeys:
                     g.trace(f"*** bad entry for {key}")
-    #@+node:ekr.20031218072017.3775: *3* LeoMenu.error and oops
-    # def oops(self) -> None:
-        # raise NotImplementedError
-
+    #@+node:ekr.20031218072017.3775: *3* LeoMenu.error
     def error(self, s: str) -> None:
         g.error('', s)
     #@+node:ekr.20031218072017.3781: *3* LeoMenu.Gui-independent menu routines

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -686,8 +686,8 @@ class NullMenu(LeoMenu):
         super().__init__(frame)
         self.isNull = True
     #@+node:ekr.20050104094029: *3* NullMenu.oops (do-nothing oops)
-    def oops(self) -> None:
-        pass
+    # def oops(self) -> None:
+        # pass
     #@-others
 #@-others
 #@@language python

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -109,8 +109,8 @@ class LeoMenu:
                 if key not in commandKeys:
                     g.trace(f"*** bad entry for {key}")
     #@+node:ekr.20031218072017.3775: *3* LeoMenu.error and oops
-    def oops(self) -> None:
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # raise NotImplementedError
 
     def error(self, s: str) -> None:
         g.error('', s)

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -103,8 +103,8 @@ class textGui(leoGui.LeoGui):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and isinstance(w, leoFrame.StringTextWrapper)
     #@+node:ekr.20150107090324.14: *3* textGui.oops
-    def oops(self):
-        raise NotImplementedError
+    # def oops(self):
+        # raise NotImplementedError
     #@+node:ekr.20150107090324.69: *3* runAskYesNoDialog
     def runAskYesNoDialog(self, c, title, message=None, yes_all=False, no_all=False):
         return 'yes'

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -102,9 +102,6 @@ class textGui(leoGui.LeoGui):
     def isTextWidget(self, w):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and isinstance(w, leoFrame.StringTextWrapper)
-    #@+node:ekr.20150107090324.14: *3* textGui.oops
-    # def oops(self):
-        # raise NotImplementedError
     #@+node:ekr.20150107090324.69: *3* runAskYesNoDialog
     def runAskYesNoDialog(self, c, title, message=None, yes_all=False, no_all=False):
         return 'yes'

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -102,9 +102,9 @@ class textGui(leoGui.LeoGui):
     def isTextWidget(self, w):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and isinstance(w, leoFrame.StringTextWrapper)
-    #@+node:ekr.20150107090324.14: *3* oops
+    #@+node:ekr.20150107090324.14: *3* textGui.oops
     def oops(self):
-        g.pr("textGui oops", g.callers(), "should be implemented")
+        raise NotImplementedError
     #@+node:ekr.20150107090324.69: *3* runAskYesNoDialog
     def runAskYesNoDialog(self, c, title, message=None, yes_all=False, no_all=False):
         return 'yes'

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2010,10 +2010,6 @@ class LeoCursesGui(leoGui.LeoGui):
     def isTextWrapper(self, w: Wrapper) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return bool(w and getattr(w, 'supportsHighLevelInterface', None))
-    #@+node:ekr.20170504052042.1: *4* CGui.oops
-    # def oops(self) -> None:
-        # """Ignore do-nothing methods."""
-        # raise NotImplementedError
     #@+node:ekr.20170612063102.1: *4* CGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         """Put a help message in a dialog."""
@@ -2286,10 +2282,6 @@ class CoreFrame(leoFrame.LeoFrame):
     def minimizeAll(self, event: Event=None) -> None:
         pass
 
-    # def oops(self) -> None:
-        # """Ignore do-nothing methods."""
-        # raise NotImplementedError
-
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         """Resize splitter1 and splitter2 using the given ratios."""
 
@@ -2424,13 +2416,9 @@ class CoreLog(leoFrame.LeoLog):
 class CoreMenu(leoMenu.LeoMenu):
 
     def __init__(self, c: Cmdr) -> None:
-
         dummy_frame = g.Bunch(c=c)
         super().__init__(dummy_frame)
         self.c = c
-
-    # def oops(self) -> None:
-        # """Ignore do-nothing methods."""
 #@+node:ekr.20170501024424.1: *3* class CoreTree (leoFrame.LeoTree)
 class CoreTree(leoFrame.LeoTree):
     """

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2011,9 +2011,9 @@ class LeoCursesGui(leoGui.LeoGui):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return bool(w and getattr(w, 'supportsHighLevelInterface', None))
     #@+node:ekr.20170504052042.1: *4* CGui.oops
-    def oops(self) -> None:
-        """Ignore do-nothing methods."""
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # """Ignore do-nothing methods."""
+        # raise NotImplementedError
     #@+node:ekr.20170612063102.1: *4* CGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         """Put a help message in a dialog."""
@@ -2286,9 +2286,9 @@ class CoreFrame(leoFrame.LeoFrame):
     def minimizeAll(self, event: Event=None) -> None:
         pass
 
-    def oops(self) -> None:
-        """Ignore do-nothing methods."""
-        raise NotImplementedError
+    # def oops(self) -> None:
+        # """Ignore do-nothing methods."""
+        # raise NotImplementedError
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         """Resize splitter1 and splitter2 using the given ratios."""
@@ -2429,8 +2429,8 @@ class CoreMenu(leoMenu.LeoMenu):
         super().__init__(dummy_frame)
         self.c = c
 
-    def oops(self) -> None:
-        """Ignore do-nothing methods."""
+    # def oops(self) -> None:
+        # """Ignore do-nothing methods."""
 #@+node:ekr.20170501024424.1: *3* class CoreTree (leoFrame.LeoTree)
 class CoreTree(leoFrame.LeoTree):
     """

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2013,7 +2013,7 @@ class LeoCursesGui(leoGui.LeoGui):
     #@+node:ekr.20170504052042.1: *4* CGui.oops
     def oops(self) -> None:
         """Ignore do-nothing methods."""
-        g.pr("CursesGui oops:", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
     #@+node:ekr.20170612063102.1: *4* CGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
         """Put a help message in a dialog."""
@@ -2288,12 +2288,10 @@ class CoreFrame(leoFrame.LeoFrame):
 
     def oops(self) -> None:
         """Ignore do-nothing methods."""
-        g.pr("CoreFrame oops:", g.callers(4), "should be overridden in subclass")
+        raise NotImplementedError
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         """Resize splitter1 and splitter2 using the given ratios."""
-        # self.divideLeoSplitter1(ratio)
-        # self.divideLeoSplitter2(secondary_ratio)
 
     def resizeToScreen(self, event: Event=None) -> None:
         pass
@@ -2433,9 +2431,6 @@ class CoreMenu(leoMenu.LeoMenu):
 
     def oops(self) -> None:
         """Ignore do-nothing methods."""
-        # g.pr("CoreMenu oops:", g.callers(4), "should be overridden in subclass")
-
-
 #@+node:ekr.20170501024424.1: *3* class CoreTree (leoFrame.LeoTree)
 class CoreTree(leoFrame.LeoTree):
     """

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -600,11 +600,6 @@ class QuickSearchController:
                 parents: Dict[str, Match_List] = {}
                 for nodeList in [hm, bm]:
                     for node in nodeList:
-                        ###
-                            # if node.level() == 0:
-                                # parents["Root"].append(node)
-                            # else:
-                                # parents[node.parent().gnx].append(node)
                         key = 'Root' if node[0].level() == 0 else node[0].parent().gnx
                         aList: Match_List = parents.get(key, [])
                         aList.append(node)


### PR DESCRIPTION
Raising `NotImplementedError` is good enough&mdash;it gives a full traceback.

Most `oops` methods are a throwback to 2001 when I was writing the first python version of Leo.