### PR TITLE
PR: Fix two comments and simplify g.isValidLanguage

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -485,7 +485,7 @@ class LeoApp:
 
         self.language_delims_dict: dict[str, str] = {
             # Internally, lower case is used for all language names.
-            # Keys are languages, values are 1,2 or 3-tuples of delims.
+            # Keys are languages, values are strings that contain 1, 2 or 3 delims separated by spaces.
             "actionscript"       : "// /* */", # jason 2003-07-03
             "ada"                : "--",
             "ada95"              : "--",
@@ -518,7 +518,7 @@ class LeoApp:
             "coffeescript"       : "#", # 2016/02/26.
             "config"             : "#", # Leo 4.5.1
             "cplusplus"          : "// /* */",
-            "cpp"                : "// /* */",# C++.
+            "cpp"                : "// /* */", # C++.
             "csharp"             : "// /* */", # C#
             "css"                : "/* */", # 4/1/04
             "cweb"               : "@q@ @>", # Use the "cweb hack"

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2847,7 +2847,7 @@ class AtFile:
             delims = lang_dict.get('delims')
         if not language:
             # No language directive.  Look for @<file> nodes.
-            # Do *not* used.get('language')!
+            # Do *not* use d.get('language')!
             language = g.getLanguageFromAncestorAtFileNode(p) or 'python'
         at.language = language
         if not delims:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3174,12 +3174,8 @@ def isDirective(s: str) -> bool:
     return False
 #@+node:ekr.20200810074755.1: *3* g.isValidLanguage
 def isValidLanguage(language: str) -> bool:
-    """True if language exists in leo/modes."""
-    # 2020/08/12: A hack for c++
-    if language in ('c++', 'cpp'):
-        language = 'cplusplus'
-    fn = g.os_path_join(g.app.loadDir, '..', 'modes', f"{language}.py")
-    return g.os_path_exists(fn)
+    """True if the given language may be used as an external file."""
+    return language and language in g.app.language_delims_dict
 #@+node:ekr.20080827175609.52: *3* g.scanAtCommentAndLanguageDirectives
 def scanAtCommentAndAtLanguageDirectives(aList: list) -> Optional[dict[str, str]]:
     """


### PR DESCRIPTION
`g.isValidLanguage` no longer tests whether a corresponding mode file exists.