### PR TITLE
PR for #3289: Remove kwargs with default values from all files in leo/modes

### DIFF
--- a/leo/modes/actionscript.py
+++ b/leo/modes/actionscript.py
@@ -674,142 +674,108 @@ keywordsDictDict = {
 # Rules for actionscript_main ruleset.
 
 def actionscript_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def actionscript_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def actionscript_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Used to color "("
 def actionscript_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def actionscript_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 # Used to color ")".  2011/05/22: change kind to "operator". Also changed actionscript.xml.
 def actionscript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 # Used to color "(".  2011/05/22: change kind to "operator". Also changed actionscript.xml.
 def actionscript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def actionscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def actionscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def actionscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def actionscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def actionscript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def actionscript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def actionscript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def actionscript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def actionscript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def actionscript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def actionscript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def actionscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def actionscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def actionscript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def actionscript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def actionscript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def actionscript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def actionscript_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def actionscript_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def actionscript_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def actionscript_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def actionscript_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def actionscript_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def actionscript_rule30(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def actionscript_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def actionscript_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ada95.py
+++ b/leo/modes/ada95.py
@@ -112,449 +112,336 @@ keywordsDictDict = {
 # Rules for ada95_main ruleset.
 
 def ada95_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def ada95_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def ada95_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def ada95_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def ada95_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="..")
 
 def ada95_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".all",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".all")
 
 def ada95_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def ada95_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/=")
 
 def ada95_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=>")
 
 def ada95_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def ada95_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="<>")
 
 def ada95_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="<<")
 
 def ada95_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq=">>")
 
 def ada95_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def ada95_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def ada95_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def ada95_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def ada95_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def ada95_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def ada95_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def ada95_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def ada95_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def ada95_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def ada95_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'access",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'access")
 
 def ada95_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'address",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'address")
 
 def ada95_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'adjacent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'adjacent")
 
 def ada95_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'aft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'aft")
 
 def ada95_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'alignment",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'alignment")
 
 def ada95_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'base",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'base")
 
 def ada95_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'bit_order",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'bit_order")
 
 def ada95_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'body_version",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'body_version")
 
 def ada95_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'callable",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'callable")
 
 def ada95_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'caller",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'caller")
 
 def ada95_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'ceiling",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'ceiling")
 
 def ada95_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'class",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'class")
 
 def ada95_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'component_size",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'component_size")
 
 def ada95_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'composed",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'composed")
 
 def ada95_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'constrained",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'constrained")
 
 def ada95_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'copy_size",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'copy_size")
 
 def ada95_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'count",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'count")
 
 def ada95_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'definite",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'definite")
 
 def ada95_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'delta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'delta")
 
 def ada95_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'denorm",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'denorm")
 
 def ada95_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'digits",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'digits")
 
 def ada95_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'exponent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'exponent")
 
 def ada95_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'external_tag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'external_tag")
 
 def ada95_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'first",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'first")
 
 def ada95_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'first_bit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'first_bit")
 
 def ada95_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'floor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'floor")
 
 def ada95_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'fore",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'fore")
 
 def ada95_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'fraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'fraction")
 
 def ada95_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'genetic",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'genetic")
 
 def ada95_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'identity",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'identity")
 
 def ada95_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'image",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'image")
 
 def ada95_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'input",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'input")
 
 def ada95_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'last",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'last")
 
 def ada95_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'last_bit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'last_bit")
 
 def ada95_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'leading_part",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'leading_part")
 
 def ada95_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'length",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'length")
 
 def ada95_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine")
 
 def ada95_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_emax",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_emax")
 
 def ada95_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_emin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_emin")
 
 def ada95_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_mantissa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_mantissa")
 
 def ada95_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_overflows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_overflows")
 
 def ada95_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_radix",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_radix")
 
 def ada95_rule65(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_rounds",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_rounds")
 
 def ada95_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'max",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'max")
 
 def ada95_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'max_size_in_storage_elements",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'max_size_in_storage_elements")
 
 def ada95_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'min",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'min")
 
 def ada95_rule69(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'model")
 
 def ada95_rule70(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_emin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'model_emin")
 
 def ada95_rule71(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_epsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'model_epsilon")
 
 def ada95_rule72(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_mantissa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'model_mantissa")
 
 def ada95_rule73(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_small",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'model_small")
 
 def ada95_rule74(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'modulus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'modulus")
 
 def ada95_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'output",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'output")
 
 def ada95_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'partition_id",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'partition_id")
 
 def ada95_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'pos",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'pos")
 
 def ada95_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'position",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'position")
 
 def ada95_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'pred",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'pred")
 
 def ada95_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'range",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'range")
 
 def ada95_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'read",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'read")
 
 def ada95_rule82(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'remainder",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'remainder")
 
 def ada95_rule83(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'round",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'round")
 
 def ada95_rule84(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'rounding",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'rounding")
 
 def ada95_rule85(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'safe_first",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'safe_first")
 
 def ada95_rule86(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'safe_last",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'safe_last")
 
 def ada95_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'scale",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'scale")
 
 def ada95_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'scaling",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'scaling")
 
 def ada95_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'signed_zeros",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'signed_zeros")
 
 def ada95_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'size",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'size")
 
 def ada95_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'small",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'small")
 
 def ada95_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'storage_pool",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'storage_pool")
 
 def ada95_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'storage_size",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'storage_size")
 
 def ada95_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'succ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'succ")
 
 def ada95_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'tag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'tag")
 
 def ada95_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'terminated",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'terminated")
 
 def ada95_rule97(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'truncation",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'truncation")
 
 def ada95_rule98(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'unbiased_rounding",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'unbiased_rounding")
 
 def ada95_rule99(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'unchecked_access",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'unchecked_access")
 
 def ada95_rule100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'val",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'val")
 
 def ada95_rule101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'valid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'valid")
 
 def ada95_rule102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'value",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'value")
 
 def ada95_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'version",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'version")
 
 def ada95_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_image",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_image")
 
 def ada95_rule105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_value",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_value")
 
 def ada95_rule106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_width",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_width")
 
 def ada95_rule107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'width",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'width")
 
 def ada95_rule108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'write",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="'write")
 
 def ada95_rule109(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def ada95_rule110(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ahk.py
+++ b/leo/modes/ahk.py
@@ -1030,65 +1030,53 @@ keywordsDictDict = {
 # Rules for ahk_main ruleset.
 
 def ahk_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def ahk_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def ahk_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def ahk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def ahk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def ahk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def ahk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def ahk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def ahk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def ahk_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def ahk_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def ahk_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def ahk_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def ahk_rule13(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def ahk_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern="::",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def ahk_rule15(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/antlr.py
+++ b/leo/modes/antlr.py
@@ -92,34 +92,22 @@ keywordsDictDict = {
 
 def antlr_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::javadoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::javadoc")
 
 def antlr_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def antlr_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def antlr_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def antlr_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def antlr_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def antlr_rule6(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/apacheconf.py
+++ b/leo/modes/apacheconf.py
@@ -956,27 +956,19 @@ keywordsDictDict = {
 # Rules for apacheconf_main ruleset.
 
 def apacheconf_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def apacheconf_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def apacheconf_rule2(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<(VirtualHost)[^>]*>", end="</$1>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="apacheconf::vhost", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="apacheconf::vhost")
 
 def apacheconf_rule3(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<(\\w+)[^>]*>", end="</$1>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="apacheconf::directive", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="apacheconf::directive")
 
 def apacheconf_rule4(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1055,27 +1047,19 @@ rulesDict1 = {
 # Rules for apacheconf_directive ruleset.
 
 def apacheconf_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#")
 
 def apacheconf_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def apacheconf_rule7(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<(VirtualHost)[^>]*>", end="</$1>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="apacheconf::vhost", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="apacheconf::vhost")
 
 def apacheconf_rule8(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<(\\w+)[^>]*>", end="</$1>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="apacheconf::directive", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="apacheconf::directive")
 
 def apacheconf_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1154,15 +1138,11 @@ rulesDict2 = {
 # Rules for apacheconf_vhost ruleset.
 
 def apacheconf_rule10(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#")
 
 def apacheconf_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def apacheconf_rule12(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/apdl.py
+++ b/leo/modes/apdl.py
@@ -2990,1445 +2990,1083 @@ keywordsDictDict = {
 
 def apdl_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="label", seq=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def apdl_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def apdl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def apdl_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ABBR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ABBR")
 
 def apdl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ABB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ABB")
 
 def apdl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*AFUN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*AFUN")
 
 def apdl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*AFU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*AFU")
 
 def apdl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ASK",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ASK")
 
 def apdl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFCLOS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CFCLOS")
 
 def apdl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CFC")
 
 def apdl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFOPEN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CFOPEN")
 
 def apdl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CFO")
 
 def apdl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFWRITE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CFWRITE")
 
 def apdl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFW",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CFW")
 
 def apdl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CREATE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CREATE")
 
 def apdl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CRE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CRE")
 
 def apdl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CYCLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CYCLE")
 
 def apdl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CYC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*CYC")
 
 def apdl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*DEL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*DEL")
 
 def apdl_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*DIM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*DIM")
 
 def apdl_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*DO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*DO")
 
 def apdl_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ELSEIF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ELSEIF")
 
 def apdl_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ELSE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ELSE")
 
 def apdl_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ENDDO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ENDDO")
 
 def apdl_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ENDIF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ENDIF")
 
 def apdl_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*END",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*END")
 
 def apdl_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EVAL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*EVAL")
 
 def apdl_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EVA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*EVA")
 
 def apdl_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EXIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*EXIT")
 
 def apdl_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EXI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*EXI")
 
 def apdl_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*GET",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*GET")
 
 def apdl_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*GO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*GO")
 
 def apdl_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*IF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*IF")
 
 def apdl_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*LIST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*LIST")
 
 def apdl_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*LIS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*LIS")
 
 def apdl_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFOURI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MFOURI")
 
 def apdl_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MFO")
 
 def apdl_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFUN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MFUN")
 
 def apdl_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MFU")
 
 def apdl_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOONEY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MOONEY")
 
 def apdl_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MOO")
 
 def apdl_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOPER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MOPER")
 
 def apdl_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MOP")
 
 def apdl_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MSG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*MSG")
 
 def apdl_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*REPEAT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*REPEAT")
 
 def apdl_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*REP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*REP")
 
 def apdl_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*SET",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*SET")
 
 def apdl_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*STATUS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*STATUS")
 
 def apdl_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*STA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*STA")
 
 def apdl_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*TREAD",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*TREAD")
 
 def apdl_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*TRE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*TRE")
 
 def apdl_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ULIB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ULIB")
 
 def apdl_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ULI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*ULI")
 
 def apdl_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*USE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*USE")
 
 def apdl_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VABS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VABS")
 
 def apdl_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VAB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VAB")
 
 def apdl_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCOL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VCOL")
 
 def apdl_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VCO")
 
 def apdl_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCUM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VCUM")
 
 def apdl_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VCU")
 
 def apdl_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VEDIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VEDIT")
 
 def apdl_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VED",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VED")
 
 def apdl_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFACT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VFACT")
 
 def apdl_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VFA")
 
 def apdl_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFILL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VFILL")
 
 def apdl_rule65(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VFI")
 
 def apdl_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFUN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VFUN")
 
 def apdl_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VFU")
 
 def apdl_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VGET",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VGET")
 
 def apdl_rule69(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VGE")
 
 def apdl_rule70(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VITRP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VITRP")
 
 def apdl_rule71(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VIT")
 
 def apdl_rule72(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VLEN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VLEN")
 
 def apdl_rule73(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VLE")
 
 def apdl_rule74(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VMASK",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VMASK")
 
 def apdl_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VMA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VMA")
 
 def apdl_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VOPER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VOPER")
 
 def apdl_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VOP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VOP")
 
 def apdl_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPLOT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VPLOT")
 
 def apdl_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VPL")
 
 def apdl_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPUT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VPUT")
 
 def apdl_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VPU")
 
 def apdl_rule82(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VREAD",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VREAD")
 
 def apdl_rule83(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VRE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VRE")
 
 def apdl_rule84(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VSCFUN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VSCFUN")
 
 def apdl_rule85(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VSC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VSC")
 
 def apdl_rule86(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VSTAT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VSTAT")
 
 def apdl_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VST")
 
 def apdl_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VWRITE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VWRITE")
 
 def apdl_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VWR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="*VWR")
 
 def apdl_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANFILE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANFILE")
 
 def apdl_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANF")
 
 def apdl_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANGLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANGLE")
 
 def apdl_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANG")
 
 def apdl_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANNOT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANNOT")
 
 def apdl_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANN")
 
 def apdl_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANUM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANUM")
 
 def apdl_rule97(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ANU")
 
 def apdl_rule98(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ASSIGN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ASSIGN")
 
 def apdl_rule99(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ASS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ASS")
 
 def apdl_rule100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUTO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AUTO")
 
 def apdl_rule101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AUT")
 
 def apdl_rule102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX15",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX15")
 
 def apdl_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX2",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX2")
 
 def apdl_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX")
 
 def apdl_rule105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AXLAB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AXLAB")
 
 def apdl_rule106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AXL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/AXL")
 
 def apdl_rule107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/BATCH",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/BATCH")
 
 def apdl_rule108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/BAT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/BAT")
 
 def apdl_rule109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLABEL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CLABEL")
 
 def apdl_rule110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CLA")
 
 def apdl_rule111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLEAR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CLEAR")
 
 def apdl_rule112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CLE")
 
 def apdl_rule113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLOG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CLOG")
 
 def apdl_rule114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CLO")
 
 def apdl_rule115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CMAP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CMAP")
 
 def apdl_rule116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CMA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CMA")
 
 def apdl_rule117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COLOR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/COLOR")
 
 def apdl_rule118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/COL")
 
 def apdl_rule119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/COM")
 
 def apdl_rule120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CONFIG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CONFIG")
 
 def apdl_rule121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CONTOUR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CONTOUR")
 
 def apdl_rule122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CON",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CON")
 
 def apdl_rule123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COPY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/COPY")
 
 def apdl_rule124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/COP")
 
 def apdl_rule125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CPLANE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CPLANE")
 
 def apdl_rule126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CPL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CPL")
 
 def apdl_rule127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CTYPE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CTYPE")
 
 def apdl_rule128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CTY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CTY")
 
 def apdl_rule129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CVAL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CVAL")
 
 def apdl_rule130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CVA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/CVA")
 
 def apdl_rule131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DELETE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DELETE")
 
 def apdl_rule132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DEL")
 
 def apdl_rule133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEVDISP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DEVDISP")
 
 def apdl_rule134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEVICE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DEVICE")
 
 def apdl_rule135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEV",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DEV")
 
 def apdl_rule136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DIST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DIST")
 
 def apdl_rule137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DIS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DIS")
 
 def apdl_rule138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DSCALE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DSCALE")
 
 def apdl_rule139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DSC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DSC")
 
 def apdl_rule140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DV3D",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DV3D")
 
 def apdl_rule141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DV3",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/DV3")
 
 def apdl_rule142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EDGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EDGE")
 
 def apdl_rule143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EDG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EDG")
 
 def apdl_rule144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EFACET",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EFACET")
 
 def apdl_rule145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EFA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EFA")
 
 def apdl_rule146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EOF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EOF")
 
 def apdl_rule147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ERASE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ERASE")
 
 def apdl_rule148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ERA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ERA")
 
 def apdl_rule149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ESHAPE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ESHAPE")
 
 def apdl_rule150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ESH",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ESH")
 
 def apdl_rule151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EXIT")
 
 def apdl_rule152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EXI")
 
 def apdl_rule153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXPAND",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EXPAND")
 
 def apdl_rule154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/EXP")
 
 def apdl_rule155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FACET",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FACET")
 
 def apdl_rule156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FAC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FAC")
 
 def apdl_rule157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FDELE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FDELE")
 
 def apdl_rule158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FDE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FDE")
 
 def apdl_rule159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FILNAME",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FILNAME")
 
 def apdl_rule160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FIL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FIL")
 
 def apdl_rule161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FOCUS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FOCUS")
 
 def apdl_rule162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FOC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FOC")
 
 def apdl_rule163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FORMAT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FORMAT")
 
 def apdl_rule164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FOR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FOR")
 
 def apdl_rule165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FTYPE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FTYPE")
 
 def apdl_rule166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FTY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/FTY")
 
 def apdl_rule167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCMD",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GCMD")
 
 def apdl_rule168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GCM")
 
 def apdl_rule169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCOLUMN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GCOLUMN")
 
 def apdl_rule170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GCO")
 
 def apdl_rule171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFILE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GFILE")
 
 def apdl_rule172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GFI")
 
 def apdl_rule173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFORMAT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GFORMAT")
 
 def apdl_rule174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GFO")
 
 def apdl_rule175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GLINE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GLINE")
 
 def apdl_rule176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GLI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GLI")
 
 def apdl_rule177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GMARKER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GMARKER")
 
 def apdl_rule178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GMA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GMA")
 
 def apdl_rule179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOLIST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GOLIST")
 
 def apdl_rule180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GOL")
 
 def apdl_rule181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOPR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GOPR")
 
 def apdl_rule182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GOP")
 
 def apdl_rule183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GO")
 
 def apdl_rule184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRAPHICS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRAPHICS")
 
 def apdl_rule185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRA")
 
 def apdl_rule186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRESUME",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRESUME")
 
 def apdl_rule187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRE")
 
 def apdl_rule188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRID",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRID")
 
 def apdl_rule189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRI")
 
 def apdl_rule190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GROPT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GROPT")
 
 def apdl_rule191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRO")
 
 def apdl_rule192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRTYP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRTYP")
 
 def apdl_rule193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GRT")
 
 def apdl_rule194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GSAVE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GSAVE")
 
 def apdl_rule195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GSA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GSA")
 
 def apdl_rule196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GST")
 
 def apdl_rule197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTHK",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GTHK")
 
 def apdl_rule198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTH",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GTH")
 
 def apdl_rule199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTYPE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GTYPE")
 
 def apdl_rule200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/GTY")
 
 def apdl_rule201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/HEADER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/HEADER")
 
 def apdl_rule202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/HEA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/HEA")
 
 def apdl_rule203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/INPUT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/INPUT")
 
 def apdl_rule204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/INP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/INP")
 
 def apdl_rule205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LARC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LARC")
 
 def apdl_rule206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LAR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LAR")
 
 def apdl_rule207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LIGHT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LIGHT")
 
 def apdl_rule208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LIG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LIG")
 
 def apdl_rule209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LINE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LINE")
 
 def apdl_rule210(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LIN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LIN")
 
 def apdl_rule211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSPEC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LSPEC")
 
 def apdl_rule212(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LSP")
 
 def apdl_rule213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSYMBOL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LSYMBOL")
 
 def apdl_rule214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/LSY")
 
 def apdl_rule215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MENU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MENU")
 
 def apdl_rule216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MEN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MEN")
 
 def apdl_rule217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MPLIB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MPLIB")
 
 def apdl_rule218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MPL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MPL")
 
 def apdl_rule219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MREP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MREP")
 
 def apdl_rule220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MRE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MRE")
 
 def apdl_rule221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MSTART",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MSTART")
 
 def apdl_rule222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/MST")
 
 def apdl_rule223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NERR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NERR")
 
 def apdl_rule224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NER")
 
 def apdl_rule225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOERASE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOERASE")
 
 def apdl_rule226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOE")
 
 def apdl_rule227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOLIST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOLIST")
 
 def apdl_rule228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOL")
 
 def apdl_rule229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOPR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOPR")
 
 def apdl_rule230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOP")
 
 def apdl_rule231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NORMAL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NORMAL")
 
 def apdl_rule232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NOR")
 
 def apdl_rule233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NUMBER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NUMBER")
 
 def apdl_rule234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NUM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/NUM")
 
 def apdl_rule235(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/OPT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/OPT")
 
 def apdl_rule236(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/OUTPUT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/OUTPUT")
 
 def apdl_rule237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/OUt",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/OUt")
 
 def apdl_rule238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PAGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PAGE")
 
 def apdl_rule239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PAG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PAG")
 
 def apdl_rule240(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PBC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PBC")
 
 def apdl_rule241(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PBF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PBF")
 
 def apdl_rule242(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCIRCLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PCIRCLE")
 
 def apdl_rule243(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PCI")
 
 def apdl_rule244(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCOPY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PCOPY")
 
 def apdl_rule245(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PCO")
 
 def apdl_rule246(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PLOPTS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PLOPTS")
 
 def apdl_rule247(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PLO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PLO")
 
 def apdl_rule248(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMACRO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PMACRO")
 
 def apdl_rule249(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PMA")
 
 def apdl_rule250(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMETH",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PMETH")
 
 def apdl_rule251(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PME",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PME")
 
 def apdl_rule252(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMORE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PMORE")
 
 def apdl_rule253(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PMO")
 
 def apdl_rule254(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PNUM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PNUM")
 
 def apdl_rule255(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PNU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PNU")
 
 def apdl_rule256(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POLYGON",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/POLYGON")
 
 def apdl_rule257(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/POL")
 
 def apdl_rule258(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POST26",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/POST26")
 
 def apdl_rule259(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POST1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/POST1")
 
 def apdl_rule260(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/POS")
 
 def apdl_rule261(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PREP7",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PREP7")
 
 def apdl_rule262(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PRE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PRE")
 
 def apdl_rule263(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSEARCH",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSEARCH")
 
 def apdl_rule264(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSE")
 
 def apdl_rule265(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSF")
 
 def apdl_rule266(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSPEC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSPEC")
 
 def apdl_rule267(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSP")
 
 def apdl_rule268(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSTATUS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSTATUS")
 
 def apdl_rule269(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PST")
 
 def apdl_rule270(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSYMB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSYMB")
 
 def apdl_rule271(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PSY")
 
 def apdl_rule272(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PWEDGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PWEDGE")
 
 def apdl_rule273(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PWE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/PWE")
 
 def apdl_rule274(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/QUIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/QUIT")
 
 def apdl_rule275(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/QUI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/QUI")
 
 def apdl_rule276(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RATIO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RATIO")
 
 def apdl_rule277(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RAT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RAT")
 
 def apdl_rule278(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RENAME",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RENAME")
 
 def apdl_rule279(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/REN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/REN")
 
 def apdl_rule280(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/REPLOT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/REPLOT")
 
 def apdl_rule281(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/REP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/REP")
 
 def apdl_rule282(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RESET",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RESET")
 
 def apdl_rule283(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RES",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RES")
 
 def apdl_rule284(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RGB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RGB")
 
 def apdl_rule285(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RUNST",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RUNST")
 
 def apdl_rule286(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RUN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/RUN")
 
 def apdl_rule287(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SECLIB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SECLIB")
 
 def apdl_rule288(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SEC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SEC")
 
 def apdl_rule289(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SEG",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SEG")
 
 def apdl_rule290(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHADE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHADE")
 
 def apdl_rule291(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHA")
 
 def apdl_rule292(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHOWDISP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHOWDISP")
 
 def apdl_rule293(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHOW",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHOW")
 
 def apdl_rule294(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHO")
 
 def apdl_rule295(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHRINK",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHRINK")
 
 def apdl_rule296(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHR",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SHR")
 
 def apdl_rule297(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SOLU",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SOLU")
 
 def apdl_rule298(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SOL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SOL")
 
 def apdl_rule299(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SSCALE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SSCALE")
 
 def apdl_rule300(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SSC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SSC")
 
 def apdl_rule301(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STATUS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/STATUS")
 
 def apdl_rule302(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/STA")
 
 def apdl_rule303(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STITLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/STITLE")
 
 def apdl_rule304(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/STI")
 
 def apdl_rule305(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SYP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SYP")
 
 def apdl_rule306(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SYS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/SYS")
 
 def apdl_rule307(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TITLE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TITLE")
 
 def apdl_rule308(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TIT")
 
 def apdl_rule309(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TLABEL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TLABEL")
 
 def apdl_rule310(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TLA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TLA")
 
 def apdl_rule311(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRIAD",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TRIAD")
 
 def apdl_rule312(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TRI")
 
 def apdl_rule313(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRLCY",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TRLCY")
 
 def apdl_rule314(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRL",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TRL")
 
 def apdl_rule315(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TSPEC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TSPEC")
 
 def apdl_rule316(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TSP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TSP")
 
 def apdl_rule317(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TYPE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TYPE")
 
 def apdl_rule318(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TYP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/TYP")
 
 def apdl_rule319(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UCMD",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/UCMD")
 
 def apdl_rule320(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UCM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/UCM")
 
 def apdl_rule321(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UIS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/UIS")
 
 def apdl_rule322(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/UI")
 
 def apdl_rule323(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UNITS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/UNITS")
 
 def apdl_rule324(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UNI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/UNI")
 
 def apdl_rule325(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/USER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/USER")
 
 def apdl_rule326(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/USE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/USE")
 
 def apdl_rule327(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VCONE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VCONE")
 
 def apdl_rule328(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VCO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VCO")
 
 def apdl_rule329(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VIEW",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VIEW")
 
 def apdl_rule330(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VIE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VIE")
 
 def apdl_rule331(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VSCALE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VSCALE")
 
 def apdl_rule332(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VSC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VSC")
 
 def apdl_rule333(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VUP",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/VUP")
 
 def apdl_rule334(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WAIT",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/WAIT")
 
 def apdl_rule335(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WAI",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/WAI")
 
 def apdl_rule336(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WINDOW",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/WINDOW")
 
 def apdl_rule337(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WIN",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/WIN")
 
 def apdl_rule338(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/XRANGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/XRANGE")
 
 def apdl_rule339(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/XRA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/XRA")
 
 def apdl_rule340(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/YRANGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/YRANGE")
 
 def apdl_rule341(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/YRA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/YRA")
 
 def apdl_rule342(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ZOOM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ZOOM")
 
 def apdl_rule343(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ZOO",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="/ZOO")
 
 def apdl_rule344(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def apdl_rule345(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def apdl_rule346(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def apdl_rule347(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def apdl_rule348(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def apdl_rule349(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def apdl_rule350(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def apdl_rule351(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=";")
 
 def apdl_rule352(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def apdl_rule353(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def apdl_rule354(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%C",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="%C")
 
 def apdl_rule355(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%G",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="%G")
 
 def apdl_rule356(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%I",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="%I")
 
 def apdl_rule357(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="%/")
 
 def apdl_rule358(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="%", end="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def apdl_rule359(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/applescript.py
+++ b/leo/modes/applescript.py
@@ -205,107 +205,78 @@ keywordsDictDict = {
 # Rules for applescript_main ruleset.
 
 def applescript_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)")
 
 def applescript_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def applescript_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def applescript_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def applescript_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def applescript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def applescript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def applescript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def applescript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def applescript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def applescript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def applescript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def applescript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def applescript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def applescript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def applescript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def applescript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def applescript_rule17(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="application[\\t\\s]+responses",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="application[\\t\\s]+responses")
 
 def applescript_rule18(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="current[\\t\\s]+application",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="current[\\t\\s]+application")
 
 def applescript_rule19(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="white[\\t\\s]+space",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="white[\\t\\s]+space")
 
 def applescript_rule20(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="all[\\t\\s]+caps",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="all[\\t\\s]+caps")
 
 def applescript_rule21(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="all[\\t\\s]+lowercase",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="all[\\t\\s]+lowercase")
 
 def applescript_rule22(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="small[\\t\\s]+caps",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="small[\\t\\s]+caps")
 
 def applescript_rule23(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="missing[\\t\\s]+value",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="missing[\\t\\s]+value")
 
 def applescript_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/asciidoc.py
+++ b/leo/modes/asciidoc.py
@@ -57,240 +57,179 @@ keywordsDictDict = {
 
 def asciidoc_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="=====",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="====",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="===",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="==",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="=",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule5(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="markup", regexp="^[=-]{4,}",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="~~~~",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="^^^^",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule8(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="++++",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule9(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="comment2", begin="^\\/\\/\\/\\/+\\s*$", end="\\/\\/\\/\\/\\s*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule10(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment3", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment3", seq="//")
 
 def asciidoc_rule11(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal1", begin="^----+\\s*$", end="----\\s*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule12(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin="^\\+\\+\\+\\++\\s*$", end="\\+\\+\\+\\+\\s*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule13(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal3", begin="^\\.\\.\\.\\.+\\s*$", end="\\.\\.\\.\\.\\s*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule14(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal4", begin="^\\*\\*\\*\\*+\\s*$", end="\\*\\*\\*\\*\\s*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule15(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="comment4", begin="^____+\\s*$", end="____\\s*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule16(colorer, s, i):
-    return colorer.match_eol_span_regexp(s, i, kind="label", regexp="^\\s*\\S+:.+\\[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="label", regexp="^\\s*\\S+:.+\\[")
 
 def asciidoc_rule17(colorer, s, i):
-    return colorer.match_eol_span_regexp(s, i, kind="label", regexp="^\\s*\\S+::.+\\[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="label", regexp="^\\s*\\S+::.+\\[")
 
 def asciidoc_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="[[", end="]]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule19(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="<<", end=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="label", begin="<<", end=">>")
 
 def asciidoc_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="[", end="]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule21(colorer, s, i):
-    return colorer.match_eol_span_regexp(s, i, kind="literal1", regexp="^:.{1,20}:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="literal1", regexp="^:.{1,20}:")
 
 def asciidoc_rule22(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])_\\S", end="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])_\\S", end="_")
 
 def asciidoc_rule23(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])'\\S", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])'\\S", end="'")
 
 def asciidoc_rule24(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword1", begin="(^|[\\s\\.,\\(])\\*[^\\*\\s]", end="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="keyword1", begin="(^|[\\s\\.,\\(])\\*[^\\*\\s]", end="*")
 
 def asciidoc_rule25(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword2", begin="(^|[\\s\\.,\\(])`\\S", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="keyword2", begin="(^|[\\s\\.,\\(])`\\S", end="`")
 
 def asciidoc_rule26(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword2", begin="(^|[\\s\\.,\\(])\\+\\S", end="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="keyword2", begin="(^|[\\s\\.,\\(])\\+\\S", end="+")
 
 def asciidoc_rule27(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="-",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule28(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule29(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="**",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule30(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="***",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule31(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="****",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule32(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="*****",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule33(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=".",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule34(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="..",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule35(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="...",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule36(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="....",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule37(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=".....",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def asciidoc_rule38(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="comment4", pattern="::",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=False)
+          at_whitespace_end=True)
 
 def asciidoc_rule39(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="comment4", pattern=":::",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=False)
+          at_whitespace_end=True)
 
 def asciidoc_rule40(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="comment4", pattern="::::",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=False)
+          at_whitespace_end=True)
 
 def asciidoc_rule41(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="^\\.\\S",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule42(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="\\s*NOTE:", end=" ",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule43(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="operator", seq="|==",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def asciidoc_rule44(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="digit", pattern="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="digit", pattern="|")
 
 def asciidoc_rule45(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="NOTE:", end=" ",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def asciidoc_rule46(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="(((", end=")))",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="markup", begin="(((", end=")))")
 
 def asciidoc_rule47(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/asp.py
+++ b/leo/modes/asp.py
@@ -124,97 +124,69 @@ keywordsDictDict = {
 
 def asp_rule0(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"VBSCRIPT\"%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="asp::aspvb")
+          delegate="asp::aspvb")
 
 def asp_rule1(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"JSCRIPT\"%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="asp::aspjs")
+          delegate="asp::aspjs")
 
 def asp_rule2(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"JAVASCRIPT\"%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="asp::aspjs")
+          delegate="asp::aspjs")
 
 def asp_rule3(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"PERLSCRIPT\"%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="asp::asppl")
+          delegate="asp::asppl")
 
 def asp_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 def asp_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"vbscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 def asp_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"perlscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def asp_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->")
 
 def asp_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def asp_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="css::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="css::main")
 
 def asp_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::aspvb_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::aspvb_tags")
 
 def asp_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for asp_main ruleset.
 rulesDict1 = {
@@ -226,87 +198,57 @@ rulesDict1 = {
 
 def asp_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 def asp_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"vbscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 def asp_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule21(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"perlscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def asp_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule24(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule25(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->")
 
 def asp_rule26(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def asp_rule27(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="css::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="css::main")
 
 def asp_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="</", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::aspvb_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::aspvb_tags")
 
 def asp_rule29(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::aspvb_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::aspvb_tags")
 
 def asp_rule30(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for asp_aspvb ruleset.
 rulesDict2 = {
@@ -318,87 +260,57 @@ rulesDict2 = {
 
 def asp_rule31(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule32(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"vbscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 def asp_rule33(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule35(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"perlscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def asp_rule36(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule37(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule38(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule39(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->")
 
 def asp_rule40(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def asp_rule41(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="css::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="css::main")
 
 def asp_rule42(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="</", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::aspjs_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::aspjs_tags")
 
 def asp_rule43(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::aspjs_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::aspjs_tags")
 
 def asp_rule44(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for asp_aspjs ruleset.
 rulesDict3 = {
@@ -410,87 +322,57 @@ rulesDict3 = {
 
 def asp_rule45(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def asp_rule46(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"vbscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 def asp_rule47(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule48(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def asp_rule49(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"perlscript\" runat=\"server\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def asp_rule50(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::asppl_csjs", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::asppl_csjs")
 
 def asp_rule51(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::asppl_csjs", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::asppl_csjs")
 
 def asp_rule52(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::asppl_csjs", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::asppl_csjs")
 
 def asp_rule53(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->")
 
 def asp_rule54(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def asp_rule55(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="css::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="css::main")
 
 def asp_rule56(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="</", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::asppl_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::asppl_tags")
 
 def asp_rule57(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="asp::asppl_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="asp::asppl_tags")
 
 def asp_rule58(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for asp_asppl ruleset.
 rulesDict4 = {
@@ -502,9 +384,7 @@ rulesDict4 = {
 
 def asp_rule59(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="vbscript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="vbscript::main")
 
 # Rules dict for asp_aspvb_tags ruleset.
 rulesDict5 = {
@@ -515,9 +395,7 @@ rulesDict5 = {
 
 def asp_rule60(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 # Rules dict for asp_aspjs_tags ruleset.
 rulesDict6 = {
@@ -528,9 +406,7 @@ rulesDict6 = {
 
 def asp_rule61(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 # Rules dict for asp_asppl_tags ruleset.
 rulesDict7 = {

--- a/leo/modes/aspect_j.py
+++ b/leo/modes/aspect_j.py
@@ -121,117 +121,88 @@ keywordsDictDict = {
 # Rules for aspect_j_main ruleset.
 
 def aspect_j_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def aspect_j_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::javadoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::javadoc")
 
 def aspect_j_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def aspect_j_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def aspect_j_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def aspect_j_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def aspect_j_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def aspect_j_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def aspect_j_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def aspect_j_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def aspect_j_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def aspect_j_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def aspect_j_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def aspect_j_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".*")
 
 def aspect_j_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def aspect_j_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def aspect_j_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def aspect_j_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def aspect_j_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def aspect_j_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def aspect_j_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def aspect_j_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def aspect_j_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def aspect_j_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def aspect_j_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def aspect_j_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def aspect_j_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_6502.py
+++ b/leo/modes/assembly_6502.py
@@ -141,125 +141,99 @@ keywordsDictDict = {
 # Rules for assembly_6502_main ruleset.
 
 def assembly_6502_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def assembly_6502_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_6502_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_6502_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=" ",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def assembly_6502_rule4(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern="\t",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def assembly_6502_rule5(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="digit", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def assembly_6502_rule6(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="digit", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def assembly_6502_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def assembly_6502_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def assembly_6502_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def assembly_6502_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def assembly_6502_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def assembly_6502_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def assembly_6502_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def assembly_6502_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def assembly_6502_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def assembly_6502_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def assembly_6502_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def assembly_6502_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def assembly_6502_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def assembly_6502_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<")
 
 def assembly_6502_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def assembly_6502_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def assembly_6502_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def assembly_6502_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def assembly_6502_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def assembly_6502_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def assembly_6502_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&&")
 
 def assembly_6502_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def assembly_6502_rule29(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_macro32.py
+++ b/leo/modes/assembly_macro32.py
@@ -530,113 +530,89 @@ keywordsDictDict = {
 # Rules for assembly_macro32_main ruleset.
 
 def assembly_macro32_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def assembly_macro32_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_macro32_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_macro32_rule3(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="%%",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_macro32_rule4(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="%",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def assembly_macro32_rule5(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_macro32_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="B^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="B^")
 
 def assembly_macro32_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="D^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="D^")
 
 def assembly_macro32_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="O^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="O^")
 
 def assembly_macro32_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="X^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="X^")
 
 def assembly_macro32_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="A^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="A^")
 
 def assembly_macro32_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="M^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="M^")
 
 def assembly_macro32_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="F^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="F^")
 
 def assembly_macro32_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="C^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="C^")
 
 def assembly_macro32_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="L^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="L^")
 
 def assembly_macro32_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="G^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="G^")
 
 def assembly_macro32_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def assembly_macro32_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def assembly_macro32_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def assembly_macro32_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def assembly_macro32_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def assembly_macro32_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def assembly_macro32_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def assembly_macro32_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def assembly_macro32_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def assembly_macro32_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def assembly_macro32_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_mcs51.py
+++ b/leo/modes/assembly_mcs51.py
@@ -194,113 +194,89 @@ keywordsDictDict = {
 # Rules for assembly_mcs51_main ruleset.
 
 def assembly_mcs51_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def assembly_mcs51_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_mcs51_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_mcs51_rule3(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="%%",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_mcs51_rule4(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def assembly_mcs51_rule5(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_mcs51_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=",")
 
 def assembly_mcs51_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=":")
 
 def assembly_mcs51_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="(")
 
 def assembly_mcs51_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=")")
 
 def assembly_mcs51_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="]")
 
 def assembly_mcs51_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="[")
 
 def assembly_mcs51_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="$")
 
 def assembly_mcs51_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def assembly_mcs51_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def assembly_mcs51_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def assembly_mcs51_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def assembly_mcs51_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def assembly_mcs51_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def assembly_mcs51_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def assembly_mcs51_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def assembly_mcs51_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def assembly_mcs51_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def assembly_mcs51_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def assembly_mcs51_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def assembly_mcs51_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def assembly_mcs51_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_parrot.py
+++ b/leo/modes/assembly_parrot.py
@@ -137,38 +137,30 @@ keywordsDictDict = {
 
 def assembly_parrot_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_parrot_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def assembly_parrot_rule2(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_parrot_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def assembly_parrot_rule4(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="I\\d{1,2}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="I\\d{1,2}")
 
 def assembly_parrot_rule5(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="S\\d{1,2}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="S\\d{1,2}")
 
 def assembly_parrot_rule6(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="N\\d{1,2}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="N\\d{1,2}")
 
 def assembly_parrot_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="P\\d{1,2}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="P\\d{1,2}")
 
 def assembly_parrot_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_r2000.py
+++ b/leo/modes/assembly_r2000.py
@@ -245,25 +245,19 @@ keywordsDictDict = {
 # Rules for assembly_r2000_main ruleset.
 
 def assembly_r2000_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def assembly_r2000_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_r2000_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_r2000_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def assembly_r2000_rule4(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_x86.py
+++ b/leo/modes/assembly_x86.py
@@ -822,85 +822,68 @@ keywordsDictDict = {
 # Rules for assembly_x86_main ruleset.
 
 def assembly_x86_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def assembly_x86_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_x86_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def assembly_x86_rule3(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="%%",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_x86_rule4(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="%",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def assembly_x86_rule5(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def assembly_x86_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def assembly_x86_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def assembly_x86_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def assembly_x86_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def assembly_x86_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def assembly_x86_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def assembly_x86_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def assembly_x86_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def assembly_x86_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def assembly_x86_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def assembly_x86_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def assembly_x86_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def assembly_x86_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def assembly_x86_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/awk.py
+++ b/leo/modes/awk.py
@@ -103,92 +103,70 @@ keywordsDictDict = {
 
 def awk_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def awk_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def awk_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def awk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def awk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def awk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def awk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def awk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def awk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def awk_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def awk_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def awk_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def awk_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def awk_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def awk_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def awk_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def awk_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def awk_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def awk_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def awk_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def awk_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def awk_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/b.py
+++ b/leo/modes/b.py
@@ -157,137 +157,99 @@ keywordsDictDict = {
 # Rules for b_main ruleset.
 
 def b_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*?", end="?*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="/*?", end="?*/")
 
 def b_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def b_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def b_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def b_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def b_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def b_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def b_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$0",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$0")
 
 def b_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def b_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def b_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def b_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def b_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def b_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def b_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def b_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def b_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def b_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def b_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def b_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def b_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def b_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def b_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def b_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def b_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def b_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def b_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def b_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def b_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def b_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def b_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def b_rule31(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/bbj.py
+++ b/leo/modes/bbj.py
@@ -295,86 +295,65 @@ keywordsDictDict = {
 # Rules for bbj_main ruleset.
 
 def bbj_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def bbj_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def bbj_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def bbj_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="REM",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="REM")
 
 def bbj_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bbj_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def bbj_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def bbj_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def bbj_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def bbj_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def bbj_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def bbj_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def bbj_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def bbj_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def bbj_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def bbj_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="and",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="and")
 
 def bbj_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="or",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="or")
 
 def bbj_rule17(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def bbj_rule18(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def bbj_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/bcel.py
+++ b/leo/modes/bcel.py
@@ -266,57 +266,42 @@ keywordsDictDict = {
 # Rules for bcel_main ruleset.
 
 def bcel_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def bcel_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bcel::javadoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bcel::javadoc")
 
 def bcel_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def bcel_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def bcel_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def bcel_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def bcel_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="%")
 
 def bcel_rule7(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="#")
 
 def bcel_rule8(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def bcel_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def bcel_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def bcel_rule11(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/bibtex.py
+++ b/leo/modes/bibtex.py
@@ -917,189 +917,127 @@ keywordsDictDict = {
 # Rules for bibtex_main ruleset.
 
 def bibtex_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def bibtex_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@article{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::article", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::article")
 
 def bibtex_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@article(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::article", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::article")
 
 def bibtex_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@book{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::book", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::book")
 
 def bibtex_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@book(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::book", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::book")
 
 def bibtex_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@booklet{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::booklet", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::booklet")
 
 def bibtex_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@booklet(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::booklet", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::booklet")
 
 def bibtex_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@conference{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::conference", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::conference")
 
 def bibtex_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@conference(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::conference", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::conference")
 
 def bibtex_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@inbook{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::inbook", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::inbook")
 
 def bibtex_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@inbook(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::inbook", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::inbook")
 
 def bibtex_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@incollection{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::incollection", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::incollection")
 
 def bibtex_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@incollection(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::incollection", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::incollection")
 
 def bibtex_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@inproceedings{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::inproceedings", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::inproceedings")
 
 def bibtex_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@inproceedings(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::inproceedings", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::inproceedings")
 
 def bibtex_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@manual{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::manual", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::manual")
 
 def bibtex_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@manual(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::manual", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::manual")
 
 def bibtex_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@mastersthesis{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::mastersthesis", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::mastersthesis")
 
 def bibtex_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@mastersthesis(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::mastersthesis", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::mastersthesis")
 
 def bibtex_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@misc{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::misc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::misc")
 
 def bibtex_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@misc(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::misc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::misc")
 
 def bibtex_rule21(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@phdthesis{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::phdthesis", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::phdthesis")
 
 def bibtex_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@phdthesis(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::phdthesis", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::phdthesis")
 
 def bibtex_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@proceedings{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::proceedings", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::proceedings")
 
 def bibtex_rule24(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@proceedings(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::proceedings", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::proceedings")
 
 def bibtex_rule25(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@techreport{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::techreport", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::techreport")
 
 def bibtex_rule26(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@techreport(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::techreport", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::techreport")
 
 def bibtex_rule27(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@unpublished{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::unpublished", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::unpublished")
 
 def bibtex_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@unpublished(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::unpublished", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::unpublished")
 
 def bibtex_rule29(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@string{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::string", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::string")
 
 def bibtex_rule30(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@string(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::string", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::string")
 
 # Rules dict for bibtex_main ruleset.
 rulesDict1 = {
@@ -1111,59 +1049,44 @@ rulesDict1 = {
 
 def bibtex_rule31(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule32(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule35(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule37(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule38(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule39(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule40(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule41(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule42(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule43(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule44(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1243,59 +1166,44 @@ rulesDict2 = {
 
 def bibtex_rule45(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule46(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule49(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule50(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule51(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule52(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule53(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule54(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule55(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule56(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule57(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule58(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1375,59 +1283,44 @@ rulesDict3 = {
 
 def bibtex_rule59(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule60(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule63(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule64(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule65(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule66(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule67(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule68(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule69(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule70(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule71(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule72(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1507,59 +1400,44 @@ rulesDict4 = {
 
 def bibtex_rule73(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule74(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule77(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule78(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule79(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule80(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule81(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule82(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule83(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule84(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule85(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule86(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1639,59 +1517,44 @@ rulesDict5 = {
 
 def bibtex_rule87(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule88(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule91(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule92(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule93(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule94(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule95(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule96(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule97(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule98(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule99(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule100(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1771,59 +1634,44 @@ rulesDict6 = {
 
 def bibtex_rule101(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule102(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule105(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule106(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule107(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule108(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule109(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule110(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule111(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule112(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule113(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule114(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1903,59 +1751,44 @@ rulesDict7 = {
 
 def bibtex_rule115(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule116(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule119(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule120(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule121(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule122(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule123(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule124(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule125(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule126(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule127(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule128(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2035,59 +1868,44 @@ rulesDict8 = {
 
 def bibtex_rule129(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule130(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule133(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule134(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule135(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule136(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule137(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule138(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule139(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule140(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule141(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule142(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2167,59 +1985,44 @@ rulesDict9 = {
 
 def bibtex_rule143(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule144(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule147(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule148(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule149(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule150(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule151(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule152(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule153(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule154(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule155(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule156(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2299,59 +2102,44 @@ rulesDict10 = {
 
 def bibtex_rule157(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule158(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule161(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule162(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule163(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule164(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule165(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule166(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule167(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule168(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule169(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule170(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2431,59 +2219,44 @@ rulesDict11 = {
 
 def bibtex_rule171(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule172(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule175(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule176(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule177(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule178(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule179(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule180(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule181(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule182(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule183(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule184(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2563,59 +2336,44 @@ rulesDict12 = {
 
 def bibtex_rule185(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule186(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule189(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule190(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule191(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule192(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule193(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule194(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule195(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule196(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule197(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule198(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2695,59 +2453,44 @@ rulesDict13 = {
 
 def bibtex_rule199(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule200(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule203(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule204(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule205(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule206(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule207(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule208(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule209(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule210(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule211(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule212(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2827,59 +2570,44 @@ rulesDict14 = {
 
 def bibtex_rule213(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule214(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule217(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
 
 def bibtex_rule218(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="2[0-9]*")
 
 def bibtex_rule219(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="3[0-9]*")
 
 def bibtex_rule220(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="4[0-9]*")
 
 def bibtex_rule221(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="5[0-9]*")
 
 def bibtex_rule222(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="6[0-9]*")
 
 def bibtex_rule223(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="7[0-9]*")
 
 def bibtex_rule224(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="8[0-9]*")
 
 def bibtex_rule225(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="9[0-9]*")
 
 def bibtex_rule226(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2958,26 +2686,18 @@ rulesDict15 = {
 # Rules for bibtex_textbraced ruleset.
 
 def bibtex_rule227(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}")
 
 def bibtex_rule228(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule229(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="\\\"")
 
 # Rules dict for bibtex_textbraced ruleset.
 rulesDict16 = {
@@ -2990,19 +2710,14 @@ rulesDict16 = {
 
 def bibtex_rule231(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule232(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="\\\"")
 
 # Rules dict for bibtex_textquoted ruleset.
 rulesDict17 = {
@@ -3014,33 +2729,23 @@ rulesDict17 = {
 
 def bibtex_rule234(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textquoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textquoted")
 
 def bibtex_rule235(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="bibtex::textbraced", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="bibtex::textbraced")
 
 def bibtex_rule236(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}")
 
 def bibtex_rule237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="\\\"")
 
 # Rules dict for bibtex_string ruleset.
 rulesDict18 = {

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -134,123 +134,92 @@ keywordsDictDict = {
 
 def c_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def c_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def c_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def c_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def c_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def c_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="##")
 
 def c_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="c::cpp", exclude_match=False)
+          delegate="c::cpp")
 
 def c_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def c_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def c_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def c_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def c_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def c_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def c_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def c_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def c_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def c_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def c_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def c_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def c_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def c_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def c_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def c_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def c_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def c_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def c_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def c_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -346,15 +315,11 @@ rulesDict1 = {
 # Rules for c_cpp ruleset.
 
 def c_rule28(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def c_rule29(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="include",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="c::include", exclude_match=False)
+          delegate="c::include")
 
 def c_rule30(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/chill.py
+++ b/leo/modes/chill.py
@@ -96,112 +96,81 @@ keywordsDictDict = {
 # Rules for chill_main ruleset.
 
 def chill_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<>", end="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<>", end="<>")
 
 def chill_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def chill_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def chill_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="H'", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def chill_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def chill_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def chill_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def chill_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def chill_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def chill_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def chill_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def chill_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def chill_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def chill_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def chill_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def chill_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def chill_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def chill_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def chill_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def chill_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def chill_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/=")
 
 def chill_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def chill_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def chill_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def chill_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def chill_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/clojure.py
+++ b/leo/modes/clojure.py
@@ -806,215 +806,146 @@ keywordsDictDict = {
 
 def clojure_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword4", begin="*", end="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="#^(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="@(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="^(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="`(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="'(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="#_(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="#(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="#^[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="@[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="^[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="'[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="#^{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="@{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="^{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="'{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="#^#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="@#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule21(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="^#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="'#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::main")
 
 def clojure_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="#'")
 
 def clojure_rule25(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal3", pattern="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal3", pattern="'")
 
 def clojure_rule26(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="label", pattern="^")
 
 def clojure_rule27(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="label", pattern="@")
 
 def clojure_rule28(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal3", pattern=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal3", pattern=".")
 
 def clojure_rule29(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="markup", pattern="#^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="markup", pattern="#^")
 
 def clojure_rule30(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment4", seq=";;;;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment4", seq=";;;;")
 
 def clojure_rule31(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment3", seq=";;;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment3", seq=";;;")
 
 def clojure_rule32(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";;")
 
 def clojure_rule33(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def clojure_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="#\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::regexps", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::regexps")
 
 def clojure_rule35(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="clojure::strings", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="clojure::strings")
 
 def clojure_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\\\(.|newline|space|tab)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\\\(.|newline|space|tab)")
 
 def clojure_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal4", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal4", seq=".")
 
 def clojure_rule38(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern=":")
 
 def clojure_rule39(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -1112,8 +1043,7 @@ rulesDict1 = {
 # Rules for clojure_strings ruleset.
 
 def clojure_rule40(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\\\.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\\\.")
 
 def clojure_rule41(colorer, s, i):
     j = s.find('"', i)
@@ -1208,8 +1138,7 @@ rulesDict2 = {
 # Rules for clojure_regexps ruleset.
 
 def clojure_rule42(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\\\.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\\\.")
 
 def clojure_rule43(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/cobol.py
+++ b/leo/modes/cobol.py
@@ -666,86 +666,61 @@ keywordsDictDict = {
 
 def cobol_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def cobol_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def cobol_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def cobol_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def cobol_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" >=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=" >=")
 
 def cobol_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" <=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=" <=")
 
 def cobol_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def cobol_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def cobol_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def cobol_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def cobol_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def cobol_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" > ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=" > ")
 
 def cobol_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" < ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=" < ")
 
 def cobol_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def cobol_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" & ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=" & ")
 
 def cobol_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def cobol_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def cobol_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def cobol_rule18(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="EXEC SQL", end="END-EXEC",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="EXEC SQL", end="END-EXEC")
 
 def cobol_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/coffeescript.py
+++ b/leo/modes/coffeescript.py
@@ -132,165 +132,117 @@ keywordsDictDict = {
 # Rules for coffeescript_main ruleset.
 
 def coffeescript_rule0(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="comment2", begin="###(?!#)", end="#{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="comment2", begin="###(?!#)", end="#{3,}")
 
 def coffeescript_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def coffeescript_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"\"\"", end="\"\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coffeescript::doublequoteliteral", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coffeescript::doublequoteliteral")
 
 def coffeescript_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''")
 
 def coffeescript_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coffeescript::doublequoteliteral", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coffeescript::doublequoteliteral")
 
 def coffeescript_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="'", end="'")
 
 def coffeescript_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def coffeescript_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="///", end="///",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coffeescript::hereregexp", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coffeescript::hereregexp")
 
 def coffeescript_rule8(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="/(?![\\s=*])", end="/[igmy]{0,4}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def coffeescript_rule9(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="function", pattern="(")
 
 def coffeescript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def coffeescript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def coffeescript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def coffeescript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def coffeescript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def coffeescript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def coffeescript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def coffeescript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def coffeescript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def coffeescript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def coffeescript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def coffeescript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def coffeescript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def coffeescript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def coffeescript_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def coffeescript_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def coffeescript_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def coffeescript_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def coffeescript_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def coffeescript_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def coffeescript_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def coffeescript_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def coffeescript_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def coffeescript_rule33(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="@([a-zA-Z\\$_][a-zA-Z0-9\\$_]*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="@([a-zA-Z\\$_][a-zA-Z0-9\\$_]*)")
 
 def coffeescript_rule34(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="([a-zA-Z\\$_][a-zA-Z0-9\\$_]*)(?=\\s*(?:[:\\.]|\\?\\.))",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="([a-zA-Z\\$_][a-zA-Z0-9\\$_]*)(?=\\s*(?:[:\\.]|\\?\\.))")
 
 def coffeescript_rule35(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="for\\s+own(?![a-zA-Z0-9\\$_])",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="for\\s+own(?![a-zA-Z0-9\\$_])")
 
 def coffeescript_rule36(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -394,9 +346,7 @@ rulesDict1 = {
 
 def coffeescript_rule37(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coffeescript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coffeescript::main")
 
 # Rules dict for coffeescript_doublequoteliteral ruleset.
 rulesDict2 = {
@@ -407,14 +357,10 @@ rulesDict2 = {
 
 def coffeescript_rule38(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coffeescript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coffeescript::main")
 
 def coffeescript_rule39(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 # Rules dict for coffeescript_hereregexp ruleset.
 rulesDict3 = {

--- a/leo/modes/coldfusion.py
+++ b/leo/modes/coldfusion.py
@@ -506,69 +506,44 @@ keywordsDictDict = {
 # Rules for coldfusion_main ruleset.
 
 def coldfusion_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment4", begin="<!---", end="--->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment4", begin="<!---", end="--->")
 
 def coldfusion_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def coldfusion_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def coldfusion_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="<!--", end="-->")
 
 def coldfusion_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="<CFSCRIPT", end="</CFSCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::cfscript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::cfscript")
 
 def coldfusion_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="<CF", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::cftags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::cftags")
 
 def coldfusion_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="</CF", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::cftags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::cftags")
 
 def coldfusion_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::javascript")
 
 def coldfusion_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::css")
 
 def coldfusion_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::tags")
 
 def coldfusion_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for coldfusion_main ruleset.
 rulesDict1 = {
@@ -580,38 +555,25 @@ rulesDict1 = {
 # Rules for coldfusion_tags ruleset.
 
 def coldfusion_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def coldfusion_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def coldfusion_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def coldfusion_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="<CF", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::cftags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::cftags")
 
 def coldfusion_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="</CF", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::cftags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::cftags")
 
 def coldfusion_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="<CFSCRIPT", end="</CFSCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="coldfusion::cfscript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="coldfusion::cfscript")
 
 # Rules dict for coldfusion_tags ruleset.
 rulesDict2 = {
@@ -624,75 +586,52 @@ rulesDict2 = {
 # Rules for coldfusion_cfscript ruleset.
 
 def coldfusion_rule17(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def coldfusion_rule18(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def coldfusion_rule19(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="label", begin="\"", end="\"")
 
 def coldfusion_rule20(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="label", begin="'", end="'")
 
 def coldfusion_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal2", seq="(")
 
 def coldfusion_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal2", seq=")")
 
 def coldfusion_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def coldfusion_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def coldfusion_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def coldfusion_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def coldfusion_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def coldfusion_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def coldfusion_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="><",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="><")
 
 def coldfusion_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def coldfusion_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!!")
 
 def coldfusion_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&&")
 
 def coldfusion_rule33(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -782,30 +721,19 @@ rulesDict3 = {
 # Rules for coldfusion_cftags ruleset.
 
 def coldfusion_rule34(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def coldfusion_rule35(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def coldfusion_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def coldfusion_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="##")
 
 def coldfusion_rule38(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="#", end="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="#", end="#")
 
 def coldfusion_rule39(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/cplusplus.py
+++ b/leo/modes/cplusplus.py
@@ -117,127 +117,95 @@ keywordsDictDict = {
 
 def cplusplus_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def cplusplus_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def cplusplus_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def cplusplus_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def cplusplus_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def cplusplus_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="##")
 
 def cplusplus_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="c::cpp", exclude_match=False)
+          delegate="c::cpp")
 
 def cplusplus_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def cplusplus_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def cplusplus_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def cplusplus_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def cplusplus_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def cplusplus_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def cplusplus_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def cplusplus_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def cplusplus_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def cplusplus_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def cplusplus_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def cplusplus_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def cplusplus_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def cplusplus_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def cplusplus_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def cplusplus_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def cplusplus_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def cplusplus_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def cplusplus_rule25(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="function", pattern="::")
 
 def cplusplus_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def cplusplus_rule27(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def cplusplus_rule28(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/csharp.py
+++ b/leo/modes/csharp.py
@@ -131,193 +131,135 @@ keywordsDictDict = {
 # Rules for csharp_main ruleset.
 
 def csharp_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def csharp_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment3", seq="///",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="csharp::doc_comment", exclude_match=False)
+          delegate="csharp::doc_comment")
 
 def csharp_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def csharp_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="@\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=True, no_line_break=False, no_word_break=False)
+          no_escape=True)
 
 def csharp_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def csharp_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def csharp_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#if",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#if")
 
 def csharp_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#else",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#else")
 
 def csharp_rule8(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#elif",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#elif")
 
 def csharp_rule9(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#endif",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#endif")
 
 def csharp_rule10(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#define",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#define")
 
 def csharp_rule11(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#undef",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#undef")
 
 def csharp_rule12(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#warning",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#warning")
 
 def csharp_rule13(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#error",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#error")
 
 def csharp_rule14(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#line",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#line")
 
 def csharp_rule15(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#region",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#region")
 
 def csharp_rule16(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#endregion",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#endregion")
 
 def csharp_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def csharp_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def csharp_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def csharp_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def csharp_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def csharp_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def csharp_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def csharp_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def csharp_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def csharp_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def csharp_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def csharp_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def csharp_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def csharp_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def csharp_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def csharp_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def csharp_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def csharp_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def csharp_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def csharp_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def csharp_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def csharp_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def csharp_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def csharp_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def csharp_rule41(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def csharp_rule42(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -419,16 +361,11 @@ rulesDict1 = {
 # Rules for csharp_doc_comment ruleset.
 
 def csharp_rule43(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<--", end="-->")
 
 def csharp_rule44(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::tags")
 
 # Rules dict for csharp_doc_comment ruleset.
 rulesDict2 = {

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -523,67 +523,50 @@ keywordsDictDict = {
 # Rules for css_main ruleset.
 
 def css_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def css_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=";")
 
 def css_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="null", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="css::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="css::literal")
 
 def css_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def css_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def css_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=",")
 
 def css_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".")
 
 def css_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def css_rule8(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="#")
 
 # For selectors...
 
 def css_rule8A(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern=".")
 
 def css_rule8B(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern=">")
 
 def css_rule8C(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="+")
 
 def css_rule8D(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="~")
 
 
 def css_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def css_rule10(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/cython.py
+++ b/leo/modes/cython.py
@@ -333,97 +333,68 @@ keywordsDictDict = {
 # Rules for cython_main ruleset.
 
 def cython_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def cython_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"")
 
 def cython_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''")
 
 def cython_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def cython_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def cython_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def cython_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def cython_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def cython_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def cython_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def cython_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def cython_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def cython_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def cython_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def cython_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def cython_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def cython_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def cython_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def cython_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def cython_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def cython_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def cython_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -435,12 +406,10 @@ if url:
     f_url_regex = r"""(file|ftp)://[^\s'"]+[\w=/]"""
 
     def cython_rule_h_url(colorer, s, i):
-        return colorer.match_seq_regexp(s, i, kind="keyword", regexp=h_url_regex,
-            at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+        return colorer.match_seq_regexp(s, i, kind="keyword", regexp=h_url_regex)
 
     def cython_rule_f_url(colorer, s, i):
-        return colorer.match_seq_regexp(s, i, kind="keyword", regexp=f_url_regex,
-            at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+        return colorer.match_seq_regexp(s, i, kind="keyword", regexp=f_url_regex)
 else:
     # Always fail.
     def cython_rule_h_url(colorer, s, i):

--- a/leo/modes/d.py
+++ b/leo/modes/d.py
@@ -132,123 +132,92 @@ keywordsDictDict = {
 # Rules for d_main ruleset.
 
 def d_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def d_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def d_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def d_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def d_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def d_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def d_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def d_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def d_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def d_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def d_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def d_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def d_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def d_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def d_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def d_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def d_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def d_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def d_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def d_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def d_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def d_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def d_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def d_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def d_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def d_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def d_rule26(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="@")
 
 def d_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/dart.py
+++ b/leo/modes/dart.py
@@ -147,168 +147,121 @@ keywordsDictDict = {
 # Rules for main ruleset.
 
 def dart_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/")
 
 def dart_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def dart_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="@\"\"\"", end="\"\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="@\"\"\"", end="\"\"\"")
 
 def dart_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="@'''", end="'''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="@'''", end="'''")
 
 def dart_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="@\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def dart_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="@'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def dart_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"\"\"", end="\"\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="dart::dart_literal1", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="dart::dart_literal1")
 
 def dart_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'''", end="'''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="dart::dart_literal1", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="dart::dart_literal1")
 
 def dart_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="dart::dart_literal1", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="dart::dart_literal1",
+          no_line_break=True)
 
 def dart_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="dart::dart_literal1", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="dart::dart_literal1",
+          no_line_break=True)
 
 def dart_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def dart_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def dart_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def dart_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def dart_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def dart_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def dart_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def dart_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def dart_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def dart_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def dart_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def dart_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def dart_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def dart_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def dart_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<")
 
 def dart_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>>")
 
 def dart_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def dart_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~/")
 
 def dart_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def dart_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def dart_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def dart_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def dart_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def dart_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 # def dart_rule36(colorer, s, i):
     # return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        # at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+        #    )
 
 def dart_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def dart_rule38(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -316,34 +269,25 @@ def dart_rule38(colorer, s, i):
 # Rules formerly in expression ruleset.
 
 def dart_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment2", seq="//-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment2", seq="//-->")
 
 def dart_rule40(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def dart_rule41(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#!")
 
 def dart_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#library",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="#library")
 
 def dart_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#import",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="#import")
 
 def dart_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#source",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="#source")
 
 def dart_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#resource",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="#resource")
 
 def dart_rule46(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/doxygen.py
+++ b/leo/modes/doxygen.py
@@ -300,35 +300,29 @@ keywordsDictDict = {
 # Rules for doxygen_main ruleset.
 
 def doxygen_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def doxygen_rule1(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword1", pattern="=",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def doxygen_rule2(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword1", pattern="+=",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def doxygen_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def doxygen_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def doxygen_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def doxygen_rule6(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -419,32 +413,24 @@ rulesDict1 = {
 # Rules for doxygen_doxygen ruleset.
 
 def doxygen_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="*")
 
 def doxygen_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def doxygen_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<<")
 
 def doxygen_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<=")
 
 def doxygen_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="< ")
 
 def doxygen_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="xml::tags",
+          no_line_break=True)
 
 def doxygen_rule13(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/eiffel.py
+++ b/leo/modes/eiffel.py
@@ -91,21 +91,15 @@ keywordsDictDict = {
 # Rules for eiffel_main ruleset.
 
 def eiffel_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def eiffel_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def eiffel_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def eiffel_rule3(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/elixir.py
+++ b/leo/modes/elixir.py
@@ -163,170 +163,128 @@ keywordsDictDict = {
 # Rules for elixir_main ruleset.
 
 def elixir_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def elixir_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def elixir_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def elixir_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def elixir_rule4(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="literal2", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 # Not used.
 def elixir_rule5(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\$.\\w*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\$.\\w*")
 
 def elixir_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="badarg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="badarg")
 
 def elixir_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="nocookie",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="nocookie")
 
 def elixir_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="false",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="false")
 
 def elixir_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="true",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="true")
 
 def elixir_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def elixir_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<-")
 
 def elixir_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def elixir_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def elixir_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def elixir_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def elixir_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def elixir_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def elixir_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def elixir_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def elixir_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def elixir_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def elixir_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def elixir_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def elixir_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def elixir_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def elixir_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def elixir_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def elixir_rule28(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bdiv\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bdiv\\b")
 
 def elixir_rule29(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\brem\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\brem\\b")
 
 def elixir_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bor\\b")
 
 def elixir_rule31(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bxor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bxor\\b")
 
 def elixir_rule32(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbor\\b")
 
 def elixir_rule33(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbxor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbxor\\b")
 
 def elixir_rule34(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsl\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsl\\b")
 
 def elixir_rule35(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsr\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsr\\b")
 
 def elixir_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\band\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\band\\b")
 
 def elixir_rule37(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bband\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bband\\b")
 
 def elixir_rule38(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bnot\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bnot\\b")
 
 def elixir_rule39(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbnot\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbnot\\b")
 
 def elixir_rule40(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/embperl.py
+++ b/leo/modes/embperl.py
@@ -33,34 +33,23 @@ keywordsDictDict = {
 # Rules for embperl_main ruleset.
 
 def embperl_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="[#", end="#]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="[#", end="#]")
 
 def embperl_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="[+", end="+]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def embperl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="[-", end="-]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def embperl_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="[$", end="$]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 def embperl_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="[!", end="!]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::main")
 
 
 # Rules dict for embperl_main ruleset.

--- a/leo/modes/erlang.py
+++ b/leo/modes/erlang.py
@@ -162,169 +162,127 @@ keywordsDictDict = {
 # Rules for erlang_main ruleset.
 
 def erlang_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def erlang_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def erlang_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def erlang_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def erlang_rule4(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="literal2", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def erlang_rule5(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\$.\\w*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\$.\\w*")
 
 def erlang_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="badarg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="badarg")
 
 def erlang_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="nocookie",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="nocookie")
 
 def erlang_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="false",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="false")
 
 def erlang_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="true",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal3", seq="true")
 
 def erlang_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def erlang_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<-")
 
 def erlang_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def erlang_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def erlang_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def erlang_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def erlang_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def erlang_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def erlang_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def erlang_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def erlang_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def erlang_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def erlang_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def erlang_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def erlang_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def erlang_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def erlang_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def erlang_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def erlang_rule28(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bdiv\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bdiv\\b")
 
 def erlang_rule29(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\brem\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\brem\\b")
 
 def erlang_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bor\\b")
 
 def erlang_rule31(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bxor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bxor\\b")
 
 def erlang_rule32(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbor\\b")
 
 def erlang_rule33(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbxor\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbxor\\b")
 
 def erlang_rule34(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsl\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsl\\b")
 
 def erlang_rule35(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsr\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbsr\\b")
 
 def erlang_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\band\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\band\\b")
 
 def erlang_rule37(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bband\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bband\\b")
 
 def erlang_rule38(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bnot\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bnot\\b")
 
 def erlang_rule39(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbnot\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bbnot\\b")
 
 def erlang_rule40(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/factor.py
+++ b/leo/modes/factor.py
@@ -70,62 +70,45 @@ keywordsDictDict = {
 # Rules for factor_main ruleset.
 
 def factor_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#!")
 
 def factor_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def factor_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp=":\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp=":\\s+(\\S+)")
 
 def factor_rule3(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="IN:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="IN:\\s+(\\S+)")
 
 def factor_rule4(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="USE:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="USE:\\s+(\\S+)")
 
 def factor_rule5(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="DEFER:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="DEFER:\\s+(\\S+)")
 
 def factor_rule6(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="POSTPONE:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="POSTPONE:\\s+(\\S+)")
 
 def factor_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="CHAR:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="CHAR:\\s+(\\S+)")
 
 def factor_rule8(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="BIN:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="BIN:\\s+(\\S+)")
 
 def factor_rule9(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="OCT:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="OCT:\\s+(\\S+)")
 
 def factor_rule10(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="HEX:\\s+(\\S+)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="HEX:\\s+(\\S+)")
 
 def factor_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="factor::stack_effect", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="factor::stack_effect")
 
 def factor_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def factor_rule13(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -215,8 +198,7 @@ rulesDict1 = {
 # Rules for factor_stack_effect ruleset.
 
 def factor_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="--")
 
 # Rules dict for factor_stack_effect ruleset.
 rulesDict2 = {

--- a/leo/modes/fortran.py
+++ b/leo/modes/fortran.py
@@ -188,105 +188,77 @@ keywordsDictDict = {
 
 def fortran_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="c",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def fortran_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="C",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def fortran_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def fortran_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def fortran_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def fortran_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="D",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def fortran_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def fortran_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def fortran_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def fortran_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def fortran_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def fortran_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def fortran_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def fortran_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/=")
 
 def fortran_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def fortran_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".lt.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".lt.")
 
 def fortran_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".gt.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".gt.")
 
 def fortran_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".eq.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".eq.")
 
 def fortran_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ne.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".ne.")
 
 def fortran_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".le.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".le.")
 
 def fortran_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ge.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".ge.")
 
 def fortran_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".AND.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".AND.")
 
 def fortran_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".OR.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".OR.")
 
 def fortran_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/fortran90.py
+++ b/leo/modes/fortran90.py
@@ -190,69 +190,52 @@ def fortran90_rule0(colorer, s, i):
     return colorer.match_terminate(s, i, kind="", at_char=132)
 
 def fortran90_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def fortran90_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def fortran90_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def fortran90_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def fortran90_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def fortran90_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def fortran90_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/=")
 
 def fortran90_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def fortran90_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".lt.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".lt.")
 
 def fortran90_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".gt.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".gt.")
 
 def fortran90_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".eq.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".eq.")
 
 def fortran90_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ne.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".ne.")
 
 def fortran90_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".le.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".le.")
 
 def fortran90_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ge.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".ge.")
 
 def fortran90_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".AND.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".AND.")
 
 def fortran90_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".OR.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".OR.")
 
 def fortran90_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/foxpro.py
+++ b/leo/modes/foxpro.py
@@ -1723,160 +1723,110 @@ keywordsDictDict = {
 
 def foxpro_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def foxpro_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def foxpro_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#if",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#if")
 
 def foxpro_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#else",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#else")
 
 def foxpro_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#end",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#end")
 
 def foxpro_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#define",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#define")
 
 def foxpro_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#include",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#include")
 
 def foxpro_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Elif",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Elif")
 
 def foxpro_rule8(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Else",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Else")
 
 def foxpro_rule9(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Endif",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Endif")
 
 def foxpro_rule10(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#If",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#If")
 
 def foxpro_rule11(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Itsexpression",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Itsexpression")
 
 def foxpro_rule12(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Readclauses",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Readclauses")
 
 def foxpro_rule13(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Region",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Region")
 
 def foxpro_rule14(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Section",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Section")
 
 def foxpro_rule15(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Undef",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Undef")
 
 def foxpro_rule16(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Wname",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#Wname")
 
 def foxpro_rule17(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="&&")
 
 def foxpro_rule18(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="*",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_whitespace_end=True)
 
 def foxpro_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def foxpro_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def foxpro_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def foxpro_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def foxpro_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def foxpro_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def foxpro_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def foxpro_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def foxpro_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def foxpro_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def foxpro_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def foxpro_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def foxpro_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def foxpro_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def foxpro_rule33(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def foxpro_rule34(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/gettext.py
+++ b/leo/modes/gettext.py
@@ -54,46 +54,32 @@ keywordsDictDict = {
 # Rules for gettext_main ruleset.
 
 def gettext_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#:")
 
 def gettext_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def gettext_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#.")
 
 def gettext_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#~")
 
 def gettext_rule4(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="comment2", pattern="#,",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="comment2", pattern="#,")
 
 def gettext_rule5(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="%")
 
 def gettext_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def gettext_rule7(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="@")
 
 def gettext_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="gettext::quoted", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="gettext::quoted")
 
 def gettext_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -175,21 +161,16 @@ rulesDict1 = {
 
 def gettext_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="\\\"", end="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def gettext_rule11(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="%")
 
 def gettext_rule12(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def gettext_rule13(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="@")
 
 # Rules dict for gettext_quoted ruleset.
 rulesDict2 = {

--- a/leo/modes/groovy.py
+++ b/leo/modes/groovy.py
@@ -202,99 +202,71 @@ keywordsDictDict = {
 # Rules for groovy_main ruleset.
 
 def groovy_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def groovy_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="groovy::groovydoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="groovy::groovydoc")
 
 def groovy_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def groovy_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="groovy::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="groovy::literal")
 
 def groovy_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def groovy_rule5(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal1", begin="<<<([[:alpha:]_][[:alnum:]_]*)\\s*", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="groovy::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="groovy::literal")
 
 def groovy_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=~")
 
 def groovy_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def groovy_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def groovy_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def groovy_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=>")
 
 def groovy_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def groovy_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def groovy_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def groovy_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def groovy_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def groovy_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def groovy_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def groovy_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".*")
 
 def groovy_rule19(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def groovy_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def groovy_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -384,13 +356,10 @@ rulesDict1 = {
 
 def groovy_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def groovy_rule23(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 # Rules dict for groovy_literal ruleset.
 rulesDict2 = {
@@ -400,40 +369,30 @@ rulesDict2 = {
 # Rules for groovy_groovydoc ruleset.
 
 def groovy_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="{")
 
 def groovy_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="*")
 
 def groovy_rule26(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def groovy_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<<")
 
 def groovy_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<=")
 
 def groovy_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="< ")
 
 def groovy_rule30(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="xml::tags",
+          no_line_break=True)
 
 def groovy_rule31(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="label", pattern="@")
 
 # Rules dict for groovy_groovydoc ruleset.
 rulesDict3 = {

--- a/leo/modes/haskell.py
+++ b/leo/modes/haskell.py
@@ -114,199 +114,148 @@ keywordsDictDict = {
 # Rules for haskell_main ruleset.
 
 def haskell_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="{-#", end="#-}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="{-#", end="#-}")
 
 def haskell_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="{-", end="-}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="{-", end="-}")
 
 def haskell_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def haskell_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def haskell_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="' '",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="' '")
 
 def haskell_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'!'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'!'")
 
 def haskell_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'\"'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'\"'")
 
 def haskell_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'$'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'$'")
 
 def haskell_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'%'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'%'")
 
 def haskell_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'/'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'/'")
 
 def haskell_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'('",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'('")
 
 def haskell_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="')'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="')'")
 
 def haskell_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'['",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'['")
 
 def haskell_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="']'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="']'")
 
 def haskell_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'+'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'+'")
 
 def haskell_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'-'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'-'")
 
 def haskell_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'*'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'*'")
 
 def haskell_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'='",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'='")
 
 def haskell_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'/'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'/'")
 
 def haskell_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'^'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'^'")
 
 def haskell_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'.'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'.'")
 
 def haskell_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="','",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="','")
 
 def haskell_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="':'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="':'")
 
 def haskell_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="';'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="';'")
 
 def haskell_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'<'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'<'")
 
 def haskell_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'>'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'>'")
 
 def haskell_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'|'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'|'")
 
 def haskell_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'@'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="'@'")
 
 def haskell_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False,
+
+
+
         ### no_word_break=True)
-        no_word_break=False)
+        )
 
 def haskell_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="..")
 
 def haskell_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&&")
 
 def haskell_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="::")
 
 def haskell_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def haskell_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def haskell_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def haskell_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def haskell_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def haskell_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def haskell_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def haskell_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def haskell_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def haskell_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def haskell_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def haskell_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def haskell_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def haskell_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def haskell_rule46(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/haxe.py
+++ b/leo/modes/haxe.py
@@ -96,140 +96,104 @@ keywordsDictDict = {
 # Rules for haxe_main ruleset.
 
 def haXe_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def haXe_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def haXe_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def haXe_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def haXe_rule4(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def haXe_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def haXe_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment3", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment3", seq="#")
 
 def haXe_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="~([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="~([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*")
 
 def haXe_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=")")
 
 def haXe_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="(")
 
 def haXe_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def haXe_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def haXe_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def haXe_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def haXe_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def haXe_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def haXe_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def haXe_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def haXe_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def haXe_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def haXe_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def haXe_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def haXe_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def haXe_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def haXe_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def haXe_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def haXe_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def haXe_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def haXe_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def haXe_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def haXe_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def haXe_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def haXe_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/i4gl.py
+++ b/leo/modes/i4gl.py
@@ -623,116 +623,83 @@ keywordsDictDict = {
 # Rules for i4gl_main ruleset.
 
 def i4gl_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def i4gl_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def i4gl_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def i4gl_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def i4gl_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="{", end="}")
 
 def i4gl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=")")
 
 def i4gl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="]")
 
 def i4gl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="[")
 
 def i4gl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".")
 
 def i4gl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=",")
 
 def i4gl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=";")
 
 def i4gl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=":")
 
 def i4gl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def i4gl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def i4gl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def i4gl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def i4gl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def i4gl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def i4gl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def i4gl_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def i4gl_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def i4gl_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def i4gl_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def i4gl_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def i4gl_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def i4gl_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def i4gl_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/icon.py
+++ b/leo/modes/icon.py
@@ -136,185 +136,139 @@ keywordsDictDict = {
 # Rules for icon_main ruleset.
 
 def icon_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def icon_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def icon_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def icon_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~===",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~===")
 
 def icon_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="===",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="===")
 
 def icon_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|||")
 
 def icon_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>=")
 
 def icon_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def icon_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<=")
 
 def icon_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<")
 
 def icon_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~==")
 
 def icon_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def icon_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def icon_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="++",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="++")
 
 def icon_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def icon_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="--")
 
 def icon_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<->")
 
 def icon_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<-")
 
 def icon_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="op:=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="op:=")
 
 def icon_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def icon_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def icon_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def icon_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def icon_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~=")
 
 def icon_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=:")
 
 def icon_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def icon_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-:")
 
 def icon_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+:")
 
 def icon_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def icon_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def icon_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def icon_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def icon_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def icon_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="not",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="not")
 
 def icon_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def icon_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def icon_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def icon_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def icon_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def icon_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def icon_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def icon_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def icon_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def icon_rule43(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def icon_rule44(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/idl.py
+++ b/leo/modes/idl.py
@@ -76,43 +76,31 @@ keywordsDictDict = {
 # Rules for idl_main ruleset.
 
 def idl_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def idl_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def idl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def idl_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def idl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def idl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def idl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def idl_rule7(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def idl_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/inform.py
+++ b/leo/modes/inform.py
@@ -147,139 +147,104 @@ keywordsDictDict = {
 # Rules for inform_main ruleset.
 
 def inform_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def inform_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inform::informinnertext", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="inform::informinnertext")
 
 def inform_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="'", end="'")
 
 def inform_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
 
 def inform_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def inform_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def inform_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def inform_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def inform_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def inform_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~=")
 
 def inform_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def inform_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def inform_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def inform_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def inform_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def inform_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def inform_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def inform_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def inform_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def inform_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def inform_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def inform_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def inform_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def inform_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def inform_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def inform_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def inform_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".&")
 
 def inform_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".#")
 
 def inform_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-->")
 
 def inform_rule29(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def inform_rule30(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def inform_rule31(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def inform_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -379,24 +344,19 @@ rulesDict1 = {
 # Rules for inform_informinnertext ruleset.
 
 def inform_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def inform_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def inform_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def inform_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def inform_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="@@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal2", seq="@@")
 
 # Rules dict for inform_informinnertext ruleset.
 rulesDict2 = {

--- a/leo/modes/ini.py
+++ b/leo/modes/ini.py
@@ -33,23 +33,20 @@ keywordsDictDict = {
 
 def ini_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="[", end="]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def ini_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def ini_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def ini_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword1", pattern="=",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 # Rules dict for ini_main ruleset.
 rulesDict1 = {

--- a/leo/modes/inno_setup.py
+++ b/leo/modes/inno_setup.py
@@ -348,213 +348,181 @@ keywordsDictDict = {
 
 def inno_setup_rule0(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[code]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="pascal::main")
+          at_line_start=True,
+          delegate="pascal::main")
 
 def inno_setup_rule1(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Setup]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule2(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Types]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule3(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Components]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule4(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Tasks]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule5(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Dirs]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule6(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Files]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule7(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Icons]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule8(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[INI]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule9(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[InstallDelete]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule10(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Languages]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule11(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Messages]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule12(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[CustomMessages]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule13(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[LangOptions]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule14(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Registry]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule15(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[Run]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule16(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[UninstallRun]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule17(colorer, s, i):
     return colorer.match_seq(s, i, kind="keyword2", seq="[UninstallDelete]",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def inno_setup_rule18(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#define",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule19(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#dim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule20(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#undef",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule21(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#include",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule22(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#emit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule23(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#expr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule24(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#insert",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule25(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#append",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule26(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#if",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule27(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#elif",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule28(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#else",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule29(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#endif",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule30(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#ifexist",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule31(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#ifnexist",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule32(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#ifdef",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule33(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#for",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule34(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#sub",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule35(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#endsub",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule36(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#pragma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule37(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal4", seq="#error",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::directive", exclude_match=False)
+          delegate="inno_setup::directive")
 
 def inno_setup_rule38(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="{#", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal4", begin="{#", end="}")
 
 def inno_setup_rule39(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="%")
 
 def inno_setup_rule40(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::string", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="inno_setup::string")
 
 def inno_setup_rule41(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::string", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="inno_setup::string")
 
 def inno_setup_rule42(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="{", end="}")
 
 def inno_setup_rule43(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def inno_setup_rule44(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def inno_setup_rule45(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -636,16 +604,11 @@ rulesDict1 = {
 # Rules for inno_setup_string ruleset.
 
 def inno_setup_rule46(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="{#", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal4", begin="{#", end="}")
 
 def inno_setup_rule47(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="inno_setup::constant", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="inno_setup::constant")
 
 # Rules dict for inno_setup_string ruleset.
 rulesDict2 = {
@@ -656,11 +619,10 @@ rulesDict2 = {
 
 def inno_setup_rule48(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="function", pattern="code:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def inno_setup_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 # Rules dict for inno_setup_constant ruleset.
 rulesDict3 = {
@@ -671,21 +633,13 @@ rulesDict3 = {
 # Rules for inno_setup_directive ruleset.
 
 def inno_setup_rule50(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def inno_setup_rule51(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="/*", end="*/")
 
 def inno_setup_rule52(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def inno_setup_rule53(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/interlis.py
+++ b/leo/modes/interlis.py
@@ -170,203 +170,149 @@ keywordsDictDict = {
 # Rules for interlis_main ruleset.
 
 def interlis_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def interlis_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!!")
 
 def interlis_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def interlis_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="//", end="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="//", end="//")
 
 def interlis_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def interlis_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<-")
 
 def interlis_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="..")
 
 def interlis_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def interlis_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def interlis_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def interlis_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def interlis_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def interlis_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def interlis_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def interlis_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def interlis_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def interlis_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def interlis_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def interlis_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def interlis_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def interlis_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def interlis_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def interlis_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def interlis_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def interlis_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def interlis_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="--")
 
 def interlis_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-<#>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-<#>")
 
 def interlis_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-<>")
 
 def interlis_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def interlis_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def interlis_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="..")
 
 def interlis_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def interlis_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def interlis_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def interlis_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def interlis_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def interlis_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def interlis_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def interlis_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def interlis_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def interlis_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def interlis_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def interlis_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def interlis_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def interlis_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def interlis_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def interlis_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def interlis_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def interlis_rule48(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/io.py
+++ b/leo/modes/io.py
@@ -71,120 +71,85 @@ keywordsDictDict = {
 # Rules for io_main ruleset.
 
 def io_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def io_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def io_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def io_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"")
 
 def io_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"")
 
 def io_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="`")
 
 def io_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def io_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def io_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@@")
 
 def io_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def io_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def io_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def io_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def io_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def io_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def io_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def io_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def io_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def io_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def io_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def io_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def io_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def io_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def io_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def io_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def io_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def io_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def io_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/java.py
+++ b/leo/modes/java.py
@@ -150,121 +150,91 @@ keywordsDictDict = {
 # Rules for java_main ruleset.
 
 def java_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def java_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::javadoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::javadoc")
 
 def java_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def java_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def java_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def java_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def java_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def java_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def java_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def java_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def java_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def java_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def java_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def java_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".*")
 
 def java_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def java_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def java_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def java_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def java_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def java_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def java_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def java_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def java_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def java_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def java_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def java_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def java_rule26(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="@")
 
 def java_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -359,36 +329,27 @@ rulesDict1 = {
 # Rules for java_javadoc ruleset.
 
 def java_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="{")
 
 def java_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="*")
 
 def java_rule30(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def java_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<<")
 
 def java_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<=")
 
 def java_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="< ")
 
 def java_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="xml::tags",
+          no_line_break=True)
 
 def java_rule35(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/jmk.py
+++ b/leo/modes/jmk.py
@@ -67,45 +67,33 @@ keywordsDictDict = {
 # Rules for jmk_main ruleset.
 
 def jmk_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def jmk_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def jmk_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def jmk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def jmk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def jmk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def jmk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def jmk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def jmk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def jmk_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/json.py
+++ b/leo/modes/json.py
@@ -31,41 +31,29 @@ keywordsDictDict = {
 # Rules for json_main ruleset.
 
 def json_string(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 if 0:
     def json_single_string(colorer, s, i):
-        return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-            at_line_start=False, at_whitespace_end=False, at_word_start=False,
-            delegate="", exclude_match=False,
-            no_escape=False, no_line_break=False, no_word_break=False)
+        return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def json_colon(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def json_comma(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def json_open_brace(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def json_close_brace(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def json_open_bracket(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def json_close_bracket(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 # Rules dict for json_main ruleset.
 rulesDict1 = {

--- a/leo/modes/jsp.py
+++ b/leo/modes/jsp.py
@@ -123,94 +123,63 @@ keywordsDictDict = {
 # Rules for jsp_main ruleset.
 
 def jsp_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>")
 
 def jsp_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%@", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::directives", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::directives")
 
 def jsp_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<jsp:directive>", end="</jsp:directive>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::directives", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::directives")
 
 def jsp_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<jsp:expression>", end="</jsp:expression>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%!", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<jsp:declaration>", end="</jsp:declaration>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<jsp:scriptlet>", end="</jsp:scriptlet>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::comment", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::comment")
 
 def jsp_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::javascript")
 
 def jsp_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::css")
 
 def jsp_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def jsp_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::tags")
 
 def jsp_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for jsp_main ruleset.
 rulesDict1 = {
@@ -221,22 +190,15 @@ rulesDict1 = {
 # Rules for jsp_comment ruleset.
 
 def jsp_rule15(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>")
 
 def jsp_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 # Rules dict for jsp_comment ruleset.
 rulesDict2 = {
@@ -247,33 +209,25 @@ rulesDict2 = {
 
 def jsp_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::attrvalue", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::attrvalue")
 
 def jsp_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::attrvalue", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::attrvalue")
 
 def jsp_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="/")
 
 def jsp_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def jsp_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def jsp_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -353,40 +307,29 @@ rulesDict3 = {
 # Rules for jsp_tags ruleset.
 
 def jsp_rule25(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>")
 
 def jsp_rule26(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 def jsp_rule27(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::attrvalue", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::attrvalue")
 
 def jsp_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="jsp::attrvalue", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="jsp::attrvalue")
 
 def jsp_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="/")
 
 def jsp_rule30(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="function", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def jsp_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 # Rules dict for jsp_tags ruleset.
 rulesDict4 = {
@@ -401,9 +344,7 @@ rulesDict4 = {
 
 def jsp_rule32(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::main")
 
 # Rules dict for jsp_attrvalue ruleset.
 rulesDict5 = {

--- a/leo/modes/kivy.py
+++ b/leo/modes/kivy.py
@@ -44,15 +44,11 @@ keywordsDictDict = {
 # Rules for kivy_main ruleset.
 
 def kivy_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def kivy_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="kivy::literal_one", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="kivy::literal_one")
 
 def kivy_rule2(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/latex.py
+++ b/leo/modes/latex.py
@@ -108,1749 +108,1301 @@ keywordsDictDict = {
 # Rules for latex_main ruleset.
 
 def latex_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__NormalMode__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="__NormalMode__")
 
 def latex_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="``", end="''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal4", begin="``", end="''")
 
 def latex_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="`", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="`", end="'")
 
 def latex_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def latex_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\"")
 
 def latex_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="`")
 
 def latex_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#1")
 
 def latex_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#2",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#2")
 
 def latex_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#3",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#3")
 
 def latex_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#4",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#4")
 
 def latex_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#5",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#5")
 
 def latex_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#6",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#6")
 
 def latex_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#7",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#7")
 
 def latex_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#8",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#8")
 
 def latex_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#9",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="function", seq="#9")
 
 def latex_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabs",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\tabs")
 
 def latex_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\tabset")
 
 def latex_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabsdone",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\tabsdone")
 
 def latex_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\cleartabs",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\cleartabs")
 
 def latex_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\settabs",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\settabs")
 
 def latex_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabalign",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\tabalign")
 
 def latex_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\+")
 
 def latex_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pageno",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\pageno")
 
 def latex_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\headline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\headline")
 
 def latex_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\footline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\footline")
 
 def latex_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\normalbottom",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\normalbottom")
 
 def latex_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\folio",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\folio")
 
 def latex_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\nopagenumbers",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\nopagenumbers")
 
 def latex_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\advancepageno",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\advancepageno")
 
 def latex_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pagebody",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\pagebody")
 
 def latex_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\plainoutput",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\plainoutput")
 
 def latex_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pagecontents",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\pagecontents")
 
 def latex_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\makeheadline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\makeheadline")
 
 def latex_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\makefootline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\makefootline")
 
 def latex_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\dosupereject",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\dosupereject")
 
 def latex_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\footstrut",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\footstrut")
 
 def latex_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\vfootnote",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\vfootnote")
 
 def latex_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\topins",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\topins")
 
 def latex_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\topinsert",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\topinsert")
 
 def latex_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\midinsert",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\midinsert")
 
 def latex_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pageinsert",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\pageinsert")
 
 def latex_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\endinsert",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\endinsert")
 
 def latex_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fivei",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\fivei")
 
 def latex_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fiverm",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\fiverm")
 
 def latex_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fivesy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\fivesy")
 
 def latex_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fivebf",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\fivebf")
 
 def latex_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\seveni",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\seveni")
 
 def latex_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\sevenbf",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\sevenbf")
 
 def latex_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\sevensy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\sevensy")
 
 def latex_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\teni",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\teni")
 
 def latex_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\oldstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\oldstyle")
 
 def latex_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\eqalign",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\eqalign")
 
 def latex_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\eqalignno",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\eqalignno")
 
 def latex_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\leqalignno",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\leqalignno")
 
 def latex_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="$$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="$$")
 
 def latex_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\beginsection",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\beginsection")
 
 def latex_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\bye",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\bye")
 
 def latex_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\magnification",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\magnification")
 
 def latex_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="#")
 
 def latex_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="&")
 
 def latex_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="_")
 
 def latex_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\\~")
 
 def latex_rule63(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="$", end="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule64(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\(", end="\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule65(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\[", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule66(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{math}", end="\\end{math}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule67(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{displaymath}", end="\\end{displaymath}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule68(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{equation}", end="\\end{equation}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule69(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\ensuremath{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::mathmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::mathmode")
 
 def latex_rule70(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{eqnarray}", end="\\end{eqnarray}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::arraymode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::arraymode")
 
 def latex_rule71(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{eqnarray*}", end="\\end{eqnarray*}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::arraymode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::arraymode")
 
 def latex_rule72(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{tabular}", end="\\end{tabular}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::tabularmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::tabularmode")
 
 def latex_rule73(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{tabular*}", end="\\end{tabular*}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::tabularmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::tabularmode")
 
 def latex_rule74(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{tabbing}", end="\\end{tabbing}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::tabbingmode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::tabbingmode")
 
 def latex_rule75(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{picture}", end="\\end{picture}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::picturemode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::picturemode")
 
 def latex_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def latex_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="}")
 
 def latex_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="{")
 
 def latex_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber")
 
 def latex_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber")
 
 def latex_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth")
 
 def latex_rule82(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth")
 
 def latex_rule83(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber")
 
 def latex_rule84(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="]")
 
 def latex_rule85(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{")
 
 def latex_rule86(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\~")
 
 def latex_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\}")
 
 def latex_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\|")
 
 def latex_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\{")
 
 def latex_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\width",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\width")
 
 def latex_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{")
 
 def latex_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{")
 
 def latex_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{")
 
 def latex_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{")
 
 def latex_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill")
 
 def latex_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*")
 
 def latex_rule97(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb")
 
 def latex_rule98(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{")
 
 def latex_rule99(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\v",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\v")
 
 def latex_rule100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{")
 
 def latex_rule101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{")
 
 def latex_rule102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[")
 
 def latex_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{")
 
 def latex_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{")
 
 def latex_rule105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape")
 
 def latex_rule106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{")
 
 def latex_rule107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\u",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\u")
 
 def latex_rule108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{")
 
 def latex_rule109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{")
 
 def latex_rule110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{")
 
 def latex_rule111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[")
 
 def latex_rule112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[")
 
 def latex_rule113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn")
 
 def latex_rule114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily")
 
 def latex_rule115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight")
 
 def latex_rule116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep")
 
 def latex_rule117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction")
 
 def latex_rule118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\today",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\today")
 
 def latex_rule119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{")
 
 def latex_rule120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny")
 
 def latex_rule121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
 
 def latex_rule122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{")
 
 def latex_rule125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth")
 
 def latex_rule126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{")
 
 def latex_rule127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{")
 
 def latex_rule128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{")
 
 def latex_rule129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{")
 
 def latex_rule130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{")
 
 def latex_rule131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{")
 
 def latex_rule132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{")
 
 def latex_rule133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{")
 
 def latex_rule134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{")
 
 def latex_rule135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction")
 
 def latex_rule136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep")
 
 def latex_rule137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{")
 
 def latex_rule138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{")
 
 def latex_rule139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents")
 
 def latex_rule140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep")
 
 def latex_rule141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep")
 
 def latex_rule142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\t",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\t")
 
 def latex_rule143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{")
 
 def latex_rule144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
 
 def latex_rule145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats")
 
 def latex_rule146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{")
 
 def latex_rule147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[")
 
 def latex_rule148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
 
 def latex_rule149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{")
 
 def latex_rule150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[")
 
 def latex_rule151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{")
 
 def latex_rule152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{")
 
 def latex_rule153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[")
 
 def latex_rule154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
 
 def latex_rule155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{")
 
 def latex_rule156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{")
 
 def latex_rule157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip")
 
 def latex_rule158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\small",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\small")
 
 def latex_rule159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape")
 
 def latex_rule160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy")
 
 def latex_rule161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily")
 
 def latex_rule162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{")
 
 def latex_rule163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{")
 
 def latex_rule164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{")
 
 def latex_rule165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{")
 
 def latex_rule166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{")
 
 def latex_rule167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{")
 
 def latex_rule168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[")
 
 def latex_rule169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{")
 
 def latex_rule170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape")
 
 def latex_rule171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize")
 
 def latex_rule172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{")
 
 def latex_rule173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{")
 
 def latex_rule174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{")
 
 def latex_rule176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[")
 
 def latex_rule177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{")
 
 def latex_rule178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{")
 
 def latex_rule179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily")
 
 def latex_rule180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin")
 
 def latex_rule181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
 
 def latex_rule182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{")
 
 def latex_rule183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{")
 
 def latex_rule184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
 
 def latex_rule185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{")
 
 def latex_rule186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{")
 
 def latex_rule187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter")
 
 def latex_rule188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{")
 
 def latex_rule189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright")
 
 def latex_rule190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft")
 
 def latex_rule191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax")
 
 def latex_rule192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{")
 
 def latex_rule193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect")
 
 def latex_rule194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex")
 
 def latex_rule195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds")
 
 def latex_rule196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{")
 
 def latex_rule197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep")
 
 def latex_rule198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[")
 
 def latex_rule199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{")
 
 def latex_rule200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip")
 
 def latex_rule201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep")
 
 def latex_rule202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent")
 
 def latex_rule203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{")
 
 def latex_rule204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[")
 
 def latex_rule205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{")
 
 def latex_rule206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[")
 
 def latex_rule207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{")
 
 def latex_rule208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\par",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\par")
 
 def latex_rule209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{")
 
 def latex_rule210(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{")
 
 def latex_rule211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
 
 def latex_rule212(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{")
 
 def latex_rule213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[")
 
 def latex_rule214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak")
 
 def latex_rule215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn")
 
 def latex_rule216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize")
 
 def latex_rule217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
 
 def latex_rule218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont")
 
 def latex_rule219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
 
 def latex_rule220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak")
 
 def latex_rule221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
 
 def latex_rule222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
 
 def latex_rule223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak")
 
 def latex_rule224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent")
 
 def latex_rule225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{")
 
 def latex_rule226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{")
 
 def latex_rule227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{")
 
 def latex_rule228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage")
 
 def latex_rule229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{")
 
 def latex_rule230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{")
 
 def latex_rule231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{")
 
 def latex_rule232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{")
 
 def latex_rule233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip")
 
 def latex_rule234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries")
 
 def latex_rule235(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule236(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{")
 
 def latex_rule240(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{")
 
 def latex_rule241(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{")
 
 def latex_rule242(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth")
 
 def latex_rule243(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep")
 
 def latex_rule244(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush")
 
 def latex_rule245(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[")
 
 def latex_rule246(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle")
 
 def latex_rule247(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel")
 
 def latex_rule248(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex")
 
 def latex_rule249(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary")
 
 def latex_rule250(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{")
 
 def latex_rule251(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[")
 
 def latex_rule252(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent")
 
 def latex_rule253(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables")
 
 def latex_rule254(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures")
 
 def latex_rule255(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles")
 
 def latex_rule256(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth")
 
 def latex_rule257(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule258(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[")
 
 def latex_rule259(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak")
 
 def latex_rule260(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{")
 
 def latex_rule261(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
 
 def latex_rule262(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv")
 
 def latex_rule263(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
 
 def latex_rule264(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
 
 def latex_rule265(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii")
 
 def latex_rule266(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini")
 
 def latex_rule267(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin")
 
 def latex_rule268(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\large",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\large")
 
 def latex_rule269(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{")
 
 def latex_rule270(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth")
 
 def latex_rule271(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep")
 
 def latex_rule272(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot")
 
 def latex_rule273(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape")
 
 def latex_rule274(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep")
 
 def latex_rule275(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent")
 
 def latex_rule276(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[")
 
 def latex_rule277(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\item",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\item")
 
 def latex_rule278(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{")
 
 def latex_rule279(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep")
 
 def latex_rule280(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{")
 
 def latex_rule281(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{")
 
 def latex_rule282(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent")
 
 def latex_rule283(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{")
 
 def latex_rule284(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{")
 
 def latex_rule285(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{")
 
 def latex_rule286(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[")
 
 def latex_rule287(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
 
 def latex_rule288(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
 
 def latex_rule289(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
 
 def latex_rule290(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{")
 
 def latex_rule291(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge")
 
 def latex_rule292(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{")
 
 def latex_rule293(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{")
 
 def latex_rule294(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill")
 
 def latex_rule295(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\height",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\height")
 
 def latex_rule296(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{")
 
 def latex_rule297(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy")
 
 def latex_rule298(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing")
 
 def latex_rule299(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{")
 
 def latex_rule300(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[")
 
 def latex_rule301(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile")
 
 def latex_rule302(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{")
 
 def latex_rule303(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{")
 
 def latex_rule304(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[")
 
 def latex_rule305(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize")
 
 def latex_rule306(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep")
 
 def latex_rule307(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule")
 
 def latex_rule308(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[")
 
 def latex_rule309(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark")
 
 def latex_rule310(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[")
 
 def latex_rule311(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
 
 def latex_rule312(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep")
 
 def latex_rule313(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
 
 def latex_rule314(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill")
 
 def latex_rule315(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
 
 def latex_rule316(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{")
 
 def latex_rule317(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep")
 
 def latex_rule318(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule")
 
 def latex_rule319(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{")
 
 def latex_rule320(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule321(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
 
 def latex_rule322(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
 
 def latex_rule323(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule324(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{")
 
 def latex_rule325(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{")
 
 def latex_rule326(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep")
 
 def latex_rule327(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{")
 
 def latex_rule328(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[")
 
 def latex_rule329(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth")
 
 def latex_rule330(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{")
 
 def latex_rule331(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag")
 
 def latex_rule332(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
 
 def latex_rule333(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
 
 def latex_rule334(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
 
 def latex_rule335(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
 
 def latex_rule336(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{")
 
 def latex_rule337(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag")
 
 def latex_rule338(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\d",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\d")
 
 def latex_rule339(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{")
 
 def latex_rule340(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright")
 
 def latex_rule341(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth")
 
 def latex_rule342(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule")
 
 def latex_rule343(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep")
 
 def latex_rule344(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{")
 
 def latex_rule345(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{")
 
 def latex_rule346(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage")
 
 def latex_rule347(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
 
 def latex_rule348(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{")
 
 def latex_rule349(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[")
 
 def latex_rule350(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{")
 
 def latex_rule351(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[")
 
 def latex_rule352(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{")
 
 def latex_rule353(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering")
 
 def latex_rule354(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{")
 
 def latex_rule355(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[")
 
 def latex_rule356(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\c",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\c")
 
 def latex_rule357(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{")
 
 def latex_rule358(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber")
 
 def latex_rule359(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction")
 
 def latex_rule360(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{")
 
 def latex_rule361(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{")
 
 def latex_rule362(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip")
 
 def latex_rule363(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{")
 
 def latex_rule364(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
 
 def latex_rule365(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent")
 
 def latex_rule366(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries")
 
 def latex_rule367(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
 
 def latex_rule368(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
 
 def latex_rule369(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule370(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch")
 
 def latex_rule371(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip")
 
 def latex_rule372(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\b")
 
 def latex_rule373(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{")
 
 def latex_rule374(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch")
 
 def latex_rule375(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
 
 def latex_rule376(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep")
 
 def latex_rule377(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{")
 
 def latex_rule378(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix")
 
 def latex_rule379(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{")
 
 def latex_rule380(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{")
 
 def latex_rule381(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{")
 
 def latex_rule382(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{")
 
 def latex_rule383(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{")
 
 def latex_rule384(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
 
 def latex_rule385(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
 
 def latex_rule386(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
 
 def latex_rule387(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{")
 
 def latex_rule388(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule389(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\_")
 
 def latex_rule390(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{")
 
 def latex_rule391(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\^")
 
 def latex_rule392(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[")
 
 def latex_rule393(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[")
 
 def latex_rule394(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\*")
 
 def latex_rule395(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule396(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX")
 
 def latex_rule397(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\S",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\S")
 
 def latex_rule398(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{")
 
 def latex_rule399(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\P",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\P")
 
 def latex_rule400(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large")
 
 def latex_rule401(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX")
 
 def latex_rule402(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE")
 
 def latex_rule403(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{")
 
 def latex_rule404(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge")
 
 def latex_rule405(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\H",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\H")
 
 def latex_rule406(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{")
 
 def latex_rule407(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\@")
 
 def latex_rule408(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\={",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\={")
 
 def latex_rule409(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule410(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{")
 
 def latex_rule411(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\.")
 
 def latex_rule412(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule413(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule414(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{")
 
 def latex_rule415(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule416(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\&")
 
 def latex_rule417(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\%")
 
 def latex_rule418(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\$")
 
 def latex_rule419(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\#")
 
 def latex_rule420(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{")
 
 def latex_rule421(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\"")
 
 def latex_rule422(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def latex_rule423(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="[")
 
 def latex_rule424(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="---",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="---")
 
 def latex_rule425(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="--")
 
 def latex_rule426(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def latex_rule427(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
 
 # Rules dict for latex_main ruleset.
 rulesDict1 = {
@@ -1876,2091 +1428,1568 @@ rulesDict1 = {
 # Rules for latex_mathmode ruleset.
 
 def latex_rule428(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__MathMode__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="__MathMode__")
 
 def latex_rule429(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule430(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def latex_rule431(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def latex_rule432(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\zeta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\zeta")
 
 def latex_rule433(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\xi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\xi")
 
 def latex_rule434(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\wr")
 
 def latex_rule435(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\wp")
 
 def latex_rule436(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widetilde{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\widetilde{")
 
 def latex_rule437(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widehat{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\widehat{")
 
 def latex_rule438(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\wedge")
 
 def latex_rule439(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\veebar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\veebar")
 
 def latex_rule440(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vee",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vee")
 
 def latex_rule441(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vec{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vec{")
 
 def latex_rule442(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdots")
 
 def latex_rule443(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdash")
 
 def latex_rule444(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleright")
 
 def latex_rule445(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleleft")
 
 def latex_rule446(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangle")
 
 def latex_rule447(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartheta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartheta")
 
 def latex_rule448(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneqq")
 
 def latex_rule449(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneq")
 
 def latex_rule450(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneqq")
 
 def latex_rule451(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneq")
 
 def latex_rule452(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsigma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsigma")
 
 def latex_rule453(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varrho",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varrho")
 
 def latex_rule454(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpropto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpropto")
 
 def latex_rule455(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpi")
 
 def latex_rule456(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varphi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varphi")
 
 def latex_rule457(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varnothing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varnothing")
 
 def latex_rule458(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varkappa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varkappa")
 
 def latex_rule459(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varepsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varepsilon")
 
 def latex_rule460(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vDash")
 
 def latex_rule461(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\urcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\urcorner")
 
 def latex_rule462(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upuparrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upuparrows")
 
 def latex_rule463(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upsilon")
 
 def latex_rule464(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\uplus")
 
 def latex_rule465(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonright")
 
 def latex_rule466(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonleft")
 
 def latex_rule467(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\updownarrow")
 
 def latex_rule468(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\uparrow")
 
 def latex_rule469(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ulcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ulcorner")
 
 def latex_rule470(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow")
 
 def latex_rule471(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow")
 
 def latex_rule472(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglerighteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglerighteq")
 
 def latex_rule473(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleright")
 
 def latex_rule474(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleq")
 
 def latex_rule475(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglelefteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglelefteq")
 
 def latex_rule476(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleleft")
 
 def latex_rule477(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangledown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangledown")
 
 def latex_rule478(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangle")
 
 def latex_rule479(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\top",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\top")
 
 def latex_rule480(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\times",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\times")
 
 def latex_rule481(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\tilde{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\tilde{")
 
 def latex_rule482(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicksim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicksim")
 
 def latex_rule483(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thickapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thickapprox")
 
 def latex_rule484(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\theta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\theta")
 
 def latex_rule485(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\therefore",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\therefore")
 
 def latex_rule486(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\text{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\text{")
 
 def latex_rule487(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\textstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\textstyle")
 
 def latex_rule488(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tau",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tau")
 
 def latex_rule489(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tanh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tanh")
 
 def latex_rule490(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tan",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tan")
 
 def latex_rule491(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\swarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\swarrow")
 
 def latex_rule492(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\surd",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\surd")
 
 def latex_rule493(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneqq")
 
 def latex_rule494(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneq")
 
 def latex_rule495(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteqq")
 
 def latex_rule496(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteq")
 
 def latex_rule497(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supset")
 
 def latex_rule498(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sum",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sum")
 
 def latex_rule499(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succsim")
 
 def latex_rule500(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnsim")
 
 def latex_rule501(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnapprox")
 
 def latex_rule502(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succeq")
 
 def latex_rule503(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succcurlyeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succcurlyeq")
 
 def latex_rule504(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succapprox")
 
 def latex_rule505(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succ")
 
 def latex_rule506(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneqq")
 
 def latex_rule507(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneq")
 
 def latex_rule508(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteqq")
 
 def latex_rule509(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteq")
 
 def latex_rule510(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subset")
 
 def latex_rule511(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\star",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\star")
 
 def latex_rule512(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stackrel{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stackrel{")
 
 def latex_rule513(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\square",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\square")
 
 def latex_rule514(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupseteq")
 
 def latex_rule515(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupset")
 
 def latex_rule516(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubseteq")
 
 def latex_rule517(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubset")
 
 def latex_rule518(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sqrt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\sqrt{")
 
 def latex_rule519(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcup")
 
 def latex_rule520(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcap")
 
 def latex_rule521(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sphericalangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sphericalangle")
 
 def latex_rule522(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\spadesuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\spadesuit")
 
 def latex_rule523(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smile")
 
 def latex_rule524(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsmile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsmile")
 
 def latex_rule525(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsetminus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsetminus")
 
 def latex_rule526(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallfrown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallfrown")
 
 def latex_rule527(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sinh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sinh")
 
 def latex_rule528(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sin")
 
 def latex_rule529(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\simeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\simeq")
 
 def latex_rule530(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sim")
 
 def latex_rule531(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sigma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sigma")
 
 def latex_rule532(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortparallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortparallel")
 
 def latex_rule533(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortmid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortmid")
 
 def latex_rule534(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sharp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sharp")
 
 def latex_rule535(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\setminus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\setminus")
 
 def latex_rule536(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sec")
 
 def latex_rule537(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\searrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\searrow")
 
 def latex_rule538(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptstyle")
 
 def latex_rule539(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle")
 
 def latex_rule540(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rtimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rtimes")
 
 def latex_rule541(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\risingdotseq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\risingdotseq")
 
 def latex_rule542(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right|")
 
 def latex_rule543(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightthreetimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightthreetimes")
 
 def latex_rule544(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightsquigarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightsquigarrow")
 
 def latex_rule545(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule546(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule547(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule548(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule549(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftarrows")
 
 def latex_rule550(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoonup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoonup")
 
 def latex_rule551(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoondown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoondown")
 
 def latex_rule552(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrowtail",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrowtail")
 
 def latex_rule553(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrow")
 
 def latex_rule554(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right]")
 
 def latex_rule555(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\|")
 
 def latex_rule556(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\updownarrow")
 
 def latex_rule557(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\uparrow")
 
 def latex_rule558(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rfloor")
 
 def latex_rule559(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rceil")
 
 def latex_rule560(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rangle")
 
 def latex_rule561(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lfloor")
 
 def latex_rule562(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lceil")
 
 def latex_rule563(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\langle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\langle")
 
 def latex_rule564(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\downarrow")
 
 def latex_rule565(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\backslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\backslash")
 
 def latex_rule566(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow")
 
 def latex_rule567(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Uparrow")
 
 def latex_rule568(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Downarrow")
 
 def latex_rule569(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\)")
 
 def latex_rule570(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\(")
 
 def latex_rule571(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\right[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\right[")
 
 def latex_rule572(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right/")
 
 def latex_rule573(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right)")
 
 def latex_rule574(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right(")
 
 def latex_rule575(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rho",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rho")
 
 def latex_rule576(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\psi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\psi")
 
 def latex_rule577(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\propto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\propto")
 
 def latex_rule578(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\prod")
 
 def latex_rule579(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prime",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\prime")
 
 def latex_rule580(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precsim")
 
 def latex_rule581(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnsim")
 
 def latex_rule582(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnapprox")
 
 def latex_rule583(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preceq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\preceq")
 
 def latex_rule584(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preccurlyeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\preccurlyeq")
 
 def latex_rule585(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precapprox")
 
 def latex_rule586(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\prec")
 
 def latex_rule587(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmod{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmod{")
 
 def latex_rule588(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmb{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmb{")
 
 def latex_rule589(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pm",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pm")
 
 def latex_rule590(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pitchfork",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pitchfork")
 
 def latex_rule591(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pi")
 
 def latex_rule592(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\phi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\phi")
 
 def latex_rule593(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\perp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\perp")
 
 def latex_rule594(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\partial",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\partial")
 
 def latex_rule595(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\parallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\parallel")
 
 def latex_rule596(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\overline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\overline{")
 
 def latex_rule597(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\otimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\otimes")
 
 def latex_rule598(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oslash")
 
 def latex_rule599(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oplus")
 
 def latex_rule600(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ominus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ominus")
 
 def latex_rule601(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\omega",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\omega")
 
 def latex_rule602(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oint",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oint")
 
 def latex_rule603(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\odot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\odot")
 
 def latex_rule604(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nwarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nwarrow")
 
 def latex_rule605(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvdash")
 
 def latex_rule606(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule607(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule608(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nu",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nu")
 
 def latex_rule609(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq")
 
 def latex_rule610(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleright")
 
 def latex_rule611(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq")
 
 def latex_rule612(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleleft")
 
 def latex_rule613(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteqq")
 
 def latex_rule614(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteq")
 
 def latex_rule615(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucceq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucceq")
 
 def latex_rule616(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucc")
 
 def latex_rule617(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsubseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsubseteq")
 
 def latex_rule618(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsim")
 
 def latex_rule619(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortparallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortparallel")
 
 def latex_rule620(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortmid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortmid")
 
 def latex_rule621(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nrightarrow")
 
 def latex_rule622(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\npreceq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\npreceq")
 
 def latex_rule623(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nprec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nprec")
 
 def latex_rule624(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nparallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nparallel")
 
 def latex_rule625(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\notin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\notin")
 
 def latex_rule626(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nmid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nmid")
 
 def latex_rule627(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nless")
 
 def latex_rule628(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqslant")
 
 def latex_rule629(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqq")
 
 def latex_rule630(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleq")
 
 def latex_rule631(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftrightarrow")
 
 def latex_rule632(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftarrow")
 
 def latex_rule633(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ni",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ni")
 
 def latex_rule634(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngtr")
 
 def latex_rule635(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqslant")
 
 def latex_rule636(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqq")
 
 def latex_rule637(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeq")
 
 def latex_rule638(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nexists",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nexists")
 
 def latex_rule639(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\neq")
 
 def latex_rule640(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\neg")
 
 def latex_rule641(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nearrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nearrow")
 
 def latex_rule642(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ncong",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ncong")
 
 def latex_rule643(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\natural",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\natural")
 
 def latex_rule644(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nabla",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nabla")
 
 def latex_rule645(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nVDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nVDash")
 
 def latex_rule646(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nRightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nRightarrow")
 
 def latex_rule647(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow")
 
 def latex_rule648(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftarrow")
 
 def latex_rule649(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\multimap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\multimap")
 
 def latex_rule650(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mu",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mu")
 
 def latex_rule651(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mp")
 
 def latex_rule652(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\models",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\models")
 
 def latex_rule653(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\min",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\min")
 
 def latex_rule654(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mid")
 
 def latex_rule655(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mho",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mho")
 
 def latex_rule656(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\measuredangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\measuredangle")
 
 def latex_rule657(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\max",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\max")
 
 def latex_rule658(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathtt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathtt{")
 
 def latex_rule659(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathsf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathsf{")
 
 def latex_rule660(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mathrm{~~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mathrm{~~")
 
 def latex_rule661(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathit{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathit{")
 
 def latex_rule662(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathcal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathcal{")
 
 def latex_rule663(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathbf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathbf{")
 
 def latex_rule664(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mapsto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mapsto")
 
 def latex_rule665(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lvertneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lvertneqq")
 
 def latex_rule666(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ltimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ltimes")
 
 def latex_rule667(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lrcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lrcorner")
 
 def latex_rule668(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lozenge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lozenge")
 
 def latex_rule669(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowright")
 
 def latex_rule670(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowleft")
 
 def latex_rule671(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longrightarrow")
 
 def latex_rule672(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longmapsto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longmapsto")
 
 def latex_rule673(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftrightarrow")
 
 def latex_rule674(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftarrow")
 
 def latex_rule675(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\log",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\log")
 
 def latex_rule676(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnsim")
 
 def latex_rule677(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneqq")
 
 def latex_rule678(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneq")
 
 def latex_rule679(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnapprox")
 
 def latex_rule680(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ln",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ln")
 
 def latex_rule681(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lll",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lll")
 
 def latex_rule682(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\llcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\llcorner")
 
 def latex_rule683(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ll",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ll")
 
 def latex_rule684(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\limsup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\limsup")
 
 def latex_rule685(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\liminf",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\liminf")
 
 def latex_rule686(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lim")
 
 def latex_rule687(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lg")
 
 def latex_rule688(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesssim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesssim")
 
 def latex_rule689(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessgtr")
 
 def latex_rule690(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqqgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqqgtr")
 
 def latex_rule691(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqgtr")
 
 def latex_rule692(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessdot")
 
 def latex_rule693(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessapprox")
 
 def latex_rule694(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqslant")
 
 def latex_rule695(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqq")
 
 def latex_rule696(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leq")
 
 def latex_rule697(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left|")
 
 def latex_rule698(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftthreetimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftthreetimes")
 
 def latex_rule699(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow")
 
 def latex_rule700(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightharpoons",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightharpoons")
 
 def latex_rule701(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrows")
 
 def latex_rule702(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrow")
 
 def latex_rule703(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftleftarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftleftarrows")
 
 def latex_rule704(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoonup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoonup")
 
 def latex_rule705(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoondown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoondown")
 
 def latex_rule706(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lefteqn{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\lefteqn{")
 
 def latex_rule707(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrowtail",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrowtail")
 
 def latex_rule708(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrow")
 
 def latex_rule709(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left]")
 
 def latex_rule710(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\|")
 
 def latex_rule711(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\updownarrow")
 
 def latex_rule712(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\uparrow")
 
 def latex_rule713(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rfloor")
 
 def latex_rule714(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rceil")
 
 def latex_rule715(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rangle")
 
 def latex_rule716(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lfloor")
 
 def latex_rule717(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lceil")
 
 def latex_rule718(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\langle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\langle")
 
 def latex_rule719(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\downarrow")
 
 def latex_rule720(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\backslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\backslash")
 
 def latex_rule721(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow")
 
 def latex_rule722(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Uparrow")
 
 def latex_rule723(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Downarrow")
 
 def latex_rule724(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\)")
 
 def latex_rule725(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\(")
 
 def latex_rule726(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\left[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\left[")
 
 def latex_rule727(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left/")
 
 def latex_rule728(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left)")
 
 def latex_rule729(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left(")
 
 def latex_rule730(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ldots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ldots")
 
 def latex_rule731(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lambda",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lambda")
 
 def latex_rule732(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ker",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ker")
 
 def latex_rule733(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\kappa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\kappa")
 
 def latex_rule734(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule735(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule736(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\iota",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\iota")
 
 def latex_rule737(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\intercal",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\intercal")
 
 def latex_rule738(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\int",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\int")
 
 def latex_rule739(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\infty",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\infty")
 
 def latex_rule740(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\inf",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\inf")
 
 def latex_rule741(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\in",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\in")
 
 def latex_rule742(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule743(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule744(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hslash")
 
 def latex_rule745(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookrightarrow")
 
 def latex_rule746(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookleftarrow")
 
 def latex_rule747(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hom",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hom")
 
 def latex_rule748(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\heartsuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\heartsuit")
 
 def latex_rule749(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hbar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hbar")
 
 def latex_rule750(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hat{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hat{")
 
 def latex_rule751(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gvertneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gvertneqq")
 
 def latex_rule752(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrsim")
 
 def latex_rule753(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrless")
 
 def latex_rule754(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqqless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqqless")
 
 def latex_rule755(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqless")
 
 def latex_rule756(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrdot")
 
 def latex_rule757(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrapprox")
 
 def latex_rule758(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\grave{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\grave{")
 
 def latex_rule759(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnsim")
 
 def latex_rule760(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneqq")
 
 def latex_rule761(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneq")
 
 def latex_rule762(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule763(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule764(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gimel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gimel")
 
 def latex_rule765(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ggg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ggg")
 
 def latex_rule766(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gg")
 
 def latex_rule767(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqslant")
 
 def latex_rule768(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqq")
 
 def latex_rule769(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\geq")
 
 def latex_rule770(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gcd",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gcd")
 
 def latex_rule771(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gamma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gamma")
 
 def latex_rule772(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\frown")
 
 def latex_rule773(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frak{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\frak{")
 
 def latex_rule774(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frac{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\frac{")
 
 def latex_rule775(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\forall",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\forall")
 
 def latex_rule776(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\flat",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\flat")
 
 def latex_rule777(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fallingdotseq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fallingdotseq")
 
 def latex_rule778(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\exp")
 
 def latex_rule779(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exists",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\exists")
 
 def latex_rule780(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eth")
 
 def latex_rule781(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eta")
 
 def latex_rule782(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\equiv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\equiv")
 
 def latex_rule783(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantless")
 
 def latex_rule784(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantgtr")
 
 def latex_rule785(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqcirc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqcirc")
 
 def latex_rule786(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\epsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\epsilon")
 
 def latex_rule787(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule788(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule789(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\emptyset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\emptyset")
 
 def latex_rule790(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ell",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ell")
 
 def latex_rule791(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonright")
 
 def latex_rule792(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonleft")
 
 def latex_rule793(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downdownarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downdownarrows")
 
 def latex_rule794(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downarrow")
 
 def latex_rule795(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doublebarwedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\doublebarwedge")
 
 def latex_rule796(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\dot{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\dot{")
 
 def latex_rule797(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dotplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dotplus")
 
 def latex_rule798(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteqdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteqdot")
 
 def latex_rule799(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteq")
 
 def latex_rule800(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\divideontimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\divideontimes")
 
 def latex_rule801(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\div",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\div")
 
 def latex_rule802(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\displaystyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\displaystyle")
 
 def latex_rule803(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dim")
 
 def latex_rule804(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\digamma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\digamma")
 
 def latex_rule805(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamondsuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamondsuit")
 
 def latex_rule806(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamond",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamond")
 
 def latex_rule807(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagup")
 
 def latex_rule808(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagdown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagdown")
 
 def latex_rule809(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\det",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\det")
 
 def latex_rule810(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\delta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\delta")
 
 def latex_rule811(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\deg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\deg")
 
 def latex_rule812(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ddot{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ddot{")
 
 def latex_rule813(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddots")
 
 def latex_rule814(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddagger",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddagger")
 
 def latex_rule815(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashv")
 
 def latex_rule816(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashrightarrow")
 
 def latex_rule817(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashleftarrow")
 
 def latex_rule818(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\daleth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\daleth")
 
 def latex_rule819(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dagger",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dagger")
 
 def latex_rule820(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowright")
 
 def latex_rule821(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowleft")
 
 def latex_rule822(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlywedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlywedge")
 
 def latex_rule823(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyvee",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyvee")
 
 def latex_rule824(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqsucc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqsucc")
 
 def latex_rule825(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqprec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqprec")
 
 def latex_rule826(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cup")
 
 def latex_rule827(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\csc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\csc")
 
 def latex_rule828(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\coth")
 
 def latex_rule829(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cot")
 
 def latex_rule830(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cosh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cosh")
 
 def latex_rule831(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cos",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cos")
 
 def latex_rule832(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coprod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\coprod")
 
 def latex_rule833(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cong",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cong")
 
 def latex_rule834(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\complement",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\complement")
 
 def latex_rule835(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clubsuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\clubsuit")
 
 def latex_rule836(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circleddash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circleddash")
 
 def latex_rule837(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledcirc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledcirc")
 
 def latex_rule838(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledast",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledast")
 
 def latex_rule839(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledS")
 
 def latex_rule840(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowright")
 
 def latex_rule841(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowleft")
 
 def latex_rule842(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circeq")
 
 def latex_rule843(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circ")
 
 def latex_rule844(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\chi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\chi")
 
 def latex_rule845(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\check{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\check{")
 
 def latex_rule846(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centerdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\centerdot")
 
 def latex_rule847(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdots")
 
 def latex_rule848(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdot")
 
 def latex_rule849(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cap")
 
 def latex_rule850(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bumpeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bumpeq")
 
 def latex_rule851(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bullet",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bullet")
 
 def latex_rule852(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\breve{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\breve{")
 
 def latex_rule853(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxtimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxtimes")
 
 def latex_rule854(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxplus")
 
 def latex_rule855(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxminus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxminus")
 
 def latex_rule856(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxdot")
 
 def latex_rule857(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bowtie",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bowtie")
 
 def latex_rule858(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bot")
 
 def latex_rule859(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldsymbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldsymbol{")
 
 def latex_rule860(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bmod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bmod")
 
 def latex_rule861(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleright")
 
 def latex_rule862(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleleft")
 
 def latex_rule863(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangledown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangledown")
 
 def latex_rule864(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangle")
 
 def latex_rule865(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacksquare",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacksquare")
 
 def latex_rule866(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacklozenge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacklozenge")
 
 def latex_rule867(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigwedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigwedge")
 
 def latex_rule868(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigvee",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigvee")
 
 def latex_rule869(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\biguplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\biguplus")
 
 def latex_rule870(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangleup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangleup")
 
 def latex_rule871(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangledown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangledown")
 
 def latex_rule872(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigstar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigstar")
 
 def latex_rule873(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigsqcup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigsqcup")
 
 def latex_rule874(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigotimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigotimes")
 
 def latex_rule875(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigoplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigoplus")
 
 def latex_rule876(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigodot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigodot")
 
 def latex_rule877(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcup")
 
 def latex_rule878(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcirc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcirc")
 
 def latex_rule879(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcap")
 
 def latex_rule880(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\between",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\between")
 
 def latex_rule881(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\beth")
 
 def latex_rule882(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\beta")
 
 def latex_rule883(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule884(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\because",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\because")
 
 def latex_rule885(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bar{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bar{")
 
 def latex_rule886(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\barwedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\barwedge")
 
 def latex_rule887(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backslash")
 
 def latex_rule888(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsimeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsimeq")
 
 def latex_rule889(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsim")
 
 def latex_rule890(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backprime",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backprime")
 
 def latex_rule891(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\asymp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\asymp")
 
 def latex_rule892(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ast",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ast")
 
 def latex_rule893(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arg")
 
 def latex_rule894(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arctan",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arctan")
 
 def latex_rule895(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arcsin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arcsin")
 
 def latex_rule896(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arccos",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arccos")
 
 def latex_rule897(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approxeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\approxeq")
 
 def latex_rule898(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approx",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\approx")
 
 def latex_rule899(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule900(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule901(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\amalg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\amalg")
 
 def latex_rule902(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\alpha",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\alpha")
 
 def latex_rule903(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\aleph",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\aleph")
 
 def latex_rule904(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\acute{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\acute{")
 
 def latex_rule905(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Xi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Xi")
 
 def latex_rule906(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vvdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vvdash")
 
 def latex_rule907(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vdash")
 
 def latex_rule908(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Upsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Upsilon")
 
 def latex_rule909(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Updownarrow")
 
 def latex_rule910(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Uparrow")
 
 def latex_rule911(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Theta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Theta")
 
 def latex_rule912(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Supset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Supset")
 
 def latex_rule913(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Subset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Subset")
 
 def latex_rule914(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Sigma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Sigma")
 
 def latex_rule915(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rsh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rsh")
 
 def latex_rule916(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rightarrow")
 
 def latex_rule917(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Re",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Re")
 
 def latex_rule918(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Psi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Psi")
 
 def latex_rule919(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pr")
 
 def latex_rule920(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pi")
 
 def latex_rule921(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Phi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Phi")
 
 def latex_rule922(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Omega",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Omega")
 
 def latex_rule923(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lsh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lsh")
 
 def latex_rule924(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longrightarrow")
 
 def latex_rule925(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow")
 
 def latex_rule926(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftarrow")
 
 def latex_rule927(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lleftarrow")
 
 def latex_rule928(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftrightarrow")
 
 def latex_rule929(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftarrow")
 
 def latex_rule930(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lambda",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lambda")
 
 def latex_rule931(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Im",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Im")
 
 def latex_rule932(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Gamma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Gamma")
 
 def latex_rule933(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Game",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Game")
 
 def latex_rule934(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Finv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Finv")
 
 def latex_rule935(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Downarrow")
 
 def latex_rule936(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Delta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Delta")
 
 def latex_rule937(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cup")
 
 def latex_rule938(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cap")
 
 def latex_rule939(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bumpeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bumpeq")
 
 def latex_rule940(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Bbb{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Bbb{")
 
 def latex_rule941(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bbbk",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bbbk")
 
 def latex_rule942(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\;")
 
 def latex_rule943(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\:")
 
 def latex_rule944(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule945(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\!")
 
 def latex_rule946(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="'")
 
 def latex_rule947(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{array}", end="\\end{array}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="latex::arraymode", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="latex::arraymode")
 
 def latex_rule948(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
 
 # Rules dict for latex_mathmode ruleset.
 rulesDict2 = {
@@ -3974,2105 +3003,1579 @@ rulesDict2 = {
 # Rules for latex_arraymode ruleset.
 
 def latex_rule949(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__ArrayMode__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="__ArrayMode__")
 
 def latex_rule950(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule951(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def latex_rule952(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def latex_rule953(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\zeta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\zeta")
 
 def latex_rule954(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\xi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\xi")
 
 def latex_rule955(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\wr")
 
 def latex_rule956(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\wp")
 
 def latex_rule957(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widetilde{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\widetilde{")
 
 def latex_rule958(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widehat{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\widehat{")
 
 def latex_rule959(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\wedge")
 
 def latex_rule960(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vline")
 
 def latex_rule961(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\veebar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\veebar")
 
 def latex_rule962(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vee",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vee")
 
 def latex_rule963(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vec{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vec{")
 
 def latex_rule964(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdots")
 
 def latex_rule965(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdash")
 
 def latex_rule966(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleright")
 
 def latex_rule967(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleleft")
 
 def latex_rule968(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangle")
 
 def latex_rule969(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartheta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartheta")
 
 def latex_rule970(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneqq")
 
 def latex_rule971(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneq")
 
 def latex_rule972(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneqq")
 
 def latex_rule973(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneq")
 
 def latex_rule974(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsigma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsigma")
 
 def latex_rule975(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varrho",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varrho")
 
 def latex_rule976(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpropto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpropto")
 
 def latex_rule977(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpi")
 
 def latex_rule978(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varphi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varphi")
 
 def latex_rule979(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varnothing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varnothing")
 
 def latex_rule980(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varkappa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varkappa")
 
 def latex_rule981(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varepsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\varepsilon")
 
 def latex_rule982(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vDash")
 
 def latex_rule983(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\urcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\urcorner")
 
 def latex_rule984(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upuparrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upuparrows")
 
 def latex_rule985(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upsilon")
 
 def latex_rule986(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\uplus")
 
 def latex_rule987(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonright")
 
 def latex_rule988(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonleft")
 
 def latex_rule989(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\updownarrow")
 
 def latex_rule990(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\uparrow")
 
 def latex_rule991(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ulcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ulcorner")
 
 def latex_rule992(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow")
 
 def latex_rule993(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow")
 
 def latex_rule994(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglerighteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglerighteq")
 
 def latex_rule995(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleright")
 
 def latex_rule996(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleq")
 
 def latex_rule997(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglelefteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglelefteq")
 
 def latex_rule998(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleleft")
 
 def latex_rule999(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangledown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangledown")
 
 def latex_rule1000(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangle")
 
 def latex_rule1001(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\top",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\top")
 
 def latex_rule1002(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\times",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\times")
 
 def latex_rule1003(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\tilde{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\tilde{")
 
 def latex_rule1004(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicksim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicksim")
 
 def latex_rule1005(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thickapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thickapprox")
 
 def latex_rule1006(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\theta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\theta")
 
 def latex_rule1007(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\therefore",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\therefore")
 
 def latex_rule1008(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\text{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\text{")
 
 def latex_rule1009(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\textstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\textstyle")
 
 def latex_rule1010(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tau",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tau")
 
 def latex_rule1011(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tanh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tanh")
 
 def latex_rule1012(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tan",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tan")
 
 def latex_rule1013(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\swarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\swarrow")
 
 def latex_rule1014(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\surd",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\surd")
 
 def latex_rule1015(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneqq")
 
 def latex_rule1016(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneq")
 
 def latex_rule1017(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteqq")
 
 def latex_rule1018(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteq")
 
 def latex_rule1019(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\supset")
 
 def latex_rule1020(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sum",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sum")
 
 def latex_rule1021(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succsim")
 
 def latex_rule1022(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnsim")
 
 def latex_rule1023(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnapprox")
 
 def latex_rule1024(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succeq")
 
 def latex_rule1025(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succcurlyeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succcurlyeq")
 
 def latex_rule1026(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succapprox")
 
 def latex_rule1027(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\succ")
 
 def latex_rule1028(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneqq")
 
 def latex_rule1029(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneq")
 
 def latex_rule1030(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteqq")
 
 def latex_rule1031(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteq")
 
 def latex_rule1032(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\subset")
 
 def latex_rule1033(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\star",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\star")
 
 def latex_rule1034(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stackrel{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stackrel{")
 
 def latex_rule1035(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\square",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\square")
 
 def latex_rule1036(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupseteq")
 
 def latex_rule1037(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupset")
 
 def latex_rule1038(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubseteq")
 
 def latex_rule1039(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubset")
 
 def latex_rule1040(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sqrt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\sqrt{")
 
 def latex_rule1041(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcup")
 
 def latex_rule1042(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcap")
 
 def latex_rule1043(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sphericalangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sphericalangle")
 
 def latex_rule1044(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\spadesuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\spadesuit")
 
 def latex_rule1045(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smile")
 
 def latex_rule1046(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsmile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsmile")
 
 def latex_rule1047(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsetminus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsetminus")
 
 def latex_rule1048(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallfrown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallfrown")
 
 def latex_rule1049(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sinh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sinh")
 
 def latex_rule1050(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sin")
 
 def latex_rule1051(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\simeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\simeq")
 
 def latex_rule1052(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sim")
 
 def latex_rule1053(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sigma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sigma")
 
 def latex_rule1054(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortparallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortparallel")
 
 def latex_rule1055(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortmid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortmid")
 
 def latex_rule1056(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sharp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sharp")
 
 def latex_rule1057(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\setminus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\setminus")
 
 def latex_rule1058(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sec")
 
 def latex_rule1059(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\searrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\searrow")
 
 def latex_rule1060(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptstyle")
 
 def latex_rule1061(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle")
 
 def latex_rule1062(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rtimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rtimes")
 
 def latex_rule1063(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\risingdotseq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\risingdotseq")
 
 def latex_rule1064(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right|")
 
 def latex_rule1065(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightthreetimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightthreetimes")
 
 def latex_rule1066(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightsquigarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightsquigarrow")
 
 def latex_rule1067(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule1068(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule1069(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule1070(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule1071(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftarrows")
 
 def latex_rule1072(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoonup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoonup")
 
 def latex_rule1073(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoondown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoondown")
 
 def latex_rule1074(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrowtail",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrowtail")
 
 def latex_rule1075(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrow")
 
 def latex_rule1076(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right]")
 
 def latex_rule1077(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\|")
 
 def latex_rule1078(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\updownarrow")
 
 def latex_rule1079(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\uparrow")
 
 def latex_rule1080(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rfloor")
 
 def latex_rule1081(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rceil")
 
 def latex_rule1082(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rangle")
 
 def latex_rule1083(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lfloor")
 
 def latex_rule1084(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lceil")
 
 def latex_rule1085(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\langle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\langle")
 
 def latex_rule1086(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\downarrow")
 
 def latex_rule1087(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\backslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\backslash")
 
 def latex_rule1088(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow")
 
 def latex_rule1089(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Uparrow")
 
 def latex_rule1090(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Downarrow")
 
 def latex_rule1091(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\)")
 
 def latex_rule1092(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\(")
 
 def latex_rule1093(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\right[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\right[")
 
 def latex_rule1094(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right/")
 
 def latex_rule1095(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right)")
 
 def latex_rule1096(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\right(")
 
 def latex_rule1097(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rho",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rho")
 
 def latex_rule1098(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\psi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\psi")
 
 def latex_rule1099(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\propto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\propto")
 
 def latex_rule1100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\prod")
 
 def latex_rule1101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prime",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\prime")
 
 def latex_rule1102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precsim")
 
 def latex_rule1103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnsim")
 
 def latex_rule1104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnapprox")
 
 def latex_rule1105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preceq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\preceq")
 
 def latex_rule1106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preccurlyeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\preccurlyeq")
 
 def latex_rule1107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\precapprox")
 
 def latex_rule1108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\prec")
 
 def latex_rule1109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmod{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmod{")
 
 def latex_rule1110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmb{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmb{")
 
 def latex_rule1111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pm",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pm")
 
 def latex_rule1112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pitchfork",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pitchfork")
 
 def latex_rule1113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pi")
 
 def latex_rule1114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\phi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\phi")
 
 def latex_rule1115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\perp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\perp")
 
 def latex_rule1116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\partial",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\partial")
 
 def latex_rule1117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\parallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\parallel")
 
 def latex_rule1118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\overline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\overline{")
 
 def latex_rule1119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\otimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\otimes")
 
 def latex_rule1120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oslash")
 
 def latex_rule1121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oplus")
 
 def latex_rule1122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ominus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ominus")
 
 def latex_rule1123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\omega",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\omega")
 
 def latex_rule1124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oint",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oint")
 
 def latex_rule1125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\odot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\odot")
 
 def latex_rule1126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nwarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nwarrow")
 
 def latex_rule1127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvdash")
 
 def latex_rule1128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule1129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule1130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nu",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nu")
 
 def latex_rule1131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq")
 
 def latex_rule1132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleright")
 
 def latex_rule1133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq")
 
 def latex_rule1134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleleft")
 
 def latex_rule1135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteqq")
 
 def latex_rule1136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteq")
 
 def latex_rule1137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucceq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucceq")
 
 def latex_rule1138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucc")
 
 def latex_rule1139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsubseteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsubseteq")
 
 def latex_rule1140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsim")
 
 def latex_rule1141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortparallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortparallel")
 
 def latex_rule1142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortmid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortmid")
 
 def latex_rule1143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nrightarrow")
 
 def latex_rule1144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\npreceq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\npreceq")
 
 def latex_rule1145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nprec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nprec")
 
 def latex_rule1146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nparallel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nparallel")
 
 def latex_rule1147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\notin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\notin")
 
 def latex_rule1148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nmid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nmid")
 
 def latex_rule1149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nless")
 
 def latex_rule1150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqslant")
 
 def latex_rule1151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqq")
 
 def latex_rule1152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleq")
 
 def latex_rule1153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftrightarrow")
 
 def latex_rule1154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftarrow")
 
 def latex_rule1155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ni",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ni")
 
 def latex_rule1156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngtr")
 
 def latex_rule1157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqslant")
 
 def latex_rule1158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqq")
 
 def latex_rule1159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeq")
 
 def latex_rule1160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nexists",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nexists")
 
 def latex_rule1161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\neq")
 
 def latex_rule1162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\neg")
 
 def latex_rule1163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nearrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nearrow")
 
 def latex_rule1164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ncong",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ncong")
 
 def latex_rule1165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\natural",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\natural")
 
 def latex_rule1166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nabla",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nabla")
 
 def latex_rule1167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nVDash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nVDash")
 
 def latex_rule1168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nRightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nRightarrow")
 
 def latex_rule1169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow")
 
 def latex_rule1170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftarrow")
 
 def latex_rule1171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\multimap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\multimap")
 
 def latex_rule1172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\multicolumn{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\multicolumn{")
 
 def latex_rule1173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mu",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mu")
 
 def latex_rule1174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mp")
 
 def latex_rule1175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\models",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\models")
 
 def latex_rule1176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\min",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\min")
 
 def latex_rule1177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mid",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mid")
 
 def latex_rule1178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mho",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mho")
 
 def latex_rule1179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\measuredangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\measuredangle")
 
 def latex_rule1180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\max",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\max")
 
 def latex_rule1181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathtt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathtt{")
 
 def latex_rule1182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathsf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathsf{")
 
 def latex_rule1183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mathrm{~~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mathrm{~~")
 
 def latex_rule1184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathit{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathit{")
 
 def latex_rule1185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathcal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathcal{")
 
 def latex_rule1186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathbf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathbf{")
 
 def latex_rule1187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mapsto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mapsto")
 
 def latex_rule1188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lvertneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lvertneqq")
 
 def latex_rule1189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ltimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ltimes")
 
 def latex_rule1190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lrcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lrcorner")
 
 def latex_rule1191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lozenge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lozenge")
 
 def latex_rule1192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowright")
 
 def latex_rule1193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowleft")
 
 def latex_rule1194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longrightarrow")
 
 def latex_rule1195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longmapsto",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longmapsto")
 
 def latex_rule1196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftrightarrow")
 
 def latex_rule1197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftarrow")
 
 def latex_rule1198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\log",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\log")
 
 def latex_rule1199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnsim")
 
 def latex_rule1200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneqq")
 
 def latex_rule1201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneq")
 
 def latex_rule1202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnapprox")
 
 def latex_rule1203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ln",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ln")
 
 def latex_rule1204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lll",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lll")
 
 def latex_rule1205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\llcorner",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\llcorner")
 
 def latex_rule1206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ll",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ll")
 
 def latex_rule1207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\limsup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\limsup")
 
 def latex_rule1208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\liminf",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\liminf")
 
 def latex_rule1209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lim")
 
 def latex_rule1210(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lg")
 
 def latex_rule1211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesssim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesssim")
 
 def latex_rule1212(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessgtr")
 
 def latex_rule1213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqqgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqqgtr")
 
 def latex_rule1214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqgtr")
 
 def latex_rule1215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessdot")
 
 def latex_rule1216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessapprox")
 
 def latex_rule1217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqslant")
 
 def latex_rule1218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqq")
 
 def latex_rule1219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leq")
 
 def latex_rule1220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left|")
 
 def latex_rule1221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftthreetimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftthreetimes")
 
 def latex_rule1222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow")
 
 def latex_rule1223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightharpoons",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightharpoons")
 
 def latex_rule1224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrows")
 
 def latex_rule1225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrow")
 
 def latex_rule1226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftleftarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftleftarrows")
 
 def latex_rule1227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoonup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoonup")
 
 def latex_rule1228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoondown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoondown")
 
 def latex_rule1229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lefteqn{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\lefteqn{")
 
 def latex_rule1230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrowtail",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrowtail")
 
 def latex_rule1231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrow")
 
 def latex_rule1232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left]")
 
 def latex_rule1233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\|")
 
 def latex_rule1234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\updownarrow")
 
 def latex_rule1235(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\uparrow")
 
 def latex_rule1236(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rfloor")
 
 def latex_rule1237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rceil")
 
 def latex_rule1238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rangle")
 
 def latex_rule1239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lfloor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lfloor")
 
 def latex_rule1240(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lceil",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lceil")
 
 def latex_rule1241(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\langle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\langle")
 
 def latex_rule1242(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\downarrow")
 
 def latex_rule1243(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\backslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\backslash")
 
 def latex_rule1244(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow")
 
 def latex_rule1245(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Uparrow")
 
 def latex_rule1246(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Downarrow")
 
 def latex_rule1247(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\)")
 
 def latex_rule1248(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\(")
 
 def latex_rule1249(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\left[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\left[")
 
 def latex_rule1250(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left/")
 
 def latex_rule1251(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left)")
 
 def latex_rule1252(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\left(")
 
 def latex_rule1253(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ldots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ldots")
 
 def latex_rule1254(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lambda",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\lambda")
 
 def latex_rule1255(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ker",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ker")
 
 def latex_rule1256(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\kappa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\kappa")
 
 def latex_rule1257(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule1258(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule1259(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\iota",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\iota")
 
 def latex_rule1260(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\intercal",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\intercal")
 
 def latex_rule1261(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\int",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\int")
 
 def latex_rule1262(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\infty",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\infty")
 
 def latex_rule1263(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\inf",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\inf")
 
 def latex_rule1264(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\in",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\in")
 
 def latex_rule1265(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule1266(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule1267(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hslash")
 
 def latex_rule1268(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookrightarrow")
 
 def latex_rule1269(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookleftarrow")
 
 def latex_rule1270(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hom",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hom")
 
 def latex_rule1271(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hline")
 
 def latex_rule1272(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\heartsuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\heartsuit")
 
 def latex_rule1273(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hbar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hbar")
 
 def latex_rule1274(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hat{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hat{")
 
 def latex_rule1275(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gvertneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gvertneqq")
 
 def latex_rule1276(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrsim")
 
 def latex_rule1277(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrless")
 
 def latex_rule1278(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqqless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqqless")
 
 def latex_rule1279(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqless")
 
 def latex_rule1280(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrdot")
 
 def latex_rule1281(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrapprox")
 
 def latex_rule1282(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\grave{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\grave{")
 
 def latex_rule1283(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnsim")
 
 def latex_rule1284(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneqq")
 
 def latex_rule1285(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneq")
 
 def latex_rule1286(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule1287(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule1288(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gimel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gimel")
 
 def latex_rule1289(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ggg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ggg")
 
 def latex_rule1290(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gg")
 
 def latex_rule1291(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqslant",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqslant")
 
 def latex_rule1292(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqq")
 
 def latex_rule1293(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\geq")
 
 def latex_rule1294(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gcd",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gcd")
 
 def latex_rule1295(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gamma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\gamma")
 
 def latex_rule1296(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\frown")
 
 def latex_rule1297(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frak{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\frak{")
 
 def latex_rule1298(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frac{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\frac{")
 
 def latex_rule1299(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\forall",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\forall")
 
 def latex_rule1300(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\flat",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\flat")
 
 def latex_rule1301(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fallingdotseq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fallingdotseq")
 
 def latex_rule1302(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\exp")
 
 def latex_rule1303(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exists",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\exists")
 
 def latex_rule1304(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eth")
 
 def latex_rule1305(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eta")
 
 def latex_rule1306(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\equiv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\equiv")
 
 def latex_rule1307(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantless",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantless")
 
 def latex_rule1308(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantgtr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantgtr")
 
 def latex_rule1309(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqcirc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqcirc")
 
 def latex_rule1310(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\epsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\epsilon")
 
 def latex_rule1311(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule1312(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule1313(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\emptyset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\emptyset")
 
 def latex_rule1314(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ell",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ell")
 
 def latex_rule1315(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonright")
 
 def latex_rule1316(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonleft")
 
 def latex_rule1317(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downdownarrows",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downdownarrows")
 
 def latex_rule1318(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\downarrow")
 
 def latex_rule1319(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doublebarwedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\doublebarwedge")
 
 def latex_rule1320(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\dot{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\dot{")
 
 def latex_rule1321(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dotplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dotplus")
 
 def latex_rule1322(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteqdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteqdot")
 
 def latex_rule1323(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteq")
 
 def latex_rule1324(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\divideontimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\divideontimes")
 
 def latex_rule1325(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\div",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\div")
 
 def latex_rule1326(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\displaystyle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\displaystyle")
 
 def latex_rule1327(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dim")
 
 def latex_rule1328(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\digamma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\digamma")
 
 def latex_rule1329(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamondsuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamondsuit")
 
 def latex_rule1330(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamond",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamond")
 
 def latex_rule1331(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagup")
 
 def latex_rule1332(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagdown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagdown")
 
 def latex_rule1333(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\det",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\det")
 
 def latex_rule1334(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\delta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\delta")
 
 def latex_rule1335(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\deg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\deg")
 
 def latex_rule1336(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ddot{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ddot{")
 
 def latex_rule1337(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddots")
 
 def latex_rule1338(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddagger",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddagger")
 
 def latex_rule1339(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashv")
 
 def latex_rule1340(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashrightarrow")
 
 def latex_rule1341(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashleftarrow")
 
 def latex_rule1342(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\daleth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\daleth")
 
 def latex_rule1343(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dagger",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dagger")
 
 def latex_rule1344(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowright")
 
 def latex_rule1345(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowleft")
 
 def latex_rule1346(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlywedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlywedge")
 
 def latex_rule1347(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyvee",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyvee")
 
 def latex_rule1348(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqsucc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqsucc")
 
 def latex_rule1349(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqprec",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqprec")
 
 def latex_rule1350(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cup")
 
 def latex_rule1351(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\csc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\csc")
 
 def latex_rule1352(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\coth")
 
 def latex_rule1353(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cot")
 
 def latex_rule1354(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cosh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cosh")
 
 def latex_rule1355(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cos",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cos")
 
 def latex_rule1356(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coprod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\coprod")
 
 def latex_rule1357(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cong",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cong")
 
 def latex_rule1358(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\complement",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\complement")
 
 def latex_rule1359(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clubsuit",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\clubsuit")
 
 def latex_rule1360(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cline{")
 
 def latex_rule1361(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circleddash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circleddash")
 
 def latex_rule1362(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledcirc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledcirc")
 
 def latex_rule1363(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledast",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledast")
 
 def latex_rule1364(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledS",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledS")
 
 def latex_rule1365(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowright")
 
 def latex_rule1366(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowleft")
 
 def latex_rule1367(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circeq")
 
 def latex_rule1368(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\circ")
 
 def latex_rule1369(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\chi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\chi")
 
 def latex_rule1370(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\check{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\check{")
 
 def latex_rule1371(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centerdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\centerdot")
 
 def latex_rule1372(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdots",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdots")
 
 def latex_rule1373(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdot")
 
 def latex_rule1374(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cap")
 
 def latex_rule1375(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bumpeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bumpeq")
 
 def latex_rule1376(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bullet",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bullet")
 
 def latex_rule1377(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\breve{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\breve{")
 
 def latex_rule1378(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxtimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxtimes")
 
 def latex_rule1379(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxplus")
 
 def latex_rule1380(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxminus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxminus")
 
 def latex_rule1381(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxdot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxdot")
 
 def latex_rule1382(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bowtie",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bowtie")
 
 def latex_rule1383(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bot")
 
 def latex_rule1384(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldsymbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldsymbol{")
 
 def latex_rule1385(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bmod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bmod")
 
 def latex_rule1386(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleright")
 
 def latex_rule1387(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleleft")
 
 def latex_rule1388(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangledown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangledown")
 
 def latex_rule1389(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangle")
 
 def latex_rule1390(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacksquare",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacksquare")
 
 def latex_rule1391(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacklozenge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacklozenge")
 
 def latex_rule1392(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigwedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigwedge")
 
 def latex_rule1393(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigvee",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigvee")
 
 def latex_rule1394(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\biguplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\biguplus")
 
 def latex_rule1395(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangleup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangleup")
 
 def latex_rule1396(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangledown",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangledown")
 
 def latex_rule1397(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigstar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigstar")
 
 def latex_rule1398(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigsqcup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigsqcup")
 
 def latex_rule1399(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigotimes",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigotimes")
 
 def latex_rule1400(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigoplus",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigoplus")
 
 def latex_rule1401(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigodot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigodot")
 
 def latex_rule1402(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcup")
 
 def latex_rule1403(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcirc",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcirc")
 
 def latex_rule1404(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcap")
 
 def latex_rule1405(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\between",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\between")
 
 def latex_rule1406(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\beth")
 
 def latex_rule1407(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\beta")
 
 def latex_rule1408(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule1409(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\because",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\because")
 
 def latex_rule1410(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bar{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bar{")
 
 def latex_rule1411(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\barwedge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\barwedge")
 
 def latex_rule1412(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backslash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backslash")
 
 def latex_rule1413(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsimeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsimeq")
 
 def latex_rule1414(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsim",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsim")
 
 def latex_rule1415(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backprime",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\backprime")
 
 def latex_rule1416(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\asymp",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\asymp")
 
 def latex_rule1417(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ast",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ast")
 
 def latex_rule1418(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arg")
 
 def latex_rule1419(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arctan",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arctan")
 
 def latex_rule1420(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arcsin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arcsin")
 
 def latex_rule1421(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arccos",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\arccos")
 
 def latex_rule1422(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approxeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\approxeq")
 
 def latex_rule1423(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approx",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\approx")
 
 def latex_rule1424(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule1425(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule1426(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\amalg",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\amalg")
 
 def latex_rule1427(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\alpha",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\alpha")
 
 def latex_rule1428(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\aleph",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\aleph")
 
 def latex_rule1429(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\acute{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\acute{")
 
 def latex_rule1430(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Xi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Xi")
 
 def latex_rule1431(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vvdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vvdash")
 
 def latex_rule1432(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vdash",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vdash")
 
 def latex_rule1433(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Upsilon",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Upsilon")
 
 def latex_rule1434(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Updownarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Updownarrow")
 
 def latex_rule1435(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Uparrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Uparrow")
 
 def latex_rule1436(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Theta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Theta")
 
 def latex_rule1437(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Supset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Supset")
 
 def latex_rule1438(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Subset",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Subset")
 
 def latex_rule1439(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Sigma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Sigma")
 
 def latex_rule1440(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rsh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rsh")
 
 def latex_rule1441(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rightarrow")
 
 def latex_rule1442(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Re",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Re")
 
 def latex_rule1443(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Psi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Psi")
 
 def latex_rule1444(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pr",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pr")
 
 def latex_rule1445(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pi")
 
 def latex_rule1446(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Phi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Phi")
 
 def latex_rule1447(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Omega",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Omega")
 
 def latex_rule1448(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lsh",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lsh")
 
 def latex_rule1449(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longrightarrow")
 
 def latex_rule1450(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow")
 
 def latex_rule1451(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftarrow")
 
 def latex_rule1452(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lleftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lleftarrow")
 
 def latex_rule1453(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftrightarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftrightarrow")
 
 def latex_rule1454(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftarrow")
 
 def latex_rule1455(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lambda",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lambda")
 
 def latex_rule1456(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Im",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Im")
 
 def latex_rule1457(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Gamma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Gamma")
 
 def latex_rule1458(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Game",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Game")
 
 def latex_rule1459(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Finv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Finv")
 
 def latex_rule1460(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Downarrow",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Downarrow")
 
 def latex_rule1461(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Delta",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Delta")
 
 def latex_rule1462(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cup",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cup")
 
 def latex_rule1463(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cap",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cap")
 
 def latex_rule1464(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bumpeq",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bumpeq")
 
 def latex_rule1465(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Bbb{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Bbb{")
 
 def latex_rule1466(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bbbk",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bbbk")
 
 def latex_rule1467(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\;")
 
 def latex_rule1468(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\:")
 
 def latex_rule1469(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule1470(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\!")
 
 def latex_rule1471(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="'")
 
 def latex_rule1472(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def latex_rule1473(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
 
 # Rules dict for latex_arraymode ruleset.
 rulesDict3 = {
@@ -6087,1467 +4590,1096 @@ rulesDict3 = {
 # Rules for latex_tabularmode ruleset.
 
 def latex_rule1474(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__TabularMode__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="__TabularMode__")
 
 def latex_rule1475(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule1476(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="``", end="''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal4", begin="``", end="''")
 
 def latex_rule1477(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="`", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="`", end="'")
 
 def latex_rule1478(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def latex_rule1479(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\"")
 
 def latex_rule1480(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="`")
 
 def latex_rule1481(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def latex_rule1482(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="}")
 
 def latex_rule1483(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="{")
 
 def latex_rule1484(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber")
 
 def latex_rule1485(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber")
 
 def latex_rule1486(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth")
 
 def latex_rule1487(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth")
 
 def latex_rule1488(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber")
 
 def latex_rule1489(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="]")
 
 def latex_rule1490(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{")
 
 def latex_rule1491(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\~")
 
 def latex_rule1492(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\}")
 
 def latex_rule1493(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\|")
 
 def latex_rule1494(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\{")
 
 def latex_rule1495(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\width",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\width")
 
 def latex_rule1496(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{")
 
 def latex_rule1497(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{")
 
 def latex_rule1498(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{")
 
 def latex_rule1499(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{")
 
 def latex_rule1500(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vline")
 
 def latex_rule1501(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill")
 
 def latex_rule1502(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*")
 
 def latex_rule1503(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb")
 
 def latex_rule1504(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{")
 
 def latex_rule1505(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\v",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\v")
 
 def latex_rule1506(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{")
 
 def latex_rule1507(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{")
 
 def latex_rule1508(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[")
 
 def latex_rule1509(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{")
 
 def latex_rule1510(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{")
 
 def latex_rule1511(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape")
 
 def latex_rule1512(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{")
 
 def latex_rule1513(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\u",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\u")
 
 def latex_rule1514(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{")
 
 def latex_rule1515(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{")
 
 def latex_rule1516(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{")
 
 def latex_rule1517(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[")
 
 def latex_rule1518(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[")
 
 def latex_rule1519(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn")
 
 def latex_rule1520(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily")
 
 def latex_rule1521(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight")
 
 def latex_rule1522(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep")
 
 def latex_rule1523(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction")
 
 def latex_rule1524(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\today",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\today")
 
 def latex_rule1525(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{")
 
 def latex_rule1526(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny")
 
 def latex_rule1527(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
 
 def latex_rule1528(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule1529(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule1530(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{")
 
 def latex_rule1531(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth")
 
 def latex_rule1532(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{")
 
 def latex_rule1533(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{")
 
 def latex_rule1534(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{")
 
 def latex_rule1535(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{")
 
 def latex_rule1536(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{")
 
 def latex_rule1537(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{")
 
 def latex_rule1538(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{")
 
 def latex_rule1539(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{")
 
 def latex_rule1540(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{")
 
 def latex_rule1541(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction")
 
 def latex_rule1542(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep")
 
 def latex_rule1543(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{")
 
 def latex_rule1544(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{")
 
 def latex_rule1545(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents")
 
 def latex_rule1546(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep")
 
 def latex_rule1547(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep")
 
 def latex_rule1548(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\t",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\t")
 
 def latex_rule1549(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{")
 
 def latex_rule1550(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
 
 def latex_rule1551(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats")
 
 def latex_rule1552(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{")
 
 def latex_rule1553(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[")
 
 def latex_rule1554(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
 
 def latex_rule1555(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{")
 
 def latex_rule1556(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[")
 
 def latex_rule1557(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{")
 
 def latex_rule1558(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{")
 
 def latex_rule1559(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[")
 
 def latex_rule1560(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
 
 def latex_rule1561(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{")
 
 def latex_rule1562(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{")
 
 def latex_rule1563(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip")
 
 def latex_rule1564(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\small",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\small")
 
 def latex_rule1565(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape")
 
 def latex_rule1566(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy")
 
 def latex_rule1567(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily")
 
 def latex_rule1568(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{")
 
 def latex_rule1569(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{")
 
 def latex_rule1570(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{")
 
 def latex_rule1571(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{")
 
 def latex_rule1572(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{")
 
 def latex_rule1573(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{")
 
 def latex_rule1574(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[")
 
 def latex_rule1575(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{")
 
 def latex_rule1576(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape")
 
 def latex_rule1577(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize")
 
 def latex_rule1578(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{")
 
 def latex_rule1579(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{")
 
 def latex_rule1580(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule1581(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{")
 
 def latex_rule1582(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[")
 
 def latex_rule1583(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{")
 
 def latex_rule1584(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{")
 
 def latex_rule1585(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily")
 
 def latex_rule1586(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin")
 
 def latex_rule1587(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
 
 def latex_rule1588(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{")
 
 def latex_rule1589(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{")
 
 def latex_rule1590(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
 
 def latex_rule1591(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{")
 
 def latex_rule1592(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{")
 
 def latex_rule1593(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter")
 
 def latex_rule1594(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{")
 
 def latex_rule1595(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright")
 
 def latex_rule1596(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft")
 
 def latex_rule1597(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax")
 
 def latex_rule1598(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{")
 
 def latex_rule1599(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect")
 
 def latex_rule1600(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex")
 
 def latex_rule1601(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds")
 
 def latex_rule1602(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{")
 
 def latex_rule1603(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep")
 
 def latex_rule1604(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[")
 
 def latex_rule1605(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{")
 
 def latex_rule1606(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip")
 
 def latex_rule1607(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep")
 
 def latex_rule1608(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent")
 
 def latex_rule1609(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{")
 
 def latex_rule1610(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[")
 
 def latex_rule1611(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{")
 
 def latex_rule1612(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[")
 
 def latex_rule1613(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{")
 
 def latex_rule1614(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\par",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\par")
 
 def latex_rule1615(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{")
 
 def latex_rule1616(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{")
 
 def latex_rule1617(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
 
 def latex_rule1618(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{")
 
 def latex_rule1619(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[")
 
 def latex_rule1620(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak")
 
 def latex_rule1621(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn")
 
 def latex_rule1622(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize")
 
 def latex_rule1623(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
 
 def latex_rule1624(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont")
 
 def latex_rule1625(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
 
 def latex_rule1626(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak")
 
 def latex_rule1627(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
 
 def latex_rule1628(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
 
 def latex_rule1629(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak")
 
 def latex_rule1630(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent")
 
 def latex_rule1631(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{")
 
 def latex_rule1632(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{")
 
 def latex_rule1633(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{")
 
 def latex_rule1634(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage")
 
 def latex_rule1635(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{")
 
 def latex_rule1636(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{")
 
 def latex_rule1637(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{")
 
 def latex_rule1638(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{")
 
 def latex_rule1639(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\multicolumn{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\multicolumn{")
 
 def latex_rule1640(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip")
 
 def latex_rule1641(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries")
 
 def latex_rule1642(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule1643(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule1644(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule1645(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule1646(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{")
 
 def latex_rule1647(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{")
 
 def latex_rule1648(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{")
 
 def latex_rule1649(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth")
 
 def latex_rule1650(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep")
 
 def latex_rule1651(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush")
 
 def latex_rule1652(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[")
 
 def latex_rule1653(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle")
 
 def latex_rule1654(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel")
 
 def latex_rule1655(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex")
 
 def latex_rule1656(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary")
 
 def latex_rule1657(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{")
 
 def latex_rule1658(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[")
 
 def latex_rule1659(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent")
 
 def latex_rule1660(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables")
 
 def latex_rule1661(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures")
 
 def latex_rule1662(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles")
 
 def latex_rule1663(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth")
 
 def latex_rule1664(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule1665(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[")
 
 def latex_rule1666(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak")
 
 def latex_rule1667(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{")
 
 def latex_rule1668(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
 
 def latex_rule1669(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv")
 
 def latex_rule1670(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
 
 def latex_rule1671(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
 
 def latex_rule1672(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii")
 
 def latex_rule1673(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini")
 
 def latex_rule1674(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin")
 
 def latex_rule1675(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\large",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\large")
 
 def latex_rule1676(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{")
 
 def latex_rule1677(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth")
 
 def latex_rule1678(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep")
 
 def latex_rule1679(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot")
 
 def latex_rule1680(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape")
 
 def latex_rule1681(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep")
 
 def latex_rule1682(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent")
 
 def latex_rule1683(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[")
 
 def latex_rule1684(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\item",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\item")
 
 def latex_rule1685(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{")
 
 def latex_rule1686(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep")
 
 def latex_rule1687(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{")
 
 def latex_rule1688(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{")
 
 def latex_rule1689(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent")
 
 def latex_rule1690(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{")
 
 def latex_rule1691(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{")
 
 def latex_rule1692(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{")
 
 def latex_rule1693(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[")
 
 def latex_rule1694(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
 
 def latex_rule1695(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
 
 def latex_rule1696(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
 
 def latex_rule1697(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{")
 
 def latex_rule1698(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge")
 
 def latex_rule1699(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{")
 
 def latex_rule1700(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{")
 
 def latex_rule1701(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hline",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hline")
 
 def latex_rule1702(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill")
 
 def latex_rule1703(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\height",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\height")
 
 def latex_rule1704(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{")
 
 def latex_rule1705(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy")
 
 def latex_rule1706(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing")
 
 def latex_rule1707(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{")
 
 def latex_rule1708(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[")
 
 def latex_rule1709(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile")
 
 def latex_rule1710(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{")
 
 def latex_rule1711(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{")
 
 def latex_rule1712(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[")
 
 def latex_rule1713(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize")
 
 def latex_rule1714(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep")
 
 def latex_rule1715(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule")
 
 def latex_rule1716(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[")
 
 def latex_rule1717(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark")
 
 def latex_rule1718(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[")
 
 def latex_rule1719(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
 
 def latex_rule1720(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep")
 
 def latex_rule1721(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
 
 def latex_rule1722(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill")
 
 def latex_rule1723(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
 
 def latex_rule1724(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{")
 
 def latex_rule1725(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep")
 
 def latex_rule1726(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule")
 
 def latex_rule1727(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{")
 
 def latex_rule1728(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule1729(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
 
 def latex_rule1730(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
 
 def latex_rule1731(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule1732(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{")
 
 def latex_rule1733(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{")
 
 def latex_rule1734(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep")
 
 def latex_rule1735(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{")
 
 def latex_rule1736(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[")
 
 def latex_rule1737(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth")
 
 def latex_rule1738(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{")
 
 def latex_rule1739(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag")
 
 def latex_rule1740(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
 
 def latex_rule1741(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
 
 def latex_rule1742(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
 
 def latex_rule1743(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
 
 def latex_rule1744(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{")
 
 def latex_rule1745(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag")
 
 def latex_rule1746(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\d",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\d")
 
 def latex_rule1747(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{")
 
 def latex_rule1748(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright")
 
 def latex_rule1749(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth")
 
 def latex_rule1750(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule")
 
 def latex_rule1751(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep")
 
 def latex_rule1752(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{")
 
 def latex_rule1753(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{")
 
 def latex_rule1754(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cline{")
 
 def latex_rule1755(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage")
 
 def latex_rule1756(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
 
 def latex_rule1757(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{")
 
 def latex_rule1758(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[")
 
 def latex_rule1759(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{")
 
 def latex_rule1760(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[")
 
 def latex_rule1761(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{")
 
 def latex_rule1762(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering")
 
 def latex_rule1763(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{")
 
 def latex_rule1764(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[")
 
 def latex_rule1765(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\c",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\c")
 
 def latex_rule1766(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{")
 
 def latex_rule1767(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber")
 
 def latex_rule1768(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction")
 
 def latex_rule1769(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{")
 
 def latex_rule1770(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{")
 
 def latex_rule1771(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip")
 
 def latex_rule1772(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{")
 
 def latex_rule1773(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
 
 def latex_rule1774(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent")
 
 def latex_rule1775(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries")
 
 def latex_rule1776(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
 
 def latex_rule1777(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
 
 def latex_rule1778(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule1779(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch")
 
 def latex_rule1780(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip")
 
 def latex_rule1781(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\b")
 
 def latex_rule1782(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{")
 
 def latex_rule1783(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch")
 
 def latex_rule1784(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
 
 def latex_rule1785(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep")
 
 def latex_rule1786(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{")
 
 def latex_rule1787(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix")
 
 def latex_rule1788(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{")
 
 def latex_rule1789(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{")
 
 def latex_rule1790(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{")
 
 def latex_rule1791(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{")
 
 def latex_rule1792(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{")
 
 def latex_rule1793(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
 
 def latex_rule1794(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
 
 def latex_rule1795(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
 
 def latex_rule1796(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{")
 
 def latex_rule1797(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule1798(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\_")
 
 def latex_rule1799(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{")
 
 def latex_rule1800(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\^")
 
 def latex_rule1801(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[")
 
 def latex_rule1802(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[")
 
 def latex_rule1803(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\*")
 
 def latex_rule1804(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule1805(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX")
 
 def latex_rule1806(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\S",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\S")
 
 def latex_rule1807(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{")
 
 def latex_rule1808(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\P",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\P")
 
 def latex_rule1809(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large")
 
 def latex_rule1810(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX")
 
 def latex_rule1811(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE")
 
 def latex_rule1812(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{")
 
 def latex_rule1813(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge")
 
 def latex_rule1814(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\H",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\H")
 
 def latex_rule1815(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{")
 
 def latex_rule1816(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\@")
 
 def latex_rule1817(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\={",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\={")
 
 def latex_rule1818(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule1819(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{")
 
 def latex_rule1820(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\.")
 
 def latex_rule1821(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule1822(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule1823(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{")
 
 def latex_rule1824(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule1825(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\&")
 
 def latex_rule1826(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\%")
 
 def latex_rule1827(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\$")
 
 def latex_rule1828(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\#")
 
 def latex_rule1829(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{")
 
 def latex_rule1830(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\"")
 
 def latex_rule1831(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def latex_rule1832(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="[")
 
 def latex_rule1833(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="---",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="---")
 
 def latex_rule1834(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="--")
 
 def latex_rule1835(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def latex_rule1836(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def latex_rule1837(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
 
 # Rules dict for latex_tabularmode ruleset.
 rulesDict4 = {
@@ -7571,1503 +5703,1123 @@ rulesDict4 = {
 # Rules for latex_tabbingmode ruleset.
 
 def latex_rule1838(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__TabbingMode__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="__TabbingMode__")
 
 def latex_rule1839(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule1840(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="``", end="''",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal4", begin="``", end="''")
 
 def latex_rule1841(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="`", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="`", end="'")
 
 def latex_rule1842(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def latex_rule1843(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="\"")
 
 def latex_rule1844(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="`")
 
 def latex_rule1845(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def latex_rule1846(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="}")
 
 def latex_rule1847(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="{")
 
 def latex_rule1848(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber")
 
 def latex_rule1849(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber")
 
 def latex_rule1850(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth")
 
 def latex_rule1851(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth")
 
 def latex_rule1852(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber")
 
 def latex_rule1853(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="]")
 
 def latex_rule1854(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{")
 
 def latex_rule1855(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\~")
 
 def latex_rule1856(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\}")
 
 def latex_rule1857(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\|")
 
 def latex_rule1858(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\{")
 
 def latex_rule1859(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\width",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\width")
 
 def latex_rule1860(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{")
 
 def latex_rule1861(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{")
 
 def latex_rule1862(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{")
 
 def latex_rule1863(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{")
 
 def latex_rule1864(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill")
 
 def latex_rule1865(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*")
 
 def latex_rule1866(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb")
 
 def latex_rule1867(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{")
 
 def latex_rule1868(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\v",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\v")
 
 def latex_rule1869(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{")
 
 def latex_rule1870(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{")
 
 def latex_rule1871(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[")
 
 def latex_rule1872(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{")
 
 def latex_rule1873(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{")
 
 def latex_rule1874(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape")
 
 def latex_rule1875(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{")
 
 def latex_rule1876(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\u",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\u")
 
 def latex_rule1877(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{")
 
 def latex_rule1878(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{")
 
 def latex_rule1879(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{")
 
 def latex_rule1880(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[")
 
 def latex_rule1881(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[")
 
 def latex_rule1882(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn")
 
 def latex_rule1883(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily")
 
 def latex_rule1884(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight")
 
 def latex_rule1885(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep")
 
 def latex_rule1886(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction")
 
 def latex_rule1887(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\today",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\today")
 
 def latex_rule1888(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{")
 
 def latex_rule1889(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny")
 
 def latex_rule1890(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
 
 def latex_rule1891(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule1892(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule1893(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{")
 
 def latex_rule1894(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth")
 
 def latex_rule1895(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{")
 
 def latex_rule1896(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{")
 
 def latex_rule1897(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{")
 
 def latex_rule1898(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{")
 
 def latex_rule1899(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{")
 
 def latex_rule1900(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{")
 
 def latex_rule1901(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{")
 
 def latex_rule1902(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{")
 
 def latex_rule1903(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{")
 
 def latex_rule1904(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction")
 
 def latex_rule1905(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep")
 
 def latex_rule1906(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{")
 
 def latex_rule1907(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{")
 
 def latex_rule1908(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents")
 
 def latex_rule1909(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep")
 
 def latex_rule1910(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep")
 
 def latex_rule1911(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\t",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\t")
 
 def latex_rule1912(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{")
 
 def latex_rule1913(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
 
 def latex_rule1914(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats")
 
 def latex_rule1915(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{")
 
 def latex_rule1916(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[")
 
 def latex_rule1917(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
 
 def latex_rule1918(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{")
 
 def latex_rule1919(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[")
 
 def latex_rule1920(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{")
 
 def latex_rule1921(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{")
 
 def latex_rule1922(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[")
 
 def latex_rule1923(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
 
 def latex_rule1924(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{")
 
 def latex_rule1925(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{")
 
 def latex_rule1926(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip")
 
 def latex_rule1927(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\small",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\small")
 
 def latex_rule1928(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape")
 
 def latex_rule1929(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy")
 
 def latex_rule1930(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily")
 
 def latex_rule1931(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{")
 
 def latex_rule1932(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{")
 
 def latex_rule1933(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{")
 
 def latex_rule1934(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{")
 
 def latex_rule1935(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{")
 
 def latex_rule1936(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{")
 
 def latex_rule1937(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[")
 
 def latex_rule1938(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{")
 
 def latex_rule1939(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape")
 
 def latex_rule1940(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize")
 
 def latex_rule1941(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{")
 
 def latex_rule1942(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{")
 
 def latex_rule1943(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule1944(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{")
 
 def latex_rule1945(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[")
 
 def latex_rule1946(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{")
 
 def latex_rule1947(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{")
 
 def latex_rule1948(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily")
 
 def latex_rule1949(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin")
 
 def latex_rule1950(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
 
 def latex_rule1951(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{")
 
 def latex_rule1952(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{")
 
 def latex_rule1953(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
 
 def latex_rule1954(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{")
 
 def latex_rule1955(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{")
 
 def latex_rule1956(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter")
 
 def latex_rule1957(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{")
 
 def latex_rule1958(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright")
 
 def latex_rule1959(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft")
 
 def latex_rule1960(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax")
 
 def latex_rule1961(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pushtabs",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pushtabs")
 
 def latex_rule1962(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{")
 
 def latex_rule1963(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect")
 
 def latex_rule1964(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex")
 
 def latex_rule1965(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds")
 
 def latex_rule1966(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\poptabs",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\poptabs")
 
 def latex_rule1967(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{")
 
 def latex_rule1968(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep")
 
 def latex_rule1969(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[")
 
 def latex_rule1970(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{")
 
 def latex_rule1971(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip")
 
 def latex_rule1972(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep")
 
 def latex_rule1973(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent")
 
 def latex_rule1974(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{")
 
 def latex_rule1975(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[")
 
 def latex_rule1976(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{")
 
 def latex_rule1977(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[")
 
 def latex_rule1978(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{")
 
 def latex_rule1979(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\par",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\par")
 
 def latex_rule1980(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{")
 
 def latex_rule1981(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{")
 
 def latex_rule1982(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
 
 def latex_rule1983(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{")
 
 def latex_rule1984(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[")
 
 def latex_rule1985(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak")
 
 def latex_rule1986(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn")
 
 def latex_rule1987(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize")
 
 def latex_rule1988(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
 
 def latex_rule1989(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont")
 
 def latex_rule1990(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
 
 def latex_rule1991(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak")
 
 def latex_rule1992(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
 
 def latex_rule1993(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
 
 def latex_rule1994(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak")
 
 def latex_rule1995(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent")
 
 def latex_rule1996(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{")
 
 def latex_rule1997(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{")
 
 def latex_rule1998(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{")
 
 def latex_rule1999(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage")
 
 def latex_rule2000(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{")
 
 def latex_rule2001(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{")
 
 def latex_rule2002(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{")
 
 def latex_rule2003(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{")
 
 def latex_rule2004(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip")
 
 def latex_rule2005(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries")
 
 def latex_rule2006(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule2007(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule2008(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule2009(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule2010(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{")
 
 def latex_rule2011(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{")
 
 def latex_rule2012(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{")
 
 def latex_rule2013(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth")
 
 def latex_rule2014(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep")
 
 def latex_rule2015(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush")
 
 def latex_rule2016(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[")
 
 def latex_rule2017(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle")
 
 def latex_rule2018(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel")
 
 def latex_rule2019(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex")
 
 def latex_rule2020(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary")
 
 def latex_rule2021(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{")
 
 def latex_rule2022(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[")
 
 def latex_rule2023(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent")
 
 def latex_rule2024(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables")
 
 def latex_rule2025(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures")
 
 def latex_rule2026(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles")
 
 def latex_rule2027(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth")
 
 def latex_rule2028(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule2029(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[")
 
 def latex_rule2030(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak")
 
 def latex_rule2031(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{")
 
 def latex_rule2032(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
 
 def latex_rule2033(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv")
 
 def latex_rule2034(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
 
 def latex_rule2035(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
 
 def latex_rule2036(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii")
 
 def latex_rule2037(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini")
 
 def latex_rule2038(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin")
 
 def latex_rule2039(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\large",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\large")
 
 def latex_rule2040(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{")
 
 def latex_rule2041(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth")
 
 def latex_rule2042(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep")
 
 def latex_rule2043(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\kill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\kill")
 
 def latex_rule2044(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot")
 
 def latex_rule2045(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape")
 
 def latex_rule2046(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep")
 
 def latex_rule2047(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent")
 
 def latex_rule2048(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[")
 
 def latex_rule2049(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\item",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\item")
 
 def latex_rule2050(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{")
 
 def latex_rule2051(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep")
 
 def latex_rule2052(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{")
 
 def latex_rule2053(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{")
 
 def latex_rule2054(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent")
 
 def latex_rule2055(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{")
 
 def latex_rule2056(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{")
 
 def latex_rule2057(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{")
 
 def latex_rule2058(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[")
 
 def latex_rule2059(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
 
 def latex_rule2060(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
 
 def latex_rule2061(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
 
 def latex_rule2062(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{")
 
 def latex_rule2063(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge")
 
 def latex_rule2064(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{")
 
 def latex_rule2065(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{")
 
 def latex_rule2066(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill")
 
 def latex_rule2067(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\height",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\height")
 
 def latex_rule2068(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{")
 
 def latex_rule2069(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy")
 
 def latex_rule2070(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing")
 
 def latex_rule2071(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{")
 
 def latex_rule2072(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[")
 
 def latex_rule2073(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile")
 
 def latex_rule2074(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{")
 
 def latex_rule2075(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{")
 
 def latex_rule2076(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[")
 
 def latex_rule2077(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize")
 
 def latex_rule2078(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep")
 
 def latex_rule2079(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule")
 
 def latex_rule2080(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[")
 
 def latex_rule2081(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark")
 
 def latex_rule2082(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[")
 
 def latex_rule2083(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
 
 def latex_rule2084(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep")
 
 def latex_rule2085(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
 
 def latex_rule2086(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill")
 
 def latex_rule2087(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
 
 def latex_rule2088(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{")
 
 def latex_rule2089(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep")
 
 def latex_rule2090(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule")
 
 def latex_rule2091(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{")
 
 def latex_rule2092(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule2093(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
 
 def latex_rule2094(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
 
 def latex_rule2095(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule2096(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{")
 
 def latex_rule2097(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{")
 
 def latex_rule2098(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep")
 
 def latex_rule2099(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{")
 
 def latex_rule2100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[")
 
 def latex_rule2101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth")
 
 def latex_rule2102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{")
 
 def latex_rule2103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag")
 
 def latex_rule2104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
 
 def latex_rule2105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
 
 def latex_rule2106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
 
 def latex_rule2107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
 
 def latex_rule2108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{")
 
 def latex_rule2109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag")
 
 def latex_rule2110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\d",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\d")
 
 def latex_rule2111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{")
 
 def latex_rule2112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright")
 
 def latex_rule2113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth")
 
 def latex_rule2114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule")
 
 def latex_rule2115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep")
 
 def latex_rule2116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{")
 
 def latex_rule2117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{")
 
 def latex_rule2118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage")
 
 def latex_rule2119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
 
 def latex_rule2120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{")
 
 def latex_rule2121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[")
 
 def latex_rule2122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{")
 
 def latex_rule2123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[")
 
 def latex_rule2124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{")
 
 def latex_rule2125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering")
 
 def latex_rule2126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{")
 
 def latex_rule2127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[")
 
 def latex_rule2128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\c",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\c")
 
 def latex_rule2129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{")
 
 def latex_rule2130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber")
 
 def latex_rule2131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction")
 
 def latex_rule2132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{")
 
 def latex_rule2133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{")
 
 def latex_rule2134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip")
 
 def latex_rule2135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{")
 
 def latex_rule2136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
 
 def latex_rule2137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent")
 
 def latex_rule2138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries")
 
 def latex_rule2139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
 
 def latex_rule2140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
 
 def latex_rule2141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule2142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch")
 
 def latex_rule2143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip")
 
 def latex_rule2144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\b")
 
 def latex_rule2145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{")
 
 def latex_rule2146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch")
 
 def latex_rule2147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
 
 def latex_rule2148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep")
 
 def latex_rule2149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{")
 
 def latex_rule2150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix")
 
 def latex_rule2151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{")
 
 def latex_rule2152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{")
 
 def latex_rule2153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{")
 
 def latex_rule2154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{")
 
 def latex_rule2155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{")
 
 def latex_rule2156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
 
 def latex_rule2157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
 
 def latex_rule2158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
 
 def latex_rule2159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\a`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\a`")
 
 def latex_rule2160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\a=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\a=")
 
 def latex_rule2161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\a'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\a'")
 
 def latex_rule2162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{")
 
 def latex_rule2163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule2164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule2165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\_")
 
 def latex_rule2166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{")
 
 def latex_rule2167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\^")
 
 def latex_rule2168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[")
 
 def latex_rule2169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[")
 
 def latex_rule2170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\*")
 
 def latex_rule2171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule2172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule2173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX")
 
 def latex_rule2174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\S",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\S")
 
 def latex_rule2175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{")
 
 def latex_rule2176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\P",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\P")
 
 def latex_rule2177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large")
 
 def latex_rule2178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX")
 
 def latex_rule2179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE")
 
 def latex_rule2180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{")
 
 def latex_rule2181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge")
 
 def latex_rule2182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\H",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\H")
 
 def latex_rule2183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{")
 
 def latex_rule2184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\@")
 
 def latex_rule2185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\={",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\={")
 
 def latex_rule2186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule2187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule2188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{")
 
 def latex_rule2189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\.",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\.")
 
 def latex_rule2190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule2191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule2192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule2193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\+")
 
 def latex_rule2194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{")
 
 def latex_rule2195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule2196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule2197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\<")
 
 def latex_rule2198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\>")
 
 def latex_rule2199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\&")
 
 def latex_rule2200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\%")
 
 def latex_rule2201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\$")
 
 def latex_rule2202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\#")
 
 def latex_rule2203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{")
 
 def latex_rule2204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\"")
 
 def latex_rule2205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def latex_rule2206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="[")
 
 def latex_rule2207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="---",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="---")
 
 def latex_rule2208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="--")
 
 def latex_rule2209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def latex_rule2210(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
 
 # Rules dict for latex_tabbingmode ruleset.
 rulesDict5 = {
@@ -9090,105 +6842,79 @@ rulesDict5 = {
 # Rules for latex_picturemode ruleset.
 
 def latex_rule2211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__PictureMode__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="__PictureMode__")
 
 def latex_rule2212(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule2213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vector(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\vector(")
 
 def latex_rule2214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule2215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule2216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\shortstack{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\shortstack{")
 
 def latex_rule2217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\shortstack[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\shortstack[")
 
 def latex_rule2218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule2219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\qbezier[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\qbezier[")
 
 def latex_rule2220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\qbezier(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\qbezier(")
 
 def latex_rule2221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\put(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\put(")
 
 def latex_rule2222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\oval[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\oval[")
 
 def latex_rule2223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oval(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\oval(")
 
 def latex_rule2224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\multiput(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\multiput(")
 
 def latex_rule2225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makebox(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\makebox(")
 
 def latex_rule2226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule2227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\line(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\line(")
 
 def latex_rule2228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\graphpaper[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\graphpaper[")
 
 def latex_rule2229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\graphpaper(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\graphpaper(")
 
 def latex_rule2230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frame{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\frame{")
 
 def latex_rule2231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\framebox(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\\framebox(")
 
 def latex_rule2232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\dashbox{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\dashbox{")
 
 def latex_rule2233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\circle{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\circle{")
 
 def latex_rule2234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\circle*{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\circle*{")
 
 def latex_rule2235(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
 
 # Rules dict for latex_picturemode ruleset.
 rulesDict6 = {

--- a/leo/modes/lilypond.py
+++ b/leo/modes/lilypond.py
@@ -159,1387 +159,1039 @@ keywordsDictDict = {
 # Rules for lilypond_main ruleset.
 
 def lilypond_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="%{", end="%}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="%{", end="%}")
 
 def lilypond_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def lilypond_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\\"")
 
 def lilypond_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\'")
 
 def lilypond_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\H",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\H")
 
 def lilypond_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="\\breve",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="\\breve")
 
 def lilypond_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="\\longa",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="\\longa")
 
 def lilypond_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="\\maxima",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="\\maxima")
 
 def lilypond_rule8(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="=",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=False)
+          at_whitespace_end=True)
 
 def lilypond_rule9(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="=",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=False)
+          at_whitespace_end=True)
 
 def lilypond_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="#(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="scheme::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="scheme::main")
 
 def lilypond_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="{")
 
 def lilypond_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="}")
 
 def lilypond_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="[")
 
 def lilypond_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="]")
 
 def lilypond_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="<<")
 
 def lilypond_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=">>")
 
 def lilypond_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="-<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="-<")
 
 def lilypond_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="->")
 
 def lilypond_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def lilypond_rule20(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def lilypond_rule21(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="-[[:digit:]]+>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="-[[:digit:]]+>")
 
 def lilypond_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="'")
 
 def lilypond_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=",")
 
 def lilypond_rule24(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="r([[:digit:]]*)\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="r([[:digit:]]*)\\>")
 
 def lilypond_rule25(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="R([[:digit:]]*)\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="R([[:digit:]]*)\\>")
 
 def lilypond_rule26(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="s([[:digit:]]*)\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="s([[:digit:]]*)\\>")
 
 def lilypond_rule27(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="1[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="1[[:digit:]]*\\>")
 
 def lilypond_rule28(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="2[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="2[[:digit:]]*\\>")
 
 def lilypond_rule29(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="3[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="3[[:digit:]]*\\>")
 
 def lilypond_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="4[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="4[[:digit:]]*\\>")
 
 def lilypond_rule31(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="5[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="5[[:digit:]]*\\>")
 
 def lilypond_rule32(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="6[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="6[[:digit:]]*\\>")
 
 def lilypond_rule33(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="7[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="7[[:digit:]]*\\>")
 
 def lilypond_rule34(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="8[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="8[[:digit:]]*\\>")
 
 def lilypond_rule35(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="9[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="9[[:digit:]]*\\>")
 
 def lilypond_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="digit", regexp="0[[:digit:]]*\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="digit", regexp="0[[:digit:]]*\\>")
 
 def lilypond_rule37(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\with\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\with\\>")
 
 def lilypond_rule38(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\whiteTriangleMarkup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\whiteTriangleMarkup\\>")
 
 def lilypond_rule39(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\vsize\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\vsize\\>")
 
 def lilypond_rule40(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceTwo\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceTwo\\>")
 
 def lilypond_rule41(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceThree\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceThree\\>")
 
 def lilypond_rule42(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceOne\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceOne\\>")
 
 def lilypond_rule43(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceFour\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\voiceFour\\>")
 
 def lilypond_rule44(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\virgula\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\virgula\\>")
 
 def lilypond_rule45(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\virga\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\virga\\>")
 
 def lilypond_rule46(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\verylongfermata\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\verylongfermata\\>")
 
 def lilypond_rule47(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\version\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\version\\>")
 
 def lilypond_rule48(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\varcoda\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\varcoda\\>")
 
 def lilypond_rule49(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\upprall\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\upprall\\>")
 
 def lilypond_rule50(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\upmordent\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\upmordent\\>")
 
 def lilypond_rule51(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\upbow\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\upbow\\>")
 
 def lilypond_rule52(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\up\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\up\\>")
 
 def lilypond_rule53(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unusedEntry\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unusedEntry\\>")
 
 def lilypond_rule54(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unset\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unset\\>")
 
 def lilypond_rule55(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unit\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unit\\>")
 
 def lilypond_rule56(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unaCorda\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unaCorda\\>")
 
 def lilypond_rule57(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unHideNotes\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\unHideNotes\\>")
 
 def lilypond_rule58(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\type\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\type\\>")
 
 def lilypond_rule59(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\turnOff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\turnOff\\>")
 
 def lilypond_rule60(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\turn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\turn\\>")
 
 def lilypond_rule61(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tupletUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tupletUp\\>")
 
 def lilypond_rule62(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tupletDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tupletDown\\>")
 
 def lilypond_rule63(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tupletBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tupletBoth\\>")
 
 def lilypond_rule64(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\trill\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\trill\\>")
 
 def lilypond_rule65(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\treCorde\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\treCorde\\>")
 
 def lilypond_rule66(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\transposition\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\transposition\\>")
 
 def lilypond_rule67(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\transpose\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\transpose\\>")
 
 def lilypond_rule68(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tiny\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tiny\\>")
 
 def lilypond_rule69(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\times\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\times\\>")
 
 def lilypond_rule70(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\time\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\time\\>")
 
 def lilypond_rule71(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieUp\\>")
 
 def lilypond_rule72(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieSolid\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieSolid\\>")
 
 def lilypond_rule73(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieDown\\>")
 
 def lilypond_rule74(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieDotted\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieDotted\\>")
 
 def lilypond_rule75(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tieBoth\\>")
 
 def lilypond_rule76(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\thumb\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\thumb\\>")
 
 def lilypond_rule77(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tenuto\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tenuto\\>")
 
 def lilypond_rule78(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tempo\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tempo\\>")
 
 def lilypond_rule79(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tag\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\tag\\>")
 
 def lilypond_rule80(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sustainUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sustainUp\\>")
 
 def lilypond_rule81(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sustainDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sustainDown\\>")
 
 def lilypond_rule82(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stropha\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stropha\\>")
 
 def lilypond_rule83(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopped\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopped\\>")
 
 def lilypond_rule84(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopTextSpan\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopTextSpan\\>")
 
 def lilypond_rule85(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopGroup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopGroup\\>")
 
 def lilypond_rule86(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopGraceMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopGraceMusic\\>")
 
 def lilypond_rule87(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopAppoggiaturaMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopAppoggiaturaMusic\\>")
 
 def lilypond_rule88(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopAcciaccaturaMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stopAcciaccaturaMusic\\>")
 
 def lilypond_rule89(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stop\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stop\\>")
 
 def lilypond_rule90(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stemUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stemUp\\>")
 
 def lilypond_rule91(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stemDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stemDown\\>")
 
 def lilypond_rule92(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stemBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\stemBoth\\>")
 
 def lilypond_rule93(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startTextSpan\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startTextSpan\\>")
 
 def lilypond_rule94(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startGroup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startGroup\\>")
 
 def lilypond_rule95(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startGraceMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startGraceMusic\\>")
 
 def lilypond_rule96(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startAppoggiaturaMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startAppoggiaturaMusic\\>")
 
 def lilypond_rule97(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startAcciaccaturaMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\startAcciaccaturaMusic\\>")
 
 def lilypond_rule98(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\start\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\start\\>")
 
 def lilypond_rule99(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\staccato\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\staccato\\>")
 
 def lilypond_rule100(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\staccatissimo\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\staccatissimo\\>")
 
 def lilypond_rule101(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\spp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\spp\\>")
 
 def lilypond_rule102(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sp\\>")
 
 def lilypond_rule103(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sostenutoUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sostenutoUp\\>")
 
 def lilypond_rule104(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sostenutoDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sostenutoDown\\>")
 
 def lilypond_rule105(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\smaller\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\smaller\\>")
 
 def lilypond_rule106(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\small\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\small\\>")
 
 def lilypond_rule107(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurUp\\>")
 
 def lilypond_rule108(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurSolid\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurSolid\\>")
 
 def lilypond_rule109(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurDown\\>")
 
 def lilypond_rule110(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurDotted\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurDotted\\>")
 
 def lilypond_rule111(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\slurBoth\\>")
 
 def lilypond_rule112(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\skip\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\skip\\>")
 
 def lilypond_rule113(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\simultaneous\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\simultaneous\\>")
 
 def lilypond_rule114(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\signumcongruentiae\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\signumcongruentiae\\>")
 
 def lilypond_rule115(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\showStaffSwitch\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\showStaffSwitch\\>")
 
 def lilypond_rule116(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shortfermata\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shortfermata\\>")
 
 def lilypond_rule117(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOnnn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOnnn\\>")
 
 def lilypond_rule118(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOnn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOnn\\>")
 
 def lilypond_rule119(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOn\\>")
 
 def lilypond_rule120(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\shiftOff\\>")
 
 def lilypond_rule121(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sfz\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sfz\\>")
 
 def lilypond_rule122(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sfp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sfp\\>")
 
 def lilypond_rule123(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sff\\>")
 
 def lilypond_rule124(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sf\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sf\\>")
 
 def lilypond_rule125(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setTextDim\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setTextDim\\>")
 
 def lilypond_rule126(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setTextDecresc\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setTextDecresc\\>")
 
 def lilypond_rule127(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setTextCresc\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setTextCresc\\>")
 
 def lilypond_rule128(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setMmRestFermata\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setMmRestFermata\\>")
 
 def lilypond_rule129(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setHairpinCresc\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setHairpinCresc\\>")
 
 def lilypond_rule130(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setEasyHeads\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\setEasyHeads\\>")
 
 def lilypond_rule131(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\set\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\set\\>")
 
 def lilypond_rule132(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sequential\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\sequential\\>")
 
 def lilypond_rule133(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\semicirculus\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\semicirculus\\>")
 
 def lilypond_rule134(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\semiGermanChords\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\semiGermanChords\\>")
 
 def lilypond_rule135(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\segno\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\segno\\>")
 
 def lilypond_rule136(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\scriptUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\scriptUp\\>")
 
 def lilypond_rule137(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\scriptDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\scriptDown\\>")
 
 def lilypond_rule138(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\scriptBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\scriptBoth\\>")
 
 def lilypond_rule139(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\score\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\score\\>")
 
 def lilypond_rule140(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rtoe\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rtoe\\>")
 
 def lilypond_rule141(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\right\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\right\\>")
 
 def lilypond_rule142(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rheel\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rheel\\>")
 
 def lilypond_rule143(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rfz\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rfz\\>")
 
 def lilypond_rule144(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\revert\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\revert\\>")
 
 def lilypond_rule145(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\reverseturn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\reverseturn\\>")
 
 def lilypond_rule146(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rest\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\rest\\>")
 
 def lilypond_rule147(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\repeat\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\repeat\\>")
 
 def lilypond_rule148(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\remove\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\remove\\>")
 
 def lilypond_rule149(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\relative\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\relative\\>")
 
 def lilypond_rule150(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\recordEventSequence\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\recordEventSequence\\>")
 
 def lilypond_rule151(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\raggedright\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\raggedright\\>")
 
 def lilypond_rule152(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\raggedlast\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\raggedlast\\>")
 
 def lilypond_rule153(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\quote\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\quote\\>")
 
 def lilypond_rule154(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\quilisma\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\quilisma\\>")
 
 def lilypond_rule155(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pt\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pt\\>")
 
 def lilypond_rule156(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prallup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prallup\\>")
 
 def lilypond_rule157(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prallprall\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prallprall\\>")
 
 def lilypond_rule158(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prallmordent\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prallmordent\\>")
 
 def lilypond_rule159(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pralldown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pralldown\\>")
 
 def lilypond_rule160(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prall\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\prall\\>")
 
 def lilypond_rule161(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ppppp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ppppp\\>")
 
 def lilypond_rule162(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pppp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pppp\\>")
 
 def lilypond_rule163(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ppp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ppp\\>")
 
 def lilypond_rule164(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pp\\>")
 
 def lilypond_rule165(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\portato\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\portato\\>")
 
 def lilypond_rule166(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrygian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrygian\\>")
 
 def lilypond_rule167(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrasingSlurUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrasingSlurUp\\>")
 
 def lilypond_rule168(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrasingSlurDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrasingSlurDown\\>")
 
 def lilypond_rule169(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrasingSlurBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\phrasingSlurBoth\\>")
 
 def lilypond_rule170(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pes\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\pes\\>")
 
 def lilypond_rule171(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partialJazzMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partialJazzMusic\\>")
 
 def lilypond_rule172(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partialJazzExceptions\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partialJazzExceptions\\>")
 
 def lilypond_rule173(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partial\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partial\\>")
 
 def lilypond_rule174(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partcombine\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partcombine\\>")
 
 def lilypond_rule175(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partCombineListener\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\partCombineListener\\>")
 
 def lilypond_rule176(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperTwentythree\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperTwentythree\\>")
 
 def lilypond_rule177(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperTwentysix\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperTwentysix\\>")
 
 def lilypond_rule178(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperTwenty\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperTwenty\\>")
 
 def lilypond_rule179(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperThirteen\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperThirteen\\>")
 
 def lilypond_rule180(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperSixteen\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperSixteen\\>")
 
 def lilypond_rule181(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperEleven\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperEleven\\>")
 
 def lilypond_rule182(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperEightteen\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paperEightteen\\>")
 
 def lilypond_rule183(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paper\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\paper\\>")
 
 def lilypond_rule184(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\packed\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\packed\\>")
 
 def lilypond_rule185(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\p\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\p\\>")
 
 def lilypond_rule186(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\override\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\override\\>")
 
 def lilypond_rule187(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\oriscus\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\oriscus\\>")
 
 def lilypond_rule188(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\open\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\open\\>")
 
 def lilypond_rule189(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\oneVoice\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\oneVoice\\>")
 
 def lilypond_rule190(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\once\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\once\\>")
 
 def lilypond_rule191(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\octave\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\octave\\>")
 
 def lilypond_rule192(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\notes\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\notes\\>")
 
 def lilypond_rule193(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\normalsize\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\normalsize\\>")
 
 def lilypond_rule194(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\noBreak\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\noBreak\\>")
 
 def lilypond_rule195(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\noBeam\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\noBeam\\>")
 
 def lilypond_rule196(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\newpage\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\newpage\\>")
 
 def lilypond_rule197(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\new\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\new\\>")
 
 def lilypond_rule198(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\name\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\name\\>")
 
 def lilypond_rule199(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mp\\>")
 
 def lilypond_rule200(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mordent\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mordent\\>")
 
 def lilypond_rule201(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mm\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mm\\>")
 
 def lilypond_rule202(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mixolydian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mixolydian\\>")
 
 def lilypond_rule203(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\minor\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\minor\\>")
 
 def lilypond_rule204(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\midi\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\midi\\>")
 
 def lilypond_rule205(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mf\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mf\\>")
 
 def lilypond_rule206(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\melismaEnd\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\melismaEnd\\>")
 
 def lilypond_rule207(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\melisma\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\melisma\\>")
 
 def lilypond_rule208(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\maxima\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\maxima\\>")
 
 def lilypond_rule209(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\markup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\markup\\>")
 
 def lilypond_rule210(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mark\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\mark\\>")
 
 def lilypond_rule211(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\marcato\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\marcato\\>")
 
 def lilypond_rule212(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\major\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\major\\>")
 
 def lilypond_rule213(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\maininput\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\maininput\\>")
 
 def lilypond_rule214(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lyricsto\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lyricsto\\>")
 
 def lilypond_rule215(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lyrics\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lyrics\\>")
 
 def lilypond_rule216(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lydian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lydian\\>")
 
 def lilypond_rule217(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ltoe\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ltoe\\>")
 
 def lilypond_rule218(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\longfermata\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\longfermata\\>")
 
 def lilypond_rule219(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\longa\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\longa\\>")
 
 def lilypond_rule220(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\locrian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\locrian\\>")
 
 def lilypond_rule221(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lineprall\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lineprall\\>")
 
 def lilypond_rule222(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\linea\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\linea\\>")
 
 def lilypond_rule223(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lheel\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\lheel\\>")
 
 def lilypond_rule224(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\left\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\left\\>")
 
 def lilypond_rule225(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\key\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\key\\>")
 
 def lilypond_rule226(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ionian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ionian\\>")
 
 def lilypond_rule227(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\include\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\include\\>")
 
 def lilypond_rule228(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\inclinatum\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\inclinatum\\>")
 
 def lilypond_rule229(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\in\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\in\\>")
 
 def lilypond_rule230(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ignatzekExceptions\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ignatzekExceptions\\>")
 
 def lilypond_rule231(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ignatzekExceptionMusic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ignatzekExceptionMusic\\>")
 
 def lilypond_rule232(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ictus\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ictus\\>")
 
 def lilypond_rule233(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\hsize\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\hsize\\>")
 
 def lilypond_rule234(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\hideStaffSwitch\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\hideStaffSwitch\\>")
 
 def lilypond_rule235(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\hideNotes\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\hideNotes\\>")
 
 def lilypond_rule236(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\header\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\header\\>")
 
 def lilypond_rule237(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\harmonic\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\harmonic\\>")
 
 def lilypond_rule238(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\grobdescriptions\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\grobdescriptions\\>")
 
 def lilypond_rule239(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\grace\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\grace\\>")
 
 def lilypond_rule240(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\glissando\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\glissando\\>")
 
 def lilypond_rule241(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\germanChords\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\germanChords\\>")
 
 def lilypond_rule242(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fz\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fz\\>")
 
 def lilypond_rule243(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fullJazzExceptions\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fullJazzExceptions\\>")
 
 def lilypond_rule244(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fp\\>")
 
 def lilypond_rule245(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\flexa\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\flexa\\>")
 
 def lilypond_rule246(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\flageolet\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\flageolet\\>")
 
 def lilypond_rule247(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\finalis\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\finalis\\>")
 
 def lilypond_rule248(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\figures\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\figures\\>")
 
 def lilypond_rule249(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ffff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ffff\\>")
 
 def lilypond_rule250(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fff\\>")
 
 def lilypond_rule251(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ff\\>")
 
 def lilypond_rule252(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fermataMarkup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fermataMarkup\\>")
 
 def lilypond_rule253(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fermata\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fermata\\>")
 
 def lilypond_rule254(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fatText\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\fatText\\>")
 
 def lilypond_rule255(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\f\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\f\\>")
 
 def lilypond_rule256(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\episemInitium\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\episemInitium\\>")
 
 def lilypond_rule257(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\episemFinis\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\episemFinis\\>")
 
 def lilypond_rule258(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\endincipit\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\endincipit\\>")
 
 def lilypond_rule259(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\enddim\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\enddim\\>")
 
 def lilypond_rule260(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\enddecr\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\enddecr\\>")
 
 def lilypond_rule261(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\endcresc\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\endcresc\\>")
 
 def lilypond_rule262(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\endcr\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\endcr\\>")
 
 def lilypond_rule263(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\emptyText\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\emptyText\\>")
 
 def lilypond_rule264(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dynamicUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dynamicUp\\>")
 
 def lilypond_rule265(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dynamicDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dynamicDown\\>")
 
 def lilypond_rule266(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dynamicBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dynamicBoth\\>")
 
 def lilypond_rule267(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\drums\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\drums\\>")
 
 def lilypond_rule268(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\downprall\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\downprall\\>")
 
 def lilypond_rule269(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\downmordent\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\downmordent\\>")
 
 def lilypond_rule270(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\downbow\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\downbow\\>")
 
 def lilypond_rule271(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\down\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\down\\>")
 
 def lilypond_rule272(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dotsUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dotsUp\\>")
 
 def lilypond_rule273(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dotsDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dotsDown\\>")
 
 def lilypond_rule274(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dotsBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dotsBoth\\>")
 
 def lilypond_rule275(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dorian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dorian\\>")
 
 def lilypond_rule276(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\divisioMinima\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\divisioMinima\\>")
 
 def lilypond_rule277(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\divisioMaxima\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\divisioMaxima\\>")
 
 def lilypond_rule278(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\divisioMaior\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\divisioMaior\\>")
 
 def lilypond_rule279(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dim\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dim\\>")
 
 def lilypond_rule280(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\description\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\description\\>")
 
 def lilypond_rule281(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\descendens\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\descendens\\>")
 
 def lilypond_rule282(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\denies\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\denies\\>")
 
 def lilypond_rule283(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\deminutum\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\deminutum\\>")
 
 def lilypond_rule284(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\default\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\default\\>")
 
 def lilypond_rule285(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\decr\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\decr\\>")
 
 def lilypond_rule286(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashUnderscore\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashUnderscore\\>")
 
 def lilypond_rule287(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashPlus\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashPlus\\>")
 
 def lilypond_rule288(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashLarger\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashLarger\\>")
 
 def lilypond_rule289(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashHat\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashHat\\>")
 
 def lilypond_rule290(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashDot\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashDot\\>")
 
 def lilypond_rule291(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashDash\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashDash\\>")
 
 def lilypond_rule292(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashBar\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\dashBar\\>")
 
 def lilypond_rule293(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cresc\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cresc\\>")
 
 def lilypond_rule294(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cr\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cr\\>")
 
 def lilypond_rule295(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\context\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\context\\>")
 
 def lilypond_rule296(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\consistsend\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\consistsend\\>")
 
 def lilypond_rule297(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\consists\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\consists\\>")
 
 def lilypond_rule298(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\coda\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\coda\\>")
 
 def lilypond_rule299(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cm\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cm\\>")
 
 def lilypond_rule300(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\clef\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\clef\\>")
 
 def lilypond_rule301(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\circulus\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\circulus\\>")
 
 def lilypond_rule302(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\chords\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\chords\\>")
 
 def lilypond_rule303(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\chordmodifiers\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\chordmodifiers\\>")
 
 def lilypond_rule304(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\change\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\change\\>")
 
 def lilypond_rule305(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\center\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\center\\>")
 
 def lilypond_rule306(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cavum\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cavum\\>")
 
 def lilypond_rule307(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\caesura\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\caesura\\>")
 
 def lilypond_rule308(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cadenzaOn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cadenzaOn\\>")
 
 def lilypond_rule309(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cadenzaOff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\cadenzaOff\\>")
 
 def lilypond_rule310(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\breve\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\breve\\>")
 
 def lilypond_rule311(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\breathe\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\breathe\\>")
 
 def lilypond_rule312(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\break\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\break\\>")
 
 def lilypond_rule313(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\blackTriangleMarkup\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\blackTriangleMarkup\\>")
 
 def lilypond_rule314(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\bigger\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\bigger\\>")
 
 def lilypond_rule315(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\bar\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\bar\\>")
 
 def lilypond_rule316(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\autochange\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\autochange\\>")
 
 def lilypond_rule317(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\autoBeamOn\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\autoBeamOn\\>")
 
 def lilypond_rule318(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\autoBeamOff\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\autoBeamOff\\>")
 
 def lilypond_rule319(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\auctum\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\auctum\\>")
 
 def lilypond_rule320(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ascendens\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\ascendens\\>")
 
 def lilypond_rule321(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioUp\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioUp\\>")
 
 def lilypond_rule322(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioDown\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioDown\\>")
 
 def lilypond_rule323(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioBracket\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioBracket\\>")
 
 def lilypond_rule324(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioBoth\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggioBoth\\>")
 
 def lilypond_rule325(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggio\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\arpeggio\\>")
 
 def lilypond_rule326(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\appoggiatura\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\appoggiatura\\>")
 
 def lilypond_rule327(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\applyoutput\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\applyoutput\\>")
 
 def lilypond_rule328(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\applycontext\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\applycontext\\>")
 
 def lilypond_rule329(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\apply\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\apply\\>")
 
 def lilypond_rule330(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\alternative\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\alternative\\>")
 
 def lilypond_rule331(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\alias\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\alias\\>")
 
 def lilypond_rule332(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\aeolian\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\aeolian\\>")
 
 def lilypond_rule333(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\addquote\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\addquote\\>")
 
 def lilypond_rule334(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\addlyrics\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\addlyrics\\>")
 
 def lilypond_rule335(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\acciaccatura\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\acciaccatura\\>")
 
 def lilypond_rule336(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\accepts\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\accepts\\>")
 
 def lilypond_rule337(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\accentus\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\accentus\\>")
 
 def lilypond_rule338(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\accent\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="\\\\accent\\>")
 
 def lilypond_rule339(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\RemoveEmptyStaffContext\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\RemoveEmptyStaffContext\\>")
 
 def lilypond_rule340(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\OrchestralScoreContext\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\OrchestralScoreContext\\>")
 
 def lilypond_rule341(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\EasyNotation\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\EasyNotation\\>")
 
 def lilypond_rule342(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\AncientRemoveEmptyStaffContext\\>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\AncientRemoveEmptyStaffContext\\>")
 
 def lilypond_rule343(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="function", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="function", pattern="\\")
 
 def lilypond_rule344(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/lisp.py
+++ b/leo/modes/lisp.py
@@ -999,60 +999,40 @@ keywordsDictDict = {
 # Rules for lisp_main ruleset.
 
 def lisp_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="#|", end="|#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="#|", end="|#")
 
 def lisp_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="'(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="'(")
 
 def lisp_rule2(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="'")
 
 def lisp_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="&")
 
 def lisp_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="`")
 
 def lisp_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def lisp_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def lisp_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment4", seq=";;;;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment4", seq=";;;;")
 
 def lisp_rule8(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment3", seq=";;;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment3", seq=";;;")
 
 def lisp_rule9(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";;")
 
 def lisp_rule10(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def lisp_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def lisp_rule12(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/lotos.py
+++ b/leo/modes/lotos.py
@@ -105,38 +105,28 @@ keywordsDictDict = {
 # Rules for lotos_main ruleset.
 
 def lotos_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)")
 
 def lotos_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def lotos_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[>")
 
 def lotos_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|||")
 
 def lotos_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def lotos_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|[")
 
 def lotos_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]|")
 
 def lotos_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[]")
 
 def lotos_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/lua.py
+++ b/leo/modes/lua.py
@@ -196,104 +196,79 @@ keywordsDictDict = {
 # Rules for lua_main ruleset.
 
 def lua_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="--[[", end="]]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="--[[", end="]]")
 
 def lua_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def lua_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="#!",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def lua_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def lua_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 # Leo issue #1175:
 def lua_rule5(colorer, s, i):
     return colorer.match_lua_literal(s, i, kind="literal1")
 
 def lua_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def lua_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def lua_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def lua_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def lua_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def lua_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="..")
 
 def lua_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def lua_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def lua_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def lua_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def lua_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def lua_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~=")
 
 def lua_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def lua_rule19(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def lua_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def lua_rule21(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def lua_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def lua_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/mail.py
+++ b/leo/modes/mail.py
@@ -64,68 +64,56 @@ keywordsDictDict = {
 
 def mail_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment3", seq=">>>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def mail_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq=">>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def mail_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=">",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def mail_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="|",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def mail_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def mail_rule5(colorer, s, i):
     return colorer.match_seq(s, i, kind="comment2", seq="--",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="mail::signature")
+          at_line_start=True,
+          delegate="mail::signature")
 
 def mail_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":-)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=":-)")
 
 def mail_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":-(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=":-(")
 
 def mail_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=":)")
 
 def mail_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=":(")
 
 def mail_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";-)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=";-)")
 
 def mail_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";-(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=";-(")
 
 def mail_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=";)")
 
 def mail_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq=";(")
 
 def mail_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 # Rules dict for mail_main ruleset.
 rulesDict1 = {
@@ -145,9 +133,7 @@ rulesDict2 = {}
 
 def mail_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Rules dict for mail_header ruleset.
 rulesDict3 = {

--- a/leo/modes/makefile.py
+++ b/leo/modes/makefile.py
@@ -69,47 +69,35 @@ keywordsDictDict = {
 # Rules for makefile_main ruleset.
 
 def makefile_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def makefile_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="$(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="makefile::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="makefile::variable",
+          no_line_break=True)
 
 def makefile_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="makefile::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="makefile::variable",
+          no_line_break=True)
 
 def makefile_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def makefile_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def makefile_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def makefile_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def makefile_rule7(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":")
 
 def makefile_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -191,21 +179,17 @@ rulesDict1 = {
 # Rules for makefile_variable ruleset.
 
 def makefile_rule9(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def makefile_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="$(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="makefile::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="makefile::variable",
+          no_line_break=True)
 
 def makefile_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="makefile::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="makefile::variable",
+          no_line_break=True)
 
 # Rules dict for makefile_variable ruleset.
 rulesDict2 = {

--- a/leo/modes/maple.py
+++ b/leo/modes/maple.py
@@ -705,107 +705,76 @@ keywordsDictDict = {
 # Rules for maple_main ruleset.
 
 def maple_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def maple_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def maple_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="`", end="`")
 
 def maple_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def maple_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def maple_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def maple_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def maple_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def maple_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def maple_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def maple_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def maple_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def maple_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def maple_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def maple_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def maple_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def maple_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@@")
 
 def maple_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def maple_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def maple_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def maple_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="::")
 
 def maple_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":-")
 
 def maple_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def maple_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def maple_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/matlab.py
+++ b/leo/modes/matlab.py
@@ -5621,150 +5621,112 @@ keywordsDictDict = {
 
 def matlab_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def matlab_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def matlab_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def matlab_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def matlab_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~=")
 
 def matlab_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def matlab_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def matlab_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def matlab_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def matlab_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def matlab_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def matlab_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def matlab_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="./",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="./")
 
 def matlab_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def matlab_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".\\")
 
 def matlab_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def matlab_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".*")
 
 def matlab_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def matlab_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".^")
 
 def matlab_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="'")
 
 def matlab_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".'")
 
 def matlab_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def matlab_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def matlab_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def matlab_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def matlab_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".")
 
 def matlab_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=",")
 
 def matlab_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=";")
 
 def matlab_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="]")
 
 def matlab_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="[")
 
 def matlab_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="(")
 
 def matlab_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=")")
 
 def matlab_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="{")
 
 def matlab_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="}")
 
 def matlab_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="?")
 
 def matlab_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="...",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="...")
 
 def matlab_rule36(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/md.py
+++ b/leo/modes/md.py
@@ -159,82 +159,66 @@ keywordsDictDict = {
 def md_heading(colorer, s, i):
     # issue 386.
     # print('md_heading',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^[#]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^[#]+")
 
 def md_link(colorer, s, i):
     # issue 386.
     # print('md_link',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\[[^]]+\]\([^)]+\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\[[^]]+\]\([^)]+\)")
 
 def md_star_emphasis1(colorer, s, i):
     # issue 386.
     # print('md_underscore_emphasis1',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*[^\\s*][^*]*\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*[^\\s*][^*]*\\*")
 
 def md_star_emphasis2(colorer, s, i):
     # issue 386.
     # print('md_star_emphasis2',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*\\*[^*]+\\*\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*\\*[^*]+\\*\\*")
 
 def md_underscore_emphasis1(colorer, s, i):
     # issue 386.
     # print('md_underscore_emphasis1',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"_[^_]+_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"_[^_]+_")
 
 def md_underline_equals(colorer, s, i):
     # issue 386.
     # print('md_underline_equals',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^===[=]+$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^===[=]+$")
 
 def md_underline_minus(colorer, s, i):
     # issue 386.
     # print('md_underline_minus',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"---[-]+$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"---[-]+$")
 
 def md_underscore_emphasis2(colorer, s, i):
     # issue 386.
     # print('md_underscore_emphasis2',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"__[^_]+__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"__[^_]+__")
 
 def md_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def md_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script", end="</script>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="html::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="html::javascript")
 
 def md_rule2(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="markup", regexp="<hr\\b([^<>])*?/?>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def md_rule3(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|noscript|form|fieldset|iframe|math|ins|del)\\b", end="</$1>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="md::block_html_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="md::block_html_tags")
 
 def md_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=" < ")
 
 def md_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::inline_markup", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="md::inline_markup")
 
 
 # Rules dict for md_main ruleset.
@@ -261,35 +245,26 @@ if 0:  # Rules 6 & 7 will never match?
 
     def md_rule6(colorer, s, i):
         return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="[\\S]+",
-            at_line_start=True, at_whitespace_end=False, at_word_start=False,
-            delegate="", exclude_match=False)
+          at_line_start=True)
 
     def md_rule7(colorer, s, i):
         return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="{1,3}[\\S]+",
-            at_line_start=True, at_whitespace_end=False, at_word_start=False,
-            delegate="", exclude_match=False)
+          at_line_start=True)
 
 def md_rule8(colorer, s, i):
     # leadin: [ \t]
     return colorer.match_eol_span_regexp(s, i, kind="", regexp="( {4}|\\t)",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="html::main", exclude_match=False)
+          at_line_start=True,
+          delegate="html::main")
 
 def md_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def md_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def md_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for md_block_html_tags ruleset.
 rulesDict3 = {
@@ -308,103 +283,84 @@ rulesDict3 = {
 def md_rule12(colorer, s, i):
     # Leadins: [ \t>]
     return colorer.match_eol_span_regexp(s, i, kind="", regexp="[ \\t]*(>[ \\t]{1})+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="md::markdown_blockquote", exclude_match=False)
+          at_line_start=True,
+          delegate="md::markdown_blockquote")
 
 def md_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="*")
 
 def md_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="_")
 
 def md_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\][",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\][")
 
 def md_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="``` ruby", end="```",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="ruby::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="ruby::main")
 
 def md_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="```", end="```",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def md_rule19(colorer, s, i):
     # leadin: `
-    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1")
 
 def md_rule20(colorer, s, i):
     # Leadins are [ \t]
     return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def md_rule21(colorer, s, i):
     # Leadins are [=-]
     return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[=-]+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def md_rule22(colorer, s, i):
     # Leadin is #
     return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def md_rule23(colorer, s, i):
     # Leadins are [ \t -_*]
     return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def md_rule24(colorer, s, i):
     # Leadins are [ \t*+-]
     return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def md_rule25(colorer, s, i):
     # Leadins are [ \t0123456789]
     return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def md_rule26(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False,
-        delegate="md::link_label_definition", exclude_match=False)
+          at_whitespace_end=True,
+          delegate="md::link_label_definition")
 
 def md_rule27(colorer, s, i):
     # leadin: [
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::link_inline_url_title", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="md::link_inline_url_title",
+          no_line_break=True)
 
 def md_rule28(colorer, s, i):
     # Leadins: [*_]
     return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def md_rule29(colorer, s, i):
     # Leadins: [*_]
     return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Rules dict for md_markdown ruleset.
 rulesDict4 = {
@@ -439,20 +395,16 @@ rulesDict4 = {
 # Rules for md_link_label_definition ruleset.
 
 def md_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\"")
 
 def md_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def md_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 # Rules dict for md_link_label_definition ruleset.
 rulesDict5 = {
@@ -465,20 +417,17 @@ rulesDict5 = {
 # Rules for md_link_inline_url_title ruleset.
 
 def md_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def md_rule35(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="\\[", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::link_inline_label_close", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="md::link_inline_label_close",
+          no_line_break=True)
 
 def md_rule36(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="\\(", end="\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::link_inline_url_title_close", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="md::link_inline_url_title_close",
+          no_line_break=True)
 
 # Rules dict for md_link_inline_url_title ruleset.
 rulesDict6 = {
@@ -491,8 +440,7 @@ rulesDict6 = {
 
 def md_rule37(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::main", exclude_match=False)
+          delegate="md::main")
 
 # Rules dict for md_link_inline_url_title_close ruleset.
 rulesDict7 = {
@@ -503,8 +451,7 @@ rulesDict7 = {
 
 def md_rule38(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="null", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::main", exclude_match=False)
+          delegate="md::main")
 
 # Rules dict for md_link_inline_label_close ruleset.
 rulesDict8 = {
@@ -514,100 +461,72 @@ rulesDict8 = {
 # Rules for md_markdown_blockquote ruleset.
 
 def md_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=" < ")
 
 def md_rule40(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::inline_markup", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="md::inline_markup")
 
 def md_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="*")
 
 def md_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="_")
 
 def md_rule43(colorer, s, i):
     # leadin: backslash.
-    return colorer.match_seq(s, i, kind="null", seq="\\][",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\][")
 
 def md_rule44(colorer, s, i):
     # leadin: backslash.
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule45(colorer, s, i):
     # leadin: `
-    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1")
 
 def md_rule46(colorer, s, i):
     # leadins: [ \t]
-    return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S")
 
 def md_rule47(colorer, s, i):
     # leadins: [=-]
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[=-]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[=-]+")
 
 def md_rule48(colorer, s, i):
     # leadin: #
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)")
 
 def md_rule49(colorer, s, i):
     # leadins: [ -_*]
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*")
 
 def md_rule50(colorer, s, i):
     # leadins: [ \t*+-]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+")
 
 def md_rule51(colorer, s, i):
     # leadins: [ \t0123456789]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+")
 
 def md_rule52(colorer, s, i):
     # leadin: [
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::link_label_definition", exclude_match=False)
+          delegate="md::link_label_definition")
 
 def md_rule53(colorer, s, i):
     # leadin: [
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="md::link_inline_url_title", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="md::link_inline_url_title",
+          no_line_break=True)
 
 def md_rule54(colorer, s, i):
     # leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1")
 
 def md_rule55(colorer, s, i):
      # leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1")
 
 # Rules dict for md_markdown_blockquote ruleset.
 rulesDict9 = {

--- a/leo/modes/ml.py
+++ b/leo/modes/ml.py
@@ -121,78 +121,57 @@ keywordsDictDict = {
 # Rules for ml_main ruleset.
 
 def ml_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)")
 
 def ml_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="#\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def ml_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def ml_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def ml_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def ml_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def ml_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def ml_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def ml_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="::")
 
 def ml_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def ml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def ml_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def ml_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def ml_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def ml_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def ml_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def ml_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def ml_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/modula3.py
+++ b/leo/modes/modula3.py
@@ -147,80 +147,57 @@ keywordsDictDict = {
 # Rules for modula3_main ruleset.
 
 def modula3_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<*", end="*>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<*", end="*>")
 
 def modula3_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)")
 
 def modula3_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def modula3_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def modula3_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def modula3_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def modula3_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def modula3_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def modula3_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def modula3_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def modula3_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def modula3_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def modula3_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def modula3_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def modula3_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def modula3_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def modula3_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def modula3_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/moin.py
+++ b/leo/modes/moin.py
@@ -33,166 +33,117 @@ keywordsDictDict = {
 # Rules for moin_main ruleset.
 
 def moin_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="##")
 
 def moin_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#pragma",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#pragma")
 
 def moin_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword4", begin="[[", end="]]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword4", begin="[[", end="]]")
 
 def moin_rule3(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\s+\\w[[:alnum:][:blank:]]+::",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def moin_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{{{", end="}}}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="{{{", end="}}}")
 
 def moin_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="`", end="`")
 
 def moin_rule6(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="('{2,5})[^']+\\1[^']",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="('{2,5})[^']+\\1[^']")
 
 def moin_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal4", regexp="-{4,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal4", regexp="-{4,}")
 
 def moin_rule8(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword1", begin="(={1,5})", end="$1",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def moin_rule9(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="A[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="A[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule10(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="B[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="B[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule11(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="C[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="C[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule12(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="D[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="D[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule13(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="E[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="E[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule14(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="F[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="F[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule15(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="G[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="G[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="H[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="H[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule17(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="I[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="I[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule18(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="J[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="J[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule19(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="K[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="K[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule20(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="L[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="L[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule21(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="M[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="M[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule22(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="N[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="N[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule23(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="O[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="O[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule24(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="P[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="P[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule25(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="Q[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="Q[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule26(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="R[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="R[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule27(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="S[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="S[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule28(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="T[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="T[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule29(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="U[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="U[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="V[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="V[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule31(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="W[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="W[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule32(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="X[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="X[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule33(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="Y[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="Y[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule34(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="Z[a-z]+[A-Z][a-zA-Z]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="Z[a-z]+[A-Z][a-zA-Z]+")
 
 def moin_rule35(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="[\"", end="\"]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword2", begin="[\"", end="\"]")
 
 def moin_rule36(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="[", end="]")
 
 # Rules dict for moin_main ruleset.
 rulesDict1 = {

--- a/leo/modes/mqsc.py
+++ b/leo/modes/mqsc.py
@@ -218,24 +218,20 @@ keywordsDictDict = {
 
 def mqsc_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def mqsc_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="('", end="')",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=True,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          exclude_match=True,
+          no_line_break=True)
 
 def mqsc_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=True,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          exclude_match=True,
+          no_line_break=True)
 
 def mqsc_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def mqsc_rule4(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/netrexx.py
+++ b/leo/modes/netrexx.py
@@ -351,104 +351,75 @@ keywordsDictDict = {
 
 def netrexx_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="java::javadoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="java::javadoc")
 
 def netrexx_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def netrexx_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def netrexx_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def netrexx_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def netrexx_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def netrexx_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def netrexx_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def netrexx_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def netrexx_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def netrexx_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def netrexx_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def netrexx_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".*")
 
 def netrexx_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def netrexx_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def netrexx_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def netrexx_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def netrexx_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def netrexx_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def netrexx_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def netrexx_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def netrexx_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def netrexx_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def netrexx_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/nqc.py
+++ b/leo/modes/nqc.py
@@ -167,108 +167,81 @@ keywordsDictDict = {
 # Rules for nqc_main ruleset.
 
 def nqc_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def nqc_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def nqc_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def nqc_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
 
 def nqc_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def nqc_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def nqc_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def nqc_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def nqc_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def nqc_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def nqc_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def nqc_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def nqc_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def nqc_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def nqc_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def nqc_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def nqc_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def nqc_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def nqc_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def nqc_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def nqc_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def nqc_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def nqc_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def nqc_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def nqc_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/nsi.py
+++ b/leo/modes/nsi.py
@@ -32,21 +32,15 @@ keywordsDictDict = {
 # Rules for nsi_main ruleset.
 
 def nsi_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def nsi_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin='"', end='"',
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def nsi_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Rules dict for nsi_main ruleset.
 rulesDict1 = {

--- a/leo/modes/nsis2.py
+++ b/leo/modes/nsis2.py
@@ -455,44 +455,33 @@ keywordsDictDict = {
 # Rules for nsis2_main ruleset.
 
 def nsis2_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def nsis2_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#")
 
 def nsis2_rule2(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def nsis2_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def nsis2_rule4(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def nsis2_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="nsis2::nsis_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="nsis2::nsis_literal")
 
 def nsis2_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="nsis2::nsis_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="nsis2::nsis_literal")
 
 def nsis2_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="nsis2::nsis_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="nsis2::nsis_literal")
 
 def nsis2_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -581,8 +570,7 @@ rulesDict1 = {
 # Rules for nsis2_nsis_literal ruleset.
 
 def nsis2_rule9(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 # Rules dict for nsis2_nsis_literal ruleset.
 rulesDict2 = {

--- a/leo/modes/objective_c.py
+++ b/leo/modes/objective_c.py
@@ -109,129 +109,96 @@ keywordsDictDict = {
 
 def objective_c_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def objective_c_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def objective_c_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def objective_c_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def objective_c_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def objective_c_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="@\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def objective_c_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="##")
 
 def objective_c_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="c::cpp", exclude_match=False)
+          delegate="c::cpp")
 
 def objective_c_rule8(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def objective_c_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def objective_c_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def objective_c_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def objective_c_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def objective_c_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def objective_c_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def objective_c_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def objective_c_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def objective_c_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def objective_c_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def objective_c_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def objective_c_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def objective_c_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def objective_c_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def objective_c_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def objective_c_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def objective_c_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def objective_c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def objective_c_rule27(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def objective_c_rule28(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/objectrexx.py
+++ b/leo/modes/objectrexx.py
@@ -209,112 +209,84 @@ keywordsDictDict = {
 # Rules for objectrexx_main ruleset.
 
 def objectrexx_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def objectrexx_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def objectrexx_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def objectrexx_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
 
 def objectrexx_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def objectrexx_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def objectrexx_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def objectrexx_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def objectrexx_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def objectrexx_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def objectrexx_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def objectrexx_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def objectrexx_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def objectrexx_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def objectrexx_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def objectrexx_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def objectrexx_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def objectrexx_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def objectrexx_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def objectrexx_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def objectrexx_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def objectrexx_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def objectrexx_rule22(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="function", pattern="::")
 
 def objectrexx_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def objectrexx_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def objectrexx_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ocaml.py
+++ b/leo/modes/ocaml.py
@@ -1204,217 +1204,163 @@ keywordsDictDict = {
 
 def ocaml_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment4", begin="(**", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=True, no_line_break=False, no_word_break=False)
+          no_escape=True)
 
 def ocaml_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="(*", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=True, no_line_break=False, no_word_break=False)
+          no_escape=True)
 
 def ocaml_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="'([^']|\\\\(['\"bntr\\\\]|[[:digit:]]{3}|x[[:xdigit:]]{2}))'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="'([^']|\\\\(['\"bntr\\\\]|[[:digit:]]{3}|x[[:xdigit:]]{2}))'")
 
 def ocaml_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"")
 
 def ocaml_rule4(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="#",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def ocaml_rule5(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="%",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def ocaml_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal3", pattern="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal3", pattern="'")
 
 def ocaml_rule7(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal4", pattern="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal4", pattern="`")
 
 def ocaml_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="}")
 
 def ocaml_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="|]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="|]")
 
 def ocaml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def ocaml_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="|")
 
 def ocaml_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="{<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="{<")
 
 def ocaml_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="{")
 
 def ocaml_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal4", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal4", seq="_")
 
 def ocaml_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="]")
 
 def ocaml_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="[]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="[]")
 
 def ocaml_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="[|")
 
 def ocaml_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="[>")
 
 def ocaml_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="[<")
 
 def ocaml_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="[")
 
 def ocaml_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=">}")
 
 def ocaml_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=">]")
 
 def ocaml_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="<-")
 
 def ocaml_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=";;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=";;")
 
 def ocaml_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=";")
 
 def ocaml_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=":>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=":>")
 
 def ocaml_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def ocaml_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="::")
 
 def ocaml_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=":")
 
 def ocaml_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="..")
 
 def ocaml_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="->")
 
 def ocaml_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=",")
 
 def ocaml_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=")")
 
 def ocaml_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="()",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="()")
 
 def ocaml_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="(")
 
 def ocaml_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="=[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="=[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule37(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="<[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="<[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule38(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp=">[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp=">[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule39(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="@[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="@[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule40(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\^[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\^[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule41(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\|[-!$%&*+./:<=>?@^|~]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\|[-!$%&*+./:<=>?@^|~]+")
 
 def ocaml_rule42(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="&[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="&[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule43(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\+[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\+[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule44(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="-[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="-[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule45(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\*[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\*[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule46(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="/[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="/[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule47(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\$[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\$[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule48(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="%[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="%[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule49(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="![-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="![-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule50(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\?[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\?[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule51(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="operator", regexp="~[-!$%&*+./:<=>?@^|~]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="operator", regexp="~[-!$%&*+./:<=>?@^|~]*")
 
 def ocaml_rule52(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/occam.py
+++ b/leo/modes/occam.py
@@ -220,106 +220,78 @@ keywordsDictDict = {
 # Rules for occam_main ruleset.
 
 def occam_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def occam_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#")
 
 def occam_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def occam_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def occam_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def occam_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def occam_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def occam_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<")
 
 def occam_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def occam_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="><",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="><")
 
 def occam_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def occam_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def occam_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def occam_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def occam_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def occam_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def occam_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def occam_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def occam_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def occam_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def occam_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def occam_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/\\")
 
 def occam_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\/")
 
 def occam_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def occam_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/omnimark.py
+++ b/leo/modes/omnimark.py
@@ -429,98 +429,71 @@ keywordsDictDict = {
 # Rules for omnimark_main ruleset.
 
 def omnimark_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#!")
 
 def omnimark_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def omnimark_rule2(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="invalid", begin="\"((?!$)[^\"])*$", end="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def omnimark_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def omnimark_rule4(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="invalid", begin="'((?!$)[^'])*$", end="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def omnimark_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def omnimark_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def omnimark_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def omnimark_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def omnimark_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def omnimark_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def omnimark_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def omnimark_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def omnimark_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def omnimark_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def omnimark_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def omnimark_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def omnimark_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def omnimark_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def omnimark_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def omnimark_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def omnimark_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/pandoc.py
+++ b/leo/modes/pandoc.py
@@ -160,82 +160,66 @@ keywordsDictDict = {
 def pandoc_heading(colorer, s, i):
     # issue 386.
     # print('pandoc_heading',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^[#]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^[#]+")
 
 def pandoc_link(colorer, s, i):
     # issue 386.
     # print('pandoc_link',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\[[^]]+\]\([^)]+\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\[[^]]+\]\([^)]+\)")
 
 def pandoc_star_emphasis1(colorer, s, i):
     # issue 386.
     # print('pandoc_underscore_emphasis1',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*[^\\s*][^*]*\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*[^\\s*][^*]*\\*")
 
 def pandoc_star_emphasis2(colorer, s, i):
     # issue 386.
     # print('pandoc_star_emphasis2',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*\\*[^*]+\\*\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*\\*[^*]+\\*\\*")
 
 def pandoc_underscore_emphasis1(colorer, s, i):
     # issue 386.
     # print('pandoc_underscore_emphasis1',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"_[^_]+_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"_[^_]+_")
 
 def pandoc_underline_equals(colorer, s, i):
     # issue 386.
     # print('pandoc_underline_equals',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^===[=]+$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"^===[=]+$")
 
 def pandoc_underline_minus(colorer, s, i):
     # issue 386.
     # print('pandoc_underline_minus',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"---[-]+$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"---[-]+$")
 
 def pandoc_underscore_emphasis2(colorer, s, i):
     # issue 386.
     # print('pandoc_underscore_emphasis2',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"__[^_]+__",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"__[^_]+__")
 
 def pandoc_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def pandoc_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script", end="</script>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="html::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="html::javascript")
 
 def pandoc_rule2(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="markup", regexp="<hr\\b([^<>])*?/?>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def pandoc_rule3(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|noscript|form|fieldset|iframe|math|ins|del)\\b", end="</$1>",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::block_html_tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="pandoc::block_html_tags")
 
 def pandoc_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=" < ")
 
 def pandoc_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::inline_markup", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pandoc::inline_markup")
 
 
 # Rules dict for pandoc_main ruleset.
@@ -262,35 +246,26 @@ if 0:  # Rules 6 & 7 will never match?
 
     def pandoc_rule6(colorer, s, i):
         return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="[\\S]+",
-            at_line_start=True, at_whitespace_end=False, at_word_start=False,
-            delegate="", exclude_match=False)
+          at_line_start=True)
 
     def pandoc_rule7(colorer, s, i):
         return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="{1,3}[\\S]+",
-            at_line_start=True, at_whitespace_end=False, at_word_start=False,
-            delegate="", exclude_match=False)
+          at_line_start=True)
 
 def pandoc_rule8(colorer, s, i):
     # leadin: [ \t]
     return colorer.match_eol_span_regexp(s, i, kind="", regexp="( {4}|\\t)",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="html::main", exclude_match=False)
+          at_line_start=True,
+          delegate="html::main")
 
 def pandoc_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def pandoc_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def pandoc_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for pandoc_block_html_tags ruleset.
 rulesDict3 = {
@@ -309,103 +284,84 @@ rulesDict3 = {
 def pandoc_rule12(colorer, s, i):
     # Leadins: [ \t>]
     return colorer.match_eol_span_regexp(s, i, kind="", regexp="[ \\t]*(>[ \\t]{1})+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::markdown_blockquote", exclude_match=False)
+          at_line_start=True,
+          delegate="pandoc::markdown_blockquote")
 
 def pandoc_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="*")
 
 def pandoc_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="_")
 
 def pandoc_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\][",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\][")
 
 def pandoc_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="``` ruby", end="```",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="ruby::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="ruby::main")
 
 def pandoc_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="```", end="```",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True)
 
 def pandoc_rule19(colorer, s, i):
     # leadin: `
-    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1")
 
 def pandoc_rule20(colorer, s, i):
     # Leadins are [ \t]
     return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def pandoc_rule21(colorer, s, i):
     # Leadins are [=-]
     return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[=-]+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def pandoc_rule22(colorer, s, i):
     # Leadin is #
     return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def pandoc_rule23(colorer, s, i):
     # Leadins are [ \t -_*]
     return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def pandoc_rule24(colorer, s, i):
     # Leadins are [ \t*+-]
     return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def pandoc_rule25(colorer, s, i):
     # Leadins are [ \t0123456789]
     return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def pandoc_rule26(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False,
-        delegate="pandoc::link_label_definition", exclude_match=False)
+          at_whitespace_end=True,
+          delegate="pandoc::link_label_definition")
 
 def pandoc_rule27(colorer, s, i):
     # leadin: [
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::link_inline_url_title", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pandoc::link_inline_url_title",
+          no_line_break=True)
 
 def pandoc_rule28(colorer, s, i):
     # Leadins: [*_]
     return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def pandoc_rule29(colorer, s, i):
     # Leadins: [*_]
     return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Rules dict for pandoc_markdown ruleset.
 rulesDict4 = {
@@ -440,20 +396,16 @@ rulesDict4 = {
 # Rules for pandoc_link_label_definition ruleset.
 
 def pandoc_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\"")
 
 def pandoc_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def pandoc_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 # Rules dict for pandoc_link_label_definition ruleset.
 rulesDict5 = {
@@ -466,20 +418,17 @@ rulesDict5 = {
 # Rules for pandoc_link_inline_url_title ruleset.
 
 def pandoc_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def pandoc_rule35(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="\\[", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::link_inline_label_close", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pandoc::link_inline_label_close",
+          no_line_break=True)
 
 def pandoc_rule36(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="\\(", end="\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::link_inline_url_title_close", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pandoc::link_inline_url_title_close",
+          no_line_break=True)
 
 # Rules dict for pandoc_link_inline_url_title ruleset.
 rulesDict6 = {
@@ -492,8 +441,7 @@ rulesDict6 = {
 
 def pandoc_rule37(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::main", exclude_match=False)
+          delegate="pandoc::main")
 
 # Rules dict for pandoc_link_inline_url_title_close ruleset.
 rulesDict7 = {
@@ -504,8 +452,7 @@ rulesDict7 = {
 
 def pandoc_rule38(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="null", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::main", exclude_match=False)
+          delegate="pandoc::main")
 
 # Rules dict for pandoc_link_inline_label_close ruleset.
 rulesDict8 = {
@@ -515,100 +462,72 @@ rulesDict8 = {
 # Rules for pandoc_markdown_blockquote ruleset.
 
 def pandoc_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=" < ")
 
 def pandoc_rule40(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::inline_markup", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pandoc::inline_markup")
 
 def pandoc_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="*")
 
 def pandoc_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="_")
 
 def pandoc_rule43(colorer, s, i):
     # leadin: backslash.
-    return colorer.match_seq(s, i, kind="null", seq="\\][",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="\\][")
 
 def pandoc_rule44(colorer, s, i):
     # leadin: backslash.
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule45(colorer, s, i):
     # leadin: `
-    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal2", begin="(`{1,2})", end="$1")
 
 def pandoc_rule46(colorer, s, i):
     # leadins: [ \t]
-    return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S")
 
 def pandoc_rule47(colorer, s, i):
     # leadins: [=-]
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[=-]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[=-]+")
 
 def pandoc_rule48(colorer, s, i):
     # leadin: #
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)")
 
 def pandoc_rule49(colorer, s, i):
     # leadins: [ -_*]
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*")
 
 def pandoc_rule50(colorer, s, i):
     # leadins: [ \t*+-]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+")
 
 def pandoc_rule51(colorer, s, i):
     # leadins: [ \t0123456789]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+")
 
 def pandoc_rule52(colorer, s, i):
     # leadin: [
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::link_label_definition", exclude_match=False)
+          delegate="pandoc::link_label_definition")
 
 def pandoc_rule53(colorer, s, i):
     # leadin: [
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pandoc::link_inline_url_title", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pandoc::link_inline_url_title",
+          no_line_break=True)
 
 def pandoc_rule54(colorer, s, i):
     # leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1")
 
 def pandoc_rule55(colorer, s, i):
      # leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1")
 
 # Rules dict for pandoc_markdown_blockquote ruleset.
 rulesDict9 = {

--- a/leo/modes/pascal.py
+++ b/leo/modes/pascal.py
@@ -172,123 +172,86 @@ keywordsDictDict = {
 # Rules for pascal_main ruleset.
 
 def pascal_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="{$", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="{$", end="}")
 
 def pascal_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="(*$", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="(*$", end="*)")
 
 def pascal_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="{", end="}")
 
 def pascal_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)")
 
 def pascal_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def pascal_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def pascal_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def pascal_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def pascal_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def pascal_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def pascal_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def pascal_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def pascal_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def pascal_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def pascal_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def pascal_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def pascal_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def pascal_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def pascal_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def pascal_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def pascal_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def pascal_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def pascal_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def pascal_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def pascal_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def pascal_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def pascal_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def pascal_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/patch.py
+++ b/leo/modes/patch.py
@@ -31,53 +31,43 @@ keywordsDictDict = {
 
 def patch_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal1", seq="+++",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="literal2", seq="---",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="Index:",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword1", seq="+",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword1", seq=">",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="-",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="<",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="!",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule8(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="@@",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def patch_rule9(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="*",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 # Rules dict for patch_main ruleset.
 rulesDict1 = {

--- a/leo/modes/perl.py
+++ b/leo/modes/perl.py
@@ -332,261 +332,201 @@ keywordsDictDict = {
 # Rules for perl_main ruleset.
 
 def perl_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def perl_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=head1", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=head2", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=head3", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=head4", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=item", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=over", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=back", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=pod", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=for", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=begin", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="=end", end="=cut",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::pod", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          at_line_start=True,
+          delegate="perl::pod")
 
 def perl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="$`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="$`")
 
 def perl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="$'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="$'")
 
 def perl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="$\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="$\"")
 
 def perl_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\$(?:#|\\w)+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\$(?:#|\\w)+")
 
 def perl_rule17(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="@(?:#|\\w)+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="@(?:#|\\w)+")
 
 def perl_rule18(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="%(?:#|\\w)+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="%(?:#|\\w)+")
 
 def perl_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="@{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="%{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule21(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def perl_rule22(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def perl_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::exec")
 
 def perl_rule24(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin="<<[:space:]*(['\"])([[:space:][:alnum:]_]*)\\1;?\\s*", end="$2",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::literal")
 
 def perl_rule25(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin="<<([[:alpha:]_][[:alnum:]_]*);?\\s*", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::literal")
 
 def perl_rule26(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="/[^[:blank:]]*?[^\\\\]/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="/[^[:blank:]]*?[^\\\\]/")
 
 def perl_rule27(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="q(?:|[qrx])\\{(?:.*?[^\\\\])*?\\}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="q(?:|[qrx])\\{(?:.*?[^\\\\])*?\\}")
 
 def perl_rule28(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="tr([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="tr([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1")
 
 def perl_rule29(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="y([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="y([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1")
 
 def perl_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="m\\{(?:.*?[^\\\\])*?\\}[sgiexom]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="m\\{(?:.*?[^\\\\])*?\\}[sgiexom]*")
 
 def perl_rule31(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="m([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="m([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*")
 
 def perl_rule32(colorer, s, i):
     return 0  # too complicated
     # return colorer.match_seq_regexp(s, i, kind="markup", regexp="s\\s*\\{(?:.*?[^\\\\])*?\\}\\s*\\{(?:.*?[^\\\\])*?\\}[sgiexom]*",
-    #    at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    #       )
 
 def perl_rule33(colorer, s, i):
     return 0  # too complicated
     #return colorer.match_seq_regexp(s, i, kind="markup", regexp="s([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1[sgiexom]*",
-    #    at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    #       )
 
 def perl_rule34(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="/[^[:blank:]]*?/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="markup", regexp="/[^[:blank:]]*?/")
 
 def perl_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def perl_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def perl_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def perl_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def perl_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def perl_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def perl_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def perl_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def perl_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def perl_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def perl_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def perl_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def perl_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def perl_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def perl_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def perl_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def perl_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def perl_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def perl_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def perl_rule54(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -689,117 +629,90 @@ rulesDict2 = {}
 
 def perl_rule55(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule56(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="@{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule57(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="%{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="|")
 
 def perl_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="&")
 
 def perl_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="!")
 
 def perl_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq=">")
 
 def perl_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="<")
 
 def perl_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq=")")
 
 def perl_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="(")
 
 def perl_rule65(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="=")
 
 def perl_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="!")
 
 def perl_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="+")
 
 def perl_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="-")
 
 def perl_rule69(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="/")
 
 def perl_rule70(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="*")
 
 def perl_rule71(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="^")
 
 def perl_rule72(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="~")
 
 def perl_rule73(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="}")
 
 def perl_rule74(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="{")
 
 def perl_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq=".")
 
 def perl_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq=",")
 
 def perl_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq=";")
 
 def perl_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="]")
 
 def perl_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="[")
 
 def perl_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="?")
 
 def perl_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq=":")
 
 # Rules dict for perl_literal ruleset.
 rulesDict3 = {
@@ -834,27 +747,19 @@ rulesDict3 = {
 # Rules for perl_exec ruleset.
 
 def perl_rule82(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def perl_rule83(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def perl_rule84(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="@{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def perl_rule85(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="%{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Rules dict for perl_exec ruleset.
 rulesDict4 = {
@@ -868,13 +773,11 @@ rulesDict4 = {
 
 def perl_rule86(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::variable", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="perl::variable",
+          no_line_break=True)
 
 def perl_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 # Rules dict for perl_variable ruleset.
 rulesDict5 = {
@@ -885,58 +788,43 @@ rulesDict5 = {
 # Rules for perl_regexp ruleset.
 
 def perl_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=")(")
 
 def perl_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=")[")
 
 def perl_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="){",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="){")
 
 def perl_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="](",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="](")
 
 def perl_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="][",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="][")
 
 def perl_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="]{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="]{")
 
 def perl_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="}(")
 
 def perl_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="}[")
 
 def perl_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="}{")
 
 def perl_rule97(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::regexp", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::regexp")
 
 def perl_rule98(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::regexp", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::regexp")
 
 def perl_rule99(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="perl::regexp", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="perl::regexp")
 
 # Rules dict for perl_regexp ruleset.
 rulesDict6 = {

--- a/leo/modes/pharo.py
+++ b/leo/modes/pharo.py
@@ -57,76 +57,58 @@ keywordsDictDict = {
 # Rules for pharo_main ruleset.
 
 def pharo_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def pharo_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"")
 
 def pharo_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def pharo_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def pharo_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def pharo_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def pharo_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def pharo_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def pharo_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def pharo_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def pharo_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def pharo_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def pharo_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def pharo_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def pharo_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword3", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def pharo_rule15(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def pharo_rule16(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal1", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def pharo_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/php.py
+++ b/leo/modes/php.py
@@ -2550,63 +2550,42 @@ keywordsDictDict = {
 
 def php_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def php_rule4(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<SCRIPT\\s+LANGUAGE=\"?PHP\"?>", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::javascript")
 
 def php_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::css")
 
 def php_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def php_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::tags")
 
 def php_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for php_main ruleset.
 rulesDict1 = {
@@ -2619,37 +2598,26 @@ rulesDict1 = {
 
 def php_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::tags_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::tags_literal")
 
 def php_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::tags_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::tags_literal")
 
 def php_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for php_tags ruleset.
 rulesDict2 = {
@@ -2663,21 +2631,15 @@ rulesDict2 = {
 
 def php_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 # Rules dict for php_tags_literal ruleset.
 rulesDict3 = {
@@ -2688,165 +2650,119 @@ rulesDict3 = {
 
 def php_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::phpdoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::phpdoc")
 
 def php_rule20(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def php_rule21(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php_literal")
 
 def php_rule22(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def php_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php_literal")
 
 def php_rule24(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def php_rule25(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def php_rule26(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal1", begin="<<<[[:space:]'\"]*([[:alnum:]_]+)[[:space:]'\"]*", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php_literal")
 
 def php_rule27(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def php_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def php_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def php_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def php_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def php_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def php_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def php_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def php_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def php_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def php_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def php_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def php_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def php_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def php_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def php_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def php_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def php_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def php_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def php_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def php_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def php_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def php_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def php_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def php_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def php_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def php_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def php_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def php_rule55(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def php_rule56(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2951,8 +2867,7 @@ rulesDict4 = {
 # Rules for php_php_literal ruleset.
 
 def php_rule57(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 # Rules dict for php_php_literal ruleset.
 rulesDict5 = {
@@ -2963,11 +2878,11 @@ rulesDict5 = {
 
 def php_rule58(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="php::javascript+php")
+          delegate="php::javascript+php")
 
 def php_rule59(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="SRC=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="php::back_to_html")
+          delegate="php::back_to_html")
 
 # Rules dict for php_javascript ruleset.
 rulesDict6 = {
@@ -2979,21 +2894,15 @@ rulesDict6 = {
 
 def php_rule60(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule61(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def php_rule62(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 
 # Rules dict for php_javascript_php ruleset.
@@ -3004,36 +2913,27 @@ rulesDict7 = {
 # Rules for php_phpdoc ruleset.
 
 def php_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="{")
 
 def php_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="*")
 
 def php_rule65(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<!--", end="-->")
 
 def php_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<<")
 
 def php_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<=")
 
 def php_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="< ")
 
 def php_rule69(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="xml::tags",
+          no_line_break=True)
 
 def php_rule70(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/phpsection.py
+++ b/leo/modes/phpsection.py
@@ -2547,63 +2547,42 @@ keywordsDictDict = {
 
 def phpsection_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def phpsection_rule4(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="markup", begin="<SCRIPT\\s+LANGUAGE=\"?PHP\"?>", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::javascript")
 
 def phpsection_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::css")
 
 def phpsection_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def phpsection_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::tags")
 
 def phpsection_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for phpsection_main ruleset.
 rulesDict1 = {
@@ -2616,37 +2595,26 @@ rulesDict1 = {
 
 def phpsection_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::tags_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::tags_literal")
 
 def phpsection_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::tags_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::tags_literal")
 
 def phpsection_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for phpsection_tags ruleset.
 rulesDict2 = {
@@ -2660,21 +2628,15 @@ rulesDict2 = {
 
 def phpsection_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 def phpsection_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php")
 
 # Rules dict for phpsection_tags_literal ruleset.
 rulesDict3 = {
@@ -2685,165 +2647,119 @@ rulesDict3 = {
 
 def phpsection_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::phpdoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::phpdoc")
 
 def phpsection_rule20(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def phpsection_rule21(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php_literal")
 
 def phpsection_rule22(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def phpsection_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php_literal")
 
 def phpsection_rule24(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def phpsection_rule25(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def phpsection_rule26(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal1", begin="<<<[[:space:]'\"]*([[:alnum:]_]+)[[:space:]'\"]*", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="phpsection::php_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="phpsection::php_literal")
 
 def phpsection_rule27(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def phpsection_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def phpsection_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def phpsection_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def phpsection_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def phpsection_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def phpsection_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def phpsection_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def phpsection_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def phpsection_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def phpsection_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def phpsection_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def phpsection_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def phpsection_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def phpsection_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def phpsection_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def phpsection_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def phpsection_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def phpsection_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def phpsection_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def phpsection_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def phpsection_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def phpsection_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def phpsection_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def phpsection_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def phpsection_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def phpsection_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def phpsection_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def phpsection_rule55(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def phpsection_rule56(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -2948,8 +2864,7 @@ rulesDict4 = {
 # Rules for phpsection_php_literal ruleset.
 
 def phpsection_rule57(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 # Rules dict for phpsection_php_literal ruleset.
 rulesDict5 = {
@@ -2960,11 +2875,11 @@ rulesDict5 = {
 
 def phpsection_rule58(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="phpsection::javascript+php")
+          delegate="phpsection::javascript+php")
 
 def phpsection_rule59(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="SRC=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="phpsection::back_to_html")
+          delegate="phpsection::back_to_html")
 
 # Rules dict for phpsection_javascript ruleset.
 rulesDict6 = {
@@ -2976,21 +2891,15 @@ rulesDict6 = {
 
 def phpsection_rule60(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def phpsection_rule61(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 def phpsection_rule62(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="php::php", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="php::php")
 
 
 # Rules dict for phpsection_javascript_php ruleset.
@@ -3001,36 +2910,27 @@ rulesDict7 = {
 # Rules for phpsection_phpdoc ruleset.
 
 def phpsection_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="{")
 
 def phpsection_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="*")
 
 def phpsection_rule65(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<!--", end="-->")
 
 def phpsection_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<<")
 
 def phpsection_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<=")
 
 def phpsection_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="< ")
 
 def phpsection_rule69(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="xml::tags",
+          no_line_break=True)
 
 def phpsection_rule70(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/pike.py
+++ b/leo/modes/pike.py
@@ -178,137 +178,105 @@ keywordsDictDict = {
 
 def pike_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::comment", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pike::comment")
 
 def pike_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="invalid", seq="*/")
 
 def pike_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="//!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::autodoc", exclude_match=False)
+          delegate="pike::autodoc")
 
 def pike_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::comment", exclude_match=False)
+          delegate="pike::comment")
 
 def pike_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::string_literal", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pike::string_literal",
+          no_line_break=True)
 
 def pike_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="#\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::string_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pike::string_literal")
 
 def pike_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def pike_rule7(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="#.*?(?=($|/\\*|//))",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def pike_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="({",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="({")
 
 def pike_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="})",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="})")
 
 def pike_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="([",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="([")
 
 def pike_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="])",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="])")
 
 def pike_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(<")
 
 def pike_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">)")
 
 def pike_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def pike_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def pike_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def pike_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def pike_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def pike_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def pike_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def pike_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def pike_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def pike_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def pike_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def pike_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def pike_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def pike_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def pike_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="`")
 
 def pike_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def pike_rule30(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def pike_rule31(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -477,32 +445,26 @@ rulesDict2 = {
 
 def pike_rule33(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="null", seq="@decl",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::main", exclude_match=True)
+          delegate="pike::main",
+          exclude_match=True)
 
 def pike_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="@xml{", end="@}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::tags")
 
 def pike_rule35(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="@[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def pike_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="function", regexp="@(b|i|u|tt|url|pre|ref|code|expr|image)?(\\{.*@\\})",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="function", regexp="@(b|i|u|tt|url|pre|ref|code|expr|image)?(\\{.*@\\})")
 
 def pike_rule37(colorer, s, i):
     return colorer.match_keywords(s, i)
 
 def pike_rule38(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="null", seq="@decl",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pike::main", exclude_match=False)
+          delegate="pike::main")
 
 # Rules dict for pike_autodoc ruleset.
 rulesDict3 = {
@@ -574,12 +536,10 @@ rulesDict3 = {
 # Rules for pike_string_literal ruleset.
 
 def pike_rule39(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="%([^ a-z]*[a-z]|\\[[^\\]]*\\])",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="%([^ a-z]*[a-z]|\\[[^\\]]*\\])")
 
 def pike_rule40(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="DEBUG:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="DEBUG:")
 
 # Rules dict for pike_string_literal ruleset.
 rulesDict4 = {

--- a/leo/modes/pl1.py
+++ b/leo/modes/pl1.py
@@ -553,95 +553,71 @@ keywordsDictDict = {
 # Rules for pl1_main ruleset.
 
 def pl1_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def pl1_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def pl1_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def pl1_rule3(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="keyword2", regexp="\\* *process",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def pl1_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def pl1_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def pl1_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def pl1_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def pl1_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def pl1_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def pl1_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def pl1_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def pl1_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def pl1_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def pl1_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def pl1_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def pl1_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def pl1_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def pl1_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def pl1_rule19(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def pl1_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def pl1_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/plain.py
+++ b/leo/modes/plain.py
@@ -33,7 +33,7 @@ keywordsDictDict = {
 if 1:
     def plain_rule0(colorer, s, i):
         # print('plain_rule0',s[i:i+10])
-        return colorer.match_eol_span(s, i, kind="null", delegate="")
+        return colorer.match_eol_span(s, i, kind="null")
 
     # Simulate a dict that returns [plain_rule0] by default.
     class RulesDict:

--- a/leo/modes/plsql.py
+++ b/leo/modes/plsql.py
@@ -373,111 +373,80 @@ keywordsDictDict = {
 # Rules for plsql_main ruleset.
 
 def plsql_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def plsql_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def plsql_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def plsql_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def plsql_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def plsql_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="REM",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def plsql_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="REMARK",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def plsql_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def plsql_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def plsql_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def plsql_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def plsql_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def plsql_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def plsql_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def plsql_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def plsql_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def plsql_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def plsql_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def plsql_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def plsql_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def plsql_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!>")
 
 def plsql_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!<")
 
 def plsql_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def plsql_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def plsql_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/pop11.py
+++ b/leo/modes/pop11.py
@@ -192,146 +192,112 @@ keywordsDictDict = {
 
 def pop11_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::comment", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::comment")
 
 def pop11_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";;;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";;;")
 
 def pop11_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::string", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pop11::string",
+          no_line_break=True)
 
 def pop11_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::string", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pop11::string",
+          no_line_break=True)
 
 def pop11_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::string", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pop11::string",
+          no_line_break=True)
 
 def pop11_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::list", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::list")
 
 def pop11_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::list", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::list")
 
 def pop11_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="![", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::list", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::list")
 
 def pop11_rule8(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def pop11_rule9(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def pop11_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="#_<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="#_<")
 
 def pop11_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=">_#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=">_#")
 
 def pop11_rule12(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="#_",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def pop11_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=")")
 
 def pop11_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="(")
 
 def pop11_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".")
 
 def pop11_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=",")
 
 def pop11_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=";")
 
 def pop11_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="^")
 
 def pop11_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="@")
 
 def pop11_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=":")
 
 def pop11_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="|")
 
 def pop11_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def pop11_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def pop11_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def pop11_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def pop11_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def pop11_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def pop11_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def pop11_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def pop11_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def pop11_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def pop11_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -430,66 +396,48 @@ rulesDict1 = {
 
 def pop11_rule33(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::list", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::list")
 
 def pop11_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::list", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::list")
 
 def pop11_rule35(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="![", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::list", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::list")
 
 def pop11_rule36(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::string", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pop11::string",
+          no_line_break=True)
 
 def pop11_rule37(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::string", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="pop11::string",
+          no_line_break=True)
 
 def pop11_rule38(colorer, s, i):
     return colorer.match_span(s, i, kind="null", begin="%", end="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::main")
 
 def pop11_rule39(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pop11::comment", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pop11::comment")
 
 def pop11_rule40(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";;;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";;;")
 
 def pop11_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal2", seq="=")
 
 def pop11_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal2", seq="==")
 
 def pop11_rule43(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="^")
 
 def pop11_rule44(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="?")
 
 # Rules dict for pop11_list ruleset.
 rulesDict2 = {
@@ -514,12 +462,10 @@ rulesDict3 = {}
 # Rules for pop11_comment ruleset.
 
 def pop11_rule45(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":")
 
 def pop11_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="*")
 
 # Rules dict for pop11_comment ruleset.
 rulesDict4 = {

--- a/leo/modes/postscript.py
+++ b/leo/modes/postscript.py
@@ -96,56 +96,38 @@ keywordsDictDict = {
 # Rules for postscript_main ruleset.
 
 def postscript_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="%!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="%!")
 
 def postscript_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="%?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="%?")
 
 def postscript_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="%%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="%%")
 
 def postscript_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def postscript_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="postscript::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="postscript::literal")
 
 def postscript_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="<", end=">")
 
 def postscript_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="label", pattern="/")
 
 def postscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def postscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def postscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def postscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def postscript_rule11(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -229,9 +211,7 @@ rulesDict1 = {
 
 def postscript_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="postscript::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="postscript::literal")
 
 # Rules dict for postscript_literal ruleset.
 rulesDict2 = {

--- a/leo/modes/povray.py
+++ b/leo/modes/povray.py
@@ -496,103 +496,78 @@ keywordsDictDict = {
 # Rules for povray_main ruleset.
 
 def povray_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def povray_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def povray_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def povray_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def povray_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def povray_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def povray_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def povray_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def povray_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def povray_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def povray_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def povray_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def povray_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def povray_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def povray_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def povray_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def povray_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def povray_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def povray_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def povray_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def povray_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def povray_rule21(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def povray_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def povray_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/powerdynamo.py
+++ b/leo/modes/powerdynamo.py
@@ -297,165 +297,110 @@ keywordsDictDict = {
 
 def powerdynamo_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--script", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-script", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-script")
 
 def powerdynamo_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--data", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-data", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-data")
 
 def powerdynamo_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--document", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-document", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-document")
 
 def powerdynamo_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--evaluate", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-script", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-script")
 
 def powerdynamo_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--execute", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-script", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-script")
 
 def powerdynamo_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--formatting", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--/formatting", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--include", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--label", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="transact-sql::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="transact-sql::main")
 
 def powerdynamo_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_error_code", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_error_info", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_state", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_on_no_error", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--/sql_on_no_error", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_on_error", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--/sql_on_error", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_on_no_rows", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--/sql_on_no_rows", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--sql_on_rows", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--/sql_on_rows", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-tag-general", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-tag-general")
 
 def powerdynamo_rule21(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def powerdynamo_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::javascript")
 
 def powerdynamo_rule23(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::css")
 
 def powerdynamo_rule24(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def powerdynamo_rule25(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::tags")
 
 def powerdynamo_rule26(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for powerdynamo_main ruleset.
 rulesDict1 = {
@@ -467,25 +412,18 @@ rulesDict1 = {
 
 def powerdynamo_rule27(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--script", end="--?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-script", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-script")
 
 def powerdynamo_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::tags_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::tags_literal")
 
 def powerdynamo_rule29(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::tags_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::tags_literal")
 
 def powerdynamo_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for powerdynamo_tags ruleset.
 rulesDict2 = {
@@ -499,9 +437,7 @@ rulesDict2 = {
 
 def powerdynamo_rule31(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="<!--script", end="?-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo-script", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo-script")
 
 # Rules dict for powerdynamo_tags_literal ruleset.
 rulesDict3 = {
@@ -511,135 +447,100 @@ rulesDict3 = {
 # Rules for powerdynamo_powerdynamo_script ruleset.
 
 def powerdynamo_rule32(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def powerdynamo_rule33(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule35(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def powerdynamo_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def powerdynamo_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def powerdynamo_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def powerdynamo_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def powerdynamo_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def powerdynamo_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def powerdynamo_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def powerdynamo_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def powerdynamo_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def powerdynamo_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def powerdynamo_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def powerdynamo_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def powerdynamo_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def powerdynamo_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def powerdynamo_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def powerdynamo_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def powerdynamo_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def powerdynamo_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def powerdynamo_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def powerdynamo_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def powerdynamo_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def powerdynamo_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def powerdynamo_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def powerdynamo_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def powerdynamo_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def powerdynamo_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def powerdynamo_rule62(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def powerdynamo_rule63(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -741,15 +642,11 @@ rulesDict4 = {
 
 def powerdynamo_rule64(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule65(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule66(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -828,15 +725,11 @@ rulesDict5 = {
 
 def powerdynamo_rule67(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule68(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule69(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -915,15 +808,11 @@ rulesDict6 = {
 
 def powerdynamo_rule70(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule71(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="powerdynamo::powerdynamo_literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="powerdynamo::powerdynamo_literal")
 
 def powerdynamo_rule72(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/prolog.py
+++ b/leo/modes/prolog.py
@@ -129,189 +129,140 @@ keywordsDictDict = {
 # Rules for prolog_main ruleset.
 
 def prolog_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def prolog_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def prolog_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def prolog_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def prolog_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="prolog::list", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="prolog::list",
+          no_line_break=True)
 
 def prolog_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-->")
 
 def prolog_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":-")
 
 def prolog_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?-")
 
 def prolog_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def prolog_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def prolog_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def prolog_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\+")
 
 def prolog_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def prolog_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\==")
 
 def prolog_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\=")
 
 def prolog_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@<")
 
 def prolog_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@=<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@=<")
 
 def prolog_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@>=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@>=")
 
 def prolog_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@>")
 
 def prolog_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=..")
 
 def prolog_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=:=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=:=")
 
 def prolog_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=\\=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=\\=")
 
 def prolog_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=<")
 
 def prolog_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def prolog_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def prolog_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def prolog_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/\\")
 
 def prolog_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\/")
 
 def prolog_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="//")
 
 def prolog_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<")
 
 def prolog_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def prolog_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def prolog_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def prolog_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def prolog_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def prolog_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def prolog_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def prolog_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def prolog_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def prolog_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def prolog_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="(")
 
 def prolog_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq=")")
 
 def prolog_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="{")
 
 def prolog_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="}")
 
 def prolog_rule44(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -411,9 +362,8 @@ rulesDict1 = {
 
 def prolog_rule45(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="prolog::list", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="prolog::list",
+          no_line_break=True)
 
 # Rules dict for prolog_list ruleset.
 rulesDict2 = {

--- a/leo/modes/pseudoplain.py
+++ b/leo/modes/pseudoplain.py
@@ -43,9 +43,7 @@ keywordsDictDict = {
 
 def pseudoplain_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="[[", end="]]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="pseudoplain::interior", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="pseudoplain::interior")
 
 # Rules dict for pseudoplain_main ruleset.
 rulesDict1 = {

--- a/leo/modes/psp.py
+++ b/leo/modes/psp.py
@@ -67,69 +67,44 @@ keywordsDictDict = {
 
 def psp_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal4", begin="<%@", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="psp::directive", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="psp::directive")
 
 def psp_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>")
 
 def psp_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="python::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="python::main")
 
 def psp_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def psp_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def psp_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="javascript::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="javascript::main")
 
 def psp_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="markup", begin="<!--#", end="-->")
 
 def psp_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def psp_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="css::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="css::main")
 
 def psp_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="psp::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="psp::tags")
 
 def psp_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for psp_main ruleset.
 rulesDict1 = {
@@ -140,32 +115,20 @@ rulesDict1 = {
 # Rules for psp_tags ruleset.
 
 def psp_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def psp_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def psp_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def psp_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>")
 
 def psp_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="<%", end="%>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="python::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="python::main")
 
 # Rules dict for psp_tags ruleset.
 rulesDict2 = {
@@ -178,20 +141,13 @@ rulesDict2 = {
 # Rules for psp_directive ruleset.
 
 def psp_rule16(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def psp_rule17(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def psp_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def psp_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ptl.py
+++ b/leo/modes/ptl.py
@@ -41,12 +41,10 @@ keywordsDictDict = {
 
 
 def ptl_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword4", seq="[html]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword4", seq="[html]")
 
 def ptl_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword4", seq="[plain]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword4", seq="[plain]")
 
 def ptl_rule2(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/pvwave.py
+++ b/leo/modes/pvwave.py
@@ -701,108 +701,80 @@ keywordsDictDict = {
 
 def pvwave_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def pvwave_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def pvwave_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def pvwave_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def pvwave_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def pvwave_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def pvwave_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def pvwave_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def pvwave_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def pvwave_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def pvwave_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def pvwave_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def pvwave_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def pvwave_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def pvwave_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def pvwave_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def pvwave_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def pvwave_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def pvwave_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def pvwave_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def pvwave_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def pvwave_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="$")
 
 def pvwave_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="&")
 
 def pvwave_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="@")
 
 def pvwave_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="!")
 
 def pvwave_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/r.py
+++ b/leo/modes/r.py
@@ -4427,152 +4427,113 @@ keywordsDictDict = {
 
 def r_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def r_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def r_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def r_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="(")
 
 def r_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=")")
 
 def r_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<-")
 
 def r_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def r_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def r_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def r_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def r_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def r_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def r_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def r_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&&")
 
 def r_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def r_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def r_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def r_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def r_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def r_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def r_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def r_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def r_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def r_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def r_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def r_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def r_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%%")
 
 def r_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%*%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%*%")
 
 def r_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%o%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%o%")
 
 def r_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%x%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%x%")
 
 def r_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%in%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%in%")
 
 def r_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def r_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def r_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def r_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def r_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def r_rule36(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rebol.py
+++ b/leo/modes/rebol.py
@@ -528,73 +528,51 @@ keywordsDictDict = {
 # Rules for rebol_main ruleset.
 
 def rebol_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="comment {", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="comment {", end="}")
 
 def rebol_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="comment{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="comment{", end="}")
 
 def rebol_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def rebol_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="{", end="}")
 
 def rebol_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def rebol_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def rebol_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def rebol_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def rebol_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def rebol_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def rebol_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def rebol_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def rebol_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def rebol_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def rebol_rule14(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal2", pattern="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def rebol_rule15(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/redcode.py
+++ b/leo/modes/redcode.py
@@ -68,158 +68,115 @@ keywordsDictDict = {
 # Rules for redcode_main ruleset.
 
 def redcode_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";redcode",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";redcode")
 
 def redcode_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";author",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";author")
 
 def redcode_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";name",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";name")
 
 def redcode_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";strategy",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";strategy")
 
 def redcode_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq=";password",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq=";password")
 
 def redcode_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def redcode_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".AB",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".AB")
 
 def redcode_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".BA",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".BA")
 
 def redcode_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".A",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".A")
 
 def redcode_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".B",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".B")
 
 def redcode_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".F",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".F")
 
 def redcode_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".X",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".X")
 
 def redcode_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".I",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq=".I")
 
 def redcode_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def redcode_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def redcode_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def redcode_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def redcode_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def redcode_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def redcode_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def redcode_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def redcode_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def redcode_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def redcode_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def redcode_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def redcode_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def redcode_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def redcode_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&&")
 
 def redcode_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def redcode_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def redcode_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def redcode_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="$")
 
 def redcode_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="@")
 
 def redcode_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="#")
 
 def redcode_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="*")
 
 def redcode_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="{")
 
 def redcode_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal1", seq="}")
 
 def redcode_rule37(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -34,116 +34,89 @@ keywordsDictDict = {
 
 def rest_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="__",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def rest_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq=".. _",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def rest_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="={3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="={3,}")
 
 def rest_rule3(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="-{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="-{3,}")
 
 def rest_rule4(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="~{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="~{3,}")
 
 def rest_rule5(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="`{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="`{3,}")
 
 def rest_rule6(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="#{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="#{3,}")
 
 def rest_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\"{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\"{3,}")
 
 def rest_rule8(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\^{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\^{3,}")
 
 def rest_rule9(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+{3,}")
 
 def rest_rule10(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
 
 def rest_rule11(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\.\\.\\s\\|[^|]+\\|",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def rest_rule12(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal4", regexp="\\|[^|]+\\|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal4", regexp="\\|[^|]+\\|")
 
 def rest_rule13(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\.\\.\\s[A-z][A-z0-9-_]+::",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def rest_rule14(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\*\\*[^*]+\\*\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\*\\*[^*]+\\*\\*")
 
 def rest_rule15(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*")
 
 def rest_rule16(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="..",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def rest_rule17(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="`[A-z0-9]+[^`]+`_{1,2}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="`[A-z0-9]+[^`]+`_{1,2}")
 
 def rest_rule18(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[0-9]+\\]_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[0-9]+\\]_")
 
 def rest_rule19(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[#[A-z0-9_]*\\]_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[#[A-z0-9_]*\\]_")
 
 def rest_rule20(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[*\\]_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[*\\]_")
 
 def rest_rule21(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[A-z][A-z0-9_-]*\\]_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[A-z][A-z0-9_-]*\\]_")
 
 def rest_rule22(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="``", end="``",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="``", end="``")
 
 def rest_rule23(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="`[^`]+`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="`[^`]+`")
 
 def rest_rule24(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=":[A-z][A-z0-9 \t=\\s\\t_]*:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=":[A-z][A-z0-9 \t=\\s\\t_]*:")
 
 def rest_rule25(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+-[+-]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+-[+-]+")
 
 def rest_rule26(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+=[+=]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+=[+=]+")
 
 # Rules dict for rest_main ruleset.
 rulesDict1 = {

--- a/leo/modes/rib.py
+++ b/leo/modes/rib.py
@@ -229,35 +229,27 @@ keywordsDictDict = {
 
 def rib_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_whitespace_end=True)
 
 def rib_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#")
 
 def rib_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def rib_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def rib_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def rib_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def rib_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="rib::literals", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="rib::literals",
+          no_line_break=True)
 
 def rib_rule7(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rpmspec.py
+++ b/leo/modes/rpmspec.py
@@ -122,76 +122,61 @@ keywordsDictDict = {
 
 def rpmspec_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def rpmspec_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def rpmspec_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def rpmspec_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def rpmspec_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="%attr(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="rpmspec::attr", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="rpmspec::attr",
+          no_line_break=True)
 
 def rpmspec_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="%verify(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="rpmspec::verify", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="rpmspec::verify",
+          no_line_break=True)
 
 def rpmspec_rule6(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword1", pattern="Source",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def rpmspec_rule7(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword1", pattern="Patch",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def rpmspec_rule8(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="function", pattern="%patch",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def rpmspec_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def rpmspec_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="%{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def rpmspec_rule11(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$#")
 
 def rpmspec_rule12(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$?")
 
 def rpmspec_rule13(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$*")
 
 def rpmspec_rule14(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$<")
 
 def rpmspec_rule15(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def rpmspec_rule16(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -273,12 +258,10 @@ rulesDict1 = {
 # Rules for rpmspec_attr ruleset.
 
 def rpmspec_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def rpmspec_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 # Rules dict for rpmspec_attr ruleset.
 rulesDict2 = {

--- a/leo/modes/rtf.py
+++ b/leo/modes/rtf.py
@@ -30,24 +30,19 @@ keywordsDictDict = {
 # Rules for rtf_main ruleset.
 
 def rtf_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def rtf_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def rtf_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\\\'\\w\\d",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\\\'\\w\\d")
 
 def rtf_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="\\*\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="\\*\\")
 
 def rtf_rule4(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword1", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword1", pattern="\\")
 
 # Rules dict for rtf_main ruleset.
 rulesDict1 = {

--- a/leo/modes/ruby.py
+++ b/leo/modes/ruby.py
@@ -96,153 +96,115 @@ keywordsDictDict = {
 # Rules for ruby_main ruleset.
 
 def ruby_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="=begin", end="=end",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="=begin", end="=end")
 
 def ruby_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=True,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          exclude_match=True)
 
 def ruby_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="ruby::doublequoteliteral", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="ruby::doublequoteliteral",
+          no_line_break=True)
 
 def ruby_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def ruby_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def ruby_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def ruby_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def ruby_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def ruby_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def ruby_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="::")
 
 def ruby_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="===",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="===")
 
 def ruby_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def ruby_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">>")
 
 def ruby_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<<")
 
 def ruby_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def ruby_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def ruby_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def ruby_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def ruby_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def ruby_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def ruby_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def ruby_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def ruby_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def ruby_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def ruby_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def ruby_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def ruby_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def ruby_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def ruby_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="...",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="...")
 
 def ruby_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="..")
 
 def ruby_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def ruby_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def ruby_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def ruby_rule33(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def ruby_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def ruby_rule35(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -344,9 +306,7 @@ rulesDict1 = {
 
 def ruby_rule36(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="#{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=True,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          exclude_match=True)
 
 # Rules dict for ruby_doublequoteliteral ruleset.
 rulesDict2 = {

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -111,123 +111,90 @@ keywordsDictDict = {
 
 def rust_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def rust_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="doxygen::doxygen", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="doxygen::doxygen")
 
 def rust_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def rust_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"")
 
 def rust_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def rust_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="##")
 
 def rust_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
 
 def rust_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def rust_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def rust_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def rust_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def rust_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def rust_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def rust_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def rust_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def rust_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def rust_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def rust_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def rust_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def rust_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def rust_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def rust_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def rust_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def rust_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def rust_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def rust_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def rust_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def rust_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rview.py
+++ b/leo/modes/rview.py
@@ -137,47 +137,35 @@ keywordsDictDict = {
 # Rules for rview_main ruleset.
 
 def rview_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def rview_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="rview::javadoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="rview::javadoc")
 
 def rview_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def rview_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="rview::rviewstmt", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="rview::rviewstmt",
+          no_line_break=True)
 
 def rview_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def rview_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def rview_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def rview_rule7(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def rview_rule8(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def rview_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -259,65 +247,50 @@ rulesDict1 = {
 
 def rview_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def rview_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def rview_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def rview_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def rview_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def rview_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def rview_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def rview_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def rview_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def rview_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def rview_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def rview_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def rview_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="::")
 
 def rview_rule23(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="label", pattern=":")
 
 def rview_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def rview_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/sas.py
+++ b/leo/modes/sas.py
@@ -289,76 +289,55 @@ keywordsDictDict = {
 # Rules for sas_main ruleset.
 
 def sas_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def sas_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def sas_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def sas_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def sas_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def sas_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def sas_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def sas_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def sas_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def sas_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def sas_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def sas_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def sas_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def sas_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def sas_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def sas_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def sas_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def sas_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/scala.py
+++ b/leo/modes/scala.py
@@ -320,8 +320,7 @@ keywordsDictDict = {
 # Rules for scala_main ruleset.
 
 def scala_rule0(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="label", pattern="@")
 
 
 # Rules dict for scala_main ruleset.
@@ -332,191 +331,144 @@ rulesDict1 = {
 # Rules for scala_primary ruleset.
 
 def scala_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def scala_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def scala_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="scala::scaladoc", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="scala::scaladoc")
 
 def scala_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def scala_rule5(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="comment2", regexp="<!--",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, delegate="scala::xml_comment")
+          at_whitespace_end=True,
+          delegate="scala::xml_comment")
 
 def scala_rule6(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="<\\/?\\w*",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, delegate="scala::xml_tag")
+          at_whitespace_end=True,
+          delegate="scala::xml_tag")
 
 def scala_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"\"\"", end="\"\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"\"\"", end="\"\"\"")
 
 def scala_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def scala_rule9(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="'([^']|\\\\.)'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal1", regexp="'([^']|\\\\.)'")
 
 def scala_rule10(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="'[0-9a-zA-Z><=+]([0-9a-zA-Z><=+]|_[0-9a-zA-Z><=+])*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="'[0-9a-zA-Z><=+]([0-9a-zA-Z><=+]|_[0-9a-zA-Z><=+])*")
 
 def scala_rule11(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\[[^\\[\\]]*(\\[[^\\[\\]]*(\\[[^\\[\\]]*\\][^\\[\\]]*)*\\][^\\[\\]]*)*\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\[[^\\[\\]]*(\\[[^\\[\\]]*(\\[[^\\[\\]]*\\][^\\[\\]]*)*\\][^\\[\\]]*)*\\]")
 
 def scala_rule12(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="<:\\s*\\w+(\\.\\w+)*(#\\w+)?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="<:\\s*\\w+(\\.\\w+)*(#\\w+)?")
 
 def scala_rule13(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=">:\\s*\\w+(\\.\\w+)*(#\\w+)?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=">:\\s*\\w+(\\.\\w+)*(#\\w+)?")
 
 def scala_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def scala_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def scala_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def scala_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def scala_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">:")
 
 def scala_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def scala_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<:")
 
 def scala_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def scala_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def scala_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def scala_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def scala_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def scala_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def scala_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def scala_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def scala_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def scala_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def scala_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="`")
 
 def scala_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def scala_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def scala_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def scala_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=".")
 
 def scala_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=",")
 
 def scala_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=";")
 
 def scala_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="]")
 
 def scala_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="[")
 
 def scala_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="?")
 
 def scala_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq=":")
 
 def scala_rule42(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=":\\s*\\w+(\\.\\w+)*(#\\w+)?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=":\\s*\\w+(\\.\\w+)*(#\\w+)?")
 
 def scala_rule43(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="function", pattern="(")
 
 def scala_rule44(colorer, s, i):
     return colorer.match_span(s, i, kind="", begin="case", end="=>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="scala::pattern", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="scala::pattern",
+          no_line_break=True)
 
 def scala_rule45(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -619,8 +571,7 @@ rulesDict2 = {
 
 
 def scala_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 # Rules dict for scala_pattern ruleset.
 rulesDict3 = {
@@ -630,42 +581,30 @@ rulesDict3 = {
 # Rules for scala_scaladoc ruleset.
 
 def scala_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="{")
 
 def scala_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="*")
 
 def scala_rule49(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<pre>", end="</pre>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="scala::scaladoc_pre", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="scala::scaladoc_pre")
 
 def scala_rule50(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def scala_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<<")
 
 def scala_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="<=")
 
 def scala_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment3", seq="< ")
 
 def scala_rule54(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::tags")
 
 def scala_rule55(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -751,37 +690,31 @@ rulesDict5 = {}
 
 def scala_rule56(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def scala_rule57(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def scala_rule58(colorer, s, i):
     return colorer.match_span(s, i, kind="", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="scala::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="scala::main")
 
 def scala_rule59(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp=">$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::main")
+          delegate="scala::main")
 
 def scala_rule60(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp=">\\s*;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::main")
+          delegate="scala::main")
 
 def scala_rule61(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp=">\\s*\\)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::main")
+          delegate="scala::main")
 
 def scala_rule62(colorer, s, i):
     return colorer.match_seq(s, i, kind="literal3", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::xml_text")
+          delegate="scala::xml_text")
 
 # Rules dict for scala_xml_tag ruleset.
 rulesDict6 = {
@@ -795,17 +728,15 @@ rulesDict6 = {
 
 def scala_rule63(colorer, s, i):
     return colorer.match_span(s, i, kind="", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="scala::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="scala::main")
 
 def scala_rule64(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="comment2", regexp="<!--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::xml_comment")
+          delegate="scala::xml_comment")
 
 def scala_rule65(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="<\\/?\\w*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::xml_tag")
+          delegate="scala::xml_tag")
 
 # Rules dict for scala_xml_text ruleset.
 rulesDict7 = {
@@ -817,15 +748,15 @@ rulesDict7 = {
 
 def scala_rule66(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="comment2", regexp="-->$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::main")
+          delegate="scala::main")
 
 def scala_rule67(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="comment2", regexp="-->\\s*;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::main")
+          delegate="scala::main")
 
 def scala_rule68(colorer, s, i):
     return colorer.match_seq(s, i, kind="comment2", seq="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="scala::xml_text")
+          delegate="scala::xml_text")
 
 # Rules dict for scala_xml_comment ruleset.
 rulesDict8 = {

--- a/leo/modes/scheme.py
+++ b/leo/modes/scheme.py
@@ -235,49 +235,34 @@ keywordsDictDict = {
 # Rules for scheme_main ruleset.
 
 def scheme_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="#|", end="|#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="#|", end="|#")
 
 def scheme_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="'(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="'(")
 
 def scheme_rule2(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="'")
 
 def scheme_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="#\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="#\\")
 
 def scheme_rule4(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="#b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="#b")
 
 def scheme_rule5(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="#d",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="#d")
 
 def scheme_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="#o",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="#o")
 
 def scheme_rule7(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="#x",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="#x")
 
 def scheme_rule8(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def scheme_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def scheme_rule10(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/sdl_pr.py
+++ b/leo/modes/sdl_pr.py
@@ -177,112 +177,81 @@ keywordsDictDict = {
 # Rules for sdl_pr_main ruleset.
 
 def sdl_pr_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="/*#SDTREF", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="/*#SDTREF", end="*/")
 
 def sdl_pr_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def sdl_pr_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def sdl_pr_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def sdl_pr_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def sdl_pr_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def sdl_pr_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def sdl_pr_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def sdl_pr_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def sdl_pr_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/=")
 
 def sdl_pr_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def sdl_pr_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def sdl_pr_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def sdl_pr_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def sdl_pr_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def sdl_pr_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def sdl_pr_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def sdl_pr_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def sdl_pr_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="//")
 
 def sdl_pr_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="and",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="and")
 
 def sdl_pr_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="mod",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="mod")
 
 def sdl_pr_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="not",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="not")
 
 def sdl_pr_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="or",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="or")
 
 def sdl_pr_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="rem",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="rem")
 
 def sdl_pr_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xor",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="xor")
 
 def sdl_pr_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/sgml.py
+++ b/leo/modes/sgml.py
@@ -33,40 +33,27 @@ keywordsDictDict = {
 # Rules for sgml_main ruleset.
 
 def sgml_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def sgml_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!ENTITY", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::entity-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::entity-tags")
 
 def sgml_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<![CDATA[", end="]]>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::cdata", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::cdata")
 
 def sgml_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def sgml_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::tags")
 
 def sgml_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for sgml_main ruleset.
 rulesDict1 = {

--- a/leo/modes/shell.py
+++ b/leo/modes/shell.py
@@ -82,122 +82,88 @@ keywordsDictDict = {
 # Rules for shell_main ruleset.
 
 def shell_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#!")
 
 def shell_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def shell_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def shell_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$#")
 
 def shell_rule4(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$?")
 
 def shell_rule5(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$*")
 
 def shell_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$@")
 
 def shell_rule7(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$$")
 
 def shell_rule8(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$<")
 
 def shell_rule9(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def shell_rule10(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword2", pattern="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def shell_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shell::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shell::exec")
 
 def shell_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shell::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shell::exec")
 
 def shell_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shell::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shell::exec")
 
 def shell_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shell::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shell::exec")
 
 def shell_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shell::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shell::literal")
 
 def shell_rule16(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def shell_rule17(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal1", begin="<<[[:space:]'\"]*([[:alnum:]_]+)[[:space:]'\"]*", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shell::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shell::literal")
 
 def shell_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def shell_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def shell_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def shell_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def shell_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def shell_rule23(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="%")
 
 def shell_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def shell_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -288,13 +254,10 @@ rulesDict1 = {
 
 def shell_rule26(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def shell_rule27(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 # Rules dict for shell_literal ruleset.
 rulesDict2 = {
@@ -305,51 +268,34 @@ rulesDict2 = {
 
 def shell_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def shell_rule29(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))")
 
 def shell_rule30(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")")
 
 def shell_rule31(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]")
 
 def shell_rule32(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def shell_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def shell_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def shell_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def shell_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def shell_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 # Rules dict for shell_exec ruleset.
 rulesDict3 = {

--- a/leo/modes/shellscript.py
+++ b/leo/modes/shellscript.py
@@ -82,122 +82,88 @@ keywordsDictDict = {
 # Rules for shellscript_main ruleset.
 
 def shellscript_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="#!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="#!")
 
 def shellscript_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def shellscript_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def shellscript_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$#")
 
 def shellscript_rule4(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$?")
 
 def shellscript_rule5(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$*")
 
 def shellscript_rule6(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$@")
 
 def shellscript_rule7(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$$")
 
 def shellscript_rule8(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$<")
 
 def shellscript_rule9(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def shellscript_rule10(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword2", pattern="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def shellscript_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shellscript::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shellscript::exec")
 
 def shellscript_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shellscript::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shellscript::exec")
 
 def shellscript_rule13(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shellscript::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shellscript::exec")
 
 def shellscript_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="`", end="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shellscript::exec", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shellscript::exec")
 
 def shellscript_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shellscript::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shellscript::literal")
 
 def shellscript_rule16(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def shellscript_rule17(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal1", begin="<<[[:space:]'\"]*([[:alnum:]_]+)[[:space:]'\"]*", end="$1",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="shellscript::literal", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="shellscript::literal")
 
 def shellscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def shellscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def shellscript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def shellscript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def shellscript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def shellscript_rule23(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="%")
 
 def shellscript_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def shellscript_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -288,13 +254,10 @@ rulesDict1 = {
 
 def shellscript_rule26(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def shellscript_rule27(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 # Rules dict for shellscript_literal ruleset.
 rulesDict2 = {
@@ -305,51 +268,34 @@ rulesDict2 = {
 
 def shellscript_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def shellscript_rule29(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))")
 
 def shellscript_rule30(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")")
 
 def shellscript_rule31(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]")
 
 def shellscript_rule32(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def shellscript_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def shellscript_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def shellscript_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def shellscript_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def shellscript_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 # Rules dict for shellscript_exec ruleset.
 rulesDict3 = {

--- a/leo/modes/smalltalk.py
+++ b/leo/modes/smalltalk.py
@@ -57,76 +57,58 @@ keywordsDictDict = {
 # Rules for smalltalk_main ruleset.
 
 def smalltalk_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def smalltalk_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"")
 
 def smalltalk_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def smalltalk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def smalltalk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def smalltalk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def smalltalk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def smalltalk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def smalltalk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def smalltalk_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def smalltalk_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def smalltalk_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def smalltalk_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def smalltalk_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def smalltalk_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword3", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def smalltalk_rule15(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def smalltalk_rule16(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal1", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def smalltalk_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/smi_mib.py
+++ b/leo/modes/smi_mib.py
@@ -116,39 +116,28 @@ keywordsDictDict = {
 # Rules for smi_mib_main ruleset.
 
 def smi_mib_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def smi_mib_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def smi_mib_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="::=")
 
 def smi_mib_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def smi_mib_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def smi_mib_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="OBJECT IDENTIFIER",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="OBJECT IDENTIFIER")
 
 def smi_mib_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="SEQUENCE OF",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="SEQUENCE OF")
 
 def smi_mib_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="OCTET STRING",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="OCTET STRING")
 
 def smi_mib_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/splus.py
+++ b/leo/modes/splus.py
@@ -56,104 +56,80 @@ keywordsDictDict = {
 
 def splus_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def splus_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def splus_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def splus_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def splus_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def splus_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def splus_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def splus_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def splus_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<-")
 
 def splus_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def splus_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def splus_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def splus_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def splus_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def splus_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def splus_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def splus_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def splus_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def splus_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def splus_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def splus_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def splus_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def splus_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def splus_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def splus_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/sql.py
+++ b/leo/modes/sql.py
@@ -373,111 +373,80 @@ keywordsDictDict = {
 # Rules for sql_main ruleset.
 
 def sql_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def sql_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def sql_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def sql_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def sql_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def sql_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="REM",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def sql_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="REMARK",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+          at_line_start=True)
 
 def sql_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def sql_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def sql_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def sql_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def sql_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def sql_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def sql_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def sql_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def sql_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def sql_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def sql_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def sql_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def sql_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def sql_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!>")
 
 def sql_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!<")
 
 def sql_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def sql_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def sql_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/sqr.py
+++ b/leo/modes/sqr.py
@@ -129,81 +129,60 @@ keywordsDictDict = {
 # Rules for sqr_main ruleset.
 
 def sqr_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def sqr_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def sqr_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def sqr_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def sqr_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def sqr_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def sqr_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def sqr_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def sqr_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def sqr_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def sqr_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def sqr_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def sqr_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def sqr_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def sqr_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def sqr_rule15(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal1", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal1", pattern="$")
 
 def sqr_rule16(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="#")
 
 def sqr_rule17(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="markup", pattern="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="markup", pattern="&")
 
 def sqr_rule18(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/squidconf.py
+++ b/leo/modes/squidconf.py
@@ -241,9 +241,7 @@ keywordsDictDict = {
 # Rules for squidconf_main ruleset.
 
 def squidconf_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def squidconf_rule1(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ssharp.py
+++ b/leo/modes/ssharp.py
@@ -95,172 +95,127 @@ keywordsDictDict = {
 # Rules for ssharp_main ruleset.
 
 def ssharp_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def ssharp_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment3", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment3", seq="#")
 
 def ssharp_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="\"\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="\"\"")
 
 def ssharp_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"")
 
 def ssharp_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="? ", end="? ",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal2", begin="? ", end="? ")
 
 def ssharp_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def ssharp_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def ssharp_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def ssharp_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def ssharp_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":=")
 
 def ssharp_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="_")
 
 def ssharp_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def ssharp_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="==")
 
 def ssharp_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def ssharp_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def ssharp_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def ssharp_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def ssharp_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def ssharp_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def ssharp_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def ssharp_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="//")
 
 def ssharp_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
 
 def ssharp_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def ssharp_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def ssharp_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def ssharp_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def ssharp_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^^")
 
 def ssharp_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def ssharp_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def ssharp_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="->")
 
 def ssharp_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&&")
 
 def ssharp_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="||")
 
 def ssharp_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^|")
 
 def ssharp_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def ssharp_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~=")
 
 def ssharp_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!==",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!==")
 
 def ssharp_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~~")
 
 def ssharp_rule37(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword3", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def ssharp_rule38(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def ssharp_rule39(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal1", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def ssharp_rule40(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/swig.py
+++ b/leo/modes/swig.py
@@ -40,14 +40,10 @@ keywordsDictDict = {
 # Rules for swig_main ruleset.
 
 def swig_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="%{", end="%}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="%{", end="%}")
 
 def swig_rule1(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword4", pattern="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword4", pattern="%")
 
 
 # Rules dict for swig_main ruleset.

--- a/leo/modes/tcl.py
+++ b/leo/modes/tcl.py
@@ -428,82 +428,61 @@ keywordsDictDict = {
 
 def tcl_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def tcl_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def tcl_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def tcl_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def tcl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def tcl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def tcl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def tcl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def tcl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def tcl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def tcl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def tcl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def tcl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def tcl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def tcl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def tcl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def tcl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def tcl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def tcl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def tcl_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/tex.py
+++ b/leo/modes/tex.py
@@ -65,15 +65,11 @@ keywordsDictDict = {
 
 def tex_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="$$", end="$$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tex::math", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="tex::math")
 
 def tex_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="$", end="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tex::math", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="tex::math")
 
 #
 # #1088: A new, general backslash rule.
@@ -84,66 +80,48 @@ def tex_general_backslash_rule(colorer, s, i):
 
 def tex_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\[", end="\\]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tex::math", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="tex::math")
 
 def tex_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\$")
 
 def tex_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\")
 
 def tex_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword1", seq="\\%")
 
 def tex_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="\\iffalse", end="\\fi",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="\\iffalse", end="\\fi")
 
 def tex_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="\\begin{verbatim}", end="\\end{verbatim}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tex::verbatim", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="tex::verbatim")
 
 def tex_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword1", begin="\\verb|", end="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tex::verbatim", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          delegate="tex::verbatim",
+          no_line_break=True)
 
 if 0:  # Use tex_general_backslash_rule instead.
 
     def tex_rule9(colorer, s, i):
-        return colorer.match_mark_following(s, i, kind="keyword1", pattern="\\",
-            at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+        return colorer.match_mark_following(s, i, kind="keyword1", pattern="\\")
 
 def tex_rule10(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def tex_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def tex_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def tex_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def tex_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 # Rules dict for tex_main ruleset.
 rulesDict1 = {
@@ -164,129 +142,97 @@ rulesDict1 = {
 # Rules for tex_math ruleset.
 
 def tex_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\$")
 
 def tex_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\\\")
 
 def tex_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword3", seq="\\%")
 
 def tex_rule18(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="\\")
 
 def tex_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq=")")
 
 def tex_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="(")
 
 def tex_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="{")
 
 def tex_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="}")
 
 def tex_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="[")
 
 def tex_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="]")
 
 def tex_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="=")
 
 def tex_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="!")
 
 def tex_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="+")
 
 def tex_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="-")
 
 def tex_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="/")
 
 def tex_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="*")
 
 def tex_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq=">")
 
 def tex_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="<")
 
 def tex_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="&")
 
 def tex_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="|")
 
 def tex_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="^")
 
 def tex_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="~")
 
 def tex_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq=".")
 
 def tex_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq=",")
 
 def tex_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq=";")
 
 def tex_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="?")
 
 def tex_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq=":")
 
 def tex_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="'")
 
 def tex_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="\"")
 
 def tex_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword2", seq="`")
 
 def tex_rule45(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 # Rules dict for tex_math ruleset.
 rulesDict2 = {

--- a/leo/modes/texinfo.py
+++ b/leo/modes/texinfo.py
@@ -32,26 +32,19 @@ keywordsDictDict = {
 # Rules for texinfo_main ruleset.
 
 def texinfo_rule0(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="@c",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="@c")
 
 def texinfo_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="@comment",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="@comment")
 
 def texinfo_rule2(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword1", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword1", pattern="@")
 
 def texinfo_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def texinfo_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 # Rules dict for texinfo_main ruleset.
 rulesDict1 = {

--- a/leo/modes/tpl.py
+++ b/leo/modes/tpl.py
@@ -68,40 +68,27 @@ keywordsDictDict = {
 # Rules for tpl_main ruleset.
 
 def tpl_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="<!--", end="-->")
 
 def tpl_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::javascript")
 
 def tpl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::css")
 
 def tpl_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tpl::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="tpl::tags")
 
 def tpl_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 def tpl_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="tpl::tpl", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="tpl::tpl")
 
 # Rules dict for tpl_main ruleset.
 rulesDict1 = {
@@ -113,20 +100,13 @@ rulesDict1 = {
 # Rules for tpl_tpl ruleset.
 
 def tpl_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="label", begin="\"", end="\"")
 
 def tpl_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="label", begin="'", end="'")
 
 def tpl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def tpl_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -205,20 +185,13 @@ rulesDict2 = {
 # Rules for tpl_tags ruleset.
 
 def tpl_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def tpl_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def tpl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for tpl_tags ruleset.
 rulesDict3 = {

--- a/leo/modes/tsql.py
+++ b/leo/modes/tsql.py
@@ -969,109 +969,79 @@ keywordsDictDict = {
 # Rules for tsql_main ruleset.
 
 def tsql_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def tsql_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def tsql_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def tsql_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def tsql_rule4(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def tsql_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def tsql_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def tsql_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def tsql_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def tsql_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def tsql_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def tsql_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def tsql_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def tsql_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def tsql_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def tsql_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def tsql_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def tsql_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def tsql_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def tsql_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!>")
 
 def tsql_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!<")
 
 def tsql_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="::")
 
 def tsql_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+          at_line_start=True)
 
 def tsql_rule23(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="@")
 
 def tsql_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/typescript.py
+++ b/leo/modes/typescript.py
@@ -196,144 +196,109 @@ keywordsDictDict = {
 
 # #1602
 def typescript_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment3", begin="/*", end="*/")
 
 def typescript_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def typescript_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def typescript_rule3(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def typescript_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def typescript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="<!--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="<!--")
 
 def typescript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def typescript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def typescript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def typescript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def typescript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def typescript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def typescript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def typescript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def typescript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def typescript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def typescript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def typescript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def typescript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def typescript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def typescript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def typescript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def typescript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def typescript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def typescript_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def typescript_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def typescript_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def typescript_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def typescript_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def typescript_rule29(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def typescript_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def typescript_rule31(colorer, s, i):
     return colorer.match_keywords(s, i)
 
 def typescript_rule32(colorer, s, i):  # #2287.
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
-      at_line_start=False, at_whitespace_end=False, at_word_start=False,
-      delegate="", exclude_match=False,
-      no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 # Rules dict for typescript_main ruleset.
 rulesDict1 = {

--- a/leo/modes/uscript.py
+++ b/leo/modes/uscript.py
@@ -123,115 +123,87 @@ keywordsDictDict = {
 # Rules for uscript_main ruleset.
 
 def uscript_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
 
 def uscript_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def uscript_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def uscript_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def uscript_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def uscript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def uscript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def uscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="@")
 
 def uscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="#")
 
 def uscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="$")
 
 def uscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def uscript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def uscript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def uscript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def uscript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def uscript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def uscript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def uscript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
 
 def uscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def uscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def uscript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def uscript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def uscript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def uscript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="`")
 
 def uscript_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=True, at_word_start=False, exclude_match=True)
+          at_whitespace_end=True,
+          exclude_match=True)
 
 def uscript_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def uscript_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/vbscript.py
+++ b/leo/modes/vbscript.py
@@ -338,94 +338,69 @@ keywordsDictDict = {
 
 def vbscript_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def vbscript_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#if",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#if")
 
 def vbscript_rule2(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#else",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#else")
 
 def vbscript_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#end",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#end")
 
 def vbscript_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="'")
 
 def vbscript_rule5(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="rem",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="rem")
 
 def vbscript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def vbscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def vbscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def vbscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def vbscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def vbscript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<>")
 
 def vbscript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=".")
 
 def vbscript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def vbscript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def vbscript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def vbscript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def vbscript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="\\")
 
 def vbscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def vbscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def vbscript_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          at_line_start=True,
+          exclude_match=True)
 
 def vbscript_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/velocity.py
+++ b/leo/modes/velocity.py
@@ -135,40 +135,27 @@ keywordsDictDict = {
 # Rules for velocity_main ruleset.
 
 def velocity_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def velocity_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="velocity::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="velocity::javascript")
 
 def velocity_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="velocity::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="velocity::css")
 
 def velocity_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def velocity_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="html::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="html::tags")
 
 def velocity_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 
 # Rules dict for velocity_main ruleset.
@@ -180,29 +167,20 @@ rulesDict1 = {
 # Rules for velocity_velocity ruleset.
 
 def velocity_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="#*", end="*#",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment2", begin="#*", end="*#")
 
 def velocity_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment3", seq="##",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment3", seq="##")
 
 def velocity_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def velocity_rule9(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$!")
 
 def velocity_rule10(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def velocity_rule11(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -280,11 +258,11 @@ rulesDict2 = {
 
 def velocity_rule12(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="velocity::javascript2")
+          delegate="velocity::javascript2")
 
 def velocity_rule13(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="SRC=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="velocity::back_to_html")
+          delegate="velocity::back_to_html")
 
 # Rules dict for velocity_javascript ruleset.
 rulesDict3 = {
@@ -303,7 +281,7 @@ rulesDict4 = {}
 
 def velocity_rule14(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="velocity::main")
+          delegate="velocity::main")
 
 # Rules dict for velocity_back_to_html ruleset.
 rulesDict5 = {
@@ -314,7 +292,7 @@ rulesDict5 = {
 
 def velocity_rule15(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="velocity::css2")
+          delegate="velocity::css2")
 
 # Rules dict for velocity_css ruleset.
 rulesDict6 = {

--- a/leo/modes/verilog.py
+++ b/leo/modes/verilog.py
@@ -179,101 +179,74 @@ keywordsDictDict = {
 # Rules for verilog_main ruleset.
 
 def verilog_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def verilog_rule1(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def verilog_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def verilog_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'d",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="'d")
 
 def verilog_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'h",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="'h")
 
 def verilog_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'b",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="'b")
 
 def verilog_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'o",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="digit", seq="'o")
 
 def verilog_rule7(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def verilog_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def verilog_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def verilog_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def verilog_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def verilog_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def verilog_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def verilog_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def verilog_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def verilog_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def verilog_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def verilog_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def verilog_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def verilog_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def verilog_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def verilog_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def verilog_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/vhdl.py
+++ b/leo/modes/vhdl.py
@@ -157,100 +157,75 @@ keywordsDictDict = {
 
 def vhdl_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def vhdl_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="'event",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="null", seq="'event")
 
 def vhdl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def vhdl_rule3(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment1", seq="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False)
+    return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def vhdl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def vhdl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/=")
 
 def vhdl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!")
 
 def vhdl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def vhdl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">=")
 
 def vhdl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def vhdl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<=")
 
 def vhdl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="<")
 
 def vhdl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def vhdl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def vhdl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def vhdl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def vhdl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="**")
 
 def vhdl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def vhdl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&")
 
 def vhdl_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def vhdl_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="^")
 
 def vhdl_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="~")
 
 def vhdl_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def vhdl_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/xml.py
+++ b/leo/modes/xml.py
@@ -104,46 +104,30 @@ keywordsDictDict = {
 # Rules for xml_main ruleset.
 
 def xml_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def xml_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!ENTITY", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::entity-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::entity-tags")
 
 def xml_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<![CDATA[", end="]]>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::cdata", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::cdata")
 
 def xml_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def xml_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="<?", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="keyword3", begin="<?", end=">")
 
 def xml_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::tags")
 
 def xml_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for xml_main ruleset.
 rulesDict1 = {
@@ -154,34 +138,25 @@ rulesDict1 = {
 # Rules for xml_tags ruleset.
 
 def xml_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def xml_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def xml_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def xml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="markup", seq="/")
 
 def xml_rule11(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def xml_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 # Rules dict for xml_tags ruleset.
 rulesDict2 = {
@@ -195,68 +170,47 @@ rulesDict2 = {
 # Rules for xml_dtd_tags ruleset.
 
 def xml_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def xml_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="--", end="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="--", end="--")
 
 def xml_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="%", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 def xml_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def xml_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def xml_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::main", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::main")
 
 def xml_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="(")
 
 def xml_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=")")
 
 def xml_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def xml_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def xml_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def xml_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def xml_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def xml_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -345,36 +299,24 @@ rulesDict3 = {
 # Rules for xml_entity_tags ruleset.
 
 def xml_rule27(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def xml_rule28(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="--", end="--",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="--", end="--")
 
 def xml_rule29(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def xml_rule30(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def xml_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def xml_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="%")
 
 def xml_rule33(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/xsl.py
+++ b/leo/modes/xsl.py
@@ -235,51 +235,34 @@ keywordsDictDict = {
 
 def xsl_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::tasks", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::tasks")
 
 def xsl_rule1(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="<(?=xsl:)", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xsltags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xsltags")
 
 def xsl_rule2(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="<(?=/xsl:)", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xsltags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xsltags")
 
 def xsl_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<![CDATA[", end="]]>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::cdata", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::cdata")
 
 def xsl_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def xsl_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 def xsl_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="<?", end="?>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal3", begin="<?", end="?>")
 
 def xsl_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::tags")
 
 # Rules dict for xsl_main ruleset.
 rulesDict1 = {
@@ -366,27 +349,20 @@ rulesDict2 = {
 
 def xsl_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::avt", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::avt")
 
 def xsl_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::avt", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::avt")
 
 def xsl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="xmlns:")
 
 def xsl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="xmlns")
 
 def xsl_rule13(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":")
 
 # Rules dict for xsl_tags ruleset.
 rulesDict3 = {
@@ -399,24 +375,18 @@ rulesDict3 = {
 # Rules for xsl_avt ruleset.
 
 def xsl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="", seq="{{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="", seq="{{")
 
 def xsl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="", seq="}}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="", seq="}}")
 
 def xsl_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="{", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for xsl_avt ruleset.
 rulesDict4 = {
@@ -429,147 +399,100 @@ rulesDict4 = {
 
 def xsl_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::avt", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::avt")
 
 def xsl_rule19(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::avt", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::avt")
 
 def xsl_rule20(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="count[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule21(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="count[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule22(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="from[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule23(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="from[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule24(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-adjacent[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule25(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-adjacent[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule26(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-by[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule27(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-by[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule28(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-ending-with[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule29(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-ending-with[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule30(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-starting-with[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule31(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="group-starting-with[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule32(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="match[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule33(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="match[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule34(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="select[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule35(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="select[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule36(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="test[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule37(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="test[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule38(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="use[[:space:]]*=[[:space:]]*\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule39(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword2", begin="use[[:space:]]*=[[:space:]]*'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="xmlns:")
 
 def xsl_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="xmlns")
 
 def xsl_rule42(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":")
 
 def xsl_rule43(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -649,98 +572,71 @@ rulesDict5 = {
 # Rules for xsl_xpath ruleset.
 
 def xsl_rule44(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def xsl_rule45(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def xsl_rule46(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="(:", end=":)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpathcomment2", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpathcomment2")
 
 def xsl_rule47(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="keyword4", pattern="::",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="keyword4", pattern="::")
 
 def xsl_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword4", seq="@",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="keyword4", seq="@")
 
 def xsl_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def xsl_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="!=")
 
 def xsl_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def xsl_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&gt;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&gt;")
 
 def xsl_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&lt;",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="&lt;")
 
 def xsl_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def xsl_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def xsl_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="*")
 
 def xsl_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="/")
 
 def xsl_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def xsl_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=",")
 
 def xsl_rule60(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="[", end="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpath", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpath")
 
 def xsl_rule61(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 def xsl_rule62(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":")
 
 def xsl_rule63(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=True)
+          exclude_match=True)
 
 def xsl_rule64(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="$")
 
 def xsl_rule65(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -833,9 +729,7 @@ rulesDict6 = {
 
 def xsl_rule66(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="(:", end=":)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpathcomment3", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpathcomment3")
 
 # Rules dict for xsl_xpathcomment2 ruleset.
 rulesDict7 = {
@@ -846,9 +740,7 @@ rulesDict7 = {
 
 def xsl_rule67(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="(:", end=":)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xsl::xpathcomment2", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xsl::xpathcomment2")
 
 # Rules dict for xsl_xpathcomment3 ruleset.
 rulesDict8 = {

--- a/leo/modes/yaml.py
+++ b/leo/modes/yaml.py
@@ -37,106 +37,82 @@ keywordsDictDict = {
 
 def yaml_rule0(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="comment1", regexp="\\s*#.*$",
-        at_line_start=True, at_whitespace_end=False, at_word_start=False, delegate="")
+          at_line_start=True)
 
 def yaml_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="---",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="---")
 
 def yaml_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="...",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="label", seq="...")
 
 def yaml_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="]")
 
 def yaml_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="[")
 
 def yaml_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="{")
 
 def yaml_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="}")
 
 def yaml_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="-")
 
 def yaml_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="+")
 
 def yaml_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def yaml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=">")
 
 def yaml_rule11(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="&",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="&")
 
 def yaml_rule12(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="*",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="*")
 
 def yaml_rule13(colorer, s, i):
     # Fix #1082:
         # Old: regexp="\\s*(-|)?\\s*[^\\s]+\\s*:(\\s|$)"
         # Old: at_line_start=True.
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=r"\s*-?\s*\w+:",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=r"\s*-?\s*\w+:")
 
 def yaml_rule14(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+~\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+~\\s*$")
 
 def yaml_rule15(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+null\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+null\\s*$")
 
 def yaml_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+true\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+true\\s*$")
 
 def yaml_rule17(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+false\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+false\\s*$")
 
 def yaml_rule18(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+yes\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+yes\\s*$")
 
 def yaml_rule19(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+no\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+no\\s*$")
 
 def yaml_rule20(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+on\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+on\\s*$")
 
 def yaml_rule21(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+off\\s*$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\s+off\\s*$")
 
 def yaml_rule22(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="!!(map|seq|str|set|omap|binary)",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="!!(map|seq|str|set|omap|binary)")
 
 def yaml_rule23(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="!![^\\s]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="!![^\\s]+")
 
 def yaml_rule24(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="![^\\s]+",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="![^\\s]+")
 
 # Rules dict for yaml_main ruleset.
 rulesDict1 = {

--- a/leo/modes/zpt.py
+++ b/leo/modes/zpt.py
@@ -154,40 +154,27 @@ keywordsDictDict = {
 # Rules for zpt_main ruleset.
 
 def zpt_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def zpt_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="zpt::javascript", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="zpt::javascript")
 
 def zpt_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="zpt::css", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="zpt::css")
 
 def zpt_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="xml::dtd-tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="xml::dtd-tags")
 
 def zpt_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="zpt::tags", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="zpt::tags")
 
 def zpt_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=True)
+          no_word_break=True)
 
 # Rules dict for zpt_main ruleset.
 rulesDict1 = {
@@ -199,19 +186,14 @@ rulesDict1 = {
 
 def zpt_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="zpt::attribute", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="zpt::attribute")
 
 def zpt_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="zpt::attribute", exclude_match=False,
-        no_escape=False, no_line_break=False, no_word_break=False)
+          delegate="zpt::attribute")
 
 def zpt_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="=")
 
 def zpt_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -290,34 +272,26 @@ rulesDict2 = {
 # Rules for zpt_attribute ruleset.
 
 def zpt_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=":")
 
 def zpt_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq=";")
 
 def zpt_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="?")
 
 def zpt_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="operator", seq="|")
 
 def zpt_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="$$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="")
+    return colorer.match_seq(s, i, kind="literal2", seq="$$")
 
 def zpt_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False,
-        delegate="", exclude_match=False,
-        no_escape=False, no_line_break=True, no_word_break=False)
+          no_line_break=True)
 
 def zpt_rule16(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, exclude_match=False)
+    return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def zpt_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -399,11 +373,11 @@ rulesDict3 = {
 
 def zpt_rule18(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="javascript::main")
+          delegate="javascript::main")
 
 def zpt_rule19(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq="SRC=",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="zpt::back_to_html")
+          delegate="zpt::back_to_html")
 
 # Rules dict for zpt_javascript ruleset.
 rulesDict4 = {
@@ -415,7 +389,7 @@ rulesDict4 = {
 
 def zpt_rule20(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="zpt::main")
+          delegate="zpt::main")
 
 # Rules dict for zpt_back_to_html ruleset.
 rulesDict5 = {
@@ -426,7 +400,7 @@ rulesDict5 = {
 
 def zpt_rule21(colorer, s, i):
     return colorer.match_seq(s, i, kind="markup", seq=">",
-        at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate="css::main")
+          delegate="css::main")
 
 # Rules dict for zpt_css ruleset.
 rulesDict6 = {


### PR DESCRIPTION
See #3289. The following script made these changes:
```python
"""Replace default kwargs in all leo/modes files"""
g.cls()
import glob
import os
import re
import time

t1 = time.process_time()

# Part 1: Calculate patterns.
bool_kwargs = (
    'at_line_start', 'at_whitespace_end', 'at_word_start',
    'exclude_match',
    'no_escape', 'no_line_break', 'no_word_break',
)
patterns = []
for bool_arg in bool_kwargs:
    # Remove kwargs inited to False.
    pattern1 = re.compile(fr"\b{bool_arg}=False,")
    patterns.append((pattern1, ''))
    pattern2 = re.compile(fr"\b{bool_arg}=False\)")
    patterns.append((pattern2, ')'))

delegate_patterns = (
    # Remove kwargs inited to "".
    (re.compile(r'\bdelegate="",'), ''),
    (re.compile(r'\bdelegate=""\)'), ')'),
)
cleanup_patterns = [
    # Remove blank lines between trailing comma and ')'.
    (re.compile(r',[ ]*(\n[ ]*)*\)', re.MULTILINE), ')'),
]
for bool_arg in bool_kwargs:
    # Remove blank lines between trailing comma and any bool kwarg.
    pattern3 = re.compile(fr",[ ]*(\n[ ]*)*\b{bool_arg}", re.MULTILINE)
    cleanup_patterns.append((pattern3, fr",\n{' '*10}{bool_arg}"))
    # Remove blank lines between trailing comma and delegate kwarg.
    pattern4 = re.compile(r",[ ]*(\n[ ]*)*\bdelegate", re.MULTILINE)
    cleanup_patterns.append((pattern4, fr",\n{' '*10}delegate"))

for aTuple in delegate_patterns:
    patterns.append(aTuple)
for aTuple in cleanup_patterns:
    patterns.append(aTuple)

# Calculate files, exclude files defined by @file nodes.
exclude = (
    'batch.py', 'forth.py', 'html.py',
    'javascript.py', 'julia.py', 'python.py',
)
modes = os.path.normpath(os.path.join(g.app.loadDir, '..', 'modes'))
paths = glob.glob(f"{modes}{os.sep}*.py")
paths = [z for z in paths if not any(z2 in z for z2 in exclude)]
for path in paths:
    with open(path, 'r') as f:
        contents = f.read()
    for pattern, repl in patterns:
        contents =  re.sub(pattern, repl, contents)
    lines = [z.rstrip() + '\n' for z in g.splitLines(contents)]
    results = ''.join(lines)
    with open(path, 'w') as f:
        f.write(results)
t2 = time.process_time()
g.es_print(f"Done! {t2-t1:5.2} sec.")
```