### PR TITLE
PR for #3121: headline numbers

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1103,6 +1103,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         for p in c.all_unique_positions():
             self.hn_add(p=p)
+        c.redraw()
     #@+node:ekr.20230328013557.1: *4* hn-add-tree
     @cmd('hn-add-tree')
     @cmd('headline-number-add-tree')
@@ -1132,6 +1133,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         for p in c.all_unique_positions():
             self.hn_delete(p=p)
+        c.redraw()
     #@+node:ekr.20230328015118.1: *4* hn-delete-tree
     @cmd('hn-delete-tree')
     @cmd('headline-number-delete-tree')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1082,12 +1082,11 @@ class EditCommandsClass(BaseEditCommandsClass):
         k.clearState()
         c.widgetWantsFocus(w)
     #@+node:ekr.20230327200504.1: *3* ec: headline numbers
-    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\.\s+')
     #@+node:ekr.20230328013256.1: *4* hn-add
     @cmd('hn-add')
     @cmd('headline-number-add')
     @cmd('add-headline-number')
-    def hn_add(self, event=None, p=None):
+    def hn_add(self, event: Event = None, p: Position = None) -> None:
         c = self.c
         if p is None:
             p = c.p
@@ -1098,7 +1097,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add-all')
     @cmd('headline-number-add-all')
     @cmd('add-all-headline-numbers')
-    def hn_add_all(self, event=None):
+    def hn_add_all(self, event: Event = None) -> None:
         c = self.c
         for p in c.all_unique_positions():
             self.hn_add(p=p)
@@ -1106,14 +1105,16 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add-tree')
     @cmd('headline-number-add-tree')
     @cmd('add-tree-headline-numbers')
-    def hn_add_tree(self, event=None):
+    def hn_add_tree(self, event: Event = None) -> None:
         for p in self.c.p.self_and_subtree():
             self.hn_add(p=p)
     #@+node:ekr.20230328014223.1: *4* hn-delete
+    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\.\s+')
+
     @cmd('hn-delete')
     @cmd('headline-number-delete')
     @cmd('delete-headline-number')
-    def hn_delete(self, event=None, p=None):
+    def hn_delete(self, event: Event = None, p: Position = None) -> None:
         c = self.c
         if p is None:
             p = c.p
@@ -1125,7 +1126,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')
     @cmd('delete-all-headline-numbers')
-    def hn_delete_all(self, event=None):
+    def hn_delete_all(self, event: Event = None) -> None:
         c = self.c
         for p in c.all_unique_positions():
             self.hn_delete(p=p)
@@ -1133,7 +1134,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete-tree')
     @cmd('headline-number-delete-tree')
     @cmd('delete-tree-headline-numbers')
-    def hn_delete_tree(self, event=None):
+    def hn_delete_tree(self, event: Event = None) -> None:
         c = self.c
         for p in c.p.self_and_subtree():
             self.hn_delete(p=p)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1086,7 +1086,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-add')
     @cmd('headline-number-add')
     @cmd('add-headline-number')
-    def hn_add(self, event: Event = None, p: Position = None) -> None:
+    def hn_add(self, event: Event = None, *, p: Position = None) -> None:
         c = self.c
         if p is None:
             p = c.p
@@ -1121,7 +1121,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('hn-delete')
     @cmd('headline-number-delete')
     @cmd('delete-headline-number')
-    def hn_delete(self, event: Event = None, p: Position = None) -> None:
+    def hn_delete(self, event: Event = None, *, p: Position = None) -> None:
         c = self.c
         if p is None:
             p = c.p

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1132,7 +1132,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def hn_add_relative(self, p: Position, root: Position) -> None:
         """
         Helper: Add a 1-based outline number (relative to the root) to p.h.
-        
+
         Never add outline numbers to @-nodes or section definition nodes.
         """
         # Don't add numbers to special nodes.

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1113,7 +1113,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             self.hn_add(p=p)
     #@+node:ekr.20230328014223.1: *4* hn-delete
     # Match exactly one trailing blank.
-    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\s')
+    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)* ')
 
     @cmd('hn-delete')
     @cmd('headline-number-delete')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1100,8 +1100,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         for p in c.all_unique_positions():
             self.hn_delete(p)
             self.hn_add(p)
-        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
+        u.afterChangeMultiHeadline(command, data)
         c.redraw()
     #@+node:ekr.20230328013256.1: *5* hn_add
     def hn_add(self, p: Position) -> None:
@@ -1146,8 +1146,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         for p in c.p.subtree():
             self.hn_delete(p)
             self.hn_add_relative(p, root)
