### PR TITLE
PR for #3276: simplify Leos path functions

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -656,14 +656,14 @@ class PylintCommand:
         local_dir = g.os_path_dirname(c.fileName())
         table = (
             # In the directory containing the outline.
-            g.os_path_finalize_join(local_dir, base1),
-            g.os_path_finalize_join(local_dir, base2),
+            g.finalize_join(local_dir, base1),
+            g.finalize_join(local_dir, base2),
             # In ~/.leo
-            g.os_path_finalize_join(g.app.homeDir, '.leo', base1),
-            g.os_path_finalize_join(g.app.homeDir, '.leo', base2),
+            g.finalize_join(g.app.homeDir, '.leo', base1),
+            g.finalize_join(g.app.homeDir, '.leo', base2),
             # In leo/test
-            g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base2),
-            g.os_path_finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base2),
+            g.finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base2),
+            g.finalize_join(g.app.loadDir, '..', '..', 'leo', 'test', base2),
         )
         for fn in table:
             fn = g.os_path_abspath(fn)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -1073,7 +1073,7 @@ def open_theme_file(self: Self, event: Event) -> None:
     if not c:
         return
     # Get the file name.
-    themes_dir = g.os_path_finalize_join(g.app.loadDir, '..', 'themes')
+    themes_dir = g.finalize_join(g.app.loadDir, '..', 'themes')
     fn = g.app.gui.runOpenFileDialog(c,
         title="Open Theme File",
         filetypes=[
@@ -1085,7 +1085,7 @@ def open_theme_file(self: Self, event: Event) -> None:
     )
     if not fn:
         return
-    leo_dir = g.os_path_finalize_join(g.app.loadDir, '..', '..')
+    leo_dir = g.finalize_join(g.app.loadDir, '..', '..')
     os.chdir(leo_dir)
     #
     # #1425: Open the theme file in a separate process.

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -71,8 +71,7 @@ def leoDocumentation(self: Self, event: Event = None) -> None:
     """Open LeoDocs.leo in a new Leo window."""
     c = self
     name = "LeoDocs.leo"
-    fileName = g.os_path_finalize_join(g.app.loadDir, "..", "doc", name)
-    # Bug fix: 2012/04/09: only call g.openWithFileName if the file exists.
+    fileName = g.finalize_join(g.app.loadDir, "..", "doc", name)
     if g.os_path_exists(fileName):
         c2 = g.openWithFileName(fileName, old_c=c)
         if c2:
@@ -85,8 +84,7 @@ def leoQuickStart(self: Self, event: Event = None) -> None:
     """Open quickstart.leo in a new Leo window."""
     c = self
     name = "quickstart.leo"
-    fileName = g.os_path_finalize_join(g.app.loadDir, "..", "doc", name)
-    # Bug fix: 2012/04/09: only call g.openWithFileName if the file exists.
+    fileName = g.finalize_join(g.app.loadDir, "..", "doc", name)
     if g.os_path_exists(fileName):
         c2 = g.openWithFileName(fileName, old_c=c)
         if c2:
@@ -99,7 +97,7 @@ def leoQuickStart(self: Self, event: Event = None) -> None:
 def openCheatSheet(self: Self, event: Event = None) -> None:
     """Open leo/doc/cheatSheet.leo"""
     c = self
-    fn = g.os_path_finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')
+    fn = g.finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')
     if not g.os_path_exists(fn):
         g.es(f"file not found: {fn}")
         return
@@ -115,9 +113,7 @@ def openCheatSheet(self: Self, event: Event = None) -> None:
 def openDesktopIntegration(self: Self, event: Event = None) -> None:
     """Open Desktop-integration.leo."""
     c = self
-    fileName = g.os_path_finalize_join(
-        g.app.loadDir, '..', 'scripts', 'desktop-integration.leo')
-    # only call g.openWithFileName if the file exists.
+    fileName = g.finalize_join(g.app.loadDir, '..', 'scripts', 'desktop-integration.leo')
     if g.os_path_exists(fileName):
         c2 = g.openWithFileName(fileName, old_c=c)
         if c2:
@@ -130,7 +126,7 @@ def openLeoDist(self: Self, event: Event = None) -> None:
     """Open leoDist.leo in a new Leo window."""
     c = self
     name = "leoDist.leo"
-    fileName = g.os_path_finalize_join(g.app.loadDir, "..", "dist", name)
+    fileName = g.finalize_join(g.app.loadDir, "..", "dist", name)
     if g.os_path_exists(fileName):
         c2 = g.openWithFileName(fileName, old_c=c)
         if c2:
@@ -144,7 +140,7 @@ def openLeoPy(self: Self, event: Event = None) -> None:
     c = self
     names = ('leoPy.leo', 'LeoPyRef.leo',)  # Used in error message.
     for name in names:
-        fileName = g.os_path_finalize_join(g.app.loadDir, "..", "core", name)
+        fileName = g.finalize_join(g.app.loadDir, "..", "core", name)
         # Only call g.openWithFileName if the file exists.
         if g.os_path_exists(fileName):
             c2 = g.openWithFileName(fileName, old_c=c)
@@ -157,8 +153,7 @@ def openLeoPy(self: Self, event: Event = None) -> None:
 def openLeoPyRef(self: Self, event: Event = None) -> None:
     """Open leoPyRef.leo in a new Leo window."""
     c = self
-    path = g.os_path_finalize_join(g.app.loadDir, "..", "core", "LeoPyRef.leo")
-    # Only call g.openWithFileName if the file exists.
+    path = g.finalize_join(g.app.loadDir, "..", "core", "LeoPyRef.leo")
     if g.os_path_exists(path):
         c2 = g.openWithFileName(path, old_c=c)
         if c2:
@@ -170,8 +165,7 @@ def openLeoPyRef(self: Self, event: Event = None) -> None:
 def openLeoScripts(self: Self, event: Event = None) -> None:
     """Open scripts.leo."""
     c = self
-    fileName = g.os_path_finalize_join(g.app.loadDir, '..', 'scripts', 'scripts.leo')
-    # Bug fix: 2012/04/09: only call g.openWithFileName if the file exists.
+    fileName = g.finalize_join(g.app.loadDir, '..', 'scripts', 'scripts.leo')
     if g.os_path_exists(fileName):
         c2 = g.openWithFileName(fileName, old_c=c)
         if c2:

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1322,7 +1322,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     return
                 if g.os_path_exists(self.output_directory):
                     base_fn = g.os_path_basename(fn)
-                    out_fn = g.os_path_finalize_join(self.output_directory, base_fn)
+                    out_fn = g.finalize_join(self.output_directory, base_fn)
                 else:
                     g.es_print('not found', self.output_directory)
                     return
@@ -1416,7 +1416,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     return
                 if g.os_path_exists(self.output_directory):
                     base_fn = g.os_path_basename(fn)
-                    out_fn = g.os_path_finalize_join(self.output_directory, base_fn)
+                    out_fn = g.finalize_join(self.output_directory, base_fn)
                 else:
                     g.es_print('not found', self.output_directory)
                     return

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1305,7 +1305,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             #@+node:ekr.20160213070235.6: *5* msf.finalize
             def finalize(self, fn: str) -> str:
                 """Finalize and regularize a filename."""
-                return g.os_path_normpath(g.os_path_abspath(g.os_path_expanduser(fn)))
+                return g.finalize(fn)
             #@+node:ekr.20160213070235.7: *5* msf.make_stub_file
             def make_stub_file(self, p: Position) -> None:
                 """Make a stub file in ~/stubs for the @<file> node at p."""
@@ -1400,7 +1400,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             #@+node:ekr.20160316094011.7: *5* py2cs.finalize
             def finalize(self, fn: str) -> str:
                 """Finalize and regularize a filename."""
-                return g.os_path_normpath(g.os_path_abspath(g.os_path_expanduser(fn)))
+                return g.finalize(fn)
             #@+node:ekr.20160316094011.8: *5* py2cs.to_coffeescript
             def to_coffeescript(self, p: Position) -> None:
                 """Convert the @<file> node at p to a .coffee file."""

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -70,7 +70,7 @@ class DebugCommandsClass(BaseEditCommandsClass):
         )
         for debugger in debuggers:
             if debugger:
-                debugger = g.os_path_finalize(debugger)
+                debugger = g.finalize(debugger)
                 if g.os_path_exists(debugger):
                     return debugger
                 # g.es_print('debugger does not exist:', debugger)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1296,13 +1296,13 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList = self.getIconList(p.v)
         if not aList:
             return
-        basePath = g.os_path_finalize_join(g.app.loadDir, "..", "Icons")  # #1341.
-        absRelPath = g.os_path_finalize_join(basePath, relPath)  # #1341
-        name = g.os_path_finalize(name)  # #1341
+        basePath = g.os_path_finalize_join(g.app.loadDir, "..", "Icons")
+        absRelPath = g.os_path_finalize_join(basePath, relPath)
+        name = g.finalize(name)
         newList = []
         for d in aList:
             name2 = d.get('file')
-            name2 = g.os_path_finalize(name2)  # #1341
+            name2 = g.finalize(name2)
             name2rel = d.get('relPath')
             if not (name == name2 or absRelPath == name2 or relPath == name2rel):
                 newList.append(d)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -422,7 +422,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                     w.setSelectionRange(
                         w.getInsertPoint() - len(start_text), w.getInsertPoint())
 
-        c.k.functionTail = g.os_path_finalize_join(self.path_for_p(c, c.p), start_text or '')
+        c.k.functionTail = g.finalize_join(self.path_for_p(c, c.p), start_text or '')
         c.k.getFileName(event, callback=callback)
     #@+node:ekr.20150514063305.279: *3* ec.insertHeadlineTime
     @cmd('insert-headline-time')
@@ -1296,8 +1296,8 @@ class EditCommandsClass(BaseEditCommandsClass):
         aList = self.getIconList(p.v)
         if not aList:
             return
-        basePath = g.os_path_finalize_join(g.app.loadDir, "..", "Icons")
-        absRelPath = g.os_path_finalize_join(basePath, relPath)
+        basePath = g.finalize_join(g.app.loadDir, "..", "Icons")
+        absRelPath = g.finalize_join(basePath, relPath)
         name = g.finalize(name)
         newList = []
         for d in aList:
@@ -1338,7 +1338,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def insertIcon(self, event: Event = None) -> None:
         """Prompt for an icon, and insert it into the node's icon list."""
         c, p = self.c, self.c.p
