### PR TITLE
Add an @file to code.leo for babel.py.  Use a variable reported as unused by pyflakes.

### DIFF
--- a/leo/plugins/leo_babel/babel.py
+++ b/leo/plugins/leo_babel/babel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #coding=utf-8
 #@+leo-ver=5-thin
-#@+node:bob.20170311140807.1: * @file leo_babel/babel.py
+#@+node:bob.20170311140807.1: * @file babel.py
 #@@first
 #@@first
 #@@language python
@@ -23,7 +23,7 @@ try:
     from leo.plugins.leo_babel import babel_lib
 
 except ImportError as err:
-    raise ImportError('Python Package required by Leo-Babel is missing')
+    raise ImportError(f'Python Package required by Leo-Babel is missing\n{err}')
 #@-<< imports >>
 #@+<< documentation >>
 #@+node:bob.20170502131205.1: ** << documentation >>

--- a/leo/plugins/leo_babel/code.leo
+++ b/leo/plugins/leo_babel/code.leo
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Created by Leo: http://leoeditor.com/leo_toc.html -->
-<leo_file xmlns:leo="http://leoeditor.com/namespaces/leo-python-editor/1.1" >
+<!-- Created by Leo: https://leo-editor.github.io/leo-editor/leo_toc.html -->
+<leo_file xmlns:leo="http://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1" >
 <leo_header file_format="2"/>
 <globals/>
 <preferences/>
 <find_panel_settings/>
 <vnodes>
 <v t="bob05.20130405124111.1504"><vh>Libraries</vh>
+<v t="bob.20170311140807.1"><vh>@file babel.py</vh></v>
 <v t="bob.20170726143458.1"><vh>@file babel_lib.py</vh></v>
 <v t="bob.20170716140541.1"><vh>@file babel_api.py</vh></v>
 </v>


### PR DESCRIPTION
Adding babel.py to code.leo fixes a maintenance problem, not a problem a user could observe.
Using the variable that was set, but not used, is safe.  At worst (if my added code is invalid) it adds some garbage to an error message.