### PR TITLE
PR: Import Callable from collections.abc insead of typing

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -4,10 +4,11 @@
 #@+<< abbrevCommands imports & abbreviations >>
 #@+node:ekr.20150514045700.1: ** << abbrevCommands imports & abbreviations >>
 from __future__ import annotations
+from collections.abc import Callable
 import functools
 import re
 import string
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.commands.baseCommands import BaseEditCommandsClass

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -4,7 +4,8 @@
 #@+<< bufferCommands imports & annotations >>
 #@+node:ekr.20150514045750.1: ** << bufferCommands imports & annotations >>
 from __future__ import annotations
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -4,10 +4,11 @@
 #@+<< commanderOutlineCommands imports & annotations >>
 #@+node:ekr.20220826123551.1: ** << commanderOutlineCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import xml.etree.ElementTree as ElementTree
 import json
 from collections import defaultdict
-from typing import Any, Callable, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.core import leoFileCommands

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -4,10 +4,11 @@
 #@+<< controlCommands imports & annotations >>
 #@+node:ekr.20150514050127.1: ** << controlCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import shlex
 import subprocess
 import sys
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -4,9 +4,10 @@
 #@+<< convertCommands imports & annotations >>
 #@+node:ekr.20220824202922.1: ** << convertCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
 import time
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoBeautify
 from leo.commands.baseCommands import BaseEditCommandsClass

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -4,9 +4,10 @@
 #@+<< debugCommands imports & annotations >>
 #@+node:ekr.20181006100818.1: ** << debugCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import os
 import sys
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -4,9 +4,10 @@
 #@+<< editCommands imports & annotations  >>
 #@+node:ekr.20150514050149.1: **  << editCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import os
 import re
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -4,11 +4,12 @@
 #@+<< editFileCommands imports & annotations >>
 #@+node:ekr.20170806094317.4: ** << editFileCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import difflib
 import io
 import os
 import re
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoCommands
 from leo.commands.baseCommands import BaseEditCommandsClass

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -4,11 +4,12 @@
 #@+<< helpCommands imports & annotations >>
 #@+node:ekr.20150514050337.1: ** << helpCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import io
 import re
 import sys
 import textwrap
-from typing import Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -4,7 +4,8 @@
 #@+<< killBufferCommands imports & annotations >>
 #@+node:ekr.20150514050411.1: ** << killBufferCommands imports & annotations >>
 from __future__ import annotations
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -4,7 +4,8 @@
 #@+<< rectangleCommands imports & annotations >>
 #@+node:ekr.20150514050446.1: ** << rectangleCommands imports & annotations >>
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -4,8 +4,9 @@
 #@+<< spellCommands imports & annotations >>
 #@+node:ekr.20150514050530.1: ** << spellCommands imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 # Third-party annotations
 try:
     # We can't assume the user has enchant..

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -4,6 +4,7 @@
 #@+node:ekr.20120219194520.10463: ** << leoApp imports >>
 from __future__ import annotations
 import argparse
+from collections.abc import Callable
 import importlib
 import io
 import os
@@ -14,7 +15,7 @@ import sys
 import textwrap
 import time
 import traceback
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 import zipfile
 import platform
 from leo.core import leoGlobals as g

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -148,6 +148,7 @@ Leo's outline structure. These comments have the form::
 #@+node:ekr.20200105054219.1: ** << leoAst imports & annotations >>
 from __future__ import annotations
 import argparse
+from collections.abc import Callable
 import ast
 import codecs
 import difflib
@@ -160,7 +161,7 @@ import sys
 import textwrap
 import tokenize
 import traceback
-from typing import Any, Callable, Generator, Optional, Union
+from typing import Any, Generator, Optional, Union
 
 Node = ast.AST
 ActionList = list[tuple[Callable, Any]]

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -4,6 +4,7 @@
 #@+<< leoAtFile imports & annotations >>
 #@+node:ekr.20041005105605.2: ** << leoAtFile imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import io
 import os
 import re
@@ -11,7 +12,7 @@ import sys
 import tabnanny
 import time
 import tokenize
-from typing import Any, Callable, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 

