### PR TITLE
PR for #3375: improve python importer

### DIFF
--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 import io
 import re
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:
@@ -125,7 +125,7 @@ class Importer:
         return f"{child_kind} {child_name}" if child_name else f"unnamed {child_kind}"
 
     #@+node:ekr.20230612170928.1: *4* i.create_preamble
-    def create_preamble(self, blocks: List[Block], parent: Position, result_list: List[str]) -> None:
+    def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
         Importer.create_preamble: Create one preamble node.
 

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -202,6 +202,7 @@ class Importer:
         if 0:
             self.trace_blocks(blocks)
         if blocks:
+            common_lws = self.compute_common_lws(blocks)
             # Start with the head: lines[start : start_start_body].
             result_list = lines[start:start_body]
             # Special case: create a preamble node as the first child of the parent.
@@ -211,13 +212,14 @@ class Importer:
                 preamble = lines[:new_start]
                 if preamble and any(z for z in preamble):
                     child = parent.insertAsLastChild()
-                    child.h = 'preamble'
+                    child.h = '<< preamble >>'
                     child.b = ''.join(preamble)
+                    result_list.insert(0, f"{common_lws}<< preamble >>\n")
                     # Adjust this block.
                     blocks[0] = child_kind, child_name, new_start, child_start_body, child_end
 
             # Add indented @others.
-            common_lws = self.compute_common_lws(blocks)
+            ### common_lws = self.compute_common_lws(blocks)
             result_list.extend([f"{common_lws}@others\n"])
 
             # Recursively generate the inner nodes/blocks.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -108,7 +108,6 @@ class Importer:
             message = 'intermixed blanks and tabs in: %s' % (fn)
         if not ok:
             if g.unitTesting:
-                ### self.report(message)
                 assert False, message
             else:
                 g.es(message)
@@ -219,7 +218,6 @@ class Importer:
                     blocks[0] = child_kind, child_name, new_start, child_start_body, child_end
 
             # Add indented @others.
-            ### common_lws = self.compute_common_lws(blocks)
             result_list.extend([f"{common_lws}@others\n"])
 
             # Recursively generate the inner nodes/blocks.
@@ -339,7 +337,6 @@ class Importer:
         kind2 = 'blanks' if self.tab_width > 0 else 'tabs'
         fn = g.shortFileName(self.root.h)
         count, result, tab_width = 0, [], self.tab_width
-        self.ws_error = False  # 2016/11/23
         if tab_width < 0:  # Convert tabs to blanks.
             for n, line in enumerate(lines):
                 i, w = g.skip_leading_ws_with_indent(line, 0, tab_width)
@@ -355,12 +352,8 @@ class Importer:
                 if s != line:
                     count += 1
                 result.append(s)
-        if count:
-            self.ws_error = True  ### A flag to check.
-            if not g.unitTesting:
-                ### g.es('changed leading %s to %s in %s line%s in %s' % (
-                ###     kind2, kind, count, g.plural(count), fn))
-                g.es(f"changed leading {kind2} to {kind} in {count} line{g.plural(count)} in {fn}")
+        if count and not g.unitTesting:
+            g.es(f"changed leading {kind2} to {kind} in {count} line{g.plural(count)} in {fn}")
         return result
     #@+node:ekr.20230529075138.7: *3* i: Utils
     # Subclasses are unlikely ever to need to override these methods.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -140,9 +140,10 @@ class Importer:
         preamble = lines[:new_start]
         if preamble and any(z for z in preamble):
             child = parent.insertAsLastChild()
-            child.h = '<< preamble >>'
+            section_name = '<< preamble >>'
+            child.h = section_name
             child.b = ''.join(preamble)
-            result_list.insert(0, f"{common_lws}<< preamble >>\n")
+            result_list.insert(0, f"{common_lws}{section_name}\n")
             # Adjust this block.
             blocks[0] = child_kind, child_name, new_start, child_start_body, child_end
     #@+node:ekr.20230529075138.10: *4* i.find_blocks

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -203,6 +203,9 @@ class Importer:
         if blocks:
             # Start with the head: lines[start : start_start_body].
             result_list = lines[start:start_body]
+            # Special case: create a preamble node as the first child of the parent.
+            if parent == self.root and any(z.strip() for z in result_list):
+                g.printObj(result_list, tag=f"Preamble: {parent.h}")
             # Add indented @others.
             common_lws = self.compute_common_lws(blocks)
             result_list.extend([f"{common_lws}@others\n"])

--- a/leo/plugins/importers/ini.py
+++ b/leo/plugins/importers/ini.py
@@ -26,7 +26,7 @@ class Ini_Importer(Importer):
         Ini_Importer.find_end_of_block.
 
         i is the index of the line *following* the start of the block.
