### PR TITLE
PR for #3381: rewrite LM.scanOptions w/o argparse

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -477,7 +477,9 @@ class LeoApp:
         # self.prolog_string = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         self.prolog_prefix_string = "<?xml version=\"1.0\" encoding="
         self.prolog_postfix_string = "?>"
-        self.prolog_namespace_string = 'xmlns:leo="https://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1"'
+        self.prolog_namespace_string = (
+            'xmlns:leo="https://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1"'
+        )
     #@+node:ekr.20120522160137.9909: *5* app.define_language_delims_dict
     #@@nobeautify
 
@@ -2677,8 +2679,14 @@ class LoadManager:
     def checkOptions(self) -> None:
         """Make sure all command-line options pass sanity checks."""
         option_prefixes = [z[:-1] for z in self.valid_options if z.endswith('=')]
-        for arg in sys.argv[:]:
-            if arg.startswith('-'):
+        obsolete_options = (
+            '--dock', '--global-docks', '--init-docks', '--no-cache',
+            '--no-dock', '--session-restore', '--session-save', '--use-docks',
+        )
+        for arg in sys.argv:
+            if arg in obsolete_options:
+                print(f"Ignoring obsolete option: {arg!r}")
+            elif arg.startswith('-'):
                 for option in self.valid_options:
                     if arg.startswith(option):
                         break
@@ -2780,7 +2788,7 @@ class LoadManager:
         # else:
             # script = None
         # return script
-    #@+node:ekr.20230615055158.1: *6* LM.doSelectOption (new) (todo)
+    #@+node:ekr.20230615055158.1: *6* LM.doSelectOption (new, todo)
     def doSelectOption(self) -> Optional[str]:
         ### args.select and args.select.strip('"'),  # --select=headline
         return None
@@ -2847,9 +2855,8 @@ class LoadManager:
         for option, helper in options_dict.items():
             if option in sys.argv:
                 helper()
-    #@+node:ekr.20230615060055.1: *6* LM.doThemeOption
-    def doThemeOption(self) -> Optional[str]:  # pylint: disable=useless-return
-        g.trace('TO DO')
+    #@+node:ekr.20230615060055.1: *6* LM.doThemeOption (new, todo)
+    def doThemeOption(self) -> Optional[str]:
         return None
     #@+node:ekr.20210927034148.10: *6* LM.doWindowSizeOption
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2763,40 +2763,54 @@ class LoadManager:
     #@+node:ekr.20230615060055.1: *7* LM.doThemeOption (new, to do)
     def doThemeOption(self) -> Optional[str]:
         return None
-    #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions (new, to do)
-    def doTraceOptions(self) -> Optional[str]:
+    #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions
+    def doTraceOptions(self) -> None:
+        """Handle --trace-binding, --trace-setting and --trace"""
+        
+        # --trace-binding
+        arg = self.findOption('--trace-binding=')
+        if arg:
+            m = re.match(r'--trace-binding=([\w\-\+]+)', arg)
+            if m:
+                # g.app.config does not exist yet.
+                # print(f"Enable {arg}")
+                g.app.trace_binding = m.group(1)
 
-        return None
-
-        # trace_m = textwrap.dedent("""\
-            # abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
-            # importers, ipython, keys, layouts, plugins, save, select, sections,
-            # shutdown, size, speed, startup, themes, undo, verbose, zoom
-        # """)
-
-        # --trace=...
-
-        # valid = trace_m.replace(' ', '').replace('\n', '').split(',')
-        # if args.trace:
-            # ok = True
-            # values = args.trace.lstrip('(').lstrip('[').rstrip(')').rstrip(']')
-            # for val in values.split(','):
-                # if val in valid:
-                    # g.app.debug.append(val)
-                # else:
-                    # g.es_print(f"unknown --trace value: {val}")
-                    # ok = False
-            # if not ok:
-                # g.es_print('Valid --trace values are...')
-                # for line in trace_m.split('\n'):
-                    # print('  ', line.rstrip())
-        # #
-        # # These are not bool args.
-        # # --trace-binding
-        # g.app.trace_binding = args.trace_binding  # g.app.config does not exist yet.
-        # #
-        # # --trace-setting=setting
-        # g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
+        # --trace-setting=setting
+        arg = self.findOption('--trace-setting=')
+        if arg:
+            m = re.match(r'--trace-setting=([\w]+)', arg)
+            if m:
+                # g.app.config does not exist yet.
+                # print(f"Enable {arg}")
+                g.app.trace_setting = m.group(1)
+        
+        # --trace=option.
+        valid = [
+            'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
+            'focus', 'git', 'gnx', 'importers', 'ipython', 'keys',
+            'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
+            'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
+        ]
+        arg = self.findOption('--trace=')
+        if not arg:
+            return
+        m = re.match(r'--trace=([\w,]+)', arg)
+        if not m:
+            return
+        values = m.group(1).split(',')
+        error = False
+        for value in values:
+            if value in valid:
+                g.app.debug.append(value)
+            else:
+                error = True
+                print(f"Ignoring invalid --trace value: {value!r}")
+        if error:
+            valid_s = '\n   '.join(valid)
+            print(f"Valid --trace values:\n   {valid_s}")
+        else:
+            print(f"Enabling --trace={', '.join(g.app.debug)}")
     #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption (to do)
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2622,6 +2622,7 @@ class LoadManager:
             self.printUsage()
             sys.exit()
 
+        # Handle all args.
         try:
             self.scanArgv()
             self.postscanArgv()
@@ -2803,7 +2804,96 @@ class LoadManager:
 
     #@+node:ekr.20230615034517.1: *6* LM.scanArgv
     def scanArgv(self) -> None:
-        g.trace()
+        
+        #@+<< define scanArgv helpers >>
+        #@+node:ekr.20230615053133.1: *7* << define scanArgv helpers >>
+        def _black() -> None:
+            g.app.write_black_sentinels = True
+            
+        def _diff() -> None:
+            g.app.diff = True
+            
+        def _fail_fast() -> None:
+            g.app.failFast = True
+            
+        def _full_screen() -> None:
+            g.app.start_fullscreen = True
+
+        def _listen_to_log() -> None:
+            g.app.listen_to_log_flag = True
+            
+        def _ipython() -> None:
+            g.app.useIpython = True
+            
+        def _maximized() -> None:
+            g.app.start_maximized = True
+
+        def _minimized() -> None:
+            g.app.start_minimized = True
+            g.app.use_splash_screen = False
+            
+        def _no_plugins() -> None:
+            g.app.enablePlugins = False
+            
+        def _no_splash() -> None:
+            g.app.use_splash_screen = False
+            
+        def _quit() -> None:
+            g.app.quit_after_load = True
+            
+        def _silent() -> None:
+            g.app.silentMode = True
+        #@-<< define scanArgv helpers >>
+       
+        options_dict: dict[str, Callable] = {
+            # Simple args.
+            '-b': _black,
+            '--black-sentinels': _black,
+            '--diff': _diff,
+            '--fail-fast': _fail_fast,
+            '--fullscreen': _full_screen,
+            '--listen-to-log': _listen_to_log,
+            '--ipython': _ipython,
+            '--maximized': _maximized,
+            '--minimized': _minimized,
+            '--no-plugins': _no_plugins,
+            '--no-splash': _no_splash,
+            '--quit': _quit,
+            '--silent': _silent,
+            # Args with arguments.
+            '--gui': self.doGuiOption,
+            '--load-type': self.doLoadTypeOption,
+        }
+        for option, function in options_dict.items():
+            if option in sys.argv:
+                g.trace(function.__name__)
+                function()
+                
+
+
+        # add('--load-type', dest='load_type', metavar='TYPE',
+            # help='@<file> type for non-outlines')
+
+        # add('--screen-shot', dest='screen_shot', metavar='PATH',
+            # help='take a screen shot and then exit')
+        # add('--script', dest='script', metavar="PATH",
+            # help='execute a script and then exit')
+        # add('--script-window', dest='script_window', action='store_true',
+            # help='execute script using default gui')
+        # add('--select', dest='select', metavar='ID',
+            # help='headline or gnx of node to select')
+        # add('--theme', dest='theme', metavar='NAME',
+            # help='use the named theme file')
+        # add('--trace', dest='trace', metavar='TRACE-KEY',
+            # help=f"add one or more strings to g.app.debug. One or more of...\n{trace_m}")
+        # add('--trace-binding', dest='trace_binding', metavar='KEY',
+            # help='trace commands bound to a key')
+        # add('--trace-setting', dest='trace_setting', metavar="NAME",
+            # help='trace where named setting is set')
+        # add('--window-size', dest='window_size', metavar='SIZE',
+            # help='initial window size (height x width)')
+        # add('--window-spot', dest='window_spot', metavar='SPOT',
+            # help='initial window position (top x left)')
     #@+node:ekr.20160718072648.1: *5* LM.setStdStreams
     def setStdStreams(self) -> None:
         """

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2613,10 +2613,10 @@ class LoadManager:
         self.old_argv = sys.argv[:]
 
         args = sys.argv[:]  ### To be removed.
-        
+
         class OptionError(Exception):
             pass
-            
+
         # Handle help args.
         if any(z in sys.argv for z in ('-h', '-?', '--help')):
             self.printUsage()
@@ -2626,7 +2626,8 @@ class LoadManager:
             self.scanArgv()
             self.postscanArgv()
         except OptionError as e:
-            self.handleOptionError(e)
+            print(f"Bad option: {e}")
+            sys.exit()
 
         # Compute the files ivar.
         self.files = self.computeFilesList(fileName)
@@ -2649,64 +2650,6 @@ class LoadManager:
             'windowSize': self.doWindowSizeOption(args),
             'windowSpot': self.doWindowSpotOption(args),
         }
-    #@+node:ekr.20210927034148.2: *6* LM.addOptionsToParser
-    #@@nobeautify
-
-    def addOptionsToParser(self, parser: Any, trace_m: str) -> None:
-        """Init the argsparse parser."""
-        add = parser.add_argument
-        add('PATHS', nargs='*', metavar='FILES',
-            help='list of files')
-        add('-b', '--black-sentinels', dest='black_sentinels', action='store_true',
-            help='write black-compatible sentinel comments')
-        add('--diff', dest='diff', action='store_true',
-            help='use Leo as an external git diff')
-        add('--fail-fast', dest='fail_fast', action='store_true',
-            help='stop unit tests after the first failure')
-        add('--fullscreen', dest='fullscreen', action='store_true',
-            help='start fullscreen')
-        add('--ipython', dest='ipython', action='store_true',
-            help='enable ipython support')
-        add('--gui', dest='gui', metavar='GUI',
-            help='gui to use (qt/console/null)')
-        add('--listen-to-log', dest='listen_to_log', action='store_true',
-            help='start log_listener.py on startup')
-        add('--load-type', dest='load_type', metavar='TYPE',
-            help='@<file> type for non-outlines')
-        add('--maximized', dest='maximized', action='store_true',
-            help='start maximized')
-        add('--minimized', dest='minimized', action='store_true',
-            help='start minimized')
-        add('--no-plugins', dest='no_plugins', action='store_true',
-            help='disable all plugins')
-        add('--no-splash', dest='no_splash', action='store_true',
-            help='disable the splash screen')
-        add('--quit', dest='quit', action='store_true',
-            help='quit immediately after loading')
-        add('--screen-shot', dest='screen_shot', metavar='PATH',
-            help='take a screen shot and then exit')
-        add('--script', dest='script', metavar="PATH",
-            help='execute a script and then exit')
-        add('--script-window', dest='script_window', action='store_true',
-            help='execute script using default gui')
-        add('--select', dest='select', metavar='ID',
-            help='headline or gnx of node to select')
-        add('--silent', dest='silent', action='store_true',
-            help='disable all log messages')
-        add('--theme', dest='theme', metavar='NAME',
-            help='use the named theme file')
-        add('--trace', dest='trace', metavar='TRACE-KEY',
-            help=f"add one or more strings to g.app.debug. One or more of...\n{trace_m}")
-        add('--trace-binding', dest='trace_binding', metavar='KEY',
-            help='trace commands bound to a key')
-        add('--trace-setting', dest='trace_setting', metavar="NAME",
-            help='trace where named setting is set')
-        add('--window-size', dest='window_size', metavar='SIZE',
-            help='initial window size (height x width)')
-        add('--window-spot', dest='window_spot', metavar='SPOT',
-            help='initial window position (top x left)')
-        add('-v', '--version', dest='version', action='store_true',
-            help='print version number and exit')
     #@+node:ekr.20210927034148.3: *6* LM.computeFilesList
     def computeFilesList(self, fileName: str) -> list[str]:
         """Return the list of files on the command line."""
@@ -2762,7 +2705,7 @@ class LoadManager:
     #@+node:ekr.20210927034148.7: *6* LM.doScriptOption
     def doScriptOption(self) -> Optional[str]:
 
-        return ###
+        return  None ###
         # --script
         script = None  ### args.script
         if script:
@@ -2803,26 +2746,26 @@ class LoadManager:
 
         return spot
     #@+node:ekr.20230615034937.1: *6* LM.postscanArgv
-    def postscanArgv(self):
+    def postscanArgv(self) -> None:
         g.trace()
     #@+node:ekr.20230615035233.1: *6* LM.printUsage
-    def printUsage(self):
+    def printUsage(self) -> None:
         print(textwrap.dedent(
         """
         usage: launchLeo.py [options] file1, file2, ...
-        
+
         simple options:
             [-h] [-b] [--diff] [--fail-fast] [--fullscreen] [--ipython] [--listen-to-log]
             [--maximized] [--minimized] [--no-plugins] [--no-splash] [--quit]  [-v]
             [--select ID] [--silent]
-            
+
         optional complex options:
             --script-window
             --load-type=@edit|@file
             --screen-shot=<path>
             --script=<path>]
-           
-            
+
+
 
         options:
           -h, --help                show this help message and exit