--- a/leo/core/leoBackground.py
+++ b/leo/core/leoBackground.py
@@ -4,11 +4,12 @@
 #@+<< leoBackground imports & annotations >>
 #@+node:ekr.20220410202718.1: ** << leoBackground imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
 import subprocess
 import _thread as thread
 from time import sleep
-from typing import Any, Callable, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore
 

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -4,9 +4,10 @@
 #@+<< leoChapters imports & annotations >>
 #@+node:ekr.20220824080606.1: ** << leoChapters imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
 import string
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -8,10 +8,11 @@
 #@+<< leoColorizer imports >>
 #@+node:ekr.20140827092102.18575: ** << leoColorizer imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
 import string
 import time
-from typing import Any, Callable, Generator, Sequence, Optional, TYPE_CHECKING
+from typing import Any, Generator, Sequence, Optional, TYPE_CHECKING
 #
 # Third-part tools.
 try:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3,6 +3,7 @@
 #@+<< leoCommands imports >>
 #@+node:ekr.20040712045933: ** << leoCommands imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import json
 import os
 import re
@@ -13,7 +14,7 @@ import tabnanny
 import tempfile
 import time
 import tokenize
-from typing import Any, Callable, Generator, Iterable, Optional, Union, TYPE_CHECKING
+from typing import Any, Generator, Iterable, Optional, Union, TYPE_CHECKING
 from leo.core import leoGlobals as g
 # The leoCommands ctor now does most leo.core.leo* imports,
 # thereby breaking circular dependencies.

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -3,11 +3,12 @@
 #@+<< leoExternalFiles imports & annotations >>
 #@+node:ekr.20220821202943.1: ** << leoExternalFiles imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import getpass
 import os
 import subprocess
 import tempfile
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 import binascii
 from collections import defaultdict
+from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import datetime
 import difflib
@@ -18,7 +19,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
-from typing import Any, Callable, Generator, Optional, Union, TYPE_CHECKING
+from typing import Any, Generator, Optional, Union, TYPE_CHECKING
 import zipfile
 import xml.etree.ElementTree as ElementTree
 import xml.sax

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -4,11 +4,12 @@
 #@+<< leoFind imports & annotations >>
 #@+node:ekr.20220415005856.1: ** << leoFind imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import keyword
 import re
 import sys
 import time
-from typing import Any, Callable, Generator, Optional, Union
+from typing import Any, Generator, Optional, Union
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -9,9 +9,10 @@ These classes should be overridden to create frames for a particular gui.
 #@+<< leoFrame imports >>
 #@+node:ekr.20120219194520.10464: ** << leoFrame imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import os
 import string
-from typing import Any, Callable, Optional, Union
+from typing import Any, Optional, Union
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColorizer  # NullColorizer is a subclass of ColorizerMixin

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -9,6 +9,7 @@ Important: This module imports no other Leo module.
 #@+node:ekr.20050208101229: ** << leoGlobals imports >>
 from __future__ import annotations
 import binascii
+from collections.abc import Callable
 import codecs
 import copy
 import fnmatch
@@ -34,8 +35,7 @@ import textwrap
 import time
 import traceback
 import types
-from typing import TYPE_CHECKING
-from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Union
+from typing import Any, Generator, Iterable, Optional, Sequence, Union, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -11,8 +11,8 @@ Plugins may define their own gui classes by setting g.app.gui.
 #@+<< leoGui imports & annotations >>
 #@+node:ekr.20220414080546.1: ** << leoGui imports & annotations >>
 from __future__ import annotations
-from typing import Any, Callable, Optional, Union
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, Optional, Union, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -3,13 +3,14 @@
 #@+<< leoImport imports >>
 #@+node:ekr.20091224155043.6539: ** << leoImport imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import csv
 import io
 import os
 import re
 import textwrap
 import time
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 import urllib
 #
 # Third-party imports.

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -6,6 +6,7 @@
 #@+<< leoKeys imports >>
 #@+node:ekr.20061031131434.1: ** << leoKeys imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import inspect
 import os
 import re
