### PR TITLE
PR for #3262: Change @solarized-purple to @solarized-violet in all theme files

### DIFF
--- a/leo/themes/DefaultTheme.leo
+++ b/leo/themes/DefaultTheme.leo
@@ -154,7 +154,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>
@@ -492,7 +492,7 @@ Terry: #dc322f</t>
 Terry: #268bd2</t>
 <t tx="ekr.20180318145515.750"># Not an official solarized color: same as solorarized-base3</t>
 <t tx="ekr.20180318145515.751"></t>
-<t tx="ekr.20180318145515.752" lineYOffset="4b002e">These settings must exist because they are *not* used in the css.</t>
+<t tx="ekr.20180318145515.752">These settings must exist because they are *not* used in the css.</t>
 <t tx="ekr.20180318145515.753">These @color names map directly to the constants defined in each .py file in the leo/modes folder.
 
 There is a script to generate these .py files directly from the jEdit .xml syntax coloring files.
@@ -681,9 +681,9 @@ something to see)</t>
 
 url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/closed.png)</t>
 <t tx="ekr.20180318145515.809">url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/open.png)</t>
-<t tx="ekr.20180318145515.811" lineYOffset="4b002e">Set to true for dark themes, so bookmarks.py can generate
+<t tx="ekr.20180318145515.811">Set to true for dark themes, so bookmarks.py can generate
 random background colors which are appropriate etc.</t>
-<t tx="ekr.20180318145515.812" lineYOffset="4b002e">Used to find icon files:
+<t tx="ekr.20180318145515.812">Used to find icon files:
 
 leo_dark_0
 ekr_dark</t>

--- a/leo/themes/EKRDark.leo
+++ b/leo/themes/EKRDark.leo
@@ -154,7 +154,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = purple</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>
@@ -676,7 +676,7 @@ something to see)</t>
 
 url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/closed.png)</t>
 <t tx="ekr.20180318145515.809">url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/open.png)</t>