@@ -2859,7 +2802,7 @@ class LoadManager:
         """))
 
     #@+node:ekr.20230615034517.1: *6* LM.scanArgv
-    def scanArgv(self):
+    def scanArgv(self) -> None:
         g.trace()
     #@+node:ekr.20160718072648.1: *5* LM.setStdStreams
     def setStdStreams(self) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2701,28 +2701,35 @@ class LoadManager:
         """Handle --qui option. Default to 'qt'"""
         gui = 'qt'  # The default.
         arg = self.findOption('--gui=')
-        if arg:
-            m = re.match(r'--gui=(\w+)', arg)
-            if m:
-                gui = m.group(1).lower()
-                if gui == 'qttabs':
-                    gui = 'qt'  # Allow legacy qttabs gui.
-                elif not (
-                    gui.startswith('browser')
-                    or gui in ('console', 'curses', 'text', 'null', 'qt')
-                ):
-                    print(f"unknown --gui option: {gui}. Using qt gui")
-                    gui = 'qt'
+        if not arg:
+            g.app.guiArgName = gui
+            return gui
+        m = re.match(r'--gui=(\w+)', arg)
+        if not m:
+            g.app.guiArgName = gui
+            return gui
+        gui = m.group(1).lower()
+        if gui == 'qttabs':
+            gui = 'qt'  # Allow legacy qttabs gui.
+        elif not (
+            gui.startswith('browser')
+            or gui in ('console', 'curses', 'text', 'null', 'qt')
+        ):
+            print(f"unknown --gui option: {gui}. Using qt gui")
+            gui = 'qt'
         g.app.guiArgName = gui
         return gui
     #@+node:ekr.20210927034148.5: *7* LM.doLoadTypeOption
     def doLoadTypeOption(self) -> Optional[str]:
-
+        arg = self.findOption('--load-type=')
+        if not arg:
+            return None
+        m = re.match(r'--load-type=(@\w+)', arg)
+        if m:
+            return m.group(1).lower()
+        print(f"Ignoring unknown --load-type option: {arg}")
         return None
-        # s = args.load_type
-        # s = s.lower() if s else 'edit'
-        # return '@' + s
-    #@+node:ekr.20210927034148.6: *7* LM.doScreenShotOption
+    #@+node:ekr.20210927034148.6: *7* LM.doScreenShotOption (to do)
     def doScreenShotOption(self) -> str:
 
         # --screen-shot=fn
@@ -2733,7 +2740,7 @@ class LoadManager:
             # if s:
                 # s = s.strip('"')
             # return s
-    #@+node:ekr.20210927034148.7: *7* LM.doScriptOption
+    #@+node:ekr.20210927034148.7: *7* LM.doScriptOption (to do)(
     def doScriptOption(self) -> Optional[str]:
 
         return None  ###
@@ -2749,14 +2756,14 @@ class LoadManager:
         # else:
             # script = None
         # return script
-    #@+node:ekr.20230615055158.1: *7* LM.doSelectOption (new, todo)
+    #@+node:ekr.20230615055158.1: *7* LM.doSelectOption (new, to do)
     def doSelectOption(self) -> Optional[str]:
         ### args.select and args.select.strip('"'),  # --select=headline
         return None
-    #@+node:ekr.20230615060055.1: *7* LM.doThemeOption (new, todo)
+    #@+node:ekr.20230615060055.1: *7* LM.doThemeOption (new, to do)
     def doThemeOption(self) -> Optional[str]:
         return None
-    #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions (new, todo)
+    #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions (new, to do)
     def doTraceOptions(self) -> Optional[str]:
 
         return None
@@ -2790,7 +2797,7 @@ class LoadManager:
         # #
         # # --trace-setting=setting
         # g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
-    #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption
+    #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption (to do)
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
 
         # --window-size
@@ -2805,7 +2812,7 @@ class LoadManager:
                 # windowSize = None
                 # print('scanOptions: bad --window-size:', windowSize)
         # return windowSize
-    #@+node:ekr.20210927034148.9: *7* LM.doWindowSpotOption
+    #@+node:ekr.20210927034148.9: *7* LM.doWindowSpotOption (to do)
     def doWindowSpotOption(self) -> Optional[tuple[int, int]]:
 
         # --window-spot

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2767,23 +2767,9 @@ class LoadManager:
         """
         usage: launchLeo.py [options] file1, file2, ...
 
-        simple options:
-            [-h] [-b] [--diff] [--fail-fast] [--fullscreen] [--ipython] [--listen-to-log]
-            [--maximized] [--minimized] [--no-plugins] [--no-splash] [--quit]  [-v]
-            [--select ID] [--silent]
-
-        optional complex options:
-            --script-window
-            --load-type=@edit|@file
-            --screen-shot=<path>
-            --script=<path>]
-
-
-
         options:
-          -h, --help                show this help message and exit
-          -b, --black-sentinels
-                                write black-compatible sentinel comments
+          -h, --help            show this help message and exit
+          -b, --black-sentinels write black-compatible sentinel comments
           --diff                use Leo as an external git diff
           --fail-fast           stop unit tests after the first failure
           --fullscreen          start fullscreen
@@ -2813,7 +2799,6 @@ class LoadManager:
           --window-spot=SPOT    initial window position (top x left)
           -v, --version         print version number and exit
         """))
-
     #@+node:ekr.20230615034517.1: *6* LM.scanArgv
     def scanArgv(self) -> None:
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2657,7 +2657,7 @@ class LoadManager:
         # Handle help args.
         if any(z in sys.argv for z in ('-h', '-?', '--help')):
             print(self.usage_message)
-            sys.exit()
+            sys.exit(1)
         self.computeValidOptions()
         self.checkOptions()
         self.doSimpleOptions()
@@ -2721,6 +2721,8 @@ class LoadManager:
         return gui
     #@+node:ekr.20210927034148.5: *7* LM.doLoadTypeOption
     def doLoadTypeOption(self) -> Optional[str]:
+        
+        # load-type=@(edit|file)
         arg = self.findOption('--load-type=')
         if not arg:
             return None
@@ -2729,39 +2731,55 @@ class LoadManager:
             return m.group(1).lower()
         print(f"Ignoring unknown --load-type option: {arg}")
         return None
-    #@+node:ekr.20210927034148.6: *7* LM.doScreenShotOption (to do)
+    #@+node:ekr.20210927034148.6: *7* LM.doScreenShotOption
     def doScreenShotOption(self) -> str:
 
-        # --screen-shot=fn
-        return None  ###
-
-        ###
-            # s = args.screen_shot
-            # if s:
-                # s = s.strip('"')
-            # return s
-    #@+node:ekr.20210927034148.7: *7* LM.doScriptOption (to do)(
+        # --screen-shot=path
+        arg = self.findOption('--screen-shot=')
+        if not arg:
+            return None
+        m = re.match(r'--screen-shot=(.*)', arg)
+        if m:
+            return m.group(1).replace('"', '')
+    #@+node:ekr.20210927034148.7: *7* LM.doScriptOption
     def doScriptOption(self) -> Optional[str]:
 
-        return None  ###
-        # --script
-        # script = None  ### args.script
-        # if script:
-            # # #1090: use cwd, not g.app.loadDir, to find scripts.
-            # fn = g.finalize_join(os.getcwd(), script)
-            # script, e = g.readFileIntoString(fn, kind='script:', verbose=False)
-            # if not script:
-                # print(f"script not found: {fn}")
-                # sys.exit(1)
-        # else:
-            # script = None
-        # return script
-    #@+node:ekr.20230615055158.1: *7* LM.doSelectOption (new, to do)
+        # --script=path
+        arg = self.findOption('--script=')
+        if not arg:
+            return None
+        m = re.match(r'--script=(.*)', arg)
+        if not m:
+            return None
+        fn = m.group(1).replace('"', '')
+        # #1090: use cwd, not g.app.loadDir, to find scripts.
+        path = g.finalize_join(os.getcwd(), fn)
+        script, e = g.readFileIntoString(path, kind='script:', verbose=False)
+        if script:
+            return script
+        print(f"script not found: {path}")
+        sys.exit(1)
+    #@+node:ekr.20230615055158.1: *7* LM.doSelectOption
     def doSelectOption(self) -> Optional[str]:
-        ### args.select and args.select.strip('"'),  # --select=headline
+        
+        # --select=headline
+        arg = self.findOption('--select=')
+        if not arg:
+            return None
+        m = re.match(r'--select=(.*)', arg)
+        if m:
+            return m.group(1)
         return None
-    #@+node:ekr.20230615060055.1: *7* LM.doThemeOption (new, to do)
+    #@+node:ekr.20230615060055.1: *7* LM.doThemeOption
     def doThemeOption(self) -> Optional[str]:
+
+        # --theme=path
+        arg = self.findOption('--theme=')
+        if not arg:
+            return None
+        m = re.match(r'--theme=(.*)', arg)
+        if m:
+            return m.group(1).replace('"', '')
         return None
     #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions
     def doTraceOptions(self) -> None:
@@ -2795,7 +2813,7 @@ class LoadManager:
         arg = self.findOption('--trace=')
         if not arg:
             return
-        m = re.match(r'--trace=([\w,]+)', arg)
+        m = re.match(r'--trace=([\w\,]+)', arg)
         if not m:
             return
         values = m.group(1).split(',')
@@ -2811,10 +2829,21 @@ class LoadManager:
             print(f"Valid --trace values:\n   {valid_s}")
         else:
             print(f"Enabling --trace={', '.join(g.app.debug)}")
-    #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption (to do)
+    #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
 
         # --window-size
+        arg = self.findOption('--window-size=')
+        if not arg:
+            return None
+        m = re.match(r'--window-size=(\d+)x(\d+)', arg)
+        if m:
+            try:
+                h, w = m.group(1), m.group(2)
+                return (int(h), int(w))
+            except ValueError:
+                pass
+        print(f"Ignoring bad --window-size: option: {arg!r}")
         return None
 
         # windowSize = args.window_size
@@ -2826,23 +2855,22 @@ class LoadManager:
                 # windowSize = None
                 # print('scanOptions: bad --window-size:', windowSize)
         # return windowSize
-    #@+node:ekr.20210927034148.9: *7* LM.doWindowSpotOption (to do)
+    #@+node:ekr.20210927034148.9: *7* LM.doWindowSpotOption
     def doWindowSpotOption(self) -> Optional[tuple[int, int]]:
 
         # --window-spot
+        arg = self.findOption('--window-spot=')
+        if not arg:
+            return None
+        m = re.match(r'--window-spot=(\d+)x(\d+)', arg)
+        if m:
+            try:
+                top, left = m.group(1), m.group(2)
+                return (int(top), int(left))
+            except ValueError:
+                pass
+        print(f"Ignoring bad --window-spot: option: {arg!r}")
         return None
-
-        ###
-        # spot = args.window_spot
-        # if spot:
-            # try:
-                # top, left = spot.split('x')
-                # spot = int(top), int(left)
-            # except ValueError:
-                # print('scanOptions: bad --window-spot:', spot)
-                # spot = None
-
-        # return spot
     #@+node:ekr.20230615034937.1: *6* LM.checkOptions
     def checkOptions(self) -> None:
         """Make sure all command-line options pass sanity checks."""
@@ -2862,14 +2890,14 @@ class LoadManager:
                     for prefix in option_prefixes:
                         if arg.startswith(prefix):
                             print(f"Invalid option: expected {arg}=VALUE")
-                            sys.exit()
+                            sys.exit(1)
                     print(f"Invalid option arg: {arg}")
-                    sys.exit()
+                    sys.exit(1)
             else:
                 # Do a simple check for file arguments.
                 if any(z in arg for z in ',='):
                     print(f"Invalid file arg: {arg}")
-                    sys.exit()
+                    sys.exit(1)
     #@+node:ekr.20230615062610.1: *6* LM.computeValidOptions
     def computeValidOptions(self) -> None:
         """

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2617,6 +2617,7 @@ class LoadManager:
         #@+node:ekr.20230615062931.1: *6* << define self.usage_message >>
         # LM.computeValidOptions uses this message to compute the list of valid options!
         self.usage_message = textwrap.dedent(
+            # Abbreviations must come first.
             """
             usage: launchLeo.py [options] file1, file2, ...
 
@@ -2728,7 +2729,8 @@ class LoadManager:
         Return a list of valid options.
         Options requiring an argument end with '='.
         """
-        option_pattern = re.compile(r'\s*(-\w)*,?\s*(--[\w-]+=?)')
+        # Abbreviations must come first.
+        option_pattern = re.compile(r'\s*(-\w)?,?\s*(--[\w-]+=?)')
         valid = ['-?']
         for line in g.splitLines(self.usage_message):
             m = option_pattern.match(line)
@@ -2737,8 +2739,8 @@ class LoadManager:
                     valid.append(m.group(1))
                 if m.group(2):
                     valid.append(m.group(2))
-        self.valid_options = sorted(list(set(valid)))
-        # g.printObj(self.valid_options)
+        self.valid_options = list(sorted(list(set(valid))))
+        g.printObj(self.valid_options)
     #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
     def doGuiOption(self) -> str:
         ### assert any(z.startswith('--gui') for z in sys.argv)
@@ -2859,21 +2861,22 @@ class LoadManager:
         }
         for option, helper in options_dict.items():
             if option in sys.argv:
+                g.trace(option)
                 helper()
     #@+node:ekr.20230615060055.1: *6* LM.doThemeOption (new, todo)
     def doThemeOption(self) -> Optional[str]:
         return None
     #@+node:ekr.20230615075314.1: *6* LM.doTraceOptions (new, todo)
     def doTraceOptions(self) -> Optional[str]:
-        
+
         return None
-        
+
         # trace_m = textwrap.dedent("""\
             # abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
             # importers, ipython, keys, layouts, plugins, save, select, sections,
             # shutdown, size, speed, startup, themes, undo, verbose, zoom
         # """)
-       
+
         # --trace=...
 
         # valid = trace_m.replace(' ', '').replace('\n', '').split(',')

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2612,8 +2612,6 @@ class LoadManager:
         # Save a copy of argv for debugging.
         self.old_argv = sys.argv[:]
 
-        args = sys.argv[:]  ### To be removed.
-
         class OptionError(Exception):
             pass
 
@@ -2637,19 +2635,15 @@ class LoadManager:
         # Return the dictionary of options.
         return {
             'qui': self.doGuiOption(),
-            'version': any(z in sys.argv for z in ('-v', '--version'))
-        }
-        return {
-            'gui': self.doGuiOption(),
-            'load_type': self.doLoadTypeOption(args),
-            'screenshot_fn': self.doScreenShotOption(args),  # --screen-shot=fn
+            'load_type': self.doLoadTypeOption(),
             'script': script,
-            'select': args.select and args.select.strip('"'),  # --select=headline
-            'theme_path': args.theme,  # --theme=name
-            'version': args.version,  # --version: print the version and exit.
-            'windowFlag': script and args.script_window,
-            'windowSize': self.doWindowSizeOption(args),
-            'windowSpot': self.doWindowSpotOption(args),
+            'screenshot_fn': self.doScreenShotOption(),
+            'select': self.doSelectOption(),  ### New.
+            'theme_path': self.doThemeOption(),  ### New.
+            'version': any(z in sys.argv for z in ('-v', '--version')),
+            'windowFlag': script and '--script-window' in sys.argv,
+            'windowSize': self.doWindowSizeOption(),
+            'windowSpot': self.doWindowSpotOption(),
         }
     #@+node:ekr.20210927034148.3: *6* LM.computeFilesList
     def computeFilesList(self, fileName: str) -> list[str]:
@@ -2672,6 +2666,7 @@ class LoadManager:
         return [g.os_path_normslashes(z) for z in result]
     #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
     def doGuiOption(self) -> str:
+        ### assert any(z.startswith('--gui') for z in sys.argv)
         gui = 'qt'  ###
         if gui:
             gui = gui.lower()
@@ -2689,63 +2684,80 @@ class LoadManager:
         assert gui
         g.app.guiArgName = gui
         return gui
+    #@+node:ekr.20230615060055.1: *6* LM.doThemeOption
+    def doThemeOption(self) -> Optional[str]:  # pylint: disable=useless-return
+        g.trace('TO DO')
+        return None
     #@+node:ekr.20210927034148.5: *6* LM.doLoadTypeOption
-    def doLoadTypeOption(self, args: Any) -> str:
+    def doLoadTypeOption(self) -> Optional[str]:
 
-        s = args.load_type
-        s = s.lower() if s else 'edit'
-        return '@' + s
+        return None
+        # s = args.load_type
+        # s = s.lower() if s else 'edit'
+        # return '@' + s
     #@+node:ekr.20210927034148.6: *6* LM.doScreenShotOption
-    def doScreenShotOption(self, args: Any) -> str:
+    def doScreenShotOption(self) -> str:
 
         # --screen-shot=fn
-        s = args.screen_shot
-        if s:
-            s = s.strip('"')
-        return s
+        return None  ###
+
+        ###
+            # s = args.screen_shot
+            # if s:
+                # s = s.strip('"')
+            # return s
     #@+node:ekr.20210927034148.7: *6* LM.doScriptOption
     def doScriptOption(self) -> Optional[str]:
 
-        return  None ###
+        return None  ###
         # --script
