### PR TITLE
PR for #3231: append to sys.path

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -447,8 +447,8 @@ class MypyCommand:
             print('install mypy with `pip install mypy`')
             return
         root = p.copy()
-        # Make sure the leo directory is on sys.path.
-        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        # Make sure the leo-editor directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.append(path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
@@ -484,8 +484,8 @@ class Flake8Command:
         c, root = self.c, p
         if not flake8:
             return
-        # Make sure the leo directory is on sys.path.
-        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        # Make sure the leo-editor directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.append(path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
@@ -574,8 +574,8 @@ class PyflakesCommand:
         c, root = self.c, p
         if not pyflakes:
             return True
-        # Make sure the leo directory is on sys.path.
-        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        # Make sure the leo-editor directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.append(path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
@@ -605,8 +605,8 @@ class PylintCommand:
         self.rc_fn = self.get_rc_file()
         if not self.rc_fn:
             return None
-        # Make sure the leo directory is on sys.path.
-        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        # Make sure the leo-editor directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.append(path)
 

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -450,7 +450,7 @@ class MypyCommand:
         # Make sure the leo-editor directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
-            sys.path.append(path)
+            sys.path.insert(0, path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         self.check_all(roots)
     #@-others
@@ -487,7 +487,7 @@ class Flake8Command:
         # Make sure the leo-editor directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
-            sys.path.append(path)
+            sys.path.insert(0, path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         if roots:
             self.check_all(roots)
@@ -577,7 +577,7 @@ class PyflakesCommand:
         # Make sure the leo-editor directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
-            sys.path.append(path)
+            sys.path.insert(0, path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         if not roots:
             return True
@@ -608,7 +608,7 @@ class PylintCommand:
         # Make sure the leo-editor directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
-            sys.path.append(path)
+            sys.path.insert(0, path)
 
         # Ignore @nopylint trees.
         def predicate(p: Position) -> bool:

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -447,7 +447,7 @@ class MypyCommand:
             print('install mypy with `pip install mypy`')
             return
         root = p.copy()
-        # Make sure the leo-editor directory is on sys.path.
+        # Make sure the parent of the leo directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.insert(0, path)
@@ -484,7 +484,7 @@ class Flake8Command:
         c, root = self.c, p
         if not flake8:
             return
-        # Make sure the leo-editor directory is on sys.path.
+        # Make sure the parent of the leo directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.insert(0, path)
@@ -574,7 +574,7 @@ class PyflakesCommand:
         c, root = self.c, p
         if not pyflakes:
             return True
-        # Make sure the leo-editor directory is on sys.path.
+        # Make sure the parent of the leo directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.insert(0, path)
@@ -605,7 +605,7 @@ class PylintCommand:
         self.rc_fn = self.get_rc_file()
         if not self.rc_fn:
             return None
-        # Make sure the leo-editor directory is on sys.path.
+        # Make sure the parent of the leo directory is on sys.path.
         path = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if path not in sys.path:
             sys.path.insert(0, path)

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -449,8 +449,7 @@ class MypyCommand:
         root = p.copy()
         # Make sure Leo is on sys.path.
         leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        if leo_path not in sys.path:
-            sys.path.append(leo_path)
+        g.appendToSysPath(leo_path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         self.check_all(roots)
     #@-others
@@ -486,8 +485,7 @@ class Flake8Command:
             return
         # Make sure Leo is on sys.path.
         leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        if leo_path not in sys.path:
-            sys.path.append(leo_path)
+        g.appendToSysPath(leo_path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         if roots:
             self.check_all(roots)
@@ -576,8 +574,7 @@ class PyflakesCommand:
             return True
         # Make sure Leo is on sys.path.
         leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        if leo_path not in sys.path:
-            sys.path.append(leo_path)
+        g.appendToSysPath(leo_path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         if not roots:
             return True
@@ -608,8 +605,7 @@ class PylintCommand:
             return None
         # Make sure Leo is on sys.path.
         leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        if leo_path not in sys.path:
-            sys.path.append(leo_path)
+        g.appendToSysPath(leo_path)
 
         # Ignore @nopylint trees.
         def predicate(p: Position) -> bool:

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -447,9 +447,10 @@ class MypyCommand:
             print('install mypy with `pip install mypy`')
             return
         root = p.copy()
-        # Make sure Leo is on sys.path.
-        leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        g.appendToSysPath(leo_path)
+        # Make sure the leo directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        if path not in sys.path:
+            sys.path.append(path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         self.check_all(roots)
     #@-others
@@ -483,9 +484,10 @@ class Flake8Command:
         c, root = self.c, p
         if not flake8:
             return
-        # Make sure Leo is on sys.path.
-        leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        g.appendToSysPath(leo_path)
+        # Make sure the leo directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        if path not in sys.path:
+            sys.path.append(path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         if roots:
             self.check_all(roots)
@@ -572,9 +574,10 @@ class PyflakesCommand:
         c, root = self.c, p
         if not pyflakes:
             return True
-        # Make sure Leo is on sys.path.
-        leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        g.appendToSysPath(leo_path)
+        # Make sure the leo directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        if path not in sys.path:
+            sys.path.append(path)
         roots = g.findRootsWithPredicate(c, root, predicate=None)
         if not roots:
             return True
@@ -583,7 +586,6 @@ class PyflakesCommand:
             # This message is important for clarity.
             g.es(f"ERROR: pyflakes: {total_errors} error{g.plural(total_errors)}")
         return total_errors == 0
-
     #@-others
 #@+node:ekr.20150514125218.8: ** class PylintCommand
 class PylintCommand:
@@ -603,9 +605,10 @@ class PylintCommand:
         self.rc_fn = self.get_rc_file()
         if not self.rc_fn:
             return None
-        # Make sure Leo is on sys.path.
-        leo_path = g.os_path_finalize_join(g.app.loadDir, '..')
-        g.appendToSysPath(leo_path)
+        # Make sure the leo directory is on sys.path.
+        path = os.path.normpath(os.path.join(g.app.loadDir, '..'))
+        if path not in sys.path:
+            sys.path.append(path)
 
         # Ignore @nopylint trees.
         def predicate(p: Position) -> bool:

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -209,13 +209,12 @@ class BridgeController:
             'config', 'doc', 'extensions', 'modes', 'plugins', 'core', 'test')  # 2008/7/30
         for theDir in leoDirs:
             path = g.os_path_finalize_join(g.app.loadDir, '..', theDir)
-            if path not in sys.path:
-                sys.path.append(path)
+            g.appendToSysPath(path)
+
         # #258: leoBridge does not work with @auto-md subtrees.
         for theDir in ('importers', 'writers'):
             path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', theDir)
-            if path not in sys.path:
-                sys.path.append(path)
+            g.appendToSysPath(path)
     #@+node:ekr.20070227095743: *4* bridge.createGui
     def createGui(self) -> None:
         g = self.g

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -211,13 +211,13 @@ class BridgeController:
         for theDir in leoDirs:
             path = os.path.normpath(os.path.join(g.app.loadDir, '..', theDir))
             if path not in sys.path:
-                sys.path.append(path)
+                sys.path.insert(0, path)
 
         # #258: leoBridge does not work with @auto-md subtrees.
         for theDir in ('importers', 'writers'):
             path = os.path.normpath(os.path.join(g.app.loadDir, '..', 'plugins', theDir))
             if path not in sys.path:
-                sys.path.append(path)
+                sys.path.insert(0, path)
     #@+node:ekr.20070227095743: *4* bridge.createGui
     def createGui(self) -> None:
         g = self.g

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -205,16 +205,19 @@ class BridgeController:
     def adjustSysPath(self) -> None:
         """Adjust sys.path to enable imports as usual with Leo."""
         g = self.g
-        leoDirs = (
-            'config', 'doc', 'extensions', 'modes', 'plugins', 'core', 'test')  # 2008/7/30
+        leoDirs = (  # 2008/7/30
+            'config', 'doc', 'extensions', 'modes', 'plugins', 'core', 'test'
+        )
         for theDir in leoDirs:
-            path = g.os_path_finalize_join(g.app.loadDir, '..', theDir)
-            g.appendToSysPath(path)
+            path = os.path.normpath(os.path.join(g.app.loadDir, '..', theDir))
+            if path not in sys.path:
+                sys.path.append(path)
 
         # #258: leoBridge does not work with @auto-md subtrees.
         for theDir in ('importers', 'writers'):
-            path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', theDir)
-            g.appendToSysPath(path)
+            path = os.path.normpath(os.path.join(g.app.loadDir, '..', 'plugins', theDir))
+            if path not in sys.path:
+                sys.path.append(path)
     #@+node:ekr.20070227095743: *4* bridge.createGui
     def createGui(self) -> None:
         g = self.g

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7115,7 +7115,7 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
         os.chdir(os.path.normpath(os.path.join(g.app.loadDir, '..')))
     else:
         # Run tests in leo-editor.
-        os.chdir(os.path.normpath.os.path.join(g.app.loadDir, '..', '..'))
+        os.chdir(os.path.normpath(os.path.join(g.app.loadDir, '..', '..')))
     verbosity = '-v' if verbose else ''
     command = f"{sys.executable} -m unittest {verbosity} {tests or ''} "
     g.execute_shell_commands(command)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3431,19 +3431,6 @@ def update_directives_pat() -> None:
 # #1688: Initialize g.directives_pat
 update_directives_pat()
 #@+node:ekr.20031218072017.3116: ** g.Files & Directories
-#@+node:ekr.20230401054152.1: *3* g.appendToSysPath (new)
-def appendToSysPath(path: str) -> str:
-    """
-    Append path to sys.path, converting slashes to os.sep.
-
-    Return the path added to sys.path or None.
-    """
-    # A horrible special case to undo the hack in g.os_path_finalize.
-    path2 = path.replace('/', '\\') if g.isWindows else path
-    if path2 in sys.path:
-        return None
-    sys.path.append(path2)
-    return path2
 #@+node:ekr.20080606074139.2: *3* g.chdir
 def chdir(path: str) -> None:
     if not g.os_path_isdir(path):
@@ -7117,7 +7104,7 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
     """
     if 'site-packages' in __file__:
         # Add site-packages to sys.path.
-        parent_dir = g.os_path_finalize_join(g.app.loadDir, '..', '..')
+        parent_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if parent_dir.endswith('site-packages'):
             changed = g.appendToSysPath(parent_dir)
             if changed:
@@ -7126,10 +7113,10 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
             g.trace('Can not happen: wrong parent directory', parent_dir)
             return
         # Run tests in site-packages/leo
-        os.chdir(g.os_path_finalize_join(g.app.loadDir, '..'))
+        os.chdir(os.path.normpath(os.path.join(g.app.loadDir, '..')))
     else:
         # Run tests in leo-editor.
-        os.chdir(g.os_path_finalize_join(g.app.loadDir, '..', '..'))
+        os.chdir(os.path.normpath.os.path.join(g.app.loadDir, '..', '..'))
     verbosity = '-v' if verbose else ''
     command = f"{sys.executable} -m unittest {verbosity} {tests or ''} "
     g.execute_shell_commands(command)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7106,8 +7106,8 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
         parent_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if parent_dir.endswith('site-packages'):
             if parent_dir not in sys.path:
-                sys.path.append(parent_dir)
                 g.trace(f"Append {parent_dir!r} to sys.path")
+                sys.path.insert(0, parent_dir)
         else:
             g.trace('Can not happen: wrong parent directory', parent_dir)
             return

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6436,8 +6436,7 @@ def os_path_finalize(path: str) -> str:
     path = os.path.expanduser(path)  # #1383.
     path = os.path.abspath(path)
     path = os.path.normpath(path)
-    # os.path.normpath uses *platform' delims (os.sep).
-    # Here we *must forward slashes to make caching work properly.
+    # We *must* use forward slashes to make caching work properly.
     if g.isWindows:
         path = path.replace('\\', '/')
     # calling os.path.realpath here would cause problems in some situations.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7105,9 +7105,9 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
         # Add site-packages to sys.path.
         parent_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         if parent_dir.endswith('site-packages'):
-            changed = g.appendToSysPath(parent_dir)
-            if changed:
-                g.trace(f"Append {changed!r} to sys.path")
+            if parent_dir not in sys.path:
+                sys.path.append(parent_dir)
+                g.trace(f"Append {parent_dir!r} to sys.path")
         else:
             g.trace('Can not happen: wrong parent directory', parent_dir)
             return

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3431,6 +3431,19 @@ def update_directives_pat() -> None:
 # #1688: Initialize g.directives_pat
 update_directives_pat()
 #@+node:ekr.20031218072017.3116: ** g.Files & Directories
+#@+node:ekr.20230401054152.1: *3* g.appendToSysPath (new)
+def appendToSysPath(path: str) -> str:
+    """
+    Append path to sys.path, converting slashes to os.sep.
+
+    Return the path added to sys.path or None.
+    """
+    # A horrible special case to undo the hack in g.os_path_finalize.
+    path2 = path.replace('/', '\\') if g.isWindows else path
+    if path2 in sys.path:
+        return None
+    sys.path.append(path2)
+    return path2
 #@+node:ekr.20080606074139.2: *3* g.chdir
 def chdir(path: str) -> None:
     if not g.os_path_isdir(path):
@@ -6436,7 +6449,8 @@ def os_path_finalize(path: str) -> str:
     path = os.path.expanduser(path)  # #1383.
     path = os.path.abspath(path)
     path = os.path.normpath(path)
-    # os.path.normpath does the *reverse* of what we want.
+    # os.path.normpath uses *platform' delims (os.sep).
+    # Here we *must forward slashes to make caching work properly.
     if g.isWindows:
         path = path.replace('\\', '/')
     # calling os.path.realpath here would cause problems in some situations.
@@ -7105,9 +7119,9 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
         # Add site-packages to sys.path.
         parent_dir = g.os_path_finalize_join(g.app.loadDir, '..', '..')
         if parent_dir.endswith('site-packages'):
-            if parent_dir not in sys.path:
-                g.trace(f"Append {parent_dir!r} to sys.path")
-                sys.path.append(parent_dir)
+            changed = g.appendToSysPath(parent_dir)
+            if changed:
+                g.trace(f"Append {changed!r} to sys.path")
         else:
             g.trace('Can not happen: wrong parent directory', parent_dir)
             return

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -66,7 +66,6 @@ def init():
     import os
     import sys
     path = os.path.normpath(os.path.join(os.path.dirname(pymacsFile), '..', '..'))
-    # Make sure the leo-editor directory is on sys.path.
     if path not in sys.path:
         sys.path.append(path)
         print(f"leoPymacs: Append {path!r} to sys.path")

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -67,8 +67,8 @@ def init():
     import sys
     path = os.path.normpath(os.path.join(os.path.dirname(pymacsFile), '..', '..'))
     if path not in sys.path:
-        sys.path.append(path)
         print(f"leoPymacs: Append {path!r} to sys.path")
+        sys.path.insert(0, path)
     del path
     # Create the dummy app
     try:

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -65,13 +65,12 @@ def init():
     # Add the parent path of this file to sys.path
     import os
     import sys
-    theDir = os.path.abspath(os.path.join(os.path.dirname(pymacsFile), '..', '..'))
-    # Like g.appendToSysPath.
-    isWindows = sys.platform.startswith('win')
-    theDir2 = theDir.replace('/', '\\') if isWindows else theDir
-    if theDir2 not in sys.path:
-        sys.path.append(theDir2)
-        print(f"leoPymacs: Append {theDir2!r} to sys.path")
+    path = os.path.normpath(os.path.join(os.path.dirname(pymacsFile), '..', '..'))
+    # Make sure the leo-editor directory is on sys.path.
+    if path not in sys.path:
+        sys.path.append(path)
+        print(f"leoPymacs: Append {path!r} to sys.path")
+    del path
     # Create the dummy app
     try:
         from leo.core import runLeo as leo

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -66,9 +66,12 @@ def init():
     import os
     import sys
     theDir = os.path.abspath(os.path.join(os.path.dirname(pymacsFile), '..', '..'))
-    if theDir not in sys.path:
-        print('leoPymacs:adding', theDir, 'to sys.path')
-        sys.path.append(theDir)
+    # Like g.appendToSysPath.
+    isWindows = sys.platform.startswith('win')
+    theDir2 = theDir.replace('/', '\\') if isWindows else theDir
+    if theDir2 not in sys.path:
+        sys.path.append(theDir2)
+        print(f"leoPymacs: Append {theDir2!r} to sys.path")
     # Create the dummy app
     try:
         from leo.core import runLeo as leo

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -35,7 +35,7 @@ try:
     import websockets
 except Exception:
     websockets = None
-# Make sure leo-editor folder is on sys.path.
+# Make sure the parent of the leo directory is on sys.path.
 core_dir = os.path.dirname(__file__)
 leo_path = os.path.normpath(os.path.join(core_dir, '..', '..'))
 assert os.path.exists(leo_path), repr(leo_path)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -40,7 +40,7 @@ core_dir = os.path.dirname(__file__)
 leo_path = os.path.normpath(os.path.join(core_dir, '..', '..'))
 assert os.path.exists(leo_path), repr(leo_path)
 if leo_path not in sys.path:
-    sys.path.append(leo_path)
+    sys.path.insert(0, leo_path)
 del core_dir, leo_path
 # Leo
 from leo.core.leoCommands import Commands as Cmdr  # noqa

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -39,11 +39,9 @@ except Exception:
 core_dir = os.path.dirname(__file__)
 leo_path = os.path.normpath(os.path.join(core_dir, '..', '..'))
 assert os.path.exists(leo_path), repr(leo_path)
-# Like g.appendToSysPath
-isWindows = sys.platform.startswith('win')
-leo_path2 = leo_path.replace('/', '\\') if isWindows else leo_path
-if leo_path2 not in sys.path:
-    sys.path.append(leo_path2)
+if leo_path not in sys.path:
+    sys.path.append(leo_path)
+del core_dir, leo_path
 # Leo
 from leo.core.leoCommands import Commands as Cmdr  # noqa
 from leo.core.leoNodes import Position, VNode  # noqa

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -39,8 +39,11 @@ except Exception:
 core_dir = os.path.dirname(__file__)
 leo_path = os.path.normpath(os.path.join(core_dir, '..', '..'))
 assert os.path.exists(leo_path), repr(leo_path)
-if leo_path not in sys.path:
-    sys.path.append(leo_path)
+# Like g.appendToSysPath
+isWindows = sys.platform.startswith('win')
+leo_path2 = leo_path.replace('/', '\\') if isWindows else leo_path
+if leo_path2 not in sys.path:
+    sys.path.append(leo_path2)
 # Leo
 from leo.core.leoCommands import Commands as Cmdr  # noqa
 from leo.core.leoNodes import Position, VNode  # noqa

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -31,9 +31,11 @@ if sys.executable.endswith("pythonw.exe"):
         os.path.join(os.getenv("TEMP", default=""),  # #1557.
         "stderr-" + os.path.basename(sys.argv[0])),
         "w")
+# Like g.appendToSysPath.
 path = os.getcwd()
+isWindows = sys.platform.startswith('win')
+theDir2 = path.replace('/', '\\') if isWindows else path
 if path not in sys.path:
-    # print('appending %s to sys.path' % path)
     sys.path.append(path)
 try:
     # #1472: bind to g immediately.

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -31,10 +31,7 @@ if sys.executable.endswith("pythonw.exe"):
         os.path.join(os.getenv("TEMP", default=""),  # #1557.
         "stderr-" + os.path.basename(sys.argv[0])),
         "w")
-# Like g.appendToSysPath.
 path = os.getcwd()
-isWindows = sys.platform.startswith('win')
-theDir2 = path.replace('/', '\\') if isWindows else path
 if path not in sys.path:
     sys.path.append(path)
 try:

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -39,15 +39,13 @@ you see is real, and most of it is "live".
 #@+node:ekr.20181113041314.1: ** << leoflexx: imports >>
 import os
 import re
-import sys
 import time
 from typing import Optional
 
 # This is what Leo typically does.
 # pylint: disable=wrong-import-position
-path = os.getcwd()
-if path not in sys.path:
-    sys.path.append(path)
+g.appendToSysPath(os.getcwd())
+
 # JS code can *not* use g.trace, g.callers or g.pdb.
 from leo.core import leoGlobals as g
 from leo.core import leoFastRedraw

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -44,7 +44,6 @@ import time
 from typing import Optional
 
 # Like g.appendToSysPath.
-# This is what Leo typically does.
 path = os.getcwd()
 isWindows = sys.platform.startswith('win')
 theDir2 = path.replace('/', '\\') if isWindows else path
@@ -53,6 +52,7 @@ if path not in sys.path:
 
 # pylint: disable=wrong-import-position
 
+# This is what Leo typically does.
 # JS code can *not* use g.trace, g.callers or g.pdb.
 from leo.core import leoGlobals as g
 from leo.core import leoFastRedraw

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -43,12 +43,10 @@ import sys
 import time
 from typing import Optional
 
-# Like g.appendToSysPath.
 path = os.getcwd()
-isWindows = sys.platform.startswith('win')
-theDir2 = path.replace('/', '\\') if isWindows else path
 if path not in sys.path:
     sys.path.append(path)
+del path
 
 # pylint: disable=wrong-import-position
 

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -45,7 +45,7 @@ from typing import Optional
 
 path = os.getcwd()
 if path not in sys.path:
-    sys.path.append(path)
+    sys.path.insert(0, path)
 del path
 
 # pylint: disable=wrong-import-position

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -39,12 +39,19 @@ you see is real, and most of it is "live".
 #@+node:ekr.20181113041314.1: ** << leoflexx: imports >>
 import os
 import re
+import sys
 import time
 from typing import Optional
 
+# Like g.appendToSysPath.
 # This is what Leo typically does.
+path = os.getcwd()
+isWindows = sys.platform.startswith('win')
+theDir2 = path.replace('/', '\\') if isWindows else path
+if path not in sys.path:
+    sys.path.append(path)
+
 # pylint: disable=wrong-import-position
-g.appendToSysPath(os.getcwd())
 
 # JS code can *not* use g.trace, g.callers or g.pdb.
 from leo.core import leoGlobals as g


### PR DESCRIPTION
See #3231.  Do *not* change `g.os_path_finalize`! Doing so will ruin all existing `.leo` files!

- [x] Use `os.path` functions (*not* `g.os_path_*`) functions whenever updating `sys.path`.
  The new pattern is:  `path = os.path.normpath.os.path.join(g.app.loadDir, ...))`
  This pattern is more explicit and avoids all complications.

The `g.os_path_*` wrappers functions are usually faux helpers. Alas, removing them is *not* generally possible.

To put the `leo-editor` directory on `sys.path`:

```python
path = os.path.normpath.os.path.join(g.app.loadDir, '..', '..'))
if path not in sys.path:
    sys.path.append(path)
```

To put the `leo-editor/leo` directory on `sys.path`:

```python
path = os.path.normpath.os.path.join(g.app.loadDir, '..'))
if path not in sys.path:
    sys.path.append(path)
```