-        
+
         Return the index of the start of next section.
         """
         while i < i2:

--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -37,7 +37,7 @@ class Rst_Importer(Importer):
         The rst writer adds section lines, so *remove* those lines here.
 
         i.gen_lines adds the @language and @tabwidth directives.
-        
+
         """
         lines = self.lines
         assert parent == self.root

--- a/leo/plugins/importers/lua.py
+++ b/leo/plugins/importers/lua.py
@@ -33,9 +33,9 @@ class Lua_Importer(Importer):
     def find_end_of_block(self, i: int, i2: int) -> int:
         """
         Lua_Importer.find_end_of_block.
-        
+
         i is the index (within the *guide* lines) of the line *following* the start of the block.
-        
+
         Return the index of end of the block.
         """
         level = 1  # The previous line starts the function.

--- a/leo/plugins/importers/otl.py
+++ b/leo/plugins/importers/otl.py
@@ -23,9 +23,9 @@ class Otl_Importer(Importer):
     def check_blanks_and_tabs(self, lines: list[str]) -> bool:  # pragma: no cover (missing test)
         """
         Otl_Importer.check_blanks_and_tabs.
-        
+
         Check for intermixed blank & tabs.
-        
+
         Tabs are part of the otl format. Never complain.
         """
         return True

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -3,7 +3,7 @@
 """The new, tokenize based, @auto importer for Python."""
 from __future__ import annotations
 import re
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 import leo.core.leoGlobals as g
 from leo.plugins.importers.base_importer import Block, Importer
 
@@ -35,7 +35,7 @@ class Python_Importer(Importer):
 
     #@+others
     #@+node:ekr.20230612171619.1: *3* python_i.create_preamble
-    def create_preamble(self, blocks: List[Block], parent: Position, result_list: List[str]) -> None:
+    def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
         Python_Importer.create_preamble:
         Create preamble nodes for the module docstrings and everything else.
@@ -46,14 +46,20 @@ class Python_Importer(Importer):
         common_lws = self.compute_common_lws(blocks)
         child_kind, child_name, child_start, child_start_body, child_end = blocks[0]
         new_start = max(0, child_start_body - 1)
-        preamble = lines[:new_start]
-        if preamble and any(z for z in preamble):
+        preamble_lines = lines[:new_start]
+        if not preamble_lines or not any(z for z in preamble_lines):
+            return
+
+        def make_node(preamble_lines: list[str], title: str) -> None:
             child = parent.insertAsLastChild()
-            child.h = '<< preamble >>'
-            child.b = ''.join(preamble)
-            result_list.insert(0, f"{common_lws}<< preamble >>\n")
-            # Adjust this block.
-            blocks[0] = child_kind, child_name, new_start, child_start_body, child_end
+            child.h = f"<< {title} >>"
+            child.b = ''.join(preamble_lines)
+            result_list.insert(0, f"{common_lws}<< {title} >>\n")
+
+        make_node(preamble_lines, "preamble")
+
+        # Adjust this block.
+        blocks[0] = child_kind, child_name, new_start, child_start_body, child_end
     #@+node:ekr.20230514140918.1: *3* python_i.find_blocks
     def find_blocks(self, i1: int, i2: int) -> list[Block]:
         """

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -19,6 +19,7 @@ class Python_Importer(Importer):
 
     language = 'python'
     string_list = ['"""', "'''", '"', "'"]  # longest first.
+    allow_preamble = True
 
     # The default patterns. Overridden in the Cython_Importer class.
     # Group 1 matches the name of the class/def.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -2,6 +2,7 @@
 #@+node:ekr.20211209153303.1: * @file ../plugins/importers/python.py
 """The new, tokenize based, @auto importer for Python."""
 from __future__ import annotations
+import os
 import re
 from typing import TYPE_CHECKING
 import leo.core.leoGlobals as g
@@ -52,7 +53,8 @@ class Python_Importer(Importer):
 
         def make_node(index: int, preamble_lines: list[str], title: str) -> None:
             child = parent.insertAsLastChild()
-            section_name = f"<< {title} >>"
+            parent_s = os.path.split(parent.h)[1].replace('@file ', '').replace('@clean ', '')
+            section_name = f"<< {parent_s}: {title} >>"
             child.h = section_name
             child.b = ''.join(preamble_lines)
             result_list.insert(index, f"{common_lws}{section_name}\n")

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -52,9 +52,10 @@ class Python_Importer(Importer):
 
         def make_node(index: int, preamble_lines: list[str], title: str) -> None:
             child = parent.insertAsLastChild()
-            child.h = f"<< {title} >>"
+            section_name = f"<< {title} >>"
+            child.h = section_name
             child.b = ''.join(preamble_lines)
-            result_list.insert(index, f"{common_lws}<< {title} >>\n")
+            result_list.insert(index, f"{common_lws}{section_name}\n")
 
         def find_docstring() -> list[str]:
             i = 0

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -74,11 +74,11 @@ class Python_Importer(Importer):
         prev_line = self.guide_lines[i - 1]
         kinds = ('class', 'def', '->')  # '->' denotes a coffeescript function.
         assert any(z in prev_line for z in kinds), (i, repr(prev_line))