-        script = None  ### args.script
-        if script:
-            # #1090: use cwd, not g.app.loadDir, to find scripts.
-            fn = g.finalize_join(os.getcwd(), script)
-            script, e = g.readFileIntoString(fn, kind='script:', verbose=False)
-            if not script:
-                print(f"script not found: {fn}")
-                sys.exit(1)
-        else:
-            script = None
-        return script
+        # script = None  ### args.script
+        # if script:
+            # # #1090: use cwd, not g.app.loadDir, to find scripts.
+            # fn = g.finalize_join(os.getcwd(), script)
+            # script, e = g.readFileIntoString(fn, kind='script:', verbose=False)
+            # if not script:
+                # print(f"script not found: {fn}")
+                # sys.exit(1)
+        # else:
+            # script = None
+        # return script
+    #@+node:ekr.20230615055158.1: *6* LM.doSelectOption (new) (todo)
+    def doSelectOption(self) -> Optional[str]:
+        ### args.select and args.select.strip('"'),  # --select=headline
+        return None
     #@+node:ekr.20210927034148.10: *6* LM.doWindowSizeOption
-    def doWindowSizeOption(self, args: Any) -> Optional[tuple[int, int]]:
+    def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
 
         # --window-size
-        windowSize = args.window_size
-        if windowSize:
-            try:
-                h, w = windowSize.split('x')
-                windowSize = int(h), int(w)
-            except ValueError:
-                windowSize = None
-                print('scanOptions: bad --window-size:', windowSize)
-        return windowSize
+        return None
+
+        # windowSize = args.window_size
+        # if windowSize:
+            # try:
+                # h, w = windowSize.split('x')
+                # windowSize = int(h), int(w)
+            # except ValueError:
+                # windowSize = None
+                # print('scanOptions: bad --window-size:', windowSize)
+        # return windowSize
     #@+node:ekr.20210927034148.9: *6* LM.doWindowSpotOption
-    def doWindowSpotOption(self, args: Any) -> Optional[tuple[int, int]]:
+    def doWindowSpotOption(self) -> Optional[tuple[int, int]]:
 
         # --window-spot
-        spot = args.window_spot
-        if spot:
-            try:
-                top, left = spot.split('x')
-                spot = int(top), int(left)
-            except ValueError:
-                print('scanOptions: bad --window-spot:', spot)
-                spot = None
+        return None
 
-        return spot
+        ###
+        # spot = args.window_spot
+        # if spot:
+            # try:
+                # top, left = spot.split('x')
+                # spot = int(top), int(left)
+            # except ValueError:
+                # print('scanOptions: bad --window-spot:', spot)
+                # spot = None
+
+        # return spot
     #@+node:ekr.20230615034937.1: *6* LM.postscanArgv
     def postscanArgv(self) -> None:
         g.trace()
@@ -2804,47 +2816,47 @@ class LoadManager:
 
     #@+node:ekr.20230615034517.1: *6* LM.scanArgv
     def scanArgv(self) -> None:
-        
+
         #@+<< define scanArgv helpers >>
         #@+node:ekr.20230615053133.1: *7* << define scanArgv helpers >>
         def _black() -> None:
             g.app.write_black_sentinels = True
-            
+
         def _diff() -> None:
             g.app.diff = True
-            
+
         def _fail_fast() -> None:
             g.app.failFast = True
-            
+
         def _full_screen() -> None:
             g.app.start_fullscreen = True
 
         def _listen_to_log() -> None:
             g.app.listen_to_log_flag = True
-            
+
         def _ipython() -> None:
             g.app.useIpython = True
-            
+
         def _maximized() -> None:
             g.app.start_maximized = True
 
         def _minimized() -> None:
             g.app.start_minimized = True
             g.app.use_splash_screen = False
-            
+
         def _no_plugins() -> None:
             g.app.enablePlugins = False
-            
+
         def _no_splash() -> None:
             g.app.use_splash_screen = False
-            
+
         def _quit() -> None:
             g.app.quit_after_load = True
-            
+
         def _silent() -> None:
             g.app.silentMode = True
         #@-<< define scanArgv helpers >>
-       
+
         options_dict: dict[str, Callable] = {
             # Simple args.
             '-b': _black,
@@ -2860,22 +2872,14 @@ class LoadManager:
             '--no-splash': _no_splash,
             '--quit': _quit,
             '--silent': _silent,
-            # Args with arguments.
-            '--gui': self.doGuiOption,
-            '--load-type': self.doLoadTypeOption,
+            # Args with arguments not handled separately.
+
         }
         for option, function in options_dict.items():
             if option in sys.argv:
                 g.trace(function.__name__)
                 function()
-                
 
-
-        # add('--load-type', dest='load_type', metavar='TYPE',
-            # help='@<file> type for non-outlines')
-
-        # add('--screen-shot', dest='screen_shot', metavar='PATH',
-            # help='take a screen shot and then exit')
         # add('--script', dest='script', metavar="PATH",
             # help='execute a script and then exit')
         # add('--script-window', dest='script_window', action='store_true',

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2677,6 +2677,151 @@ class LoadManager:
             'windowSize': self.doWindowSizeOption(),
             'windowSpot': self.doWindowSpotOption(),
         }
+    #@+node:ekr.20230615083942.1: *6* complex args
+    #@+node:ekr.20210927034148.3: *7* LM.computeFilesList
+    def computeFilesList(self, fileName: str) -> list[str]:
+        """Return the list of files on the command line."""
+        lm = self
+        files = []
+        if fileName:
+            files.append(fileName)
+        for arg in sys.argv[1:]:
+            if arg and not arg.startswith('-'):
+                files.append(arg)
+        result = []
+        for z in files:
+            aList = g.glob_glob(lm.completeFileName(z))
+            if aList:
+                result.extend(aList)
+            else:
+                result.append(z)
+        return [g.os_path_normslashes(z) for z in result]
+    #@+node:ekr.20210927034148.4: *7* LM.doGuiOption
+    def doGuiOption(self) -> str:
+        """Handle --qui option. Default to 'qt'"""
+        gui = 'qt'  # The default.
+        arg = self.findOption('--gui=')
+        if arg:
+            m = re.match(r'--gui=(\w+)', arg)
+            if m:
+                gui = m.group(1).lower()
+                if gui == 'qttabs':
+                    gui = 'qt'  # Allow legacy qttabs gui.
+                elif not (
+                    gui.startswith('browser')
+                    or gui in ('console', 'curses', 'text', 'null', 'qt')
+                ):
+                    print(f"unknown --gui option: {gui}. Using qt gui")
+                    gui = 'qt'
+        g.app.guiArgName = gui
+        return gui
+    #@+node:ekr.20210927034148.5: *7* LM.doLoadTypeOption
+    def doLoadTypeOption(self) -> Optional[str]:
+
+        return None
+        # s = args.load_type
+        # s = s.lower() if s else 'edit'
+        # return '@' + s
+    #@+node:ekr.20210927034148.6: *7* LM.doScreenShotOption
+    def doScreenShotOption(self) -> str:
+
+        # --screen-shot=fn
+        return None  ###
+
+        ###
+            # s = args.screen_shot
+            # if s:
+                # s = s.strip('"')
+            # return s
+    #@+node:ekr.20210927034148.7: *7* LM.doScriptOption
+    def doScriptOption(self) -> Optional[str]:
+
+        return None  ###
+        # --script
+        # script = None  ### args.script
+        # if script:
+            # # #1090: use cwd, not g.app.loadDir, to find scripts.
+            # fn = g.finalize_join(os.getcwd(), script)
+            # script, e = g.readFileIntoString(fn, kind='script:', verbose=False)
+            # if not script:
+                # print(f"script not found: {fn}")
+                # sys.exit(1)
+        # else:
+            # script = None
+        # return script
+    #@+node:ekr.20230615055158.1: *7* LM.doSelectOption (new, todo)
+    def doSelectOption(self) -> Optional[str]:
+        ### args.select and args.select.strip('"'),  # --select=headline
+        return None
+    #@+node:ekr.20230615060055.1: *7* LM.doThemeOption (new, todo)
+    def doThemeOption(self) -> Optional[str]:
+        return None
+    #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions (new, todo)
+    def doTraceOptions(self) -> Optional[str]:
+
+        return None
+
+        # trace_m = textwrap.dedent("""\
+            # abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
+            # importers, ipython, keys, layouts, plugins, save, select, sections,
+            # shutdown, size, speed, startup, themes, undo, verbose, zoom
+        # """)
+
+        # --trace=...
+
+        # valid = trace_m.replace(' ', '').replace('\n', '').split(',')
+        # if args.trace:
+            # ok = True
+            # values = args.trace.lstrip('(').lstrip('[').rstrip(')').rstrip(']')
+            # for val in values.split(','):
+                # if val in valid:
+                    # g.app.debug.append(val)
+                # else:
+                    # g.es_print(f"unknown --trace value: {val}")
+                    # ok = False
+            # if not ok:
+                # g.es_print('Valid --trace values are...')
+                # for line in trace_m.split('\n'):
+                    # print('  ', line.rstrip())
+        # #
+        # # These are not bool args.
+        # # --trace-binding
+        # g.app.trace_binding = args.trace_binding  # g.app.config does not exist yet.
+        # #
+        # # --trace-setting=setting
+        # g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
+    #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption
+    def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
+
+        # --window-size
+        return None
+
+        # windowSize = args.window_size
+        # if windowSize:
+            # try:
+                # h, w = windowSize.split('x')
+                # windowSize = int(h), int(w)
+            # except ValueError:
+                # windowSize = None
+                # print('scanOptions: bad --window-size:', windowSize)
+        # return windowSize
+    #@+node:ekr.20210927034148.9: *7* LM.doWindowSpotOption
+    def doWindowSpotOption(self) -> Optional[tuple[int, int]]:
+
+        # --window-spot
+        return None
+
+        ###
+        # spot = args.window_spot
+        # if spot:
+            # try:
+                # top, left = spot.split('x')
+                # spot = int(top), int(left)
+            # except ValueError:
+                # print('scanOptions: bad --window-spot:', spot)
+                # spot = None
+
+        # return spot
     #@+node:ekr.20230615034937.1: *6* LM.checkOptions
     def checkOptions(self) -> None:
         """Make sure all command-line options pass sanity checks."""
