### PR TITLE
PR for #3232: change Leo's URL in Leo's sources, including xml elements

### DIFF
--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -30,7 +30,7 @@ def about(self: Self, event: Event = None) -> None:
         "Copyright 1999-%s by Edward K. Ream\n" +
         "All Rights Reserved\n" +
         "Leo is distributed under the MIT License") % datetime.date.today().year
-    url = "http://leoeditor.com/"
+    url = "https://leo-editor.github.io/leo-editor/"
     email = "edreamleo@gmail.com"
     g.app.gui.runAboutLeoDialog(c, version, theCopyright, url, email)
 #@+node:vitalije.20170713174950.1: ** c_help.editOneSetting
@@ -239,7 +239,7 @@ def createMyLeoSettings(c: Cmdr) -> Optional[Cmdr]:
         "Only nodes that are descendants of the @settings node are read.\n\n"
         "Only settings you need to modify should be in this file, do\n"
         "not copy large parts of leoSettings.py here.\n\n"
-        "For more information see http://leoeditor.com/customizing.html"
+        "For more information see https://leo-editor.github.io/leo-editor/customizing.html"
         "".format(time=time.asctime())
     )
     nd = nd.insertAfter()
@@ -264,7 +264,7 @@ def createMyLeoSettings(c: Cmdr) -> Optional[Cmdr]:
 def leoHome(self: Self, event: Event = None) -> None:
     """Open Leo's Home page in a web browser."""
     import webbrowser
-    url = "http://leoeditor.com/"
+    url = "https://leo-editor.github.io/leo-editor/"
     try:
         webbrowser.open_new(url)
     except Exception:
@@ -274,7 +274,7 @@ def leoHome(self: Self, event: Event = None) -> None:
 def openLeoTOC(self: Self, event: Event = None) -> None:
     """Open Leo's tutorials page in a web browser."""
     import webbrowser
-    url = "http://leoeditor.com/leo_toc.html"
+    url = "https://leo-editor.github.io/leo-editor/leo_toc.html"
     try:
         webbrowser.open_new(url)
     except Exception:
@@ -284,7 +284,7 @@ def openLeoTOC(self: Self, event: Event = None) -> None:
 def openLeoScriptingMiscellany(self: Self, event: Event = None) -> None:
     """Open Leo's scripting miscellany page in a web browser."""
     import webbrowser
-    url = "http://leoeditor.com/scripting-miscellany.html"
+    url = "https://leo-editor.github.io/leo-editor/scripting-miscellany.html"
     try:
         webbrowser.open_new(url)
     except Exception:
@@ -294,7 +294,7 @@ def openLeoScriptingMiscellany(self: Self, event: Event = None) -> None:
 def openLeoTutorials(self: Self, event: Event = None) -> None:
     """Open Leo's tutorials page in a web browser."""
     import webbrowser
-    url = "http://leoeditor.com/tutorial.html"
+    url = "https://leo-editor.github.io/leo-editor/tutorial.html"
     try:
         webbrowser.open_new(url)
     except Exception:
@@ -304,7 +304,7 @@ def openLeoTutorials(self: Self, event: Event = None) -> None:
 def openLeoUsersGuide(self: Self, event: Event = None) -> None:
     """Open Leo's users guide in a web browser."""
     import webbrowser
-    url = "http://leoeditor.com/usersguide.html"
+    url = "https://leo-editor.github.io/leo-editor/usersguide.html"
     try:
         webbrowser.open_new(url)
     except Exception:
@@ -314,7 +314,7 @@ def openLeoUsersGuide(self: Self, event: Event = None) -> None:
 def openLeoVideos(self: Self, event: Event = None) -> None:
     """Open Leo's videos page in a web browser."""
     import webbrowser
-    url = "http://leoeditor.com/screencasts.html"
+    url = "https://leo-editor.github.io/leo-editor/screencasts.html"
     try:
         webbrowser.open_new(url)
     except Exception:

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -463,8 +463,8 @@ class HelpCommandsClass(BaseEditCommandsClass):
         This help discusses only @file nodes.
         For other ways of creating external files, see::
 