-        # Handle multi-line def's. Scan to the line containing "->"
-        if prev_line.strip().startswith('def ') and '->' not in prev_line:
+        # Handle multi-line def's. Scan to the line containing a close parenthesis.
+        if prev_line.strip().startswith('def ') and ')' not in prev_line:
             while i < i2:
                 i += 1
-                if '->' in self.guide_lines[i - 1]:
+                if ')' in self.guide_lines[i - 1]:
                     break
         tail_lines = 0
         if i < i2:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -74,6 +74,12 @@ class Python_Importer(Importer):
         prev_line = self.guide_lines[i - 1]
         kinds = ('class', 'def', '->')  # '->' denotes a coffeescript function.
         assert any(z in prev_line for z in kinds), (i, repr(prev_line))
+        # Handle multi-line def's. Scan to the line containing "->"
+        if prev_line.strip().startswith('def ') and '->' not in prev_line:
+            while i < i2:
+                i += 1
+                if '->' in self.guide_lines[i - 1]:
+                    break
         tail_lines = 0
         if i < i2:
             lws1 = lws_n(prev_line)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -53,7 +53,7 @@ class Python_Importer(Importer):
 
         def make_node(index: int, preamble_lines: list[str], title: str) -> None:
             child = parent.insertAsLastChild()
-            parent_s = os.path.split(parent.h)[1].replace('@file ', '').replace('@clean ', '')
+            parent_s = os.path.split(parent.h)[1].replace('@file', '').replace('@clean', '').strip()
             section_name = f"<< {parent_s}: {title} >>"
             child.h = section_name
             child.b = ''.join(preamble_lines)

--- a/leo/plugins/importers/treepad.py
+++ b/leo/plugins/importers/treepad.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class Treepad_Importer(Importer):
     """
     The importer for the TreePad file format.
-    
+
     See: http://download.nust.na/pub2/FreeStuff/Software/Home%20office%20helpers/TreePad%20Lite/fileformat.txt
     """
 

--- a/leo/scripts/reindent-leo.cmd
+++ b/leo/scripts/reindent-leo.cmd
@@ -16,6 +16,9 @@ call py %REINDENT_PATH% -r leo\core
 echo reindent leo/commands
 call py %REINDENT_PATH% -r leo\commands
 echo reindent leo/plugins/importers
+call py %REINDENT_PATH% -r leo\plugins\importers
+echo reindent leo/plugins/writers
+call py %REINDENT_PATH% -r leo\plugins\writers
 goto done
 
 :no_reindent

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -63,9 +63,11 @@ class TestLeoImport(BaseTestImporter):
                 '@language python\n'
                 '@tabwidth -4\n'
             ),