@@ -2704,25 +2849,6 @@ class LoadManager:
                 if any(z in arg for z in ',='):
                     print(f"Invalid file arg: {arg}")
                     sys.exit()
-    #@+node:ekr.20210927034148.3: *6* LM.computeFilesList
-    def computeFilesList(self, fileName: str) -> list[str]:
-        """Return the list of files on the command line."""
-        lm = self
-        files = []
-        if fileName:
-            files.append(fileName)
-        for arg in sys.argv[1:]:
-            if arg and not arg.startswith('-'):
-                files.append(arg)
-        result = []
-        for z in files:
-            # Fix #245: wrong: result.extend(glob.glob(lm.completeFileName(z)))
-            aList = g.glob_glob(lm.completeFileName(z))
-            if aList:
-                result.extend(aList)
-            else:
-                result.append(z)
-        return [g.os_path_normslashes(z) for z in result]
     #@+node:ekr.20230615062610.1: *6* LM.computeValidOptions
     def computeValidOptions(self) -> None:
         """
@@ -2740,65 +2866,7 @@ class LoadManager:
                 if m.group(2):
                     valid.append(m.group(2))
         self.valid_options = list(sorted(list(set(valid))))
-        g.printObj(self.valid_options)
-    #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
-    def doGuiOption(self) -> str:
-        ### assert any(z.startswith('--gui') for z in sys.argv)
-        gui = 'qt'  ###
-        if gui:
-            gui = gui.lower()
-            if gui in ('qt', 'qttabs'):
-                gui = 'qt'  # Allow qttabs gui.
-            elif gui.startswith('browser'):
-                pass
-            elif gui in ('console', 'curses', 'text', 'null'):
-                pass
-            else:
-                print(f"scanOptions: unknown gui: {gui}.  Using qt gui")
-                gui = 'qt'
-        else:
-            gui = 'qt'
-        assert gui
-        g.app.guiArgName = gui
-        return gui
-    #@+node:ekr.20210927034148.5: *6* LM.doLoadTypeOption
-    def doLoadTypeOption(self) -> Optional[str]:
-
-        return None
-        # s = args.load_type
-        # s = s.lower() if s else 'edit'
-        # return '@' + s
-    #@+node:ekr.20210927034148.6: *6* LM.doScreenShotOption
-    def doScreenShotOption(self) -> str:
-
-        # --screen-shot=fn
-        return None  ###
-
-        ###
-            # s = args.screen_shot
-            # if s:
-                # s = s.strip('"')
-            # return s
-    #@+node:ekr.20210927034148.7: *6* LM.doScriptOption
-    def doScriptOption(self) -> Optional[str]:
-
-        return None  ###
-        # --script
-        # script = None  ### args.script
-        # if script:
-            # # #1090: use cwd, not g.app.loadDir, to find scripts.
-            # fn = g.finalize_join(os.getcwd(), script)
-            # script, e = g.readFileIntoString(fn, kind='script:', verbose=False)
-            # if not script:
-                # print(f"script not found: {fn}")
-                # sys.exit(1)
-        # else:
-            # script = None
-        # return script
-    #@+node:ekr.20230615055158.1: *6* LM.doSelectOption (new, todo)
-    def doSelectOption(self) -> Optional[str]:
-        ### args.select and args.select.strip('"'),  # --select=headline
-        return None
+        # g.printObj(self.valid_options)
     #@+node:ekr.20230615034517.1: *6* LM.doSimpleOptions
     def doSimpleOptions(self) -> None:
         """
@@ -2863,75 +2931,18 @@ class LoadManager:
             if option in sys.argv:
                 g.trace(option)
                 helper()
-    #@+node:ekr.20230615060055.1: *6* LM.doThemeOption (new, todo)
-    def doThemeOption(self) -> Optional[str]:
+    #@+node:ekr.20230615084117.1: *6* LM.findOption
+    def findOption(self, prefix: str) -> Optional[str]:
+        """Return the argument starting with the given prefix."""
+        if '=' in prefix:
+            for arg in sys.argv:
+                if arg.startswith(prefix):
+                    return arg
+        else:
+            for arg in sys.argv:
+                if arg == prefix:
+                    return arg
         return None
