### PR TITLE
command execute-external-file:

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1057,10 +1057,11 @@ class Commands:
 
             # Check terminal from MAP_SETTING_NODE setting
             setting_terminal = terminal
-            terminal = which(terminal)
-            if not terminal:
-                g.es(f'Cannot find terminal specified in setting: {setting_terminal}')
-                g.es('Trying an alternative')
+            if setting_terminal:
+                terminal = which(terminal)
+                if not terminal:
+                    g.es(f'Cannot find terminal specified in setting: {setting_terminal}')
+                    g.es('Trying an alternative')
 
             path = g.fullPath(c, root)
             path = g.os_path_finalize(path)


### PR DESCRIPTION
1. Clean up and fix logic to process `@data` TERMINAL  setting;
2. Print terminal string from `@data `setting if not found on computer;
3. Fix errors in docstring of the command and of get_external_maps() function.
4.  Add x-terminal-emulator to list of "bad" terminals.

pylint: OK.

Addresses Issue https://github.com/leo-editor/leo-editor/issues/3195