### PR TITLE
PR for #3266: simplify path handling further

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Created by Leo: http://leoeditor.com/leo_toc.html -->
-<leo_file xmlns:leo="http://leoeditor.com/namespaces/leo-python-editor/1.1" >
+<!-- Created by Leo: https://leo-editor.github.io/leo-editor/leo_toc.html -->
+<leo_file xmlns:leo="http://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1" >
 <leo_header file_format="2"/>
 <globals/>
 <preferences/>
@@ -121,6 +121,7 @@
 </v>
 <v t="ekr.20071213061923.2"><vh>@bool rst3-generate-rst = True</vh></v>
 </v>
+<v t="ekr.20041119041304.1"><vh>@string relative-path-base-directory = .</vh></v>
 </v>
 <v t="ekr.20200226104131.1"><vh>Future settings</vh>
 <v t="ekr.20190926110217.1"><vh>@string adoc-base-directory = None</vh></v>
@@ -658,7 +659,6 @@
 <v t="ekr.20230113102630.1"><vh>@string gnx-kind = none</vh></v>
 <v t="ekr.20181018113812.1"><vh>@string initial-chooser-directory = None</vh></v>
 <v t="ekr.20170718054951.1"><vh>@string log-timestamp-format = %H:%M:%S</vh></v>
-<v t="ekr.20041119041304.1"><vh>@string relative-path-base-directory = .</vh></v>
 <v t="ekr.20181018113813.1"><vh>@string script-file-path = None</vh></v>
 <v t="ekr.20170706103843.1"><vh>Checking files</vh>
 <v t="ekr.20071110153046"><vh>@bool at-auto-warns-about-leading-whitespace = True</vh></v>

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2514,7 +2514,7 @@ class Commands:
             "lang-dict":    lang_dict,  # Leo 6.4: New.
             "lineending":   d.get('lineending'),
             "pagewidth":    d.get('pagewidth'),
-            "path":         d.get('path'), # Redundant: or g.getBaseDirectory(c),
+            "path":         d.get('path'),
             "tabwidth":     d.get('tabwidth'),
             "wrap":         d.get('wrap'),
         }

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2561,7 +2561,7 @@ class Commands:
         paths.reverse()
         # Step 3: Compute the full, effective, absolute path.
         path = g.os_path_finalize_join(*paths)