-    #@+node:ekr.20230615075314.1: *6* LM.doTraceOptions (new, todo)
-    def doTraceOptions(self) -> Optional[str]:
-
-        return None
-
-        # trace_m = textwrap.dedent("""\
-            # abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
-            # importers, ipython, keys, layouts, plugins, save, select, sections,
-            # shutdown, size, speed, startup, themes, undo, verbose, zoom
-        # """)
-
-        # --trace=...
-
-        # valid = trace_m.replace(' ', '').replace('\n', '').split(',')
-        # if args.trace:
-            # ok = True
-            # values = args.trace.lstrip('(').lstrip('[').rstrip(')').rstrip(']')
-            # for val in values.split(','):
-                # if val in valid:
-                    # g.app.debug.append(val)
-                # else:
-                    # g.es_print(f"unknown --trace value: {val}")
-                    # ok = False
-            # if not ok:
-                # g.es_print('Valid --trace values are...')
-                # for line in trace_m.split('\n'):
-                    # print('  ', line.rstrip())
-        # #
-        # # These are not bool args.
-        # # --trace-binding
-        # g.app.trace_binding = args.trace_binding  # g.app.config does not exist yet.
-        # #
-        # # --trace-setting=setting
-        # g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
-    #@+node:ekr.20210927034148.10: *6* LM.doWindowSizeOption
-    def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
-
-        # --window-size
-        return None
-
-        # windowSize = args.window_size
-        # if windowSize:
-            # try:
-                # h, w = windowSize.split('x')
-                # windowSize = int(h), int(w)
-            # except ValueError:
-                # windowSize = None
-                # print('scanOptions: bad --window-size:', windowSize)
-        # return windowSize
-    #@+node:ekr.20210927034148.9: *6* LM.doWindowSpotOption
-    def doWindowSpotOption(self) -> Optional[tuple[int, int]]:
-
-        # --window-spot
-        return None
-
-        ###
-        # spot = args.window_spot
-        # if spot:
-            # try:
-                # top, left = spot.split('x')
-                # spot = int(top), int(left)
-            # except ValueError:
-                # print('scanOptions: bad --window-spot:', spot)
-                # spot = None
-
-        # return spot
     #@+node:ekr.20160718072648.1: *5* LM.setStdStreams
     def setStdStreams(self) -> None:
         """

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2608,8 +2608,11 @@ class LoadManager:
     #@+node:ekr.20210927034148.1: *5* LM.scanOptions & helpers
     def scanOptions(self, fileName: str, pymacs: bool) -> dict[str, Any]:
         """Handle all options, remove them from sys.argv and set lm.options."""
+
+        # Save a copy of argv for debugging.
         self.old_argv = sys.argv[:]
-        args = sys.argv[:]
+
+        args = sys.argv[:]  ### To be removed.
         
         class OptionError(Exception):
             pass
@@ -2799,8 +2802,13 @@ class LoadManager:
         g.trace()
     #@+node:ekr.20230615034509.1: *6* LM.prescanArgv
     def prescanArgv(self):
-        g.trace()
-    #@+node:ekr.20230615035115.1: *6* LM.printUsage
+        """Handle options that cause an immediate exit."""
+        if any(z in sys.argv for z in ('-h', '-?', '--help')):
+            self.printUsage()
+            sys.exit()
+        if any(z in sys.argv for z in ('-v', '--version')):
+            self.printVersion()
+            sys.exit()
     #@+node:ekr.20230615035233.1: *6* LM.printUsage
     def printUsage(self):
         print(textwrap.dedent(

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2613,6 +2613,7 @@ class LoadManager:
         self.old_argv = sys.argv[:]
         #@+<< define self.usage_message >>
         #@+node:ekr.20230615062931.1: *6* << define self.usage_message >>
+        # LM.computeValidOptions uses this message to compute the list of valid options!
         self.usage_message = textwrap.dedent(
             """
             usage: launchLeo.py [options] file1, file2, ...

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2860,6 +2860,59 @@ class LoadManager:
                 windowSize = None
                 print('scanOptions: bad --window-size:', windowSize)
         return windowSize
+    #@+node:ekr.20230615035233.1: *6* LM.printUsage
+    def printUsage(self):
+        print(textwrap.dedent(
+        """
+        usage: launchLeo.py [options] file1, file2, ...
+        
+        simple options:
+            [-h] [-b] [--diff] [--fail-fast] [--fullscreen] [--ipython] [--listen-to-log]
+            [--maximized] [--minimized] [--no-plugins] [--no-splash] [--quit]  [-v]
+            [--select ID] [--silent]
+            
+        optional complex options:
+            --script-window
+            --load-type=@edit|@file
+            --screen-shot=<path>
+            --script=<path>]
+           
+            
+
+        options:
+          -h, --help                show this help message and exit
+          -b, --black-sentinels
+                                write black-compatible sentinel comments
+          --diff                use Leo as an external git diff
+          --fail-fast           stop unit tests after the first failure
+          --fullscreen          start fullscreen
+          --ipython             enable ipython support
+          --gui=<gui>           specify gui: browser|console|curses|qt|text|null
+          --listen-to-log       start log_listener.py on startup
+          --load-type=<type>    @<file> type for non-outlines: @edit or @file
+          --maximized           start maximized
+          --minimized           start minimized
+          --no-plugins          disable all plugins
+          --no-splash           disable the splash screen
+          --quit                quit immediately after loading
+          --screen-shot=<path>  take a screen shot and then exit
+          --script=<path>       execute a script and then exit
+          --script-window=      execute script using default gui
+          --select=ID           headline or gnx of node to select
+          --silent              disable all log messages
+          --theme=NAME          use the named theme file
+          --trace=LIST          add one or more strings to g.app.debug.
+                                A comma-separated list of one or more of:
+                                abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
+                                importers, ipython, keys, layouts, plugins, save, select, sections,
+                                shutdown, size, speed, startup, themes, undo, verbose, zoom
+          --trace-binding=KEY   trace commands bound to a key
+          --trace-setting=NAME  trace where named setting is set
+          --window-size=SIZE    initial window size (height x width)
+          --window-spot=SPOT    initial window position (top x left)
+          -v, --version         print version number and exit
+        """))
+
     #@+node:ekr.20160718072648.1: *5* LM.setStdStreams
     def setStdStreams(self) -> None:
         """

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2727,13 +2727,17 @@ class LoadManager:
         Return a list of valid options.
         Options requiring an argument end with '='.
         """
-        option_pattern = re.compile(r'\s*(--[\w-]+=?)')
-        valid = ['-b', '-h', '-v']  # Start with short options.
+        option_pattern = re.compile(r'\s*(-\w)*,?\s*(--[\w-]+=?)')
+        valid = ['-?']
         for line in g.splitLines(self.usage_message):
             m = option_pattern.match(line)
             if m:
-                valid.append(m.group(1))
+                if m.group(1):
+                    valid.append(m.group(1))
+                if m.group(2):
+                    valid.append(m.group(2))
         self.valid_options = sorted(list(set(valid)))
+        # g.printObj(self.valid_options)
     #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
     def doGuiOption(self) -> str:
         ### assert any(z.startswith('--gui') for z in sys.argv)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2700,7 +2700,7 @@ class LoadManager:
     def doGuiOption(self) -> str:
         """Handle --qui option. Default to 'qt'"""
         gui = 'qt'  # The default.
-        arg = self.findOption('--gui=')
+        arg = self.findComplexOption('--gui=')
         if not arg:
             g.app.guiArgName = gui
             return gui
@@ -2721,9 +2721,9 @@ class LoadManager:
         return gui
     #@+node:ekr.20210927034148.5: *7* LM.doLoadTypeOption
     def doLoadTypeOption(self) -> Optional[str]:
-        
+
         # load-type=@(edit|file)
-        arg = self.findOption('--load-type=')
+        arg = self.findComplexOption('--load-type=')
         if not arg:
             return None
         m = re.match(r'--load-type=(@\w+)', arg)
@@ -2735,17 +2735,18 @@ class LoadManager:
     def doScreenShotOption(self) -> str:
 
         # --screen-shot=path
-        arg = self.findOption('--screen-shot=')
+        arg = self.findComplexOption('--screen-shot=')
         if not arg:
             return None
         m = re.match(r'--screen-shot=(.*)', arg)
         if m:
             return m.group(1).replace('"', '')
+        return None
     #@+node:ekr.20210927034148.7: *7* LM.doScriptOption
     def doScriptOption(self) -> Optional[str]:
 
         # --script=path
-        arg = self.findOption('--script=')
+        arg = self.findComplexOption('--script=')
         if not arg:
             return None
         m = re.match(r'--script=(.*)', arg)
@@ -2761,9 +2762,9 @@ class LoadManager:
         sys.exit(1)
     #@+node:ekr.20230615055158.1: *7* LM.doSelectOption
     def doSelectOption(self) -> Optional[str]:
-        
+
         # --select=headline
-        arg = self.findOption('--select=')
+        arg = self.findComplexOption('--select=')
         if not arg:
             return None
         m = re.match(r'--select=(.*)', arg)
@@ -2774,7 +2775,7 @@ class LoadManager:
     def doThemeOption(self) -> Optional[str]:
 
         # --theme=path