-        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
+        u.afterChangeMultiHeadline(command, data)
         root.expand()
         c.redraw()
     #@+node:ekr.20230329031045.1: *5* hn_add_relative
@@ -1175,8 +1175,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         data = u.beforeChangeMultiHeadline(c.p)
         for p in c.all_unique_positions():
             self.hn_delete(p)
-        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
+        u.afterChangeMultiHeadline(command, data)
         c.redraw()
     #@+node:ekr.20230328015118.1: *4* hn-delete-subtree
     @cmd('hn-delete-subtree')
@@ -1189,8 +1189,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         data = u.beforeChangeMultiHeadline(c.p)
         for p in c.p.subtree():
             self.hn_delete(p)
-        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
+        u.afterChangeMultiHeadline(command, data)
         c.redraw()
     #@+node:ekr.20230328014223.1: *4* hn_delete
     # Match exactly one trailing blank.
@@ -1204,10 +1204,6 @@ class EditCommandsClass(BaseEditCommandsClass):
             n = len(m.group(0))
             p.v.h = p.v.h[n:]
             p.v.setDirty()
-    #@+node:ekr.20230329031137.1: *4* hn_is_section_def
-    def hn_is_section_def(self, p: Position) -> bool:
-        """True if p is a section definition node."""
-        return '>>' in p.h and p.h.strip().startswith('<<')
     #@+node:ekr.20150514063305.229: *3* ec: icons
     #@+at
     # To do:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1101,7 +1101,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         Helper: Add a 1-based outline number to p.h.
 
-        Never add outline numbers to @<file> or section defintion nodes.
+        Never add outline numbers to @<file> or section definition nodes.
         """
         # Don't add numbers to special nodes.
         if p.h.startswith('@') or self.hn_is_section_def(p):
@@ -1133,7 +1133,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         Helper: Add a 1-based outline number (relative to the root) to p.h.
 
-        Never add outline numbers to @<file> or section defintion nodes.
+        Never add outline numbers to @<file> or section definition nodes.
         """
         # Don't add numbers to special nodes.
         if p.h.startswith('@') or self.hn_is_section_def(p):

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1090,7 +1090,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         if p is None:
             p = c.p
-        if p.isAnyAtFileNode():
+        # Don't add numbers anywhere in @<file> trees.
+        if any(z.isAnyAtFileNode() for z in p.self_and_parents()):
             return
         self.hn_delete(p=p)
         s = '.'.join(reversed(list(str(z.childIndex()) for z in p.self_and_parents())))

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1112,7 +1112,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         for p in self.c.p.self_and_subtree():
             self.hn_add(p=p)
     #@+node:ekr.20230328014223.1: *4* hn-delete
-    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\s+')
+    # Match exactly one trailing blank.
+    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\s')
 
     @cmd('hn-delete')
     @cmd('headline-number-delete')
@@ -1124,7 +1125,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         m = re.match(self.hn_pattern, p.h)
         if m:
             n = len(m.group(0))
-            p.h = p.h[n:].lstrip()
+            p.h = p.h[n:]
     #@+node:ekr.20230328014542.1: *4* hn-delete-all
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1092,7 +1092,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             p = c.p
         self.hn_delete(p=p)
         s = '.'.join(reversed(list(str(z.childIndex()) for z in p.self_and_parents())))
-        p.h = s + '. ' + p.h.lstrip()
+        p.h = s + ' ' + p.h.lstrip()
     #@+node:ekr.20230328012036.1: *4* hn-add-all
     @cmd('hn-add-all')
     @cmd('headline-number-add-all')
@@ -1109,7 +1109,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         for p in self.c.p.self_and_subtree():
             self.hn_add(p=p)
     #@+node:ekr.20230328014223.1: *4* hn-delete
-    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\.\s+')
+    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\s+')
 
     @cmd('hn-delete')
     @cmd('headline-number-delete')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1088,17 +1088,19 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('add-all-headline-numbers')
     def hn_add_all(self, event: Event = None) -> None:
         """
-        Add headline numbers to all nodes of the outline,
-        except for:
+        Add headline numbers to all nodes of the outline *except*:
         -  @<file> nodes and their descendants.
         - Any node whose headline starts with "@".
 
         Use the *first* clone's position for all clones.
         """
-        c = self.c
+        c, command = self.c, 'add-all-headline-numbers'
+        u = c.undoer
+        data = u.beforeChangeMultiHeadline(c.p)
         for p in c.all_unique_positions():
             self.hn_delete(p)
             self.hn_add(p)