-        return path or g.getBaseDirectory(c)  # 2010/10/22: A useful default.
+        return path
     #@+node:ekr.20171123201514.1: *3* c.Executing commands & scripts
     #@+node:ekr.20110605040658.17005: *4* c.check_event
     def check_event(self, event: Event) -> None:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3557,30 +3557,14 @@ def get_files_in_directory(directory: str, kinds: List = None, recursive: bool =
         g.es_exception()
         return []
 #@+node:ekr.20031218072017.1264: *3* g.getBaseDirectory
-# Handles the conventions applying to the "relative-path-base- directory" configuration option.
-
 def getBaseDirectory(c: Cmdr) -> str:
-    """Convert '!' or '.' to proper directory references."""
-    if not c:
-        return ''  # No relative base given.
-    base = c.config.getString('relative-path-base-directory')
-    if base and base == "!":
-        base = app.loadDir
-    elif base and base == ".":
-        base = c.openDirectory
-    else:
-        return ''  # Settings error.
-    if not base:
-        return ''
-    if g.os_path_isabs(base):
-        # Set c.chdir_to_relative_path as needed.
-        if not hasattr(c, 'chdir_to_relative_path'):
-            c.chdir_to_relative_path = c.config.getBool('chdir-to-relative-path')
-        # Call os.chdir if requested.
-        if c.chdir_to_relative_path:
-            os.chdir(base)
-        return base  # base need not exist yet.
-    return ''  # No relative base given.
+    """
+    This function is deprectated.
+    
+    Previously it convert '!' or '.' to proper directory references using
+    @string relative-path-base-directory.
+    """
+    return ''
 #@+node:ekr.20170223093758.1: *3* g.getEncodingAt
 def getEncodingAt(p: Position, s: bytes = None) -> str:
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6454,41 +6454,15 @@ def os_path_isfile(path: str) -> bool:
 #@+node:ekr.20031218072017.2154: *3* g.os_path_join
 def os_path_join(*args: Any, **keys: Any) -> str:
     """
-    Join paths, like os.path.join, with enhancements:
-
-    A '!!' arg prepends g.app.loadDir to the list of paths.
-    A '.'  arg prepends c.openDirectory to the list of paths,
-           provided there is a 'c' kwarg.
+    Wrap os.path.join.
     """
-    c = keys.get('c')
+
     uargs = [z for z in args if z]
     if not uargs:
         return ''
     path = os.path.join(*uargs)
     path = g.os_path_normslashes(path)
     return path
-
-    if 0:
-        # Note:  This is exactly the same convention as used by getBaseDirectory.
-        if uargs[0] == '!!':
-            uargs[0] = g.app.loadDir
-        elif uargs[0] == '.':
-            c = keys.get('c')
-            if c and c.openDirectory:
-                uargs[0] = c.openDirectory
-        try:
-            path = os.path.join(*uargs)
-        except TypeError:
-            g.trace(uargs, args, keys, g.callers())
-            raise
-        # May not be needed on some Pythons.
-        if '\x00' in path:
-            g.trace('NULL in', repr(path), g.callers())
-            path = path.replace('\x00', '')  # Fix Python 3 bug on Windows 10.
-        # os.path.normpath does the *reverse* of what we want.
-        if g.isWindows:
-            path = path.replace('\\', '/')
-        return path
 #@+node:ekr.20031218072017.2156: *3* g.os_path_normcase
 def os_path_normcase(path: str) -> str:
     """Normalize the path's case."""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3560,7 +3560,7 @@ def get_files_in_directory(directory: str, kinds: List = None, recursive: bool =
 def getBaseDirectory(c: Cmdr) -> str:
     """
     This function is deprectated.
-    
+
     Previously it convert '!' or '.' to proper directory references using
     @string relative-path-base-directory.
     """
@@ -6464,26 +6464,31 @@ def os_path_join(*args: Any, **keys: Any) -> str:
     uargs = [z for z in args if z]
     if not uargs:
         return ''
-    # Note:  This is exactly the same convention as used by getBaseDirectory.
-    if uargs[0] == '!!':
-        uargs[0] = g.app.loadDir
-    elif uargs[0] == '.':
-        c = keys.get('c')
-        if c and c.openDirectory:
-            uargs[0] = c.openDirectory
-    try:
-        path = os.path.join(*uargs)
-    except TypeError:
-        g.trace(uargs, args, keys, g.callers())
-        raise
-    # May not be needed on some Pythons.
-    if '\x00' in path:
-        g.trace('NULL in', repr(path), g.callers())
-        path = path.replace('\x00', '')  # Fix Python 3 bug on Windows 10.
-    # os.path.normpath does the *reverse* of what we want.
-    if g.isWindows:
-        path = path.replace('\\', '/')
+    path = os.path.join(*uargs)
+    path = g.os_path_normslashes(path)
     return path
+
+    if 0:
+        # Note:  This is exactly the same convention as used by getBaseDirectory.
+        if uargs[0] == '!!':
+            uargs[0] = g.app.loadDir
+        elif uargs[0] == '.':
+            c = keys.get('c')
+            if c and c.openDirectory:
+                uargs[0] = c.openDirectory
+        try:
+            path = os.path.join(*uargs)
+        except TypeError:
+            g.trace(uargs, args, keys, g.callers())
+            raise
+        # May not be needed on some Pythons.
+        if '\x00' in path:
+            g.trace('NULL in', repr(path), g.callers())
+            path = path.replace('\x00', '')  # Fix Python 3 bug on Windows 10.
+        # os.path.normpath does the *reverse* of what we want.
+        if g.isWindows:
+            path = path.replace('\\', '/')
+        return path
 #@+node:ekr.20031218072017.2156: *3* g.os_path_normcase
 def os_path_normcase(path: str) -> str:
     """Normalize the path's case."""

--- a/leo/plugins/textnode.py
+++ b/leo/plugins/textnode.py
@@ -65,7 +65,7 @@ def on_save(tag, keywords):
         if g.match_word(h, 0, "@text") and p.isDirty():
             savetextnode(c, p)
             p.b = ""
-#@+node:tbrown.20080128221824: ** getPath
+#@+node:tbrown.20080128221824: ** getPath (textnode.py)
 def getPath(c, p):
     path = [i.h[6:] for i in p.self_and_parents()
             if i.h[:6] in ('@path ', '@text ')]


### PR DESCRIPTION
See #3266. This PR is a follow-on to PR #3260.

Now is the time to remove *all* dubious Leonine path conventions!

- [x] Deprecate `g.getBaseDirectory`.
- [x] Don't support '.' and '!' in `g.os_path_join`.