@@ -13,7 +14,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands import gotoCommands
 from leo.external import codewise

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -4,7 +4,8 @@
 #@+<< leoMenu imports & annotations >>
 #@+node:ekr.20220414095908.1: ** << leoMenu imports & annotations >>
 from __future__ import annotations
-from typing import Any, Callable, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -4,10 +4,11 @@
 #@+<< leoNodes imports & annotations >>
 #@+node:ekr.20060904165452.1: ** << leoNodes imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import copy
 import time
 import uuid
-from typing import Any, Callable, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
 

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -4,8 +4,9 @@
 #@+<< leoPlugins imports & annotations >>
 #@+node:ekr.20220901071118.1: ** << leoPlugins imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import sys
-from typing import Any, Callable, Iterator, TYPE_CHECKING
+from typing import Any, Iterator, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -7,7 +7,8 @@ Adapted from printing plugin.
 #@+<< leoPrinting imports & annotations >>
 #@+node:ekr.20220901091411.1: ** << leoPrinting imports & annotations >>
 from __future__ import annotations
-from typing import Any, Callable, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 # Qt imports. May fail from the bridge.

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -13,11 +13,12 @@ available."""
 #@+<< leoRst imports >>
 #@+node:ekr.20100908120927.5971: ** << leoRst imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import io
 import os
 import re
 import time
-from typing import Any, Callable, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, Optional, TYPE_CHECKING
 # Third-part imports...
 try:
     import docutils

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -45,7 +45,8 @@
 #@+<< leoUndo imports & annotations >>
 #@+node:ekr.20220821074023.1: ** << leoUndo imports & annotations >>
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -19,9 +19,10 @@ doing the normal key handling that vim emulation uses.
 #@+<< leoVim imports & annotations >>
 #@+node:ekr.20220901100947.1: ** << leoVim imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import os
 import string
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoGui import LeoKeyEvent
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -12,6 +12,7 @@ Written by Félix Malboeuf and Edward K. Ream.
 # pylint: disable=import-self,raise-missing-from,wrong-import-position
 import argparse
 import asyncio
+from collections.abc import Callable
 import fnmatch
 import inspect
 import itertools
@@ -22,7 +23,7 @@ import sys
 import socket
 import textwrap
 import time
-from typing import Any, Callable, Generator, Iterable, Iterator, Optional, Union
+from typing import Any, Generator, Iterable, Iterator, Optional, Union
 import warnings
 
 # Third-party.

--- a/leo/core/signal_manager.py
+++ b/leo/core/signal_manager.py
@@ -15,7 +15,8 @@ Terry Brown, terrynbrown@gmail.com, Thu Mar 23 21:13:38 2017
 #@+node:ekr.20220901092745.1: ** << signal_manager imports >>
 from __future__ import annotations
 from collections import defaultdict
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 #@-<< signal_manager imports >>
 
 #@+others

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -44,8 +44,9 @@ And call this in your plugin *once*::
 #@+<< contextmenu imports & annotations >>
 #@+node:ekr.20220828123814.1: ** << contextmenu imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import os
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore
 from leo.core.leoGui import LeoKeyEvent

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -9,8 +9,9 @@
 # pylint: disable=arguments-differ
 #@+<< imports >>
 #@+node:ekr.20150107090324.2: ** << imports >>
+from collections.abc import Callable
 import os
-from typing import Any, Callable
+from typing import Any
 from leo.core import leoGlobals as g
 from leo.core import leoChapters
 from leo.core import leoGui

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -27,13 +27,13 @@ https://leo-editor.github.io/leo-editor/console-gui.html#developing-the-cursesgu
 #@+<< cursesGui2 imports >>
 #@+node:ekr.20170419172102.1: ** << cursesGui2 imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import copy
 import logging
 import logging.handlers
 import re
 import sys
-from typing import Any, Callable, Generator, Optional, Union
-from typing import TYPE_CHECKING
+from typing import Any, Generator, Optional, Union, TYPE_CHECKING
 
 # Third-party.
 try:

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -224,11 +224,12 @@ most brilliant idea in Leo's history.
 #@+node:ekr.20060328125248.2: ** << mod_scripting imports & annotations >>
 from __future__ import annotations
 from collections import namedtuple
+from collections.abc import Callable
 import pprint
 import re
 import sys
 import textwrap
-from typing import Any, Callable, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoGui

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -97,8 +97,9 @@ whitespace (calling .strip()).
 #@+<< nodetags imports & annotations >>
 #@+node:ekr.20220828131647.1: ** << nodetags imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
-from typing import Any, Callable, Generator, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
 from leo.core.leoQt import QtCore, QtWidgets

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -5,12 +5,13 @@
 #@+node:ekr.20110605121601.18003: **  << qt_frame imports >>
 from __future__ import annotations
 from collections import defaultdict
+from collections.abc import Callable
 import os
 import platform
 import string
 import sys
 import time
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoColorizer

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -5,12 +5,13 @@
 #@+<< qt_gui imports  >>
 #@+node:ekr.20140918102920.17891: ** << qt_gui imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import datetime
 import functools
 import re
 import sys
 import textwrap
-from typing import Any, Callable, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 from leo.core import leoColor
 from leo.core import leoGlobals as g
 from leo.core import leoGui

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -4,9 +4,8 @@
 #@+<< qt_text imports & annotations>>
 #@+node:ekr.20220416085845.1: ** << qt_text imports & annotations >>
 from __future__ import annotations
-import time
-assert time
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import isQt6, QtCore, QtGui, Qsci, QtWidgets
 from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -4,9 +4,10 @@
 #@+<< qt_tree imports >>
 #@+node:ekr.20140907131341.18709: ** << qt_tree imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import re
 import time
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core.leoQt import isQt6, QtCore, QtGui, QtWidgets
 from leo.core.leoQt import EndEditHint, Format, ItemFlag, KeyboardModifier
 from leo.core import leoGlobals as g

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -79,10 +79,11 @@ This plugin defines the following commands that can be bound to keys:
 #@+<< quicksearch imports >>
 #@+node:ville.20090314215508.7: ** << quicksearch imports >>
 from __future__ import annotations
+from collections.abc import Callable
 import fnmatch
 import itertools
 import re
-from typing import Any, Callable, Iterable, Iterator, Union
+from typing import Any, Iterable, Iterator, Union
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtConst, QtWidgets

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -63,11 +63,12 @@ todo_calendar_cols
 #@+<< todo imports & annotations >>
 #@+node:tbrown.20090119215428.4: ** << todo imports & annotations >>
 from __future__ import annotations
+from collections.abc import Callable
 import os
 import re
 import datetime
 import time
-from typing import Any, Callable, Iterable, Optional, Union
+from typing import Any, Iterable, Optional, Union
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import isQt6, QtConst, QtCore, QtGui, QtWidgets, uic

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -200,12 +200,13 @@ Jacob Peck added markdown support to this plugin.
 #@+node:tbrown.20100318101414.5993: ** << vr imports >>
 # pylint: disable = c-extension-no-member
 from __future__ import annotations
+from collections.abc import Callable
 import json
 import os
 from pathlib import Path
 import shutil
 import textwrap
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from urllib.request import urlopen
 from leo.core import leoGlobals as g
 from leo.core.leoQt import isQt5, QtCore, QtGui, QtWidgets

--- a/leo/plugins/writers/org.py
+++ b/leo/plugins/writers/org.py
@@ -1,7 +1,7 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20140726091031.18079: * @file ../plugins/writers/org.py
 """The @auto write code for Emacs org-mode (.org) files."""
-from typing import Callable
+from collections.abc import Callable
 from leo.core import leoGlobals as g  # Required.
 from leo.core.leoCommands import Commands as Cmdr
 from leo.core.leoNodes import Position

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -4,12 +4,13 @@
 #@+<< test_leoAst imports >>
 #@+node:ekr.20210902074548.1: ** << test_leoAst imports >>
 import ast
+from collections.abc import Callable
 import os
 import sys
 import textwrap
 import time
 import token as token_module
-from typing import Any, Callable
+from typing import Any
 import unittest
 import warnings
 warnings.simplefilter("ignore")


### PR DESCRIPTION
`typing.Callable` is deprecated and will removed in Python 3.13.

- [x] Test with both Python 3.9 and 3.10.