### PR TITLE
PR for #3310: problems with @language md

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -732,7 +732,6 @@ class BaseColorizer:
                 s2 = repr(s[i : i + 17 - 2] + '...')
             delegate_s = f"{self.delegate_name}:" if self.delegate_name else ''
             font_s = id(font) if font else 'None'
-            g.trace(g.callers())  ###
             print(
                 f"setTag: {full_tag:32} {i:3} {j:3} {colorName:7} font: {font_s:14} {s2:>22} "
                 f"{self.rulesetName}:{delegate_s}{self.matcher_name}"

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1020,8 +1020,9 @@ class JEditColorizer(BaseColorizer):
         language, rulesetName = self.nameToRulesetName(name)
         bunch = self.modes.get(rulesetName)
         if bunch:
-            if bunch.language == 'unknown-language':
-                return False
+            # if bunch.language == 'unknown-language':
+                # g.trace('FAIL', rulesetName)
+                # return False
             self.initModeFromBunch(bunch)
             self.language = language  # 2011/05/30
             return True

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1020,6 +1020,8 @@ class JEditColorizer(BaseColorizer):
         language, rulesetName = self.nameToRulesetName(name)
         bunch = self.modes.get(rulesetName)
         if bunch:
+            if bunch.language == 'unknown-language':
+                return False
             self.initModeFromBunch(bunch)
             self.language = language  # 2011/05/30
             return True

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1021,7 +1021,6 @@ class JEditColorizer(BaseColorizer):
         bunch = self.modes.get(rulesetName)
         if bunch:
             if bunch.language == 'unknown-language':
-                g.trace('unknown-language', name, rulesetName)
                 return False
             self.initModeFromBunch(bunch)
             self.language = language  # 2011/05/30

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -732,9 +732,10 @@ class BaseColorizer:
                 s2 = repr(s[i : i + 17 - 2] + '...')
             delegate_s = f"{self.delegate_name}:" if self.delegate_name else ''
             font_s = id(font) if font else 'None'
+            matcher_name = g.caller(3)
             print(
-                f"setTag: {full_tag:32} {i:3} {j:3} {colorName:7} font: {font_s:14} {s2:>22} "
-                f"{self.rulesetName}:{delegate_s}{self.matcher_name}"
+                f"setTag: {full_tag:32} {i:3} {j:3} {colorName:7} font: {font_s:<14} {s2:>22} "
+                f"{self.rulesetName}:{delegate_s}{matcher_name}"
             )
             if extra:
                 print(f"{' ':48} {extra}")
@@ -1258,7 +1259,6 @@ class JEditColorizer(BaseColorizer):
                     g.trace('Can not happen: n is None', repr(f))
                     break
                 elif n > 0:  # Success. The match has already been colored.
-                    self.matcher_name = f.__name__  # For traces.
                     i += n
                     break
                 elif n < 0:  # Total failure.
@@ -1380,15 +1380,6 @@ class JEditColorizer(BaseColorizer):
             return
         self.delegate_name = delegate
         if delegate:
-            if trace:
-                if len(repr(s[i:j])) <= 20:
-                    s2 = repr(s[i:j])
-                else:
-                    s2 = repr(s[i : i + 17 - 2] + '...')
-                kind_s = f"{delegate}:{tag}"
-                print(
-                    f"\ncolorRangeWithTag: {kind_s:25} {i:3} {j:3} "
-                    f"{s2:>20} {self.matcher_name}\n")
             self.modeStack.append(self.modeBunch)
             self.init_mode(delegate)
             while 0 <= i < j and i < len(s):
@@ -1399,7 +1390,6 @@ class JEditColorizer(BaseColorizer):
                     if n is None:
                         g.trace('Can not happen: delegate matcher returns None')
                     elif n > 0:
-                        self.matcher_name = f.__name__
                         i += n
                         break
                 else:
@@ -2232,7 +2222,6 @@ class JEditColorizer(BaseColorizer):
         no_word_break: bool = False,
     ) -> int:
         """Remain in this state until 'end' is seen."""