-            (1, 'def macro',
+            (1, 'preamble',
                 'import os\n'
                 '\n'
+            ),
+            (1, 'def macro',
                 'def macro(func):\n'
                 '    @others\n'
             ),

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -58,12 +58,13 @@ class TestLeoImport(BaseTestImporter):
 
         expected_results = (
             (0, '',  # Ignore the top-level headline.
+                '<< preamble >>\n'
                 '@others\n'
                 'return new_func\n'
                 '@language python\n'
                 '@tabwidth -4\n'
             ),
-            (1, 'preamble',
+            (1, '<< preamble >>',
                 'import os\n'
                 '\n'
             ),

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -27,12 +27,12 @@ class TestLeoImport(BaseTestImporter):
         """)
         f = StringIO(s)
         x.scan(f, target)
-        # self.dump_tree(target, tag='Actual results...')
 
         # #2760: These results ignore way too much.
-
+        
+        # Don't call run_test.
         self.check_outline(target, (
-            (0, '',  # check_outline ignores the top-level headline.
+            (0, '',  # Ignore the top-level headline.
                 ''
             ),
             (1, 'a1', ''),
@@ -57,7 +57,7 @@ class TestLeoImport(BaseTestImporter):
         x.parse_body(target)
 
         expected_results = (
-            (0, '',  # check_outline ignores the top-level headline.
+            (0, '',  # Ignore the top-level headline.
                 '@others\n'
                 'return new_func\n'
                 '@language python\n'
@@ -76,7 +76,6 @@ class TestLeoImport(BaseTestImporter):
         )
         # Don't call run_test.
         self.check_outline(target, expected_results)
-
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -58,13 +58,13 @@ class TestLeoImport(BaseTestImporter):
 
         expected_results = (
             (0, '',  # Ignore the top-level headline.
-                '<< preamble >>\n'
+                '<< target: preamble >>\n'
                 '@others\n'
                 'return new_func\n'
                 '@language python\n'
                 '@tabwidth -4\n'
             ),
-            (1, '<< preamble >>',
+            (1, '<< target: preamble >>',
                 'import os\n'
                 '\n'
             ),

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3407,16 +3407,19 @@ class TestPython(BaseTestImporter):
         '''
         expected_results = (
             (0, '',  # Ignore the first headline.
-                    '<< preamble >>\n'
+                    '<< docstring >>\n'
+                    '<< declarations >>\n'
                    '@others\n'
                    '@language python\n'
                    '@tabwidth -4\n'
             ),
-            (1, '<< preamble >>',
+            (1, '<< docstring >>',
                     '# This file is part of Leo: https://leo-editor.github.io/leo-editor\n'
                     '"""\n'
                     'This is a docstring.\n'
                     '"""\n'
+            ),
+            (1, '<< declarations >>',
                     'import sys\n'
                     'from leo.core import leoGlobals as g\n'
                     '\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3405,7 +3405,7 @@ class TestPython(BaseTestImporter):
         
         # ekr-mypy2/mypy/applytype.py
         
-        # Note the return type.
+        # Note: the return type uses the python 3.11 syntax for Union.
         
         s = """
         def get_target_type(
@@ -3419,8 +3419,26 @@ class TestPython(BaseTestImporter):
                 return type
             return type
         """
-        p = self.run_test(s)
-        self.dump_tree(p, tag='Actual results...')
+        expected_results = (
+            (0, '',  # check_outline ignores the first headline.
+                    '@others\n'
+                    '@language python\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, 'def get_target_type',
+                    'def get_target_type(\n'
+                    '    tvar: TypeVarLikeType,\n'
+                    '    type: Type,\n'
+                    '    callable: CallableType,\n'
+                    ') -> Type | None:\n'
+                    '    if isinstance(tvar, ParamSpecType):\n'
+                    '        return type\n'
+                    '    if isinstance(tvar, TypeVarTupleType):\n'
+                    '        return type\n'
+                    '    return type\n'
+            ),
+        )
+        self.new_run_test(s, expected_results)
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -34,19 +34,25 @@ class BaseTestImporter(LeoUnitTest):
         
         Dump the actual outline if there is a mismatch.
         """
-        p0_level = p.level()
-        actual = [(z.level(), z.h, z.b) for z in p.self_and_subtree()]
-        for i, actual in enumerate(actual):
-            try:
-                a_level, a_h, a_str = actual
-                e_level, e_h, e_str = expected[i]
-            except ValueError:
-                assert False  # So we print the actual results.
-            msg = f"FAIL in node {i} {e_h}"
-            self.assertEqual(a_level - p0_level, e_level, msg=msg)
-            if i > 0:  # Don't test top-level headline.
-                self.assertEqual(e_h, a_h, msg=msg)
-            self.assertEqual(g.splitLines(e_str), g.splitLines(a_str), msg=msg)
+        try:
+            p0_level = p.level()
+            actual = [(z.level(), z.h, z.b) for z in p.self_and_subtree()]
+            for i, actual in enumerate(actual):
+                try:
+                    a_level, a_h, a_str = actual
+                    e_level, e_h, e_str = expected[i]
+                except ValueError:
+                    assert False  # So we print the actual results.
+                msg = f"FAIL in node {i} {e_h}"
+                self.assertEqual(a_level - p0_level, e_level, msg=msg)
+                if i > 0:  # Don't test top-level headline.
+                    self.assertEqual(e_h, a_h, msg=msg)
+                self.assertEqual(g.splitLines(e_str), g.splitLines(a_str), msg=msg)
+        except AssertionError:
+            # Dump actual results, including bodies.
+            self.dump_tree(p, tag='Actual results...')
+            raise
+
     #@+node:ekr.20220809054555.1: *3* BaseTestImporter.check_round_trip
     def check_round_trip(self, p: Position, s: str) -> None:
         """Assert that p's outline is equivalent to s."""
@@ -106,12 +112,8 @@ class BaseTestImporter(LeoUnitTest):
         test_s = textwrap.dedent(s).strip() + '\n'
         c.importCommands.createOutline(parent.copy(), ext, test_s)
 
-        try:
-            self.check_outline(parent, expected_results)
-        except AssertionError:
-            # Dump actual results, including bodies.
-            self.dump_tree(parent, tag='Actual results...')
-            raise
+        # Dump the actual results on failure and raise AssertionError.
+        self.check_outline(parent, expected_results)
     #@+node:ekr.20211127042843.1: *3* BaseTestImporter.run_test
     def run_test(self, s: str) -> Position:
         """
@@ -172,7 +174,7 @@ class TestC(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language c\n'
                 '@tabwidth -4\n'
@@ -213,7 +215,7 @@ class TestC(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language c\n'
                 '@tabwidth -4\n'
@@ -255,7 +257,7 @@ class TestC(BaseTestImporter):
             } // comment
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language c\n'
                 '@tabwidth -4\n'
@@ -288,7 +290,7 @@ class TestC(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 'extern "C"\n'
                 '{\n'
                 '#include "stuff.h"\n'
@@ -316,7 +318,7 @@ class TestC(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 'static void\n'
                 'ReleaseCharSet(cset)\n'
                 '    CharSet *cset;\n'
@@ -345,7 +347,7 @@ class TestC(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 'Tcl_Obj *\n'
                 'Tcl_NewLongObj(longValue)\n'
                 '    register long longValue; /* Long integer used to initialize the\n'
@@ -370,7 +372,7 @@ class TestC(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language c\n'
                 '@tabwidth -4\n'
@@ -520,7 +522,7 @@ class TestC(BaseTestImporter):
         };
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language c\n'
                 '@tabwidth -4\n'
@@ -567,7 +569,7 @@ class TestCoffeescript(BaseTestImporter):
         """
 
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language coffeescript\n'
                     '@tabwidth -4\n'
@@ -626,7 +628,7 @@ class TestCoffeescript(BaseTestImporter):
               
           """
         expected_results = (
-          (0, '',  # check_outline ignores the first headline.
+          (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language coffeescript\n'
                 '@tabwidth -4\n'
@@ -699,7 +701,7 @@ class TestCSharp(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language csharp\n'
                     '@tabwidth -4\n'
@@ -727,7 +729,7 @@ class TestCSharp(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language csharp\n'
                     '@tabwidth -4\n'
@@ -777,7 +779,7 @@ class TestCText(BaseTestImporter):
         """
         # Round-tripping is not guaranteed.
         expected_results = (
-            (0, '', # check_outline ignores the first headline.
+            (0, '', # Ignore the first headline.
                     'Leading text in root node of subtree\n'
                     '\n'
                     'Etc. etc.\n'
@@ -878,7 +880,7 @@ class TestDart(BaseTestImporter):
         }
         '''
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language dart\n'
                     '@tabwidth -4\n'
@@ -931,7 +933,7 @@ class TestElisp(BaseTestImporter):
                (+ 1 2 3))
         """
         expected_results = (
-            (0, '', # check_outline ignores the first headline.
+            (0, '', # Ignore the first headline.
                     '@others\n'
                     '@language lisp\n'
                     '@tabwidth -4\n'
@@ -993,7 +995,7 @@ class TestHtml(BaseTestImporter):
         '''
 
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language html\n'
                     '@tabwidth -4\n'
@@ -1046,7 +1048,7 @@ class TestHtml(BaseTestImporter):
             </body>
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language html\n'
                     '@tabwidth -4\n'
@@ -1092,7 +1094,7 @@ class TestHtml(BaseTestImporter):
             <!-- oops: missing tags. -->
         '''
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '    <!-- oops: link elements terminated two different ways -->\n'
                     '    <link id="L1">\n'
@@ -1127,7 +1129,7 @@ class TestHtml(BaseTestImporter):
             </HTML>
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language html\n'
                     '@tabwidth -4\n'
@@ -1257,7 +1259,7 @@ class TestHtml(BaseTestImporter):
             </html>
         '''
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language html\n'
                     '@tabwidth -4\n'
@@ -1443,7 +1445,7 @@ class TestHtml(BaseTestImporter):
             </html>
         '''
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language html\n'
                     '@tabwidth -4\n'
@@ -1490,7 +1492,7 @@ class TestHtml(BaseTestImporter):
             <p>Paragraph</p>
         '''
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '<p>Paragraph</p>\n'
                     '@language html\n'
@@ -1528,7 +1530,7 @@ class TestHtml(BaseTestImporter):
             </HTML>
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language html\n'
                 '@tabwidth -4\n'
@@ -1641,7 +1643,7 @@ class TestJava(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline does not check the first outline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language java\n'
                     '@tabwidth -4\n'
@@ -1691,7 +1693,7 @@ class TestJava(BaseTestImporter):
 
         """
         expected_results = (
-            (0, '',  # check_outline does not check the first outline.
+            (0, '', # Ignore the first headline.
                 '@others\n'
                 '@language java\n'
                 '@tabwidth -4\n'
@@ -1733,7 +1735,7 @@ class TestJava(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 'interface Bicycle {\n'
                 '    void changeCadence(int newValue);\n'
                 '    void changeGear(int newValue);\n'
@@ -1753,7 +1755,7 @@ class TestJava(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 'interface Bicycle {\n'
                 'void changeCadence(int newValue);\n'
                 'void changeGear(int newValue);\n'
@@ -1788,7 +1790,7 @@ class TestJavascript(BaseTestImporter):
         """
         
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language javascript\n'
                 '@tabwidth -4\n'
@@ -1827,7 +1829,7 @@ class TestJavascript(BaseTestImporter):
         """
 
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language javascript\n'
                 '@tabwidth -4\n'
@@ -1889,7 +1891,7 @@ class TestLua (BaseTestImporter):
              print("main", coroutine.resume(co, "x", "y"))
         """
         expected_results = (
-            (0, '', # check_outline ignores the first headline'
+            (0, '', # Ignore the first headline.
                     '@others\n'
                     '\n'
                     'print("main", coroutine.resume(co, 1, 10))\n'
@@ -2022,7 +2024,7 @@ class TestMarkdown(BaseTestImporter):
             section 3, line 1
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language md\n'
                 '@tabwidth -4\n'
             ),
@@ -2084,7 +2086,7 @@ class TestMarkdown(BaseTestImporter):
             # Last header: no text
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language md\n'
                 '@tabwidth -4\n'
             ),
@@ -2133,7 +2135,7 @@ class TestMarkdown(BaseTestImporter):
             #Last header: no text
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language md\n'
                 '@tabwidth -4\n'
             ),
@@ -2179,7 +2181,7 @@ class TestMarkdown(BaseTestImporter):
             # Last header
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language md\n'
                 '@tabwidth -4\n'
             ),
@@ -2253,7 +2255,7 @@ class TestOrg(BaseTestImporter):
             Sec 3.1
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language org\n'
                 '@tabwidth -4\n'
             ),
@@ -2285,7 +2287,7 @@ class TestOrg(BaseTestImporter):
             First line.
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@language org\n'
                     '@tabwidth -4\n'
             ),
@@ -2306,7 +2308,7 @@ class TestOrg(BaseTestImporter):
             *** 每周惯例
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@language org\n'
                     '@tabwidth -4\n'
             ),
@@ -2334,7 +2336,7 @@ class TestOrg(BaseTestImporter):
             Sec 2.
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 'Intro line.\n'
                 '@language org\n'
                 '@tabwidth -4\n'
@@ -2367,7 +2369,7 @@ class TestOrg(BaseTestImporter):
             Sec 3.1
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language org\n'
                 '@tabwidth -4\n'
             ),
@@ -2410,7 +2412,7 @@ class TestOrg(BaseTestImporter):
         c.theTagController = TagController(c)
         # Run the test.
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@language org\n'
                     '@tabwidth -4\n'
             ),
