### PR TITLE
PR for #3291: Replace match_seq by match_plain_seq where possible

### DIFF
--- a/leo/modes/actionscript.py
+++ b/leo/modes/actionscript.py
@@ -694,80 +694,80 @@ def actionscript_rule4(colorer, s, i):
 
 # Used to color ")".  2011/05/22: change kind to "operator". Also changed actionscript.xml.
 def actionscript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 # Used to color "(".  2011/05/22: change kind to "operator". Also changed actionscript.xml.
 def actionscript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def actionscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def actionscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def actionscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def actionscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def actionscript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def actionscript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def actionscript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def actionscript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def actionscript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def actionscript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def actionscript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def actionscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def actionscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def actionscript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def actionscript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def actionscript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def actionscript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def actionscript_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def actionscript_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def actionscript_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def actionscript_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def actionscript_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def actionscript_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def actionscript_rule30(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
@@ -775,7 +775,7 @@ def actionscript_rule30(colorer, s, i):
           exclude_match=True)
 
 def actionscript_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def actionscript_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ada95.py
+++ b/leo/modes/ada95.py
@@ -119,325 +119,325 @@ def ada95_rule1(colorer, s, i):
           no_line_break=True)
 
 def ada95_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def ada95_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def ada95_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="..")
 
 def ada95_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".all")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".all")
 
 def ada95_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def ada95_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/=")
 
 def ada95_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=>")
 
 def ada95_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def ada95_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="null", seq="<>")
 
 def ada95_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="label", seq="<<")
 
 def ada95_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="label", seq=">>")
 
 def ada95_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def ada95_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def ada95_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def ada95_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def ada95_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def ada95_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def ada95_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def ada95_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def ada95_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def ada95_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def ada95_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'access")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'access")
 
 def ada95_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'address")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'address")
 
 def ada95_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'adjacent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'adjacent")
 
 def ada95_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'aft")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'aft")
 
 def ada95_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'alignment")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'alignment")
 
 def ada95_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'base")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'base")
 
 def ada95_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'bit_order")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'bit_order")
 
 def ada95_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'body_version")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'body_version")
 
 def ada95_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'callable")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'callable")
 
 def ada95_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'caller")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'caller")
 
 def ada95_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'ceiling")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'ceiling")
 
 def ada95_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'class")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'class")
 
 def ada95_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'component_size")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'component_size")
 
 def ada95_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'composed")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'composed")
 
 def ada95_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'constrained")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'constrained")
 
 def ada95_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'copy_size")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'copy_size")
 
 def ada95_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'count")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'count")
 
 def ada95_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'definite")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'definite")
 
 def ada95_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'delta")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'delta")
 
 def ada95_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'denorm")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'denorm")
 
 def ada95_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'digits")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'digits")
 
 def ada95_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'exponent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'exponent")
 
 def ada95_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'external_tag")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'external_tag")
 
 def ada95_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'first")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'first")
 
 def ada95_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'first_bit")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'first_bit")
 
 def ada95_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'floor")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'floor")
 
 def ada95_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'fore")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'fore")
 
 def ada95_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'fraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'fraction")
 
 def ada95_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'genetic")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'genetic")
 
 def ada95_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'identity")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'identity")
 
 def ada95_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'image")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'image")
 
 def ada95_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'input")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'input")
 
 def ada95_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'last")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'last")
 
 def ada95_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'last_bit")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'last_bit")
 
 def ada95_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'leading_part")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'leading_part")
 
 def ada95_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'length")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'length")
 
 def ada95_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine")
 
 def ada95_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_emax")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine_emax")
 
 def ada95_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_emin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine_emin")
 
 def ada95_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_mantissa")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine_mantissa")
 
 def ada95_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_overflows")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine_overflows")
 
 def ada95_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_radix")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine_radix")
 
 def ada95_rule65(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'machine_rounds")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'machine_rounds")
 
 def ada95_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'max")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'max")
 
 def ada95_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'max_size_in_storage_elements")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'max_size_in_storage_elements")
 
 def ada95_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'min")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'min")
 
 def ada95_rule69(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'model")
 
 def ada95_rule70(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_emin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'model_emin")
 
 def ada95_rule71(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_epsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'model_epsilon")
 
 def ada95_rule72(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_mantissa")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'model_mantissa")
 
 def ada95_rule73(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'model_small")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'model_small")
 
 def ada95_rule74(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'modulus")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'modulus")
 
 def ada95_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'output")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'output")
 
 def ada95_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'partition_id")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'partition_id")
 
 def ada95_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'pos")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'pos")
 
 def ada95_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'position")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'position")
 
 def ada95_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'pred")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'pred")
 
 def ada95_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'range")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'range")
 
 def ada95_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'read")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'read")
 
 def ada95_rule82(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'remainder")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'remainder")
 
 def ada95_rule83(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'round")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'round")
 
 def ada95_rule84(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'rounding")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'rounding")
 
 def ada95_rule85(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'safe_first")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'safe_first")
 
 def ada95_rule86(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'safe_last")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'safe_last")
 
 def ada95_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'scale")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'scale")
 
 def ada95_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'scaling")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'scaling")
 
 def ada95_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'signed_zeros")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'signed_zeros")
 
 def ada95_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'size")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'size")
 
 def ada95_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'small")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'small")
 
 def ada95_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'storage_pool")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'storage_pool")
 
 def ada95_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'storage_size")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'storage_size")
 
 def ada95_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'succ")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'succ")
 
 def ada95_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'tag")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'tag")
 
 def ada95_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'terminated")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'terminated")
 
 def ada95_rule97(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'truncation")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'truncation")
 
 def ada95_rule98(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'unbiased_rounding")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'unbiased_rounding")
 
 def ada95_rule99(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'unchecked_access")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'unchecked_access")
 
 def ada95_rule100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'val")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'val")
 
 def ada95_rule101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'valid")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'valid")
 
 def ada95_rule102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'value")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'value")
 
 def ada95_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'version")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'version")
 
 def ada95_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_image")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'wide_image")
 
 def ada95_rule105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_value")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'wide_value")
 
 def ada95_rule106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'wide_width")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'wide_width")
 
 def ada95_rule107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'width")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'width")
 
 def ada95_rule108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="'write")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="'write")
 
 def ada95_rule109(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",

--- a/leo/modes/ahk.py
+++ b/leo/modes/ahk.py
@@ -1033,40 +1033,40 @@ def ahk_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def ahk_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def ahk_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def ahk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def ahk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def ahk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def ahk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def ahk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def ahk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def ahk_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def ahk_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def ahk_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def ahk_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def ahk_rule13(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/antlr.py
+++ b/leo/modes/antlr.py
@@ -104,10 +104,10 @@ def antlr_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def antlr_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def antlr_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def antlr_rule6(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/apdl.py
+++ b/leo/modes/apdl.py
@@ -3000,1069 +3000,1069 @@ def apdl_rule2(colorer, s, i):
           no_line_break=True)
 
 def apdl_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ABBR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ABBR")
 
 def apdl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ABB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ABB")
 
 def apdl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*AFUN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*AFUN")
 
 def apdl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*AFU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*AFU")
 
 def apdl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ASK")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ASK")
 
 def apdl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFCLOS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CFCLOS")
 
 def apdl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CFC")
 
 def apdl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFOPEN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CFOPEN")
 
 def apdl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CFO")
 
 def apdl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFWRITE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CFWRITE")
 
 def apdl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CFW")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CFW")
 
 def apdl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CREATE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CREATE")
 
 def apdl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CRE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CRE")
 
 def apdl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CYCLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CYCLE")
 
 def apdl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*CYC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*CYC")
 
 def apdl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*DEL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*DEL")
 
 def apdl_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*DIM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*DIM")
 
 def apdl_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*DO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*DO")
 
 def apdl_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ELSEIF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ELSEIF")
 
 def apdl_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ELSE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ELSE")
 
 def apdl_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ENDDO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ENDDO")
 
 def apdl_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ENDIF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ENDIF")
 
 def apdl_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*END")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*END")
 
 def apdl_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EVAL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*EVAL")
 
 def apdl_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EVA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*EVA")
 
 def apdl_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EXIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*EXIT")
 
 def apdl_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*EXI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*EXI")
 
 def apdl_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*GET")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*GET")
 
 def apdl_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*GO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*GO")
 
 def apdl_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*IF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*IF")
 
 def apdl_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*LIST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*LIST")
 
 def apdl_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*LIS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*LIS")
 
 def apdl_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFOURI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MFOURI")
 
 def apdl_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MFO")
 
 def apdl_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFUN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MFUN")
 
 def apdl_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MFU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MFU")
 
 def apdl_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOONEY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MOONEY")
 
 def apdl_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MOO")
 
 def apdl_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOPER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MOPER")
 
 def apdl_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MOP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MOP")
 
 def apdl_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*MSG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*MSG")
 
 def apdl_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*REPEAT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*REPEAT")
 
 def apdl_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*REP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*REP")
 
 def apdl_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*SET")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*SET")
 
 def apdl_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*STATUS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*STATUS")
 
 def apdl_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*STA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*STA")
 
 def apdl_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*TREAD")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*TREAD")
 
 def apdl_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*TRE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*TRE")
 
 def apdl_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ULIB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ULIB")
 
 def apdl_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*ULI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*ULI")
 
 def apdl_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*USE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*USE")
 
 def apdl_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VABS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VABS")
 
 def apdl_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VAB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VAB")
 
 def apdl_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCOL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VCOL")
 
 def apdl_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VCO")
 
 def apdl_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCUM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VCUM")
 
 def apdl_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VCU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VCU")
 
 def apdl_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VEDIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VEDIT")
 
 def apdl_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VED")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VED")
 
 def apdl_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFACT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VFACT")
 
 def apdl_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VFA")
 
 def apdl_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFILL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VFILL")
 
 def apdl_rule65(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VFI")
 
 def apdl_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFUN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VFUN")
 
 def apdl_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VFU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VFU")
 
 def apdl_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VGET")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VGET")
 
 def apdl_rule69(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VGE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VGE")
 
 def apdl_rule70(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VITRP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VITRP")
 
 def apdl_rule71(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VIT")
 
 def apdl_rule72(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VLEN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VLEN")
 
 def apdl_rule73(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VLE")
 
 def apdl_rule74(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VMASK")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VMASK")
 
 def apdl_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VMA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VMA")
 
 def apdl_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VOPER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VOPER")
 
 def apdl_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VOP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VOP")
 
 def apdl_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPLOT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VPLOT")
 
 def apdl_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VPL")
 
 def apdl_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPUT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VPUT")
 
 def apdl_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VPU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VPU")
 
 def apdl_rule82(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VREAD")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VREAD")
 
 def apdl_rule83(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VRE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VRE")
 
 def apdl_rule84(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VSCFUN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VSCFUN")
 
 def apdl_rule85(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VSC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VSC")
 
 def apdl_rule86(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VSTAT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VSTAT")
 
 def apdl_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VST")
 
 def apdl_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VWRITE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VWRITE")
 
 def apdl_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="*VWR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="*VWR")
 
 def apdl_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANFILE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANFILE")
 
 def apdl_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANF")
 
 def apdl_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANGLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANGLE")
 
 def apdl_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANG")
 
 def apdl_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANNOT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANNOT")
 
 def apdl_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANN")
 
 def apdl_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANUM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANUM")
 
 def apdl_rule97(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ANU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ANU")
 
 def apdl_rule98(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ASSIGN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ASSIGN")
 
 def apdl_rule99(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ASS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ASS")
 
 def apdl_rule100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUTO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AUTO")
 
 def apdl_rule101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AUT")
 
 def apdl_rule102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX15")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AUX15")
 
 def apdl_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX2")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AUX2")
 
 def apdl_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AUX")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AUX")
 
 def apdl_rule105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AXLAB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AXLAB")
 
 def apdl_rule106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/AXL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/AXL")
 
 def apdl_rule107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/BATCH")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/BATCH")
 
 def apdl_rule108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/BAT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/BAT")
 
 def apdl_rule109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLABEL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CLABEL")
 
 def apdl_rule110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CLA")
 
 def apdl_rule111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLEAR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CLEAR")
 
 def apdl_rule112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CLE")
 
 def apdl_rule113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLOG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CLOG")
 
 def apdl_rule114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CLO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CLO")
 
 def apdl_rule115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CMAP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CMAP")
 
 def apdl_rule116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CMA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CMA")
 
 def apdl_rule117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COLOR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/COLOR")
 
 def apdl_rule118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/COL")
 
 def apdl_rule119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/COM")
 
 def apdl_rule120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CONFIG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CONFIG")
 
 def apdl_rule121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CONTOUR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CONTOUR")
 
 def apdl_rule122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CON")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CON")
 
 def apdl_rule123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COPY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/COPY")
 
 def apdl_rule124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/COP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/COP")
 
 def apdl_rule125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CPLANE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CPLANE")
 
 def apdl_rule126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CPL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CPL")
 
 def apdl_rule127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CTYPE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CTYPE")
 
 def apdl_rule128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CTY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CTY")
 
 def apdl_rule129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CVAL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CVAL")
 
 def apdl_rule130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/CVA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/CVA")
 
 def apdl_rule131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DELETE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DELETE")
 
 def apdl_rule132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DEL")
 
 def apdl_rule133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEVDISP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DEVDISP")
 
 def apdl_rule134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEVICE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DEVICE")
 
 def apdl_rule135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DEV")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DEV")
 
 def apdl_rule136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DIST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DIST")
 
 def apdl_rule137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DIS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DIS")
 
 def apdl_rule138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DSCALE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DSCALE")
 
 def apdl_rule139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DSC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DSC")
 
 def apdl_rule140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DV3D")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DV3D")
 
 def apdl_rule141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/DV3")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/DV3")
 
 def apdl_rule142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EDGE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EDGE")
 
 def apdl_rule143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EDG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EDG")
 
 def apdl_rule144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EFACET")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EFACET")
 
 def apdl_rule145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EFA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EFA")
 
 def apdl_rule146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EOF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EOF")
 
 def apdl_rule147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ERASE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ERASE")
 
 def apdl_rule148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ERA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ERA")
 
 def apdl_rule149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ESHAPE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ESHAPE")
 
 def apdl_rule150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ESH")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ESH")
 
 def apdl_rule151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EXIT")
 
 def apdl_rule152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EXI")
 
 def apdl_rule153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXPAND")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EXPAND")
 
 def apdl_rule154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/EXP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/EXP")
 
 def apdl_rule155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FACET")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FACET")
 
 def apdl_rule156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FAC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FAC")
 
 def apdl_rule157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FDELE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FDELE")
 
 def apdl_rule158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FDE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FDE")
 
 def apdl_rule159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FILNAME")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FILNAME")
 
 def apdl_rule160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FIL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FIL")
 
 def apdl_rule161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FOCUS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FOCUS")
 
 def apdl_rule162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FOC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FOC")
 
 def apdl_rule163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FORMAT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FORMAT")
 
 def apdl_rule164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FOR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FOR")
 
 def apdl_rule165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FTYPE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FTYPE")
 
 def apdl_rule166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/FTY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/FTY")
 
 def apdl_rule167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCMD")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GCMD")
 
 def apdl_rule168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GCM")
 
 def apdl_rule169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCOLUMN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GCOLUMN")
 
 def apdl_rule170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GCO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GCO")
 
 def apdl_rule171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFILE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GFILE")
 
 def apdl_rule172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GFI")
 
 def apdl_rule173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFORMAT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GFORMAT")
 
 def apdl_rule174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GFO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GFO")
 
 def apdl_rule175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GLINE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GLINE")
 
 def apdl_rule176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GLI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GLI")
 
 def apdl_rule177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GMARKER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GMARKER")
 
 def apdl_rule178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GMA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GMA")
 
 def apdl_rule179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOLIST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GOLIST")
 
 def apdl_rule180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GOL")
 
 def apdl_rule181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOPR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GOPR")
 
 def apdl_rule182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GOP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GOP")
 
 def apdl_rule183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GO")
 
 def apdl_rule184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRAPHICS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRAPHICS")
 
 def apdl_rule185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRA")
 
 def apdl_rule186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRESUME")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRESUME")
 
 def apdl_rule187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRE")
 
 def apdl_rule188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRID")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRID")
 
 def apdl_rule189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRI")
 
 def apdl_rule190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GROPT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GROPT")
 
 def apdl_rule191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRO")
 
 def apdl_rule192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRTYP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRTYP")
 
 def apdl_rule193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GRT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GRT")
 
 def apdl_rule194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GSAVE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GSAVE")
 
 def apdl_rule195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GSA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GSA")
 
 def apdl_rule196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GST")
 
 def apdl_rule197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTHK")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GTHK")
 
 def apdl_rule198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTH")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GTH")
 
 def apdl_rule199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTYPE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GTYPE")
 
 def apdl_rule200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/GTY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/GTY")
 
 def apdl_rule201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/HEADER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/HEADER")
 
 def apdl_rule202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/HEA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/HEA")
 
 def apdl_rule203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/INPUT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/INPUT")
 
 def apdl_rule204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/INP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/INP")
 
 def apdl_rule205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LARC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LARC")
 
 def apdl_rule206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LAR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LAR")
 
 def apdl_rule207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LIGHT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LIGHT")
 
 def apdl_rule208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LIG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LIG")
 
 def apdl_rule209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LINE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LINE")
 
 def apdl_rule210(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LIN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LIN")
 
 def apdl_rule211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSPEC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LSPEC")
 
 def apdl_rule212(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LSP")
 
 def apdl_rule213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSYMBOL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LSYMBOL")
 
 def apdl_rule214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/LSY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/LSY")
 
 def apdl_rule215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MENU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MENU")
 
 def apdl_rule216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MEN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MEN")
 
 def apdl_rule217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MPLIB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MPLIB")
 
 def apdl_rule218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MPL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MPL")
 
 def apdl_rule219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MREP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MREP")
 
 def apdl_rule220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MRE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MRE")
 
 def apdl_rule221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MSTART")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MSTART")
 
 def apdl_rule222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/MST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/MST")
 
 def apdl_rule223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NERR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NERR")
 
 def apdl_rule224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NER")
 
 def apdl_rule225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOERASE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOERASE")
 
 def apdl_rule226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOE")
 
 def apdl_rule227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOLIST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOLIST")
 
 def apdl_rule228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOL")
 
 def apdl_rule229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOPR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOPR")
 
 def apdl_rule230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOP")
 
 def apdl_rule231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NORMAL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NORMAL")
 
 def apdl_rule232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NOR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NOR")
 
 def apdl_rule233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NUMBER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NUMBER")
 
 def apdl_rule234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/NUM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/NUM")
 
 def apdl_rule235(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/OPT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/OPT")
 
 def apdl_rule236(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/OUTPUT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/OUTPUT")
 
 def apdl_rule237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/OUt")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/OUt")
 
 def apdl_rule238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PAGE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PAGE")
 
 def apdl_rule239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PAG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PAG")
 
 def apdl_rule240(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PBC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PBC")
 
 def apdl_rule241(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PBF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PBF")
 
 def apdl_rule242(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCIRCLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PCIRCLE")
 
 def apdl_rule243(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PCI")
 
 def apdl_rule244(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCOPY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PCOPY")
 
 def apdl_rule245(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PCO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PCO")
 
 def apdl_rule246(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PLOPTS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PLOPTS")
 
 def apdl_rule247(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PLO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PLO")
 
 def apdl_rule248(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMACRO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PMACRO")
 
 def apdl_rule249(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PMA")
 
 def apdl_rule250(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMETH")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PMETH")
 
 def apdl_rule251(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PME")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PME")
 
 def apdl_rule252(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMORE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PMORE")
 
 def apdl_rule253(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PMO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PMO")
 
 def apdl_rule254(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PNUM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PNUM")
 
 def apdl_rule255(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PNU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PNU")
 
 def apdl_rule256(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POLYGON")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/POLYGON")
 
 def apdl_rule257(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/POL")
 
 def apdl_rule258(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POST26")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/POST26")
 
 def apdl_rule259(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POST1")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/POST1")
 
 def apdl_rule260(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/POS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/POS")
 
 def apdl_rule261(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PREP7")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PREP7")
 
 def apdl_rule262(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PRE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PRE")
 
 def apdl_rule263(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSEARCH")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSEARCH")
 
 def apdl_rule264(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSE")
 
 def apdl_rule265(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSF")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSF")
 
 def apdl_rule266(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSPEC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSPEC")
 
 def apdl_rule267(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSP")
 
 def apdl_rule268(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSTATUS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSTATUS")
 
 def apdl_rule269(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PST")
 
 def apdl_rule270(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSYMB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSYMB")
 
 def apdl_rule271(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PSY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PSY")
 
 def apdl_rule272(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PWEDGE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PWEDGE")
 
 def apdl_rule273(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/PWE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/PWE")
 
 def apdl_rule274(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/QUIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/QUIT")
 
 def apdl_rule275(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/QUI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/QUI")
 
 def apdl_rule276(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RATIO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RATIO")
 
 def apdl_rule277(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RAT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RAT")
 
 def apdl_rule278(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RENAME")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RENAME")
 
 def apdl_rule279(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/REN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/REN")
 
 def apdl_rule280(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/REPLOT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/REPLOT")
 
 def apdl_rule281(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/REP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/REP")
 
 def apdl_rule282(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RESET")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RESET")
 
 def apdl_rule283(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RES")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RES")
 
 def apdl_rule284(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RGB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RGB")
 
 def apdl_rule285(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RUNST")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RUNST")
 
 def apdl_rule286(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/RUN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/RUN")
 
 def apdl_rule287(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SECLIB")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SECLIB")
 
 def apdl_rule288(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SEC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SEC")
 
 def apdl_rule289(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SEG")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SEG")
 
 def apdl_rule290(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHADE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHADE")
 
 def apdl_rule291(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHA")
 
 def apdl_rule292(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHOWDISP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHOWDISP")
 
 def apdl_rule293(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHOW")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHOW")
 
 def apdl_rule294(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHO")
 
 def apdl_rule295(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHRINK")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHRINK")
 
 def apdl_rule296(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SHR")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SHR")
 
 def apdl_rule297(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SOLU")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SOLU")
 
 def apdl_rule298(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SOL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SOL")
 
 def apdl_rule299(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SSCALE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SSCALE")
 
 def apdl_rule300(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SSC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SSC")
 
 def apdl_rule301(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STATUS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/STATUS")
 
 def apdl_rule302(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/STA")
 
 def apdl_rule303(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STITLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/STITLE")
 
 def apdl_rule304(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/STI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/STI")
 
 def apdl_rule305(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SYP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SYP")
 
 def apdl_rule306(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/SYS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/SYS")
 
 def apdl_rule307(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TITLE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TITLE")
 
 def apdl_rule308(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TIT")
 
 def apdl_rule309(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TLABEL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TLABEL")
 
 def apdl_rule310(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TLA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TLA")
 
 def apdl_rule311(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRIAD")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TRIAD")
 
 def apdl_rule312(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TRI")
 
 def apdl_rule313(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRLCY")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TRLCY")
 
 def apdl_rule314(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TRL")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TRL")
 
 def apdl_rule315(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TSPEC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TSPEC")
 
 def apdl_rule316(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TSP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TSP")
 
 def apdl_rule317(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TYPE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TYPE")
 
 def apdl_rule318(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/TYP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/TYP")
 
 def apdl_rule319(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UCMD")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/UCMD")
 
 def apdl_rule320(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UCM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/UCM")
 
 def apdl_rule321(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UIS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/UIS")
 
 def apdl_rule322(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/UI")
 
 def apdl_rule323(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UNITS")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/UNITS")
 
 def apdl_rule324(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/UNI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/UNI")
 
 def apdl_rule325(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/USER")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/USER")
 
 def apdl_rule326(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/USE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/USE")
 
 def apdl_rule327(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VCONE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VCONE")
 
 def apdl_rule328(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VCO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VCO")
 
 def apdl_rule329(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VIEW")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VIEW")
 
 def apdl_rule330(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VIE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VIE")
 
 def apdl_rule331(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VSCALE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VSCALE")
 
 def apdl_rule332(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VSC")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VSC")
 
 def apdl_rule333(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/VUP")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/VUP")
 
 def apdl_rule334(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WAIT")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/WAIT")
 
 def apdl_rule335(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WAI")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/WAI")
 
 def apdl_rule336(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WINDOW")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/WINDOW")
 
 def apdl_rule337(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/WIN")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/WIN")
 
 def apdl_rule338(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/XRANGE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/XRANGE")
 
 def apdl_rule339(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/XRA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/XRA")
 
 def apdl_rule340(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/YRANGE")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/YRANGE")
 
 def apdl_rule341(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/YRA")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/YRA")
 
 def apdl_rule342(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ZOOM")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ZOOM")
 
 def apdl_rule343(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="/ZOO")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="/ZOO")
 
 def apdl_rule344(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def apdl_rule345(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def apdl_rule346(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def apdl_rule347(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def apdl_rule348(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def apdl_rule349(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def apdl_rule350(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def apdl_rule351(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";")
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
 
 def apdl_rule352(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def apdl_rule353(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def apdl_rule354(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%C")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="%C")
 
 def apdl_rule355(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%G")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="%G")
 
 def apdl_rule356(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%I")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="%I")
 
 def apdl_rule357(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="%/")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="%/")
 
 def apdl_rule358(colorer, s, i):
     return colorer.match_span(s, i, kind="function", begin="%", end="%",

--- a/leo/modes/applescript.py
+++ b/leo/modes/applescript.py
@@ -219,43 +219,43 @@ def applescript_rule3(colorer, s, i):
           no_line_break=True)
 
 def applescript_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def applescript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def applescript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def applescript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def applescript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def applescript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def applescript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def applescript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def applescript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def applescript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def applescript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def applescript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def applescript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def applescript_rule17(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="application[\\t\\s]+responses")

--- a/leo/modes/aspect_j.py
+++ b/leo/modes/aspect_j.py
@@ -121,7 +121,7 @@ keywordsDictDict = {
 # Rules for aspect_j_main ruleset.
 
 def aspect_j_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def aspect_j_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
@@ -142,58 +142,58 @@ def aspect_j_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def aspect_j_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def aspect_j_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def aspect_j_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def aspect_j_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def aspect_j_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def aspect_j_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def aspect_j_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def aspect_j_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".*")
 
 def aspect_j_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def aspect_j_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def aspect_j_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def aspect_j_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def aspect_j_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def aspect_j_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def aspect_j_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def aspect_j_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def aspect_j_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def aspect_j_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def aspect_j_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/assembly_6502.py
+++ b/leo/modes/assembly_6502.py
@@ -170,70 +170,70 @@ def assembly_6502_rule6(colorer, s, i):
           exclude_match=True)
 
 def assembly_6502_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def assembly_6502_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def assembly_6502_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def assembly_6502_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def assembly_6502_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def assembly_6502_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def assembly_6502_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def assembly_6502_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def assembly_6502_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def assembly_6502_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def assembly_6502_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def assembly_6502_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def assembly_6502_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def assembly_6502_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<")
 
 def assembly_6502_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def assembly_6502_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def assembly_6502_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def assembly_6502_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def assembly_6502_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def assembly_6502_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def assembly_6502_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&&")
 
 def assembly_6502_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def assembly_6502_rule29(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_macro32.py
+++ b/leo/modes/assembly_macro32.py
@@ -555,64 +555,64 @@ def assembly_macro32_rule5(colorer, s, i):
           exclude_match=True)
 
 def assembly_macro32_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="B^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="B^")
 
 def assembly_macro32_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="D^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="D^")
 
 def assembly_macro32_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="O^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="O^")
 
 def assembly_macro32_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="X^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="X^")
 
 def assembly_macro32_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="A^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="A^")
 
 def assembly_macro32_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="M^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="M^")
 
 def assembly_macro32_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="F^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="F^")
 
 def assembly_macro32_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="C^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="C^")
 
 def assembly_macro32_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="L^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="L^")
 
 def assembly_macro32_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="G^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="G^")
 
 def assembly_macro32_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def assembly_macro32_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def assembly_macro32_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def assembly_macro32_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def assembly_macro32_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def assembly_macro32_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def assembly_macro32_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def assembly_macro32_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def assembly_macro32_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def assembly_macro32_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def assembly_macro32_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_mcs51.py
+++ b/leo/modes/assembly_mcs51.py
@@ -219,64 +219,64 @@ def assembly_mcs51_rule5(colorer, s, i):
           exclude_match=True)
 
 def assembly_mcs51_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",")
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
 
 def assembly_mcs51_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":")
+    return colorer.match_plain_seq(s, i, kind="null", seq=":")
 
 def assembly_mcs51_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="(")
 
 def assembly_mcs51_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")")
+    return colorer.match_plain_seq(s, i, kind="null", seq=")")
 
 def assembly_mcs51_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]")
+    return colorer.match_plain_seq(s, i, kind="null", seq="]")
 
 def assembly_mcs51_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[")
+    return colorer.match_plain_seq(s, i, kind="null", seq="[")
 
 def assembly_mcs51_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="$")
+    return colorer.match_plain_seq(s, i, kind="null", seq="$")
 
 def assembly_mcs51_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def assembly_mcs51_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def assembly_mcs51_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def assembly_mcs51_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def assembly_mcs51_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def assembly_mcs51_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def assembly_mcs51_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def assembly_mcs51_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def assembly_mcs51_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def assembly_mcs51_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def assembly_mcs51_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def assembly_mcs51_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def assembly_mcs51_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def assembly_mcs51_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/assembly_parrot.py
+++ b/leo/modes/assembly_parrot.py
@@ -148,7 +148,7 @@ def assembly_parrot_rule2(colorer, s, i):
           exclude_match=True)
 
 def assembly_parrot_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def assembly_parrot_rule4(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="I\\d{1,2}")

--- a/leo/modes/assembly_x86.py
+++ b/leo/modes/assembly_x86.py
@@ -847,43 +847,43 @@ def assembly_x86_rule5(colorer, s, i):
           exclude_match=True)
 
 def assembly_x86_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def assembly_x86_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def assembly_x86_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def assembly_x86_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def assembly_x86_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def assembly_x86_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def assembly_x86_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def assembly_x86_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def assembly_x86_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def assembly_x86_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def assembly_x86_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def assembly_x86_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def assembly_x86_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def assembly_x86_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/awk.py
+++ b/leo/modes/awk.py
@@ -113,55 +113,55 @@ def awk_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def awk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def awk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def awk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def awk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def awk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def awk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def awk_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def awk_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def awk_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def awk_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def awk_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def awk_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def awk_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def awk_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def awk_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def awk_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def awk_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def awk_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/b.py
+++ b/leo/modes/b.py
@@ -174,82 +174,82 @@ def b_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def b_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def b_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def b_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$0")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$0")
 
 def b_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def b_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def b_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def b_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def b_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def b_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def b_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def b_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def b_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def b_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def b_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def b_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def b_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def b_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def b_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def b_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def b_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def b_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def b_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def b_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def b_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def b_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def b_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def b_rule31(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/bbj.py
+++ b/leo/modes/bbj.py
@@ -308,43 +308,43 @@ def bbj_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="REM")
 
 def bbj_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bbj_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def bbj_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def bbj_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def bbj_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def bbj_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def bbj_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def bbj_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def bbj_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def bbj_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def bbj_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def bbj_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="and")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="and")
 
 def bbj_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="or")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="or")
 
 def bbj_rule17(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/bcel.py
+++ b/leo/modes/bcel.py
@@ -266,7 +266,7 @@ keywordsDictDict = {
 # Rules for bcel_main ruleset.
 
 def bcel_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def bcel_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
@@ -298,10 +298,10 @@ def bcel_rule8(colorer, s, i):
           exclude_match=True)
 
 def bcel_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def bcel_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def bcel_rule11(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/bibtex.py
+++ b/leo/modes/bibtex.py
@@ -1056,10 +1056,10 @@ def bibtex_rule32(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule35(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1173,10 +1173,10 @@ def bibtex_rule46(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule49(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1290,10 +1290,10 @@ def bibtex_rule60(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule63(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1407,10 +1407,10 @@ def bibtex_rule74(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule77(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1524,10 +1524,10 @@ def bibtex_rule88(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule91(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1641,10 +1641,10 @@ def bibtex_rule102(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule105(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1758,10 +1758,10 @@ def bibtex_rule116(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule119(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1875,10 +1875,10 @@ def bibtex_rule130(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule133(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -1992,10 +1992,10 @@ def bibtex_rule144(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule147(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -2109,10 +2109,10 @@ def bibtex_rule158(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule161(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -2226,10 +2226,10 @@ def bibtex_rule172(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule175(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -2343,10 +2343,10 @@ def bibtex_rule186(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule189(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -2460,10 +2460,10 @@ def bibtex_rule200(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule203(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -2577,10 +2577,10 @@ def bibtex_rule214(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule217(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal1", regexp="1[0-9]*")
@@ -2697,7 +2697,7 @@ def bibtex_rule229(colorer, s, i):
           delegate="bibtex::textquoted")
 
 def bibtex_rule230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="\\\"")
 
 # Rules dict for bibtex_textbraced ruleset.
 rulesDict16 = {
@@ -2717,7 +2717,7 @@ def bibtex_rule232(colorer, s, i):
           delegate="bibtex::textbraced")
 
 def bibtex_rule233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="\\\"")
 
 # Rules dict for bibtex_textquoted ruleset.
 rulesDict17 = {
@@ -2739,13 +2739,13 @@ def bibtex_rule236(colorer, s, i):
     return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}")
 
 def bibtex_rule237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def bibtex_rule238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def bibtex_rule239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="\\\"")
 
 # Rules dict for bibtex_string ruleset.
 rulesDict18 = {

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -152,7 +152,7 @@ def c_rule4(colorer, s, i):
           no_line_break=True)
 
 def c_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
 
 def c_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
@@ -162,55 +162,55 @@ def c_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def c_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def c_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def c_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def c_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def c_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def c_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def c_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def c_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def c_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def c_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def c_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def c_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def c_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def c_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def c_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def c_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def c_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def c_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/chill.py
+++ b/leo/modes/chill.py
@@ -110,67 +110,67 @@ def chill_rule3(colorer, s, i):
           no_line_break=True)
 
 def chill_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def chill_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def chill_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def chill_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def chill_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def chill_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def chill_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def chill_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def chill_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def chill_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def chill_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def chill_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def chill_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def chill_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def chill_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def chill_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def chill_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/=")
 
 def chill_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def chill_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def chill_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def chill_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def chill_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/clojure.py
+++ b/leo/modes/clojure.py
@@ -901,7 +901,7 @@ def clojure_rule23(colorer, s, i):
           delegate="clojure::main")
 
 def clojure_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#'")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="#'")
 
 def clojure_rule25(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal3", pattern="'")
@@ -942,7 +942,7 @@ def clojure_rule36(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\\\(.|newline|space|tab)")
 
 def clojure_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal4", seq=".")
+    return colorer.match_plain_seq(s, i, kind="literal4", seq=".")
 
 def clojure_rule38(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern=":")

--- a/leo/modes/cobol.py
+++ b/leo/modes/cobol.py
@@ -675,49 +675,49 @@ def cobol_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def cobol_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def cobol_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" >=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=" >=")
 
 def cobol_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" <=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=" <=")
 
 def cobol_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def cobol_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def cobol_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def cobol_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def cobol_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def cobol_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" > ")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=" > ")
 
 def cobol_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" < ")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=" < ")
 
 def cobol_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def cobol_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=" & ")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=" & ")
 
 def cobol_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def cobol_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def cobol_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def cobol_rule18(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="EXEC SQL", end="END-EXEC")

--- a/leo/modes/coffeescript.py
+++ b/leo/modes/coffeescript.py
@@ -167,73 +167,73 @@ def coffeescript_rule9(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(")
 
 def coffeescript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def coffeescript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def coffeescript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def coffeescript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def coffeescript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def coffeescript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def coffeescript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def coffeescript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def coffeescript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def coffeescript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def coffeescript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def coffeescript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def coffeescript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def coffeescript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def coffeescript_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def coffeescript_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def coffeescript_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def coffeescript_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def coffeescript_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def coffeescript_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def coffeescript_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def coffeescript_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def coffeescript_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def coffeescript_rule33(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword3", regexp="@([a-zA-Z\\$_][a-zA-Z0-9\\$_]*)")

--- a/leo/modes/coldfusion.py
+++ b/leo/modes/coldfusion.py
@@ -561,7 +561,7 @@ def coldfusion_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def coldfusion_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def coldfusion_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword3", begin="<CF", end=">",
@@ -598,40 +598,40 @@ def coldfusion_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="'", end="'")
 
 def coldfusion_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="(")
+    return colorer.match_plain_seq(s, i, kind="literal2", seq="(")
 
 def coldfusion_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq=")")
+    return colorer.match_plain_seq(s, i, kind="literal2", seq=")")
 
 def coldfusion_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def coldfusion_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def coldfusion_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def coldfusion_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def coldfusion_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def coldfusion_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def coldfusion_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="><")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="><")
 
 def coldfusion_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def coldfusion_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!!")
 
 def coldfusion_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&&")
 
 def coldfusion_rule33(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -727,10 +727,10 @@ def coldfusion_rule35(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def coldfusion_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def coldfusion_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="##")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="##")
 
 def coldfusion_rule38(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="#", end="#")

--- a/leo/modes/cplusplus.py
+++ b/leo/modes/cplusplus.py
@@ -135,7 +135,7 @@ def cplusplus_rule4(colorer, s, i):
           no_line_break=True)
 
 def cplusplus_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
 
 def cplusplus_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
@@ -145,55 +145,55 @@ def cplusplus_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def cplusplus_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def cplusplus_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def cplusplus_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def cplusplus_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def cplusplus_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def cplusplus_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def cplusplus_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def cplusplus_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def cplusplus_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def cplusplus_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def cplusplus_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def cplusplus_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def cplusplus_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def cplusplus_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def cplusplus_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def cplusplus_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def cplusplus_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def cplusplus_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="::")

--- a/leo/modes/csharp.py
+++ b/leo/modes/csharp.py
@@ -186,76 +186,76 @@ def csharp_rule16(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#endregion")
 
 def csharp_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def csharp_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def csharp_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def csharp_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def csharp_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def csharp_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def csharp_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def csharp_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def csharp_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def csharp_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def csharp_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def csharp_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def csharp_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def csharp_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def csharp_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def csharp_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def csharp_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def csharp_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def csharp_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def csharp_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def csharp_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def csharp_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def csharp_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def csharp_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def csharp_rule41(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -523,29 +523,29 @@ keywordsDictDict = {
 # Rules for css_main ruleset.
 
 def css_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def css_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";")
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
 
 def css_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="null", begin="(", end=")",
           delegate="css::literal")
 
 def css_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def css_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def css_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",")
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
 
 def css_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".")
 
 def css_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def css_rule8(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal2", pattern="#")

--- a/leo/modes/cython.py
+++ b/leo/modes/cython.py
@@ -348,49 +348,49 @@ def cython_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def cython_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def cython_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def cython_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def cython_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def cython_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def cython_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def cython_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def cython_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def cython_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def cython_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def cython_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def cython_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def cython_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def cython_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def cython_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def cython_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/d.py
+++ b/leo/modes/d.py
@@ -132,7 +132,7 @@ keywordsDictDict = {
 # Rules for d_main ruleset.
 
 def d_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def d_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
@@ -157,55 +157,55 @@ def d_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def d_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def d_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def d_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def d_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def d_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def d_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def d_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def d_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def d_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def d_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def d_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def d_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def d_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def d_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def d_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def d_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def d_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def d_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/dart.py
+++ b/leo/modes/dart.py
@@ -185,83 +185,83 @@ def dart_rule11(colorer, s, i):
           no_line_break=True)
 
 def dart_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def dart_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def dart_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def dart_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def dart_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def dart_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def dart_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def dart_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def dart_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def dart_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def dart_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def dart_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def dart_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def dart_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def dart_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<")
 
 def dart_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>>")
 
 def dart_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def dart_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~/")
 
 def dart_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def dart_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def dart_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def dart_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def dart_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def dart_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 # def dart_rule36(colorer, s, i):
     # return colorer.match_mark_previous(s, i, kind="function", pattern="(",
         #    )
 
 def dart_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def dart_rule38(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -269,7 +269,7 @@ def dart_rule38(colorer, s, i):
 # Rules formerly in expression ruleset.
 
 def dart_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment2", seq="//-->")
+    return colorer.match_plain_seq(s, i, kind="comment2", seq="//-->")
 
 def dart_rule40(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
@@ -278,16 +278,16 @@ def dart_rule41(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#!")
 
 def dart_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#library")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="#library")
 
 def dart_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#import")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="#import")
 
 def dart_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#source")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="#source")
 
 def dart_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="#resource")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="#resource")
 
 def dart_rule46(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/doxygen.py
+++ b/leo/modes/doxygen.py
@@ -413,19 +413,19 @@ rulesDict1 = {
 # Rules for doxygen_doxygen ruleset.
 
 def doxygen_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
 
 def doxygen_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def doxygen_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
 
 def doxygen_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
 
 def doxygen_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
 
 def doxygen_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",

--- a/leo/modes/elixir.py
+++ b/leo/modes/elixir.py
@@ -185,70 +185,70 @@ def elixir_rule5(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\$.\\w*")
 
 def elixir_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="badarg")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="badarg")
 
 def elixir_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="nocookie")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="nocookie")
 
 def elixir_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="false")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="false")
 
 def elixir_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="true")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="true")
 
 def elixir_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def elixir_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<-")
 
 def elixir_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def elixir_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def elixir_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def elixir_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def elixir_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def elixir_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def elixir_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def elixir_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def elixir_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def elixir_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def elixir_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def elixir_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def elixir_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def elixir_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def elixir_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def elixir_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def elixir_rule28(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bdiv\\b")

--- a/leo/modes/erlang.py
+++ b/leo/modes/erlang.py
@@ -183,70 +183,70 @@ def erlang_rule5(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\$.\\w*")
 
 def erlang_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="badarg")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="badarg")
 
 def erlang_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="nocookie")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="nocookie")
 
 def erlang_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="false")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="false")
 
 def erlang_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal3", seq="true")
+    return colorer.match_plain_seq(s, i, kind="literal3", seq="true")
 
 def erlang_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def erlang_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<-")
 
 def erlang_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def erlang_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def erlang_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def erlang_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def erlang_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def erlang_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def erlang_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def erlang_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def erlang_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def erlang_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def erlang_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def erlang_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def erlang_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def erlang_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def erlang_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def erlang_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def erlang_rule28(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="operator", regexp="\\bdiv\\b")

--- a/leo/modes/factor.py
+++ b/leo/modes/factor.py
@@ -198,7 +198,7 @@ rulesDict1 = {
 # Rules for factor_stack_effect ruleset.
 
 def factor_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="--")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="--")
 
 # Rules dict for factor_stack_effect ruleset.
 rulesDict2 = {

--- a/leo/modes/fortran.py
+++ b/leo/modes/fortran.py
@@ -216,49 +216,49 @@ def fortran_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def fortran_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def fortran_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def fortran_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def fortran_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def fortran_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def fortran_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/=")
 
 def fortran_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def fortran_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".lt.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".lt.")
 
 def fortran_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".gt.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".gt.")
 
 def fortran_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".eq.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".eq.")
 
 def fortran_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ne.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".ne.")
 
 def fortran_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".le.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".le.")
 
 def fortran_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ge.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".ge.")
 
 def fortran_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".AND.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".AND.")
 
 def fortran_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".OR.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".OR.")
 
 def fortran_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/fortran90.py
+++ b/leo/modes/fortran90.py
@@ -193,49 +193,49 @@ def fortran90_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def fortran90_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def fortran90_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def fortran90_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def fortran90_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def fortran90_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def fortran90_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/=")
 
 def fortran90_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def fortran90_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".lt.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".lt.")
 
 def fortran90_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".gt.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".gt.")
 
 def fortran90_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".eq.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".eq.")
 
 def fortran90_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ne.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".ne.")
 
 def fortran90_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".le.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".le.")
 
 def fortran90_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".ge.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".ge.")
 
 def fortran90_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".AND.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".AND.")
 
 def fortran90_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".OR.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".OR.")
 
 def fortran90_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/foxpro.py
+++ b/leo/modes/foxpro.py
@@ -1782,46 +1782,46 @@ def foxpro_rule18(colorer, s, i):
           at_whitespace_end=True)
 
 def foxpro_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def foxpro_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def foxpro_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def foxpro_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def foxpro_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def foxpro_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def foxpro_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def foxpro_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def foxpro_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def foxpro_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def foxpro_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def foxpro_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def foxpro_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def foxpro_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def foxpro_rule33(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/groovy.py
+++ b/leo/modes/groovy.py
@@ -202,7 +202,7 @@ keywordsDictDict = {
 # Rules for groovy_main ruleset.
 
 def groovy_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def groovy_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
@@ -223,43 +223,43 @@ def groovy_rule5(colorer, s, i):
           delegate="groovy::literal")
 
 def groovy_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=~")
 
 def groovy_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def groovy_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def groovy_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def groovy_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=>")
 
 def groovy_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def groovy_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def groovy_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def groovy_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def groovy_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def groovy_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def groovy_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def groovy_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".*")
 
 def groovy_rule19(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="//")
@@ -369,22 +369,22 @@ rulesDict2 = {
 # Rules for groovy_groovydoc ruleset.
 
 def groovy_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="{")
 
 def groovy_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
 
 def groovy_rule26(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def groovy_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
 
 def groovy_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
 
 def groovy_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
 
 def groovy_rule30(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",

--- a/leo/modes/haskell.py
+++ b/leo/modes/haskell.py
@@ -127,76 +127,76 @@ def haskell_rule3(colorer, s, i):
           no_line_break=True)
 
 def haskell_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="' '")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="' '")
 
 def haskell_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'!'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'!'")
 
 def haskell_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'\"'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'\"'")
 
 def haskell_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'$'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'$'")
 
 def haskell_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'%'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'%'")
 
 def haskell_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'/'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'/'")
 
 def haskell_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'('")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'('")
 
 def haskell_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="')'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="')'")
 
 def haskell_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'['")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'['")
 
 def haskell_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="']'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="']'")
 
 def haskell_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'+'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'+'")
 
 def haskell_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'-'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'-'")
 
 def haskell_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'*'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'*'")
 
 def haskell_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'='")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'='")
 
 def haskell_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'/'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'/'")
 
 def haskell_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'^'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'^'")
 
 def haskell_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'.'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'.'")
 
 def haskell_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="','")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="','")
 
 def haskell_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="':'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="':'")
 
 def haskell_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="';'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="';'")
 
 def haskell_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'<'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'<'")
 
 def haskell_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'>'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'>'")
 
 def haskell_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'|'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'|'")
 
 def haskell_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="'@'")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="'@'")
 
 def haskell_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
@@ -207,55 +207,55 @@ def haskell_rule28(colorer, s, i):
         )
 
 def haskell_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="..")
 
 def haskell_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&&")
 
 def haskell_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="::")
 
 def haskell_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def haskell_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def haskell_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def haskell_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def haskell_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def haskell_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def haskell_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def haskell_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def haskell_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def haskell_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def haskell_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def haskell_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def haskell_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def haskell_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def haskell_rule46(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/haxe.py
+++ b/leo/modes/haxe.py
@@ -124,76 +124,76 @@ def haXe_rule7(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="markup", regexp="~([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*")
 
 def haXe_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")")
+    return colorer.match_plain_seq(s, i, kind="null", seq=")")
 
 def haXe_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="(")
 
 def haXe_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def haXe_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def haXe_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def haXe_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def haXe_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def haXe_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def haXe_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def haXe_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def haXe_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def haXe_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def haXe_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def haXe_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def haXe_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def haXe_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def haXe_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def haXe_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def haXe_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def haXe_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def haXe_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def haXe_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def haXe_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def haXe_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def haXe_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/i4gl.py
+++ b/leo/modes/i4gl.py
@@ -638,64 +638,64 @@ def i4gl_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="{", end="}")
 
 def i4gl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")")
+    return colorer.match_plain_seq(s, i, kind="null", seq=")")
 
 def i4gl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]")
+    return colorer.match_plain_seq(s, i, kind="null", seq="]")
 
 def i4gl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[")
+    return colorer.match_plain_seq(s, i, kind="null", seq="[")
 
 def i4gl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".")
 
 def i4gl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",")
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
 
 def i4gl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";")
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
 
 def i4gl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":")
+    return colorer.match_plain_seq(s, i, kind="null", seq=":")
 
 def i4gl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def i4gl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def i4gl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def i4gl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def i4gl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def i4gl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def i4gl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def i4gl_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def i4gl_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def i4gl_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def i4gl_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def i4gl_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def i4gl_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def i4gl_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/icon.py
+++ b/leo/modes/icon.py
@@ -147,124 +147,124 @@ def icon_rule2(colorer, s, i):
           no_line_break=True)
 
 def icon_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~===")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~===")
 
 def icon_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="===")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="===")
 
 def icon_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|||")
 
 def icon_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>=")
 
 def icon_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def icon_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<=")
 
 def icon_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<")
 
 def icon_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~==")
 
 def icon_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def icon_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def icon_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="++")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="++")
 
 def icon_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def icon_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="--")
 
 def icon_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<->")
 
 def icon_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<-")
 
 def icon_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="op:=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="op:=")
 
 def icon_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def icon_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def icon_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def icon_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def icon_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~=")
 
 def icon_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=:")
 
 def icon_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def icon_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-:")
 
 def icon_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+:")
 
 def icon_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def icon_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def icon_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def icon_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def icon_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def icon_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="not")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="not")
 
 def icon_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def icon_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def icon_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def icon_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def icon_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def icon_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def icon_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def icon_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def icon_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def icon_rule43(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/idl.py
+++ b/leo/modes/idl.py
@@ -90,13 +90,13 @@ def idl_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def idl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def idl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def idl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def idl_rule7(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/inform.py
+++ b/leo/modes/inform.py
@@ -163,76 +163,76 @@ def inform_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="!")
 
 def inform_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def inform_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def inform_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def inform_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def inform_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~=")
 
 def inform_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def inform_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def inform_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def inform_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def inform_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def inform_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def inform_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def inform_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def inform_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def inform_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def inform_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def inform_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def inform_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def inform_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def inform_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def inform_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def inform_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".&")
 
 def inform_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".#")
 
 def inform_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-->")
 
 def inform_rule29(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
@@ -344,19 +344,19 @@ rulesDict1 = {
 # Rules for inform_informinnertext ruleset.
 
 def inform_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def inform_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def inform_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def inform_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def inform_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="@@")
+    return colorer.match_plain_seq(s, i, kind="literal2", seq="@@")
 
 # Rules dict for inform_informinnertext ruleset.
 rulesDict2 = {

--- a/leo/modes/inno_setup.py
+++ b/leo/modes/inno_setup.py
@@ -622,7 +622,7 @@ def inno_setup_rule48(colorer, s, i):
           exclude_match=True)
 
 def inno_setup_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 # Rules dict for inno_setup_constant ruleset.
 rulesDict3 = {

--- a/leo/modes/interlis.py
+++ b/leo/modes/interlis.py
@@ -183,136 +183,136 @@ def interlis_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="//", end="//")
 
 def interlis_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def interlis_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<-")
 
 def interlis_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="..")
 
 def interlis_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def interlis_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def interlis_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def interlis_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def interlis_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def interlis_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def interlis_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def interlis_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def interlis_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def interlis_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def interlis_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def interlis_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def interlis_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def interlis_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def interlis_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def interlis_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def interlis_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def interlis_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def interlis_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="--")
 
 def interlis_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-<#>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-<#>")
 
 def interlis_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-<>")
 
 def interlis_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def interlis_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def interlis_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="..")
 
 def interlis_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def interlis_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def interlis_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def interlis_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def interlis_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def interlis_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def interlis_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def interlis_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def interlis_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def interlis_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def interlis_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def interlis_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def interlis_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def interlis_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def interlis_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def interlis_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def interlis_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def interlis_rule48(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/io.py
+++ b/leo/modes/io.py
@@ -86,70 +86,70 @@ def io_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"")
 
 def io_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="`")
 
 def io_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def io_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def io_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@@")
 
 def io_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def io_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def io_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def io_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def io_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def io_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def io_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def io_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def io_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def io_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def io_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def io_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def io_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def io_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def io_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def io_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def io_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def io_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def io_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/java.py
+++ b/leo/modes/java.py
@@ -150,7 +150,7 @@ keywordsDictDict = {
 # Rules for java_main ruleset.
 
 def java_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def java_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
@@ -171,58 +171,58 @@ def java_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def java_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def java_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def java_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def java_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def java_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def java_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def java_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def java_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".*")
 
 def java_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def java_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def java_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def java_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def java_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def java_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def java_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def java_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def java_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def java_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def java_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
@@ -329,22 +329,22 @@ rulesDict1 = {
 # Rules for java_javadoc ruleset.
 
 def java_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="{")
 
 def java_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
 
 def java_rule30(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def java_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
 
 def java_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
 
 def java_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
 
 def java_rule34(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",

--- a/leo/modes/jmk.py
+++ b/leo/modes/jmk.py
@@ -78,22 +78,22 @@ def jmk_rule2(colorer, s, i):
           no_line_break=True)
 
 def jmk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def jmk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def jmk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def jmk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def jmk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def jmk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def jmk_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/json.py
+++ b/leo/modes/json.py
@@ -38,22 +38,22 @@ if 0:
         return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def json_colon(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def json_comma(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def json_open_brace(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def json_close_brace(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def json_open_bracket(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def json_close_bracket(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 # Rules dict for json_main ruleset.
 rulesDict1 = {

--- a/leo/modes/jsp.py
+++ b/leo/modes/jsp.py
@@ -220,14 +220,14 @@ def jsp_rule20(colorer, s, i):
           delegate="jsp::attrvalue")
 
 def jsp_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="/")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="/")
 
 def jsp_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
           exclude_match=True)
 
 def jsp_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def jsp_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -322,14 +322,14 @@ def jsp_rule28(colorer, s, i):
           delegate="jsp::attrvalue")
 
 def jsp_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="/")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="/")
 
 def jsp_rule30(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="function", pattern=":",
           exclude_match=True)
 
 def jsp_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 # Rules dict for jsp_tags ruleset.
 rulesDict4 = {

--- a/leo/modes/latex.py
+++ b/leo/modes/latex.py
@@ -108,7 +108,7 @@ keywordsDictDict = {
 # Rules for latex_main ruleset.
 
 def latex_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__NormalMode__")
+    return colorer.match_plain_seq(s, i, kind="label", seq="__NormalMode__")
 
 def latex_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
@@ -123,178 +123,178 @@ def latex_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def latex_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\"")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\"")
 
 def latex_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="`")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="`")
 
 def latex_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#1")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#1")
 
 def latex_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#2")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#2")
 
 def latex_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#3")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#3")
 
 def latex_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#4")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#4")
 
 def latex_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#5")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#5")
 
 def latex_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#6")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#6")
 
 def latex_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#7")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#7")
 
 def latex_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#8")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#8")
 
 def latex_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="function", seq="#9")
+    return colorer.match_plain_seq(s, i, kind="function", seq="#9")
 
 def latex_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabs")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\tabs")
 
 def latex_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabset")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\tabset")
 
 def latex_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabsdone")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\tabsdone")
 
 def latex_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\cleartabs")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\cleartabs")
 
 def latex_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\settabs")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\settabs")
 
 def latex_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\tabalign")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\tabalign")
 
 def latex_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\+")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\+")
 
 def latex_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pageno")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\pageno")
 
 def latex_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\headline")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\headline")
 
 def latex_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\footline")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\footline")
 
 def latex_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\normalbottom")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\normalbottom")
 
 def latex_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\folio")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\folio")
 
 def latex_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\nopagenumbers")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\nopagenumbers")
 
 def latex_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\advancepageno")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\advancepageno")
 
 def latex_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pagebody")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\pagebody")
 
 def latex_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\plainoutput")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\plainoutput")
 
 def latex_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pagecontents")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\pagecontents")
 
 def latex_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\makeheadline")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\makeheadline")
 
 def latex_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\makefootline")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\makefootline")
 
 def latex_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\dosupereject")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\dosupereject")
 
 def latex_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\footstrut")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\footstrut")
 
 def latex_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\vfootnote")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\vfootnote")
 
 def latex_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\topins")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\topins")
 
 def latex_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\topinsert")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\topinsert")
 
 def latex_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\midinsert")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\midinsert")
 
 def latex_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\pageinsert")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\pageinsert")
 
 def latex_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\endinsert")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\endinsert")
 
 def latex_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fivei")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\fivei")
 
 def latex_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fiverm")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\fiverm")
 
 def latex_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fivesy")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\fivesy")
 
 def latex_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\fivebf")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\fivebf")
 
 def latex_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\seveni")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\seveni")
 
 def latex_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\sevenbf")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\sevenbf")
 
 def latex_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\sevensy")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\sevensy")
 
 def latex_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\teni")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\teni")
 
 def latex_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\oldstyle")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\oldstyle")
 
 def latex_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\eqalign")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\eqalign")
 
 def latex_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\eqalignno")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\eqalignno")
 
 def latex_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\leqalignno")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\leqalignno")
 
 def latex_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="$$")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="$$")
 
 def latex_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\beginsection")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\beginsection")
 
 def latex_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\bye")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\bye")
 
 def latex_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\magnification")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\magnification")
 
 def latex_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="#")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="#")
 
 def latex_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="&")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="&")
 
 def latex_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="_")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="_")
 
 def latex_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\\~")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\\~")
 
 def latex_rule63(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="$", end="$",
@@ -349,1057 +349,1057 @@ def latex_rule75(colorer, s, i):
           delegate="latex::picturemode")
 
 def latex_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def latex_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="}")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="}")
 
 def latex_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="{")
 
 def latex_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="totalnumber")
 
 def latex_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="topnumber")
 
 def latex_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="tocdepth")
 
 def latex_rule82(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="secnumdepth")
 
 def latex_rule83(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="dbltopnumber")
 
 def latex_rule84(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="]")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="]")
 
 def latex_rule85(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\~{")
 
 def latex_rule86(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\~")
 
 def latex_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\}")
 
 def latex_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\|")
 
 def latex_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\{")
 
 def latex_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\width")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\width")
 
 def latex_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\whiledo{")
 
 def latex_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\v{")
 
 def latex_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vspace{")
 
 def latex_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vspace*{")
 
 def latex_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vfill")
 
 def latex_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\verb*")
 
 def latex_rule97(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\verb")
 
 def latex_rule98(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\value{")
 
 def latex_rule99(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\v")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\v")
 
 def latex_rule100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\u{")
 
 def latex_rule101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usepackage{")
 
 def latex_rule102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usepackage[")
 
 def latex_rule103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usecounter{")
 
 def latex_rule104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usebox{")
 
 def latex_rule105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upshape")
 
 def latex_rule106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\unboldmath{")
 
 def latex_rule107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\u")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\u")
 
 def latex_rule108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\t{")
 
 def latex_rule109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typeout{")
 
 def latex_rule110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typein{")
 
 def latex_rule111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typein[")
 
 def latex_rule112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\twocolumn[")
 
 def latex_rule113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twocolumn")
 
 def latex_rule114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ttfamily")
 
 def latex_rule115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\totalheight")
 
 def latex_rule116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\topsep")
 
 def latex_rule117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\topfraction")
 
 def latex_rule118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\today")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\today")
 
 def latex_rule119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\title{")
 
 def latex_rule120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tiny")
 
 def latex_rule121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
 
 def latex_rule122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\thanks{")
 
 def latex_rule125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textwidth")
 
 def latex_rule126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textup{")
 
 def latex_rule127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\texttt{")
 
 def latex_rule128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsl{")
 
 def latex_rule129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsf{")
 
 def latex_rule130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsc{")
 
 def latex_rule131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textrm{")
 
 def latex_rule132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textnormal{")
 
 def latex_rule133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textmd{")
 
 def latex_rule134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textit{")
 
 def latex_rule135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textfraction")
 
 def latex_rule136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textfloatsep")
 
 def latex_rule137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textcolor{")
 
 def latex_rule138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textbf{")
 
 def latex_rule139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tableofcontents")
 
 def latex_rule140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\tabcolsep")
 
 def latex_rule141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\tabbingsep")
 
 def latex_rule142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\t")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\t")
 
 def latex_rule143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\symbol{")
 
 def latex_rule144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
 
 def latex_rule145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\suppressfloats")
 
 def latex_rule146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection{")
 
 def latex_rule147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection[")
 
 def latex_rule148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
 
 def latex_rule149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection{")
 
 def latex_rule150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection[")
 
 def latex_rule151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection*{")
 
 def latex_rule152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph{")
 
 def latex_rule153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph[")
 
 def latex_rule154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
 
 def latex_rule155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stretch{")
 
 def latex_rule156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stepcounter{")
 
 def latex_rule157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallskip")
 
 def latex_rule158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\small")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\small")
 
 def latex_rule159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\slshape")
 
 def latex_rule160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sloppy")
 
 def latex_rule161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sffamily")
 
 def latex_rule162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settowidth{")
 
 def latex_rule163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settoheight{")
 
 def latex_rule164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settodepth{")
 
 def latex_rule165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\setlength{")
 
 def latex_rule166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\setcounter{")
 
 def latex_rule167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section{")
 
 def latex_rule168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section[")
 
 def latex_rule169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section*{")
 
 def latex_rule170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scshape")
 
 def latex_rule171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptsize")
 
 def latex_rule172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\scalebox{")
 
 def latex_rule173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\sbox{")
 
 def latex_rule174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rule{")
 
 def latex_rule176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rule[")
 
 def latex_rule177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rp,am{")
 
 def latex_rule178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rotatebox{")
 
 def latex_rule179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rmfamily")
 
 def latex_rule180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\rightmargin")
 
 def latex_rule181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
 
 def latex_rule182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\resizebox{")
 
 def latex_rule183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\resizebox*{")
 
 def latex_rule184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
 
 def latex_rule185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\renewcommand{")
 
 def latex_rule186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ref{")
 
 def latex_rule187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\refstepcounter")
 
 def latex_rule188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\raisebox{")
 
 def latex_rule189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\raggedright")
 
 def latex_rule190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\raggedleft")
 
 def latex_rule191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\qbeziermax")
 
 def latex_rule192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\providecommand{")
 
 def latex_rule193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\protect")
 
 def latex_rule194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\printindex")
 
 def latex_rule195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pounds")
 
 def latex_rule196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part{")
 
 def latex_rule197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\partopsep")
 
 def latex_rule198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part[")
 
 def latex_rule199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part*{")
 
 def latex_rule200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parskip")
 
 def latex_rule201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parsep")
 
 def latex_rule202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parindent")
 
 def latex_rule203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\parbox{")
 
 def latex_rule204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\parbox[")
 
 def latex_rule205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph{")
 
 def latex_rule206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph[")
 
 def latex_rule207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph*{")
 
 def latex_rule208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\par")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\par")
 
 def latex_rule209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagestyle{")
 
 def latex_rule210(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pageref{")
 
 def latex_rule211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
 
 def latex_rule212(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagecolor{")
 
 def latex_rule213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagebreak[")
 
 def latex_rule214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pagebreak")
 
 def latex_rule215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\onecolumn")
 
 def latex_rule216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalsize")
 
 def latex_rule217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
 
 def latex_rule218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalfont")
 
 def latex_rule219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
 
 def latex_rule220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nopagebreak")
 
 def latex_rule221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
 
 def latex_rule222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
 
 def latex_rule223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nolinebreak")
 
 def latex_rule224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\noindent")
 
 def latex_rule225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nocite{")
 
 def latex_rule226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newtheorem{")
 
 def latex_rule227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newsavebox{")
 
 def latex_rule228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\newpage")
 
 def latex_rule229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newlength{")
 
 def latex_rule230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newenvironment{")
 
 def latex_rule231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newcounter{")
 
 def latex_rule232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newcommand{")
 
 def latex_rule233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\medskip")
 
 def latex_rule234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mdseries")
 
 def latex_rule235(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule236(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\markright{")
 
 def latex_rule240(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\markboth{")
 
 def latex_rule241(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\marginpar{")
 
 def latex_rule242(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparwidth")
 
 def latex_rule243(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparsep")
 
 def latex_rule244(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparpush")
 
 def latex_rule245(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\marginpar[")
 
 def latex_rule246(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\maketitle")
 
 def latex_rule247(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\makelabel")
 
 def latex_rule248(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makeindex")
 
 def latex_rule249(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makeglossary")
 
 def latex_rule250(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\makebox{")
 
 def latex_rule251(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\makebox[")
 
 def latex_rule252(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\listparindent")
 
 def latex_rule253(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listoftables")
 
 def latex_rule254(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listoffigures")
 
 def latex_rule255(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listfiles")
 
 def latex_rule256(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\linewidth")
 
 def latex_rule257(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule258(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linebreak[")
 
 def latex_rule259(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\linebreak")
 
 def latex_rule260(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\lengthtest{")
 
 def latex_rule261(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
 
 def latex_rule262(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginv")
 
 def latex_rule263(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
 
 def latex_rule264(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
 
 def latex_rule265(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginii")
 
 def latex_rule266(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmargini")
 
 def latex_rule267(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmargin")
 
 def latex_rule268(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\large")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\large")
 
 def latex_rule269(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\label{")
 
 def latex_rule270(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\labelwidth")
 
 def latex_rule271(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\labelsep")
 
 def latex_rule272(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\jot")
 
 def latex_rule273(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\itshape")
 
 def latex_rule274(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\itemsep")
 
 def latex_rule275(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\itemindent")
 
 def latex_rule276(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\item[")
 
 def latex_rule277(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\item")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\item")
 
 def latex_rule278(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\isodd{")
 
 def latex_rule279(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\intextsep")
 
 def latex_rule280(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\input{")
 
 def latex_rule281(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\index{")
 
 def latex_rule282(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\indent")
 
 def latex_rule283(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\include{")
 
 def latex_rule284(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includeonly{")
 
 def latex_rule285(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics{")
 
 def latex_rule286(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics[")
 
 def latex_rule287(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
 
 def latex_rule288(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
 
 def latex_rule289(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
 
 def latex_rule290(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hyphenation{")
 
 def latex_rule291(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\huge")
 
 def latex_rule292(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hspace{")
 
 def latex_rule293(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hspace*{")
 
 def latex_rule294(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hfill")
 
 def latex_rule295(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\height")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\height")
 
 def latex_rule296(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\glossary{")
 
 def latex_rule297(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fussy")
 
 def latex_rule298(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\frenchspacing")
 
 def latex_rule299(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\framebox{")
 
 def latex_rule300(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\framebox[")
 
 def latex_rule301(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fragile")
 
 def latex_rule302(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnote{")
 
 def latex_rule303(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotetext{")
 
 def latex_rule304(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotetext[")
 
 def latex_rule305(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\footnotesize")
 
 def latex_rule306(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\footnotesep")
 
 def latex_rule307(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\footnoterule")
 
 def latex_rule308(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotemark[")
 
 def latex_rule309(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\footnotemark")
 
 def latex_rule310(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnote[")
 
 def latex_rule311(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
 
 def latex_rule312(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\floatsep")
 
 def latex_rule313(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
 
 def latex_rule314(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fill")
 
 def latex_rule315(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
 
 def latex_rule316(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fbox{")
 
 def latex_rule317(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\fboxsep")
 
 def latex_rule318(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\fboxrule")
 
 def latex_rule319(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\equal{")
 
 def latex_rule320(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule321(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
 
 def latex_rule322(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
 
 def latex_rule323(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule324(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\emph{")
 
 def latex_rule325(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\d{")
 
 def latex_rule326(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\doublerulesep")
 
 def latex_rule327(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\documentclass{")
 
 def latex_rule328(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\documentclass[")
 
 def latex_rule329(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\depth")
 
 def latex_rule330(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\definecolor{")
 
 def latex_rule331(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddag")
 
 def latex_rule332(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
 
 def latex_rule333(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
 
 def latex_rule334(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
 
 def latex_rule335(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
 
 def latex_rule336(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\date{")
 
 def latex_rule337(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dag")
 
 def latex_rule338(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\d")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\d")
 
 def latex_rule339(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\c{")
 
 def latex_rule340(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\copyright")
 
 def latex_rule341(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnwidth")
 
 def latex_rule342(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnseprule")
 
 def latex_rule343(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnsep")
 
 def latex_rule344(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\color{")
 
 def latex_rule345(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\colorbox{")
 
 def latex_rule346(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\clearpage")
 
 def latex_rule347(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
 
 def latex_rule348(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cite{")
 
 def latex_rule349(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cite[")
 
 def latex_rule350(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter{")
 
 def latex_rule351(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter[")
 
 def latex_rule352(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter*{")
 
 def latex_rule353(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\centering")
 
 def latex_rule354(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\caption{")
 
 def latex_rule355(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\caption[")
 
 def latex_rule356(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\c")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\c")
 
 def latex_rule357(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\b{")
 
 def latex_rule358(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bottomnumber")
 
 def latex_rule359(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bottomfraction")
 
 def latex_rule360(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boolean{")
 
 def latex_rule361(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boldmath{")
 
 def latex_rule362(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigskip")
 
 def latex_rule363(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bibliography{")
 
 def latex_rule364(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
 
 def latex_rule365(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bibindent")
 
 def latex_rule366(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bfseries")
 
 def latex_rule367(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
 
 def latex_rule368(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
 
 def latex_rule369(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule370(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\baselinestretch")
 
 def latex_rule371(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\baselineskip")
 
 def latex_rule372(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\b")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\b")
 
 def latex_rule373(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\author{")
 
 def latex_rule374(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arraystgretch")
 
 def latex_rule375(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
 
 def latex_rule376(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arraycolsep")
 
 def latex_rule377(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\arabic{")
 
 def latex_rule378(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\appendix")
 
 def latex_rule379(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\alph{")
 
 def latex_rule380(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addvspace{")
 
 def latex_rule381(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtolength{")
 
 def latex_rule382(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtocounter{")
 
 def latex_rule383(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtocontents{")
 
 def latex_rule384(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
 
 def latex_rule385(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
 
 def latex_rule386(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
 
 def latex_rule387(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\`{")
 
 def latex_rule388(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule389(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\_")
 
 def latex_rule390(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\^{")
 
 def latex_rule391(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\^")
 
 def latex_rule392(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\[")
 
 def latex_rule393(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\*[")
 
 def latex_rule394(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\*")
 
 def latex_rule395(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule396(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\TeX")
 
 def latex_rule397(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\S")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\S")
 
 def latex_rule398(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Roman{")
 
 def latex_rule399(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\P")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\P")
 
 def latex_rule400(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Large")
 
 def latex_rule401(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\LaTeX")
 
 def latex_rule402(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\LARGE")
 
 def latex_rule403(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\H{")
 
 def latex_rule404(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Huge")
 
 def latex_rule405(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\H")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\H")
 
 def latex_rule406(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Alph{")
 
 def latex_rule407(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\@")
 
 def latex_rule408(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\={")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\={")
 
 def latex_rule409(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule410(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\.{")
 
 def latex_rule411(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\.")
 
 def latex_rule412(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule413(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule414(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\'{")
 
 def latex_rule415(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule416(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\&")
 
 def latex_rule417(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\%")
 
 def latex_rule418(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\$")
 
 def latex_rule419(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\#")
 
 def latex_rule420(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\"{")
 
 def latex_rule421(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\"")
 
 def latex_rule422(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def latex_rule423(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="[")
 
 def latex_rule424(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="---")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="---")
 
 def latex_rule425(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="--")
 
 def latex_rule426(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def latex_rule427(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
@@ -1428,1561 +1428,1561 @@ rulesDict1 = {
 # Rules for latex_mathmode ruleset.
 
 def latex_rule428(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__MathMode__")
+    return colorer.match_plain_seq(s, i, kind="label", seq="__MathMode__")
 
 def latex_rule429(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule430(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def latex_rule431(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def latex_rule432(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\zeta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\zeta")
 
 def latex_rule433(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\xi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\xi")
 
 def latex_rule434(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\wr")
 
 def latex_rule435(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\wp")
 
 def latex_rule436(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widetilde{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\widetilde{")
 
 def latex_rule437(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widehat{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\widehat{")
 
 def latex_rule438(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\wedge")
 
 def latex_rule439(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\veebar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\veebar")
 
 def latex_rule440(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vee")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vee")
 
 def latex_rule441(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vec{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vec{")
 
 def latex_rule442(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vdots")
 
 def latex_rule443(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vdash")
 
 def latex_rule444(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartriangleright")
 
 def latex_rule445(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartriangleleft")
 
 def latex_rule446(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartriangle")
 
 def latex_rule447(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartheta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartheta")
 
 def latex_rule448(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsupsetneqq")
 
 def latex_rule449(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsupsetneq")
 
 def latex_rule450(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsubsetneqq")
 
 def latex_rule451(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsubsetneq")
 
 def latex_rule452(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsigma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsigma")
 
 def latex_rule453(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varrho")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varrho")
 
 def latex_rule454(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpropto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varpropto")
 
 def latex_rule455(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varpi")
 
 def latex_rule456(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varphi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varphi")
 
 def latex_rule457(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varnothing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varnothing")
 
 def latex_rule458(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varkappa")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varkappa")
 
 def latex_rule459(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varepsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varepsilon")
 
 def latex_rule460(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vDash")
 
 def latex_rule461(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\urcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\urcorner")
 
 def latex_rule462(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upuparrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upuparrows")
 
 def latex_rule463(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upsilon")
 
 def latex_rule464(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\uplus")
 
 def latex_rule465(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upharpoonright")
 
 def latex_rule466(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upharpoonleft")
 
 def latex_rule467(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\updownarrow")
 
 def latex_rule468(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\uparrow")
 
 def latex_rule469(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ulcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ulcorner")
 
 def latex_rule470(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow")
 
 def latex_rule471(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow")
 
 def latex_rule472(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglerighteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\trianglerighteq")
 
 def latex_rule473(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangleright")
 
 def latex_rule474(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangleq")
 
 def latex_rule475(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglelefteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\trianglelefteq")
 
 def latex_rule476(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangleleft")
 
 def latex_rule477(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangledown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangledown")
 
 def latex_rule478(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangle")
 
 def latex_rule479(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\top")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\top")
 
 def latex_rule480(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\times")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\times")
 
 def latex_rule481(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\tilde{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\tilde{")
 
 def latex_rule482(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicksim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thicksim")
 
 def latex_rule483(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thickapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thickapprox")
 
 def latex_rule484(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\theta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\theta")
 
 def latex_rule485(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\therefore")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\therefore")
 
 def latex_rule486(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\text{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\text{")
 
 def latex_rule487(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\textstyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\textstyle")
 
 def latex_rule488(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tau")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tau")
 
 def latex_rule489(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tanh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tanh")
 
 def latex_rule490(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tan")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tan")
 
 def latex_rule491(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\swarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\swarrow")
 
 def latex_rule492(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\surd")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\surd")
 
 def latex_rule493(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supsetneqq")
 
 def latex_rule494(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supsetneq")
 
 def latex_rule495(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supseteqq")
 
 def latex_rule496(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supseteq")
 
 def latex_rule497(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supset")
 
 def latex_rule498(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sum")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sum")
 
 def latex_rule499(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succsim")
 
 def latex_rule500(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succnsim")
 
 def latex_rule501(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succnapprox")
 
 def latex_rule502(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succeq")
 
 def latex_rule503(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succcurlyeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succcurlyeq")
 
 def latex_rule504(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succapprox")
 
 def latex_rule505(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succ")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succ")
 
 def latex_rule506(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subsetneqq")
 
 def latex_rule507(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subsetneq")
 
 def latex_rule508(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subseteqq")
 
 def latex_rule509(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subseteq")
 
 def latex_rule510(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subset")
 
 def latex_rule511(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\star")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\star")
 
 def latex_rule512(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stackrel{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stackrel{")
 
 def latex_rule513(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\square")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\square")
 
 def latex_rule514(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsupseteq")
 
 def latex_rule515(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsupset")
 
 def latex_rule516(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsubseteq")
 
 def latex_rule517(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsubset")
 
 def latex_rule518(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sqrt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\sqrt{")
 
 def latex_rule519(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqcup")
 
 def latex_rule520(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqcap")
 
 def latex_rule521(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sphericalangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sphericalangle")
 
 def latex_rule522(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\spadesuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\spadesuit")
 
 def latex_rule523(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smile")
 
 def latex_rule524(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsmile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallsmile")
 
 def latex_rule525(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsetminus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallsetminus")
 
 def latex_rule526(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallfrown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallfrown")
 
 def latex_rule527(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sinh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sinh")
 
 def latex_rule528(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sin")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sin")
 
 def latex_rule529(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\simeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\simeq")
 
 def latex_rule530(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sim")
 
 def latex_rule531(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sigma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sigma")
 
 def latex_rule532(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortparallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\shortparallel")
 
 def latex_rule533(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortmid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\shortmid")
 
 def latex_rule534(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sharp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sharp")
 
 def latex_rule535(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\setminus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\setminus")
 
 def latex_rule536(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sec")
 
 def latex_rule537(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\searrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\searrow")
 
 def latex_rule538(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptstyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptstyle")
 
 def latex_rule539(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle")
 
 def latex_rule540(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rtimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rtimes")
 
 def latex_rule541(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\risingdotseq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\risingdotseq")
 
 def latex_rule542(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right|")
 
 def latex_rule543(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightthreetimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightthreetimes")
 
 def latex_rule544(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightsquigarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightsquigarrow")
 
 def latex_rule545(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule546(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule547(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule548(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule549(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightleftarrows")
 
 def latex_rule550(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoonup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightharpoonup")
 
 def latex_rule551(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoondown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightharpoondown")
 
 def latex_rule552(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrowtail")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightarrowtail")
 
 def latex_rule553(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightarrow")
 
 def latex_rule554(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right]")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right]")
 
 def latex_rule555(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\|")
 
 def latex_rule556(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\updownarrow")
 
 def latex_rule557(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\uparrow")
 
 def latex_rule558(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\rfloor")
 
 def latex_rule559(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\rceil")
 
 def latex_rule560(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\rangle")
 
 def latex_rule561(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\lfloor")
 
 def latex_rule562(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\lceil")
 
 def latex_rule563(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\langle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\langle")
 
 def latex_rule564(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\downarrow")
 
 def latex_rule565(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\backslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\backslash")
 
 def latex_rule566(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow")
 
 def latex_rule567(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\Uparrow")
 
 def latex_rule568(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\Downarrow")
 
 def latex_rule569(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\)")
 
 def latex_rule570(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\(")
 
 def latex_rule571(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\right[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\right[")
 
 def latex_rule572(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right/")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right/")
 
 def latex_rule573(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right)")
 
 def latex_rule574(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right(")
 
 def latex_rule575(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rho")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rho")
 
 def latex_rule576(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\psi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\psi")
 
 def latex_rule577(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\propto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\propto")
 
 def latex_rule578(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prod")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\prod")
 
 def latex_rule579(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prime")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\prime")
 
 def latex_rule580(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precsim")
 
 def latex_rule581(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precnsim")
 
 def latex_rule582(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precnapprox")
 
 def latex_rule583(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preceq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\preceq")
 
 def latex_rule584(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preccurlyeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\preccurlyeq")
 
 def latex_rule585(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precapprox")
 
 def latex_rule586(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\prec")
 
 def latex_rule587(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmod{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pmod{")
 
 def latex_rule588(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmb{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pmb{")
 
 def latex_rule589(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pm")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pm")
 
 def latex_rule590(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pitchfork")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pitchfork")
 
 def latex_rule591(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pi")
 
 def latex_rule592(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\phi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\phi")
 
 def latex_rule593(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\perp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\perp")
 
 def latex_rule594(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\partial")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\partial")
 
 def latex_rule595(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\parallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\parallel")
 
 def latex_rule596(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\overline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\overline{")
 
 def latex_rule597(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\otimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\otimes")
 
 def latex_rule598(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oslash")
 
 def latex_rule599(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oplus")
 
 def latex_rule600(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ominus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ominus")
 
 def latex_rule601(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\omega")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\omega")
 
 def latex_rule602(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oint")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oint")
 
 def latex_rule603(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\odot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\odot")
 
 def latex_rule604(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nwarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nwarrow")
 
 def latex_rule605(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nvdash")
 
 def latex_rule606(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule607(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule608(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nu")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nu")
 
 def latex_rule609(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq")
 
 def latex_rule610(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntriangleright")
 
 def latex_rule611(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq")
 
 def latex_rule612(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntriangleleft")
 
 def latex_rule613(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsupseteqq")
 
 def latex_rule614(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsupseteq")
 
 def latex_rule615(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucceq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsucceq")
 
 def latex_rule616(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsucc")
 
 def latex_rule617(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsubseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsubseteq")
 
 def latex_rule618(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsim")
 
 def latex_rule619(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortparallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nshortparallel")
 
 def latex_rule620(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortmid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nshortmid")
 
 def latex_rule621(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nrightarrow")
 
 def latex_rule622(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\npreceq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\npreceq")
 
 def latex_rule623(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nprec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nprec")
 
 def latex_rule624(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nparallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nparallel")
 
 def latex_rule625(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\notin")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\notin")
 
 def latex_rule626(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nmid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nmid")
 
 def latex_rule627(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nless")
 
 def latex_rule628(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleqslant")
 
 def latex_rule629(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleqq")
 
 def latex_rule630(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleq")
 
 def latex_rule631(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleftrightarrow")
 
 def latex_rule632(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleftarrow")
 
 def latex_rule633(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ni")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ni")
 
 def latex_rule634(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngtr")
 
 def latex_rule635(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngeqslant")
 
 def latex_rule636(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngeqq")
 
 def latex_rule637(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngeq")
 
 def latex_rule638(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nexists")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nexists")
 
 def latex_rule639(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\neq")
 
 def latex_rule640(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\neg")
 
 def latex_rule641(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nearrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nearrow")
 
 def latex_rule642(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ncong")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ncong")
 
 def latex_rule643(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\natural")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\natural")
 
 def latex_rule644(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nabla")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nabla")
 
 def latex_rule645(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nVDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nVDash")
 
 def latex_rule646(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nRightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nRightarrow")
 
 def latex_rule647(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow")
 
 def latex_rule648(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nLeftarrow")
 
 def latex_rule649(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\multimap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\multimap")
 
 def latex_rule650(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mu")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mu")
 
 def latex_rule651(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mp")
 
 def latex_rule652(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\models")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\models")
 
 def latex_rule653(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\min")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\min")
 
 def latex_rule654(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mid")
 
 def latex_rule655(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mho")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mho")
 
 def latex_rule656(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\measuredangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\measuredangle")
 
 def latex_rule657(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\max")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\max")
 
 def latex_rule658(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathtt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathtt{")
 
 def latex_rule659(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathsf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathsf{")
 
 def latex_rule660(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mathrm{~~")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mathrm{~~")
 
 def latex_rule661(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathit{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathit{")
 
 def latex_rule662(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathcal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathcal{")
 
 def latex_rule663(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathbf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathbf{")
 
 def latex_rule664(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mapsto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mapsto")
 
 def latex_rule665(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lvertneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lvertneqq")
 
 def latex_rule666(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ltimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ltimes")
 
 def latex_rule667(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lrcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lrcorner")
 
 def latex_rule668(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lozenge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lozenge")
 
 def latex_rule669(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\looparrowright")
 
 def latex_rule670(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\looparrowleft")
 
 def latex_rule671(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longrightarrow")
 
 def latex_rule672(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longmapsto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longmapsto")
 
 def latex_rule673(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longleftrightarrow")
 
 def latex_rule674(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longleftarrow")
 
 def latex_rule675(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\log")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\log")
 
 def latex_rule676(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lnsim")
 
 def latex_rule677(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lneqq")
 
 def latex_rule678(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lneq")
 
 def latex_rule679(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lnapprox")
 
 def latex_rule680(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ln")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ln")
 
 def latex_rule681(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lll")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lll")
 
 def latex_rule682(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\llcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\llcorner")
 
 def latex_rule683(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ll")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ll")
 
 def latex_rule684(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\limsup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\limsup")
 
 def latex_rule685(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\liminf")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\liminf")
 
 def latex_rule686(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lim")
 
 def latex_rule687(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lg")
 
 def latex_rule688(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesssim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lesssim")
 
 def latex_rule689(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lessgtr")
 
 def latex_rule690(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqqgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lesseqqgtr")
 
 def latex_rule691(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lesseqgtr")
 
 def latex_rule692(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lessdot")
 
 def latex_rule693(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lessapprox")
 
 def latex_rule694(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leqslant")
 
 def latex_rule695(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leqq")
 
 def latex_rule696(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leq")
 
 def latex_rule697(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left|")
 
 def latex_rule698(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftthreetimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftthreetimes")
 
 def latex_rule699(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow")
 
 def latex_rule700(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightharpoons")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightharpoons")
 
 def latex_rule701(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightarrows")
 
 def latex_rule702(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightarrow")
 
 def latex_rule703(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftleftarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftleftarrows")
 
 def latex_rule704(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoonup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftharpoonup")
 
 def latex_rule705(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoondown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftharpoondown")
 
 def latex_rule706(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lefteqn{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\lefteqn{")
 
 def latex_rule707(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrowtail")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftarrowtail")
 
 def latex_rule708(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftarrow")
 
 def latex_rule709(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left]")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left]")
 
 def latex_rule710(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\|")
 
 def latex_rule711(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\updownarrow")
 
 def latex_rule712(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\uparrow")
 
 def latex_rule713(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\rfloor")
 
 def latex_rule714(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\rceil")
 
 def latex_rule715(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\rangle")
 
 def latex_rule716(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\lfloor")
 
 def latex_rule717(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\lceil")
 
 def latex_rule718(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\langle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\langle")
 
 def latex_rule719(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\downarrow")
 
 def latex_rule720(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\backslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\backslash")
 
 def latex_rule721(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow")
 
 def latex_rule722(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\Uparrow")
 
 def latex_rule723(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\Downarrow")
 
 def latex_rule724(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\)")
 
 def latex_rule725(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\(")
 
 def latex_rule726(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\left[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\left[")
 
 def latex_rule727(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left/")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left/")
 
 def latex_rule728(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left)")
 
 def latex_rule729(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left(")
 
 def latex_rule730(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ldots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ldots")
 
 def latex_rule731(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lambda")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lambda")
 
 def latex_rule732(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ker")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ker")
 
 def latex_rule733(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\kappa")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\kappa")
 
 def latex_rule734(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule735(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule736(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\iota")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\iota")
 
 def latex_rule737(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\intercal")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\intercal")
 
 def latex_rule738(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\int")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\int")
 
 def latex_rule739(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\infty")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\infty")
 
 def latex_rule740(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\inf")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\inf")
 
 def latex_rule741(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\in")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\in")
 
 def latex_rule742(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule743(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule744(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hslash")
 
 def latex_rule745(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hookrightarrow")
 
 def latex_rule746(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hookleftarrow")
 
 def latex_rule747(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hom")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hom")
 
 def latex_rule748(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\heartsuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\heartsuit")
 
 def latex_rule749(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hbar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hbar")
 
 def latex_rule750(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hat{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hat{")
 
 def latex_rule751(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gvertneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gvertneqq")
 
 def latex_rule752(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrsim")
 
 def latex_rule753(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrless")
 
 def latex_rule754(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqqless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtreqqless")
 
 def latex_rule755(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtreqless")
 
 def latex_rule756(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrdot")
 
 def latex_rule757(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrapprox")
 
 def latex_rule758(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\grave{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\grave{")
 
 def latex_rule759(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gnsim")
 
 def latex_rule760(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gneqq")
 
 def latex_rule761(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gneq")
 
 def latex_rule762(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule763(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule764(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gimel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gimel")
 
 def latex_rule765(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ggg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ggg")
 
 def latex_rule766(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gg")
 
 def latex_rule767(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\geqslant")
 
 def latex_rule768(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\geqq")
 
 def latex_rule769(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\geq")
 
 def latex_rule770(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gcd")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gcd")
 
 def latex_rule771(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gamma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gamma")
 
 def latex_rule772(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\frown")
 
 def latex_rule773(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frak{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\frak{")
 
 def latex_rule774(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frac{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\frac{")
 
 def latex_rule775(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\forall")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\forall")
 
 def latex_rule776(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\flat")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\flat")
 
 def latex_rule777(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fallingdotseq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fallingdotseq")
 
 def latex_rule778(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\exp")
 
 def latex_rule779(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exists")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\exists")
 
 def latex_rule780(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eth")
 
 def latex_rule781(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eta")
 
 def latex_rule782(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\equiv")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\equiv")
 
 def latex_rule783(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eqslantless")
 
 def latex_rule784(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eqslantgtr")
 
 def latex_rule785(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqcirc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eqcirc")
 
 def latex_rule786(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\epsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\epsilon")
 
 def latex_rule787(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule788(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule789(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\emptyset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\emptyset")
 
 def latex_rule790(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ell")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ell")
 
 def latex_rule791(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downharpoonright")
 
 def latex_rule792(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downharpoonleft")
 
 def latex_rule793(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downdownarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downdownarrows")
 
 def latex_rule794(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downarrow")
 
 def latex_rule795(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doublebarwedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\doublebarwedge")
 
 def latex_rule796(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\dot{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\dot{")
 
 def latex_rule797(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dotplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dotplus")
 
 def latex_rule798(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteqdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\doteqdot")
 
 def latex_rule799(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\doteq")
 
 def latex_rule800(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\divideontimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\divideontimes")
 
 def latex_rule801(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\div")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\div")
 
 def latex_rule802(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\displaystyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\displaystyle")
 
 def latex_rule803(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dim")
 
 def latex_rule804(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\digamma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\digamma")
 
 def latex_rule805(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamondsuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diamondsuit")
 
 def latex_rule806(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamond")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diamond")
 
 def latex_rule807(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diagup")
 
 def latex_rule808(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagdown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diagdown")
 
 def latex_rule809(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\det")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\det")
 
 def latex_rule810(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\delta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\delta")
 
 def latex_rule811(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\deg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\deg")
 
 def latex_rule812(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ddot{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ddot{")
 
 def latex_rule813(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddots")
 
 def latex_rule814(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddagger")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddagger")
 
 def latex_rule815(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashv")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dashv")
 
 def latex_rule816(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dashrightarrow")
 
 def latex_rule817(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dashleftarrow")
 
 def latex_rule818(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\daleth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\daleth")
 
 def latex_rule819(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dagger")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dagger")
 
 def latex_rule820(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curvearrowright")
 
 def latex_rule821(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curvearrowleft")
 
 def latex_rule822(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlywedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlywedge")
 
 def latex_rule823(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyvee")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlyvee")
 
 def latex_rule824(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqsucc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlyeqsucc")
 
 def latex_rule825(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqprec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlyeqprec")
 
 def latex_rule826(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cup")
 
 def latex_rule827(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\csc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\csc")
 
 def latex_rule828(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\coth")
 
 def latex_rule829(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cot")
 
 def latex_rule830(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cosh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cosh")
 
 def latex_rule831(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cos")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cos")
 
 def latex_rule832(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coprod")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\coprod")
 
 def latex_rule833(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cong")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cong")
 
 def latex_rule834(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\complement")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\complement")
 
 def latex_rule835(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clubsuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\clubsuit")
 
 def latex_rule836(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circleddash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circleddash")
 
 def latex_rule837(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledcirc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circledcirc")
 
 def latex_rule838(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledast")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circledast")
 
 def latex_rule839(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledS")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circledS")
 
 def latex_rule840(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circlearrowright")
 
 def latex_rule841(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circlearrowleft")
 
 def latex_rule842(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circeq")
 
 def latex_rule843(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circ")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circ")
 
 def latex_rule844(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\chi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\chi")
 
 def latex_rule845(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\check{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\check{")
 
 def latex_rule846(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centerdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\centerdot")
 
 def latex_rule847(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cdots")
 
 def latex_rule848(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cdot")
 
 def latex_rule849(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cap")
 
 def latex_rule850(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bumpeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bumpeq")
 
 def latex_rule851(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bullet")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bullet")
 
 def latex_rule852(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\breve{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\breve{")
 
 def latex_rule853(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxtimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxtimes")
 
 def latex_rule854(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxplus")
 
 def latex_rule855(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxminus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxminus")
 
 def latex_rule856(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxdot")
 
 def latex_rule857(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bowtie")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bowtie")
 
 def latex_rule858(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bot")
 
 def latex_rule859(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldsymbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boldsymbol{")
 
 def latex_rule860(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bmod")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bmod")
 
 def latex_rule861(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangleright")
 
 def latex_rule862(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangleleft")
 
 def latex_rule863(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangledown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangledown")
 
 def latex_rule864(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangle")
 
 def latex_rule865(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacksquare")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacksquare")
 
 def latex_rule866(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacklozenge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacklozenge")
 
 def latex_rule867(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigwedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigwedge")
 
 def latex_rule868(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigvee")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigvee")
 
 def latex_rule869(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\biguplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\biguplus")
 
 def latex_rule870(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangleup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigtriangleup")
 
 def latex_rule871(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangledown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigtriangledown")
 
 def latex_rule872(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigstar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigstar")
 
 def latex_rule873(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigsqcup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigsqcup")
 
 def latex_rule874(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigotimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigotimes")
 
 def latex_rule875(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigoplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigoplus")
 
 def latex_rule876(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigodot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigodot")
 
 def latex_rule877(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigcup")
 
 def latex_rule878(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcirc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigcirc")
 
 def latex_rule879(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigcap")
 
 def latex_rule880(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\between")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\between")
 
 def latex_rule881(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\beth")
 
 def latex_rule882(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\beta")
 
 def latex_rule883(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule884(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\because")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\because")
 
 def latex_rule885(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bar{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bar{")
 
 def latex_rule886(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\barwedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\barwedge")
 
 def latex_rule887(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backslash")
 
 def latex_rule888(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsimeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backsimeq")
 
 def latex_rule889(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backsim")
 
 def latex_rule890(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backprime")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backprime")
 
 def latex_rule891(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\asymp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\asymp")
 
 def latex_rule892(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ast")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ast")
 
 def latex_rule893(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arg")
 
 def latex_rule894(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arctan")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arctan")
 
 def latex_rule895(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arcsin")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arcsin")
 
 def latex_rule896(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arccos")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arccos")
 
 def latex_rule897(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approxeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\approxeq")
 
 def latex_rule898(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approx")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\approx")
 
 def latex_rule899(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule900(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule901(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\amalg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\amalg")
 
 def latex_rule902(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\alpha")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\alpha")
 
 def latex_rule903(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\aleph")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\aleph")
 
 def latex_rule904(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\acute{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\acute{")
 
 def latex_rule905(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Xi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Xi")
 
 def latex_rule906(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vvdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Vvdash")
 
 def latex_rule907(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Vdash")
 
 def latex_rule908(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Upsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Upsilon")
 
 def latex_rule909(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Updownarrow")
 
 def latex_rule910(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Uparrow")
 
 def latex_rule911(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Theta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Theta")
 
 def latex_rule912(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Supset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Supset")
 
 def latex_rule913(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Subset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Subset")
 
 def latex_rule914(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Sigma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Sigma")
 
 def latex_rule915(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rsh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Rsh")
 
 def latex_rule916(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Rightarrow")
 
 def latex_rule917(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Re")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Re")
 
 def latex_rule918(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Psi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Psi")
 
 def latex_rule919(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Pr")
 
 def latex_rule920(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Pi")
 
 def latex_rule921(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Phi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Phi")
 
 def latex_rule922(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Omega")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Omega")
 
 def latex_rule923(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lsh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Lsh")
 
 def latex_rule924(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Longrightarrow")
 
 def latex_rule925(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow")
 
 def latex_rule926(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Longleftarrow")
 
 def latex_rule927(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Lleftarrow")
 
 def latex_rule928(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Leftrightarrow")
 
 def latex_rule929(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Leftarrow")
 
 def latex_rule930(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lambda")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Lambda")
 
 def latex_rule931(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Im")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Im")
 
 def latex_rule932(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Gamma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Gamma")
 
 def latex_rule933(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Game")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Game")
 
 def latex_rule934(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Finv")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Finv")
 
 def latex_rule935(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Downarrow")
 
 def latex_rule936(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Delta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Delta")
 
 def latex_rule937(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Cup")
 
 def latex_rule938(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Cap")
 
 def latex_rule939(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bumpeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Bumpeq")
 
 def latex_rule940(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Bbb{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Bbb{")
 
 def latex_rule941(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bbbk")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Bbbk")
 
 def latex_rule942(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\;")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\;")
 
 def latex_rule943(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\:")
 
 def latex_rule944(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule945(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\!")
 
 def latex_rule946(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="'")
 
 def latex_rule947(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="\\begin{array}", end="\\end{array}",
@@ -3003,1576 +3003,1576 @@ rulesDict2 = {
 # Rules for latex_arraymode ruleset.
 
 def latex_rule949(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__ArrayMode__")
+    return colorer.match_plain_seq(s, i, kind="label", seq="__ArrayMode__")
 
 def latex_rule950(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule951(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def latex_rule952(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def latex_rule953(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\zeta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\zeta")
 
 def latex_rule954(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\xi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\xi")
 
 def latex_rule955(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\wr")
 
 def latex_rule956(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\wp")
 
 def latex_rule957(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widetilde{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\widetilde{")
 
 def latex_rule958(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\widehat{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\widehat{")
 
 def latex_rule959(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\wedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\wedge")
 
 def latex_rule960(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vline")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vline")
 
 def latex_rule961(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\veebar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\veebar")
 
 def latex_rule962(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vee")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vee")
 
 def latex_rule963(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vec{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vec{")
 
 def latex_rule964(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vdots")
 
 def latex_rule965(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vdash")
 
 def latex_rule966(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartriangleright")
 
 def latex_rule967(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartriangleleft")
 
 def latex_rule968(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartriangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartriangle")
 
 def latex_rule969(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vartheta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vartheta")
 
 def latex_rule970(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsupsetneqq")
 
 def latex_rule971(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsupsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsupsetneq")
 
 def latex_rule972(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsubsetneqq")
 
 def latex_rule973(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsubsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsubsetneq")
 
 def latex_rule974(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varsigma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varsigma")
 
 def latex_rule975(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varrho")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varrho")
 
 def latex_rule976(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpropto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varpropto")
 
 def latex_rule977(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varpi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varpi")
 
 def latex_rule978(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varphi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varphi")
 
 def latex_rule979(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varnothing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varnothing")
 
 def latex_rule980(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varkappa")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varkappa")
 
 def latex_rule981(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\varepsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\varepsilon")
 
 def latex_rule982(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vDash")
 
 def latex_rule983(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\urcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\urcorner")
 
 def latex_rule984(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upuparrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upuparrows")
 
 def latex_rule985(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upsilon")
 
 def latex_rule986(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\uplus")
 
 def latex_rule987(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upharpoonright")
 
 def latex_rule988(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upharpoonleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upharpoonleft")
 
 def latex_rule989(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\updownarrow")
 
 def latex_rule990(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\uparrow")
 
 def latex_rule991(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ulcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ulcorner")
 
 def latex_rule992(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twoheadrightarrow")
 
 def latex_rule993(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twoheadleftarrow")
 
 def latex_rule994(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglerighteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\trianglerighteq")
 
 def latex_rule995(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangleright")
 
 def latex_rule996(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangleq")
 
 def latex_rule997(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\trianglelefteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\trianglelefteq")
 
 def latex_rule998(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangleleft")
 
 def latex_rule999(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangledown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangledown")
 
 def latex_rule1000(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\triangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\triangle")
 
 def latex_rule1001(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\top")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\top")
 
 def latex_rule1002(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\times")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\times")
 
 def latex_rule1003(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\tilde{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\tilde{")
 
 def latex_rule1004(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicksim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thicksim")
 
 def latex_rule1005(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thickapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thickapprox")
 
 def latex_rule1006(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\theta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\theta")
 
 def latex_rule1007(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\therefore")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\therefore")
 
 def latex_rule1008(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\text{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\text{")
 
 def latex_rule1009(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\textstyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\textstyle")
 
 def latex_rule1010(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tau")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tau")
 
 def latex_rule1011(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tanh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tanh")
 
 def latex_rule1012(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tan")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tan")
 
 def latex_rule1013(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\swarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\swarrow")
 
 def latex_rule1014(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\surd")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\surd")
 
 def latex_rule1015(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supsetneqq")
 
 def latex_rule1016(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supsetneq")
 
 def latex_rule1017(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supseteqq")
 
 def latex_rule1018(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supseteq")
 
 def latex_rule1019(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\supset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\supset")
 
 def latex_rule1020(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sum")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sum")
 
 def latex_rule1021(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succsim")
 
 def latex_rule1022(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succnsim")
 
 def latex_rule1023(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succnapprox")
 
 def latex_rule1024(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succeq")
 
 def latex_rule1025(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succcurlyeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succcurlyeq")
 
 def latex_rule1026(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succapprox")
 
 def latex_rule1027(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\succ")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\succ")
 
 def latex_rule1028(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subsetneqq")
 
 def latex_rule1029(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subsetneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subsetneq")
 
 def latex_rule1030(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subseteqq")
 
 def latex_rule1031(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subseteq")
 
 def latex_rule1032(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\subset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\subset")
 
 def latex_rule1033(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\star")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\star")
 
 def latex_rule1034(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stackrel{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stackrel{")
 
 def latex_rule1035(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\square")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\square")
 
 def latex_rule1036(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsupseteq")
 
 def latex_rule1037(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsupset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsupset")
 
 def latex_rule1038(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsubseteq")
 
 def latex_rule1039(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqsubset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqsubset")
 
 def latex_rule1040(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sqrt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\sqrt{")
 
 def latex_rule1041(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqcup")
 
 def latex_rule1042(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sqcap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sqcap")
 
 def latex_rule1043(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sphericalangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sphericalangle")
 
 def latex_rule1044(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\spadesuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\spadesuit")
 
 def latex_rule1045(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smile")
 
 def latex_rule1046(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsmile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallsmile")
 
 def latex_rule1047(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallsetminus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallsetminus")
 
 def latex_rule1048(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallfrown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallfrown")
 
 def latex_rule1049(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sinh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sinh")
 
 def latex_rule1050(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sin")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sin")
 
 def latex_rule1051(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\simeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\simeq")
 
 def latex_rule1052(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sim")
 
 def latex_rule1053(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sigma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sigma")
 
 def latex_rule1054(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortparallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\shortparallel")
 
 def latex_rule1055(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\shortmid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\shortmid")
 
 def latex_rule1056(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sharp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sharp")
 
 def latex_rule1057(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\setminus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\setminus")
 
 def latex_rule1058(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sec")
 
 def latex_rule1059(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\searrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\searrow")
 
 def latex_rule1060(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptstyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptstyle")
 
 def latex_rule1061(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptscriptstyle")
 
 def latex_rule1062(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rtimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rtimes")
 
 def latex_rule1063(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\risingdotseq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\risingdotseq")
 
 def latex_rule1064(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right|")
 
 def latex_rule1065(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightthreetimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightthreetimes")
 
 def latex_rule1066(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightsquigarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightsquigarrow")
 
 def latex_rule1067(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule1068(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightrightarrows")
 
 def latex_rule1069(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule1070(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightleftharpoons")
 
 def latex_rule1071(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightleftarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightleftarrows")
 
 def latex_rule1072(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoonup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightharpoonup")
 
 def latex_rule1073(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightharpoondown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightharpoondown")
 
 def latex_rule1074(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrowtail")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightarrowtail")
 
 def latex_rule1075(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rightarrow")
 
 def latex_rule1076(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right]")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right]")
 
 def latex_rule1077(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\|")
 
 def latex_rule1078(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\updownarrow")
 
 def latex_rule1079(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\uparrow")
 
 def latex_rule1080(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\rfloor")
 
 def latex_rule1081(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\rceil")
 
 def latex_rule1082(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\rangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\rangle")
 
 def latex_rule1083(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\lfloor")
 
 def latex_rule1084(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\lceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\lceil")
 
 def latex_rule1085(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\langle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\langle")
 
 def latex_rule1086(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\downarrow")
 
 def latex_rule1087(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\backslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\backslash")
 
 def latex_rule1088(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\Updownarrow")
 
 def latex_rule1089(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\Uparrow")
 
 def latex_rule1090(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\Downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\Downarrow")
 
 def latex_rule1091(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\)")
 
 def latex_rule1092(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right\\(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right\\(")
 
 def latex_rule1093(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\right[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\right[")
 
 def latex_rule1094(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right/")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right/")
 
 def latex_rule1095(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right)")
 
 def latex_rule1096(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\right(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\right(")
 
 def latex_rule1097(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rho")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rho")
 
 def latex_rule1098(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\psi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\psi")
 
 def latex_rule1099(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\propto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\propto")
 
 def latex_rule1100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prod")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\prod")
 
 def latex_rule1101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prime")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\prime")
 
 def latex_rule1102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precsim")
 
 def latex_rule1103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precnsim")
 
 def latex_rule1104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precnapprox")
 
 def latex_rule1105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preceq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\preceq")
 
 def latex_rule1106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\preccurlyeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\preccurlyeq")
 
 def latex_rule1107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\precapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\precapprox")
 
 def latex_rule1108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\prec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\prec")
 
 def latex_rule1109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmod{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pmod{")
 
 def latex_rule1110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pmb{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pmb{")
 
 def latex_rule1111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pm")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pm")
 
 def latex_rule1112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pitchfork")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pitchfork")
 
 def latex_rule1113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pi")
 
 def latex_rule1114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\phi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\phi")
 
 def latex_rule1115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\perp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\perp")
 
 def latex_rule1116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\partial")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\partial")
 
 def latex_rule1117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\parallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\parallel")
 
 def latex_rule1118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\overline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\overline{")
 
 def latex_rule1119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\otimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\otimes")
 
 def latex_rule1120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oslash")
 
 def latex_rule1121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oplus")
 
 def latex_rule1122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ominus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ominus")
 
 def latex_rule1123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\omega")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\omega")
 
 def latex_rule1124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oint")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oint")
 
 def latex_rule1125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\odot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\odot")
 
 def latex_rule1126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nwarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nwarrow")
 
 def latex_rule1127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nvdash")
 
 def latex_rule1128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule1129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nvDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nvDash")
 
 def latex_rule1130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nu")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nu")
 
 def latex_rule1131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntrianglerighteq")
 
 def latex_rule1132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntriangleright")
 
 def latex_rule1133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntrianglelefteq")
 
 def latex_rule1134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ntriangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ntriangleleft")
 
 def latex_rule1135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsupseteqq")
 
 def latex_rule1136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsupseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsupseteq")
 
 def latex_rule1137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucceq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsucceq")
 
 def latex_rule1138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsucc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsucc")
 
 def latex_rule1139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsubseteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsubseteq")
 
 def latex_rule1140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nsim")
 
 def latex_rule1141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortparallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nshortparallel")
 
 def latex_rule1142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nshortmid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nshortmid")
 
 def latex_rule1143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nrightarrow")
 
 def latex_rule1144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\npreceq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\npreceq")
 
 def latex_rule1145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nprec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nprec")
 
 def latex_rule1146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nparallel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nparallel")
 
 def latex_rule1147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\notin")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\notin")
 
 def latex_rule1148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nmid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nmid")
 
 def latex_rule1149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nless")
 
 def latex_rule1150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleqslant")
 
 def latex_rule1151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleqq")
 
 def latex_rule1152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleq")
 
 def latex_rule1153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleftrightarrow")
 
 def latex_rule1154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nleftarrow")
 
 def latex_rule1155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ni")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ni")
 
 def latex_rule1156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngtr")
 
 def latex_rule1157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngeqslant")
 
 def latex_rule1158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngeqq")
 
 def latex_rule1159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ngeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ngeq")
 
 def latex_rule1160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nexists")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nexists")
 
 def latex_rule1161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\neq")
 
 def latex_rule1162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\neg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\neg")
 
 def latex_rule1163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nearrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nearrow")
 
 def latex_rule1164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ncong")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ncong")
 
 def latex_rule1165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\natural")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\natural")
 
 def latex_rule1166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nabla")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nabla")
 
 def latex_rule1167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nVDash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nVDash")
 
 def latex_rule1168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nRightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nRightarrow")
 
 def latex_rule1169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nLeftrightarrow")
 
 def latex_rule1170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nLeftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nLeftarrow")
 
 def latex_rule1171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\multimap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\multimap")
 
 def latex_rule1172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\multicolumn{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\multicolumn{")
 
 def latex_rule1173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mu")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mu")
 
 def latex_rule1174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mp")
 
 def latex_rule1175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\models")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\models")
 
 def latex_rule1176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\min")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\min")
 
 def latex_rule1177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mid")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mid")
 
 def latex_rule1178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mho")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mho")
 
 def latex_rule1179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\measuredangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\measuredangle")
 
 def latex_rule1180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\max")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\max")
 
 def latex_rule1181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathtt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathtt{")
 
 def latex_rule1182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathsf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathsf{")
 
 def latex_rule1183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mathrm{~~")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mathrm{~~")
 
 def latex_rule1184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathit{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathit{")
 
 def latex_rule1185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathcal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathcal{")
 
 def latex_rule1186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mathbf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mathbf{")
 
 def latex_rule1187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mapsto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mapsto")
 
 def latex_rule1188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lvertneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lvertneqq")
 
 def latex_rule1189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ltimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ltimes")
 
 def latex_rule1190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lrcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lrcorner")
 
 def latex_rule1191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lozenge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lozenge")
 
 def latex_rule1192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\looparrowright")
 
 def latex_rule1193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\looparrowleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\looparrowleft")
 
 def latex_rule1194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longrightarrow")
 
 def latex_rule1195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longmapsto")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longmapsto")
 
 def latex_rule1196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longleftrightarrow")
 
 def latex_rule1197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\longleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\longleftarrow")
 
 def latex_rule1198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\log")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\log")
 
 def latex_rule1199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lnsim")
 
 def latex_rule1200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lneqq")
 
 def latex_rule1201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lneq")
 
 def latex_rule1202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lnapprox")
 
 def latex_rule1203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ln")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ln")
 
 def latex_rule1204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lll")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lll")
 
 def latex_rule1205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\llcorner")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\llcorner")
 
 def latex_rule1206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ll")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ll")
 
 def latex_rule1207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\limsup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\limsup")
 
 def latex_rule1208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\liminf")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\liminf")
 
 def latex_rule1209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lim")
 
 def latex_rule1210(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lg")
 
 def latex_rule1211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesssim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lesssim")
 
 def latex_rule1212(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lessgtr")
 
 def latex_rule1213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqqgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lesseqqgtr")
 
 def latex_rule1214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lesseqgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lesseqgtr")
 
 def latex_rule1215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lessdot")
 
 def latex_rule1216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lessapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lessapprox")
 
 def latex_rule1217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leqslant")
 
 def latex_rule1218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leqq")
 
 def latex_rule1219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leq")
 
 def latex_rule1220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left|")
 
 def latex_rule1221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftthreetimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftthreetimes")
 
 def latex_rule1222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightsquigarrow")
 
 def latex_rule1223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightharpoons")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightharpoons")
 
 def latex_rule1224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightarrows")
 
 def latex_rule1225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftrightarrow")
 
 def latex_rule1226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftleftarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftleftarrows")
 
 def latex_rule1227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoonup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftharpoonup")
 
 def latex_rule1228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftharpoondown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftharpoondown")
 
 def latex_rule1229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lefteqn{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\lefteqn{")
 
 def latex_rule1230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrowtail")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftarrowtail")
 
 def latex_rule1231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\leftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\leftarrow")
 
 def latex_rule1232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left]")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left]")
 
 def latex_rule1233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\|")
 
 def latex_rule1234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\updownarrow")
 
 def latex_rule1235(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\uparrow")
 
 def latex_rule1236(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\rfloor")
 
 def latex_rule1237(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\rceil")
 
 def latex_rule1238(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\rangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\rangle")
 
 def latex_rule1239(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lfloor")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\lfloor")
 
 def latex_rule1240(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\lceil")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\lceil")
 
 def latex_rule1241(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\langle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\langle")
 
 def latex_rule1242(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\downarrow")
 
 def latex_rule1243(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\backslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\backslash")
 
 def latex_rule1244(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\Updownarrow")
 
 def latex_rule1245(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\Uparrow")
 
 def latex_rule1246(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\Downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\Downarrow")
 
 def latex_rule1247(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\)")
 
 def latex_rule1248(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left\\(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left\\(")
 
 def latex_rule1249(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\left[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\left[")
 
 def latex_rule1250(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left/")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left/")
 
 def latex_rule1251(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left)")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left)")
 
 def latex_rule1252(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\left(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\left(")
 
 def latex_rule1253(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ldots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ldots")
 
 def latex_rule1254(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\lambda")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\lambda")
 
 def latex_rule1255(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ker")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ker")
 
 def latex_rule1256(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\kappa")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\kappa")
 
 def latex_rule1257(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule1258(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\jmath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\jmath")
 
 def latex_rule1259(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\iota")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\iota")
 
 def latex_rule1260(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\intercal")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\intercal")
 
 def latex_rule1261(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\int")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\int")
 
 def latex_rule1262(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\infty")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\infty")
 
 def latex_rule1263(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\inf")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\inf")
 
 def latex_rule1264(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\in")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\in")
 
 def latex_rule1265(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule1266(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\imath")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\imath")
 
 def latex_rule1267(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hslash")
 
 def latex_rule1268(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hookrightarrow")
 
 def latex_rule1269(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hookleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hookleftarrow")
 
 def latex_rule1270(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hom")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hom")
 
 def latex_rule1271(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hline")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hline")
 
 def latex_rule1272(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\heartsuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\heartsuit")
 
 def latex_rule1273(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hbar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hbar")
 
 def latex_rule1274(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hat{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hat{")
 
 def latex_rule1275(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gvertneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gvertneqq")
 
 def latex_rule1276(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrsim")
 
 def latex_rule1277(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrless")
 
 def latex_rule1278(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqqless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtreqqless")
 
 def latex_rule1279(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtreqless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtreqless")
 
 def latex_rule1280(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrdot")
 
 def latex_rule1281(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gtrapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gtrapprox")
 
 def latex_rule1282(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\grave{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\grave{")
 
 def latex_rule1283(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gnsim")
 
 def latex_rule1284(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gneqq")
 
 def latex_rule1285(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gneq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gneq")
 
 def latex_rule1286(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule1287(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gnapprox")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gnapprox")
 
 def latex_rule1288(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gimel")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gimel")
 
 def latex_rule1289(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ggg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ggg")
 
 def latex_rule1290(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gg")
 
 def latex_rule1291(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqslant")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\geqslant")
 
 def latex_rule1292(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geqq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\geqq")
 
 def latex_rule1293(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\geq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\geq")
 
 def latex_rule1294(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gcd")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gcd")
 
 def latex_rule1295(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\gamma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\gamma")
 
 def latex_rule1296(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\frown")
 
 def latex_rule1297(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frak{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\frak{")
 
 def latex_rule1298(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frac{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\frac{")
 
 def latex_rule1299(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\forall")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\forall")
 
 def latex_rule1300(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\flat")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\flat")
 
 def latex_rule1301(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fallingdotseq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fallingdotseq")
 
 def latex_rule1302(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\exp")
 
 def latex_rule1303(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\exists")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\exists")
 
 def latex_rule1304(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eth")
 
 def latex_rule1305(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eta")
 
 def latex_rule1306(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\equiv")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\equiv")
 
 def latex_rule1307(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantless")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eqslantless")
 
 def latex_rule1308(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqslantgtr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eqslantgtr")
 
 def latex_rule1309(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\eqcirc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\eqcirc")
 
 def latex_rule1310(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\epsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\epsilon")
 
 def latex_rule1311(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule1312(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule1313(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\emptyset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\emptyset")
 
 def latex_rule1314(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ell")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ell")
 
 def latex_rule1315(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downharpoonright")
 
 def latex_rule1316(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downharpoonleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downharpoonleft")
 
 def latex_rule1317(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downdownarrows")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downdownarrows")
 
 def latex_rule1318(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\downarrow")
 
 def latex_rule1319(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doublebarwedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\doublebarwedge")
 
 def latex_rule1320(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\dot{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\dot{")
 
 def latex_rule1321(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dotplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dotplus")
 
 def latex_rule1322(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteqdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\doteqdot")
 
 def latex_rule1323(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\doteq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\doteq")
 
 def latex_rule1324(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\divideontimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\divideontimes")
 
 def latex_rule1325(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\div")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\div")
 
 def latex_rule1326(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\displaystyle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\displaystyle")
 
 def latex_rule1327(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dim")
 
 def latex_rule1328(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\digamma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\digamma")
 
 def latex_rule1329(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamondsuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diamondsuit")
 
 def latex_rule1330(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diamond")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diamond")
 
 def latex_rule1331(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diagup")
 
 def latex_rule1332(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\diagdown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\diagdown")
 
 def latex_rule1333(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\det")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\det")
 
 def latex_rule1334(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\delta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\delta")
 
 def latex_rule1335(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\deg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\deg")
 
 def latex_rule1336(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ddot{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ddot{")
 
 def latex_rule1337(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddots")
 
 def latex_rule1338(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddagger")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddagger")
 
 def latex_rule1339(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashv")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dashv")
 
 def latex_rule1340(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dashrightarrow")
 
 def latex_rule1341(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dashleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dashleftarrow")
 
 def latex_rule1342(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\daleth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\daleth")
 
 def latex_rule1343(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dagger")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dagger")
 
 def latex_rule1344(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curvearrowright")
 
 def latex_rule1345(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curvearrowleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curvearrowleft")
 
 def latex_rule1346(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlywedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlywedge")
 
 def latex_rule1347(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyvee")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlyvee")
 
 def latex_rule1348(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqsucc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlyeqsucc")
 
 def latex_rule1349(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\curlyeqprec")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\curlyeqprec")
 
 def latex_rule1350(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cup")
 
 def latex_rule1351(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\csc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\csc")
 
 def latex_rule1352(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\coth")
 
 def latex_rule1353(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cot")
 
 def latex_rule1354(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cosh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cosh")
 
 def latex_rule1355(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cos")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cos")
 
 def latex_rule1356(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\coprod")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\coprod")
 
 def latex_rule1357(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cong")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cong")
 
 def latex_rule1358(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\complement")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\complement")
 
 def latex_rule1359(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clubsuit")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\clubsuit")
 
 def latex_rule1360(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cline{")
 
 def latex_rule1361(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circleddash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circleddash")
 
 def latex_rule1362(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledcirc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circledcirc")
 
 def latex_rule1363(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledast")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circledast")
 
 def latex_rule1364(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circledS")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circledS")
 
 def latex_rule1365(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circlearrowright")
 
 def latex_rule1366(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circlearrowleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circlearrowleft")
 
 def latex_rule1367(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circeq")
 
 def latex_rule1368(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\circ")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\circ")
 
 def latex_rule1369(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\chi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\chi")
 
 def latex_rule1370(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\check{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\check{")
 
 def latex_rule1371(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centerdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\centerdot")
 
 def latex_rule1372(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdots")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cdots")
 
 def latex_rule1373(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cdot")
 
 def latex_rule1374(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cap")
 
 def latex_rule1375(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bumpeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bumpeq")
 
 def latex_rule1376(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bullet")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bullet")
 
 def latex_rule1377(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\breve{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\breve{")
 
 def latex_rule1378(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxtimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxtimes")
 
 def latex_rule1379(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxplus")
 
 def latex_rule1380(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxminus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxminus")
 
 def latex_rule1381(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\boxdot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\boxdot")
 
 def latex_rule1382(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bowtie")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bowtie")
 
 def latex_rule1383(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bot")
 
 def latex_rule1384(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldsymbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boldsymbol{")
 
 def latex_rule1385(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bmod")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bmod")
 
 def latex_rule1386(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangleright")
 
 def latex_rule1387(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangleleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangleleft")
 
 def latex_rule1388(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangledown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangledown")
 
 def latex_rule1389(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacktriangle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacktriangle")
 
 def latex_rule1390(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacksquare")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacksquare")
 
 def latex_rule1391(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\blacklozenge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\blacklozenge")
 
 def latex_rule1392(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigwedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigwedge")
 
 def latex_rule1393(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigvee")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigvee")
 
 def latex_rule1394(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\biguplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\biguplus")
 
 def latex_rule1395(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangleup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigtriangleup")
 
 def latex_rule1396(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigtriangledown")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigtriangledown")
 
 def latex_rule1397(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigstar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigstar")
 
 def latex_rule1398(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigsqcup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigsqcup")
 
 def latex_rule1399(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigotimes")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigotimes")
 
 def latex_rule1400(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigoplus")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigoplus")
 
 def latex_rule1401(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigodot")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigodot")
 
 def latex_rule1402(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigcup")
 
 def latex_rule1403(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcirc")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigcirc")
 
 def latex_rule1404(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigcap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigcap")
 
 def latex_rule1405(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\between")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\between")
 
 def latex_rule1406(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\beth")
 
 def latex_rule1407(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\beta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\beta")
 
 def latex_rule1408(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule1409(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\because")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\because")
 
 def latex_rule1410(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bar{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bar{")
 
 def latex_rule1411(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\barwedge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\barwedge")
 
 def latex_rule1412(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backslash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backslash")
 
 def latex_rule1413(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsimeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backsimeq")
 
 def latex_rule1414(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backsim")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backsim")
 
 def latex_rule1415(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\backprime")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\backprime")
 
 def latex_rule1416(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\asymp")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\asymp")
 
 def latex_rule1417(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ast")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ast")
 
 def latex_rule1418(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arg")
 
 def latex_rule1419(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arctan")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arctan")
 
 def latex_rule1420(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arcsin")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arcsin")
 
 def latex_rule1421(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\arccos")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\arccos")
 
 def latex_rule1422(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approxeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\approxeq")
 
 def latex_rule1423(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\approx")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\approx")
 
 def latex_rule1424(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule1425(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\angle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\angle")
 
 def latex_rule1426(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\amalg")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\amalg")
 
 def latex_rule1427(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\alpha")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\alpha")
 
 def latex_rule1428(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\aleph")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\aleph")
 
 def latex_rule1429(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\acute{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\acute{")
 
 def latex_rule1430(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Xi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Xi")
 
 def latex_rule1431(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vvdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Vvdash")
 
 def latex_rule1432(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Vdash")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Vdash")
 
 def latex_rule1433(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Upsilon")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Upsilon")
 
 def latex_rule1434(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Updownarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Updownarrow")
 
 def latex_rule1435(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Uparrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Uparrow")
 
 def latex_rule1436(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Theta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Theta")
 
 def latex_rule1437(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Supset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Supset")
 
 def latex_rule1438(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Subset")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Subset")
 
 def latex_rule1439(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Sigma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Sigma")
 
 def latex_rule1440(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rsh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Rsh")
 
 def latex_rule1441(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Rightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Rightarrow")
 
 def latex_rule1442(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Re")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Re")
 
 def latex_rule1443(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Psi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Psi")
 
 def latex_rule1444(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pr")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Pr")
 
 def latex_rule1445(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Pi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Pi")
 
 def latex_rule1446(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Phi")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Phi")
 
 def latex_rule1447(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Omega")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Omega")
 
 def latex_rule1448(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lsh")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Lsh")
 
 def latex_rule1449(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Longrightarrow")
 
 def latex_rule1450(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Longleftrightarrow")
 
 def latex_rule1451(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Longleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Longleftarrow")
 
 def latex_rule1452(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lleftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Lleftarrow")
 
 def latex_rule1453(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftrightarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Leftrightarrow")
 
 def latex_rule1454(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Leftarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Leftarrow")
 
 def latex_rule1455(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Lambda")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Lambda")
 
 def latex_rule1456(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Im")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Im")
 
 def latex_rule1457(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Gamma")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Gamma")
 
 def latex_rule1458(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Game")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Game")
 
 def latex_rule1459(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Finv")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Finv")
 
 def latex_rule1460(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Downarrow")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Downarrow")
 
 def latex_rule1461(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Delta")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Delta")
 
 def latex_rule1462(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cup")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Cup")
 
 def latex_rule1463(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Cap")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Cap")
 
 def latex_rule1464(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bumpeq")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Bumpeq")
 
 def latex_rule1465(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Bbb{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Bbb{")
 
 def latex_rule1466(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Bbbk")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Bbbk")
 
 def latex_rule1467(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\;")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\;")
 
 def latex_rule1468(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\:")
 
 def latex_rule1469(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule1470(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\!")
 
 def latex_rule1471(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="'")
 
 def latex_rule1472(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def latex_rule1473(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
@@ -4590,7 +4590,7 @@ rulesDict3 = {
 # Rules for latex_tabularmode ruleset.
 
 def latex_rule1474(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__TabularMode__")
+    return colorer.match_plain_seq(s, i, kind="label", seq="__TabularMode__")
 
 def latex_rule1475(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
@@ -4605,1078 +4605,1078 @@ def latex_rule1478(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def latex_rule1479(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\"")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\"")
 
 def latex_rule1480(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="`")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="`")
 
 def latex_rule1481(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def latex_rule1482(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="}")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="}")
 
 def latex_rule1483(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="{")
 
 def latex_rule1484(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="totalnumber")
 
 def latex_rule1485(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="topnumber")
 
 def latex_rule1486(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="tocdepth")
 
 def latex_rule1487(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="secnumdepth")
 
 def latex_rule1488(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="dbltopnumber")
 
 def latex_rule1489(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="]")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="]")
 
 def latex_rule1490(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\~{")
 
 def latex_rule1491(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\~")
 
 def latex_rule1492(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\}")
 
 def latex_rule1493(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\|")
 
 def latex_rule1494(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\{")
 
 def latex_rule1495(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\width")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\width")
 
 def latex_rule1496(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\whiledo{")
 
 def latex_rule1497(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\v{")
 
 def latex_rule1498(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vspace{")
 
 def latex_rule1499(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vspace*{")
 
 def latex_rule1500(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vline")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vline")
 
 def latex_rule1501(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vfill")
 
 def latex_rule1502(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\verb*")
 
 def latex_rule1503(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\verb")
 
 def latex_rule1504(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\value{")
 
 def latex_rule1505(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\v")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\v")
 
 def latex_rule1506(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\u{")
 
 def latex_rule1507(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usepackage{")
 
 def latex_rule1508(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usepackage[")
 
 def latex_rule1509(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usecounter{")
 
 def latex_rule1510(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usebox{")
 
 def latex_rule1511(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upshape")
 
 def latex_rule1512(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\unboldmath{")
 
 def latex_rule1513(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\u")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\u")
 
 def latex_rule1514(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\t{")
 
 def latex_rule1515(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typeout{")
 
 def latex_rule1516(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typein{")
 
 def latex_rule1517(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typein[")
 
 def latex_rule1518(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\twocolumn[")
 
 def latex_rule1519(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twocolumn")
 
 def latex_rule1520(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ttfamily")
 
 def latex_rule1521(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\totalheight")
 
 def latex_rule1522(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\topsep")
 
 def latex_rule1523(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\topfraction")
 
 def latex_rule1524(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\today")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\today")
 
 def latex_rule1525(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\title{")
 
 def latex_rule1526(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tiny")
 
 def latex_rule1527(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
 
 def latex_rule1528(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule1529(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule1530(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\thanks{")
 
 def latex_rule1531(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textwidth")
 
 def latex_rule1532(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textup{")
 
 def latex_rule1533(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\texttt{")
 
 def latex_rule1534(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsl{")
 
 def latex_rule1535(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsf{")
 
 def latex_rule1536(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsc{")
 
 def latex_rule1537(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textrm{")
 
 def latex_rule1538(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textnormal{")
 
 def latex_rule1539(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textmd{")
 
 def latex_rule1540(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textit{")
 
 def latex_rule1541(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textfraction")
 
 def latex_rule1542(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textfloatsep")
 
 def latex_rule1543(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textcolor{")
 
 def latex_rule1544(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textbf{")
 
 def latex_rule1545(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tableofcontents")
 
 def latex_rule1546(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\tabcolsep")
 
 def latex_rule1547(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\tabbingsep")
 
 def latex_rule1548(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\t")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\t")
 
 def latex_rule1549(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\symbol{")
 
 def latex_rule1550(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
 
 def latex_rule1551(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\suppressfloats")
 
 def latex_rule1552(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection{")
 
 def latex_rule1553(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection[")
 
 def latex_rule1554(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
 
 def latex_rule1555(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection{")
 
 def latex_rule1556(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection[")
 
 def latex_rule1557(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection*{")
 
 def latex_rule1558(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph{")
 
 def latex_rule1559(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph[")
 
 def latex_rule1560(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
 
 def latex_rule1561(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stretch{")
 
 def latex_rule1562(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stepcounter{")
 
 def latex_rule1563(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallskip")
 
 def latex_rule1564(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\small")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\small")
 
 def latex_rule1565(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\slshape")
 
 def latex_rule1566(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sloppy")
 
 def latex_rule1567(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sffamily")
 
 def latex_rule1568(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settowidth{")
 
 def latex_rule1569(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settoheight{")
 
 def latex_rule1570(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settodepth{")
 
 def latex_rule1571(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\setlength{")
 
 def latex_rule1572(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\setcounter{")
 
 def latex_rule1573(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section{")
 
 def latex_rule1574(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section[")
 
 def latex_rule1575(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section*{")
 
 def latex_rule1576(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scshape")
 
 def latex_rule1577(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptsize")
 
 def latex_rule1578(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\scalebox{")
 
 def latex_rule1579(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\sbox{")
 
 def latex_rule1580(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule1581(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rule{")
 
 def latex_rule1582(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rule[")
 
 def latex_rule1583(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rp,am{")
 
 def latex_rule1584(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rotatebox{")
 
 def latex_rule1585(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rmfamily")
 
 def latex_rule1586(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\rightmargin")
 
 def latex_rule1587(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
 
 def latex_rule1588(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\resizebox{")
 
 def latex_rule1589(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\resizebox*{")
 
 def latex_rule1590(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
 
 def latex_rule1591(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\renewcommand{")
 
 def latex_rule1592(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ref{")
 
 def latex_rule1593(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\refstepcounter")
 
 def latex_rule1594(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\raisebox{")
 
 def latex_rule1595(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\raggedright")
 
 def latex_rule1596(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\raggedleft")
 
 def latex_rule1597(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\qbeziermax")
 
 def latex_rule1598(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\providecommand{")
 
 def latex_rule1599(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\protect")
 
 def latex_rule1600(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\printindex")
 
 def latex_rule1601(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pounds")
 
 def latex_rule1602(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part{")
 
 def latex_rule1603(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\partopsep")
 
 def latex_rule1604(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part[")
 
 def latex_rule1605(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part*{")
 
 def latex_rule1606(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parskip")
 
 def latex_rule1607(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parsep")
 
 def latex_rule1608(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parindent")
 
 def latex_rule1609(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\parbox{")
 
 def latex_rule1610(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\parbox[")
 
 def latex_rule1611(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph{")
 
 def latex_rule1612(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph[")
 
 def latex_rule1613(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph*{")
 
 def latex_rule1614(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\par")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\par")
 
 def latex_rule1615(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagestyle{")
 
 def latex_rule1616(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pageref{")
 
 def latex_rule1617(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
 
 def latex_rule1618(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagecolor{")
 
 def latex_rule1619(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagebreak[")
 
 def latex_rule1620(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pagebreak")
 
 def latex_rule1621(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\onecolumn")
 
 def latex_rule1622(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalsize")
 
 def latex_rule1623(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
 
 def latex_rule1624(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalfont")
 
 def latex_rule1625(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
 
 def latex_rule1626(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nopagebreak")
 
 def latex_rule1627(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
 
 def latex_rule1628(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
 
 def latex_rule1629(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nolinebreak")
 
 def latex_rule1630(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\noindent")
 
 def latex_rule1631(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nocite{")
 
 def latex_rule1632(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newtheorem{")
 
 def latex_rule1633(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newsavebox{")
 
 def latex_rule1634(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\newpage")
 
 def latex_rule1635(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newlength{")
 
 def latex_rule1636(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newenvironment{")
 
 def latex_rule1637(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newcounter{")
 
 def latex_rule1638(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newcommand{")
 
 def latex_rule1639(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\multicolumn{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\multicolumn{")
 
 def latex_rule1640(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\medskip")
 
 def latex_rule1641(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mdseries")
 
 def latex_rule1642(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule1643(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule1644(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule1645(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule1646(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\markright{")
 
 def latex_rule1647(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\markboth{")
 
 def latex_rule1648(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\marginpar{")
 
 def latex_rule1649(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparwidth")
 
 def latex_rule1650(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparsep")
 
 def latex_rule1651(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparpush")
 
 def latex_rule1652(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\marginpar[")
 
 def latex_rule1653(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\maketitle")
 
 def latex_rule1654(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\makelabel")
 
 def latex_rule1655(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makeindex")
 
 def latex_rule1656(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makeglossary")
 
 def latex_rule1657(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\makebox{")
 
 def latex_rule1658(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\makebox[")
 
 def latex_rule1659(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\listparindent")
 
 def latex_rule1660(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listoftables")
 
 def latex_rule1661(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listoffigures")
 
 def latex_rule1662(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listfiles")
 
 def latex_rule1663(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\linewidth")
 
 def latex_rule1664(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule1665(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linebreak[")
 
 def latex_rule1666(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\linebreak")
 
 def latex_rule1667(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\lengthtest{")
 
 def latex_rule1668(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
 
 def latex_rule1669(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginv")
 
 def latex_rule1670(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
 
 def latex_rule1671(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
 
 def latex_rule1672(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginii")
 
 def latex_rule1673(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmargini")
 
 def latex_rule1674(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmargin")
 
 def latex_rule1675(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\large")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\large")
 
 def latex_rule1676(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\label{")
 
 def latex_rule1677(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\labelwidth")
 
 def latex_rule1678(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\labelsep")
 
 def latex_rule1679(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\jot")
 
 def latex_rule1680(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\itshape")
 
 def latex_rule1681(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\itemsep")
 
 def latex_rule1682(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\itemindent")
 
 def latex_rule1683(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\item[")
 
 def latex_rule1684(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\item")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\item")
 
 def latex_rule1685(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\isodd{")
 
 def latex_rule1686(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\intextsep")
 
 def latex_rule1687(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\input{")
 
 def latex_rule1688(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\index{")
 
 def latex_rule1689(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\indent")
 
 def latex_rule1690(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\include{")
 
 def latex_rule1691(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includeonly{")
 
 def latex_rule1692(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics{")
 
 def latex_rule1693(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics[")
 
 def latex_rule1694(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
 
 def latex_rule1695(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
 
 def latex_rule1696(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
 
 def latex_rule1697(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hyphenation{")
 
 def latex_rule1698(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\huge")
 
 def latex_rule1699(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hspace{")
 
 def latex_rule1700(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hspace*{")
 
 def latex_rule1701(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hline")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hline")
 
 def latex_rule1702(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hfill")
 
 def latex_rule1703(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\height")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\height")
 
 def latex_rule1704(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\glossary{")
 
 def latex_rule1705(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fussy")
 
 def latex_rule1706(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\frenchspacing")
 
 def latex_rule1707(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\framebox{")
 
 def latex_rule1708(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\framebox[")
 
 def latex_rule1709(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fragile")
 
 def latex_rule1710(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnote{")
 
 def latex_rule1711(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotetext{")
 
 def latex_rule1712(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotetext[")
 
 def latex_rule1713(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\footnotesize")
 
 def latex_rule1714(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\footnotesep")
 
 def latex_rule1715(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\footnoterule")
 
 def latex_rule1716(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotemark[")
 
 def latex_rule1717(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\footnotemark")
 
 def latex_rule1718(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnote[")
 
 def latex_rule1719(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
 
 def latex_rule1720(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\floatsep")
 
 def latex_rule1721(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
 
 def latex_rule1722(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fill")
 
 def latex_rule1723(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
 
 def latex_rule1724(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fbox{")
 
 def latex_rule1725(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\fboxsep")
 
 def latex_rule1726(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\fboxrule")
 
 def latex_rule1727(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\equal{")
 
 def latex_rule1728(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule1729(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
 
 def latex_rule1730(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
 
 def latex_rule1731(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule1732(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\emph{")
 
 def latex_rule1733(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\d{")
 
 def latex_rule1734(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\doublerulesep")
 
 def latex_rule1735(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\documentclass{")
 
 def latex_rule1736(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\documentclass[")
 
 def latex_rule1737(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\depth")
 
 def latex_rule1738(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\definecolor{")
 
 def latex_rule1739(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddag")
 
 def latex_rule1740(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
 
 def latex_rule1741(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
 
 def latex_rule1742(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
 
 def latex_rule1743(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
 
 def latex_rule1744(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\date{")
 
 def latex_rule1745(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dag")
 
 def latex_rule1746(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\d")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\d")
 
 def latex_rule1747(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\c{")
 
 def latex_rule1748(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\copyright")
 
 def latex_rule1749(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnwidth")
 
 def latex_rule1750(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnseprule")
 
 def latex_rule1751(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnsep")
 
 def latex_rule1752(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\color{")
 
 def latex_rule1753(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\colorbox{")
 
 def latex_rule1754(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cline{")
 
 def latex_rule1755(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\clearpage")
 
 def latex_rule1756(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
 
 def latex_rule1757(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cite{")
 
 def latex_rule1758(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cite[")
 
 def latex_rule1759(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter{")
 
 def latex_rule1760(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter[")
 
 def latex_rule1761(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter*{")
 
 def latex_rule1762(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\centering")
 
 def latex_rule1763(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\caption{")
 
 def latex_rule1764(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\caption[")
 
 def latex_rule1765(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\c")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\c")
 
 def latex_rule1766(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\b{")
 
 def latex_rule1767(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bottomnumber")
 
 def latex_rule1768(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bottomfraction")
 
 def latex_rule1769(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boolean{")
 
 def latex_rule1770(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boldmath{")
 
 def latex_rule1771(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigskip")
 
 def latex_rule1772(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bibliography{")
 
 def latex_rule1773(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
 
 def latex_rule1774(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bibindent")
 
 def latex_rule1775(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bfseries")
 
 def latex_rule1776(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
 
 def latex_rule1777(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
 
 def latex_rule1778(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule1779(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\baselinestretch")
 
 def latex_rule1780(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\baselineskip")
 
 def latex_rule1781(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\b")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\b")
 
 def latex_rule1782(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\author{")
 
 def latex_rule1783(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arraystgretch")
 
 def latex_rule1784(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
 
 def latex_rule1785(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arraycolsep")
 
 def latex_rule1786(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\arabic{")
 
 def latex_rule1787(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\appendix")
 
 def latex_rule1788(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\alph{")
 
 def latex_rule1789(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addvspace{")
 
 def latex_rule1790(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtolength{")
 
 def latex_rule1791(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtocounter{")
 
 def latex_rule1792(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtocontents{")
 
 def latex_rule1793(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
 
 def latex_rule1794(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
 
 def latex_rule1795(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
 
 def latex_rule1796(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\`{")
 
 def latex_rule1797(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule1798(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\_")
 
 def latex_rule1799(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\^{")
 
 def latex_rule1800(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\^")
 
 def latex_rule1801(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\[")
 
 def latex_rule1802(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\*[")
 
 def latex_rule1803(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\*")
 
 def latex_rule1804(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule1805(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\TeX")
 
 def latex_rule1806(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\S")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\S")
 
 def latex_rule1807(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Roman{")
 
 def latex_rule1808(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\P")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\P")
 
 def latex_rule1809(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Large")
 
 def latex_rule1810(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\LaTeX")
 
 def latex_rule1811(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\LARGE")
 
 def latex_rule1812(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\H{")
 
 def latex_rule1813(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Huge")
 
 def latex_rule1814(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\H")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\H")
 
 def latex_rule1815(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Alph{")
 
 def latex_rule1816(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\@")
 
 def latex_rule1817(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\={")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\={")
 
 def latex_rule1818(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule1819(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\.{")
 
 def latex_rule1820(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\.")
 
 def latex_rule1821(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule1822(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule1823(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\'{")
 
 def latex_rule1824(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule1825(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\&")
 
 def latex_rule1826(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\%")
 
 def latex_rule1827(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\$")
 
 def latex_rule1828(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\#")
 
 def latex_rule1829(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\"{")
 
 def latex_rule1830(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\"")
 
 def latex_rule1831(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def latex_rule1832(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="[")
 
 def latex_rule1833(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="---")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="---")
 
 def latex_rule1834(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="--")
 
 def latex_rule1835(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def latex_rule1836(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def latex_rule1837(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
@@ -5703,7 +5703,7 @@ rulesDict4 = {
 # Rules for latex_tabbingmode ruleset.
 
 def latex_rule1838(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__TabbingMode__")
+    return colorer.match_plain_seq(s, i, kind="label", seq="__TabbingMode__")
 
 def latex_rule1839(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
@@ -5718,1105 +5718,1105 @@ def latex_rule1842(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def latex_rule1843(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="\"")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="\"")
 
 def latex_rule1844(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="`")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="`")
 
 def latex_rule1845(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def latex_rule1846(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="}")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="}")
 
 def latex_rule1847(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="{")
 
 def latex_rule1848(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="totalnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="totalnumber")
 
 def latex_rule1849(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="topnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="topnumber")
 
 def latex_rule1850(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="tocdepth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="tocdepth")
 
 def latex_rule1851(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="secnumdepth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="secnumdepth")
 
 def latex_rule1852(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="dbltopnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="dbltopnumber")
 
 def latex_rule1853(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="]")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="]")
 
 def latex_rule1854(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\~{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\~{")
 
 def latex_rule1855(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\~")
 
 def latex_rule1856(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\}")
 
 def latex_rule1857(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\|")
 
 def latex_rule1858(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\{")
 
 def latex_rule1859(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\width")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\width")
 
 def latex_rule1860(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\whiledo{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\whiledo{")
 
 def latex_rule1861(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\v{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\v{")
 
 def latex_rule1862(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vspace{")
 
 def latex_rule1863(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\vspace*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\vspace*{")
 
 def latex_rule1864(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vfill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vfill")
 
 def latex_rule1865(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb*")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\verb*")
 
 def latex_rule1866(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\verb")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\verb")
 
 def latex_rule1867(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\value{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\value{")
 
 def latex_rule1868(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\v")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\v")
 
 def latex_rule1869(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\u{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\u{")
 
 def latex_rule1870(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usepackage{")
 
 def latex_rule1871(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usepackage[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usepackage[")
 
 def latex_rule1872(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usecounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usecounter{")
 
 def latex_rule1873(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\usebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\usebox{")
 
 def latex_rule1874(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\upshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\upshape")
 
 def latex_rule1875(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\unboldmath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\unboldmath{")
 
 def latex_rule1876(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\u")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\u")
 
 def latex_rule1877(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\t{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\t{")
 
 def latex_rule1878(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typeout{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typeout{")
 
 def latex_rule1879(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typein{")
 
 def latex_rule1880(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\typein[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\typein[")
 
 def latex_rule1881(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\twocolumn[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\twocolumn[")
 
 def latex_rule1882(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\twocolumn")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\twocolumn")
 
 def latex_rule1883(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ttfamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ttfamily")
 
 def latex_rule1884(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\totalheight")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\totalheight")
 
 def latex_rule1885(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\topsep")
 
 def latex_rule1886(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\topfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\topfraction")
 
 def latex_rule1887(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\today")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\today")
 
 def latex_rule1888(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\title{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\title{")
 
 def latex_rule1889(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tiny")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tiny")
 
 def latex_rule1890(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\thispagestyle{")
 
 def latex_rule1891(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule1892(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule1893(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\thanks{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\thanks{")
 
 def latex_rule1894(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textwidth")
 
 def latex_rule1895(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textup{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textup{")
 
 def latex_rule1896(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\texttt{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\texttt{")
 
 def latex_rule1897(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsl{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsl{")
 
 def latex_rule1898(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsf{")
 
 def latex_rule1899(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textsc{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textsc{")
 
 def latex_rule1900(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textrm{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textrm{")
 
 def latex_rule1901(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textnormal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textnormal{")
 
 def latex_rule1902(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textmd{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textmd{")
 
 def latex_rule1903(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textit{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textit{")
 
 def latex_rule1904(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textfraction")
 
 def latex_rule1905(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\textfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\textfloatsep")
 
 def latex_rule1906(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textcolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textcolor{")
 
 def latex_rule1907(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\textbf{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\textbf{")
 
 def latex_rule1908(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\tableofcontents")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\tableofcontents")
 
 def latex_rule1909(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabcolsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\tabcolsep")
 
 def latex_rule1910(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\tabbingsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\tabbingsep")
 
 def latex_rule1911(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\t")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\t")
 
 def latex_rule1912(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\symbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\symbol{")
 
 def latex_rule1913(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\suppressfloats[")
 
 def latex_rule1914(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\suppressfloats")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\suppressfloats")
 
 def latex_rule1915(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection{")
 
 def latex_rule1916(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection[")
 
 def latex_rule1917(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsubsection*{")
 
 def latex_rule1918(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection{")
 
 def latex_rule1919(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection[")
 
 def latex_rule1920(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subsection*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subsection*{")
 
 def latex_rule1921(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph{")
 
 def latex_rule1922(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph[")
 
 def latex_rule1923(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\subparagraph*{")
 
 def latex_rule1924(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stretch{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stretch{")
 
 def latex_rule1925(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\stepcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\stepcounter{")
 
 def latex_rule1926(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\smallskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\smallskip")
 
 def latex_rule1927(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\small")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\small")
 
 def latex_rule1928(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\slshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\slshape")
 
 def latex_rule1929(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sloppy")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sloppy")
 
 def latex_rule1930(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\sffamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\sffamily")
 
 def latex_rule1931(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settowidth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settowidth{")
 
 def latex_rule1932(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settoheight{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settoheight{")
 
 def latex_rule1933(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\settodepth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\settodepth{")
 
 def latex_rule1934(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setlength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\setlength{")
 
 def latex_rule1935(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\setcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\setcounter{")
 
 def latex_rule1936(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section{")
 
 def latex_rule1937(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section[")
 
 def latex_rule1938(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\section*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\section*{")
 
 def latex_rule1939(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scshape")
 
 def latex_rule1940(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\scriptsize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\scriptsize")
 
 def latex_rule1941(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\scalebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\scalebox{")
 
 def latex_rule1942(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\sbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\sbox{")
 
 def latex_rule1943(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule1944(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rule{")
 
 def latex_rule1945(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rule[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rule[")
 
 def latex_rule1946(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rp,am{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rp,am{")
 
 def latex_rule1947(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\rotatebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\rotatebox{")
 
 def latex_rule1948(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\rmfamily")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\rmfamily")
 
 def latex_rule1949(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\rightmargin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\rightmargin")
 
 def latex_rule1950(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\reversemarginpar")
 
 def latex_rule1951(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\resizebox{")
 
 def latex_rule1952(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\resizebox*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\resizebox*{")
 
 def latex_rule1953(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\renewenvironment{")
 
 def latex_rule1954(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\renewcommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\renewcommand{")
 
 def latex_rule1955(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ref{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ref{")
 
 def latex_rule1956(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\refstepcounter")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\refstepcounter")
 
 def latex_rule1957(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\raisebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\raisebox{")
 
 def latex_rule1958(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\raggedright")
 
 def latex_rule1959(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\raggedleft")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\raggedleft")
 
 def latex_rule1960(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\qbeziermax")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\qbeziermax")
 
 def latex_rule1961(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pushtabs")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pushtabs")
 
 def latex_rule1962(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\providecommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\providecommand{")
 
 def latex_rule1963(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\protect")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\protect")
 
 def latex_rule1964(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\printindex")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\printindex")
 
 def latex_rule1965(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pounds")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pounds")
 
 def latex_rule1966(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\poptabs")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\poptabs")
 
 def latex_rule1967(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part{")
 
 def latex_rule1968(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\partopsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\partopsep")
 
 def latex_rule1969(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part[")
 
 def latex_rule1970(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\part*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\part*{")
 
 def latex_rule1971(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parskip")
 
 def latex_rule1972(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parsep")
 
 def latex_rule1973(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\parindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\parindent")
 
 def latex_rule1974(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\parbox{")
 
 def latex_rule1975(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\parbox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\parbox[")
 
 def latex_rule1976(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph{")
 
 def latex_rule1977(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph[")
 
 def latex_rule1978(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\paragraph*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\paragraph*{")
 
 def latex_rule1979(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\par")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\par")
 
 def latex_rule1980(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagestyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagestyle{")
 
 def latex_rule1981(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pageref{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pageref{")
 
 def latex_rule1982(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagenumbering{")
 
 def latex_rule1983(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagecolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagecolor{")
 
 def latex_rule1984(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\pagebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\pagebreak[")
 
 def latex_rule1985(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\pagebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\pagebreak")
 
 def latex_rule1986(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\onecolumn")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\onecolumn")
 
 def latex_rule1987(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalsize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalsize")
 
 def latex_rule1988(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalmarginpar")
 
 def latex_rule1989(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\normalfont")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\normalfont")
 
 def latex_rule1990(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nopagebreak[")
 
 def latex_rule1991(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nopagebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nopagebreak")
 
 def latex_rule1992(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nonfrenchspacing")
 
 def latex_rule1993(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nolinebreak[")
 
 def latex_rule1994(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\nolinebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\nolinebreak")
 
 def latex_rule1995(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\noindent")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\noindent")
 
 def latex_rule1996(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\nocite{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\nocite{")
 
 def latex_rule1997(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newtheorem{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newtheorem{")
 
 def latex_rule1998(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newsavebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newsavebox{")
 
 def latex_rule1999(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\newpage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\newpage")
 
 def latex_rule2000(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newlength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newlength{")
 
 def latex_rule2001(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newenvironment{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newenvironment{")
 
 def latex_rule2002(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newcounter{")
 
 def latex_rule2003(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\newcommand{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\newcommand{")
 
 def latex_rule2004(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\medskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\medskip")
 
 def latex_rule2005(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\mdseries")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\mdseries")
 
 def latex_rule2006(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule2007(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\mbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\mbox{")
 
 def latex_rule2008(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule2009(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\mathindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\mathindent")
 
 def latex_rule2010(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markright{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\markright{")
 
 def latex_rule2011(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\markboth{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\markboth{")
 
 def latex_rule2012(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\marginpar{")
 
 def latex_rule2013(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparwidth")
 
 def latex_rule2014(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparsep")
 
 def latex_rule2015(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\marginparpush")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\marginparpush")
 
 def latex_rule2016(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\marginpar[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\marginpar[")
 
 def latex_rule2017(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\maketitle")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\maketitle")
 
 def latex_rule2018(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\makelabel")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\makelabel")
 
 def latex_rule2019(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeindex")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makeindex")
 
 def latex_rule2020(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makeglossary")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makeglossary")
 
 def latex_rule2021(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\makebox{")
 
 def latex_rule2022(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\makebox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\makebox[")
 
 def latex_rule2023(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\listparindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\listparindent")
 
 def latex_rule2024(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoftables")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listoftables")
 
 def latex_rule2025(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listoffigures")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listoffigures")
 
 def latex_rule2026(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\listfiles")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\listfiles")
 
 def latex_rule2027(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\linewidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\linewidth")
 
 def latex_rule2028(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule2029(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linebreak[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linebreak[")
 
 def latex_rule2030(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\linebreak")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\linebreak")
 
 def latex_rule2031(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\lengthtest{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\lengthtest{")
 
 def latex_rule2032(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginvi")
 
 def latex_rule2033(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginv")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginv")
 
 def latex_rule2034(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginiv")
 
 def latex_rule2035(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginiii")
 
 def latex_rule2036(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmarginii")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmarginii")
 
 def latex_rule2037(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargini")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmargini")
 
 def latex_rule2038(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\leftmargin")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\leftmargin")
 
 def latex_rule2039(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\large")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\large")
 
 def latex_rule2040(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\label{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\label{")
 
 def latex_rule2041(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\labelwidth")
 
 def latex_rule2042(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\labelsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\labelsep")
 
 def latex_rule2043(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\kill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\kill")
 
 def latex_rule2044(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\jot")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\jot")
 
 def latex_rule2045(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\itshape")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\itshape")
 
 def latex_rule2046(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\itemsep")
 
 def latex_rule2047(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\itemindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\itemindent")
 
 def latex_rule2048(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\item[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\item[")
 
 def latex_rule2049(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\item")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\item")
 
 def latex_rule2050(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\isodd{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\isodd{")
 
 def latex_rule2051(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\intextsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\intextsep")
 
 def latex_rule2052(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\input{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\input{")
 
 def latex_rule2053(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\index{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\index{")
 
 def latex_rule2054(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\indent")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\indent")
 
 def latex_rule2055(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\include{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\include{")
 
 def latex_rule2056(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includeonly{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includeonly{")
 
 def latex_rule2057(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics{")
 
 def latex_rule2058(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics[")
 
 def latex_rule2059(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics*{")
 
 def latex_rule2060(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\includegraphics*[")
 
 def latex_rule2061(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ifthenelse{")
 
 def latex_rule2062(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hyphenation{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hyphenation{")
 
 def latex_rule2063(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\huge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\huge")
 
 def latex_rule2064(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hspace{")
 
 def latex_rule2065(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\hspace*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\hspace*{")
 
 def latex_rule2066(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\hfill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\hfill")
 
 def latex_rule2067(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\height")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\height")
 
 def latex_rule2068(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\glossary{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\glossary{")
 
 def latex_rule2069(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fussy")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fussy")
 
 def latex_rule2070(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\frenchspacing")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\frenchspacing")
 
 def latex_rule2071(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\framebox{")
 
 def latex_rule2072(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\framebox[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\framebox[")
 
 def latex_rule2073(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fragile")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fragile")
 
 def latex_rule2074(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnote{")
 
 def latex_rule2075(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotetext{")
 
 def latex_rule2076(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotetext[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotetext[")
 
 def latex_rule2077(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotesize")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\footnotesize")
 
 def latex_rule2078(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnotesep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\footnotesep")
 
 def latex_rule2079(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\footnoterule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\footnoterule")
 
 def latex_rule2080(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnotemark[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnotemark[")
 
 def latex_rule2081(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\footnotemark")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\footnotemark")
 
 def latex_rule2082(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\footnote[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\footnote[")
 
 def latex_rule2083(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fnsymbol{")
 
 def latex_rule2084(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\floatsep")
 
 def latex_rule2085(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\floatpagefraction")
 
 def latex_rule2086(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\fill")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\fill")
 
 def latex_rule2087(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fcolorbox{")
 
 def latex_rule2088(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\fbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\fbox{")
 
 def latex_rule2089(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\fboxsep")
 
 def latex_rule2090(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\fboxrule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\fboxrule")
 
 def latex_rule2091(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\equal{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\equal{")
 
 def latex_rule2092(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\ensuremath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\ensuremath{")
 
 def latex_rule2093(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\enlargethispage{")
 
 def latex_rule2094(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\enlargethispage*{")
 
 def latex_rule2095(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\end{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\end{")
 
 def latex_rule2096(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\emph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\emph{")
 
 def latex_rule2097(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\d{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\d{")
 
 def latex_rule2098(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\doublerulesep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\doublerulesep")
 
 def latex_rule2099(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\documentclass{")
 
 def latex_rule2100(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\documentclass[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\documentclass[")
 
 def latex_rule2101(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\depth")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\depth")
 
 def latex_rule2102(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\definecolor{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\definecolor{")
 
 def latex_rule2103(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\ddag")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\ddag")
 
 def latex_rule2104(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dbltopfraction")
 
 def latex_rule2105(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dbltextfloatsep")
 
 def latex_rule2106(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dblfloatsep")
 
 def latex_rule2107(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\dblfloatpagefraction")
 
 def latex_rule2108(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\date{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\date{")
 
 def latex_rule2109(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\dag")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\dag")
 
 def latex_rule2110(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\d")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\d")
 
 def latex_rule2111(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\c{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\c{")
 
 def latex_rule2112(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\copyright")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\copyright")
 
 def latex_rule2113(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnwidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnwidth")
 
 def latex_rule2114(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnseprule")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnseprule")
 
 def latex_rule2115(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\columnsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\columnsep")
 
 def latex_rule2116(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\color{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\color{")
 
 def latex_rule2117(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\colorbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\colorbox{")
 
 def latex_rule2118(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\clearpage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\clearpage")
 
 def latex_rule2119(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\cleardoublepage")
 
 def latex_rule2120(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cite{")
 
 def latex_rule2121(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\cite[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\cite[")
 
 def latex_rule2122(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter{")
 
 def latex_rule2123(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter[")
 
 def latex_rule2124(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\chapter*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\chapter*{")
 
 def latex_rule2125(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\centering")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\centering")
 
 def latex_rule2126(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\caption{")
 
 def latex_rule2127(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\caption[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\caption[")
 
 def latex_rule2128(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\c")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\c")
 
 def latex_rule2129(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\b{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\b{")
 
 def latex_rule2130(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomnumber")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bottomnumber")
 
 def latex_rule2131(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bottomfraction")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bottomfraction")
 
 def latex_rule2132(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boolean{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boolean{")
 
 def latex_rule2133(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\boldmath{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\boldmath{")
 
 def latex_rule2134(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bigskip")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bigskip")
 
 def latex_rule2135(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliography{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bibliography{")
 
 def latex_rule2136(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\bibliographystyle{")
 
 def latex_rule2137(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\bibindent")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\bibindent")
 
 def latex_rule2138(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\bfseries")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\bfseries")
 
 def latex_rule2139(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\belowdisplayskip")
 
 def latex_rule2140(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\belowdisplayshortskip")
 
 def latex_rule2141(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\begin{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\begin{")
 
 def latex_rule2142(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselinestretch")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\baselinestretch")
 
 def latex_rule2143(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\baselineskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\baselineskip")
 
 def latex_rule2144(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\b")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\b")
 
 def latex_rule2145(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\author{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\author{")
 
 def latex_rule2146(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraystgretch")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arraystgretch")
 
 def latex_rule2147(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arrayrulewidth")
 
 def latex_rule2148(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\arraycolsep")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\arraycolsep")
 
 def latex_rule2149(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\arabic{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\arabic{")
 
 def latex_rule2150(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\appendix")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\appendix")
 
 def latex_rule2151(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\alph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\alph{")
 
 def latex_rule2152(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addvspace{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addvspace{")
 
 def latex_rule2153(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtolength{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtolength{")
 
 def latex_rule2154(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocounter{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtocounter{")
 
 def latex_rule2155(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addtocontents{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addtocontents{")
 
 def latex_rule2156(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\addcontentsline{")
 
 def latex_rule2157(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\abovedisplayskip")
 
 def latex_rule2158(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\abovedisplayshortskip")
 
 def latex_rule2159(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\a`")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\a`")
 
 def latex_rule2160(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\a=")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\a=")
 
 def latex_rule2161(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\a'")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\a'")
 
 def latex_rule2162(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\`{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\`{")
 
 def latex_rule2163(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule2164(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\`")
 
 def latex_rule2165(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\_")
 
 def latex_rule2166(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\^{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\^{")
 
 def latex_rule2167(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\^")
 
 def latex_rule2168(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\[")
 
 def latex_rule2169(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\*[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\*[")
 
 def latex_rule2170(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\*")
 
 def latex_rule2171(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule2172(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\")
 
 def latex_rule2173(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\TeX")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\TeX")
 
 def latex_rule2174(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\S")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\S")
 
 def latex_rule2175(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Roman{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Roman{")
 
 def latex_rule2176(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\P")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\P")
 
 def latex_rule2177(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Large")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Large")
 
 def latex_rule2178(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LaTeX")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\LaTeX")
 
 def latex_rule2179(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\LARGE")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\LARGE")
 
 def latex_rule2180(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\H{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\H{")
 
 def latex_rule2181(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\Huge")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\Huge")
 
 def latex_rule2182(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\H")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\H")
 
 def latex_rule2183(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\Alph{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\Alph{")
 
 def latex_rule2184(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\@")
 
 def latex_rule2185(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\={")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\={")
 
 def latex_rule2186(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule2187(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\=")
 
 def latex_rule2188(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\.{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\.{")
 
 def latex_rule2189(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\.")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\.")
 
 def latex_rule2190(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule2191(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\-")
 
 def latex_rule2192(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\,")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\,")
 
 def latex_rule2193(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\+")
 
 def latex_rule2194(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\'{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\'{")
 
 def latex_rule2195(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule2196(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\'")
 
 def latex_rule2197(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\<")
 
 def latex_rule2198(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\>")
 
 def latex_rule2199(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\&")
 
 def latex_rule2200(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\%")
 
 def latex_rule2201(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\$")
 
 def latex_rule2202(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\#")
 
 def latex_rule2203(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\"{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\"{")
 
 def latex_rule2204(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\"")
 
 def latex_rule2205(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def latex_rule2206(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="[")
 
 def latex_rule2207(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="---")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="---")
 
 def latex_rule2208(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="--")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="--")
 
 def latex_rule2209(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def latex_rule2210(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")
@@ -6842,76 +6842,76 @@ rulesDict5 = {
 # Rules for latex_picturemode ruleset.
 
 def latex_rule2211(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="__PictureMode__")
+    return colorer.match_plain_seq(s, i, kind="label", seq="__PictureMode__")
 
 def latex_rule2212(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def latex_rule2213(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\vector(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\vector(")
 
 def latex_rule2214(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thinlines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thinlines")
 
 def latex_rule2215(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\thicklines")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\thicklines")
 
 def latex_rule2216(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\shortstack{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\shortstack{")
 
 def latex_rule2217(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\shortstack[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\shortstack[")
 
 def latex_rule2218(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\savebox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\savebox{")
 
 def latex_rule2219(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\qbezier[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\qbezier[")
 
 def latex_rule2220(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\qbezier(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\qbezier(")
 
 def latex_rule2221(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\put(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\put(")
 
 def latex_rule2222(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\oval[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\oval[")
 
 def latex_rule2223(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\oval(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\oval(")
 
 def latex_rule2224(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\multiput(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\multiput(")
 
 def latex_rule2225(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\makebox(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\makebox(")
 
 def latex_rule2226(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\linethickness{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\linethickness{")
 
 def latex_rule2227(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\line(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\line(")
 
 def latex_rule2228(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\graphpaper[")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\graphpaper[")
 
 def latex_rule2229(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\graphpaper(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\graphpaper(")
 
 def latex_rule2230(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\frame{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\frame{")
 
 def latex_rule2231(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\\framebox(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\\framebox(")
 
 def latex_rule2232(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\dashbox{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\dashbox{")
 
 def latex_rule2233(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\circle{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\circle{")
 
 def latex_rule2234(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\circle*{")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\circle*{")
 
 def latex_rule2235(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern="\\")

--- a/leo/modes/lilypond.py
+++ b/leo/modes/lilypond.py
@@ -165,22 +165,22 @@ def lilypond_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def lilypond_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\\"")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\\"")
 
 def lilypond_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\'")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\'")
 
 def lilypond_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\H")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\H")
 
 def lilypond_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="\\breve")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="\\breve")
 
 def lilypond_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="\\longa")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="\\longa")
 
 def lilypond_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="\\maxima")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="\\maxima")
 
 def lilypond_rule8(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="=",
@@ -195,31 +195,31 @@ def lilypond_rule10(colorer, s, i):
           delegate="scheme::main")
 
 def lilypond_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="{")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="{")
 
 def lilypond_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="}")
 
 def lilypond_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="[")
 
 def lilypond_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="]")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="]")
 
 def lilypond_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="<<")
 
 def lilypond_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=">>")
 
 def lilypond_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="-<")
+    return colorer.match_plain_seq(s, i, kind="null", seq="-<")
 
 def lilypond_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="->")
+    return colorer.match_plain_seq(s, i, kind="null", seq="->")
 
 def lilypond_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def lilypond_rule20(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
@@ -228,10 +228,10 @@ def lilypond_rule21(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="digit", regexp="-[[:digit:]]+>")
 
 def lilypond_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="'")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="'")
 
 def lilypond_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=",")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=",")
 
 def lilypond_rule24(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="comment2", regexp="r([[:digit:]]*)\\>")

--- a/leo/modes/lisp.py
+++ b/leo/modes/lisp.py
@@ -1002,7 +1002,7 @@ def lisp_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="#|", end="|#")
 
 def lisp_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="'(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="'(")
 
 def lisp_rule2(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal1", pattern="'")
@@ -1011,13 +1011,13 @@ def lisp_rule3(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword4", pattern="&")
 
 def lisp_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="`")
 
 def lisp_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def lisp_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def lisp_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment4", seq=";;;;")

--- a/leo/modes/lotos.py
+++ b/leo/modes/lotos.py
@@ -108,25 +108,25 @@ def lotos_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="(*", end="*)")
 
 def lotos_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def lotos_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[>")
 
 def lotos_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|||")
 
 def lotos_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def lotos_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|[")
 
 def lotos_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]|")
 
 def lotos_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[]")
 
 def lotos_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/lua.py
+++ b/leo/modes/lua.py
@@ -216,43 +216,43 @@ def lua_rule5(colorer, s, i):
     return colorer.match_lua_literal(s, i, kind="literal1")
 
 def lua_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def lua_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def lua_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def lua_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def lua_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def lua_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="..")
 
 def lua_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def lua_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def lua_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def lua_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def lua_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def lua_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~=")
 
 def lua_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def lua_rule19(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/mail.py
+++ b/leo/modes/mail.py
@@ -88,28 +88,28 @@ def mail_rule5(colorer, s, i):
           delegate="mail::signature")
 
 def mail_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":-)")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=":-)")
 
 def mail_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":-(")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=":-(")
 
 def mail_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":)")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=":)")
 
 def mail_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=":(")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=":(")
 
 def mail_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";-)")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=";-)")
 
 def mail_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";-(")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=";-(")
 
 def mail_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";)")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=";)")
 
 def mail_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq=";(")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq=";(")
 
 def mail_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/maple.py
+++ b/leo/modes/maple.py
@@ -717,64 +717,64 @@ def maple_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def maple_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def maple_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def maple_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def maple_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def maple_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def maple_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def maple_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def maple_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def maple_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def maple_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def maple_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def maple_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def maple_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@@")
 
 def maple_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def maple_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def maple_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def maple_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="::")
 
 def maple_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":-")
 
 def maple_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def maple_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def maple_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/matlab.py
+++ b/leo/modes/matlab.py
@@ -5627,106 +5627,106 @@ def matlab_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def matlab_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def matlab_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def matlab_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~=")
 
 def matlab_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def matlab_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def matlab_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def matlab_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def matlab_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def matlab_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def matlab_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def matlab_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="./")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="./")
 
 def matlab_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def matlab_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".\\")
 
 def matlab_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def matlab_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".*")
 
 def matlab_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def matlab_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".^")
 
 def matlab_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="'")
 
 def matlab_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".'")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".'")
 
 def matlab_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def matlab_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def matlab_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def matlab_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def matlab_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".")
 
 def matlab_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",")
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
 
 def matlab_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";")
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
 
 def matlab_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]")
+    return colorer.match_plain_seq(s, i, kind="null", seq="]")
 
 def matlab_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[")
+    return colorer.match_plain_seq(s, i, kind="null", seq="[")
 
 def matlab_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="(")
 
 def matlab_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")")
+    return colorer.match_plain_seq(s, i, kind="null", seq=")")
 
 def matlab_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="{")
+    return colorer.match_plain_seq(s, i, kind="null", seq="{")
 
 def matlab_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="}")
+    return colorer.match_plain_seq(s, i, kind="null", seq="}")
 
 def matlab_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="?")
+    return colorer.match_plain_seq(s, i, kind="null", seq="?")
 
 def matlab_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="...")
+    return colorer.match_plain_seq(s, i, kind="null", seq="...")
 
 def matlab_rule36(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/md.py
+++ b/leo/modes/md.py
@@ -214,7 +214,7 @@ def md_rule3(colorer, s, i):
           delegate="md::block_html_tags")
 
 def md_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ")
+    return colorer.match_plain_seq(s, i, kind="null", seq=" < ")
 
 def md_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
@@ -264,7 +264,7 @@ def md_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def md_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for md_block_html_tags ruleset.
 rulesDict3 = {
@@ -287,13 +287,13 @@ def md_rule12(colorer, s, i):
           delegate="md::markdown_blockquote")
 
 def md_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*")
+    return colorer.match_plain_seq(s, i, kind="null", seq="*")
 
 def md_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_")
+    return colorer.match_plain_seq(s, i, kind="null", seq="_")
 
 def md_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\][")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
 
 def md_rule16(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
@@ -398,13 +398,13 @@ def md_rule30(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\"")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\"")
 
 def md_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def md_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 # Rules dict for md_link_label_definition ruleset.
 rulesDict5 = {
@@ -417,7 +417,7 @@ rulesDict5 = {
 # Rules for md_link_inline_url_title ruleset.
 
 def md_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def md_rule35(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="\\[", end="\\]",
@@ -461,21 +461,21 @@ rulesDict8 = {
 # Rules for md_markdown_blockquote ruleset.
 
 def md_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ")
+    return colorer.match_plain_seq(s, i, kind="null", seq=" < ")
 
 def md_rule40(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
           delegate="md::inline_markup")
 
 def md_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*")
+    return colorer.match_plain_seq(s, i, kind="null", seq="*")
 
 def md_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_")
+    return colorer.match_plain_seq(s, i, kind="null", seq="_")
 
 def md_rule43(colorer, s, i):
     # leadin: backslash.
-    return colorer.match_seq(s, i, kind="null", seq="\\][")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
 
 def md_rule44(colorer, s, i):
     # leadin: backslash.

--- a/leo/modes/ml.py
+++ b/leo/modes/ml.py
@@ -132,46 +132,46 @@ def ml_rule2(colorer, s, i):
           no_line_break=True)
 
 def ml_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def ml_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def ml_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def ml_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def ml_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def ml_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="::")
 
 def ml_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def ml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def ml_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def ml_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def ml_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def ml_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def ml_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def ml_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def ml_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/modula3.py
+++ b/leo/modes/modula3.py
@@ -161,43 +161,43 @@ def modula3_rule3(colorer, s, i):
           no_line_break=True)
 
 def modula3_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def modula3_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def modula3_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def modula3_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def modula3_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def modula3_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def modula3_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def modula3_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def modula3_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def modula3_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def modula3_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def modula3_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def modula3_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def modula3_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/mqsc.py
+++ b/leo/modes/mqsc.py
@@ -231,7 +231,7 @@ def mqsc_rule2(colorer, s, i):
           no_line_break=True)
 
 def mqsc_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def mqsc_rule4(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/netrexx.py
+++ b/leo/modes/netrexx.py
@@ -368,58 +368,58 @@ def netrexx_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def netrexx_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def netrexx_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def netrexx_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def netrexx_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def netrexx_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def netrexx_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def netrexx_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def netrexx_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".*")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".*")
 
 def netrexx_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def netrexx_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def netrexx_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def netrexx_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def netrexx_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def netrexx_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def netrexx_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def netrexx_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def netrexx_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def netrexx_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def netrexx_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/nqc.py
+++ b/leo/modes/nqc.py
@@ -184,55 +184,55 @@ def nqc_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def nqc_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def nqc_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def nqc_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def nqc_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def nqc_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def nqc_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def nqc_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def nqc_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def nqc_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def nqc_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def nqc_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def nqc_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def nqc_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def nqc_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def nqc_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def nqc_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def nqc_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def nqc_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/objective_c.py
+++ b/leo/modes/objective_c.py
@@ -131,7 +131,7 @@ def objective_c_rule5(colorer, s, i):
           no_line_break=True)
 
 def objective_c_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
 
 def objective_c_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
@@ -141,55 +141,55 @@ def objective_c_rule8(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def objective_c_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def objective_c_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def objective_c_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def objective_c_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def objective_c_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def objective_c_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def objective_c_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def objective_c_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def objective_c_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def objective_c_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def objective_c_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def objective_c_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def objective_c_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def objective_c_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def objective_c_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def objective_c_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def objective_c_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def objective_c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/objectrexx.py
+++ b/leo/modes/objectrexx.py
@@ -226,55 +226,55 @@ def objectrexx_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def objectrexx_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def objectrexx_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def objectrexx_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def objectrexx_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def objectrexx_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def objectrexx_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def objectrexx_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def objectrexx_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def objectrexx_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def objectrexx_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def objectrexx_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def objectrexx_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def objectrexx_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def objectrexx_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def objectrexx_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def objectrexx_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def objectrexx_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def objectrexx_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="::")

--- a/leo/modes/ocaml.py
+++ b/leo/modes/ocaml.py
@@ -1231,88 +1231,88 @@ def ocaml_rule7(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal4", pattern="`")
 
 def ocaml_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="}")
 
 def ocaml_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="|]")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="|]")
 
 def ocaml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def ocaml_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="|")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="|")
 
 def ocaml_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="{<")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="{<")
 
 def ocaml_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="{")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="{")
 
 def ocaml_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal4", seq="_")
+    return colorer.match_plain_seq(s, i, kind="literal4", seq="_")
 
 def ocaml_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="]")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="]")
 
 def ocaml_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="[]")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="[]")
 
 def ocaml_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[|")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="[|")
 
 def ocaml_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[>")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="[>")
 
 def ocaml_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[<")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="[<")
 
 def ocaml_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="[")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="[")
 
 def ocaml_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">}")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=">}")
 
 def ocaml_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">]")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=">]")
 
 def ocaml_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="<-")
 
 def ocaml_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=";;")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=";;")
 
 def ocaml_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=";")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=";")
 
 def ocaml_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=":>")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=":>")
 
 def ocaml_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def ocaml_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="::")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="::")
 
 def ocaml_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=":")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=":")
 
 def ocaml_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="..")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="..")
 
 def ocaml_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="->")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="->")
 
 def ocaml_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=",")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=",")
 
 def ocaml_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=")")
 
 def ocaml_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="()")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="()")
 
 def ocaml_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="(")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="(")
 
 def ocaml_rule36(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="operator", regexp="=[-!$%&*+./:<=>?@^|~]*")

--- a/leo/modes/occam.py
+++ b/leo/modes/occam.py
@@ -234,64 +234,64 @@ def occam_rule3(colorer, s, i):
           no_line_break=True)
 
 def occam_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def occam_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def occam_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def occam_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<")
 
 def occam_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def occam_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="><")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="><")
 
 def occam_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def occam_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def occam_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def occam_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def occam_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def occam_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def occam_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def occam_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def occam_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def occam_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def occam_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def occam_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/\\")
 
 def occam_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\/")
 
 def occam_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def occam_rule24(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/omnimark.py
+++ b/leo/modes/omnimark.py
@@ -451,49 +451,49 @@ def omnimark_rule5(colorer, s, i):
           no_line_break=True)
 
 def omnimark_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def omnimark_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def omnimark_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def omnimark_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def omnimark_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def omnimark_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def omnimark_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def omnimark_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def omnimark_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def omnimark_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def omnimark_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def omnimark_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def omnimark_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def omnimark_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def omnimark_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def omnimark_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/pandoc.py
+++ b/leo/modes/pandoc.py
@@ -215,7 +215,7 @@ def pandoc_rule3(colorer, s, i):
           delegate="pandoc::block_html_tags")
 
 def pandoc_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ")
+    return colorer.match_plain_seq(s, i, kind="null", seq=" < ")
 
 def pandoc_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
@@ -265,7 +265,7 @@ def pandoc_rule10(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def pandoc_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for pandoc_block_html_tags ruleset.
 rulesDict3 = {
@@ -288,13 +288,13 @@ def pandoc_rule12(colorer, s, i):
           delegate="pandoc::markdown_blockquote")
 
 def pandoc_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*")
+    return colorer.match_plain_seq(s, i, kind="null", seq="*")
 
 def pandoc_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_")
+    return colorer.match_plain_seq(s, i, kind="null", seq="_")
 
 def pandoc_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="\\][")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
 
 def pandoc_rule16(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
@@ -399,13 +399,13 @@ def pandoc_rule30(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\"")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\"")
 
 def pandoc_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def pandoc_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 # Rules dict for pandoc_link_label_definition ruleset.
 rulesDict5 = {
@@ -418,7 +418,7 @@ rulesDict5 = {
 # Rules for pandoc_link_inline_url_title ruleset.
 
 def pandoc_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def pandoc_rule35(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="keyword4", begin="\\[", end="\\]",
@@ -462,21 +462,21 @@ rulesDict8 = {
 # Rules for pandoc_markdown_blockquote ruleset.
 
 def pandoc_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=" < ")
+    return colorer.match_plain_seq(s, i, kind="null", seq=" < ")
 
 def pandoc_rule40(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
           delegate="pandoc::inline_markup")
 
 def pandoc_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="*")
+    return colorer.match_plain_seq(s, i, kind="null", seq="*")
 
 def pandoc_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="_")
+    return colorer.match_plain_seq(s, i, kind="null", seq="_")
 
 def pandoc_rule43(colorer, s, i):
     # leadin: backslash.
-    return colorer.match_seq(s, i, kind="null", seq="\\][")
+    return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
 
 def pandoc_rule44(colorer, s, i):
     # leadin: backslash.

--- a/leo/modes/pascal.py
+++ b/leo/modes/pascal.py
@@ -191,67 +191,67 @@ def pascal_rule5(colorer, s, i):
           no_line_break=True)
 
 def pascal_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def pascal_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def pascal_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def pascal_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def pascal_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def pascal_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def pascal_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def pascal_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def pascal_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def pascal_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def pascal_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def pascal_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def pascal_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def pascal_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def pascal_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def pascal_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def pascal_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def pascal_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def pascal_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def pascal_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def pascal_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def pascal_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/perl.py
+++ b/leo/modes/perl.py
@@ -390,13 +390,13 @@ def perl_rule11(colorer, s, i):
           delegate="perl::pod")
 
 def perl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="$`")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="$`")
 
 def perl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="$'")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="$'")
 
 def perl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="$\"")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="$\"")
 
 def perl_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",
@@ -472,61 +472,61 @@ def perl_rule34(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="markup", regexp="/[^[:blank:]]*?/")
 
 def perl_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def perl_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def perl_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def perl_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def perl_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def perl_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def perl_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def perl_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def perl_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def perl_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def perl_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def perl_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def perl_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def perl_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def perl_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def perl_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def perl_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def perl_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def perl_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def perl_rule54(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -643,76 +643,76 @@ def perl_rule57(colorer, s, i):
           no_line_break=True)
 
 def perl_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="|")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="|")
 
 def perl_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="&")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="&")
 
 def perl_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="!")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="!")
 
 def perl_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=">")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq=">")
 
 def perl_rule62(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="<")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="<")
 
 def perl_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=")")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq=")")
 
 def perl_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="(")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="(")
 
 def perl_rule65(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="=")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="=")
 
 def perl_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="!")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="!")
 
 def perl_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="+")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="+")
 
 def perl_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="-")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="-")
 
 def perl_rule69(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="/")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="/")
 
 def perl_rule70(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="*")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="*")
 
 def perl_rule71(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="^")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="^")
 
 def perl_rule72(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="~")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="~")
 
 def perl_rule73(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="}")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="}")
 
 def perl_rule74(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="{")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="{")
 
 def perl_rule75(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=".")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq=".")
 
 def perl_rule76(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=",")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq=",")
 
 def perl_rule77(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=";")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq=";")
 
 def perl_rule78(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="]")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="]")
 
 def perl_rule79(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="[")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="[")
 
 def perl_rule80(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="?")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="?")
 
 def perl_rule81(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq=":")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq=":")
 
 # Rules dict for perl_literal ruleset.
 rulesDict3 = {
@@ -777,7 +777,7 @@ def perl_rule86(colorer, s, i):
           no_line_break=True)
 
 def perl_rule87(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 # Rules dict for perl_variable ruleset.
 rulesDict5 = {
@@ -788,31 +788,31 @@ rulesDict5 = {
 # Rules for perl_regexp ruleset.
 
 def perl_rule88(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")(")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=")(")
 
 def perl_rule89(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")[")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=")[")
 
 def perl_rule90(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="){")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="){")
 
 def perl_rule91(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="](")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="](")
 
 def perl_rule92(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="][")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="][")
 
 def perl_rule93(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="]{")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="]{")
 
 def perl_rule94(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}(")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="}(")
 
 def perl_rule95(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}[")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="}[")
 
 def perl_rule96(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="}{")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="}{")
 
 def perl_rule97(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="(", end=")",

--- a/leo/modes/pharo.py
+++ b/leo/modes/pharo.py
@@ -63,40 +63,40 @@ def pharo_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"")
 
 def pharo_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def pharo_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def pharo_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def pharo_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def pharo_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def pharo_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def pharo_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def pharo_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def pharo_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def pharo_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def pharo_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def pharo_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def pharo_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword3", pattern=":",

--- a/leo/modes/php.py
+++ b/leo/modes/php.py
@@ -2617,7 +2617,7 @@ def php_rule14(colorer, s, i):
           delegate="php::tags_literal")
 
 def php_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for php_tags ruleset.
 rulesDict2 = {
@@ -2680,85 +2680,85 @@ def php_rule27(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def php_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def php_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def php_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def php_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def php_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def php_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def php_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def php_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def php_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def php_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def php_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def php_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def php_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def php_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def php_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def php_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def php_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def php_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def php_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def php_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def php_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def php_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def php_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def php_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def php_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def php_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def php_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def php_rule55(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
@@ -2913,22 +2913,22 @@ rulesDict7 = {
 # Rules for php_phpdoc ruleset.
 
 def php_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="{")
 
 def php_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
 
 def php_rule65(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="<!--", end="-->")
 
 def php_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
 
 def php_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
 
 def php_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
 
 def php_rule69(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",

--- a/leo/modes/phpsection.py
+++ b/leo/modes/phpsection.py
@@ -2614,7 +2614,7 @@ def phpsection_rule14(colorer, s, i):
           delegate="phpsection::tags_literal")
 
 def phpsection_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for phpsection_tags ruleset.
 rulesDict2 = {
@@ -2677,85 +2677,85 @@ def phpsection_rule27(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword3", pattern="$")
 
 def phpsection_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def phpsection_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def phpsection_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def phpsection_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def phpsection_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def phpsection_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def phpsection_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def phpsection_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def phpsection_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def phpsection_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def phpsection_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def phpsection_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def phpsection_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def phpsection_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def phpsection_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def phpsection_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def phpsection_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def phpsection_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def phpsection_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def phpsection_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def phpsection_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def phpsection_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def phpsection_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def phpsection_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def phpsection_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def phpsection_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def phpsection_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def phpsection_rule55(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
@@ -2910,22 +2910,22 @@ rulesDict7 = {
 # Rules for phpsection_phpdoc ruleset.
 
 def phpsection_rule63(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="{")
 
 def phpsection_rule64(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
 
 def phpsection_rule65(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="<!--", end="-->")
 
 def phpsection_rule66(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
 
 def phpsection_rule67(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
 
 def phpsection_rule68(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
 
 def phpsection_rule69(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",

--- a/leo/modes/pike.py
+++ b/leo/modes/pike.py
@@ -181,7 +181,7 @@ def pike_rule0(colorer, s, i):
           delegate="pike::comment")
 
 def pike_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="invalid", seq="*/")
+    return colorer.match_plain_seq(s, i, kind="invalid", seq="*/")
 
 def pike_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="//!",
@@ -209,70 +209,70 @@ def pike_rule7(colorer, s, i):
           at_line_start=True)
 
 def pike_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="({")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="({")
 
 def pike_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="})")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="})")
 
 def pike_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="([")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="([")
 
 def pike_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="])")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="])")
 
 def pike_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(<")
 
 def pike_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">)")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">)")
 
 def pike_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def pike_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def pike_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def pike_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def pike_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def pike_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def pike_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def pike_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def pike_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def pike_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def pike_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def pike_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def pike_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def pike_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def pike_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="`")
 
 def pike_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def pike_rule30(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/pl1.py
+++ b/leo/modes/pl1.py
@@ -566,49 +566,49 @@ def pl1_rule3(colorer, s, i):
           at_line_start=True)
 
 def pl1_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def pl1_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def pl1_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def pl1_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def pl1_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def pl1_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def pl1_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def pl1_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def pl1_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def pl1_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def pl1_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def pl1_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def pl1_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def pl1_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def pl1_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def pl1_rule19(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/plsql.py
+++ b/leo/modes/plsql.py
@@ -397,52 +397,52 @@ def plsql_rule6(colorer, s, i):
           at_line_start=True)
 
 def plsql_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def plsql_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def plsql_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def plsql_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def plsql_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def plsql_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def plsql_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def plsql_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def plsql_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def plsql_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def plsql_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def plsql_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def plsql_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def plsql_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!>")
 
 def plsql_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!<")
 
 def plsql_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def plsql_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/pop11.py
+++ b/leo/modes/pop11.py
@@ -233,71 +233,71 @@ def pop11_rule9(colorer, s, i):
           at_line_start=True)
 
 def pop11_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="#_<")
+    return colorer.match_plain_seq(s, i, kind="null", seq="#_<")
 
 def pop11_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=">_#")
+    return colorer.match_plain_seq(s, i, kind="null", seq=">_#")
 
 def pop11_rule12(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="#_",
           at_line_start=True)
 
 def pop11_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")")
+    return colorer.match_plain_seq(s, i, kind="null", seq=")")
 
 def pop11_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="(")
 
 def pop11_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".")
 
 def pop11_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",")
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
 
 def pop11_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";")
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
 
 def pop11_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="^")
+    return colorer.match_plain_seq(s, i, kind="null", seq="^")
 
 def pop11_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="@")
+    return colorer.match_plain_seq(s, i, kind="null", seq="@")
 
 def pop11_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":")
+    return colorer.match_plain_seq(s, i, kind="null", seq=":")
 
 def pop11_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="|")
+    return colorer.match_plain_seq(s, i, kind="null", seq="|")
 
 def pop11_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def pop11_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def pop11_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def pop11_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def pop11_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def pop11_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def pop11_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def pop11_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def pop11_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def pop11_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def pop11_rule32(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -428,10 +428,10 @@ def pop11_rule40(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";;;")
 
 def pop11_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="=")
+    return colorer.match_plain_seq(s, i, kind="literal2", seq="=")
 
 def pop11_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="==")
+    return colorer.match_plain_seq(s, i, kind="literal2", seq="==")
 
 def pop11_rule43(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal2", pattern="^")
@@ -465,7 +465,7 @@ def pop11_rule45(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":")
 
 def pop11_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="*")
 
 # Rules dict for pop11_comment ruleset.
 rulesDict4 = {

--- a/leo/modes/postscript.py
+++ b/leo/modes/postscript.py
@@ -118,16 +118,16 @@ def postscript_rule6(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern="/")
 
 def postscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def postscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def postscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def postscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def postscript_rule11(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/povray.py
+++ b/leo/modes/povray.py
@@ -510,55 +510,55 @@ def povray_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def povray_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def povray_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def povray_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def povray_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def povray_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def povray_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def povray_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def povray_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def povray_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def povray_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def povray_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def povray_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def povray_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def povray_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def povray_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def povray_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def povray_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def povray_rule21(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/powerdynamo.py
+++ b/leo/modes/powerdynamo.py
@@ -423,7 +423,7 @@ def powerdynamo_rule29(colorer, s, i):
           delegate="powerdynamo::tags_literal")
 
 def powerdynamo_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for powerdynamo_tags ruleset.
 rulesDict2 = {
@@ -461,82 +461,82 @@ def powerdynamo_rule35(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def powerdynamo_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def powerdynamo_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def powerdynamo_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def powerdynamo_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def powerdynamo_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def powerdynamo_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def powerdynamo_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def powerdynamo_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def powerdynamo_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def powerdynamo_rule45(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def powerdynamo_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def powerdynamo_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def powerdynamo_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def powerdynamo_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def powerdynamo_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def powerdynamo_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def powerdynamo_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def powerdynamo_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def powerdynamo_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def powerdynamo_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def powerdynamo_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def powerdynamo_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def powerdynamo_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def powerdynamo_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def powerdynamo_rule60(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def powerdynamo_rule61(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def powerdynamo_rule62(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",

--- a/leo/modes/prolog.py
+++ b/leo/modes/prolog.py
@@ -148,121 +148,121 @@ def prolog_rule4(colorer, s, i):
           no_line_break=True)
 
 def prolog_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-->")
 
 def prolog_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":-")
 
 def prolog_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?-")
 
 def prolog_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def prolog_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def prolog_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def prolog_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\+")
 
 def prolog_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def prolog_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\==")
 
 def prolog_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\=")
 
 def prolog_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@<")
 
 def prolog_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@=<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@=<")
 
 def prolog_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@>=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@>=")
 
 def prolog_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@>")
 
 def prolog_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=..")
 
 def prolog_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=:=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=:=")
 
 def prolog_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=\\=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=\\=")
 
 def prolog_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=<")
 
 def prolog_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def prolog_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def prolog_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def prolog_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/\\")
 
 def prolog_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\/")
 
 def prolog_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="//")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="//")
 
 def prolog_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<")
 
 def prolog_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def prolog_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def prolog_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def prolog_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def prolog_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def prolog_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def prolog_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def prolog_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def prolog_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def prolog_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def prolog_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="(")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="(")
 
 def prolog_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=")")
+    return colorer.match_plain_seq(s, i, kind="markup", seq=")")
 
 def prolog_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="{")
+    return colorer.match_plain_seq(s, i, kind="null", seq="{")
 
 def prolog_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="}")
+    return colorer.match_plain_seq(s, i, kind="null", seq="}")
 
 def prolog_rule44(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/psp.py
+++ b/leo/modes/psp.py
@@ -121,7 +121,7 @@ def psp_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def psp_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def psp_rule14(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="<%--", end="--%>")
@@ -147,7 +147,7 @@ def psp_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def psp_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def psp_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/ptl.py
+++ b/leo/modes/ptl.py
@@ -41,10 +41,10 @@ keywordsDictDict = {
 
 
 def ptl_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword4", seq="[html]")
+    return colorer.match_plain_seq(s, i, kind="keyword4", seq="[html]")
 
 def ptl_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword4", seq="[plain]")
+    return colorer.match_plain_seq(s, i, kind="keyword4", seq="[plain]")
 
 def ptl_rule2(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/pvwave.py
+++ b/leo/modes/pvwave.py
@@ -711,70 +711,70 @@ def pvwave_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def pvwave_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def pvwave_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def pvwave_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def pvwave_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def pvwave_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def pvwave_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def pvwave_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def pvwave_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def pvwave_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def pvwave_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def pvwave_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def pvwave_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def pvwave_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def pvwave_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def pvwave_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def pvwave_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def pvwave_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def pvwave_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def pvwave_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="$")
+    return colorer.match_plain_seq(s, i, kind="label", seq="$")
 
 def pvwave_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="&")
+    return colorer.match_plain_seq(s, i, kind="label", seq="&")
 
 def pvwave_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="@")
+    return colorer.match_plain_seq(s, i, kind="label", seq="@")
 
 def pvwave_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="!")
+    return colorer.match_plain_seq(s, i, kind="label", seq="!")
 
 def pvwave_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/r.py
+++ b/leo/modes/r.py
@@ -4437,103 +4437,103 @@ def r_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def r_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="(")
 
 def r_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=")")
+    return colorer.match_plain_seq(s, i, kind="null", seq=")")
 
 def r_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<-")
 
 def r_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def r_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def r_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def r_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def r_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def r_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def r_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def r_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&&")
 
 def r_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def r_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def r_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def r_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def r_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def r_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def r_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def r_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def r_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def r_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def r_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def r_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def r_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%%")
 
 def r_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%*%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%*%")
 
 def r_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%o%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%o%")
 
 def r_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%x%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%x%")
 
 def r_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%in%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%in%")
 
 def r_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def r_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def r_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def r_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def r_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def r_rule36(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rebol.py
+++ b/leo/modes/rebol.py
@@ -544,31 +544,31 @@ def rebol_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def rebol_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def rebol_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def rebol_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def rebol_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def rebol_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def rebol_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def rebol_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def rebol_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def rebol_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def rebol_rule14(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal2", pattern="'",

--- a/leo/modes/redcode.py
+++ b/leo/modes/redcode.py
@@ -86,97 +86,97 @@ def redcode_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq=";")
 
 def redcode_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".AB")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".AB")
 
 def redcode_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".BA")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".BA")
 
 def redcode_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".A")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".A")
 
 def redcode_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".B")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".B")
 
 def redcode_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".F")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".F")
 
 def redcode_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".X")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".X")
 
 def redcode_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq=".I")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq=".I")
 
 def redcode_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def redcode_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def redcode_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def redcode_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def redcode_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def redcode_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def redcode_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def redcode_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def redcode_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def redcode_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def redcode_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def redcode_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def redcode_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def redcode_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def redcode_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&&")
 
 def redcode_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def redcode_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def redcode_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def redcode_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="$")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="$")
 
 def redcode_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="@")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="@")
 
 def redcode_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="#")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="#")
 
 def redcode_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="*")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="*")
 
 def redcode_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="{")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="{")
 
 def redcode_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal1", seq="}")
+    return colorer.match_plain_seq(s, i, kind="literal1", seq="}")
 
 def redcode_rule37(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rib.py
+++ b/leo/modes/rib.py
@@ -235,16 +235,16 @@ def rib_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="#")
 
 def rib_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def rib_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def rib_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def rib_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def rib_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",

--- a/leo/modes/rpmspec.py
+++ b/leo/modes/rpmspec.py
@@ -125,13 +125,13 @@ def rpmspec_rule0(colorer, s, i):
           at_line_start=True)
 
 def rpmspec_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def rpmspec_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def rpmspec_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def rpmspec_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="%attr(", end=")",
@@ -258,10 +258,10 @@ rulesDict1 = {
 # Rules for rpmspec_attr ruleset.
 
 def rpmspec_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def rpmspec_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 # Rules dict for rpmspec_attr ruleset.
 rulesDict2 = {

--- a/leo/modes/rtf.py
+++ b/leo/modes/rtf.py
@@ -30,10 +30,10 @@ keywordsDictDict = {
 # Rules for rtf_main ruleset.
 
 def rtf_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def rtf_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def rtf_rule2(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\\\'\\w\\d")

--- a/leo/modes/ruby.py
+++ b/leo/modes/ruby.py
@@ -115,88 +115,88 @@ def ruby_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def ruby_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def ruby_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def ruby_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def ruby_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def ruby_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="::")
 
 def ruby_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="===")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="===")
 
 def ruby_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def ruby_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">>")
 
 def ruby_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<<")
 
 def ruby_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def ruby_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def ruby_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def ruby_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def ruby_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def ruby_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def ruby_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def ruby_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def ruby_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def ruby_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def ruby_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def ruby_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def ruby_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def ruby_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def ruby_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="...")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="...")
 
 def ruby_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="..")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="..")
 
 def ruby_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def ruby_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def ruby_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def ruby_rule33(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
@@ -204,7 +204,7 @@ def ruby_rule33(colorer, s, i):
           exclude_match=True)
 
 def ruby_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def ruby_rule35(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -128,7 +128,7 @@ def rust_rule4(colorer, s, i):
           no_line_break=True)
 
 def rust_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="##")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
 
 def rust_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
@@ -137,55 +137,55 @@ def rust_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def rust_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def rust_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def rust_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def rust_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def rust_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def rust_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def rust_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def rust_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def rust_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def rust_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def rust_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def rust_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def rust_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def rust_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def rust_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def rust_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def rust_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def rust_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/rview.py
+++ b/leo/modes/rview.py
@@ -137,7 +137,7 @@ keywordsDictDict = {
 # Rules for rview_main ruleset.
 
 def rview_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def rview_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/",
@@ -152,13 +152,13 @@ def rview_rule3(colorer, s, i):
           no_line_break=True)
 
 def rview_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def rview_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def rview_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def rview_rule7(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
@@ -250,40 +250,40 @@ def rview_rule10(colorer, s, i):
           no_line_break=True)
 
 def rview_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def rview_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def rview_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def rview_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def rview_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def rview_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def rview_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def rview_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def rview_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def rview_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def rview_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def rview_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="::")
+    return colorer.match_plain_seq(s, i, kind="null", seq="::")
 
 def rview_rule23(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="label", pattern=":")

--- a/leo/modes/sas.py
+++ b/leo/modes/sas.py
@@ -295,49 +295,49 @@ def sas_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def sas_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def sas_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def sas_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def sas_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def sas_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def sas_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def sas_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def sas_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def sas_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def sas_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def sas_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def sas_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def sas_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def sas_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def sas_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def sas_rule17(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/scala.py
+++ b/leo/modes/scala.py
@@ -331,7 +331,7 @@ rulesDict1 = {
 # Rules for scala_primary ruleset.
 
 def scala_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def scala_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
@@ -376,88 +376,88 @@ def scala_rule13(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp=">:\\s*\\w+(\\.\\w+)*(#\\w+)?")
 
 def scala_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def scala_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def scala_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def scala_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def scala_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">:")
 
 def scala_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def scala_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<:")
 
 def scala_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def scala_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def scala_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def scala_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def scala_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def scala_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def scala_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def scala_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def scala_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def scala_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def scala_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="`")
 
 def scala_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def scala_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def scala_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def scala_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=".")
+    return colorer.match_plain_seq(s, i, kind="null", seq=".")
 
 def scala_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=",")
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
 
 def scala_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=";")
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
 
 def scala_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="]")
+    return colorer.match_plain_seq(s, i, kind="null", seq="]")
 
 def scala_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="[")
+    return colorer.match_plain_seq(s, i, kind="null", seq="[")
 
 def scala_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="?")
+    return colorer.match_plain_seq(s, i, kind="null", seq="?")
 
 def scala_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq=":")
+    return colorer.match_plain_seq(s, i, kind="null", seq=":")
 
 def scala_rule42(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp=":\\s*\\w+(\\.\\w+)*(#\\w+)?")
@@ -571,7 +571,7 @@ rulesDict2 = {
 
 
 def scala_rule46(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 # Rules dict for scala_pattern ruleset.
 rulesDict3 = {
@@ -581,10 +581,10 @@ rulesDict3 = {
 # Rules for scala_scaladoc ruleset.
 
 def scala_rule47(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="{")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="{")
 
 def scala_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="*")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
 
 def scala_rule49(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<pre>", end="</pre>",
@@ -594,13 +594,13 @@ def scala_rule50(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 def scala_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<<")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
 
 def scala_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
 
 def scala_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment3", seq="< ")
+    return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
 
 def scala_rule54(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",

--- a/leo/modes/scheme.py
+++ b/leo/modes/scheme.py
@@ -238,7 +238,7 @@ def scheme_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="#|", end="|#")
 
 def scheme_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="'(")
+    return colorer.match_plain_seq(s, i, kind="null", seq="'(")
 
 def scheme_rule2(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal1", pattern="'")

--- a/leo/modes/sdl_pr.py
+++ b/leo/modes/sdl_pr.py
@@ -191,67 +191,67 @@ def sdl_pr_rule3(colorer, s, i):
           no_line_break=True)
 
 def sdl_pr_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def sdl_pr_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def sdl_pr_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def sdl_pr_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def sdl_pr_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def sdl_pr_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/=")
 
 def sdl_pr_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def sdl_pr_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def sdl_pr_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def sdl_pr_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def sdl_pr_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def sdl_pr_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def sdl_pr_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def sdl_pr_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def sdl_pr_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="//")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="//")
 
 def sdl_pr_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="and")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="and")
 
 def sdl_pr_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="mod")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="mod")
 
 def sdl_pr_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="not")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="not")
 
 def sdl_pr_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="or")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="or")
 
 def sdl_pr_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="rem")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="rem")
 
 def sdl_pr_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xor")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="xor")
 
 def sdl_pr_rule25(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/shell.py
+++ b/leo/modes/shell.py
@@ -144,19 +144,19 @@ def shell_rule17(colorer, s, i):
           delegate="shell::literal")
 
 def shell_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def shell_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def shell_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def shell_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def shell_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def shell_rule23(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="%")
@@ -283,19 +283,19 @@ def shell_rule32(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def shell_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def shell_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def shell_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def shell_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def shell_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 # Rules dict for shell_exec ruleset.
 rulesDict3 = {

--- a/leo/modes/shellscript.py
+++ b/leo/modes/shellscript.py
@@ -144,19 +144,19 @@ def shellscript_rule17(colorer, s, i):
           delegate="shellscript::literal")
 
 def shellscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def shellscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def shellscript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def shellscript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def shellscript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def shellscript_rule23(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="%")
@@ -283,19 +283,19 @@ def shellscript_rule32(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="$")
 
 def shellscript_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def shellscript_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def shellscript_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def shellscript_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def shellscript_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 # Rules dict for shellscript_exec ruleset.
 rulesDict3 = {

--- a/leo/modes/smalltalk.py
+++ b/leo/modes/smalltalk.py
@@ -63,40 +63,40 @@ def smalltalk_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="\"", end="\"")
 
 def smalltalk_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def smalltalk_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def smalltalk_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def smalltalk_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def smalltalk_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def smalltalk_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def smalltalk_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def smalltalk_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def smalltalk_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def smalltalk_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def smalltalk_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def smalltalk_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def smalltalk_rule14(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword3", pattern=":",

--- a/leo/modes/smi_mib.py
+++ b/leo/modes/smi_mib.py
@@ -122,22 +122,22 @@ def smi_mib_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def smi_mib_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="::=")
 
 def smi_mib_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def smi_mib_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def smi_mib_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="OBJECT IDENTIFIER")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="OBJECT IDENTIFIER")
 
 def smi_mib_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="SEQUENCE OF")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="SEQUENCE OF")
 
 def smi_mib_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="OCTET STRING")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="OCTET STRING")
 
 def smi_mib_rule8(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/splus.py
+++ b/leo/modes/splus.py
@@ -66,61 +66,61 @@ def splus_rule2(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def splus_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def splus_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def splus_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def splus_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def splus_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def splus_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<-")
 
 def splus_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def splus_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def splus_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def splus_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def splus_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def splus_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def splus_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def splus_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def splus_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def splus_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def splus_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def splus_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def splus_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def splus_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/sql.py
+++ b/leo/modes/sql.py
@@ -397,52 +397,52 @@ def sql_rule6(colorer, s, i):
           at_line_start=True)
 
 def sql_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def sql_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def sql_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def sql_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def sql_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def sql_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def sql_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def sql_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def sql_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def sql_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def sql_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def sql_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def sql_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def sql_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!>")
 
 def sql_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!<")
 
 def sql_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def sql_rule23(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/sqr.py
+++ b/leo/modes/sqr.py
@@ -140,40 +140,40 @@ def sqr_rule2(colorer, s, i):
           no_line_break=True)
 
 def sqr_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def sqr_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def sqr_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def sqr_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def sqr_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def sqr_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def sqr_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def sqr_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def sqr_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def sqr_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def sqr_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def sqr_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def sqr_rule15(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal1", pattern="$")

--- a/leo/modes/ssharp.py
+++ b/leo/modes/ssharp.py
@@ -110,100 +110,100 @@ def ssharp_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="? ", end="? ")
 
 def ssharp_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def ssharp_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def ssharp_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def ssharp_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def ssharp_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":=")
 
 def ssharp_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="_")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="_")
 
 def ssharp_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def ssharp_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="==")
 
 def ssharp_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def ssharp_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def ssharp_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def ssharp_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def ssharp_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def ssharp_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def ssharp_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def ssharp_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="//")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="//")
 
 def ssharp_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\")
 
 def ssharp_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def ssharp_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def ssharp_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def ssharp_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def ssharp_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^^")
 
 def ssharp_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def ssharp_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def ssharp_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="->")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="->")
 
 def ssharp_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&&")
 
 def ssharp_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="||")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="||")
 
 def ssharp_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^|")
 
 def ssharp_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def ssharp_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~=")
 
 def ssharp_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!==")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!==")
 
 def ssharp_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~~")
 
 def ssharp_rule37(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword3", pattern=":",

--- a/leo/modes/tcl.py
+++ b/leo/modes/tcl.py
@@ -434,55 +434,55 @@ def tcl_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
 def tcl_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def tcl_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def tcl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def tcl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def tcl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def tcl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def tcl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def tcl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def tcl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def tcl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def tcl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def tcl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def tcl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def tcl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def tcl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def tcl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def tcl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def tcl_rule19(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/tex.py
+++ b/leo/modes/tex.py
@@ -83,13 +83,13 @@ def tex_rule2(colorer, s, i):
           delegate="tex::math")
 
 def tex_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\$")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\$")
 
 def tex_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\\\")
 
 def tex_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword1", seq="\\%")
+    return colorer.match_plain_seq(s, i, kind="keyword1", seq="\\%")
 
 def tex_rule6(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="\\iffalse", end="\\fi")
@@ -112,16 +112,16 @@ def tex_rule10(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")
 
 def tex_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def tex_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def tex_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def tex_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 # Rules dict for tex_main ruleset.
 rulesDict1 = {
@@ -142,94 +142,94 @@ rulesDict1 = {
 # Rules for tex_math ruleset.
 
 def tex_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\$")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\$")
 
 def tex_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\\\")
 
 def tex_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword3", seq="\\%")
+    return colorer.match_plain_seq(s, i, kind="keyword3", seq="\\%")
 
 def tex_rule18(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword3", pattern="\\")
 
 def tex_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=")")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq=")")
 
 def tex_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="(")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="(")
 
 def tex_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="{")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="{")
 
 def tex_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="}")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="}")
 
 def tex_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="[")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="[")
 
 def tex_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="]")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="]")
 
 def tex_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="=")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="=")
 
 def tex_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="!")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="!")
 
 def tex_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="+")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="+")
 
 def tex_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="-")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="-")
 
 def tex_rule29(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="/")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="/")
 
 def tex_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="*")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="*")
 
 def tex_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=">")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq=">")
 
 def tex_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="<")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="<")
 
 def tex_rule33(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="&")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="&")
 
 def tex_rule34(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="|")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="|")
 
 def tex_rule35(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="^")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="^")
 
 def tex_rule36(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="~")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="~")
 
 def tex_rule37(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=".")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq=".")
 
 def tex_rule38(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=",")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq=",")
 
 def tex_rule39(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=";")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq=";")
 
 def tex_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="?")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="?")
 
 def tex_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq=":")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq=":")
 
 def tex_rule42(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="'")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="'")
 
 def tex_rule43(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="\"")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="\"")
 
 def tex_rule44(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="`")
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="`")
 
 def tex_rule45(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="%")

--- a/leo/modes/texinfo.py
+++ b/leo/modes/texinfo.py
@@ -41,10 +41,10 @@ def texinfo_rule2(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword1", pattern="@")
 
 def texinfo_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def texinfo_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 # Rules dict for texinfo_main ruleset.
 rulesDict1 = {

--- a/leo/modes/tpl.py
+++ b/leo/modes/tpl.py
@@ -106,7 +106,7 @@ def tpl_rule7(colorer, s, i):
     return colorer.match_span(s, i, kind="label", begin="'", end="'")
 
 def tpl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def tpl_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -191,7 +191,7 @@ def tpl_rule11(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def tpl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for tpl_tags ruleset.
 rulesDict3 = {

--- a/leo/modes/tsql.py
+++ b/leo/modes/tsql.py
@@ -989,52 +989,52 @@ def tsql_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def tsql_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def tsql_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def tsql_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def tsql_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def tsql_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def tsql_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def tsql_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def tsql_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def tsql_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def tsql_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def tsql_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def tsql_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def tsql_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def tsql_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!>")
 
 def tsql_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!<")
 
 def tsql_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="::")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="::")
 
 def tsql_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/typescript.py
+++ b/leo/modes/typescript.py
@@ -214,76 +214,76 @@ def typescript_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 def typescript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="<!--")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="<!--")
 
 def typescript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def typescript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def typescript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def typescript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def typescript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def typescript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def typescript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def typescript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def typescript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def typescript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def typescript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def typescript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def typescript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def typescript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def typescript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def typescript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def typescript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def typescript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def typescript_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def typescript_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def typescript_rule26(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def typescript_rule27(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def typescript_rule28(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def typescript_rule29(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
@@ -291,7 +291,7 @@ def typescript_rule29(colorer, s, i):
           exclude_match=True)
 
 def typescript_rule30(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def typescript_rule31(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/uscript.py
+++ b/leo/modes/uscript.py
@@ -123,7 +123,7 @@ keywordsDictDict = {
 # Rules for uscript_main ruleset.
 
 def uscript_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment1", seq="/**/")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="/**/")
 
 def uscript_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
@@ -140,61 +140,61 @@ def uscript_rule4(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="//")
 
 def uscript_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def uscript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def uscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="@")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 
 def uscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="#")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="#")
 
 def uscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="$")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="$")
 
 def uscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def uscript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def uscript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def uscript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def uscript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def uscript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def uscript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def uscript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\\\")
 
 def uscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def uscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def uscript_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def uscript_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def uscript_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def uscript_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="`")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="`")
 
 def uscript_rule24(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/vbscript.py
+++ b/leo/modes/vbscript.py
@@ -356,46 +356,46 @@ def vbscript_rule5(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="rem")
 
 def vbscript_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def vbscript_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def vbscript_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def vbscript_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def vbscript_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def vbscript_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<>")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<>")
 
 def vbscript_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=".")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
 
 def vbscript_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def vbscript_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def vbscript_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def vbscript_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def vbscript_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="\\")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="\\")
 
 def vbscript_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def vbscript_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def vbscript_rule20(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/verilog.py
+++ b/leo/modes/verilog.py
@@ -188,65 +188,65 @@ def verilog_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def verilog_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'d")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="'d")
 
 def verilog_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'h")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="'h")
 
 def verilog_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'b")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="'b")
 
 def verilog_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="digit", seq="'o")
+    return colorer.match_plain_seq(s, i, kind="digit", seq="'o")
 
 def verilog_rule7(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
           exclude_match=True)
 
 def verilog_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def verilog_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def verilog_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def verilog_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def verilog_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def verilog_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def verilog_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def verilog_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def verilog_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def verilog_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def verilog_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def verilog_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def verilog_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def verilog_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def verilog_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def verilog_rule23(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/vhdl.py
+++ b/leo/modes/vhdl.py
@@ -160,7 +160,7 @@ def vhdl_rule0(colorer, s, i):
           no_line_break=True)
 
 def vhdl_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="null", seq="'event")
+    return colorer.match_plain_seq(s, i, kind="null", seq="'event")
 
 def vhdl_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
@@ -170,58 +170,58 @@ def vhdl_rule3(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="--")
 
 def vhdl_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def vhdl_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/=")
 
 def vhdl_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def vhdl_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def vhdl_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def vhdl_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def vhdl_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def vhdl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def vhdl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def vhdl_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def vhdl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def vhdl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def vhdl_rule16(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="**")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="**")
 
 def vhdl_rule17(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def vhdl_rule18(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def vhdl_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def vhdl_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def vhdl_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="~")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def vhdl_rule22(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",

--- a/leo/modes/xml.py
+++ b/leo/modes/xml.py
@@ -149,14 +149,14 @@ def xml_rule9(colorer, s, i):
           no_line_break=True)
 
 def xml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="/")
+    return colorer.match_plain_seq(s, i, kind="markup", seq="/")
 
 def xml_rule11(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
           exclude_match=True)
 
 def xml_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 # Rules dict for xml_tags ruleset.
 rulesDict2 = {
@@ -192,25 +192,25 @@ def xml_rule18(colorer, s, i):
           delegate="xml::main")
 
 def xml_rule19(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="(")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="(")
 
 def xml_rule20(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=")")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=")")
 
 def xml_rule21(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def xml_rule22(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def xml_rule23(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def xml_rule24(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def xml_rule25(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def xml_rule26(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -313,10 +313,10 @@ def xml_rule30(colorer, s, i):
           no_line_break=True)
 
 def xml_rule31(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def xml_rule32(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def xml_rule33(colorer, s, i):
     return colorer.match_keywords(s, i)

--- a/leo/modes/xsl.py
+++ b/leo/modes/xsl.py
@@ -356,10 +356,10 @@ def xsl_rule10(colorer, s, i):
           delegate="xsl::avt")
 
 def xsl_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="xmlns:")
 
 def xsl_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="xmlns")
 
 def xsl_rule13(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":")
@@ -375,10 +375,10 @@ rulesDict3 = {
 # Rules for xsl_avt ruleset.
 
 def xsl_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="", seq="{{")
+    return colorer.match_plain_seq(s, i, kind="", seq="{{")
 
 def xsl_rule15(colorer, s, i):
-    return colorer.match_seq(s, i, kind="", seq="}}")
+    return colorer.match_plain_seq(s, i, kind="", seq="}}")
 
 def xsl_rule16(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="{", end="}",
@@ -486,10 +486,10 @@ def xsl_rule39(colorer, s, i):
           delegate="xsl::xpath")
 
 def xsl_rule40(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns:")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="xmlns:")
 
 def xsl_rule41(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="xmlns")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="xmlns")
 
 def xsl_rule42(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":")
@@ -585,40 +585,40 @@ def xsl_rule47(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword4", pattern="::")
 
 def xsl_rule48(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword4", seq="@")
+    return colorer.match_plain_seq(s, i, kind="keyword4", seq="@")
 
 def xsl_rule49(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def xsl_rule50(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="!=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!=")
 
 def xsl_rule51(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def xsl_rule52(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&gt;")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&gt;")
 
 def xsl_rule53(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="&lt;")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&lt;")
 
 def xsl_rule54(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def xsl_rule55(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def xsl_rule56(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def xsl_rule57(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def xsl_rule58(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def xsl_rule59(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 def xsl_rule60(colorer, s, i):
     return colorer.match_span(s, i, kind="operator", begin="[", end="]",

--- a/leo/modes/yaml.py
+++ b/leo/modes/yaml.py
@@ -40,34 +40,34 @@ def yaml_rule0(colorer, s, i):
           at_line_start=True)
 
 def yaml_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="---")
+    return colorer.match_plain_seq(s, i, kind="label", seq="---")
 
 def yaml_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="label", seq="...")
+    return colorer.match_plain_seq(s, i, kind="label", seq="...")
 
 def yaml_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 def yaml_rule4(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 def yaml_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="{")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def yaml_rule6(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def yaml_rule7(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def yaml_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def yaml_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def yaml_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def yaml_rule11(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="keyword2", pattern="&")

--- a/leo/modes/zpt.py
+++ b/leo/modes/zpt.py
@@ -193,7 +193,7 @@ def zpt_rule7(colorer, s, i):
           delegate="zpt::attribute")
 
 def zpt_rule8(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def zpt_rule9(colorer, s, i):
     return colorer.match_keywords(s, i)
@@ -272,19 +272,19 @@ rulesDict2 = {
 # Rules for zpt_attribute ruleset.
 
 def zpt_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 def zpt_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 def zpt_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 def zpt_rule13(colorer, s, i):
-    return colorer.match_seq(s, i, kind="operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def zpt_rule14(colorer, s, i):
-    return colorer.match_seq(s, i, kind="literal2", seq="$$")
+    return colorer.match_plain_seq(s, i, kind="literal2", seq="$$")
 
 def zpt_rule15(colorer, s, i):
     return colorer.match_span(s, i, kind="keyword2", begin="${", end="}",


### PR DESCRIPTION
See #3291. Here is the script that made the substitutions:
```python
"""Replace match_seq with match_plain_seq where possible in all leo/modes files"""
g.cls()
import glob
import os
import re
import time

t1 = time.process_time()
pattern = re.compile(r'colorer.(match_seq)\(s, i, kind=".*?", seq=".*?"\)')

# Exclude leo/modes files defined by @file nodes.
exclude = (
    'batch.py', 'forth.py', 'html.py',
    'javascript.py', 'julia.py', 'python.py',
)
modes = os.path.normpath(os.path.join(g.app.loadDir, '..', 'modes'))
paths = glob.glob(f"{modes}{os.sep}*.py")
paths = [z for z in paths if not any(z2 in z for z2 in exclude)]

def repl(m):
    """repl function for re.sub."""
    global file_count
    file_count += 1
    return m.group(0).replace('match_seq', 'match_plain_seq')
    
for path in paths:
    file_count = 0
    sfn = g.shortFileName(path)
    with open(path, 'r') as f:
        contents = f.read()
        results =  re.sub(pattern, repl, contents)
    if file_count:
        print(f"{sfn:>15}: {file_count}")
        with open(path, 'w') as f:
            f.write(results)
t2 = time.process_time()
g.es_print(f"Done! {t2-t1:5.2} sec.")

```