-        iconDir = g.os_path_finalize_join(g.app.loadDir, "..", "Icons")
+        iconDir = g.finalize_join(g.app.loadDir, "..", "Icons")
         os.chdir(iconDir)
         paths = g.app.gui.runOpenFileDialog(c,
             title='Get Icons',

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -733,7 +733,7 @@ class GitDiffController:
             self.file_node.h = f"Deleted: {self.file_node.h}"
             return
         # Finish.
-        path = g.os_path_finalize_join(directory, fn)  # #1781: bug fix.
+        path = g.finalize_join(directory, fn)  # #1781: bug fix.
         c1 = c2 = None
         if fn.endswith('.leo'):
             c1 = self.make_leo_outline(fn, path, s1, rev1)
@@ -982,9 +982,9 @@ class GitDiffController:
     def find_git_working_directory(self, directory: str) -> Optional[str]:
         """Return the git working directory, starting at directory."""
         while directory:
-            if g.os_path_exists(g.os_path_finalize_join(directory, '.git')):
+            if g.os_path_exists(g.finalize_join(directory, '.git')):
                 return directory
-            path2 = g.os_path_finalize_join(directory, '..')
+            path2 = g.finalize_join(directory, '..')
             if path2 == directory:
                 break
             directory = path2
@@ -1027,7 +1027,7 @@ class GitDiffController:
             print(f"git-diff: no .git directory: {directory!r} filename: {filename!r}")
             return None
         # This should guarantee that the directory contains a .git directory.
-        directory = g.os_path_finalize_join(base_directory, '..', '..')
+        directory = g.finalize_join(base_directory, '..', '..')
         return directory
     #@+node:ekr.20180506064102.11: *4* gdc.get_file_from_branch
     def get_file_from_branch(self, branch: str, fn: str) -> str:
@@ -1047,7 +1047,7 @@ class GitDiffController:
         directory = self.get_directory()
         if not directory:
             return ''
-        path = g.os_path_finalize_join(directory, fn)
+        path = g.finalize_join(directory, fn)
         if not g.os_path_exists(path):
             g.trace(f"File not found: {path!r} fn: {fn!r}")
             return ''

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -77,7 +77,7 @@ class BaseSpellWrapper:
     def find_user_dict(self) -> str:
         """Return the full path to the local dictionary."""
         c = self.c
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         table = (
             # Settings first.
             c.config.getString('enchant-local-dictionary'),
@@ -240,8 +240,7 @@ class DefaultWrapper(BaseSpellWrapper):
         if fn and g.os_path_exists(fn):
             return fn
         # Default to ~/.leo/main_spelling_dict.txt
-        fn = g.os_path_finalize_join(
-            g.app.homeDir, '.leo', 'main_spelling_dict.txt')
+        fn = g.finalize_join(g.app.homeDir, '.leo', 'main_spelling_dict.txt')
         return fn if g.os_path_exists(fn) else None
     #@+node:ekr.20180207073815.1: *3* default.read_words
     def read_words(self, kind: Any, fn: str) -> Set[str]:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1468,8 +1468,7 @@ class LeoApp:
             app.log_listener = None
         # Start a new listener.
         g.es_print('Starting log_listener.py')
-        path = g.os_path_finalize_join(app.loadDir,
-            '..', 'external', 'log_listener.py')
+        path = g.finalize_join(app.loadDir, '..', 'external', 'log_listener.py')
         app.log_listener = subprocess.Popen(
             [sys.executable, path],
             shell=False,
@@ -1569,7 +1568,7 @@ class LoadManager:
     def computeLeoSettingsPath(self) -> Optional[str]:
         """Return the full path to leoSettings.leo."""
         # lm = self
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         settings_fn = 'leoSettings.leo'
         table = (
             # First, leoSettings.leo in the home directories.
@@ -1592,7 +1591,7 @@ class LoadManager:
         The "footnote": Get the local directory from lm.files[0]
         """
         lm = self
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         settings_fn = 'myLeoSettings.leo'
         # This seems pointless: we need a machine *directory*.
         # For now, however, we'll keep the existing code as is.
@@ -1666,7 +1665,7 @@ class LoadManager:
     #@+node:ekr.20120209051836.10260: *5* LM.computeHomeLeoDir
     def computeHomeLeoDir(self) -> str:
         # lm = self
-        homeLeoDir = g.os_path_finalize_join(g.app.homeDir, '.leo')
+        homeLeoDir = g.finalize_join(g.app.homeDir, '.leo')
         if g.os_path_exists(homeLeoDir):
             return homeLeoDir
         ok = g.makeAllNonExistentDirectories(homeLeoDir)
@@ -1740,7 +1739,7 @@ class LoadManager:
         """
         Return a list of *existing* directories that might contain theme .leo files.
         """
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         home = g.app.homeDir
         leo = join(g.app.loadDir, '..')
         table = [
@@ -2339,7 +2338,7 @@ class LoadManager:
         if not fn:
             return None  # #1415
         # Open CheatSheet.leo.
-        fn2 = g.os_path_finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')
+        fn2 = g.finalize_join(g.app.loadDir, '..', 'doc', 'CheatSheet.leo')
         if not g.os_path_exists(fn2):
             return None
         c = self.loadLocalFile(fn2, gui=g.app.gui, old_c=None)
@@ -2407,9 +2406,9 @@ class LoadManager:
         # Allow plugins to be defined in ~/.leo/plugins.
         for pattern in (
             # ~/.leo/plugins.
-            g.os_path_finalize_join(g.app.homeDir, '.leo', 'plugins'),
+            g.finalize_join(g.app.homeDir, '.leo', 'plugins'),
             # leo/plugins/importers.
-            g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'importers', '*.py'),
+            g.finalize_join(g.app.loadDir, '..', 'plugins', 'importers', '*.py'),
         ):
             filenames = g.glob_glob(pattern)
             for filename in filenames:
@@ -2467,8 +2466,8 @@ class LoadManager:
 
         # Allow plugins to be defined in ~/.leo/plugins.
         for pattern in (
-            g.os_path_finalize_join(g.app.homeDir, '.leo', 'plugins'),  # ~/.leo/plugins.
-            g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'writers', '*.py'),  # leo/plugins/writers
+            g.finalize_join(g.app.homeDir, '.leo', 'plugins'),  # ~/.leo/plugins.
+            g.finalize_join(g.app.loadDir, '..', 'plugins', 'writers', '*.py'),  # leo/plugins/writers
         ):
             for filename in g.glob_glob(pattern):
                 sfn = g.shortFileName(filename)
@@ -2770,7 +2769,7 @@ class LoadManager:
         script = args.script
         if script:
             # #1090: use cwd, not g.app.loadDir, to find scripts.
-            fn = g.os_path_finalize_join(os.getcwd(), script)
+            fn = g.finalize_join(os.getcwd(), script)
             script, e = g.readFileIntoString(fn, kind='script:', verbose=False)
             if not script:
                 print(f"script not found: {fn}")
@@ -3546,7 +3545,7 @@ class RecentFilesManager:
             return g.finalize(name or '').lower()
 
         def munge2(name: str) -> str:
-            return g.os_path_finalize_join(g.app.loadDir, name or '')
+            return g.finalize_join(g.app.loadDir, name or '')
 
         # Update the recent files list in all windows.
 
@@ -3615,7 +3614,7 @@ class RecentFilesManager:
         else:
             # Attempt to create .leoRecentFiles.txt in the user's home directory.
             if g.app.homeLeoDir:
-                fileName = g.os_path_finalize_join(g.app.homeLeoDir, tag)
+                fileName = g.finalize_join(g.app.homeLeoDir, tag)
                 if not g.os_path_exists(fileName):
                     g.red(f"creating: {fileName}")
                 rf.writeRecentFilesFileHelper(fileName)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1562,7 +1562,7 @@ class LoadManager:
     #@+node:ekr.20120219154958.10481: *4* LM.completeFileName
     def completeFileName(self, fileName: str) -> str:
         fileName = g.toUnicode(fileName)
-        fileName = g.os_path_finalize(fileName)
+        fileName = g.finalize(fileName)
         # 2011/10/12: don't add .leo to *any* file.
         return fileName
     #@+node:ekr.20120209051836.10372: *4* LM.computeLeoSettingsPath
@@ -1659,7 +1659,7 @@ class LoadManager:
         if home:
             # Important: This returns the _working_ directory if home is None!
             # This was the source of the 4.3 .leoID.txt problems.
-            home = g.os_path_finalize(home)
+            home = g.finalize(home)
             if (not g.os_path_exists(home) or not g.os_path_isdir(home)):
                 home = None
         return home
@@ -1699,7 +1699,7 @@ class LoadManager:
                     if len(path) > 2 and path[1] == ':':
                         # Convert the drive name to upper case.
                         path = path[0].upper() + path[1:]
-                path = g.os_path_finalize(path)
+                path = g.finalize(path)
                 loadDir = g.os_path_dirname(path)
             else:
                 loadDir = None
@@ -1714,7 +1714,7 @@ class LoadManager:
                     loadDir += "/leo/plugins"
                 else:
                     g.pr("Exception getting load directory")
-            loadDir = g.os_path_finalize(loadDir)
+            loadDir = g.finalize(loadDir)
             return loadDir
         except Exception:
             print("Exception getting load directory")
@@ -1833,8 +1833,8 @@ class LoadManager:
         if g.unitTesting or g.app.batchMode:
             return None
         fn = g.app.config.getString(setting='default_leo_file') or '~/.leo/workbook.leo'
-        fn = g.os_path_finalize(fn)
-        directory = g.os_path_finalize(os.path.dirname(fn))
+        fn = g.finalize(fn)
+        directory = g.finalize(os.path.dirname(fn))
         # #1415.
         return fn if os.path.exists(directory) else None
     #@+node:ekr.20120219154958.10485: *4* LM.reportDirectories
@@ -2559,7 +2559,7 @@ class LoadManager:
     def getDefaultFile(self) -> Optional[str]:
         # Get the name of the workbook.
         fn = g.app.config.getString('default-leo-file')
-        fn = g.os_path_finalize(fn)
+        fn = g.finalize(fn)
         if not fn:
             return None
         if g.os_path_exists(fn):
@@ -2966,7 +2966,7 @@ class LoadManager:
         if not fn:
             return lm.openEmptyLeoFile(gui, old_c)
         # Return the commander if the file is an already open outline.
-        fn = g.os_path_finalize(fn)  # #2489.
+        fn = g.finalize(fn)
         c = lm.findOpenFile(fn)
         if c:
             return c
@@ -3248,7 +3248,7 @@ class LoadManager:
             theFile, fn, readAtFileNodesFlag=readAtFileNodesFlag)
         if v:
             if not c.openDirectory:
-                theDir = g.os_path_finalize(g.os_path_dirname(fn))  # 1341
+                theDir = g.finalize(g.os_path_dirname(fn))
                 c.openDirectory = c.frame.openDirectory = theDir
         else:
             # #970: Never close Leo here.
@@ -3461,7 +3461,7 @@ class RecentFilesManager:
         localConfigPath: str = g.os_path_dirname(localConfigFile)
         for path in (g.app.homeLeoDir, g.app.globalConfigDir, localConfigPath):
             if path:
-                path = g.os_path_realpath(g.os_path_finalize(path))
+                path = g.os_path_realpath(g.finalize(path))
             if path and path not in seen:
                 ok = rf.readRecentFilesFile(path)
                 if ok:
@@ -3543,7 +3543,7 @@ class RecentFilesManager:
             return
 
         def munge(name: str) -> str:
-            return g.os_path_finalize(name or '').lower()
+            return g.finalize(name or '').lower()
 
         def munge2(name: str) -> str:
             return g.os_path_finalize_join(g.app.loadDir, name or '')

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -282,7 +282,7 @@ class AtFile:
     def read(self, root: Position, fromString: str = None) -> bool:
         """Read an @thin or @file tree."""
         at, c = self, self.c
-        fileName = c.fullPath(root)  # #1341. #1889.
+        fileName = c.fullPath(root)
         if not fileName:  # pragma: no cover
             at.error("Missing file name. Restoring @file tree from .leo file.")
             return False
@@ -440,7 +440,7 @@ class AtFile:
     def readOneAtAutoNode(self, p: Position) -> Position:  # pragma: no cover
         """Read an @auto file into p. Return the *new* position."""
         at, c, ic = self, self.c, self.c.importCommands
-        fileName = c.fullPath(p)  # #1521, #1341, #1914.
+        fileName = c.fullPath(p)
         if not g.os_path_exists(fileName):
             g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL())
             return p
@@ -506,7 +506,6 @@ class AtFile:
     def readOneAtAsisNode(self, fn: str, p: Position) -> None:  # pragma: no cover
         """Read one @asis node. Used only by refresh-from-disk"""
         at, c = self, self.c
-        # #1521 & #1341.
         fn = c.fullPath(p)
         junk, ext = g.os_path_splitext(fn)
         # Remember the full fileName.
@@ -597,7 +596,7 @@ class AtFile:
                 f"can not happen: fn: {fn} != atShadowNodeName: "
                 f"{p.atShadowFileNodeName()}")
             return
-        fn = c.fullPath(p)  # #1521 & #1341.
+        fn = c.fullPath(p)
         # #889175: Remember the full fileName.
         at.rememberReadPath(fn, p)
         shadow_fn = x.shadowPathName(fn)
@@ -615,7 +614,7 @@ class AtFile:
     #@+node:ekr.20080712080505.1: *6* at.importAtShadowNode
     def importAtShadowNode(self, p: Position) -> bool:  # pragma: no cover
         c, ic = self.c, self.c.importCommands
-        fn = c.fullPath(p)  # #1521, #1341, #1914.
+        fn = c.fullPath(p)
         if not g.os_path_exists(fn):
             g.error(f"not found: {p.h!r}", nodeLink=p.get_UNL())
             return False

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -311,7 +311,7 @@ class BridgeController:
         g = self.g
         if not (fileName and fileName.strip()):
             return ''
-        fileName = g.os_path_finalize_join(os.getcwd(), fileName)
+        fileName = g.finalize_join(os.getcwd(), fileName)
         head, ext = g.os_path_splitext(fileName)
         if not ext:
             fileName = fileName + ".leo"

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2266,11 +2266,8 @@ class Commands:
         for p in p.self_and_parents(copy=False):
             aList = g.get_directives_dict_list(p)
             path = c.scanAtPathDirectives(aList)
-            path = c.expand_path_expression(path)
             fn = p.h if simulate else p.anyAtFileNodeName()  # Use p.h for unit tests.
             if fn:
-                ### fn = c.expand_path_expression(fn)
-                ### fn = os.path.expanduser(fn)  # 1900.
                 return g.finalize_join(path, fn)
         return ''
     #@+node:ekr.20171123135625.39: *4* c.getTime
@@ -2527,10 +2524,9 @@ class Commands:
         c = self
         c.scanAtPathDirectivesCount += 1  # An important statistic.
         base = c.openDirectory
-        ### base = c.expand_path_expression(base)
-        ### base = g.os_path_expanduser(base)  # #1889.
         absbase = g.finalize_join(g.app.loadDir, base)
-        # Step 2: look for @path directives.
+
+        # Look for @path directives.
         paths = []
         for d in aList:
             # Look for @path directives.
@@ -2539,15 +2535,14 @@ class Commands:
             if path is not None:  # retain empty paths for warnings.
                 # Convert "path" or <path> to path.
                 path = g.stripPathCruft(path)
-                # Silently ignore empty @path directives.
-                if path and not warning:
-                    path = c.expand_path_expression(path)  # #1341.
-                    ### path = g.os_path_expanduser(path)  # #1889.
+                if path and not warning:  # Silently ignore empty @path directives.
                     paths.append(path)
+
         # Add absbase and reverse the list.
         paths.append(absbase)
         paths.reverse()
-        # Step 3: Compute the full, effective, absolute path.
+
+        # Compute the full, effective, absolute path.
         path = g.finalize_join(*paths)
         return path
     #@+node:ekr.20171123201514.1: *3* c.Executing commands & scripts

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1002,7 +1002,7 @@ class Commands:
         #@+node:tom.20230308193758.17: *4* checkShebang
         def checkShebang(path: str) -> bool:
             """Return True if file begins with a shebang line, else False."""
-            path = g.os_path_expanduser(path)
+            path = g.finalize(path)
             with open(path, encoding='utf-8') as f:
                 first_line = f.readline()
             return first_line.startswith('#!')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1114,7 +1114,7 @@ class Commands:
             'else:\n'
             '    g.es(f"failed:{failed} tests")\n')
 
-        fname = g.os_path_finalize_join(g.app.homeLeoDir, 'leoPytestScript.py')
+        fname = g.finalize_join(g.app.homeLeoDir, 'leoPytestScript.py')
         with open(fname, 'wt', encoding='utf8') as out:
             out.write(script)
         tree = ast.parse(script, filename=fname)
@@ -2266,12 +2266,12 @@ class Commands:
         for p in p.self_and_parents(copy=False):
             aList = g.get_directives_dict_list(p)
             path = c.scanAtPathDirectives(aList)
+            path = c.expand_path_expression(path)
             fn = p.h if simulate else p.anyAtFileNodeName()  # Use p.h for unit tests.
             if fn:
-                # Fix #102: expand path expressions.
-                fn = c.expand_path_expression(fn)  # #1341.
-                fn = os.path.expanduser(fn)  # 1900.
-                return g.os_path_finalize_join(path, fn)
+                ### fn = c.expand_path_expression(fn)
+                ### fn = os.path.expanduser(fn)  # 1900.
+                return g.finalize_join(path, fn)
         return ''
     #@+node:ekr.20171123135625.39: *4* c.getTime
     def getTime(self, body: bool = True) -> str:
@@ -2527,9 +2527,9 @@ class Commands:
         c = self
         c.scanAtPathDirectivesCount += 1  # An important statistic.
         base = c.openDirectory
-        base = c.expand_path_expression(base)  # #1341.
-        base = g.os_path_expanduser(base)  # #1889.
-        absbase = g.os_path_finalize_join(g.app.loadDir, base)  # #1341.
+        ### base = c.expand_path_expression(base)
+        ### base = g.os_path_expanduser(base)  # #1889.
+        absbase = g.finalize_join(g.app.loadDir, base)
         # Step 2: look for @path directives.
         paths = []
         for d in aList:
@@ -2542,13 +2542,13 @@ class Commands:
                 # Silently ignore empty @path directives.
                 if path and not warning:
                     path = c.expand_path_expression(path)  # #1341.
-                    path = g.os_path_expanduser(path)  # #1889.
+                    ### path = g.os_path_expanduser(path)  # #1889.
                     paths.append(path)
         # Add absbase and reverse the list.
         paths.append(absbase)
         paths.reverse()
         # Step 3: Compute the full, effective, absolute path.
-        path = g.os_path_finalize_join(*paths)
+        path = g.finalize_join(*paths)
         return path
     #@+node:ekr.20171123201514.1: *3* c.Executing commands & scripts
     #@+node:ekr.20110605040658.17005: *4* c.check_event
@@ -2973,10 +2973,10 @@ class Commands:
                 # make the first element absolute
                 parts[0] = driveSpec + os.sep + parts[0]
             allParts = [path] + parts
-            path = g.os_path_finalize_join(*allParts)  # #1431
+            path = g.finalize_join(*allParts)
         else:
-            path = g.os_path_finalize_join(g.app.homeLeoDir, 'scriptFile.py')  # #1431
-        #
+            path = g.finalize_join(g.app.homeLeoDir, 'scriptFile.py')
+
         # Write the file.
         try:
             with open(path, encoding='utf-8', mode='w') as f:
@@ -3054,7 +3054,7 @@ class Commands:
             stamp = time.strftime("%Y%m%d-%H%M%S")
             branch = prefix + '-' if prefix else ''
             fn = f"{branch}{base}-{stamp}.leo"
-            path = g.os_path_finalize_join(theDir, fn)
+            path = g.finalize_join(theDir, fn)
         else:
             path = fn
         if path:
@@ -3078,7 +3078,7 @@ class Commands:
         """
         c = self
         old_cwd = os.getcwd()
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         if not base_dir:
             if env_key:
                 try:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1064,7 +1064,6 @@ class Commands:
                     g.es('Trying an alternative')
 
             path = c.fullPath(root)
-            ### path = g.finalize(path)  ### redundant.
             language = getExeKind(root, ext)
             processor = getProcessor(language, path, ext)
             runfile(path, processor, terminal)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -471,7 +471,7 @@ class Commands:
     def hash(self) -> str:  # Leo 6.6.2: Always return a string.
         c = self
         if c.mFileName:
-            return g.os_path_finalize(c.mFileName).lower()  # #1341.
+            return g.finalize(c.mFileName).lower()
         return f"{id(self)!s}"
     #@+node:ekr.20110509064011.14563: *4* c.idle_focus_helper & helpers
     idle_focus_count = 0
@@ -1064,7 +1064,7 @@ class Commands:
                     g.es('Trying an alternative')
 
             path = c.fullPath(root)
-            path = g.os_path_finalize(path)
+            ### path = g.finalize(path)  ### redundant.
             language = getExeKind(root, ext)
             processor = getProcessor(language, path, ext)
             runfile(path, processor, terminal)

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -874,7 +874,7 @@ class ParserBaseClass:
         if gs:
             assert isinstance(gs, g.GeneralSetting), gs
             path = gs.path
-            if g.os_path_finalize(c.mFileName) != g.os_path_finalize(path):
+            if g.finalize(c.mFileName) != g.finalize(path):
                 g.es("over-riding setting:", name, "from", path)  # 1341
         # Important: we can't use c here: it may be destroyed!
         d[key] = g.GeneralSetting(kind,
@@ -2028,7 +2028,7 @@ class LocalConfigManager:
         if gs:
             assert isinstance(gs, g.GeneralSetting), repr(gs)
             path = gs.path
-            if warn and g.os_path_finalize(c.mFileName) != g.os_path_finalize(path):  # #1341.
+            if warn and g.finalize(c.mFileName) != g.finalize(path):
                 g.trace("over-riding setting:", name, "from", path)
         d[key] = g.GeneralSetting(
             kind,

--- a/leo/core/leoDebugger.py
+++ b/leo/core/leoDebugger.py
@@ -414,7 +414,7 @@ def make_at_file_node(line, path):
     c = g.app.log.c
     if not c:
         return None
-    path = g.finalize(path)  ### .replace('\\', '/')
+    path = g.finalize(path)
     if not g.os_path_exists(path):
         g.trace('Not found:', repr(path))
         return None
@@ -439,7 +439,7 @@ def show_line(line, fn) -> None:
     fn should be a full path to a file.
     """
     c = g.app.log.c
-    target = g.finalize(fn)  ### .replace('\\', '/')
+    target = g.finalize(fn)
     if not g.os_path_exists(fn):
         g.trace('===== Does not exist', fn)
         return

--- a/leo/core/leoDebugger.py
+++ b/leo/core/leoDebugger.py
@@ -414,7 +414,7 @@ def make_at_file_node(line, path):
     c = g.app.log.c
     if not c:
         return None
-    path = g.os_path_finalize(path).replace('\\', '/')
+    path = g.finalize(path)  ### .replace('\\', '/')
     if not g.os_path_exists(path):
         g.trace('Not found:', repr(path))
         return None
@@ -439,7 +439,7 @@ def show_line(line, fn) -> None:
     fn should be a full path to a file.
     """
     c = g.app.log.c
-    target = g.os_path_finalize(fn).replace('\\', '/')
+    target = g.finalize(fn)  ### .replace('\\', '/')
     if not g.os_path_exists(fn):
         g.trace('===== Does not exist', fn)
         return

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1553,7 +1553,7 @@ class FileCommands:
         ok = g.doHook("save1", c=c, p=p, fileName=fileName)
         if ok is None:
             fileName, content = getPublicLeoFile()
-            fileName = g.os_path_finalize_join(c.openDirectory, fileName)
+            fileName = g.finalize_join(c.openDirectory, fileName)
             with open(fileName, 'w', encoding="utf-8", newline='\n') as out:
                 out.write(content)
             g.es('updated reference file:',

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6366,26 +6366,17 @@ def finalize_join(*args: Any) -> str:
     uargs = [z for z in args if z]
     if not uargs:
         return ''
-    if 0:  # Legacy
-        # 'c:/Repos/leo-editor/leo/core/d.py' != '/leo_base/d.py'
-        if 0:  # Exact legacy.
-            path = os.path.join(*uargs)
-        else:  # Legacy with expansion.
-            path = os.path.join(*uargs)
-            path = os.path.expanduser(path)
-            path = os.path.expandvars(path)  ### Added
-            ### path = os.path.abspath(path)
-            ### path = os.path.normpath(path)
-      
-    else:
-        #  'c:/Repos/leo-editor/leo/core/d.py' != '/leo_base/d.py'
-        # Expand everything before joining.
-        uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
-        path = os.path.join(*uargs2)
-        path = os.path.abspath(path)
-        ### path = os.path.normpath(path)
-        os.path.normpath(os.path.join(g.app.loadDir, path))
+    # Expand everything before joining.
+    uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
 
+    # Relative paths are relative to g.app.loadDir.
+    uargs2.insert(0, g.app.loadDir)
+
+    # Joint the paths and convert them to an absolute path.
+    path = os.path.join(*uargs2)
+    path = os.path.abspath(path)
+
+    # Normalize slashes.
     path = g.os_path_normslashes(path)
     return path
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6345,7 +6345,7 @@ def windows() -> Optional[List]:
 def finalize(path: str) -> str:
     """
     Finalize the path. Do not call os.path.realpath.
-        
+
     - Call os.path.expanduser and  os.path.expandvars.
     - Convert to an absolute path, relative to os.getwd().
     - On Windows, convert backslashes to forward slashes.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6353,6 +6353,8 @@ def finalize(path: str) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
+
+### os_path_finalize = finalize  ### Experimental.
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -6368,6 +6370,8 @@ def finalize_join(*args: Any) -> str:
     path = g.os_path_normslashes(path)
     # calling os.path.realpath here would cause problems in some situations.
     return path
+
+### os_path_finalize_join = finalize_join  ### Experimental.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6354,9 +6354,9 @@ def finalize(path: str) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
-    
+
 os_path_finalize = finalize  # compatibility.
-    
+
 
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6354,7 +6354,7 @@ def finalize(path: str) -> str:
     path = g.os_path_normslashes(path)
     return path
 
-### os_path_finalize = finalize  ### Experimental.
+os_path_finalize = finalize  ### Experimental.
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -6371,7 +6371,7 @@ def finalize_join(*args: Any) -> str:
     # calling os.path.realpath here would cause problems in some situations.
     return path
 
-### os_path_finalize_join = finalize_join  ### Experimental.
+os_path_finalize_join = finalize_join  ### Experimental.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
@@ -6420,7 +6420,7 @@ def os_path_expanduser(path: str) -> str:
     path = g.os_path_normslashes(path)
     return path
 #@+node:ekr.20080921060401.14: *3* g.os_path_finalize
-def os_path_finalize(path: str) -> str:
+def xxx_os_path_finalize(path: str) -> str:
     """
     Expand '~', then return os.path.normpath, os.path.abspath of the path.
     There is no corresponding os.path method
@@ -6431,8 +6431,8 @@ def os_path_finalize(path: str) -> str:
     path = g.os_path_normslashes(path)
     # calling os.path.realpath here would cause problems in some situations.
     return path
-#@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join
-def os_path_finalize_join(*args: Any, **keys: Any) -> str:
+#@+node:ekr.20140917154740.19483: *3* g.xxx_os_path_finalize_join
+def xxx_os_path_finalize_join(*args: Any, **keys: Any) -> str:
     """Join and finalize."""
     path = g.os_path_join(*args, **keys)
     path = g.os_path_finalize(path)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6353,8 +6353,6 @@ def finalize(path: str) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
-
-### os_path_finalize = finalize  ### Experimental.
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -7095,7 +7093,6 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
     if i > -1:
         # Expand '~'.
         path = url[i:]
-        ### path = g.os_path_expanduser(path)  ## Redundant.
         path = g.finalize(path)
         url = url[:i] + path
     else:
@@ -7107,8 +7104,6 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
             path = url[len(tag) :].lstrip()
         else:
             path = url
-        # #1338: This is way too dangerous, and a serious security violation.
-            # path = c.expand_path_expression(path)
         # Handle ancestor @path directives.
         if c and c.openDirectory:
             base = c.getNodePath(p)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6373,6 +6373,10 @@ def finalize_join(*args: Any) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
+
+os_path_finalize_join = finalize_join
+
+
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
@@ -6419,17 +6423,6 @@ def os_path_expanduser(path: str) -> str:
     path = os.path.expanduser(path)
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
-    return path
-#@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join (deprecated)
-def os_path_finalize_join(*args: Any, **keys: Any) -> str:
-    """
-    Join and finalize.
-
-    This function is deprecated. Use g.finalize_join instead.
-    """
-    # This logic is fragile (wrong). Leo never uses the 'keys' kwarg.
-    path = g.os_path_join(*args, **keys)
-    path = g.os_path_finalize(path)
     return path
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
 def os_path_getmtime(path: str) -> float:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6341,6 +6341,33 @@ def windows() -> Optional[List]:
 #@+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers
 #@+at Note: all these methods return Unicode strings. It is up to the user to
 # convert to an encoded string as needed, say when opening a file.
+#@+node:ekr.20230410134119.1: *3* g.finalize
+def finalize(path: str) -> str:
+    """
+    Finalize the path. Do not call os.path.realpath.
+    """
+    if not path:
+        return ''
+    path = os.path.expanduser(path)
+    path = os.path.abspath(path)
+    path = os.path.normpath(path)
+    path = g.os_path_normslashes(path)
+    return path
+#@+node:ekr.20230410133838.1: *3* g.finalize_join
+def finalize_join(*args: Any) -> str:
+    """
+    Join and finalize. Do not call os.path.realpath.
+    """
+    uargs = [z for z in args if z]
+    if not uargs:
+        return ''
+    path = os.path.join(*uargs)
+    path = os.path.expanduser(path)
+    path = os.path.abspath(path)
+    path = os.path.normpath(path)
+    path = g.os_path_normslashes(path)
+    # calling os.path.realpath here would cause problems in some situations.
+    return path
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6368,14 +6368,9 @@ def finalize_join(*args: Any) -> str:
         return ''
     # Expand everything before joining.
     uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
-
-    # Relative paths are relative to g.app.loadDir.
-    uargs2.insert(0, g.app.loadDir)
-
-    # Joint the paths and convert them to an absolute path.
+    # Join the paths and convert them to an absolute path.
     path = os.path.join(*uargs2)
     path = os.path.abspath(path)
-
     # Normalize slashes.
     path = g.os_path_normslashes(path)
     return path

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6350,8 +6350,12 @@ def finalize(path: str) -> str:
         return ''
     path = os.path.expanduser(path)
     path = os.path.expandvars(path)
+
+    # Convert to an abosolute path, similar to os.path.normpath(os.getcwd(), path)
     path = os.path.abspath(path)
     path = os.path.normpath(path)
+
+    # Convert backslashes to forward slashes, regradless of platform.
     path = g.os_path_normslashes(path)
     return path
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
@@ -6364,10 +6368,15 @@ def finalize_join(*args: Any) -> str:
         return ''
     # Expand everything before joining.
     uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
-    # Join the paths and convert them to an absolute path.
+
+    # Join the paths.
     path = os.path.join(*uargs2)
+
+    # Convert to an abosolute path, similar to os.path.normpath(os.getcwd(), path)
     path = os.path.abspath(path)
-    # Normalize slashes.
+    path = os.path.normpath(path)
+
+    # Convert backslashes to forward slashes, regradless of platform.
     path = g.os_path_normslashes(path)
     return path
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
@@ -6479,13 +6488,13 @@ def os_path_normpath(path: str) -> str:
 #@+node:ekr.20180314081254.1: *3* g.os_path_normslashes
 def os_path_normslashes(path: str) -> str:
     """
-    Convert backslashes to slashes (Windows only).
+    Convert backslashes forward slashes (Windows only).
 
-    os.path.normpath does the *reverse* of what we want.
+    In effect, this convert Windows paths to POSIX paths.
     """
-    if g.isWindows and path:
-        path = path.replace('\\', '/')
-    return path
+    if not path:
+        return ''
+    return path.replace('\\', '/') if g.isWindows else path
 #@+node:ekr.20080605064555.2: *3* g.os_path_realpath
 def os_path_realpath(path: str) -> str:
     """Return the canonical path of the specified filename, eliminating any

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5944,7 +5944,7 @@ def internalError(*args: Any) -> None:
 def log_to_file(s: str, fn: str = None) -> None:
     """Write a message to ~/test/leo_log.txt."""
     if fn is None:
-        fn = g.os_path_expanduser('~/test/leo_log.txt')
+        fn = g.finalize('~/test/leo_log.txt')
     if not s.endswith('\n'):
         s = s + '\n'
     try:
@@ -6358,6 +6358,9 @@ def finalize(path: str) -> str:
     # Convert backslashes to forward slashes, regradless of platform.
     path = g.os_path_normslashes(path)
     return path
+
+# g.finalize will *always* be better than the legacy g.os_path_expanduser.
+os_path_expanduser = finalize  # Compatibility.
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -6379,6 +6382,9 @@ def finalize_join(*args: Any) -> str:
     # Convert backslashes to forward slashes, regradless of platform.
     path = g.os_path_normslashes(path)
     return path
+
+# g.finalize_join will *always* be better than the legacy g.os_path_join.
+os_path_join = finalize_join  # Compatibility.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
@@ -6415,23 +6421,6 @@ def os_path_dirname(path: str) -> str:
 def os_path_exists(path: str) -> bool:
     """Return True if path exists."""
     return os.path.exists(path) if path else False
-#@+node:ekr.20080921060401.13: *3* g.os_path_expanduser
-def os_path_expanduser(path: str) -> str:
-    """
-    wrap os.path.expanduser.
-    """
-    if not path:
-        return ''
-    path = os.path.expanduser(path)
-    path = os.path.normpath(path)
-    path = g.os_path_normslashes(path)
-    return path
-#@+node:ekr.20230412072239.1: *3* g.os_path_finalize_join (unchanged)
-def os_path_finalize_join(*args: Any, **keys: Any) -> str:
-    """Join and finalize."""
-    path = g.os_path_join(*args, **keys)
-    path = g.os_path_finalize(path)
-    return path
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
 def os_path_getmtime(path: str) -> float:
     """Return the modification time of path."""
@@ -6457,17 +6446,6 @@ def os_path_isdir(path: str) -> bool:
 def os_path_isfile(path: str) -> bool:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
-#@+node:ekr.20031218072017.2154: *3* g.os_path_join (unchanged)
-def os_path_join(*args: Any, **keys: Any) -> str:
-    """
-    Wrap os.path.join.
-    """
-    uargs = [z for z in args if z]
-    if not uargs:
-        return ''
-    path = os.path.join(*uargs)
-    path = g.os_path_normslashes(path)
-    return path
 #@+node:ekr.20031218072017.2156: *3* g.os_path_normcase
 def os_path_normcase(path: str) -> str:
     """Normalize the path's case."""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6366,17 +6366,30 @@ def finalize_join(*args: Any) -> str:
     uargs = [z for z in args if z]
     if not uargs:
         return ''
-    # Expand everything before joining.
-    uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
-    path = os.path.join(*uargs2)
-    path = os.path.abspath(path)
-    path = os.path.normpath(path)
+    if 0:  # Legacy
+        # 'c:/Repos/leo-editor/leo/core/d.py' != '/leo_base/d.py'
+        if 0:  # Exact legacy.
+            path = os.path.join(*uargs)
+        else:  # Legacy with expansion.
+            path = os.path.join(*uargs)
+            path = os.path.expanduser(path)
+            path = os.path.expandvars(path)  ### Added
+            ### path = os.path.abspath(path)
+            ### path = os.path.normpath(path)
+      
+    else:
+        #  'c:/Repos/leo-editor/leo/core/d.py' != '/leo_base/d.py'
+        # Expand everything before joining.
+        uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
+        path = os.path.join(*uargs2)
+        path = os.path.abspath(path)
+        ### path = os.path.normpath(path)
+        os.path.normpath(os.path.join(g.app.loadDir, path))
+
     path = g.os_path_normslashes(path)
     return path
 
 os_path_finalize_join = finalize_join
-
-
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
@@ -6449,7 +6462,7 @@ def os_path_isdir(path: str) -> bool:
 def os_path_isfile(path: str) -> bool:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
-#@+node:ekr.20031218072017.2154: *3* g.os_path_join
+#@+node:ekr.20031218072017.2154: *3* g.os_path_join (unchanged)
 def os_path_join(*args: Any, **keys: Any) -> str:
     """
     Wrap os.path.join.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6368,7 +6368,6 @@ def finalize_join(*args: Any) -> str:
     path = os.path.abspath(path)
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
-    # calling os.path.realpath here would cause problems in some situations.
     return path
 
 os_path_finalize_join = finalize_join  ### Experimental.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6354,10 +6354,6 @@ def finalize(path: str) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
-
-os_path_finalize = finalize  # compatibility.
-
-
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -6374,8 +6370,6 @@ def finalize_join(*args: Any) -> str:
     # Normalize slashes.
     path = g.os_path_normslashes(path)
     return path
-
-os_path_finalize_join = finalize_join
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
@@ -6422,6 +6416,12 @@ def os_path_expanduser(path: str) -> str:
     path = os.path.expanduser(path)
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
+    return path
+#@+node:ekr.20230412072239.1: *3* g.os_path_finalize_join (unchanged)
+def os_path_finalize_join(*args: Any, **keys: Any) -> str:
+    """Join and finalize."""
+    path = g.os_path_join(*args, **keys)
+    path = g.os_path_finalize(path)
     return path
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
 def os_path_getmtime(path: str) -> float:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6345,6 +6345,10 @@ def windows() -> Optional[List]:
 def finalize(path: str) -> str:
     """
     Finalize the path. Do not call os.path.realpath.
+        
+    - Call os.path.expanduser and  os.path.expandvars.
+    - Convert to an absolute path, relative to os.getwd().
+    - On Windows, convert backslashes to forward slashes.
     """
     if not path:
         return ''
@@ -6365,6 +6369,12 @@ os_path_expanduser = finalize  # Compatibility.
 def finalize_join(*args: Any) -> str:
     """
     Join and finalize. Do not call os.path.realpath.
+
+    - Return an empty string if all of the args are empty.
+    - Call os.path.expanduser and  os.path.expandvars for each arg.
+    - Call os.path.join on the resulting list of expanded arguments.
+    - Convert to an absolute path, relative to os.getwd().
+    - On Windows, convert backslashes to forward slashes.
     """
     uargs = [z for z in args if z]
     if not uargs:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6354,7 +6354,7 @@ def finalize(path: str) -> str:
     path = g.os_path_normslashes(path)
     return path
 
-os_path_finalize = finalize  ### Experimental.
+### os_path_finalize = finalize  ### Experimental.
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -7095,10 +7095,8 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
     if i > -1:
         # Expand '~'.
         path = url[i:]
-        path = g.os_path_expanduser(path)
-        # #1338: This is way too dangerous, and a serious security violation.
-            # path = c.expand_path_expression(path)
-        path = g.os_path_finalize(path)
+        ### path = g.os_path_expanduser(path)  ## Redundant.
+        path = g.finalize(path)
         url = url[:i] + path
     else:
         tag = 'file://'
@@ -7116,7 +7114,7 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
             base = c.getNodePath(p)
             path = g.os_path_finalize_join(c.openDirectory, base, path)
         else:
-            path = g.os_path_finalize(path)
+            path = g.finalize(path)
         url = f"{tag}{path}"
     return url
 #@+node:ekr.20190608090856.1: *3* g.es_clickable_link

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6476,7 +6476,7 @@ def os_path_normpath(path: str) -> str:
 #@+node:ekr.20180314081254.1: *3* g.os_path_normslashes
 def os_path_normslashes(path: str) -> str:
     """
-    Convert backslashes forward slashes (Windows only).
+    Convert backslashes to forward slashes (Windows only).
 
     In effect, this convert Windows paths to POSIX paths.
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6354,6 +6354,10 @@ def finalize(path: str) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
+    
+os_path_finalize = finalize  # compatibility.
+    
+
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
 def finalize_join(*args: Any) -> str:
     """
@@ -6369,8 +6373,6 @@ def finalize_join(*args: Any) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
-
-os_path_finalize_join = finalize_join  ### Experimental.
 #@+node:ekr.20180314120442.1: *3* g.glob_glob
 def glob_glob(pattern: str) -> List:
     """Return the regularized glob.glob(pattern)"""
@@ -6418,25 +6420,14 @@ def os_path_expanduser(path: str) -> str:
     path = os.path.normpath(path)
     path = g.os_path_normslashes(path)
     return path
-#@+node:ekr.20080921060401.14: *3* g.os_path_finalize
-def os_path_finalize(path: str) -> str:
-    """
-    Expand '~', then return os.path.normpath, os.path.abspath of the path.
-    There is no corresponding os.path method
-    """
-    path = os.path.expanduser(path)
-    path = os.path.abspath(path)
-    path = os.path.normpath(path)
-    path = g.os_path_normslashes(path)
-    # calling os.path.realpath here would cause problems in some situations.
-    return path
-#@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join
+#@+node:ekr.20140917154740.19483: *3* g.os_path_finalize_join (deprecated)
 def os_path_finalize_join(*args: Any, **keys: Any) -> str:
     """
     Join and finalize.
-    
+
     This function is deprecated. Use g.finalize_join instead.
     """
+    # This logic is fragile (wrong). Leo never uses the 'keys' kwarg.
     path = g.os_path_join(*args, **keys)
     path = g.os_path_finalize(path)
     return path

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -549,10 +549,10 @@ class LeoImportCommands:
             if not ext:
                 ext = ".txt"
             if ext[0] == '.':
-                newFileName = g.os_path_finalize_join(path, fileName + ext)  # 1341
+                newFileName = g.finalize_join(path, fileName + ext)  # 1341
             else:
                 head, ext2 = g.os_path_splitext(fileName)
-                newFileName = g.os_path_finalize_join(path, head + ext + ext2)  # 1341
+                newFileName = g.finalize_join(path, head + ext + ext2)  # 1341
             if toString:
                 return s
             #@+<< Write s into newFileName >>

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1201,7 +1201,7 @@ class FileNameChooser:
             self.prompt = prompt
             self.tabName = tabName
             join = g.os_path_finalize_join
-            finalize = g.os_path_finalize
+            finalize = g.finalize
             normslashes = g.os_path_normslashes
             # #467: Add setting for preferred directory.
             directory = c.config.getString('initial-chooser-directory')
@@ -1260,7 +1260,7 @@ class FileNameChooser:
     def show_tab_list(self, tabList: List[str]) -> None:
         """Show the tab list in the log tab."""
         self.log.clearTab(self.tabName)
-        s = g.os_path_finalize(os.curdir) + os.sep
+        s = g.finalize(os.curdir) + os.sep
         es = []
         for path in tabList:
             theDir, fileName = g.os_path_split(path)

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1200,7 +1200,7 @@ class FileNameChooser:
             self.filterExt = filterExt or ['.pyc', '.bin',]
             self.prompt = prompt
             self.tabName = tabName
-            join = g.os_path_finalize_join
+            join = g.finalize_join
             finalize = g.finalize
             normslashes = g.os_path_normslashes
             # #467: Add setting for preferred directory.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1096,7 +1096,7 @@ class FileNameChooser:
         """Compute the list of completions."""
         path = self.get_label()
         # #215: insert-file-name doesn't process ~
-        path = g.os_path_expanduser(path)
+        path = g.finalize(path)
         sep = os.path.sep
         if g.os_path_exists(path):
             if g.os_path_isdir(path):

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -259,7 +259,7 @@ class MarkupCommands:
                 # #1398.
                 i_path = c.expand_path_expression(i_path)
                 n_path = c.getNodePath(c.p)  # node path
-                i_path = g.os_path_finalize_join(n_path, i_path)
+                i_path = g.finalize_join(n_path, i_path)
                 with open(i_path, 'w', encoding='utf-8', errors='replace') as self.output_file:
                     self.write_root(p)
                     i_paths.append(i_path)
@@ -329,7 +329,7 @@ class MarkupCommands:
                 break
         # #1373.
         base_dir = os.path.dirname(c.fileName())
-        return g.os_path_finalize_join(base_dir, i_path + '.html')
+        return g.finalize_join(base_dir, i_path + '.html')
     #@+node:ekr.20191007043110.1: *4* markup.run_asciidoctor
     def run_asciidoctor(self, i_path: str, o_path: str) -> None:
         """

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -358,8 +358,7 @@ class MarkupCommands:
         """Process i_path and o_path with sphinx."""
         trace = True
         # cd to the command directory, or i_path's directory.
-        command_dir = g.os_path_finalize(
-            self.sphinx_command_dir or os.path.dirname(i_path))
+        command_dir = g.finalize(self.sphinx_command_dir or os.path.dirname(i_path))
         if os.path.exists(command_dir):
             if trace:
                 g.trace(f"\nos.chdir: {command_dir!r}")
@@ -376,14 +375,13 @@ class MarkupCommands:
             g.execute_shell_commands(self.sphinx_default_command)
             return
         # Compute the input directory.
-        input_dir = g.os_path_finalize(
+        input_dir = g.finalize(
             self.sphinx_input_dir or os.path.dirname(i_path))
         if not os.path.exists(input_dir):
             g.error(f"input directory not found: {input_dir!r}")
             return
         # Compute the output directory.
-        output_dir = g.os_path_finalize(
-            self.sphinx_output_dir or os.path.dirname(o_path))
+        output_dir = g.finalize(self.sphinx_output_dir or os.path.dirname(o_path))
         if not os.path.exists(output_dir):
             g.error(f"output directory not found: {output_dir!r}")
             return

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -412,7 +412,7 @@ class RstCommands:
         """
         c = self.c
         theDir, junk = g.os_path_split(fn)
-        theDir = g.os_path_finalize(theDir)  # 1341
+        theDir = g.finalize(theDir)
         if g.os_path_exists(theDir):
             return True
         if c and c.config and c.config.getBool('create-nonexistent-directories', default=False):
@@ -742,8 +742,7 @@ class RstCommands:
         """Issue a report to the log pane."""
         if self.silent:
             return
-        name = g.os_path_finalize(name)  # 1341
-        g.pr(f"wrote: {name}")
+        g.pr(f"wrote: {g.finalize(name)}")
     #@+node:ekr.20090502071837.92: *4* rst.rstComment
     def rstComment(self, s: str) -> str:
         return f".. {s}"

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -393,13 +393,13 @@ class RstCommands:
         c = self.c
         openDirectory = c.frame.openDirectory
         if self.default_path:
-            path = g.os_path_finalize_join(self.path, self.default_path, fn)
+            path = g.finalize_join(self.path, self.default_path, fn)
         elif self.path:
-            path = g.os_path_finalize_join(self.path, fn)
+            path = g.finalize_join(self.path, fn)
         elif openDirectory:
-            path = g.os_path_finalize_join(self.path, openDirectory, fn)
+            path = g.finalize_join(self.path, openDirectory, fn)
         else:
-            path = g.os_path_finalize_join(fn)
+            path = g.finalize_join(fn)
         return path
     #@+node:ekr.20100813041139.5914: *5* rst.createDirectoryForFile
     def createDirectoryForFile(self, fn: str) -> bool:
@@ -449,7 +449,7 @@ class RstCommands:
         if not docutils:
             g.error('writeToDocutils: docutils not present')
             return None
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         openDirectory = self.c.frame.openDirectory
         overrides = {'output_encoding': self.encoding}
         #

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -57,7 +57,7 @@ class SessionManager:
         """Return the path to the session file."""
         for path in (g.app.homeLeoDir, g.app.homeDir):
             if g.os_path_exists(path):
-                return g.os_path_finalize_join(path, 'leo.session')
+                return g.finalize_join(path, 'leo.session')
         return None
     #@+node:ekr.20120420054855.14247: *3* SessionManager.load_session
     def load_session(self, c: Cmdr = None, unls: List[str] = None) -> None:

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -77,7 +77,7 @@ class ShadowController:
         c = self.c
         filename = c.fileName()
         if filename:
-            return g.os_path_dirname(g.os_path_finalize(filename))  # 1341
+            return g.os_path_dirname(g.finalize(filename))
         print('')
         self.error('Can not compute shadow path: .leo file has not been saved')
         return None

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -91,7 +91,7 @@ class ShadowController:
         """Return the full path name of filename."""
         x = self
         theDir = x.baseDirName()
-        return g.os_path_finalize_join(theDir, filename) if theDir else ''  # 1341
+        return g.finalize_join(theDir, filename) if theDir else ''
     #@+node:ekr.20080712080505.3: *4* x.isSignificantPublicFile
     def isSignificantPublicFile(self, fn: str) -> bool:
         """
@@ -173,7 +173,7 @@ class ShadowController:
                 fileDir = fileDir.replace(':', '%')
             # build the cache path as a subdir of the base dir
             fileDir = "/".join([baseDir, fname, fileDir])
-        return baseDir and g.os_path_finalize_join(  # 1341
+        return baseDir and g.finalize_join(
                 baseDir,
                 fileDir,  # Bug fix: honor any directories specified in filename.
                 x.shadow_subdir,

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -46,7 +46,7 @@ def _get_action_list():
     import os
     server = leoserver.LeoServer()
     # file_name = "xyzzy.leo"
-    file_name = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
+    file_name = g.finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
     assert os.path.exists(file_name), repr(file_name)
     log = False
     exclude_names = [

--- a/leo/plugins/bibtex.py
+++ b/leo/plugins/bibtex.py
@@ -165,7 +165,7 @@ def onIconDoubleClick(tag, keywords):
     h = p.h.strip()
     if g.match_word(h, 0, "@bibtex"):
         base = g.os_path_dirname(c.fileName() or '')
-        fn = g.os_path_finalize_join(base, h[8:])
+        fn = g.finalize_join(base, h[8:])
         if p.hasChildren():
             writeTreeAsBibTex(c, fn, p)
         else:

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -342,7 +342,7 @@ def openwith_rclick(c: Cmdr, p: Position, menu: Wrapper) -> None:
         return
 
     path = g.scanAllAtPathDirectives(c, p)
-    absp = g.os_path_finalize_join(path, fname)
+    absp = g.finalize_join(path, fname)
     exists = os.path.exists(absp)
     if not exists and head == "@path":
         action = menu.addAction("Create dir " + absp + "/")

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -392,8 +392,8 @@ class Demo:
     #@+node:ekr.20170208093727.1: *4* demo.get_icon_fn
     def get_icon_fn(self, fn):
         """Resolve fn relative to the Icons directory."""
-        dir_ = g.os_path_finalize_join(g.app.loadDir, '..', 'Icons')
-        path = g.os_path_finalize_join(dir_, fn)
+        dir_ = g.finalize_join(g.app.loadDir, '..', 'Icons')
+        path = g.finalize_join(dir_, fn)
         if g.os_path_exists(path):
             return path
         g.trace('does not exist: %s' % (path))

--- a/leo/plugins/gitarchive.py
+++ b/leo/plugins/gitarchive.py
@@ -32,7 +32,7 @@ def git_dump_f(event):
             codecs.open(fname, 'w', encoding='utf-8').write(p.b)
             print("wrote", fname)
 
-    flatroot = g.os_path_finalize('~/.leo/dump')
+    flatroot = g.finalize('~/.leo/dump')
     if not os.path.isdir(flatroot):
         g.es("Initializing git repo at " + flatroot)
         os.makedirs(flatroot)
@@ -43,7 +43,7 @@ def git_dump_f(event):
     if not comment:
         comment = "Leo dump"
     wb = c.config.getString(setting='default_leo_file')
-    wb = g.os_path_finalize(wb)
+    wb = g.finalize(wb)
     shutil.copy2(wb, flatroot)
     os.chdir(flatroot)
     dump_nodes()

--- a/leo/plugins/graphcanvas.py
+++ b/leo/plugins/graphcanvas.py
@@ -260,7 +260,7 @@ class GetImage:
                 testpath = testpath.split('//', 1)[-1]
             #
             # file on local file system
-            testpath = g.os_path_finalize_join(path, testpath)
+            testpath = g.finalize_join(path, testpath)
             if g.os_path_exists(testpath):
                 return QtWidgets.QGraphicsPixmapItem(QtGui.QPixmap(testpath))
             #

--- a/leo/plugins/jinjarender.py
+++ b/leo/plugins/jinjarender.py
@@ -63,7 +63,7 @@ def jinja_act_on_node(c, p, event):
         raise leoPlugins.TryNext
     tail = h[7:].strip()
     pth = c.getNodePath(p)
-    fullpath = g.os_path_finalize_join(pth, tail)
+    fullpath = g.finalize_join(pth, tail)
     g.es("Rendering " + fullpath)
     body = untangle(c, p)
     jinja_render(body, fullpath, c.vs)

--- a/leo/plugins/leo_to_html.py
+++ b/leo/plugins/leo_to_html.py
@@ -152,9 +152,7 @@ def safe(s):
 #@+node:bob.20080110210953: *3* abspath
 def abspath(*args):
     """Join the arguments and convert to an absolute file path."""
-    # return g.os_path_abspath(g.os_path_join(*args))
-
-    return g.os_path_finalize_join(*args)
+    return g.finalize_join(*args)
 #@+node:bob.20080107154936.3: *3* onCreate
 def onCreate(tag, keys):
 
@@ -598,11 +596,11 @@ class Leo_to_HTML:
         Setting browser_command to a bad command will slow down browser launch.
 
         """
-        tempdir = g.os_path_finalize_join(tempfile.gettempdir(), 'leo_show')
+        tempdir = g.finalize_join(tempfile.gettempdir(), 'leo_show')
         if not g.os_path_exists(tempdir):
             os.mkdir(tempdir)
         filename = g.sanitize_filename(self.myFileName)
-        filepath = g.os_path_finalize_join(tempdir, filename + '.html')
+        filepath = g.finalize_join(tempdir, filename + '.html')
         self.write(filepath, self.xhtml, basedir='', path='')
         url = "file://%s" % filepath
         msg = ''

--- a/leo/plugins/leomail.py
+++ b/leo/plugins/leomail.py
@@ -35,7 +35,7 @@ def mail_refresh(event):
         aList = g.get_directives_dict_list(p)
         path = c.scanAtPathDirectives(aList)
         h = p.h[5:].strip()
-        mb = g.os_path_finalize_join(path, h)
+        mb = g.finalize_join(path, h)
         if g.os_path_exists(mb):
             n = 0
             root = p.copy()

--- a/leo/plugins/md_docer.py
+++ b/leo/plugins/md_docer.py
@@ -94,7 +94,7 @@ def md_write_files(event):
             h = v.h
             if h.startswith('md:'):
                 pth = c.getNodePath(p)
-                fname = g.os_path_finalize_join(pth, h[3:].strip())
+                fname = g.finalize_join(pth, h[3:].strip())
                 if not fname.endswith('.md'):
                     fname = fname + '.md'
                 process(v, fname)

--- a/leo/plugins/mime.py
+++ b/leo/plugins/mime.py
@@ -103,7 +103,7 @@ def open_mimetype(tag, keywords, val=None):
         # honor @path
         d = c.scanAllDirectives(p)
         path = d.get('path')
-        fpath = g.os_path_finalize_join(path, fname)
+        fpath = g.finalize_join(path, fname)
 
         # stop here if the file doesn't exist
         if not g.os_path_exists(fpath):

--- a/leo/plugins/mod_speedups.py
+++ b/leo/plugins/mod_speedups.py
@@ -28,8 +28,8 @@ g.os_path_exists = os.path.exists
 
 
 #@+node:ville.20090804155017.12333: ** os_path_finalize caching (mod_speedups.py)
-os_path_finalize_orig = g.os_path_finalize
-os_path_finalize_join_orig = g.os_path_finalize_join
+os_path_finalize_orig = g.finalize
+os_path_finalize_join_orig = g.finalize_join
 
 _finalized_cache = {}
 _finalized_join_cache = {}
@@ -52,21 +52,21 @@ def os_path_finalize_join_cached(*args, **keys):
     _finalized_join_cache[args] = res
     return res
 
-def os_path_expanduser_cached(path, encoding=None):
-    res = _expanduser_cache.get(path)
-    if res:
-        return res
-    res = os.path.expanduser(path)
-    _expanduser_cache[path] = res
-    return res
+# def os_path_expanduser_cached(path, encoding=None):
+    # res = _expanduser_cache.get(path)
+    # if res:
+        # return res
+    # res = os.path.expanduser(path)
+    # _expanduser_cache[path] = res
+    # return res
 
 def os_path_join_speedup(*args, **kw):
     path = os.path.join(*args)
     return path
 
-g.os_path_finalize = os_path_finalize_cached
-g.os_path_finalize_join = os_path_finalize_join_cached
-g.os_path_expanduser = os_path_expanduser_cached
+g.finalize = os_path_finalize_cached
+g.finalize_join = os_path_finalize_join_cached
+# g.os_path_expanduser = os_path_expanduser_cached
 
 #@-others
 #@@language python

--- a/leo/plugins/mod_speedups.py
+++ b/leo/plugins/mod_speedups.py
@@ -27,7 +27,7 @@ g.os_path_exists = os.path.exists
 
 
 
-#@+node:ville.20090804155017.12333: ** os_path_finalize caching
+#@+node:ville.20090804155017.12333: ** os_path_finalize caching (mod_speedups.py)
 os_path_finalize_orig = g.os_path_finalize
 os_path_finalize_join_orig = g.os_path_finalize_join
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -995,7 +995,7 @@ class LeoQtGui(leoGui.LeoGui):
             iconsDir = g.os_path_join(g.app.loadDir, "..", "Icons")
             homeIconsDir = g.os_path_join(g.app.homeLeoDir, "Icons")
             for theDir in (homeIconsDir, iconsDir):
-                fullname = g.os_path_finalize_join(theDir, name)
+                fullname = g.finalize_join(theDir, name)
                 if g.os_path_exists(fullname):
                     if 0:  # Not needed: use QTreeWidget.setIconsize.
                         pixmap = QtGui.QPixmap()
@@ -1371,7 +1371,7 @@ class LeoQtGui(leoGui.LeoGui):
             'SplashScreen.svg',  # Leo's licensed .svg logo.
             'Leosplash.GIF',  # Leo's public domain bitmaped image.
         ):
-            path = g.os_path_finalize_join(g.app.loadDir, '..', 'Icons', fn)
+            path = g.finalize_join(g.app.loadDir, '..', 'Icons', fn)
             if g.os_path_exists(path):
                 if fn.endswith('svg'):
                     # Convert SVG to un-pixelated pixmap
@@ -1694,7 +1694,7 @@ class StyleSheetManager:
         """
         exists = g.os_path_exists
         home = g.app.homeDir
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         leo = join(g.app.loadDir, '..')
         table = [
             join(home, '.leo', 'Icons'),
@@ -1731,7 +1731,7 @@ class StyleSheetManager:
         if not s:
             return None  # Not an error.
         for directory in self.compute_icon_directories():
-            path = g.os_path_finalize_join(directory, s)
+            path = g.finalize_join(directory, s)
             if g.os_path_exists(path):
                 return path
         g.es_print('no icon found for:', setting)
@@ -1983,7 +1983,7 @@ class StyleSheetManager:
         """Resolve all relative url's so they use absolute paths."""
         trace = 'themes' in g.app.debug
         pattern = re.compile(r'url\((.*)\)')
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         directories = self.compute_icon_directories()
         paths_traced = False
         if trace:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1071,8 +1071,8 @@ class NumberBar(QtWidgets.QFrame):  # type:ignore
         self.d = e.document()  # A QTextDocument.
         self.fm = self.fontMetrics()  # A QFontMetrics
         self.image = QtGui.QImage(g.app.gui.getImageImage(
-            g.os_path_finalize_join(g.app.loadDir,
-                '..', 'Icons', 'Tango', '16x16', 'actions', 'stop.png')))
+            g.finalize_join(g.app.loadDir,
+            '..', 'Icons', 'Tango', '16x16', 'actions', 'stop.png')))
         self.highest_line = 0  # The highest line that is currently visibile.
         # Set the name to gutter so that the QFrame#gutter style sheet applies.
         self.offsets: List[Tuple[int, Any]] = []

--- a/leo/plugins/screen_capture.py
+++ b/leo/plugins/screen_capture.py
@@ -159,7 +159,7 @@ def screen_capture_now(kwargs=None):
             '.leo',
             'screen_captures'
         )
-    dirname = g.os_path_expanduser(dirname)
+    dirname = g.finalize(dirname)
     if not g.os_path_isdir(dirname):
         os.makedirs(dirname)
     filename = g.os_path_join(

--- a/leo/plugins/screencast.py
+++ b/leo/plugins/screencast.py
@@ -792,8 +792,8 @@ class ScreenCastController:
     def resolve_icon_fn(self, fn):
         """Resolve fn relative to the Icons directory."""
         # m = self
-        dir_ = g.os_path_finalize_join(g.app.loadDir, '..', 'Icons')
-        path = g.os_path_finalize_join(dir_, fn)
+        dir_ = g.finalize_join(g.app.loadDir, '..', 'Icons')
+        path = g.finalize_join(dir_, fn)
         if g.os_path_exists(path):
             return path
         g.trace('does not exist: %s' % (path))

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -758,7 +758,7 @@ class ScreenShotController:
         @image directives are relative to g.app.loadDir.
         """
         sc = self
-        base = sc.fix(g.os_path_finalize(g.app.loadDir))
+        base = sc.fix(g.finalize(g.app.loadDir))
         fn = sc.fix(sc.output_fn)
         fn = os.path.relpath(fn, base)
         fn = sc.fix(fn)
@@ -869,7 +869,7 @@ class ScreenShotController:
         # c = sc.c
         template_fn = sc.get_option('template_fn')
         if template_fn:
-            fn = sc.fix(g.os_path_finalize(template_fn))
+            fn = sc.fix(g.finalize(template_fn))
         else:
             fn = sc.fix(g.os_path_finalize_join(g.app.loadDir,
                 '..', 'doc', 'inkscape-template.svg'))

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -736,7 +736,7 @@ class ScreenShotController:
     def finalize(self, fn):
         """Return the absolute path to fn in the slideshow folder."""
         sc = self
-        return sc.fix(g.os_path_finalize_join(sc.slideshow_path, fn))
+        return sc.fix(g.finalize_join(sc.slideshow_path, fn))
     #@+node:ekr.20100911044508.5632: *5* fix
     def fix(self, fn):
         """Fix the case of a file name,
@@ -826,7 +826,7 @@ class ScreenShotController:
         h = h[len(tag) :].strip()
         if h:
             theDir = sc.sanitize(h)
-            path = sc.fix(g.os_path_finalize_join(sc.sphinx_path, 'slides', theDir))
+            path = sc.fix(g.finalize_join(sc.sphinx_path, 'slides', theDir))
             return path
         g.error('@slideshow node has no name')
         return None
@@ -854,12 +854,12 @@ class ScreenShotController:
                 if not leo_fn:
                     g.error('relative sphinx path given but outline not named')
                     return None
-                leo_fn = g.os_path_finalize_join(g.app.loadDir, leo_fn)
+                leo_fn = g.finalize_join(g.app.loadDir, leo_fn)
                 base, junk = g.os_path_split(leo_fn)
-                path = g.os_path_finalize_join(base, sphinx_path)
+                path = g.finalize_join(base, sphinx_path)
         else:
             # The default is the leo/doc/html directory.
-            path = g.os_path_finalize_join(g.app.loadDir, '..', 'doc', 'html')
+            path = g.finalize_join(g.app.loadDir, '..', 'doc', 'html')
         path = sc.fix(path)
         return path
     #@+node:ekr.20100908110845.5542: *5* get_template_fn
@@ -871,8 +871,7 @@ class ScreenShotController:
         if template_fn:
             fn = sc.fix(g.finalize(template_fn))
         else:
-            fn = sc.fix(g.os_path_finalize_join(g.app.loadDir,
-                '..', 'doc', 'inkscape-template.svg'))
+            fn = sc.fix(g.finalize_join(g.app.loadDir, '..', 'doc', 'inkscape-template.svg'))
         if g.os_path_exists(fn):
             return fn
         g.error('template file not found:', fn)
@@ -909,9 +908,9 @@ class ScreenShotController:
         if not leo_fn:
             g.error('relative wink path given but outline not named')
             return None
-        leo_fn = g.os_path_finalize_join(g.app.loadDir, leo_fn)
+        leo_fn = g.finalize_join(g.app.loadDir, leo_fn)
         base, junk = g.os_path_split(leo_fn)
-        path = g.os_path_finalize_join(base, path)
+        path = g.finalize_join(base, path)
         path = sc.fix(path)
         g.trace(path)
         return path
@@ -1076,13 +1075,13 @@ class ScreenShotController:
         )
         slide_path, junk = g.os_path_split(sc.slide_fn)
         for fn in table:
-            path = g.os_path_finalize_join(slide_path, fn)
+            path = g.finalize_join(slide_path, fn)
             if not g.os_path_exists(path):
                 sc.copy_file(sc.sphinx_path, slide_path, fn)
     #@+node:ekr.20101005193146.5688: *5* copy_file
     def copy_file(self, src_path, dst_path, fn):
-        src_fn = g.os_path_finalize_join(src_path, fn)
-        dst_fn = g.os_path_finalize_join(dst_path, fn)
+        src_fn = g.finalize_join(src_path, fn)
+        dst_fn = g.finalize_join(dst_path, fn)
         junk, dst_dir = g.os_path_split(dst_path)
         g.note('creating', g.os_path_join('slides', dst_dir, fn))
         shutil.copyfile(src_fn, dst_fn)
@@ -1131,7 +1130,7 @@ class ScreenShotController:
         sc = self
         # Don't create path for at_image_fn or directive_fn
         # They are relative paths!
-        static_dir = g.os_path_finalize_join(
+        static_dir = g.finalize_join(
             sc.slideshow_path, '_static')
         table = (
             # ('at_image_fn   ',sc.at_image_fn),
@@ -1164,7 +1163,7 @@ class ScreenShotController:
                 fn = fn[:-4]
             p2 = p.insertAsLastChild()
             p2.h = h
-            p2.b = g.os_path_finalize_join(
+            p2.b = g.finalize_join(
                 sc.slideshow_path, '_build', 'html', fn)
     #@+node:ekr.20101008112639.5631: *4* make_at_url_node_for_output_file
     def make_at_url_node_for_output_file(self):
@@ -1739,8 +1738,7 @@ class ScreenShotController:
         verbose = False
         sc = self
         c = sc.c
-        launch = g.os_path_finalize_join(g.app.loadDir,
-            '..', '..', 'launchLeo.py')
+        launch = g.finalize_join(g.app.loadDir, '..', '..', 'launchLeo.py')
         python = sys.executable
         h, w = sc.screenshot_height, sc.screenshot_width
         cmd = [python, launch, '--window-size=%sx%s' % (h, w)]

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -407,7 +407,7 @@ class todoController:
 
         for i in range(10):
             button = getattr(ui, f"butPri{i}")
-            path = g.os_path_finalize_join(g.app.loadDir, '..', 'Icons', "cleo", f"pri{i}.png")
+            path = g.finalize_join(g.app.loadDir, '..', 'Icons', "cleo", f"pri{i}.png")
             button.setIcon(QtGui.QIcon(path))
             button.setIconSize(size)
             button.setToolTip(f"Priority {i}")
@@ -432,7 +432,7 @@ class todoController:
 
         for attr, icon, tooltip in table:
             button = getattr(ui, attr)
-            path = g.os_path_finalize_join(g.app.loadDir, '..', 'Icons', "cleo", icon)
+            path = g.finalize_join(g.app.loadDir, '..', 'Icons', "cleo", icon)
             button.setIcon(QtGui.QIcon(path))
             button.setIconSize(size)
             button.setToolTip(tooltip)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1690,20 +1690,20 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         fn = fn.strip()
         # Similar to code in g.computeFileUrl
         if fn.startswith('~'):
-            # Expand '~' and handle Leo expressions.
+            ### Expand '~' and handle Leo expressions.
             fn = fn[1:]
-            fn = g.os_path_expanduser(fn)
-            fn = c.expand_path_expression(fn)
+            ### fn = g.os_path_expanduser(fn)
+            ### fn = c.expand_path_expression(fn)
             fn = g.os_path_finalize(fn)
         else:
-            # Handle Leo expressions.
-            fn = c.expand_path_expression(fn)
+            ### Handle Leo expressions.
+            ### fn = c.expand_path_expression(fn)
             # Handle ancestor @path directives.
             if c and c.openDirectory:
                 base = c.getNodePath(c.p)
                 fn = g.os_path_finalize_join(c.openDirectory, base, fn)
             else:
-                fn = g.os_path_finalize(fn)
+                fn = g.finalize(fn)
         ok = g.os_path_exists(fn)
         # if not ok: g.trace('not found', fn)
         return ok, fn

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1041,8 +1041,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         global asciidoctor_exec, asciidoc3_exec
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         home = g.os.path.expanduser('~')
-        i_path = g.os_path_finalize_join(home, 'vr_input.adoc')
-        o_path = g.os_path_finalize_join(home, 'vr_output.html')
+        i_path = g.finalize_join(home, 'vr_input.adoc')
+        o_path = g.finalize_join(home, 'vr_output.html')
         # Write the input file.
         with open(i_path, 'w') as f:
             f.write(s)
@@ -1363,8 +1363,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         global pandoc_exec
         assert pandoc_exec, g.callers()
         home = g.os.path.expanduser('~')
-        i_path = g.os_path_finalize_join(home, 'vr_input.pandoc')
-        o_path = g.os_path_finalize_join(home, 'vr_output.html')
+        i_path = g.finalize_join(home, 'vr_input.pandoc')
+        o_path = g.finalize_join(home, 'vr_output.html')
         # Write the input file.
         with open(i_path, 'w') as f:
             f.write(s)
@@ -1385,7 +1385,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         c = self.c
 
         if pyplot.get_backend() != 'module://leo.plugins.pyplot_backend':
-            backend = g.os_path_finalize_join(
+            backend = g.finalize_join(
                 g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
             if g.os_path_exists(backend):
                 try:
@@ -1536,7 +1536,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         template_data = {}
         for child in p.children():
             if child.h == '@jinja template':
-                template_path = g.os_path_finalize_join(c.getNodePath(p), untangle(c, child).strip())
+                template_path = g.finalize_join(c.getNodePath(p), untangle(c, child).strip())
             elif child.h == '@jinja inputs':
                 for template_var_node in child.children():
                     # pylint: disable=line-too-long
@@ -1696,7 +1696,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             # Handle ancestor @path directives.
             if c and c.openDirectory:
                 base = c.getNodePath(c.p)
-                fn = g.os_path_finalize_join(c.openDirectory, base, fn)
+                fn = g.finalize_join(c.openDirectory, base, fn)
             else:
                 fn = g.finalize(fn)
         ok = g.os_path_exists(fn)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1690,14 +1690,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         fn = fn.strip()
         # Similar to code in g.computeFileUrl
         if fn.startswith('~'):
-            ### Expand '~' and handle Leo expressions.
             fn = fn[1:]
-            ### fn = g.os_path_expanduser(fn)
-            ### fn = c.expand_path_expression(fn)
             fn = g.os_path_finalize(fn)
         else:
-            ### Handle Leo expressions.
-            ### fn = c.expand_path_expression(fn)
             # Handle ancestor @path directives.
             if c and c.openDirectory:
                 base = c.getNodePath(c.p)
@@ -1705,7 +1700,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             else:
                 fn = g.finalize(fn)
         ok = g.os_path_exists(fn)
-        # if not ok: g.trace('not found', fn)
         return ok, fn
     #@+node:ekr.20110321005148.14536: *5* vr.get_url
     def get_url(self, s: str, tag: str) -> str:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4535,20 +4535,22 @@ class ViewRenderedController3(QtWidgets.QWidget):
         fn = fn.strip()
         # Similar to code in g.computeFileUrl
         if fn.startswith('~'):
-            # Expand '~' and handle Leo expressions.
+            #### Expand '~' and handle Leo expressions.
+            ### fn = g.os_path_expanduser(fn)
+            ### fn = c.expand_path_expression(fn)
+
             fn = fn[1:]
-            fn = g.os_path_expanduser(fn)
-            fn = c.expand_path_expression(fn)
-            fn = g.os_path_finalize(fn)
+            fn = g.finalize(fn)
         else:
-            # Handle Leo expressions.
-            fn = c.expand_path_expression(fn)
+            ### Handle Leo expressions.
+            ### fn = c.expand_path_expression(fn)
+            
             # Handle ancestor @path directives.
             if c and c.openDirectory:
                 base = c.getNodePath(c.p)
                 fn = g.os_path_finalize_join(c.openDirectory, base, fn)
             else:
-                fn = g.os_path_finalize(fn)
+                fn = g.finalize(fn)
 
         ok = g.os_path_exists(fn)
         return ok, fn

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4535,16 +4535,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
         fn = fn.strip()
         # Similar to code in g.computeFileUrl
         if fn.startswith('~'):
-            #### Expand '~' and handle Leo expressions.
-            ### fn = g.os_path_expanduser(fn)
-            ### fn = c.expand_path_expression(fn)
-
             fn = fn[1:]
             fn = g.finalize(fn)
         else:
-            ### Handle Leo expressions.
-            ### fn = c.expand_path_expression(fn)
-            
             # Handle ancestor @path directives.
             if c and c.openDirectory:
                 base = c.getNodePath(c.p)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1789,7 +1789,7 @@ def export_rst_html(event):
     # Write to temp file
     c = vr3.c
     path = c.getNodePath(c.rootPosition())
-    pathname = g.os_path_finalize_join(path, VR3_TEMP_FILE)
+    pathname = g.finalize_join(path, VR3_TEMP_FILE)
     with ioOpen(pathname, 'w', encoding='utf-8') as f:
         f.write(_html)
     webbrowser.open_new_tab(pathname)
@@ -2042,7 +2042,7 @@ def vr3_help_for_plot_2d(event):
             output += f'<pre style="{RST_ERROR_BODY_STYLE}">{docstr}</pre>'
 
     path = c.getNodePath(c.rootPosition())
-    pathname = g.os_path_finalize_join(path, VR3_TEMP_FILE)
+    pathname = g.finalize_join(path, VR3_TEMP_FILE)
     with ioOpen(pathname, 'w', encoding='utf-8') as f:
         f.write(_html)
     webbrowser.open_new_tab(pathname)
@@ -2633,10 +2633,10 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
             if is_abs:
                 # This method changes '\' to '/' in the path if needed.
-                self.rst_stylesheet = g.os_path_finalize_join(pth)
+                self.rst_stylesheet = g.finalize_join(pth)
             else:
                 self.rst_stylesheet = g.os_path_join(leodir, VR3_DIR, self.rst_stylesheet)
-                self.rst_stylesheet = g.os_path_finalize_join(self.rst_stylesheet)
+                self.rst_stylesheet = g.finalize_join(self.rst_stylesheet)
 
             if not os.path.exists(self.rst_stylesheet):
                 use_default = True
@@ -3347,8 +3347,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         # Find path relative to this file.  Needed as the base of relative
         # URLs, e.g., image or included files.
         path = c.getNodePath(c.p)
-        i_path = g.os_path_finalize_join(path, 'vr3_adoc.adoc')
-        o_path = g.os_path_finalize_join(path, 'vr3_adoc.html')
+        i_path = g.finalize_join(path, 'vr3_adoc.adoc')
+        o_path = g.finalize_join(path, 'vr3_adoc.html')
 
         # Write the input file.
         with open(i_path, 'w', encoding='utf-8') as f:
@@ -3798,8 +3798,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         global pandoc_exec
         assert pandoc_exec, g.callers()
         home = g.os.path.expanduser('~')
-        i_path = g.os_path_finalize_join(home, 'vr3_input.pandoc')
-        o_path = g.os_path_finalize_join(home, 'vr3_output.html')
+        i_path = g.finalize_join(home, 'vr3_input.pandoc')
+        o_path = g.finalize_join(home, 'vr3_output.html')
         # Write the input file.
         with open(i_path, 'w', encoding = ENCODING) as f:
             f.write(s)
@@ -3819,7 +3819,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             c = self.c
             if not self.pyplot_imported:
                 self.pyplot_imported = True
-                backend = g.os_path_finalize_join(
+                backend = g.finalize_join(
                     g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
                 if g.os_path_exists(backend):
                     if matplotlib:
@@ -4541,7 +4541,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # Handle ancestor @path directives.
             if c and c.openDirectory:
                 base = c.getNodePath(c.p)
-                fn = g.os_path_finalize_join(c.openDirectory, base, fn)
+                fn = g.finalize_join(c.openDirectory, base, fn)
             else:
                 fn = g.finalize(fn)
 

--- a/leo/plugins/xdb_pane.py
+++ b/leo/plugins/xdb_pane.py
@@ -122,8 +122,7 @@ if g.app.gui.guiName() == "qt":
         #@+node:ekr.20181004143535.20: *4* get_icon
         def get_icon(self, fn):
             """return the icon from Icons/debug_icons"""
-            path = g.os_path_finalize_join(
-                g.app.loadDir, '..', 'Icons', 'debug_icons', fn)
+            path = g.finalize_join(g.app.loadDir, '..', 'Icons', 'debug_icons', fn)
             return QtGui.QIcon(g.app.gui.getImageImage(path))
         #@+node:ekr.20181005042637.1: *3* debug_*
         def debug_break(self, checked):

--- a/leo/unittests/core/test_leoApp.py
+++ b/leo/unittests/core/test_leoApp.py
@@ -65,7 +65,7 @@ class TestApp(LeoUnitTest):
         s = 'this is a test file'
         testDir = g.os_path_join(g.app.loadDir, '..', 'test')
         assert g.os_path_exists(testDir), testDir
-        path = g.os_path_finalize_join(testDir, 'testzip.zip')
+        path = g.finalize_join(testDir, 'testzip.zip')
         if os.path.exists(path):
             os.remove(path)  # pragma: no cover
         f = zipfile.ZipFile(path, 'x')

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -206,7 +206,7 @@ class BaseTest(unittest.TestCase):
     def make_file_data(self, filename):
         """Return (contents, tokens, tree) from the given file."""
         directory = os.path.dirname(__file__)
-        filename = g.os_path_finalize_join(directory, '..', '..', 'core', filename)
+        filename = g.finalize_join(directory, '..', '..', 'core', filename)
         assert os.path.exists(filename), repr(filename)
         contents = read_file(filename)
         contents, tokens, tree = self.make_data(contents, filename)

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -91,7 +91,7 @@ class TestAtFile(LeoUnitTest):
     #@+node:ekr.20230410082517.1: *3* TestAtFile.test_bug_3270_at_path
     def test_bug_3270_at_path(self):
         #  @path c:/temp/leo
-        #    @file at_file_test.py.
+        #    @file at_file_test.py
         c = self.c
         root = c.rootPosition()
         root.h = '@path c:/temp/leo'
@@ -99,6 +99,18 @@ class TestAtFile(LeoUnitTest):
         child.h = '@file at_file_test.py'
         path = c.fullPath(child)
         expected = 'c:/temp/leo/at_file_test.py'
+        self.assertTrue(path, expected)
+    #@+node:ekr.20230411094250.1: *3* TestAtFile.test_bug_3272_at_path
+    def test_bug_3272_at_path(self):
+        #  @path bookmarks
+        #    @file at_file_test.py
+        c = self.c
+        root = c.rootPosition()
+        root.h = '@path bookmarks'
+        child = root.insertAsLastChild()
+        child.h = '@file at_file_test.py'
+        path = c.fullPath(child)
+        expected = 'bookmarks/at_file_test.py'
         self.assertTrue(path, expected)
     #@+node:ekr.20210901140645.13: *3* TestAtFile.test_checkPythonSyntax
     def test_checkPythonSyntax(self):

--- a/leo/unittests/core/test_leoBridge.py
+++ b/leo/unittests/core/test_leoBridge.py
@@ -25,7 +25,7 @@ class TestBridge(LeoUnitTest):
         self.assertTrue(g)
         unittest_dir = os.path.abspath(os.path.dirname(__file__))
         self.assertTrue(os.path.exists(unittest_dir))
-        test_dot_leo = g.os_path_finalize_join(unittest_dir, '..', '..', 'test', 'test.leo')
+        test_dot_leo = g.finalize_join(unittest_dir, '..', '..', 'test', 'test.leo')
         self.assertTrue(os.path.exists(test_dot_leo), msg=test_dot_leo)
         c = controller.openLeoFile(test_dot_leo)
         self.assertTrue(c)

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -129,15 +129,16 @@ class TestCommands(LeoUnitTest):
         abs_base = '/leo_base'
         c.mFileName = f"{abs_base}/test.leo"
         os.environ = {
-            'HOME': '/home/',  # Linux.
+            'HOME': '/home',  # Linux.
             'USERPROFILE': r'c:\EKR',  # Windows.
             'LEO_BASE': abs_base,
         }
         home = os.path.expanduser('~')
         assert home in (os.environ['HOME'], os.environ['USERPROFILE']), repr(home)
 
-        # c.expand_path_expressions *only* calls os.path.expanduser and os.path.expandvars.   
-        for sep in ('\\', '/'):
+        # c.expand_path_expressions *only* calls os.path.expanduser and os.path.expandvars.
+        seps = ('\\', '/') if g.isWindows else ('/',)
+        for sep in seps:
             table = (
                 (f"~{sep}a.py", f"{home}{sep}a.py"),
                 (f"~{sep}x{sep}..{sep}b.py", f"{home}{sep}x{sep}..{sep}b.py"),

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -137,7 +137,7 @@ class TestGlobals(LeoUnitTest):
         import os
         c = self.c
         normslashes = g.os_path_normslashes
-        
+
         # Setup environment.
         expected_leo_base = 'C:/leo_base' if g.isWindows else '/leo_base'
         c.mFileName = "/leo_base/test.leo"
@@ -146,17 +146,16 @@ class TestGlobals(LeoUnitTest):
             'USERPROFILE': normslashes(r'c:/EKR'),  # Windows.
             'LEO_BASE': expected_leo_base,
         }
-        
-        # Compute home and load_dir.
+
+        curdir = normslashes(os.getcwd())
         home = normslashes(os.path.expanduser('~'))
         assert home in (os.environ['HOME'], os.environ['USERPROFILE']), repr(home)
-        
 
         seps = ('\\', '/') if g.isWindows else ('/',)
         for sep in seps:
             table = (
                 # The most basic test.
-                (('basic.py',),                     f"{expected_leo_base}/basic.py"),
+                (('basic.py',),                     f"{curdir}/basic.py"),
                 # One element in *args...
                 ((f"~{sep}a.py",),                  f"{home}/a.py"),
                 ((f"~{sep}x{sep}..{sep}b.py",),     f"{home}/b.py"),
@@ -181,7 +180,8 @@ class TestGlobals(LeoUnitTest):
             )
             for args, expected in table:
                 got = g.finalize_join(*args)
-                if g.isWindows:  # Weird: the case is wrong whatever the case of expected_leo_base!
+                # Weird: the case is wrong whatever the case of expected_leo_base!
+                if g.isWindows:
                     expected = expected.replace('C:', 'c:')
                     got = got.replace('C:', 'c:')
                 self.assertEqual(expected, got)

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -654,7 +654,7 @@ class TestGlobals(LeoUnitTest):
     def test_g_warnOnReadOnlyFile(self):
         c = self.c
         fc = c.fileCommands
-        path = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test-read-only.txt')
+        path = g.finalize_join(g.app.loadDir, '..', 'test', 'test-read-only.txt')
         if os.path.exists(path):  # pragma: no cover
             os.chmod(path, stat.S_IREAD)
             fc.warnOnReadOnlyFiles(path)

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -151,8 +151,6 @@ class TestGlobals(LeoUnitTest):
         home = normslashes(os.path.expanduser('~'))
         assert home in (os.environ['HOME'], os.environ['USERPROFILE']), repr(home)
         
-        ### load_dir = normslashes(os.path.abspath(g.app.loadDir))
-        ### outline_dir = normslashes(os.path.abspath(os.path.dirname(c.mFileName)))
 
         seps = ('\\', '/') if g.isWindows else ('/',)
         for sep in seps:

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -143,9 +143,11 @@ class TestGlobals(LeoUnitTest):
         # Setup environment.
         expected_leo_base = 'C:/leo_base' if g.isWindows else '/leo_base'
         c.mFileName = "/leo_base/test.leo"
+        
+        # Note: These directories do *not* have to exist.
         os.environ = {
             'HOME': '/home',  # Linux.
-            'USERPROFILE': normslashes(r'c:/EKR'),  # Windows.
+            'USERPROFILE': normslashes(r'c:/Whatever'),  # Windows.
             'LEO_BASE': expected_leo_base,
         }
 
@@ -180,9 +182,11 @@ class TestGlobals(LeoUnitTest):
         # Setup environment.
         expected_leo_base = 'C:/leo_base' if g.isWindows else '/leo_base'
         c.mFileName = "/leo_base/test.leo"
+        
+        # Note: These directories do *not* have to exist.
         os.environ = {
             'HOME': '/home',  # Linux.
-            'USERPROFILE': normslashes(r'c:/EKR'),  # Windows.
+            'USERPROFILE': normslashes(r'c:/Whatever'),  # Windows.
             'LEO_BASE': expected_leo_base,
         }
 

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -147,21 +147,18 @@ class TestGlobals(LeoUnitTest):
             'LEO_BASE': expected_leo_base,
         }
         
-        # Compute home.
+        # Compute home and load_dir.
         home = normslashes(os.path.expanduser('~'))
         assert home in (os.environ['HOME'], os.environ['USERPROFILE']), repr(home)
         
-        # Verify that curdir == load_dir
-        curdir = normslashes(os.getcwd())
-        load_dir = normslashes(os.path.normpath(os.path.join(g.app.loadDir)))
-        self.assertTrue(curdir, load_dir)
+        ### load_dir = normslashes(os.path.abspath(g.app.loadDir))
+        ### outline_dir = normslashes(os.path.abspath(os.path.dirname(c.mFileName)))
 
         seps = ('\\', '/') if g.isWindows else ('/',)
         for sep in seps:
             table = (
                 # The most basic test.
-                (('basic.py',),                     f"{curdir}/basic.py"),
-                (('basic.py',),                     f"{load_dir}/basic.py"),
+                (('basic.py',),                     f"{expected_leo_base}/basic.py"),
                 # One element in *args...
                 ((f"~{sep}a.py",),                  f"{home}/a.py"),
                 ((f"~{sep}x{sep}..{sep}b.py",),     f"{home}/b.py"),

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -20,7 +20,7 @@ class TestAtShadow(LeoUnitTest):
         delims = '#', '', ''
         c = self.c
         base_dir = os.path.dirname(__file__)
-        c.mFileName = g.os_path_finalize_join(base_dir, '..', '..', 'test666.leo')
+        c.mFileName = g.finalize_join(base_dir, '..', '..', 'test666.leo')
         self.shadow_controller = ShadowController(c)
         self.marker = self.shadow_controller.Marker(delims)
 

--- a/leo/unittests/core/test_leoserver.py
+++ b/leo/unittests/core/test_leoserver.py
@@ -72,7 +72,7 @@ class TestLeoServer(LeoUnitTest):
         server = self.server
         tag = 'test_most_public_server_methods'
         assert isinstance(server, g_leoserver.LeoServer), self.server
-        test_dot_leo = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
+        test_dot_leo = g.finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
         assert os.path.exists(test_dot_leo), repr(test_dot_leo)
         # Remove all uA's.
         methods = server._get_all_server_commands()
@@ -152,7 +152,7 @@ class TestLeoServer(LeoUnitTest):
     #@+node:felix.20210621233316.103: *3* TestLeoServer.test_open_and_close
     def test_open_and_close(self):
         # server = self.server
-        test_dot_leo = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
+        test_dot_leo = g.finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
         assert os.path.exists(test_dot_leo), repr(test_dot_leo)
         log = False
         table = [
@@ -182,7 +182,7 @@ class TestLeoServer(LeoUnitTest):
     def test_find_commands(self):
 
         tag = 'test_find_commands'
-        test_dot_leo = g.os_path_finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
+        test_dot_leo = g.finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
         assert os.path.exists(test_dot_leo), repr(test_dot_leo)
         log = False
         # Open the file & create the StringFindTabManager.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -139,9 +139,9 @@ class TestAtAuto(BaseTestImporter):
     #@+others
     #@+node:ekr.20210904065459.122: *3* TestAtAuto.test_importers_can_be_imported
     def test_importers_can_be_imported(self):
-        path = g.os_path_finalize_join(g.app.loadDir, '..', 'plugins', 'importers')
+        path = g.finalize_join(g.app.loadDir, '..', 'plugins', 'importers')
         assert g.os_path_exists(path), repr(path)
-        pattern = g.os_path_finalize_join(path, '*.py')
+        pattern = g.finalize_join(path, '*.py')
         for fn in glob.glob(pattern):
             sfn = g.shortFileName(fn)
             m = importlib.import_module('leo.plugins.importers.%s' % sfn[:-3])

--- a/leo/unittests/test_syntax.py
+++ b/leo/unittests/test_syntax.py
@@ -30,11 +30,11 @@ class TestSyntax(LeoUnitTest):
             ('extensions', 'asciidoc.py'),
             ('test', 'scriptFile.py'),
         )
-        join = g.os_path_finalize_join
+        join = g.finalize_join
         skip_list = [join(g.app.loadDir, '..', a, b) for a, b in skip_tuples]
         n = 0
         for theDir in ('core', 'external', 'extensions', 'modes', 'plugins', 'scripts', 'test'):
-            path = g.os_path_finalize_join(g.app.loadDir, '..', theDir)
+            path = g.finalize_join(g.app.loadDir, '..', theDir)
             self.assertTrue(g.os_path_exists(path), msg=path)
             aList = glob.glob(g.os_path_join(path, '*.py'))
             if g.isWindows:
@@ -47,7 +47,7 @@ class TestSyntax(LeoUnitTest):
                     self.assertTrue(self.check_syntax(fn, s), msg=fn)
     #@+node:ekr.20210901140645.22: *4* TestSyntax.test_syntax_of_setup_py
     def test_syntax_of_setup_py(self):
-        fn = g.os_path_finalize_join(g.app.loadDir, '..', '..', 'setup.py')
+        fn = g.finalize_join(g.app.loadDir, '..', '..', 'setup.py')
         # Only run this test if setup.py exists: it may not in the actual distribution.
         if not g.os_path_exists(fn):
             self.skipTest('setup.py not found')  # pragma: no cover


### PR DESCRIPTION
See #3276.  The new code is *much* better than the old. We aren't going back.

- [x] Leave all `g.os_path` functions unchanged for compatibility, except as discussed next.
- [x] Make `g.os_path_finalize_join` a deprecated alias for the (improved) `g.finalize_join`. The old code was dubious.
- [x] Make `g.os_path_finalize` a deprecated alias for `g.finalize`. The old code did not call `os.path.expanduser`.

**Renamed functions**

- [x] Replace `g.os_path_finalize` with `f.finalize` *everywhere*.
- [x] Replace `g.os_path_finalize_join` with `g.finalize_join` *everywhere*.

These two new names emphasize the differences with the corresponding `os.path` functions.

The following sections discuss all important changes to the code.

**g.finalize**

- [x] `g.finalize` calls both `os.path.expanduser` and (new) `os.path.expandvars`:

<details>

```python
def finalize(path: str) -> str:
    """
    Finalize the path. Do not call os.path.realpath.
    """
    if not path:
        return ''
    path = os.path.expanduser(path)
    path = os.path.expandvars(path)
    path = os.path.abspath(path)
    path = os.path.normpath(path)
    path = g.os_path_normslashes(path)
    return path

os_path_finalize = finalize  # compatibility.
```

</details>

**g.finalize_join**

- [x] `g.finalize_join` expands all parts *before* calling `os.path.join`:

<details>

```python
def finalize_join(*args: Any) -> str:
    """
    Join and finalize. Do not call os.path.realpath.
    """
    uargs = [z for z in args if z]
    if not uargs:
        return ''
    # Expand everything before joining.
    uargs2 = [os.path.expandvars(os.path.expanduser(z)) for z in uargs]
    path = os.path.join(*uargs2)
    path = os.path.abspath(path)
    path = os.path.normpath(path)
    path = g.os_path_normslashes(path)
    return path

os_path_finalize_join = finalize_join
```

</details>

**c.fullPath**

- [x] Simplify  `c.fullPath` using the improved `g.finalize_join`:

<details>

```python
def fullPath(self, p: Position, simulate: bool = False) -> str:
    """
    Return the full path (including fileName) in effect at p. Neither the
    path nor the fileName will be created if it does not exist.
    """
    c = self
    # Search p and p's parents.
    for p in p.self_and_parents(copy=False):
        aList = g.get_directives_dict_list(p)
        path = c.scanAtPathDirectives(aList)
        fn = p.h if simulate else p.anyAtFileNodeName()  # Use p.h for unit tests.
        if fn:
            return g.finalize_join(path, fn) if fn else ''
    return ''
```
</details>

**c.scanAtPathDirectives**

- [x] Simplify `c.scanAtPathDirectives`using the improved `g.finalize_join`:

<details>

```python
def scanAtPathDirectives(self, aList: List) -> str:
    """
    Scan aList for @path directives.
    Return a reasonable default if no @path directive is found.
    """
    c = self
    c.scanAtPathDirectivesCount += 1  # An important statistic.
    base = c.openDirectory
    absbase = g.finalize_join(g.app.loadDir, base)

    # Look for @path directives.
    paths = []
    for d in aList:
        # Look for @path directives.
        path = d.get('path')
        warning = d.get('@path_in_body')
        if path is not None:  # retain empty paths for warnings.
            # Convert "path" or <path> to path.
            path = g.stripPathCruft(path)
            if path and not warning:  # Silently ignore empty @path directives.
                paths.append(path)

    # Add absbase and reverse the list.
    paths.append(absbase)
    paths.reverse()

    # Compute the full, effective, absolute path.
    path = g.finalize_join(*paths)
    return path
```

</Details>

**VR plugin**

- [x] Simplify `VR.get_fn` using the improved `g.finalize_join`.

<details>

```python
def get_fn(self, s: str, tag: str) -> Tuple[bool, str]:
    pc = self
    c = pc.c
    fn = s or c.p.h[len(tag) :]
    fn = fn.strip()
    # Similar to code in g.computeFileUrl
    if fn.startswith('~'):
        fn = fn[1:]
        fn = g.os_path_finalize(fn)
    else:
        # Handle ancestor @path directives.
        if c and c.openDirectory:
            base = c.getNodePath(c.p)
            fn = g.finalize_join(c.openDirectory, base, fn)
        else:
            fn = g.finalize(fn)
    ok = g.os_path_exists(fn)
    return ok, fn
```

</details>

**VR3 plugin**

- [x] Simplify `VR3.get_fn` using the improved `g.finalize_join`.

<details>

```python
def get_fn(self, s, tag):
    pc = self
    c = pc.c
    fn = s or c.p.h[len(tag) :]
    fn = fn.strip()
    # Similar to code in g.computeFileUrl
    if fn.startswith('~'):
        fn = fn[1:]
        fn = g.finalize(fn)
    else:
        # Handle ancestor @path directives.
        if c and c.openDirectory:
            base = c.getNodePath(c.p)
            fn = g.finalize_join(c.openDirectory, base, fn)
        else:
            fn = g.finalize(fn)

    ok = g.os_path_exists(fn)
    return ok, fn
```

</details>

**Remove obsolete comments**

- [x] Remove comments referring to old issues. They are now neither useful nor accurate.