### PR TITLE
PR for #3343: New python-based importers

### DIFF
--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -188,7 +188,7 @@ class LeoUnitTest(unittest.TestCase):
             print(tag)
         _iter = root.self_and_subtree if root else self.c.all_positions
         for p in _iter():
-            print('level:', p.level(), p.h)
+            print('level:', p.level(), repr(p.h))
     #@+node:ekr.20211129062220.1: *3* LeoUnitTest.dump_tree
     def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
         """

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -14,16 +14,16 @@ if TYPE_CHECKING:
 #@+others
 #@+node:ekr.20140723122936.17928: ** class C_Importer
 class C_Importer(Importer):
-
-    #@+others
-    #@+node:ekr.20200819144754.1: *3* c_i.__init__
+    
     def __init__(self, c: Cmdr) -> None:
         """C_Importer.__init__"""
 
         # Init the base class.
         super().__init__(c, language='c')
         self.string_list = ['"']  # Not single quotes.
-    #@+node:ekr.20220728055719.1: *3* c_i.find_blocks & helper (override)
+
+    #@+others
+    #@+node:ekr.20220728055719.1: *3* c_i.find_blocks (override)
     #@+<< define block_patterns >>
     #@+node:ekr.20230511083510.1: *4* << define block_patterns >>
     # Pattern that matches the start of any block.
@@ -58,11 +58,12 @@ class C_Importer(Importer):
         """
         C_Importer.find_blocks: override Importer.find_blocks.
 
-        Find all blocks in the given range of lines.
+        Find all blocks in the given range of *guide* lines from which blanks
+        and tabs have been deleted.
 
-        Return a list of tuples(name, start, start_body, end) for each block.
+        Return a list of Blocks, that is, tuples(name, start, start_body, end).
         """
-        lines = self.lines
+        lines = self.guide_lines
         i, prev_i, result = i1, i1, []
         while i < i2:
             s = lines[i]
@@ -98,15 +99,15 @@ class C_Importer(Importer):
                         i = prev_i = end
                         break
         return result
-    #@+node:ekr.20230511054807.1: *4* c_i.find_end_of_block
+    #@+node:ekr.20230511054807.1: *3* c_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:
         """
-        i is the index (within lines) of the line *following* the start of the block.
-        Return the index (within lines) of end of the block that starts at guide_lines[i].
+        i is the index (within the *guide* lines) of the line *following* the start of the block.
+        Return the index of end of the block that starts at guide_lines[i].
         """
         level = 1  # All blocks start with '{'
         while i < i2:
-            line = self.lines[i]
+            line = self.guide_lines[i]
             i += 1
             for ch in line:
                 if ch == '{':

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -27,6 +27,7 @@ class C_Importer(Importer):
     #@+<< define block_patterns >>
     #@+node:ekr.20230511083510.1: *4* << define block_patterns >>
     # Pattern that matches the start of any block.
+    # Group 1 matches the name of the class/func/namespace/struct.
     class_pat = re.compile(r'.*?\bclass\s+(\w+)\s*\{')
     function_pat = re.compile(r'.*?\b(\w+)\s*\(.*?\)\s*(const)?\s*{')
     namespace_pat = re.compile(r'.*?\bnamespace\s*(\w+)?\s*\{')

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 #@+others
 #@+node:ekr.20140723122936.17928: ** class C_Importer
 class C_Importer(Importer):
-    
+
     def __init__(self, c: Cmdr) -> None:
         """C_Importer.__init__"""
 

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 #@+others
 #@+node:ekr.20160505094722.2: ** class Coffeescript_Importer(Python_Importer)
 class Coffeescript_Importer(Python_Importer):
-    
+
     block_patterns: Tuple = (
         ('class', re.compile(r'^\s*class')),
         ('def', re.compile(r'^\s*(.+):(.*)->')),

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -16,8 +16,6 @@ class Coffeescript_Importer(Python_Importer):
         super().__init__(c, language='coffeescript')
 
     #@+others
-    #@+node:ekr.20160505101118.1: *3* coffee_i.__init__
-
     #@+node:ekr.20220729104712.1: *3* coffee_i.compute_headline
     def compute_headline(self, s: str) -> str:
         """

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -1,65 +1,26 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20160505094722.1: * @file ../plugins/importers/coffeescript.py
 """The @auto importer for coffeescript."""
+from __future__ import annotations
 import re
-from typing import Optional
-from leo.core import leoGlobals as g  # Required.
-from leo.core.leoCommands import Commands as Cmdr
-from leo.core.leoNodes import Position
+from typing import Tuple, TYPE_CHECKING
 from leo.plugins.importers.python import Python_Importer
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoNodes import Position
 #@+others
 #@+node:ekr.20160505094722.2: ** class Coffeescript_Importer(Python_Importer)
 class Coffeescript_Importer(Python_Importer):
+    
+    block_patterns: Tuple = (
+        ('class', re.compile(r'^\s*class')),
+        ('def', re.compile(r'^\s*(.+):(.*)->')),
+        ('def', re.compile(r'^\s*(.+)=(.*)->')),
+    )
 
     def __init__(self, c: Cmdr) -> None:
         """Ctor for CoffeeScriptScanner class."""
         super().__init__(c, language='coffeescript')
-
-    #@+others
-    #@+node:ekr.20220729104712.1: *3* coffee_i.compute_headline
-    def compute_headline(self, s: str) -> str:
-        """
-        Coffeescript_Importer.compute_headline.
-
-        Don't strip arguments.
-        """
-        return s.strip()
-    #@+node:ekr.20161118134555.7: *3* coffee_i.new_starts_block
-    pattern_table = [
-        re.compile(r'^\s*class'),
-        re.compile(r'^\s*(.+):(.*)->'),
-        re.compile(r'^\s*(.+)=(.*)->'),
-    ]
-
-    def new_starts_block(self, i: int) -> Optional[int]:
-        """
-        Return None if lines[i] does not start a class, function or method.
-
-        Otherwise, return the index of the first line of the body.
-        """
-        lines, line_states = self.lines, self.line_states
-        line = lines[i]
-        if line.isspace() or line_states[i].context:
-            return None  # pragma: no cover (mysterious)
-        prev_state = line_states[i - 1] if i > 0 else self.state_class()
-        if prev_state.context:
-            return None  # pragma: no cover (mysterious)
-        line = lines[i]
-        for pattern in self.pattern_table:
-            if pattern.match(line):
-                return i + 1
-        return None
-    #@+node:ekr.20220806164640.1: *3* coffee_i.is_intro_line
-    def is_intro_line(self, n: int, col: int) -> bool:
-        """
-        Return True if line n is a comment line or decorator that starts at the give column.
-        """
-        line = self.lines[n]
-        return (
-            line.strip().startswith('#')
-            and col == g.computeLeadingWhitespaceWidth(line, self.tab_width)
-        )
-    #@-others
 #@-others
 
 def do_import(c: Cmdr, parent: Position, s: str) -> None:

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
 class Coffeescript_Importer(Python_Importer):
 
     block_patterns: Tuple = (
-        ('class', re.compile(r'^\s*class')),
-        ('def', re.compile(r'^\s*(.+):(.*)->')),
-        ('def', re.compile(r'^\s*(.+)=(.*)->')),
+        ('class', re.compile(r'^\s*class\s+([\w]+)')),
+        ('def', re.compile(r'^\s*(.+?):.*?->')),
+        ('def', re.compile(r'^\s*(.+?)=.*?->')),
     )
 
     def __init__(self, c: Cmdr) -> None:

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -3,7 +3,7 @@
 """@auto importer for cython."""
 from __future__ import annotations
 import re
-from typing import TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING
 from leo.plugins.importers.python import Python_Importer
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
@@ -22,7 +22,7 @@ class Cython_Importer(Python_Importer):
     cpdef_pat = re.compile(r'\s*cpdef\s+([\w_ ]+)')
     def_pat = re.compile(r'\s*def\s+([\w_ ]+)')
 
