### PR TITLE
PR for #3278: crash in g.openUrlHelper

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7542,7 +7542,7 @@ def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
         IMPORTre = r'^import\s+[\./\\]*([^\s/\\].+)'
         IMPORTSre = FROMre + '|' + IMPORTre
 
-        m = re.match(IMPORTSre, line)
+        m = re.match(IMPORTSre, s[i:], re.MULTILINE)
         module = m and (m[2] or m[1])
         if module:
             filename = module + '.py'


### PR DESCRIPTION
See #3278.  This PR only eliminates the unbound variable crash.