@@ -2446,7 +2448,7 @@ class TestOtl(BaseTestImporter):
             : Sec 3.1
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 # 'line in root node\n'
                 '@language otl\n'
                 '@tabwidth -4\n'
@@ -2472,7 +2474,7 @@ class TestOtl(BaseTestImporter):
             : Sec 3.
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language otl\n'
                 '@tabwidth -4\n'
             ),
@@ -2549,7 +2551,7 @@ class TestPascal(BaseTestImporter):
         #@-<< define s >>
         
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language pascal\n'
                 '@tabwidth -4\n'
@@ -2674,7 +2676,7 @@ class TestPascal(BaseTestImporter):
         """).strip() + '\n'
         #@-<< define s >>
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language pascal\n'
                     '@tabwidth -4\n'
@@ -2789,7 +2791,7 @@ class TestPerl(BaseTestImporter):
             Hello();
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '            "ﬁ" =~ /fi/i;\n'
                     '\n'
@@ -2840,7 +2842,7 @@ class TestPerl(BaseTestImporter):
             world\n";
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '#!/usr/bin/perl\n'
                     '\n'
                     '            # This would print with a line break in the middle\n'
@@ -2879,7 +2881,7 @@ class TestPerl(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language perl\n'
                     '@tabwidth -4\n'
@@ -2932,7 +2934,7 @@ class TestPerl(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language perl\n'
                     '@tabwidth -4\n'
@@ -3157,7 +3159,7 @@ class TestPython(BaseTestImporter):
         """).replace('AT', '@')
 
         expected_results = (
-            (0, '', # check_outline ignores the first headline'
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '\n'
                     "if __name__ == '__main__':\n"
@@ -3239,7 +3241,7 @@ class TestPython(BaseTestImporter):
                 c=3
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                    '@others\n'
                    '@language python\n'
                    '@tabwidth -4\n'
@@ -3276,7 +3278,7 @@ class TestPython(BaseTestImporter):
 
         # Note: new_gen_block deletes leading and trailing whitespace from all blocks.
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '\n'
                     "if __name__ == '__main__':\n"
@@ -3320,7 +3322,7 @@ class TestPython(BaseTestImporter):
             """
         # mypy/test-data/stdlib-samples/3.2/test/shutil.py
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                    '@others\n'
                    '@language python\n'
                    '@tabwidth -4\n'
@@ -3369,7 +3371,7 @@ class TestPython(BaseTestImporter):
                 print('12')
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                'a = 1\n'
                'if 1:\n'
                " print('1')\n"
@@ -3420,7 +3422,7 @@ class TestPython(BaseTestImporter):
             return type
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language python\n'
                     '@tabwidth -4\n'
@@ -3498,7 +3500,7 @@ class TestRst(BaseTestImporter):
             section 3.1.1, line 1
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language rest\n'
                 '@tabwidth -4\n'
             ),
@@ -3568,7 +3570,7 @@ class TestRst(BaseTestImporter):
             The top chapter.
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language rest\n'
                 '@tabwidth -4\n'
             ),
@@ -3634,7 +3636,7 @@ class TestRst(BaseTestImporter):
             section 3.1.1, line 1
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@language rest\n'
                     '@tabwidth -4\n'
             ),
@@ -3701,7 +3703,7 @@ class TestRst(BaseTestImporter):
             The top section
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@language rest\n'
                     '@tabwidth -4\n'
             ),
@@ -3734,7 +3736,7 @@ class TestRst(BaseTestImporter):
             The top section
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language rest\n'
                 '@tabwidth -4\n'
             ),
@@ -3769,7 +3771,7 @@ class TestRst(BaseTestImporter):
             The top section.
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                 '@language rest\n'
                 '@tabwidth -4\n'
             ),
@@ -3813,7 +3815,7 @@ class TestRst(BaseTestImporter):
             Sec 2.
         """
         expected_results = (
-            (0, '',  # check_outline ignores the first headline.
+            (0, '',  # Ignore the first headline.
                     '@language rest\n'
                     '@tabwidth -4\n'
             ),
@@ -3859,7 +3861,7 @@ class TestRust(BaseTestImporter):
             }
         """
         expected_results = (
-            (0, '', # check_outline ignores the first headline'
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language rust\n'
                     '@tabwidth -4\n'
@@ -3916,7 +3918,7 @@ class TestTcl (BaseTestImporter):
              }
         """
         expected_results = (
-            (0, '', # check_outline ignores the first headline'
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '\n'
                     ' # Main program\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -831,12 +831,12 @@ class TestCython(BaseTestImporter):
         '''
         expected_results = (
             (0, '',  # check_outlines ignores the first headline.
-                    '<< preamble >>\n'
+                    '<< TestCython.test_importer: preamble >>\n'
                     '@others\n'
                     '@language cython\n'
                     '@tabwidth -4\n'
             ),
-            (1, '<< preamble >>',
+            (1, '<< TestCython.test_importer: preamble >>',
                     'from libc.math cimport pow\n'
                     '\n'
             ),
@@ -3165,7 +3165,7 @@ class TestPython(BaseTestImporter):
 
         expected_results = (
             (0, '',  # Ignore the first headline.
-                    '<< preamble >>\n'
+                    '<< TestPython.test_general_test_1: preamble >>\n'
                     '@others\n'
                     '\n'
                     "if __name__ == '__main__':\n"
@@ -3173,7 +3173,7 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, '<< preamble >>',
+            (1, '<< TestPython.test_general_test_1: preamble >>',
                     'import sys\n'
             ),
             (1, 'def f1',
@@ -3358,7 +3358,7 @@ class TestPython(BaseTestImporter):
         # Note: new_gen_block deletes leading and trailing whitespace from all blocks.
         expected_results = (
             (0, '',  # Ignore the first headline.
-                    '<< preamble >>\n'
+                    '<< TestPython.test_oneliners: preamble >>\n'
                     '@others\n'
                     '\n'
                     "if __name__ == '__main__':\n"
@@ -3366,7 +3366,7 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, '<< preamble >>',
+            (1, '<< TestPython.test_oneliners: preamble >>',
                     'import sys\n'
             ),
             (1, 'def f1',
@@ -3407,19 +3407,19 @@ class TestPython(BaseTestImporter):
         '''
         expected_results = (
             (0, '',  # Ignore the first headline.
-                    '<< docstring >>\n'
-                    '<< declarations >>\n'
+                    '<< TestPython.test_preamble: docstring >>\n'
+                    '<< TestPython.test_preamble: declarations >>\n'
                    '@others\n'
                    '@language python\n'
                    '@tabwidth -4\n'
             ),
-            (1, '<< docstring >>',
+            (1, '<< TestPython.test_preamble: docstring >>',
                     '# This file is part of Leo: https://leo-editor.github.io/leo-editor\n'
                     '"""\n'
                     'This is a docstring.\n'
                     '"""\n'
             ),
-            (1, '<< declarations >>',
+            (1, '<< TestPython.test_preamble: declarations >>',
                     'import sys\n'
                     'from leo.core import leoGlobals as g\n'
                     '\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -569,11 +569,12 @@ class TestCoffeescript(BaseTestImporter):
 
         expected_results = (
             (0, '',  # Ignore the first headline.
+                    '<< preamble >>\n'
                     '@others\n'
                     '@language coffeescript\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'preamble',
+            (1, '<< preamble >>',
                     "# Js2coffee relies on Narcissus's parser.\n"
                     '\n'
                     "{parser} = @Narcissus or require('./narcissus_packed')\n"
@@ -830,11 +831,12 @@ class TestCython(BaseTestImporter):
         '''
         expected_results = (
             (0, '',  # check_outlines ignores the first headline.
+                    '<< preamble >>\n'
                     '@others\n'
                     '@language cython\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'preamble',
+            (1, '<< preamble >>',
                     'from libc.math cimport pow\n'
                     '\n'
             ),
@@ -3163,6 +3165,7 @@ class TestPython(BaseTestImporter):
 
         expected_results = (
             (0, '',  # Ignore the first headline.
+                    '<< preamble >>\n'
                     '@others\n'
                     '\n'
                     "if __name__ == '__main__':\n"
@@ -3170,7 +3173,7 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'preamble',
+            (1, '<< preamble >>',
                     'import sys\n'
             ),
             (1, 'def f1',
@@ -3355,6 +3358,7 @@ class TestPython(BaseTestImporter):
         # Note: new_gen_block deletes leading and trailing whitespace from all blocks.
         expected_results = (
             (0, '',  # Ignore the first headline.
+                    '<< preamble >>\n'
                     '@others\n'
                     '\n'
                     "if __name__ == '__main__':\n"
@@ -3362,7 +3366,7 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'preamble',
+            (1, '<< preamble >>',
                     'import sys\n'
             ),
             (1, 'def f1',
@@ -3403,11 +3407,12 @@ class TestPython(BaseTestImporter):
         '''
         expected_results = (
             (0, '',  # Ignore the first headline.
+                    '<< preamble >>\n'
                    '@others\n'
                    '@language python\n'
                    '@tabwidth -4\n'
             ),
-            (1, 'preamble',
+            (1, '<< preamble >>',
                     '# This file is part of Leo: https://leo-editor.github.io/leo-editor\n'
                     '"""\n'
                     'This is a docstring.\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -573,13 +573,15 @@ class TestCoffeescript(BaseTestImporter):
                     '@language coffeescript\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'def buildCoffee',
+            (1, 'preamble',
                     "# Js2coffee relies on Narcissus's parser.\n"
                     '\n'
                     "{parser} = @Narcissus or require('./narcissus_packed')\n"
                     '\n'
                     '# Main entry point\n'
                     '\n'
+            ),
+            (1, 'def buildCoffee',
                     'buildCoffee = (str) ->\n'
                     "  str  = str.replace /\\r/g, ''\n"
                     '  str += "\\n"\n'
@@ -832,9 +834,11 @@ class TestCython(BaseTestImporter):
                     '@language cython\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'cdef double square_and_add',
+            (1, 'preamble',
                     'from libc.math cimport pow\n'
                     '\n'
+            ),
+            (1, 'cdef double square_and_add',
                     'cdef double square_and_add (double x):\n'
                     '    """Compute x^2 + x as double.\n'
                     '\n'
@@ -3166,8 +3170,10 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'def f1',
+            (1, 'preamble',
                     'import sys\n'
+            ),
+            (1, 'def f1',
                     'def f1():\n'
                     '    pass\n'
             ),
@@ -3356,8 +3362,10 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'def f1',
+            (1, 'preamble',
                     'import sys\n'
+            ),
+            (1, 'def f1',
                     'def f1():\n'
                     '    pass\n'
             ),
@@ -3406,6 +3414,7 @@ class TestPython(BaseTestImporter):
                     '"""\n'
                     'import sys\n'
                     'from leo.core import leoGlobals as g\n'
+                    '\n'
             ),
             (1, 'def f',
                    'def f():\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -569,12 +569,12 @@ class TestCoffeescript(BaseTestImporter):
 
         expected_results = (
             (0, '',  # Ignore the first headline.
-                    '<< preamble >>\n'
+                    '<< TestCoffeescript.test_1: preamble >>\n'
                     '@others\n'
                     '@language coffeescript\n'
                     '@tabwidth -4\n'
             ),
-            (1, '<< preamble >>',
+            (1, '<< TestCoffeescript.test_1: preamble >>',
                     "# Js2coffee relies on Narcissus's parser.\n"
                     '\n'
                     "{parser} = @Narcissus or require('./narcissus_packed')\n"


### PR DESCRIPTION
See #3375.

- [x] Scan for ')' before computing leading whitespace.
- [x] Generate `<< preamble >>` nodes and related section refs for lines appearing before the block.
- [x] Create `Importer.create_preamble` and `Python_Importer.create_preamble'.
- [x] Add `allow_prefix` and related logic. Change unit tests accordingly.
- [x] Add unit test.
- [x] Simplify `check_outline` and `new_run_test`.
- [x] Clean import of all mypy files.
- [x] Reindent all importer files.