-        arg = self.findOption('--theme=')
+        arg = self.findComplexOption('--theme=')
         if not arg:
             return None
         m = re.match(r'--theme=(.*)', arg)
@@ -2784,9 +2785,9 @@ class LoadManager:
     #@+node:ekr.20230615075314.1: *7* LM.doTraceOptions
     def doTraceOptions(self) -> None:
         """Handle --trace-binding, --trace-setting and --trace"""
-        
+
         # --trace-binding
-        arg = self.findOption('--trace-binding=')
+        arg = self.findComplexOption('--trace-binding=')
         if arg:
             m = re.match(r'--trace-binding=([\w\-\+]+)', arg)
             if m:
@@ -2795,14 +2796,14 @@ class LoadManager:
                 g.app.trace_binding = m.group(1)
 
         # --trace-setting=setting
-        arg = self.findOption('--trace-setting=')
+        arg = self.findComplexOption('--trace-setting=')
         if arg:
             m = re.match(r'--trace-setting=([\w]+)', arg)
             if m:
                 # g.app.config does not exist yet.
                 # print(f"Enable {arg}")
                 g.app.trace_setting = m.group(1)
-        
+
         # --trace=option.
         valid = [
             'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
@@ -2810,7 +2811,7 @@ class LoadManager:
             'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
             'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
         ]
-        arg = self.findOption('--trace=')
+        arg = self.findComplexOption('--trace=')
         if not arg:
             return
         m = re.match(r'--trace=([\w\,]+)', arg)
@@ -2833,7 +2834,7 @@ class LoadManager:
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
 
         # --window-size
-        arg = self.findOption('--window-size=')
+        arg = self.findComplexOption('--window-size=')
         if not arg:
             return None
         m = re.match(r'--window-size=(\d+)x(\d+)', arg)
@@ -2859,7 +2860,7 @@ class LoadManager:
     def doWindowSpotOption(self) -> Optional[tuple[int, int]]:
 
         # --window-spot
-        arg = self.findOption('--window-spot=')
+        arg = self.findComplexOption('--window-spot=')
         if not arg:
             return None
         m = re.match(r'--window-spot=(\d+)x(\d+)', arg)
@@ -2978,19 +2979,14 @@ class LoadManager:
         }
         for option, helper in options_dict.items():
             if option in sys.argv:
-                g.trace(option)
                 helper()
-    #@+node:ekr.20230615084117.1: *6* LM.findOption
-    def findOption(self, prefix: str) -> Optional[str]:
+    #@+node:ekr.20230615084117.1: *6* LM.findComplexOption
+    def findComplexOption(self, prefix: str) -> Optional[str]:
         """Return the argument starting with the given prefix."""
-        if '=' in prefix:
-            for arg in sys.argv:
-                if arg.startswith(prefix):
-                    return arg
-        else:
-            for arg in sys.argv:
-                if arg == prefix:
-                    return arg
+        assert '=' in prefix, repr(prefix)
+        for arg in sys.argv:
+            if arg.startswith(prefix):
+                return arg
         return None
     #@+node:ekr.20160718072648.1: *5* LM.setStdStreams
     def setStdStreams(self) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2660,6 +2660,7 @@ class LoadManager:
         self.computeValidOptions()
         self.checkOptions()
         self.doSimpleOptions()
+        self.doTraceOptions()
         self.files = self.computeFilesList(fileName)
         # Return a dictionary of complex options.
         script = None if pymacs else self.doScriptOption()  # Used twice below.
@@ -2862,6 +2863,40 @@ class LoadManager:
     #@+node:ekr.20230615060055.1: *6* LM.doThemeOption (new, todo)
     def doThemeOption(self) -> Optional[str]:
         return None
+    #@+node:ekr.20230615075314.1: *6* LM.doTraceOptions (new, todo)
+    def doTraceOptions(self) -> Optional[str]:
+        
+        return None
+        
+        # trace_m = textwrap.dedent("""\
+            # abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
+            # importers, ipython, keys, layouts, plugins, save, select, sections,
+            # shutdown, size, speed, startup, themes, undo, verbose, zoom
+        # """)
+       
+        # --trace=...
+
+        # valid = trace_m.replace(' ', '').replace('\n', '').split(',')
+        # if args.trace:
+            # ok = True
+            # values = args.trace.lstrip('(').lstrip('[').rstrip(')').rstrip(']')
+            # for val in values.split(','):
+                # if val in valid:
+                    # g.app.debug.append(val)
+                # else:
+                    # g.es_print(f"unknown --trace value: {val}")
+                    # ok = False
+            # if not ok:
+                # g.es_print('Valid --trace values are...')
+                # for line in trace_m.split('\n'):
+                    # print('  ', line.rstrip())
+        # #
+        # # These are not bool args.
+        # # --trace-binding
+        # g.app.trace_binding = args.trace_binding  # g.app.config does not exist yet.
+        # #
+        # # --trace-setting=setting
+        # g.app.trace_setting = args.trace_setting  # g.app.config does not exist yet.
     #@+node:ekr.20210927034148.10: *6* LM.doWindowSizeOption
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2657,7 +2657,7 @@ class LoadManager:
         # Handle help args.
         if any(z in sys.argv for z in ('-h', '-?', '--help')):
             print(self.usage_message)
-            sys.exit(1)
+            sys.exit()
         self.computeValidOptions()
         self.checkOptions()
         self.doSimpleOptions()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2705,7 +2705,7 @@ class LoadManager:
             if m:
                 valid.append(m.group(1))
         self.valid_options = sorted(list(set(valid)))
-        g.printObj(self.valid_options)
+        # g.printObj(self.valid_options)
     #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
     def doGuiOption(self) -> str:
         ### assert any(z.startswith('--gui') for z in sys.argv)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2616,9 +2616,13 @@ class LoadManager:
         
         class OptionError(Exception):
             pass
+            
+        # Handle help args.
+        if any(z in sys.argv for z in ('-h', '-?', '--help')):
+            self.printUsage()
+            sys.exit()
 
         try:
-            self.prescanArgv()
             self.scanArgv()
             self.postscanArgv()
         except OptionError as e:
@@ -2630,10 +2634,11 @@ class LoadManager:
         script = None if pymacs else self.doScriptOption()
         # Return the dictionary of options.
         return {
-            'qui': self.doGuiOption(args),
+            'qui': self.doGuiOption(),
+            'version': any(z in sys.argv for z in ('-v', '--version'))
         }
         return {
-            'gui': self.doGuiOption(args),
+            'gui': self.doGuiOption(),
             'load_type': self.doLoadTypeOption(args),
             'screenshot_fn': self.doScreenShotOption(args),  # --screen-shot=fn
             'script': script,
@@ -2722,7 +2727,7 @@ class LoadManager:
                 result.append(z)
         return [g.os_path_normslashes(z) for z in result]
     #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
-    def doGuiOption(self, args: list[str]) -> str:
+    def doGuiOption(self) -> str:
         gui = 'qt'  ###
         if gui:
             gui = gui.lower()
@@ -2800,15 +2805,6 @@ class LoadManager:
     #@+node:ekr.20230615034937.1: *6* LM.postscanArgv
     def postscanArgv(self):
         g.trace()
-    #@+node:ekr.20230615034509.1: *6* LM.prescanArgv
-    def prescanArgv(self):
-        """Handle options that cause an immediate exit."""
-        if any(z in sys.argv for z in ('-h', '-?', '--help')):
-            self.printUsage()
-            sys.exit()
-        if any(z in sys.argv for z in ('-v', '--version')):
-            self.printVersion()
-            sys.exit()
     #@+node:ekr.20230615035233.1: *6* LM.printUsage
     def printUsage(self):
         print(textwrap.dedent(


### PR DESCRIPTION
See #3381. This project is easier than expected! It is easy to compute:

- the list of valid options from the help message.
- the list of options that require arguments. This is not possible (easily) with argparse!

See LM.computeValidOptions and LM.checkOptions.