-        self.matcher_name = 'restart:' + self.matcher_name.replace('restart:', '')
         i = 0
         j = self.match_span_helper(s, i, end,
             # Must be keyword arguments.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2087,8 +2087,8 @@ class JEditColorizer(BaseColorizer):
         self,
         s: str,
         i: int,
-        kind: str,
         *,
+        kind: str,
         begin: str,
         end: str,
         at_line_start: bool = False,
@@ -2417,7 +2417,7 @@ class JEditColorizer(BaseColorizer):
         self.trace_match(kind2, s, j, k)
         return k - i
     #@+node:ekr.20230420052804.1: *4* jedit.match_plain_seq
-    def match_plain_seq(self, s: str, i: int, kind: str, *, seq: str) -> int:
+    def match_plain_seq(self, s: str, i: int, *, kind: str, seq: str) -> int:
         """Matcher for plain sequence match at at s[i:]."""
         if not g.match(s, i, seq):
             return 0

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1020,9 +1020,6 @@ class JEditColorizer(BaseColorizer):
         language, rulesetName = self.nameToRulesetName(name)
         bunch = self.modes.get(rulesetName)
         if bunch:
-            # if bunch.language == 'unknown-language':
-                # g.trace('FAIL', rulesetName)
-                # return False
             self.initModeFromBunch(bunch)
             self.language = language  # 2011/05/30
             return True

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1011,7 +1011,7 @@ class JEditColorizer(BaseColorizer):
                 else:
                     theList.append(rule)
                 theDict[ch] = theList
-    #@+node:ekr.20110605121601.18581: *4* jedit.init_mode & helpers (trace)
+    #@+node:ekr.20110605121601.18581: *4* jedit.init_mode & helpers
     def init_mode(self, name: str) -> bool:
         """Name may be a language name or a delegate name."""
         if not name:
@@ -1035,7 +1035,7 @@ class JEditColorizer(BaseColorizer):
         else:
             mode = None
         return self.init_mode_from_module(name, mode)
-    #@+node:btheado.20131124162237.16303: *5* jedit.init_mode_from_module (trace)
+    #@+node:btheado.20131124162237.16303: *5* jedit.init_mode_from_module
     def init_mode_from_module(self, name: str, mode: Mode) -> bool:
         """
         Name may be a language name or a delegate name.
@@ -1049,7 +1049,6 @@ class JEditColorizer(BaseColorizer):
                 mode.pre_init_mode(self.c)
         else:
             # Create a dummy bunch to limit recursion.
-            ### g.trace('===== Dummy', name, rulesetName)
             self.modes[language] = self.modeBunch = g.Bunch(
                 attributesDict={},
                 defaultColor=None,
@@ -1107,7 +1106,6 @@ class JEditColorizer(BaseColorizer):
         # Complete the late replacements.
         self.modeBunch.language = self.language
         self.modes[rulesetName] = self.modeBunch
-        ### g.trace(f"{name:>8} {rulesetName:12} language: {self.language:8} {self.mode}")
         return True
     #@+node:ekr.20110605121601.18582: *5* jedit.nameToRulesetName
     def nameToRulesetName(self, name: str) -> Tuple[str, str]:
@@ -1517,8 +1515,6 @@ class JEditColorizer(BaseColorizer):
             k = g.skip_c_id(s, j)
             name = s[j:k]
             ok = self.init_mode(name)
-            if not ok:
-                g.trace('FAIL', name)
             if ok:
                 self.colorRangeWithTag(s, i, k, 'leokeyword')
                 if name != old_name:

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -107,7 +107,7 @@ keywordsDictDict = {
 #@+others
 #@+node:ekr.20230419050050.1: *3* html_rule0
 def html_rule0(colorer, s, i):
-    return colorer.match_span(s, i, "comment1", begin="<!--", end="-->")
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
 
 #@+node:ekr.20230419050050.2: *3* html_rule1 <script..</script>
 def match(s: str, i: int, pattern: str) -> bool:
@@ -120,32 +120,32 @@ def html_rule1(colorer: Any, s: str, i: int) -> int:
     if not match(s, i, '<script') and not match(s, i, '<SCRIPT'):
         return 0
 
-    return colorer.match_span(s, i, "markup", begin="<script", end="</script>",
+    return colorer.match_span(s, i, kind="markup", begin="<script", end="</script>",
         delegate='javascript')  # "html::javascript"
 
 #@+node:ekr.20230419050050.4: *3* html_rule2 <style..</style>
 def html_rule2(colorer, s, i):
-    return colorer.match_span(s, i, "markup", begin="<style", end="</style>",
+    return colorer.match_span(s, i, kind="markup", begin="<style", end="</style>",
         delegate="html::css")
 
 #@+node:ekr.20230419050050.6: *3* html_rule3 <!..>
 def html_rule3(colorer, s, i):
-    return colorer.match_span(s, i, "keyword2", begin="<!", end=">")
+    return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">")
 
 #@+node:ekr.20230419050050.7: *3* html_rule4 <..>
 def html_rule4(colorer, s, i):
-    return colorer.match_span(s, i, "markup", begin="<", end=">",
+    return colorer.match_span(s, i, kind="markup", begin="<", end=">",
         delegate="html::tags")
 
 #@+node:ekr.20230419050050.8: *3* html_rule5 &..;
 def html_rule5(colorer, s, i):
-    return colorer.match_span(s, i, "literal2", begin="&", end=";",
+    return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
         no_word_break=True)
 
 #@+node:ekr.20230419050050.9: *3* html_rule_handlebar {{..}}
 # New rule for handlebar markup, colored with the literal3 color.
 def html_rule_handlebar(colorer, s, i):
-    return colorer.match_span(s, i, "literal3", begin="{{", end="}}")
+    return colorer.match_span(s, i, kind="literal3", begin="{{", end="}}")
 
 #@-others
 
@@ -160,13 +160,13 @@ rulesDict1 = {
 # Rules for html_tags ruleset.
 
 def html_rule6(colorer, s, i):
-    return colorer.match_span(s, i, "literal1", begin="\"", end="\"")
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 
 def html_rule7(colorer, s, i):
-    return colorer.match_span(s, i, "literal1", begin="'", end="'")
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 
 def html_rule8(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for html_tags ruleset.
 rulesDict2 = {

--- a/leo/modes/javascript.py
+++ b/leo/modes/javascript.py
@@ -210,16 +210,16 @@ keywordsDictDict = {
 #@+others
 #@+node:ekr.20230419052250.1: *3* javascript_rule0
 def javascript_rule0(colorer, s, i):
-    return colorer.match_span(s, i, "comment1", begin="/*", end="*/")
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 #@+node:ekr.20230419052250.2: *3* javascript_rule1
 def javascript_rule1(colorer, s, i):
-    return colorer.match_span(s, i, "literal1", begin="\"", end="\"",
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
         no_line_break=True)
 
 #@+node:ekr.20230419052250.3: *3* javascript_rule2
 def javascript_rule2(colorer, s, i):
-    return colorer.match_span(s, i, "literal1", begin="'", end="'",
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
         no_line_break=True)
 
 #@+node:ekr.20230419052250.4: *3* javascript_rule3
@@ -233,63 +233,63 @@ def javascript_rule4(colorer, s, i):
 
 #@+node:ekr.20230419052250.6: *3* javascript_rule5
 def javascript_rule5(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "comment1", seq="<!--")
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="<!--")
 
 #@+node:ekr.20230419052250.7: *3* javascript_rule6
 def javascript_rule6(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 #@+node:ekr.20230419052250.8: *3* javascript_rule7
 def javascript_rule7(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="!")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 #@+node:ekr.20230419052250.9: *3* javascript_rule8
 def javascript_rule8(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq=">=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 #@+node:ekr.20230419052250.10: *3* javascript_rule9
 def javascript_rule9(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="<=")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 #@+node:ekr.20230419052250.11: *3* javascript_rule10
 def javascript_rule10(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="+")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 #@+node:ekr.20230419052250.12: *3* javascript_rule11
 def javascript_rule11(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="-")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 #@+node:ekr.20230419052250.13: *3* javascript_rule12
 def javascript_rule12(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="/")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 #@+node:ekr.20230419052250.14: *3* javascript_rule13
 def javascript_rule13(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="*")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 #@+node:ekr.20230419052250.15: *3* javascript_rule14
 def javascript_rule14(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq=">")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 #@+node:ekr.20230419052250.16: *3* javascript_rule15
 def javascript_rule15(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="<")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 #@+node:ekr.20230419052250.17: *3* javascript_rule16
 def javascript_rule16(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="%")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 #@+node:ekr.20230419052250.18: *3* javascript_rule17
 def javascript_rule17(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="&")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 #@+node:ekr.20230419052250.19: *3* javascript_rule18
 def javascript_rule18(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="|")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 #@+node:ekr.20230419052250.20: *3* javascript_rule19
 def javascript_rule19(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="^")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 #@+node:ekr.20230419052250.21: *3* javascript_rule20
 def javascript_rule20(colorer, s, i):
@@ -301,7 +301,7 @@ def javascript_rule21(colorer, s, i):
 
 #@+node:ekr.20230419052250.23: *3* javascript_rule22
 def javascript_rule22(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="}")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 #@+node:ekr.20230419052250.24: *3* javascript_rule23
 def javascript_rule23(colorer, s, i):
@@ -309,23 +309,23 @@ def javascript_rule23(colorer, s, i):
 
 #@+node:ekr.20230419052250.25: *3* javascript_rule24
 def javascript_rule24(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq=",")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
 
 #@+node:ekr.20230419052250.26: *3* javascript_rule25
 def javascript_rule25(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq=";")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 #@+node:ekr.20230419052250.27: *3* javascript_rule26
 def javascript_rule26(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="]")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
 
 #@+node:ekr.20230419052250.28: *3* javascript_rule27
 def javascript_rule27(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="[")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
 
 #@+node:ekr.20230419052250.29: *3* javascript_rule28
 def javascript_rule28(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq="?")
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
 
 #@+node:ekr.20230419052250.30: *3* javascript_rule29
 def javascript_rule29(colorer, s, i):
@@ -334,7 +334,7 @@ def javascript_rule29(colorer, s, i):
 
 #@+node:ekr.20230419052250.31: *3* javascript_rule30
 def javascript_rule30(colorer, s, i):
-    return colorer.match_plain_seq(s, i, "operator", seq=":")
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
 #@+node:ekr.20230419052250.32: *3* javascript_rule31
 def javascript_rule31(colorer, s, i):

--- a/leo/modes/md.py
+++ b/leo/modes/md.py
@@ -169,12 +169,12 @@ def md_link(colorer, s, i):
 def md_star_emphasis1(colorer, s, i):
     # issue 386.
     # print('md_underscore_emphasis1',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*[^\\s*][^*]*\\*")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\*[^\s*][^*]*\*")
 
 def md_star_emphasis2(colorer, s, i):
     # issue 386.
     # print('md_star_emphasis2',i)
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\\*\\*[^*]+\\*\\*")
+    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp=r"\*\*[^*]+\*\*")
 
 def md_underscore_emphasis1(colorer, s, i):
     # issue 386.

--- a/leo/modes/perl.py
+++ b/leo/modes/perl.py
@@ -465,7 +465,7 @@ def perl_rule32(colorer, s, i):
 
 def perl_rule33(colorer, s, i):
     return 0  # too complicated
-    #return colorer.match_seq_regexp(s, i, kind="markup", regexp="s([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1[sgiexom]*",
+    # return colorer.match_seq_regexp(s, i, kind="markup", regexp="s([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1[sgiexom]*",
     #       )
 
 def perl_rule34(colorer, s, i):

--- a/leo/scripts/beautify-leo.cmd
+++ b/leo/scripts/beautify-leo.cmd
@@ -6,3 +6,5 @@ call py -m leo.core.leoAst --orange --recursive leo\core
 call py -m leo.core.leoAst --orange --recursive leo\commands
 call py -m leo.core.leoAst --orange --recursive leo\plugins\importers
 call py -m leo.core.leoAst --orange --recursive leo\plugins\writers
+rem call py -m leo.core.leoAst --orange --recursive leo\modes
+


### PR DESCRIPTION
See #3310.

- [x] Fix two regexs in `md.py`. These errors predate Leo 6.7.2.
- [x] Require `kind` arg to be a kwarg.
- [x] Update `self.modes[rulesetName]` in `init_mode_from_module`. This fixes the reported problem.
- [x] Improve the traces produced by the `report` function in the `setTag` method:
  - Remove the `match_name` ivar. It was updated too late to appear in the traces.
  - The `match_name` var is the caller three-levels up.