### PR TITLE
Boltex/issue3219

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -773,8 +773,8 @@ class EditCommandsClass(BaseEditCommandsClass):
     #@+node:ekr.20150514063305.214: *3* ec: fill column and centering
     #@@language rest
     #@+at
-    # These methods are currently just used in tandem to center the line or
-    # region within the fill column. for example, dependent upon the fill column, this text:
+    # These methods are currently just used in tandem to center the line or region
+    # within the fill column. for example, dependent upon the fill column, this text:
     #
     #     cats
     #     raaaaaaaaaaaats
@@ -1155,6 +1155,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         """
         Add a 1-based outline number (relative to the root) to p.h.
         """
+        c = self.c
         indices: List[int] = []
         for p2 in p.self_and_parents():
             if p2 == root:
@@ -1162,7 +1163,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             indices.insert(0, p2.childIndex())
         s = '.'.join([str(1 + z) for z in indices])
         # Do not strip the original headline!
-        p.v.h = f"{s} {p.v.h}"
+        c.setHeadString(p, f"{s} {p.v.h}")
         p.v.setDirty()
     #@+node:ekr.20230328014542.1: *4* hn-delete-all
     @cmd('hn-delete-all')
@@ -1198,11 +1199,12 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     def hn_delete(self, p: Position) -> None:
         """Helper: delete the headline number in p.h."""
+        c = self.c
         m = re.match(self.hn_pattern, p.h)
         if m:
             # Do not strip the headline!
             n = len(m.group(0))
-            p.v.h = p.v.h[n:]
+            c.setHeadString(p, p.v.h[n:])
             p.v.setDirty()
     #@+node:ekr.20150514063305.229: *3* ec: icons
     #@+at

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -522,16 +522,6 @@ class Undoer:
         if u.redoing or u.undoing:
             return  # pragma: no cover
         #
-        # Note : The currently selected node may be reverted to its original headline
-        #        string by leoFrame's unselect_helper by the next node selection!
-        #        (This can happen if changed by user script instead of the Tree UI.)
-        if p == c.p:
-            w = c.frame.tree.edit_widget(c.p)
-            if w:
-                s = w.getAllText()
-                if s != p.h:
-                    w.setAllText(p.h)  # was c.p, and different
-        #
         # Set the type & helpers.
         bunch.kind = 'headline'
         bunch.undoType = command
@@ -558,15 +548,6 @@ class Undoer:
         for p in c.all_unique_positions():
             if p.h != oldHeadlines[p.gnx][0]:
                 newHeadlines[p.gnx] = (oldHeadlines[p.gnx][0], p.h)
-                # Note : The currently selected node may be reverted to its original headline
-                #        string by leoFrame's unselect_helper by the next node selection!
-                #        (This can happen if changed by user script instead of the Tree UI.)
-                if p == c.p:
-                    w = c.frame.tree.edit_widget(c.p)
-                    if w:
-                        s = w.getAllText()
-                        if s != p.h:
-                            w.setAllText(p.h)  # was c.p, and different
         # Filtered down dict containing only the changed ones.
         bunch.headlines = newHeadlines
         u.pushBead(bunch)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1536,6 +1536,7 @@ class LeoServer:
                     g.chdir(fileName)  # TODO : IS THIS NEEDED
                     s = '@nocolor\n' + s  # TODO : MAKE THIS UNDOABLE !
                     p = c.insertHeadline(op_name=undoType)
+                    # New node does not need c.setHeadString. p.setHeadString is ok.
                     p.setHeadString('@read-file-into-node ' + fileName)
                     p.setBodyString(s)
             except Exception as err:
@@ -3000,7 +3001,8 @@ class LeoServer:
         if h == oldH:
             return self._make_response()
         bunch = u.beforeChangeHeadline(p)
-        p.initHeadString(h)  # change p.h *after* calling undoer's before method.
+        # p.initHeadString(h)  # change p.h *after* calling undoer's before method.
+        c.setHeadString(p, h)  # c.setHeadString fixes the headline revert bug of p.initHeadString(h)
         c.setChanged()
         p.setDirty()
         u.afterChangeHeadline(p, 'Change Headline', bunch)


### PR DESCRIPTION
Switched to usage of c.setHeadString in commands that only change headlines and removed thus extraneous code in the undoer.