+        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
         c.redraw()
     #@+node:ekr.20230328013256.1: *5* hn_add
@@ -1137,11 +1139,14 @@ class EditCommandsClass(BaseEditCommandsClass):
 
         Use the *last* clone's position for all clones.
         """
-        c = self.c
+        c, command = self.c, 'add-subtree-headline-numbers'
+        u = c.undoer
         root = c.p
+        data = u.beforeChangeMultiHeadline(root)
         for p in c.p.subtree():
             self.hn_delete(p)
             self.hn_add_relative(p, root)
+        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
         root.expand()
         c.redraw()
@@ -1165,9 +1170,12 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('delete-all-headline-numbers')
     def hn_delete_all(self, event: Event = None) -> None:
         """Delete all headline numbers in the entire outline."""
-        c = self.c
+        c, command = self.c, 'delete-all-headline-numbers'
+        u = c.undoer
+        data = u.beforeChangeMultiHeadline(c.p)
         for p in c.all_unique_positions():
             self.hn_delete(p)
+        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
         c.redraw()
     #@+node:ekr.20230328015118.1: *4* hn-delete-subtree
@@ -1176,9 +1184,12 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('delete-subtree-headline-numbers')
     def hn_delete_tree(self, event: Event = None) -> None:
         """Delete all headline numbers in c.p's subtree."""
-        c = self.c
+        c, command = self.c, 'delete-subtree-headline-numbers'
+        u = c.undoer
+        data = u.beforeChangeMultiHeadline(c.p)
         for p in c.p.subtree():
             self.hn_delete(p)
+        u.afterChangeMultiHeadline(command, data)
         c.setChanged()
         c.redraw()
     #@+node:ekr.20230328014223.1: *4* hn_delete

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1090,13 +1090,18 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         if p is None:
             p = c.p
-        # Don't add numbers anywhere in @<file> trees.
-        if any(z.isAnyAtFileNode() for z in p.self_and_parents()):
+
+        def is_section_def(p: Position) -> bool:
+            return any('>>' in z.h and z.h.strip().startswith('<<')
+                for z in p.self_and_parents())
+
+        # Don't add numbers to @<file> or section definition nodes.
+        if p.isAnyAtFileNode() or is_section_def(p):
             return
         self.hn_delete(p=p)
-        s = '.'.join(reversed(list(str(z.childIndex()) for z in p.self_and_parents())))
+        s = '.'.join(reversed(list(str(1 + z.childIndex()) for z in p.self_and_parents())))
         # Do not strip the original headline!
-        p.h = s + ' ' + p.h
+        p.v.h = s + ' ' + p.v.h
 
     #@+node:ekr.20230328012036.1: *4* hn-add-all
     @cmd('hn-add-all')
@@ -1128,7 +1133,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         m = re.match(self.hn_pattern, p.h)
         if m:
             n = len(m.group(0))
-            p.h = p.h[n:]
+            p.v.h = p.v.h[n:]
     #@+node:ekr.20230328014542.1: *4* hn-delete-all
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1121,7 +1121,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         m = re.match(self.hn_pattern, p.h)
         if m:
             n = len(m.group(0))
-            p.h = p.h[:n]
+            p.h = p.h[n:]
     #@+node:ekr.20230328014542.1: *4* hn-delete-all
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1081,6 +1081,62 @@ class EditCommandsClass(BaseEditCommandsClass):
         k.resetLabel()
         k.clearState()
         c.widgetWantsFocus(w)
