### PR TITLE
PR: Remove test_bug_3270_at_path

### DIFF
--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -2,5 +2,5 @@
 cls
 call %~dp0\set-repo-dir
 
-echo test-one-leo: test_leoFind.TestFind
+echo test-one-leo
 call py -m unittest leo.unittests.core.test_leoGlobals.TestGlobals.test_g_handleScriptException

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -88,18 +88,6 @@ class TestAtFile(LeoUnitTest):
             child.b = '@language python\n# test #1889'
             path = c.fullPath(child)
             assert '~' not in path, repr(path)
-    #@+node:ekr.20230410082517.1: *3* TestAtFile.test_bug_3270_at_path
-    def test_bug_3270_at_path(self):
-        #  @path c:/temp/leo
-        #    @file at_file_test.py
-        c = self.c
-        root = c.rootPosition()
-        root.h = '@path c:/temp/leo'
-        child = root.insertAsLastChild()
-        child.h = '@file at_file_test.py'
-        path = c.fullPath(child)
-        expected = 'c:/temp/leo/at_file_test.py'
-        self.assertEqual(path, expected)
     #@+node:ekr.20230411094250.1: *3* TestAtFile.test_bug_3272_at_path
     def test_bug_3272_at_path(self):
         #  @path bookmarks


### PR DESCRIPTION
See #3369.  This unit test:
- is a poor test of the original issue.
- uses bad style in its specification of file paths.

leoPyRef.leo contains only relative paths (good style) because absolute paths will never work across different platforms.

As a result, the easiest/best thing to do is to remove the test entirely.