-    block_patterns = (
+    block_patterns: Tuple = (
         ('async class', async_class_pat),
         ('class', class_pat),
         ('cdef', cdef_pat),

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -3,8 +3,7 @@
 """@auto importer for cython."""
 from __future__ import annotations
 import re
-from typing import List, TYPE_CHECKING
-from leo.plugins.importers.linescanner import Block
+from typing import TYPE_CHECKING
 from leo.plugins.importers.python import Python_Importer
 if TYPE_CHECKING:
     from leo.core.leoCommands import Commands as Cmdr
@@ -37,58 +36,6 @@ class Cython_Importer(Python_Importer):
         )
 
     #@+others
-    #@+node:ekr.20230514220727.1: *3* cython_i.find_blocks & helper (override)
-    async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
-    def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
-    class_pat = re.compile(r'\s*class\s*(\w+)')
-
-
-    def find_blocks(self, i1: int, i2: int) -> List[Block]:
-        """
-        Python_Importer.find_blocks: override Importer.find_blocks.
-
-        Find all blocks in the given range of *guide* lines from which blanks
-        and tabs have been deleted.
-
-        Return a list of Blocks, that is, tuples(name, start, start_body, end).
-        """
-        i, prev_i, result = i1, i1, []
-        while i < i2:
-            s = self.guide_lines[i]
-            # g.trace(repr(s))
-            i += 1
-            for kind, pattern in self.block_patterns:
-                m = pattern.match(s)
-                if m:
-                    name = m.group(1)
-                    end = self.find_end_of_block(i, i2)
-                    assert i1 + 1 <= end <= i2, (i1, end, i2)
-                    result.append((kind, name, prev_i, i, end))
-                    i = prev_i = end
-                    break
-        # g.printObj(result, tag=f"{i1}:{i2}")
-        return result
-    #@+node:ekr.20230514220727.2: *4* python_i.find_end_of_block
-    def find_end_of_block(self, i: int, i2: int) -> int:
-        """
-        i is the index of the class/def line (within the *guide* lines).
-
-        Return the index of the line *following* the entire class/def
-        """
-        def lws_n(s: str) -> int:
-            """Return the length of the leading whitespace for s."""
-            return len(s) - len(s.lstrip())
-
-        prev_line = self.guide_lines[i-1]
-        assert any(z in prev_line for z in ('class', 'def')), (i, repr(prev_line))
-        if i < i2:
-            lws1 = lws_n(prev_line)
-            while i < i2:
-                s = self.guide_lines[i]
-                i += 1
-                if s.strip() and lws_n(s) <= lws1:
-                    return i
-        return i2
     #@-others
 #@-others
 

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -1,11 +1,15 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20200619141135.1: * @file ../plugins/importers/cython.py
 """@auto importer for cython."""
+from __future__ import annotations
 import re
-from typing import Optional
-from leo.core.leoCommands import Commands as Cmdr
-from leo.core.leoNodes import Position
+from typing import List, TYPE_CHECKING
+from leo.plugins.importers.linescanner import Block
 from leo.plugins.importers.python import Python_Importer
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoNodes import Position
+
 #@+others
 #@+node:ekr.20200619141201.2: ** class Cython_Importer(Python_Importer)
 class Cython_Importer(Python_Importer):
@@ -14,34 +18,77 @@ class Cython_Importer(Python_Importer):
     def __init__(self, c: Cmdr) -> None:
         """Cython_Importer.ctor."""
         super().__init__(c, language='cython')
-        self.put_decorators = self.c.config.getBool('put-cython-decorators-in-imported-headlines')
 
+        # Override the Python class patterns.
+        # m.group(1) must be the class/def name.
+        self.async_class_pat = re.compile(r'\s*async\s+class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
+        self.class_pat = re.compile(r'\s*class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
+
+        self.cdef_pat = re.compile(r'\s*cdef\s+([\w_ ]+)')
+        self.cpdef_pat = re.compile(r'\s*cpdef\s+([\w_ ]+)')
+        self.def_pat = re.compile(r'\s*def\s+([\w_ ]+)')
+
+        self.block_patterns = (
+            ('async class', self.async_class_pat),
+            ('class', self.class_pat),
+            ('cdef', self.cdef_pat),
+            ('cpdef', self.cpdef_pat),
+            ('def', self.def_pat),
+        )
 
     #@+others
-    #@+node:ekr.20220806173547.1: *3* cython_i.new_starts_block
-    class_pat_s = r'\s*(class|async class)\s+([\w_]+)\s*(\(.*?\))?(.*?):'
-    class_pat = re.compile(class_pat_s, re.MULTILINE)
+    #@+node:ekr.20230514220727.1: *3* cython_i.find_blocks & helper (override)
+    async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
+    def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
+    class_pat = re.compile(r'\s*class\s*(\w+)')
 
-    # m.group(2) might not be the def name!
-    # compute_headline must handle the complications.
-    def_pat_s = r'\s*\b(cdef|cpdef|def)\s+([\w_]+)'
-    def_pat = re.compile(def_pat_s, re.MULTILINE)
 
-    def new_starts_block(self, i: int) -> Optional[int]:
+    def find_blocks(self, i1: int, i2: int) -> List[Block]:
         """
-        Return None if lines[i] does not start a class, function or method.
+        Python_Importer.find_blocks: override Importer.find_blocks.
 
-        Otherwise, return the index of the first line of the body.
+        Find all blocks in the given range of *guide* lines from which blanks
+        and tabs have been deleted.
+
+        Return a list of Blocks, that is, tuples(name, start, start_body, end).
         """
-        lines, line_states = self.lines, self.line_states
-        line = lines[i]
-        if line.isspace() or line_states[i].context:
-            return None  # pragma: no cover (mysterious)
-        m = self.class_pat.match(line) or self.def_pat.match(line)
-        if not m:
-            return None  # pragma: no cover (mysterious)
-        newlines = m.group(0).count('\n')
-        return i + newlines + 1
+        i, prev_i, result = i1, i1, []
+        while i < i2:
+            s = self.guide_lines[i]
+            # g.trace(repr(s))
+            i += 1
+            for kind, pattern in self.block_patterns:
+                m = pattern.match(s)
+                if m:
+                    name = m.group(1)
+                    end = self.find_end_of_block(i, i2)
+                    assert i1 + 1 <= end <= i2, (i1, end, i2)
+                    result.append((kind, name, prev_i, i, end))
+                    i = prev_i = end
+                    break
+        # g.printObj(result, tag=f"{i1}:{i2}")
+        return result
+    #@+node:ekr.20230514220727.2: *4* python_i.find_end_of_block
+    def find_end_of_block(self, i: int, i2: int) -> int:
+        """
+        i is the index of the class/def line (within the *guide* lines).
+
+        Return the index of the line *following* the entire class/def
+        """
+        def lws_n(s: str) -> int:
+            """Return the length of the leading whitespace for s."""
+            return len(s) - len(s.lstrip())
+
+        prev_line = self.guide_lines[i-1]
+        assert any(z in prev_line for z in ('class', 'def')), (i, repr(prev_line))
+        if i < i2:
+            lws1 = lws_n(prev_line)
+            while i < i2:
+                s = self.guide_lines[i]
+                i += 1
+                if s.strip() and lws_n(s) <= lws1:
+                    return i
+        return i2
     #@-others
 #@-others
 

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -14,26 +14,26 @@ if TYPE_CHECKING:
 class Cython_Importer(Python_Importer):
     """A class to store and update scanning state."""
 
+    # Override the Python patterns.
+    async_class_pat = re.compile(r'\s*async\s+class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
+    class_pat = re.compile(r'\s*class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
+
+    cdef_pat = re.compile(r'\s*cdef\s+([\w_ ]+)')
+    cpdef_pat = re.compile(r'\s*cpdef\s+([\w_ ]+)')
+    def_pat = re.compile(r'\s*def\s+([\w_ ]+)')
+
+    block_patterns = (
+        ('async class', async_class_pat),
+        ('class', class_pat),
+        ('cdef', cdef_pat),
+        ('cpdef', cpdef_pat),
+        ('def', def_pat),
+    )
+
     def __init__(self, c: Cmdr) -> None:
         """Cython_Importer.ctor."""
         super().__init__(c, language='cython')
-
-        # Override the Python class patterns.
-        # m.group(1) must be the class/def name.
-        self.async_class_pat = re.compile(r'\s*async\s+class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
-        self.class_pat = re.compile(r'\s*class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
-
-        self.cdef_pat = re.compile(r'\s*cdef\s+([\w_ ]+)')
-        self.cpdef_pat = re.compile(r'\s*cpdef\s+([\w_ ]+)')
-        self.def_pat = re.compile(r'\s*def\s+([\w_ ]+)')
-
-        self.block_patterns = (
-            ('async class', self.async_class_pat),
-            ('class', self.class_pat),
-            ('cdef', self.cdef_pat),
-            ('cpdef', self.cpdef_pat),
-            ('def', self.def_pat),
-        )
+        assert len(self.block_patterns) == 5, self.block_patterns
 
     #@+others
     #@-others

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -15,6 +15,7 @@ class Cython_Importer(Python_Importer):
     """A class to store and update scanning state."""
 
     # Override the Python patterns.
+    # Group 1 matches the name of the class/cdef/cpdef/def.
     async_class_pat = re.compile(r'\s*async\s+class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
     class_pat = re.compile(r'\s*class\s+([\w_]+)\s*(\(.*?\))?(.*?):')
 

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -179,7 +179,7 @@ class Importer:
                 elif ch == escape:
                     skip_count = 1
                     continue
-                elif line.startswith(line_comment, i):
+                elif line_comment and line.startswith(line_comment, i):
                     break  # Skip the rest of the line.
                 elif any(line.startswith(z, i) for z in string_delims):
                     # Allow multi-character string delimiters.
@@ -189,7 +189,7 @@ class Importer:
                             if len(z) > 1:
                                 skip_count = len(z) - 1
                             break
-                elif line.startswith(start_comment, i):
+                elif start_comment and line.startswith(start_comment, i):
                     target = end_comment
                     if len(start_comment) > 1:
                         # Skip the remaining characters of the starting comment delim.
@@ -275,6 +275,7 @@ class Importer:
             parent.deleteAllChildren()
             # Create the guide lines.
             self.guide_lines = self.make_guide_lines(lines)
+            ### g.printObj(self.guide_lines, tag='new_gen_lines')
             n1, n2 = len(self.lines), len(self.guide_lines)
             assert n1 == n2, (n1, n2)
             # Start the recursion.
@@ -772,7 +773,7 @@ class Importer:
 
         # Call gen_lines or new_gen_lines, depending on language.
         # Eventually, new_gen_lines will replace gen_lines for *all* languages.
-        if self.language in ('c',):
+        if self.language in ('c', 'python'):
             self.new_gen_lines(lines, parent)
         else:
             self.gen_lines(lines, parent)

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -226,17 +226,7 @@ class Importer:
         # Find all blocks in the body of this block.
         blocks = self.find_blocks(start_body, end)
         if 0:
-            #@+<< trace blocks >>
-            #@+node:ekr.20230511121416.1: *5* << trace blocks >>
-            n = len(blocks)
-            if n > 0:
-                print('')
-                g.trace(f"{n} block{g.plural(n)} in [{start_body}:{end}] parent: {parent.h}")
-                for z in blocks:
-                    kind2, name2, start2, start_body2, end2 = z
-                    tag = f"  {kind2:>10} {name2:<20} {start2:4} {start_body2:4} {end2:4}"
-                    g.printObj(lines[start2:end2], tag=tag)
-            #@-<< trace blocks >>
+            self.trace_blocks(blocks)
         if blocks:
             # Start with the head: lines[start : start_start_body].
             result_list = lines[start:start_body]
@@ -304,6 +294,21 @@ class Importer:
             assert not stripped_line or line.startswith(lws), repr(line)
             result.append(line[n:] if stripped_line else line)
         p.b = ''.join(result)
+    #@+node:ekr.20230515082848.1: *4* i.trace_blocks
+    def trace_blocks(self, blocks: List[Block]) -> None:
+
+        if not blocks:
+            g.trace('No blocks')
+            return
+        print('')
+        print('Blocks...')
+        lines = self.lines
+        for z in blocks:
+            kind2, name2, start2, start_body2, end2 = z
+            tag = f"  {kind2:>10} {name2:<20} {start2:4} {start_body2:4} {end2:4}"
+            g.printObj(lines[start2:end2], tag=tag)
+        print('End of Blocks')
+        print('')
     #@+node:ekr.20230513091923.1: *3* i: Old methods (to be deleted)
     #@+node:ekr.20220727073906.1: *4* i.gen_lines & helpers (OLD: to be deleted)
     def gen_lines(self, lines: List[str], parent: Position) -> None:

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -777,7 +777,7 @@ class Importer:
 
         # Call gen_lines or new_gen_lines, depending on language.
         # Eventually, new_gen_lines will replace gen_lines for *all* languages.
-        if self.language in ('c', 'cython', 'python'):
+        if self.language in ('c', 'coffeescript', 'cython', 'python'):
             self.new_gen_lines(lines, parent)
         else:
             self.gen_lines(lines, parent)

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -275,7 +275,6 @@ class Importer:
             parent.deleteAllChildren()
             # Create the guide lines.
             self.guide_lines = self.make_guide_lines(lines)
-            ### g.printObj(self.guide_lines, tag='new_gen_lines')
             n1, n2 = len(self.lines), len(self.guide_lines)
             assert n1 == n2, (n1, n2)
             # Start the recursion.

--- a/leo/plugins/importers/linescanner.py
+++ b/leo/plugins/importers/linescanner.py
@@ -773,7 +773,7 @@ class Importer:
 
         # Call gen_lines or new_gen_lines, depending on language.
         # Eventually, new_gen_lines will replace gen_lines for *all* languages.
-        if self.language in ('c', 'python'):
+        if self.language in ('c', 'cython', 'python'):
             self.new_gen_lines(lines, parent)
         else:
             self.gen_lines(lines, parent)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -50,7 +50,8 @@ class Python_Importer(Importer):
             for kind, pattern in self.block_patterns:
                 m = pattern.match(s)
                 if m:
-                    name = m.group(1).strip()  # cython may include trailing whitespace.
+                    # cython may include trailing whitespace.
+                    name = m.group(1).strip()
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
                     results.append((kind, name, prev_i, i, end))
@@ -71,7 +72,8 @@ class Python_Importer(Importer):
             return len(s) - len(s.lstrip())
 
         prev_line = self.guide_lines[i - 1]
-        assert any(z in prev_line for z in ('class', 'def')), (i, repr(prev_line))
+        kinds = ('class', 'def', '->')  # '->' denotes a coffeescript function.
+        assert any(z in prev_line for z in kinds), (i, repr(prev_line))
         tail_lines = 0
         if i < i2:
             lws1 = lws_n(prev_line)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -14,14 +14,9 @@ if TYPE_CHECKING:
 #@+node:ekr.20220720043557.1: ** class Python_Importer
 class Python_Importer(Importer):
     """Leo's Python importer"""
-
-    def __init__(self, c: Cmdr, language: str = 'python') -> None:
-        """Py_Importer.ctor."""
-        super().__init__(c, language=language, strict=True)
-        self.string_list = ['"""', "'''", '"', "'"]  # longest first.
-
-    #@+others
-    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks & helper (override)
+    
+    string_list = ['"""', "'''", '"', "'"]  # longest first.
+    
     # The default patterns. Overridden in the Cython_Importer class.
     async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
     def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
@@ -32,6 +27,12 @@ class Python_Importer(Importer):
         ('def', def_pat),
     )
 
+    def __init__(self, c: Cmdr, language: str = 'python') -> None:
+        """Py_Importer.ctor."""
+        super().__init__(c, language=language, strict=True)
+
+    #@+others
+    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks & helper (override)
     def find_blocks(self, i1: int, i2: int) -> List[Block]:
         """
         Python_Importer.find_blocks: override Importer.find_blocks.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -49,7 +49,7 @@ class Python_Importer(Importer):
             for kind, pattern in self.block_patterns:
                 m = pattern.match(s)
                 if m:
-                    name = m.group(1)
+                    name = m.group(1).strip()  # cython may include trailing whitespace.
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
                     result.append((kind, name, prev_i, i, end))

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -22,6 +22,7 @@ class Python_Importer(Importer):
 
     #@+others
     #@+node:ekr.20230514140918.1: *3* python_i.find_blocks & helper (override)
+    # The default patterns. Overridden in the Cython_Importer class.
     async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
     def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
     class_pat = re.compile(r'\s*class\s*(\w+)')
@@ -54,7 +55,7 @@ class Python_Importer(Importer):
                     result.append((kind, name, prev_i, i, end))
                     i = prev_i = end
                     break
-        # g.printObj(result, tag=f"{i1}:{i2}")
+        # g.printObj(result, tag=f"python_i.findblocks: {i1}:{i2}")
         return result
     #@+node:ekr.20230514140918.4: *4* python_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:
@@ -75,7 +76,7 @@ class Python_Importer(Importer):
                 s = self.guide_lines[i]
                 i += 1
                 if s.strip() and lws_n(s) <= lws1:
-                    return i
+                    return i - 1
         return i2
     #@-others
 #@-others

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -46,7 +46,6 @@ class Python_Importer(Importer):
         i, prev_i, results = i1, i1, []
         while i < i2:
             s = self.guide_lines[i]
-            # g.trace(repr(s))
             i += 1
             for kind, pattern in self.block_patterns:
                 m = pattern.match(s)
@@ -57,9 +56,6 @@ class Python_Importer(Importer):
                     results.append((kind, name, prev_i, i, end))
                     i = prev_i = end
                     break
-        if 0:  ###
-            g.trace(f"python_i.findblocks: {i1}:{i2}")
-            self.trace_blocks(results)
         return results
     #@+node:ekr.20230514140918.4: *4* python_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -3,7 +3,7 @@
 """The new, tokenize based, @auto importer for Python."""
 from __future__ import annotations
 import re
-from typing import List, TYPE_CHECKING
+from typing import List, Tuple, TYPE_CHECKING
 import leo.core.leoGlobals as g
 from leo.plugins.importers.linescanner import Block, Importer
 if TYPE_CHECKING:
@@ -14,14 +14,15 @@ if TYPE_CHECKING:
 #@+node:ekr.20220720043557.1: ** class Python_Importer
 class Python_Importer(Importer):
     """Leo's Python importer"""
-    
+
     string_list = ['"""', "'''", '"', "'"]  # longest first.
-    
+
     # The default patterns. Overridden in the Cython_Importer class.
     async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
     def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
     class_pat = re.compile(r'\s*class\s*(\w+)')
-    block_patterns = (
+
+    block_patterns: Tuple = (
         ('class', class_pat),
         ('async def', async_def_pat),
         ('def', def_pat),
@@ -42,7 +43,7 @@ class Python_Importer(Importer):
 
         Return a list of Blocks, that is, tuples(name, start, start_body, end).
         """
-        i, prev_i, result = i1, i1, []
+        i, prev_i, results = i1, i1, []
         while i < i2:
             s = self.guide_lines[i]
             # g.trace(repr(s))
@@ -53,11 +54,13 @@ class Python_Importer(Importer):
                     name = m.group(1).strip()  # cython may include trailing whitespace.
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
-                    result.append((kind, name, prev_i, i, end))
+                    results.append((kind, name, prev_i, i, end))
                     i = prev_i = end
                     break
-        # g.printObj(result, tag=f"python_i.findblocks: {i1}:{i2}")
-        return result
+        if 0:  ###
+            g.trace(f"python_i.findblocks: {i1}:{i2}")
+            self.trace_blocks(results)
+        return results
     #@+node:ekr.20230514140918.4: *4* python_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:
         """
@@ -71,7 +74,7 @@ class Python_Importer(Importer):
             """Return the length of the leading whitespace for s."""
             return len(s) - len(s.lstrip())
 
-        prev_line = self.guide_lines[i-1]
+        prev_line = self.guide_lines[i - 1]
         assert any(z in prev_line for z in ('class', 'def')), (i, repr(prev_line))
         tail_lines = 0
         if i < i2:
@@ -89,7 +92,7 @@ class Python_Importer(Importer):
                 else:
                     # A comment line.
                     tail_lines += 1
-        return i2
+        return i2 - tail_lines
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -64,6 +64,8 @@ class Python_Importer(Importer):
         i is the index of the class/def line (within the *guide* lines).
 
         Return the index of the line *following* the entire class/def
+        
+        Note: All following blank/comment lines are *excluded* from the block.
         """
         def lws_n(s: str) -> int:
             """Return the length of the leading whitespace for s."""
@@ -71,13 +73,22 @@ class Python_Importer(Importer):
 
         prev_line = self.guide_lines[i-1]
         assert any(z in prev_line for z in ('class', 'def')), (i, repr(prev_line))
+        tail_lines = 0
         if i < i2:
             lws1 = lws_n(prev_line)
             while i < i2:
                 s = self.guide_lines[i]
                 i += 1
-                if s.strip() and lws_n(s) <= lws1:
-                    return i - 1
+                if s.strip():
+                    if lws_n(s) <= lws1:
+                        # A non-comment line that ends the block.
+                        # Exclude all tail lines.
+                        return i - tail_lines - 1
+                    # A non-comment line that does not end the block.
+                    tail_lines = 0
+                else:
+                    # A comment line.
+                    tail_lines += 1
         return i2
     #@-others
 #@-others

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -1,510 +1,88 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20211209153303.1: * @file ../plugins/importers/python.py
 """The new, tokenize based, @auto importer for Python."""
+from __future__ import annotations
 import re
-import tokenize
-import token
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
-from collections import defaultdict, namedtuple
+from typing import List, TYPE_CHECKING
 import leo.core.leoGlobals as g
-from leo.core.leoCommands import Commands as Cmdr
-from leo.core.leoNodes import Position
-from leo.plugins.importers.linescanner import Importer, block_tuple
-#@+<< define def_tuple >>
-#@+node:ekr.20220724060054.1: ** << define def_tuple >>
-# For the new token-based python importer.
-def_tuple = namedtuple('def_tuple', [
-    'body_indent',  # Indentation of body.
-    'body_line9',  # Line number of the first line after the definition.
-    'decl_indent',  # Indentation of the class or def line.
-    'decl_line1',  # Line number of the first line of this node.
-                   # This line may be a comment or decorator.
-    'kind',  # 'def' or 'class'.
-    'name',  # name of the function, class or method.
-])
-#@-<< define def_tuple >>
+from leo.plugins.importers.linescanner import Block, Importer
+if TYPE_CHECKING:
+    assert g
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoNodes import Position
 #@+others
-#@+node:ekr.20220720043557.1: ** class Python_Importer(Importer)
+#@+node:ekr.20220720043557.1: ** class Python_Importer
 class Python_Importer(Importer):
-    """
-    A Python importer for eventual use by leoJS.
-
-    Also, the base class of other importers.
-    """
+    """Leo's Python importer"""
 
     def __init__(self, c: Cmdr, language: str = 'python') -> None:
         """Py_Importer.ctor."""
         super().__init__(c, language=language, strict=True)
         self.string_list = ['"""', "'''", '"', "'"]  # longest first.
-        self.add_class_to_headlines = c.config.getBool('put-class-in-imported-headlines')
 
     #@+others
-    #@+node:ekr.20220805071145.1: *3* python_i.compute_headline
-    def compute_headline(self, s: str) -> str:
-        """
-        Python_Importer.compute_headline.
+    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks & helper (override)
+    async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
+    def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
+    class_pat = re.compile(r'\s*class\s*(\w+)')
+    block_patterns = (
+        ('class', class_pat),
+        ('async def', async_def_pat),
+        ('def', def_pat),
+    )
 
-        Return the cleaned version headline s.
+    def find_blocks(self, i1: int, i2: int) -> List[Block]:
         """
-        s = s.strip()
-        # Remove '(' and ':' and everything after.
-        for ch in '(:':
-            i = s.find(ch)
-            if i > -1:
-                s = s[:i]
-        # Remove leading 'def'
-        if s.startswith('def '):  # pragma: no cover
-            s = s[len('def') :]
-        elif s.startswith('async def '):  # pragma: no cover (missing test)
-            s = s[len('async def') :]
-        # Remove leading 'class'.
-        elif (
-            s.startswith('class ')
-            and not g.unitTesting
-            and not self.add_class_to_headlines
-        ):
-            s = s[5:]  # pragma: no cover (missing test).
-        return s.strip()
-    #@+node:ekr.20220720060831.3: *3* python_i.declaration_headline
-    def declaration_headline(self, body: str) -> str:  # #2500
+        Python_Importer.find_blocks: override Importer.find_blocks.
+
+        Find all blocks in the given range of *guide* lines from which blanks
+        and tabs have been deleted.
+
+        Return a list of Blocks, that is, tuples(name, start, start_body, end).
         """
-        Return an informative headline for body, a group of declarations.
-        """
-        for s in g.splitLines(body):
-            strip_s = s.strip()
-            if strip_s:
-                if strip_s.startswith('#'):
-                    strip_comment = strip_s[1:].strip()
-                    if strip_comment:
-                        # A non-trivial comment: Return the comment w/o the leading '#'.
-                        return strip_comment
-                else:
-                    # A non-trivial non-comment.
-                    return strip_s
-        # Return legacy headline.
-        return "...some declarations"  # pragma: no cover (missing test)
-    #@+node:ekr.20220720050740.1: *3* python_i.get_block
-    def get_block(self, i: int) -> block_tuple:
-        """
-        Python_Importer.get_block, based on Vitalije's getdefn function.
-
-        Look for a def or class at lines[i].
-
-        Return None or a block_tuple describing the class or def.
-        """
-        line, state = self.lines[i], self.line_states[i]
-        if state.context or not line.strip():
-            return None
-        i2 = self.new_starts_block(i)
-        if i2 is None:
-            return None
-
-        # Compute declaration data.
-        decl_line = i
-        decl_indent = self.get_int_lws(line)
-        decl_level = decl_indent
-
-        # Set body_indent to the indentation of the first non-blank line of the body.
-        # Test for a single-line class or def.
-        i = i2
-        while i < len(self.lines):
-            line = self.lines[i]
-            if line.isspace():
-                i += 1
-            else:
-                body_indent = self.get_int_lws(line)
-                single_line = body_indent == decl_indent
-                break
-        else:  # pragma: no cover (mysterious)
-            single_line = True
-            body_indent = decl_indent
-
-        # Multi-line bodies end at the next non-blank with less indentation than body_indent.
-        # This is tricky because of underindented strings and docstrings.
-        if not single_line:
-            last_state = None
-            while i < len(self.lines):
-                line = self.lines[i]
-                this_state = self.line_states[i]
-                last_context = last_state.context if last_state else ''
-                this_context = this_state.context if this_state else ''
-                if (
-                    not line.isspace()
-                    and this_context not in ("'''", '"""', "'", '"')
-                    and last_context not in ("'''", '"""', "'", '"')
-                    and self.get_int_lws(line) < body_indent
-                ):
+        i, prev_i, result = i1, i1, []
+        while i < i2:
+            s = self.guide_lines[i]
+            # g.trace(repr(s))
+            i += 1
+            for kind, pattern in self.block_patterns:
+                m = pattern.match(s)
+                if m:
+                    name = m.group(1)
+                    end = self.find_end_of_block(i, i2)
+                    assert i1 + 1 <= end <= i2, (i1, end, i2)
+                    result.append((kind, name, prev_i, i, end))
+                    i = prev_i = end
                     break
-                last_state = this_state
+        # g.printObj(result, tag=f"{i1}:{i2}")
+        return result
+    #@+node:ekr.20230514140918.4: *4* python_i.find_end_of_block
+    def find_end_of_block(self, i: int, i2: int) -> int:
+        """
+        i is the index of the class/def line (within the *guide* lines).
+
+        Return the index of the line *following* the entire class/def
+        """
+        def lws_n(s: str) -> int:
+            """Return the length of the leading whitespace for s."""
+            return len(s) - len(s.lstrip())
+
+        prev_line = self.guide_lines[i-1]
+        assert any(z in prev_line for z in ('class', 'def')), (i, repr(prev_line))
+        if i < i2:
+            lws1 = lws_n(prev_line)
+            while i < i2:
+                s = self.guide_lines[i]
                 i += 1
-
-        # Include all following blank lines.
-        while i < len(self.lines) and self.lines[i].isspace():  # pragma: no cover (mysterious).
-            i += 1
-
-        # Return the description of the block.
-        return block_tuple(
-            body_indent=body_indent,
-            body_line9=i,
-            decl_indent=decl_indent,
-            decl_line1=decl_line - self.get_intro(decl_line, decl_indent),
-            decl_level=decl_level,
-            name=self.compute_headline(self.lines[decl_line])
-        )
-    #@+node:ekr.20220729081229.1: *3* python_i.is_intro_line
-    def is_intro_line(self, n: int, col: int) -> bool:
-        """
-        Return True if line n is a comment line or decorator that starts at the give column.
-        """
-        line = self.lines[n]
-        return (
-            line.strip().startswith(('#', '@'))
-            and col == g.computeLeadingWhitespaceWidth(line, self.tab_width)
-        )
-    #@+node:ekr.20220806085448.1: *3* python_i.new_starts_block
-    # Optional base classes.
-    class_pat_s = r'\s*(class|async class)\s+([\w_]+)\s*(\(.*?\))?(.*?):'
-    class_pat = re.compile(class_pat_s, re.MULTILINE)
-
-    # Requred argument list.
-    def_pat_s = r'\s*(async def|def)\s+([\w_]+)\s*(\(.*?\))(.*?):'
-    def_pat = re.compile(def_pat_s, re.MULTILINE)
-
-    def new_starts_block(self, i: int) -> Optional[int]:
-        """
-        Return None if lines[i] does not start a class, function or method.
-
-        Otherwise, return the index of the first line of the body.
-        """
-        line = self.lines[i]
-        m = self.class_pat.match(line) or self.def_pat.match(line)
-        if not m:
-            return None
-        newlines = m.group(0).count('\n')
-        return i + newlines + 1
+                if s.strip() and lws_n(s) <= lws1:
+                    return i
+        return i2
     #@-others
-#@+node:vitalije.20211201230203.1: ** function: token_based_python_importer
-SPLIT_THRESHOLD = 10  # Don't split blocks shorter than this threshold.
-
-def token_based_python_importer(c: Cmdr, root: Position, s: str) -> None:
-    """
-    An importer that uses python's tokenizer module to analyze program structure.
-    By Виталије Милошевић, (Vitalije Milosevic).
-
-    Create direct children of root for all top level function definitions and class definitions.
-
-    For longer class nodes, create separate child nodes for each method.
-
-    Helpers use a token-oriented "parse" of the lines.
-    Tokens are named 5-tuples, but this code uses only three fields:
-
-    t.type:   token type
-    t.string: the token string;
-    t.start:  a tuple (srow, scol) of starting row/column numbers.
-    """
-    trace = False
-    add_class_to_headlines = g.unitTesting or c.config.getBool('put-class-in-imported-headlines')
-    lines: List[str] = s.splitlines(True)
-    rawtokens: List
-
-    #@+others
-    #@+node:vitalije.20211208092910.1: *3* function: getdefn & helper
-    def getdefn(start: int) -> def_tuple:
-        """
-        Look for an 'async', 'def' or `class` token at rawtokens[start].
-        Return None or a def_tuple describing the def or class.
-        """
-        nonlocal add_class_to_headlines
-        nonlocal lines  # 'lines' is a kwarg to split_root.
-        nonlocal rawtokens
-
-        # pylint: disable=undefined-loop-variable
-        # tok will never be empty, but pylint doesn't know that.
-
-        # Ignore all tokens except 'async', 'def', 'class'
-        tok = rawtokens[start]
-        if tok.type != token.NAME or tok.string not in ('async', 'def', 'class'):
-            return None
-
-        # Compute 'kind' and 'name'.
-        if tok.string == 'async':
-            kind = rawtokens[start + 1][1]
-            name = rawtokens[start + 2][1]
-        else:
-            kind = tok.string
-            name = rawtokens[start + 1][1]
-
-        # Don't include 'async def' twice.
-        if kind == 'def' and rawtokens[start - 1][1] == 'async':
-            return None
-
-        decl_line, decl_indent = tok.start
-
-        # Find the end of the definition line, ending in a NEWLINE token.
-        # This one logical line may span several physical lines.
-        i, t = find_token(start + 1, token.NEWLINE)
-        body_line9 = t.start[0] + 1
-
-        # Look ahead to see if we have a one-line definition (INDENT comes after the NEWLINE).
-        i1, t = find_token(i + 1, token.INDENT)  # t is used below.
-        i2, t2 = find_token(i + 1, token.NEWLINE)
-        if t is None or t2 is None:
-            return None
-        oneliner = i1 > i2
-
-        # Find the end of this definition
-        if oneliner:
-            # The entire decl is on the same line.
-            body_indent = decl_indent
-        else:
-            body_indent = len(t.string) + decl_indent
-            # Skip the INDENT token.
-            assert t.type == token.INDENT, t.type
-            i += 1
-            # The body ends at the next DEDENT or COMMENT token with less indentation.
-            for i, t in itoks(i + 1):
-                col2 = t.start[1]
-                if col2 <= decl_indent and t.type in (token.DEDENT, token.COMMENT):
-                    body_line9 = t.start[0]
-                    break
-
-        # Increase body_line9 to include all following blank lines.
-        for j in range(body_line9, len(lines) + 1):
-            if lines[j - 1].isspace():
-                body_line9 = j + 1
-            else:
-                break
-
-        if add_class_to_headlines:
-            name = f"class {name}" if kind == 'class' else name
-
-        # This is the only instantiation of def_tuple.
-        return def_tuple(
-            body_indent=body_indent,
-            body_line9=body_line9,
-            decl_indent=decl_indent,
-            decl_line1=decl_line - get_intro(decl_line, decl_indent),
-            kind=kind,
-            name=name,
-        )
-    #@+node:vitalije.20211208084231.1: *4* function: get_intro (Vitalije's importer)
-    def get_intro(row: int, col: int) -> int:
-        """
-        Return the number of preceeding lines that should be added to this class or def.
-        """
-        last = row
-        for i in range(row - 1, 0, -1):
-            if is_intro_line(i, col):
-                last = i
-            else:
-                break
-        # Remove blank lines from the start of the intro.
-        # Leading blank lines should be added to the end of the preceeding node.
-        for i in range(last, row):
-            if lines[i - 1].isspace():
-                last = i + 1
-        return row - last
-    #@+node:vitalije.20211208183603.1: *4* function: is_intro_line (Vitalije's importer)
-    def is_intro_line(n: int, col: int) -> bool:
-        """
-        Return True if line n is either:
-        - a comment line that starts at the same column as the def/class line,
-        - a decorator line
-        """
-        # Filter out all whitespace tokens.
-        xs = [z for z in lntokens[n] if z[0] not in (token.DEDENT, token.INDENT, token.NL)]
-        if not xs:  # A blank line.
-            return True  # Allow blank lines in a block of comments.
-        t = xs[0]  # The first non blank token in line n.
-        if t.start[1] != col:
-            # Not the same indentation as the definition.
-            return False
-        if t.type == token.OP and t.string == '@':
-            # A decorator.
-            return True
-        if t.type == token.COMMENT:
-            # A comment at the same indentation as the definition.
-            return True
-        return False
-    #@+node:vitalije.20211208104408.1: *3* mknode & helpers
-    def mknode(
-        p: Position,  # The starting (local root) position.
-        start: int,  # The first line to allocate.
-        end: int,  # The last line to allocate.
-        others_indent: int,  # @others indentation (to be stripped from left).
-        inner_indent: int,  # The indentation of all of the inner definitions.
-        definitions: List[def_tuple],  # The definitions occuring within lines[start : end].
-    ) -> None:
-        """
-        Allocate lines[start : end] to p.b or descendants of p.
-        """
-        nonlocal lines
-
-        # Find all defs with the given inner indentation.
-        inner_defs = [z for z in definitions if z.decl_indent == inner_indent]
-
-        # Don't use the threshold for unit tests. It's too confusing.
-        if not inner_defs or (not g.unitTesting and end - start < SPLIT_THRESHOLD):
-            # Don't split the body.
-            p.b = body(start, end, others_indent)
-            return
-
-        # Calculate head, the lines preceding the @others.
-        decl_line1 = inner_defs[0].decl_line1
-        head = body(start, decl_line1, others_indent) if decl_line1 > start else ''
-        others_line = ' ' * max(0, inner_indent - others_indent) + '@others\n'
-
-        # Calculate tail, the lines following the @others line.
-        last_tail_line = inner_defs[-1].body_line9
-        tail = body(last_tail_line, end, others_indent) if last_tail_line < end else ''
-        p.b = f'{head}{others_line}{tail}'
-
-        # Generate (allocate to body text) all @others lines, that is, all lines from:
-        # - the first line of the first inner definition to
-        # - the last line of the last inner definition.
-        # *including* lines *between* inner defitions.
-
-        last = decl_line1  # The last @other line that has been allocated.
-
-        for inner_def in inner_defs:
-
-            # Add a child for in-between (declaration) lines.
-            if inner_def.decl_line1 > last:
-                new_body = body(last, inner_def.decl_line1, inner_indent)  # #2500.
-                child1 = p.insertAsLastChild()
-                child1.h = declaration_headline(new_body)  # #2500
-                child1.b = new_body
-                last = inner_def.decl_line1
-
-            # Add a child holding the inner definition.
-            child = p.insertAsLastChild()
-            child.h = inner_def.name
-
-            # Compute the inner definitions of *this* inner definition.
-            # Note: The calculation uses only the the position of each definition.
-            #       The calculation *ignores* indentation!
-            inner_inner_defs = [z for z in definitions if
-                z.decl_line1 > inner_def.decl_line1 and z.body_line9 <= inner_def.body_line9
-            ]
-            if inner_inner_defs:
-                # Recursively allocate all lines of all inner inner defs.
-                # This will set child.b to include the head lines, @others lines, and tail lines.
-                mknode(
-                    p=child,
-                    start=inner_def.decl_line1,
-                    end=inner_def.body_line9,
-                    others_indent=others_indent + inner_indent,
-                    inner_indent=inner_def.body_indent,
-                    definitions=inner_inner_defs,
-                )
-            else:
-                # There are no inner defs, so this node will contain no @others directive.
-                child.b = body(inner_def.decl_line1, inner_def.body_line9, inner_indent)
-
-            # Remember the last allocated line.
-            last = inner_def.body_line9
-    #@+node:vitalije.20211208101750.1: *4* body & bodyLine
-    def bodyLine(s: str, i: int) -> str:
-        """Massage line s, adding the underindent string if necessary."""
-        # Vitalije's legacy importer generated underindented escape strings.
-        # However, this seems unlikely to be useful.
-        legacy = False
-        if i == 0 or s[:i].isspace():
-            return s[i:] or '\n'
-        # An underindented string.
-        n = len(s) - len(s.lstrip())
-        return f"\\\\-{i-n}.{s[n:]}" if legacy else s[n:]
-
-    def body(a: int, b: Optional[int], i: int) -> str:
-        """Return the (massaged) concatentation of lines[a: b]"""
-        nonlocal lines  # 'lines' is a kwarg to split_root.
-        return ''.join(bodyLine(s, i) for s in lines[a - 1 : b and (b - 1)])
-    #@+node:ekr.20220320055103.1: *4* declaration_headline
-    def declaration_headline(body_string: str) -> str:  # #2500
-        """
-        Return an informative headline for s, a group of declarations.
-        """
-        for s1 in g.splitLines(body_string):
-            s = s1.strip()
-            if s.startswith('#') and len(s.replace('#', '').strip()) > 1:
-                # A non-trivial comment: Return the comment w/o the leading '#'.
-                return s[1:].strip()
-            if s and not s.startswith('#'):
-                # A non-trivial non-comment.
-                return s
-        # Return legacy headline.
-        return "...some declarations"  # pragma: no cover (missing tests)
-    #@+node:ekr.20220717080934.1: *3* utils
-    #@+node:vitalije.20211208092833.1: *4* find_token
-    def find_token(i: int, k: int) -> Tuple[int, int]:
-        """
-        Return (j, t), the first token in "rawtokens[i:] with t.type == k.
-        Return (None, None) if there is no such token.
-        """
-        for j, t in itoks(i):
-            if t.type == k:
-                return j, t
-        return None, None  # pragma: no cover (missing test)
-    #@+node:vitalije.20211208092828.1: *4* itoks
-    def itoks(i: int) -> Generator:
-        """Generate (n, rawtokens[n]) starting with i."""
-        nonlocal rawtokens
-
-        # Same as `enumerate(rawtokens[i:], start=i)` without allocating substrings.
-        while i < len(rawtokens):
-            yield(i, rawtokens[i])
-            i += 1
-    #@+node:vitalije.20211206182505.1: *4* mkreadline
-    def mkreadline(lines: List[str]) -> Callable:
-        """Return an readline-like interface for tokenize."""
-        itlines = iter(lines)
-
-        def nextline() -> str:
-            try:
-                return next(itlines)
-            except StopIteration:
-                return ''
-
-        return nextline
-    #@-others
-
-    # Create rawtokens: a list of all tokens found in input lines
-    rawtokens = list(tokenize.generate_tokens(mkreadline(lines)))
-
-    # lntokens groups tokens by line number.
-    lntokens: Dict[int, Any] = defaultdict(list)
-    for t in rawtokens:
-        row = t.start[0]
-        lntokens[row].append(t)
-
-    # Make a list of *all* definitions.
-    aList = [getdefn(i) for i, z in enumerate(rawtokens)]
-    all_definitions = [z for z in aList if z]
-
-    if trace:  # pragma: no cover
-        # trace results.
-        for i, z in enumerate(all_definitions):
-            g.trace(i, repr(z))
-
-    # Start the recursion.
-    root.deleteAllChildren()
-    mknode(
-        p=root, start=1, end=len(lines) + 1,
-        others_indent=0, inner_indent=0, definitions=all_definitions)
-
-    # Add *trailing* lines, just like the Importer class.
-    root.b += '@language python\n@tabwidth -4\n'
 #@-others
-
-# Define this top-level for unit/coverage tests
-USE_PYTHON_TOKENS = True
 
 def do_import(c: Cmdr, parent: Position, s: str) -> None:
     """The importer callback for python."""
-    if USE_PYTHON_TOKENS:  # For desktop Leo: use an importer based on python tokens.
-        token_based_python_importer(c, parent, s)
-    else:  # For leoJS: use a subclass of the Importer class.
-        Python_Importer(c).import_from_string(parent, s)
+    Python_Importer(c).import_from_string(parent, s)
 
 importer_dict = {
     'extensions': ['.py', '.pyw', '.pyi', '.codon'],  # mypy uses .pyi extension.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -18,6 +18,7 @@ class Python_Importer(Importer):
     string_list = ['"""', "'''", '"', "'"]  # longest first.
 
     # The default patterns. Overridden in the Cython_Importer class.
+    # Group 1 matches the name of the class/def.
     async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
     def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
     class_pat = re.compile(r'\s*class\s*(\w+)')
@@ -33,7 +34,7 @@ class Python_Importer(Importer):
         super().__init__(c, language=language, strict=True)
 
     #@+others
-    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks & helper (override)
+    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks (override)
     def find_blocks(self, i1: int, i2: int) -> List[Block]:
         """
         Python_Importer.find_blocks: override Importer.find_blocks.
@@ -58,7 +59,7 @@ class Python_Importer(Importer):
                     i = prev_i = end
                     break
         return results
-    #@+node:ekr.20230514140918.4: *4* python_i.find_end_of_block
+    #@+node:ekr.20230514140918.4: *3* python_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:
         """
         i is the index of the class/def line (within the *guide* lines).

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -45,36 +45,38 @@ class TestLeoImport(BaseTestImporter):
         x = c.importCommands
         target = c.p.insertAfter()
         target.h = 'target'
-        target.b = textwrap.dedent("""\
+        target.b = textwrap.dedent(
+        """
             import os
 
             def macro(func):
                 def new_func(*args, **kwds):
                     raise RuntimeError('blah blah blah')
             return new_func
-        """)
+        """).strip() + '\n'
         x.parse_body(target)
 
-        # self.dump_tree(target, tag='Actual results...')
-
-        self.check_outline(target, (
+        expected_results = (
             (0, '',  # check_outline ignores the top-level headline.
-                'import os\n'
-                '\n'
                 '@others\n'
                 'return new_func\n'
                 '@language python\n'
                 '@tabwidth -4\n'
             ),
-            (1, 'macro',
+            (1, 'def macro',
+                'import os\n'
+                '\n'
                 'def macro(func):\n'
                 '    @others\n'
             ),
-            (2, 'new_func',
+            (2, 'def new_func',
                 'def new_func(*args, **kwds):\n'
                 "    raise RuntimeError('blah blah blah')\n"
             ),
-        ))
+        )
+        # Don't call run_test.
+        self.check_outline(target, expected_results, trace_results=False)
+
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3685,7 +3685,8 @@ class TestPython(BaseTestImporter):
     #@+node:vitalije.20211206201240.1: *3* TestPython.test_longer_classes
     def test_longer_classes(self):
 
-        s = self.dedent("""\
+        s = self.dedent(
+        """
               import sys
               def f1():
                   pass
@@ -3706,26 +3707,14 @@ class TestPython(BaseTestImporter):
               # An outer comment
               ATmyClassDecorator
               class Class2:
-                  def meth00():
+                  def method21():
                       print(1)
                       print(2)
                       print(3)
-                      print(4)
-                      print(5)
-                      print(6)
-                      print(7)
-                      print(8)
-                      print(9)
-                      print(10)
-                      print(11)
-                      print(12)
-                      print(13)
-                      print(14)
-                      print(15)
                   ATmyDecorator
-                  def method21():
-                      pass
                   def method22():
+                      pass
+                  def method23():
                       pass
 
               # About main.
@@ -3735,56 +3724,41 @@ class TestPython(BaseTestImporter):
 
               if __name__ == '__main__':
                   main()
-        """).replace('AT', '@')
+        """).replace('AT', '@').strip() + '\n'
 
-        p = self.run_test(s, strict_flag=True)
-        self.check_outline(p, (
+        expected_results = (
             (0, '', # check_outline ignores the first headline'
-                    'import sys\n'
                     '@others\n'
+                    '\n'
                     "if __name__ == '__main__':\n"
                     '    main()\n'
-                    '\n'
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'f1',
+            (1, 'def f1',
+                    'import sys\n'
                     'def f1():\n'
                     '    pass\n'
-                    '\n'
             ),
-            # Use this if unit tests *do* honor threshold.
-            # (1, 'Class1',
-                       # 'class Class1:\n'
-                       # '    def method11():\n'
-                       # '        pass\n'
-                       # '    def method12():\n'
-                       # '        pass\n'
-                       # '\n'
-            # ),
             (1, 'class Class1',
                        'class Class1:\n'
                        '    @others\n'
             ),
-            (2, 'method11',
+            (2, 'def method11',
                        'def method11():\n'
                        '    pass\n'
             ),
-            (2, 'method12',
+            (2, 'def method12',
                        'def method12():\n'
                        '    pass\n'
-                       '\n'
             ),
-            (1, 'Define a = 2',  # #2500
+            (1, 'def f2',
                        '#\n'
                        '# Define a = 2\n'
                        'a = 2\n'
                        '\n'
-            ),
-            (1, 'f2',
                        'def f2():\n'
                        '    pass\n'
-                       '\n'
             ),
             (1, 'class Class2',
                        '# An outer comment\n'
@@ -3792,42 +3766,30 @@ class TestPython(BaseTestImporter):
                        'class Class2:\n'
                        '    @others\n'
             ),
-            (2, 'meth00',
-                       'def meth00():\n'
+            (2, 'def method21',
+                       'def method21():\n'
                        '    print(1)\n'
                        '    print(2)\n'
                        '    print(3)\n'
-                       '    print(4)\n'
-                       '    print(5)\n'
-                       '    print(6)\n'
-                       '    print(7)\n'
-                       '    print(8)\n'
-                       '    print(9)\n'
-                       '    print(10)\n'
-                       '    print(11)\n'
-                       '    print(12)\n'
-                       '    print(13)\n'
-                       '    print(14)\n'
-                       '    print(15)\n'
             ),
-            (2, 'method21',
+            (2, 'def method22',
                        '@myDecorator\n'
-                       'def method21():\n'
-                       '    pass\n'
-            ),
-            (2, 'method22',
                        'def method22():\n'
                        '    pass\n'
-                       '\n'
             ),
-            (1, 'main',
+            (2, 'def method23',
+                       'def method23():\n'
+                       '    pass\n'
+            ),
+            (1, 'def main',
                        '# About main.\n'
                        '\n'
                        'def main():\n'
                        '    pass\n'
-                       '\n'
             ),
-        ))
+        )
+        p = self.run_test(s, check_flag=False, strict_flag=True)
+        self.check_outline(p, expected_results, trace_results=False)
 
     #@+node:vitalije.20211206212507.1: *3* TestPython.test_oneliners
     def test_oneliners(self):
@@ -4031,7 +3993,7 @@ class TestPython(BaseTestImporter):
                '    pass\n'
             ),
         ))
-    #@+node:vitalije.20211207200701.1: *3* TestPython: test_no_methods
+    #@+node:vitalije.20211207200701.1: *3* TestPython.test_no_methods
     def test_no_methods(self):
 
         s = textwrap.dedent(

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3625,22 +3625,15 @@ class TestPhp(BaseTestImporter):
 #@+node:ekr.20211108082509.1: ** class TestPython (BaseTestImporter)
 class TestPython(BaseTestImporter):
 
-    check_tree = False
     ext = '.py'
-    treeType = '@file'
 
-    def run_test(self, s: str, check_flag: bool=True, strict_flag: bool=False) -> Position:
-        """Run tests with both values of python.USE_PYTHON_TOKENS."""
-        import leo.plugins.importers.python as python
-        try:
-            p = None
-            self.assertTrue(python.USE_PYTHON_TOKENS)
-            super().run_test(s, check_flag, strict_flag)
-            python.USE_PYTHON_TOKENS = False
-            p = super().run_test(s, check_flag, strict_flag)
-        finally:
-            python.USE_PYTHON_TOKENS = True
-        return p
+    ###
+        # check_tree = False
+        # treeType = '@file'
+
+        # def run_test(self, s: str, check_flag: bool=True, strict_flag: bool=False) -> Position:
+            # import leo.plugins.importers.python as python
+            # super().run_test(s, check_flag, strict_flag)
 
     #@+others
     #@+node:vitalije.20211206201240.1: *3* TestPython.test_longer_classes
@@ -4616,6 +4609,43 @@ class TestPython(BaseTestImporter):
                        '  pass\n\n'
             )
         ))
+    #@+node:ekr.20230514195224.1: *3* TestPython.test_delete_comments_and_strings
+    def test_delete_comments_and_strings(self):
+
+        from leo.plugins.importers.python import Python_Importer
+        importer = Python_Importer(self.c)
+
+        lines = [
+            'i = 1 # comment.\n',
+            's = "string"\n',
+            "s2 = 'string'\n",
+            'if 1:\n',
+            '    pass \n',
+            '"""\n',
+            '    if 1: a = 2\n',
+            '"""\n',
+            "'''\n",
+            '    if 2: a = 2\n',
+            "'''\n",
+            'i = 2\n'
+        ]
+        expected_lines = [
+            'i = 1 \n',
+            's = \n',
+            's2 = \n',
+            'if 1:\n',
+            '    pass \n',
+            '\n',
+            '\n',
+            '\n',
+            '\n',
+            '\n',
+            '\n',
+            'i = 2\n'
+        ]
+        result = importer.delete_comments_and_strings(lines)
+        self.assertEqual(len(result), len(expected_lines))
+        self.assertEqual(result, expected_lines)
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -70,7 +70,8 @@ class BaseTestImporter(LeoUnitTest):
     def check_round_trip(self, p: Position, s: str, strict_flag: bool=False) -> None:
         """Assert that p's outline is equivalent to s."""
         c = self.c
-        result_s = c.atFileCommands.atAutoToString(p)
+        s = s.rstrip()  # Ignore trailing whitespace.
+        result_s = c.atFileCommands.atAutoToString(p).rstrip()  # Ignore trailing whitespace.
         if strict_flag:
             s_lines = g.splitLines(s)
             result_lines = g.splitLines(result_s)
@@ -79,7 +80,7 @@ class BaseTestImporter(LeoUnitTest):
             s_lines = [z.lstrip() for z in g.splitLines(s) if z.strip()]
             result_lines = [z.lstrip() for z in g.splitLines(result_s) if z.strip()]
         if s_lines != result_lines:
-            g.trace('FAIL', p.h)
+            g.trace('FAIL', g.caller(2))
             g.printObj([f"{i:<4} {z}" for i, z in enumerate(s_lines)], tag=f"expected: {p.h}")
             g.printObj([f"{i:<4} {z}" for i, z in enumerate(result_lines)], tag=f"results: {p.h}")
         self.assertEqual(s_lines, result_lines)
@@ -832,7 +833,7 @@ class TestCython(BaseTestImporter):
             ),
         )
         p = self.run_test(s, strict_flag=True, check_flag=False)
-        self.check_outline(p, expected_result, trace_results=True)
+        self.check_outline(p, expected_result, trace_results=False)
     #@-others
 #@+node:ekr.20211108064115.1: ** class TestDart (BaseTestImporter)
 class TestDart(BaseTestImporter):
@@ -4030,77 +4031,32 @@ class TestPython(BaseTestImporter):
                '    pass\n'
             ),
         ))
-    #@+node:vitalije.20211207200701.1: *3* TestPython: test_large_class_no_methods
-    def test_large_class_no_methods(self):
+    #@+node:vitalije.20211207200701.1: *3* TestPython: test_no_methods
+    def test_no_methods(self):
 
-        s = (
-                'class A:\n'
-                '    a=1\n'
-                '    b=1\n'
-                '    c=1\n'
-                '    d=1\n'
-                '    e=1\n'
-                '    f=1\n'
-                '    g=1\n'
-                '    h=1\n'
-                '    i=1\n'
-                '    j=1\n'
-                '    k=1\n'
-                '    l=1\n'
-                '    m=1\n'
-                '    n=1\n'
-                '    o=1\n'
-                '    p=1\n'
-                '    q=1\n'
-                '    r=1\n'
-                '    s=1\n'
-                '    t=1\n'
-                '    u=1\n'
-                '    v=1\n'
-                '    w=1\n'
-                '    x=1\n'
-                '    y=1\n'
-                '    x=1\n'
-                '\n'
-            )
-        p = self.run_test(s, strict_flag=True)
-        self.check_outline(p, (
+        s = textwrap.dedent(
+        """
+            class A:
+                a=1
+                b=2
+                c=3
+        """).strip() + '\n'
+       
+        expected_results = (
             (0, '',  # check_outline ignores the first headline.
-                       '@others\n'
-                       '@language python\n'
-                       '@tabwidth -4\n'
+                   '@others\n'
+                   '@language python\n'
+                   '@tabwidth -4\n'
             ),
             (1, 'class A',
-                       'class A:\n'
-                       '    a=1\n'
-                       '    b=1\n'
-                       '    c=1\n'
-                       '    d=1\n'
-                       '    e=1\n'
-                       '    f=1\n'
-                       '    g=1\n'
-                       '    h=1\n'
-                       '    i=1\n'
-                       '    j=1\n'
-                       '    k=1\n'
-                       '    l=1\n'
-                       '    m=1\n'
-                       '    n=1\n'
-                       '    o=1\n'
-                       '    p=1\n'
-                       '    q=1\n'
-                       '    r=1\n'
-                       '    s=1\n'
-                       '    t=1\n'
-                       '    u=1\n'
-                       '    v=1\n'
-                       '    w=1\n'
-                       '    x=1\n'
-                       '    y=1\n'
-                       '    x=1\n'
-                       '\n'
+                   'class A:\n'
+                   '    a=1\n'
+                   '    b=2\n'
+                   '    c=3\n'
             )
-        ))
+        )
+        p = self.run_test(s, strict_flag=True)
+        self.check_outline(p, expected_results)
 
     #@+node:vitalije.20211213125307.1: *3* TestPython: test_large_class_under_indented
     def test_large_class_under_indented(self):

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -570,7 +570,8 @@ class TestCoffeescript(BaseTestImporter):
 
     def test_2(self):
 
-        s = """
+        s = textwrap.dedent(
+        """
           class Builder
             constructor: ->
               @transformer = new Transformer
@@ -599,9 +600,9 @@ class TestCoffeescript(BaseTestImporter):
               str = blockTrim(str)
               str = unshift(str)
               if str.length > 0 then str else ""
-        """
-        p = self.run_test(s)
-        self.check_outline(p, (
+              
+          """).strip() + '\n'
+        expected_results = (
           (0, '',  # check_outline ignores the first headline.
                 '@others\n'
                 '@language coffeescript\n'
@@ -647,7 +648,11 @@ class TestCoffeescript(BaseTestImporter):
               '  if str.length > 0 then str else ""\n'
               '\n'
           ),
-        ))
+        )
+        p = self.run_test(s, check_flag=False, strict_flag=True)
+        self.check_outline(p, expected_results, trace_results=True)
+
+
     #@+node:ekr.20211108085023.1: *3* TestCoffeescript.test_get_leading_indent
     def test_get_leading_indent(self):
         c = self.c

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -525,10 +525,12 @@ class TestCoffeescript(BaseTestImporter):
 
     #@+others
     #@+node:ekr.20210904065459.15: *3* TestCoffeescript.test_1
+    #@@tabwidth -2 # Required
+
     def test_1(self):
 
-        s = r'''
-
+        s = textwrap.dedent(
+        r"""
         # Js2coffee relies on Narcissus's parser.
 
         {parser} = @Narcissus or require('./narcissus_packed')
@@ -541,19 +543,19 @@ class TestCoffeescript(BaseTestImporter):
 
           builder    = new Builder
           scriptNode = parser.parse str
-        '''
-        p = self.run_test(s)
-        self.check_outline(p, (
+        """).strip() + '\n'
+
+        expected_results = (
             (0, '',  # check_outline ignores the first headline.
-                    "# Js2coffee relies on Narcissus's parser.\n"
-                    '\n'
-                    "{parser} = @Narcissus or require('./narcissus_packed')\n"
-                    '\n'
                     '@others\n'
                     '@language coffeescript\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'buildCoffee = (str) ->',
+            (1, 'def buildCoffee',
+                    "# Js2coffee relies on Narcissus's parser.\n"
+                    '\n'
+                    "{parser} = @Narcissus or require('./narcissus_packed')\n"
+                    '\n'
                     '# Main entry point\n'
                     '\n'
                     'buildCoffee = (str) ->\n'
@@ -562,9 +564,10 @@ class TestCoffeescript(BaseTestImporter):
                     '\n'
                     '  builder    = new Builder\n'
                     '  scriptNode = parser.parse str\n'
-                    '\n'
             ),
-        ))
+        )
+        p = self.run_test(s, check_flag=False, strict_flag=True)
+        self.check_outline(p, expected_results, trace_results=False)
     #@+node:ekr.20210904065459.16: *3* TestCoffeescript.test_2
     #@@tabwidth -2 # Required
 
@@ -612,11 +615,11 @@ class TestCoffeescript(BaseTestImporter):
                 'class Builder\n'
                 '  @others\n'
           ),
-          (2, 'constructor: ->',
+          (2, 'def constructor',
               'constructor: ->\n'
               '  @transformer = new Transformer\n'
           ),
-          (2, 'build: (args...) ->',
+          (2, 'def build',
                 '# `build()`\n'
                 '\n'
                 'build: (args...) ->\n'
@@ -631,14 +634,13 @@ class TestCoffeescript(BaseTestImporter):
                 '\n'
                 '  if node.parenthesized then paren(out) else out\n'
           ),
-          (2, 'transform: (args...) ->',
+          (2, 'def transform',
               '# `transform()`\n'
               '\n'
               'transform: (args...) ->\n'
               '  @transformer.transform.apply(@transformer, args)\n'
-              '\n'
           ),
-          (2, 'body: (node, opts={}) ->',
+          (2, 'def body',
               '# `body()`\n'
               '\n'
               'body: (node, opts={}) ->\n'
@@ -646,13 +648,10 @@ class TestCoffeescript(BaseTestImporter):
               '  str = blockTrim(str)\n'
               '  str = unshift(str)\n'
               '  if str.length > 0 then str else ""\n'
-              '\n'
           ),
         )
         p = self.run_test(s, check_flag=False, strict_flag=True)
-        self.check_outline(p, expected_results, trace_results=True)
-
-
+        self.check_outline(p, expected_results, trace_results=False)
     #@+node:ekr.20211108085023.1: *3* TestCoffeescript.test_get_leading_indent
     def test_get_leading_indent(self):
         c = self.c

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -811,13 +811,13 @@ class TestCython(BaseTestImporter):
 
         expected_result = (
             (0, '',  # check_outlines ignores the first headline.
-                    'from libc.math cimport pow\n'
-                    '\n'
                     '@others\n'
                     '@language cython\n'
                     '@tabwidth -4\n'
             ),
             (1, 'cdef double square_and_add',
+                    'from libc.math cimport pow\n'
+                    '\n'
                     'cdef double square_and_add (double x):\n'
                     '    """Compute x^2 + x as double.\n'
                     '\n'
@@ -825,7 +825,6 @@ class TestCython(BaseTestImporter):
                     '    a Cython program, but not from Python.\n'
                     '    """\n'
                     '    return pow(x, 2.0) + x\n'
-                    '\n'
             ),
             (1, 'cpdef print_result',
                     'cpdef print_result (double x):\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -170,7 +170,6 @@ class TestC(BaseTestImporter):
             }
         """).strip() + '\n'
 
-        ### To do: indent @others. undent inner bodies.
         expected_results = (
             (0, '',  # check_outline ignores the first headline.
                 '@others\n'
@@ -3626,14 +3625,6 @@ class TestPhp(BaseTestImporter):
 class TestPython(BaseTestImporter):
 
     ext = '.py'
-
-    ###
-        # check_tree = False
-        # treeType = '@file'
-
-        # def run_test(self, s: str, check_flag: bool=True, strict_flag: bool=False) -> Position:
-            # import leo.plugins.importers.python as python
-            # super().run_test(s, check_flag, strict_flag)
 
     #@+others
     #@+node:ekr.20230514223556.1: *3* TestPython.test_basic

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -792,7 +792,8 @@ class TestCython(BaseTestImporter):
     #@+node:ekr.20210904065459.11: *3* TestCython.test_importer
     def test_importer(self):
 
-        s = '''
+        s = textwrap.dedent(
+        '''
             from libc.math cimport pow
 
             cdef double square_and_add (double x):
@@ -806,10 +807,9 @@ class TestCython(BaseTestImporter):
             cpdef print_result (double x):
                 """This is a cpdef function that can be called from Python."""
                 print("({} ^ 2) + {} = {}".format(x, x, square_and_add(x)))
+        ''').strip() + '\n'
 
-        '''
-        p = self.run_test(s, strict_flag=True)
-        self.check_outline(p, (
+        expected_result = (
             (0, '',  # check_outlines ignores the first headline.
                     'from libc.math cimport pow\n'
                     '\n'
@@ -831,9 +831,10 @@ class TestCython(BaseTestImporter):
                     'cpdef print_result (double x):\n'
                     '    """This is a cpdef function that can be called from Python."""\n'
                     '    print("({} ^ 2) + {} = {}".format(x, x, square_and_add(x)))\n'
-                    '\n'
             ),
-        ))
+        )
+        p = self.run_test(s, strict_flag=True, check_flag=False)
+        self.check_outline(p, expected_result, trace_results=True)
     #@-others
 #@+node:ekr.20211108064115.1: ** class TestDart (BaseTestImporter)
 class TestDart(BaseTestImporter):
@@ -3636,6 +3637,60 @@ class TestPython(BaseTestImporter):
             # super().run_test(s, check_flag, strict_flag)
 
     #@+others
+    #@+node:ekr.20230514223556.1: *3* TestPython.test_basic
+    def test_basic(self):
+        s = (
+            'import sys\n'
+            'def f1():\n'
+            '    pass # comment 1\n'
+            # 'class Class1:\n'
+            # '    def method1():\n'
+            # '        pass # comment1\n'
+            # '    def method2():\n'
+            # '        pass # comment2\n'
+            # '\n'
+            
+            '# About main.\n'  # This will be associated with the *previous* block.
+            'def main():\n'
+            '    pass\n'
+            '\n'
+            "if __name__ == '__main__':\n"
+            '    main()\n'
+        )
+        expected_results = (
+            (0, '', # check_outline ignores the first headline
+                    '@others\n'
+                    "if __name__ == '__main__':\n"
+                    '    main()\n'
+                    '@language python\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, 'def f1',
+                    'import sys\n'
+                    'def f1():\n'
+                    '    pass # comment 1\n'
+                    '# About main.\n'
+            ),
+            ### Not yet.
+            # (1, 'class Class1',
+                        # 'class Class1:\n'  # Don't split very short classes.
+                        # '    @others\n'
+            # ),
+            # (2, 'method11',
+                        # 'def method1():\n'
+                        # '    pass # comment 2\n'
+            # ),
+            # (2, 'method12',
+                        # 'def method2():\n'
+                        # '    pass\n'
+            # ),
+            (1, 'def main',
+                    'def main():\n'
+                    '    pass\n'
+            )
+        )
+        p = self.run_test(s, strict_flag=False, check_flag=False)
+        self.check_outline(p, expected_results, trace_results=False)
     #@+node:vitalije.20211206201240.1: *3* TestPython.test_longer_classes
     def test_longer_classes(self):
 
@@ -3874,8 +3929,7 @@ class TestPython(BaseTestImporter):
             "if __name__ == '__main__':\n"
             '    main()\n'
         )
-        p = self.run_test(s, strict_flag=True)
-        self.check_outline(p, (
+        expected_results = (
             (0, '', # check_outline ignores the first headline
                     'import sys\n'
                     '@others\n'
@@ -3952,7 +4006,9 @@ class TestPython(BaseTestImporter):
                         '    pass\n'
                         '\n'
             )
-        ))
+        )
+        p = self.run_test(s, strict_flag=False, check_flag=False)
+        self.check_outline(p, expected_results, trace_results=True)
 
     #@+node:ekr.20211126055349.1: *3* TestPython.test_short_file
     def test_short_file(self):


### PR DESCRIPTION
See #3343.

- [x] Fix recent bugs in the base Importer class.
- [x] Fix recent bugs in the c importer.
- [x] Convert the python importer. It overrides `i.find_blocks` and defines `python_i.find_end_of_block`.
- [x] Convert the cython importer, removing all old methods.
- [x] Convert the coffeescript importer, removing all old methods.
- [x] Adjust all relevant unit tests to account for the improved code generation.