+    #@+node:ekr.20230327200504.1: *3* ec: headline numbers
+    hn_pattern = re.compile(r'^[0-9]+(\.[0-9]+)*\.\s+')
+    #@+node:ekr.20230328013256.1: *4* hn-add
+    @cmd('hn-add')
+    @cmd('headline-number-add')
+    @cmd('add-headline-number')
+    def hn_add(self, event=None, p=None):
+        c = self.c
+        if p is None:
+            p = c.p
+        self.hn_delete(p=p)
+        s = '.'.join(reversed(list(str(z.childIndex()) for z in p.self_and_parents())))
+        p.h = s + '. ' + p.h.lstrip()
+    #@+node:ekr.20230328012036.1: *4* hn-add-all
+    @cmd('hn-add-all')
+    @cmd('headline-number-add-all')
+    @cmd('add-all-headline-numbers')
+    def hn_add_all(self, event=None):
+        c = self.c
+        for p in c.all_unique_positions():
+            self.hn_add(p=p)
+    #@+node:ekr.20230328013557.1: *4* hn-add-tree
+    @cmd('hn-add-tree')
+    @cmd('headline-number-add-tree')
+    @cmd('add-tree-headline-numbers')
+    def hn_add_tree(self, event=None):
+        for p in self.c.p.self_and_subtree():
+            self.hn_add(p=p)
+    #@+node:ekr.20230328014223.1: *4* hn-delete
+    @cmd('hn-delete')
+    @cmd('headline-number-delete')
+    @cmd('delete-headline-number')
+    def hn_delete(self, event=None, p=None):
+        c = self.c
+        if p is None:
+            p = c.p
+        m = re.match(self.hn_pattern, p.h)
+        if m:
+            n = len(m.group(0))
+            p.h = p.h[:n]
+    #@+node:ekr.20230328014542.1: *4* hn-delete-all
+    @cmd('hn-delete-all')
+    @cmd('headline-number-delete-all')
+    @cmd('delete-all-headline-numbers')
+    def hn_delete_all(self, event=None):
+        c = self.c
+        for p in c.all_unique_positions():
+            self.hn_delete(p=p)
+    #@+node:ekr.20230328015118.1: *4* hn-delete-tree
+    @cmd('hn-delete-tree')
+    @cmd('headline-number-delete-tree')
+    @cmd('delete-tree-headline-numbers')
+    def hn_delete_tree(self, event=None):
+        c = self.c
+        for p in c.p.self_and_subtree():
+            self.hn_delete(p=p)
     #@+node:ekr.20150514063305.229: *3* ec: icons
     #@+at
     # To do:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1090,6 +1090,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         c = self.c
         if p is None:
             p = c.p
+        if p.isAnyAtFileNode():
+            return
         self.hn_delete(p=p)
         s = '.'.join(reversed(list(str(z.childIndex()) for z in p.self_and_parents())))
         p.h = s + ' ' + p.h.lstrip()
@@ -1121,7 +1123,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         m = re.match(self.hn_pattern, p.h)
         if m:
             n = len(m.group(0))
-            p.h = p.h[n:]
+            p.h = p.h[n:].lstrip()
     #@+node:ekr.20230328014542.1: *4* hn-delete-all
     @cmd('hn-delete-all')
     @cmd('headline-number-delete-all')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1094,7 +1094,9 @@ class EditCommandsClass(BaseEditCommandsClass):
             return
         self.hn_delete(p=p)
         s = '.'.join(reversed(list(str(z.childIndex()) for z in p.self_and_parents())))
-        p.h = s + ' ' + p.h.lstrip()
+        # Do not strip the original headline!
+        p.h = s + ' ' + p.h
+
     #@+node:ekr.20230328012036.1: *4* hn-add-all
     @cmd('hn-add-all')
     @cmd('headline-number-add-all')

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1101,7 +1101,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         Helper: Add a 1-based outline number to p.h.
 
-        Never add outline numbers to @<file> or section definition nodes.
+        Never add outline numbers to @-nodes or section definition nodes.
         """
         # Don't add numbers to special nodes.
         if p.h.startswith('@') or self.hn_is_section_def(p):
@@ -1132,8 +1132,8 @@ class EditCommandsClass(BaseEditCommandsClass):
     def hn_add_relative(self, p: Position, root: Position) -> None:
         """
         Helper: Add a 1-based outline number (relative to the root) to p.h.
-
-        Never add outline numbers to @<file> or section definition nodes.
+        
+        Never add outline numbers to @-nodes or section definition nodes.
         """
         # Don't add numbers to special nodes.
         if p.h.startswith('@') or self.hn_is_section_def(p):
@@ -1154,6 +1154,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('headline-number-delete-all')
     @cmd('delete-all-headline-numbers')
     def hn_delete_all(self, event: Event = None) -> None:
+        """Delete all headline numbers in the entire outline."""
         c = self.c
         for p in c.all_unique_positions():
             self.hn_delete(p)
@@ -1164,6 +1165,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('headline-number-delete-subtree')
     @cmd('delete-subtree-headline-numbers')
     def hn_delete_tree(self, event: Event = None) -> None:
+        """Delete all headline numbers in c.p's subtree."""
         c = self.c
         for p in c.p.subtree():
             self.hn_delete(p)


### PR DESCRIPTION
See #3121.

PR #3228 (merged into devel) adds related undo/redo helpers.

- [x] Add `hn-add-all`, `hn-add-subtree`, `hn-delete-all`, and `hn-delete-subtree` commands,
    including various aliases.
    - Redraw the resulting trees and mark nodes dirty.
    - Add docstrings.
- [x] Make all commands undoable.