-            http://leoeditor.com/tutorial-programming.html or
-            http://leoeditor.com/directives.html
+            https://leo-editor.github.io/leo-editor/tutorial-scripting.html or
+            https://leo-editor.github.io/leo-editor/directives.html
 
         Leo creates external files in an unusual way.
         Please fee free to ask for help::

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -474,7 +474,7 @@ class LeoApp:
         # self.prolog_string = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         self.prolog_prefix_string = "<?xml version=\"1.0\" encoding="
         self.prolog_postfix_string = "?>"
-        self.prolog_namespace_string = 'xmlns:leo="http://edreamleo.org/namespaces/leo-python-editor/1.1"'
+        self.prolog_namespace_string = 'xmlns:leo="https://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1"'
     #@+node:ekr.20120522160137.9909: *5* app.define_language_delims_dict
     #@@nobeautify
 

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1,7 +1,8 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20141012064706.18389: * @file leoAst.py
-# This file is part of Leo: https://leoeditor.com
-# Leo's copyright notice is based on the MIT license: http://leoeditor.com/license.html
+# This file is part of Leo: https://leo-editor.github.io/leo-editor
+# Leo's copyright notice is based on the MIT license:
+# https://leo-editor.github.io/leo-editor/license.html
 
 # For now, suppress all mypy checks
 # type: ignore
@@ -126,7 +127,7 @@ variable-length data at all.
 Leo...
 Ask for help:       https://groups.google.com/forum/#!forum/leo-editor
 Report a bug:       https://github.com/leo-editor/leo-editor/issues
-leoAst.py docs:     http://leoeditor.com/appendices.html#leoast-py
+leoAst.py docs:     https://leo-editor.github.io/leo-editor/appendices.html#leoast-py
 
 Other tools...
 asttokens:          https://pypi.org/project/asttokens
@@ -2834,9 +2835,9 @@ class TokenOrderGenerator:
 
     Theory of operation:
     - https://github.com/leo-editor/leo-editor/issues/1440#issuecomment-573661883
-    - http://leoeditor.com/appendices.html#tokenorder-classes-theory-of-operation
+    - https://leo-editor.github.io/leo-editor/appendices.html#tokenorder-classes-theory-of-operation
 
-    How to: http://leoeditor.com/appendices.html#tokenorder-class-how-to
+    How to: https://leo-editor.github.io/leo-editor/appendices.html#tokenorder-class-how-to
 
     Project history: https://github.com/leo-editor/leo-editor/issues/1440#issuecomment-574145510
     """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3349,7 +3349,7 @@ class FastAtRead:
             #@-<< handle @first and @last >>
             #@+<< handle @comment >>
             #@+node:ekr.20180621050901.1: *4* << handle @comment >>
-            # http://leoeditor.com/directives.html#part-4-dangerous-directives
+            # https://leo-editor.github.io/leo-editor/directives.html#part-4-dangerous-directives
             m = self.comment_pat.match(line)
             if m:
                 # <1, 2 or 3 comment delims>

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -2173,11 +2173,13 @@ class FileCommands:
         self.put("<preferences/>\n")
     #@+node:ekr.20031218072017.1246: *5* fc.putProlog
     def putProlog(self) -> None:
-        """Put the prolog of the xml file."""
-        tag = 'http://leoeditor.com/namespaces/leo-python-editor/1.1'
+        """
+        Put the prolog of the xml file.
+        """
+        tag = 'http://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1'
         self.putXMLLine()
         # Put "created by Leo" line.
-        self.put('<!-- Created by Leo: http://leoeditor.com/leo_toc.html -->\n')
+        self.put('<!-- Created by Leo: https://leo-editor.github.io/leo-editor/leo_toc.html -->\n')
         self.putStyleSheetLine()
         # Put the namespace
         self.put(f'<leo_file xmlns:leo="{tag}" >\n')

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -4,7 +4,7 @@
 #@+node:ekr.20180326102140.1: ** << leoIpython docstring >>
 """
 Support for the --ipython command-line option and the IPython bridge:
-http://leoeditor.com/IPythonBridge.html
+https://leo-editor.github.io/leo-editor/IPythonBridge.html
 
 This code will run on IPython 1.0 and higher, as well as the IPython
 0.x versions that define the IPKernelApp class.

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -4,7 +4,7 @@
 #@+node:ekr.20090502071837.4: ** << leoRst docstring >>
 """Support for restructured text (rST), adapted from rst3 plugin.
 
-For full documentation, see: http://leoeditor.com/rstplugin3.html
+For full documentation, see: https://leo-editor.github.io/leo-editor/tutorial-rst3.html
 
 To generate documents from rST files, Python's docutils_ module must be
 installed. The code will use the SilverCity_ syntax coloring package if is is

--- a/leo/core/leoTips.py
+++ b/leo/core/leoTips.py
@@ -358,7 +358,7 @@ UserTip(
     text="""\
 <p>The rst3 command converts an @rst tree to a document file.</p>
 
-<p>See <a href="http://leoeditor.com/tutorial-rst3.html">Leo's rst3 tutorial.</a></p>
+<p>See <a href="https://leo-editor.github.io/leo-editor/tutorial-rst3.html">Leo's rst3 tutorial.</a></p>
 
 </html>"""),
 #@+node:ekr.20180324072625.1: *4* sort-siblings command
@@ -401,7 +401,7 @@ For example:</p>
 <p><pre>    g.trace(g.callers())</pre></p>
 
 <p>You must
-<a href="http://leoeditor.com/running.html#running-leo-from-a-console-window">
+<a href="https://leo-editor.github.io/leo-editor/running.html#running-leo-from-a-console-window">
 run Leo from a console</a> for this to work.</p>
 
 </html>"""),
@@ -416,7 +416,7 @@ UserTip(
 adapted for Leo.</p>
 
 <p>You must
-<a href="http://leoeditor.com/running.html#running-leo-from-a-console-window">
+<a href="https://leo-editor.github.io/leo-editor/running.html#running-leo-from-a-console-window">
 run Leo from a console</a> for this to work.</p>
 
 </html>"""),
@@ -431,7 +431,7 @@ UserTip(
 <p>It's great for seeing patterns in running code.</p>
 
 <p>You must
-<a href="http://leoeditor.com/running.html#running-leo-from-a-console-window">
+<a href="https://leo-editor.github.io/leo-editor/running.html#running-leo-from-a-console-window">
 run Leo from a console</a> for this to work.</p>
 
 </html>"""),
