### PR TITLE
qt_tree.py Mouse Gestures

### DIFF
--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -125,6 +125,9 @@ class LeoQtTree(leoFrame.LeoTree):
         self.stayInTree = c.config.getBool('stayInTreeAfterSelect')
         self.use_chapters = c.config.getBool('use-chapters')
         self.use_declutter = c.config.getBool('tree-declutter', default=False)
+        self.use_mouse_expand_gestures = c.config.getBool('use-mouse-expand-gestures',
+                                                           default = False)
+        g.es(self.use_mouse_expand_gestures)
     #@+node:ekr.20110605121601.17940: *4* qtree.wrapQLineEdit
     def wrapQLineEdit(self, w: Wrapper) -> Wrapper:
         """A wretched kludge for MacOs k.masterMenuHandler."""
@@ -727,21 +730,6 @@ class LeoQtTree(leoFrame.LeoTree):
         # Only methods that actually generate events should set lockouts.
         self.select(p)  # This is a call to LeoTree.select(!!)
         c.outerUpdate()
-    #@+node:tom.20230324155453.1: *4* qtree.onItemEntered
-    def onItemEntered(self, item: Item, col: int):
-        """Expand/Contract a node when mouse moves over it.
-        
-        <CTRL-hover> -- expand;
-        <SHIFT-hover> -- contract.
-        """
-        if hasattr(g.app.gui, 'qtApp'):
-            mods = g.app.gui.qtApp.keyboardModifiers()
-            isCtrl = bool(mods & KeyboardModifier.ControlModifier)
-            isShift = bool(mods & KeyboardModifier.ShiftModifier)
-            if isCtrl:
-                self.expandItem(item)
-            elif isShift:
-                self.contractItem(item)
     #@+node:ekr.20110605121601.17944: *3* qtree.Focus
     def getFocus(self) -> Any:
         return g.app.gui.get_focus(self.c)  # Bug fix: 2009/6/30
@@ -750,6 +738,24 @@ class LeoQtTree(leoFrame.LeoTree):
 
     def setFocus(self) -> None:
         g.app.gui.set_focus(self.c, self.treeWidget)
+    #@+node:tom.20230324155453.1: *3* qtree.onItemEntered
+    def onItemEntered(self, item: Item, col: int):
+        """Expand/Contract a node when mouse moves over it.
+        
+        <CTRL-hover> -- expand;
+        <SHIFT-hover> -- contract.
+        """
+        if not self.use_mouse_expand_gestures:
+            return
+
+        if hasattr(g.app.gui, 'qtApp'):
+            mods = g.app.gui.qtApp.keyboardModifiers()
+            isCtrl = bool(mods & KeyboardModifier.ControlModifier)
+            isShift = bool(mods & KeyboardModifier.ShiftModifier)
+            if isCtrl and not isShift:
+                self.expandItem(item)
+            elif isShift and not isCtrl:
+                self.contractItem(item)
     #@+node:ekr.20110605121601.18409: *3* qtree.Icons
     #@+node:ekr.20110605121601.18411: *4* qtree.getIcon & helpers
     def getIcon(self, v: VNode) -> Icon:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -127,7 +127,6 @@ class LeoQtTree(leoFrame.LeoTree):
         self.use_declutter = c.config.getBool('tree-declutter', default=False)
         self.use_mouse_expand_gestures = c.config.getBool('use-mouse-expand-gestures',
                                                            default = False)
-        g.es(self.use_mouse_expand_gestures)
     #@+node:ekr.20110605121601.17940: *4* qtree.wrapQLineEdit
     def wrapQLineEdit(self, w: Wrapper) -> Wrapper:
         """A wretched kludge for MacOs k.masterMenuHandler."""


### PR DESCRIPTION
qt_tree.py:

1. Add boolean setting _use-mouse-expand-gestures_ to control tree expansion by mouse gesture;
2. Do not expand or contract tree on mouse enter if both CTRL and SHIFT keys are depressed.
3. Remove temporary diagnostic line.