-<t tx="ekr.20180318145515.811" lineYOffset="4b002e">Set to true for dark themes, so bookmarks.py can generate
+<t tx="ekr.20180318145515.811">Set to true for dark themes, so bookmarks.py can generate
 random background colors which are appropriate etc.</t>
 <t tx="ekr.20180318145515.813">/*
 @language css

--- a/leo/themes/LeoBlackSolarized.leo
+++ b/leo/themes/LeoBlackSolarized.leo
@@ -173,7 +173,7 @@
 <v t="ekr.20180307010409.42"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180307010409.43"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180307010409.44"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180307010409.45"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180307010409.45"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180314165700.1"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180314165700.2"><vh>@color patch_keyword1_color = @solarized-green</vh></v>
@@ -224,7 +224,7 @@ def spam():
 for s in table:
     g.es(s, color=s)
 </t>
-<t tx="ekr.20180307010409.1" lineYOffset="4b002e">@language rest
+<t tx="ekr.20180307010409.1">@language rest
 @wrap
 
 A black theme with solarized colors.  Based on Chris George's superb work.
@@ -251,9 +251,9 @@ Changes made by EKR:
 
 url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/closed.png)</t>
 <t tx="ekr.20180307010409.101">url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/open.png)</t>
-<t tx="ekr.20180307010409.103" lineYOffset="4b002e">Set to true for dark themes, so bookmarks.py can generate
+<t tx="ekr.20180307010409.103">Set to true for dark themes, so bookmarks.py can generate
 random background colors which are appropriate etc.</t>
-<t tx="ekr.20180307010409.104" lineYOffset="4b002e">Name of the theme,
+<t tx="ekr.20180307010409.104">Name of the theme,
 used to find icon files</t>
 <t tx="ekr.20180307010409.105">/*
 @language css
@@ -503,7 +503,7 @@ QWidget {
 <t tx="ekr.20180307010409.14"></t>
 <t tx="ekr.20180307010409.15"># Not an official solarized color: same as solorarized-base3</t>
 <t tx="ekr.20180307010409.16"></t>
-<t tx="ekr.20180307010409.17" lineYOffset="4b002e">These settings must exist because they are *not* used in the css.</t>
+<t tx="ekr.20180307010409.17">These settings must exist because they are *not* used in the css.</t>
 <t tx="ekr.20180307010409.18">These @color names map directly to the constants defined in each .py file in the leo/modes folder.
 
 There is a script to generate these .py files directly from the jEdit .xml syntax coloring files.

--- a/leo/themes/minimal-ui-tbp_dark_solarized.leo
+++ b/leo/themes/minimal-ui-tbp_dark_solarized.leo
@@ -97,7 +97,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>

--- a/leo/themes/minimal-ui-tbp_light_solarized.leo
+++ b/leo/themes/minimal-ui-tbp_light_solarized.leo
@@ -98,7 +98,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>

--- a/leo/themes/tbp_dark.leo
+++ b/leo/themes/tbp_dark.leo
@@ -97,7 +97,7 @@
 <v t="tom.20230218225544.76"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="tom.20230218225544.77"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="tom.20230218225544.78"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="tom.20230218225544.79"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="tom.20230218225544.79"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="tom.20230218225544.80"><vh>Colors: patch (diff)</vh>
 <v t="tom.20230218225544.81"><vh>@color patch_keyword1_color = @solarized-green</vh></v>

--- a/leo/themes/tbp_dark_solarized.leo
+++ b/leo/themes/tbp_dark_solarized.leo
@@ -97,7 +97,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>
@@ -237,14 +237,14 @@ def spam():
 <t tx="ekr.20180318145515.1">@language rest
 @wrap
 </t>
-<t tx="ekr.20180318145515.704" lineYOffset="4b002e" __bookmarks="7d7100580700000069735f6475706571014930300a732e">@language rest
+<t tx="ekr.20180318145515.704" __bookmarks="7d7100580700000069735f6475706571014930300a732e">@language rest
 @wrap
 @tabwidth -2
 
 Same as tbp_light_solarized except swapped the solarized
 colors base0 - base3 and base00 - base03.  Also change log panel
 background color.</t>
-<t tx="ekr.20180318145515.710" lineYOffset="4b002e"></t>
+<t tx="ekr.20180318145515.710"></t>
 <t tx="ekr.20180318145515.711"></t>
 <t tx="ekr.20180318145515.712"></t>
 <t tx="ekr.20180318145515.713">Original solarized base0: #839496</t>
@@ -442,7 +442,7 @@ Terry: #dc322f</t>
 Terry: #268bd2</t>
 <t tx="ekr.20180318145515.750"># Not an official solarized color: same as solorarized-base3</t>
 <t tx="ekr.20180318145515.751"></t>
-<t tx="ekr.20180318145515.752" lineYOffset="4b002e">These settings must exist because they are *not* used in the css.</t>
+<t tx="ekr.20180318145515.752">These settings must exist because they are *not* used in the css.</t>
 <t tx="ekr.20180318145515.753">These @color names map directly to the constants defined in each .py file in the leo/modes folder.
 
 There is a script to generate these .py files directly from the jEdit .xml syntax coloring files.
@@ -634,9 +634,9 @@ The following settings specify the indicators.  You can use an absolute path, or
 url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/closed.png)</t>
 <t tx="ekr.20180318145515.809">url(/home/edward/leo.repo/leo-editor/leo/Icons/nodes-dark/triangles/open.png)</t>
 <t tx="ekr.20180318145515.810"></t>
-<t tx="ekr.20180318145515.811" lineYOffset="4b002e">Set to true for dark themes, so bookmarks.py can generate
+<t tx="ekr.20180318145515.811">Set to true for dark themes, so bookmarks.py can generate
 random background colors which are appropriate etc.</t>
-<t tx="ekr.20180318145515.812" lineYOffset="4b002e">Name of the theme, used to find icon files:
+<t tx="ekr.20180318145515.812">Name of the theme, used to find icon files:
 
 leo_dark_0
 ekr_dark</t>

--- a/leo/themes/tbp_light.leo
+++ b/leo/themes/tbp_light.leo
@@ -98,7 +98,7 @@
 <v t="tom.20230218225544.76"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="tom.20230218225544.77"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="tom.20230218225544.78"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="tom.20230218225544.79"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="tom.20230218225544.79"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="tom.20230218225544.80"><vh>Colors: patch (diff)</vh>
 <v t="tom.20230218225544.81"><vh>@color patch_keyword1_color = @solarized-green</vh></v>

--- a/leo/themes/tbp_light_quasi_solarized.leo
+++ b/leo/themes/tbp_light_quasi_solarized.leo
@@ -98,7 +98,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>
@@ -242,14 +242,14 @@ def spam():
 
 2018/03/18: from myLeoSettings.leo
 </t>
-<t tx="ekr.20180318145515.704" lineYOffset="4b002e" __bookmarks="7d7100580700000069735f6475706571014930300a732e">@language rest
+<t tx="ekr.20180318145515.704" __bookmarks="7d7100580700000069735f6475706571014930300a732e">@language rest
 @wrap
 @tabwidth -2
 
 This is Leo's default theme.
 
 Same as EKRDark theme except it uses smaller text sizes.</t>
-<t tx="ekr.20180318145515.710" lineYOffset="4b002e"></t>
+<t tx="ekr.20180318145515.710"></t>
 <t tx="ekr.20180318145515.711"></t>
 <t tx="ekr.20180318145515.712">Solarized colors were developed by Ethan Schoonover.  See::
 
@@ -477,7 +477,7 @@ Terry: #dc322f</t>
 Terry: #268bd2</t>
 <t tx="ekr.20180318145515.750"># Not an official solarized color: same as solorarized-base3</t>
 <t tx="ekr.20180318145515.751"></t>
-<t tx="ekr.20180318145515.752" lineYOffset="4b002e">These settings must exist because they are *not* used in the css.</t>
+<t tx="ekr.20180318145515.752">These settings must exist because they are *not* used in the css.</t>
 <t tx="ekr.20180318145515.753">These @color names map directly to the constants defined in each .py file in the leo/modes folder.
 
 There is a script to generate these .py files directly from the jEdit .xml syntax coloring files.
@@ -683,9 +683,9 @@ The following settings specify the indicators.  You can use an absolute path, or
 url(nodes-light/triangles/closed.png)</t>
 <t tx="ekr.20180318145515.809">url(nodes-light/triangles/open.png)</t>
 <t tx="ekr.20180318145515.810"></t>
-<t tx="ekr.20180318145515.811" lineYOffset="4b002e">Set to true for dark themes, so bookmarks.py can generate
+<t tx="ekr.20180318145515.811">Set to true for dark themes, so bookmarks.py can generate
 random background colors which are appropriate etc.</t>
-<t tx="ekr.20180318145515.812" lineYOffset="4b002e">Name of the theme, used to find icon files:
+<t tx="ekr.20180318145515.812">Name of the theme, used to find icon files:
 
 leo_dark_0
 ekr_dark</t>

--- a/leo/themes/tbp_light_solarized.leo
+++ b/leo/themes/tbp_light_solarized.leo
@@ -98,7 +98,7 @@
 <v t="ekr.20180318145515.777"><vh>@color show_invisibles_space_color = #E5E5E5</vh></v>
 <v t="ekr.20180318145515.778"><vh>@color show_invisibles_tab_color = #CCCCCC</vh></v>
 <v t="ekr.20180318145515.779"><vh>@color undefined_section_name_color = red</vh></v>
-<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-purple</vh></v>
+<v t="ekr.20180318145515.780"><vh>@color url_color = @solarized-violet</vh></v>
 </v>
 <v t="ekr.20180318145515.781"><vh>Colors: patch (diff)</vh>
 <v t="ekr.20180318145515.782"><vh>@color patch_keyword1_color = @solarized-green</vh></v>
@@ -242,14 +242,14 @@ def spam():
 
 2018/03/18: from myLeoSettings.leo
 </t>
-<t tx="ekr.20180318145515.704" lineYOffset="4b002e" __bookmarks="7d7100580700000069735f6475706571014930300a732e">@language rest
+<t tx="ekr.20180318145515.704" __bookmarks="7d7100580700000069735f6475706571014930300a732e">@language rest
 @wrap
 @tabwidth -2
 
 This is Leo's default theme.
 
 Same as EKRDark theme except it uses smaller text sizes.</t>
-<t tx="ekr.20180318145515.710" lineYOffset="4b002e"></t>
+<t tx="ekr.20180318145515.710"></t>
 <t tx="ekr.20180318145515.711"></t>
 <t tx="ekr.20180318145515.712">Solarized colors were developed by Ethan Schoonover.  See::
 
@@ -477,7 +477,7 @@ Terry: #dc322f</t>
 Terry: #268bd2</t>
 <t tx="ekr.20180318145515.750"># Not an official solarized color: same as solorarized-base3</t>
 <t tx="ekr.20180318145515.751"></t>
-<t tx="ekr.20180318145515.752" lineYOffset="4b002e">These settings must exist because they are *not* used in the css.</t>
+<t tx="ekr.20180318145515.752">These settings must exist because they are *not* used in the css.</t>
 <t tx="ekr.20180318145515.753">These @color names map directly to the constants defined in each .py file in the leo/modes folder.
 
 There is a script to generate these .py files directly from the jEdit .xml syntax coloring files.
@@ -683,9 +683,9 @@ The following settings specify the indicators.  You can use an absolute path, or
 url(nodes-light/triangles/closed.png)</t>
 <t tx="ekr.20180318145515.809">url(nodes-light/triangles/open.png)</t>
 <t tx="ekr.20180318145515.810"></t>
-<t tx="ekr.20180318145515.811" lineYOffset="4b002e">Set to true for dark themes, so bookmarks.py can generate
+<t tx="ekr.20180318145515.811">Set to true for dark themes, so bookmarks.py can generate
 random background colors which are appropriate etc.</t>
-<t tx="ekr.20180318145515.812" lineYOffset="4b002e">Name of the theme, used to find icon files:
+<t tx="ekr.20180318145515.812">Name of the theme, used to find icon files:
 
 leo_dark_0
 ekr_dark</t>


### PR DESCRIPTION
See #3262.

Some theme files used `purple` or colors specified by value. Those files did not change.