@@ -506,7 +506,7 @@ UserTip(
     text="""
 
 <p>Leo's
-<a href="http://leoeditor.com/tutorial-pim.html#using-abbreviations-and-templates">
+<a href="https://leo-editor.github.io/leo-editor/tutorial-pim.html#using-abbreviations-and-templates">
 abbreviations</a>
 can correct spelling mistakes, expand to multiple lines or even trees of nodes.
 </p>
@@ -522,7 +522,7 @@ UserTip(
     title="<html>Clones",
     text="""
 <p>
-<a href="http://leoeditor.com/tutorial-pim.html#clones">Clones</a>
+<a href="https://leo-editor.github.io/leo-editor/tutorial-pim.html#clones">Clones</a>
 are "live" copies of the node itself and all its descendants.</p>
 
 <p>Clones are a unique feature of Leo.</p>

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -41,9 +41,9 @@ try:
     g.app = leoApp.LeoApp()
 except Exception as e:
     print(e)
-    msg = "\n*** Leo could not be started ***"
-    msg += "\nPlease verify you've installed the required dependencies:"
-    msg += "\nhttps://leoeditor.com/installing.html"
+    msg = "\n*** Leo could not be started ***\n"
+    msg += "Please verify you've installed the required dependencies:\n"
+    msg += "https://leo-editor.github.io/leo-editor/installing.html"
     sys.exit(msg)
 #@-<< imports and inits >>
 #@+others

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -14,13 +14,14 @@ The ``--gui=curses`` command-line option enables this plugin.
 - This is beta-level code. Be prepared to recover from data loss. Testing
   on files under git control gives you diffs and easy reverts.
 
-- There are many limitations: see http://leoeditor.com/console-gui.html
+- There are many limitations: see
+  https://leo-editor.github.io/leo-editor/console-gui.html
 
 Please report any problem here:
 https://github.com/leo-editor/leo-editor/issues/488
 
 Devs, please read:
-http://leoeditor.com/console-gui.html#developing-the-cursesgui2-plugin
+https://leo-editor.github.io/leo-editor/console-gui.html#developing-the-cursesgui2-plugin
 """
 #@-<< cursesGui2 docstring >>
 #@+<< cursesGui2 imports >>

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -316,7 +316,7 @@ class FreeLayoutController:
             self.get_top_splitter().load_layout(c, layout=self.default_layout)
         if id_.startswith('_fl_help'):
             self.c.putHelpFor(__doc__)
-            # g.handleUrl("http://leoeditor.com/")
+            # g.handleUrl("https://leo-editor.github.io/leo-editor/")
             return True
         if id_ == '_fl_save_layout':
             if self.c.config.getData("free-layout-layout"):

--- a/leo/plugins/mod_leo2ascd.txt
+++ b/leo/plugins/mod_leo2ascd.txt
@@ -431,7 +431,7 @@ From there:
 Here are some web locations for the items I've referenced above:
 
 Leo::
-    http://leoeditor.com/
+    https://leo-editor.github.io/leo-editor/
 Python::
     http://www.python.org[]
 Docbook::

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1671,7 +1671,7 @@ class StyleSheetManager:
         # This warning is inappropriate in some contexts.
             # if not self.settings_p:
                 # g.es("No '@settings' node found in outline.  See:")
-                # g.es("http://leoeditor.com/tutorial-basics.html#configuring-leo")
+                # g.es("https://leo-editor.github.io/leo-editor/tutorial-basics.html#configuring-leo")
     #@+node:ekr.20170222051716.1: *4* ssm.reload_settings
     def reload_settings(self, sheet: str=None) -> None:
         """

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -229,12 +229,12 @@ class TestGlobals(LeoUnitTest):
         #         See the hacks in jedit.match_any_url and g.handleUrl.
         table1 = (
             (
-                "http://leoeditor.com/preface.html).",
-                "http://leoeditor.com/preface.html",
+                "https://leo-editor.github.io/leo-editor/preface.html).",
+                "https://leo-editor.github.io/leo-editor/preface.html",
             ),
             (
-                "http://leoeditor.com/leo_toc.html)",
-                "http://leoeditor.com/leo_toc.html",
+                "https://leo-editor.github.io/leo-editor/leo_toc.html)",
+                "https://leo-editor.github.io/leo-editor/leo_toc.html",
             ),
             (
                 "https://github.com/leo-editor/leo-editor/issues?q=is%3Aissue+milestone%3A6.6.3+",

--- a/setup.py
+++ b/setup.py
@@ -139,13 +139,13 @@ if production:
         version=version,
         author='Edward K. Ream',
         author_email='edreamleo@gmail.com',
-        url='http://leo-editor.github.io/leo-editor',
+        url='https://leo-editor.github.io/leo-editor',
         license='MIT License',
         description='An IDE, PIM and Outliner',  # becomes 'Summary' in pkg-info
         long_description=long_description,
         long_description_content_type="text/markdown",  # PEP566
         platforms=['Linux', 'Windows', 'MacOS'],
-        download_url='http://leo-editor.github.io/leo-editor/download.html',
+        download_url='https://leo-editor.github.io/leo-editor/download.html',
         classifiers=classifiers,
         packages=setuptools.find_packages(),
         include_package_data=True,  # also include MANIFEST files in wheels


### PR DESCRIPTION
See #3232.

- [x] Change `http://leoeditor.com` to `https://leo-editor.github.io/leo-editor` everywhere,
    including in the message in `runLeo.py` written when Leo can't be started.
- [x] Change the `xmlns` element of `.leo` files
    from `http://edreamleo.org/namespaces/leo-python-editor/1.1`
    to `https://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1`
- [x] Change the `Created by Leo` comment in `.leo` files
        from `http://leoeditor.com/leo_toc.html`
        to `https://leo-editor.github.io/leo-editor/leo_toc.html`