### PR TITLE
PR: improve options handling

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2612,56 +2612,16 @@ class LoadManager:
         """Handle all options, remove them from sys.argv and set lm.options."""
         # Save a copy of argv for debugging.
         self.old_argv = sys.argv[:]
-        #@+<< define self.usage_message >>
-        #@+node:ekr.20230615062931.1: *6* << define self.usage_message >>
-        # g.computeValidOptions uses this message to compute the list of valid options!
-        # Abbreviations (-whatever) must appear before full options (--whatever).
-        self.usage_message = textwrap.dedent(
-            """
-            usage: launchLeo.py [options] file1, file2, ...
-
-            options:
-              -h, --help            show this help message and exit
-              -b, --black-sentinels write black-compatible sentinel comments
-              --diff                use Leo as an external git diff
-              --fail-fast           stop unit tests after the first failure
-              --fullscreen          start fullscreen
-              --ipython             enable ipython support
-              --gui=GUI             specify gui: browser,console,curses,qt,text,null
-              --listen-to-log       start log_listener.py on startup
-              --load-type=TYPE      @<file> type for non-outlines: @edit or @file
-              --maximized           start maximized
-              --minimized           start minimized
-              --no-plugins          disable all plugins
-              --no-splash           disable the splash screen
-              --quit                quit immediately after loading
-              --screen-shot=PATH    take a screen shot and then exit
-              --script=PATH         execute a script and then exit
-              --script-window       execute script using default gui
-              --select=ID           headline or gnx of node to select
-              --silent              disable all log messages
-              --theme=NAME          use the named theme file
-              --trace=LIST          add one or more strings to g.app.debug.
-                                    A comma-separated list of one or more of:
-                                    abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
-                                    importers, ipython, keys, layouts, plugins, save, select, sections,
-                                    shutdown, size, speed, startup, themes, undo, verbose, zoom
-              --trace-binding=KEY   trace commands bound to a key
-              --trace-setting=NAME  trace where named setting is set
-              --window-size=SIZE    initial window size (height x width)
-              --window-spot=SPOT    initial window position (top x left)
-              -v, --version         print version number and exit
-            """)
-        #@-<< define self.usage_message >>
+        usage_message = self.defineUsage()
         # Handle help args.
         if any(z in sys.argv for z in ('-h', '-?', '--help')):
-            print(self.usage_message)
+            print(usage_message)
             sys.exit()
         obsolete_options = (
             '--dock', '--global-docks', '--init-docks', '--no-cache',
             '--no-dock', '--session-restore', '--session-save', '--use-docks',
         )
-        valid_options = g.computeValidOptions(self.usage_message)
+        valid_options = g.computeValidOptions(usage_message)
         g.checkOptions(obsolete_options, valid_options)
         self.doSimpleOptions()
         self.doTraceOptions()
@@ -2698,6 +2658,46 @@ class LoadManager:
             else:
                 result.append(z)
         return [g.os_path_normslashes(z) for z in result]
+    #@+node:ekr.20230615062931.1: *6* LM.defineUsage
+    # g.computeValidOptions uses this message to compute the list of valid options!
+    # Abbreviations (-whatever) must appear before full options (--whatever).
+    def defineUsage(self):
+        return textwrap.dedent(
+        """
+        usage: launchLeo.py [options] file1, file2, ...
+
+        options:
+          -h, --help            show this help message and exit
+          -b, --black-sentinels write black-compatible sentinel comments
+          --diff                use Leo as an external git diff
+          --fail-fast           stop unit tests after the first failure
+          --fullscreen          start fullscreen
+          --ipython             enable ipython support
+          --gui=GUI             specify gui: browser,console,curses,qt,text,null
+          --listen-to-log       start log_listener.py on startup
+          --load-type=TYPE      @<file> type for non-outlines: @edit or @file
+          --maximized           start maximized
+          --minimized           start minimized
+          --no-plugins          disable all plugins
+          --no-splash           disable the splash screen
+          --quit                quit immediately after loading
+          --screen-shot=PATH    take a screen shot and then exit
+          --script=PATH         execute a script and then exit
+          --script-window       execute script using default gui
+          --select=ID           headline or gnx of node to select
+          --silent              disable all log messages
+          --theme=NAME          use the named theme file
+          --trace=LIST          add one or more strings to g.app.debug.
+                                A comma-separated list of one or more of:
+                                abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
+                                importers, ipython, keys, layouts, plugins, save, select, sections,
+                                shutdown, size, speed, startup, themes, undo, verbose, zoom
+          --trace-binding=KEY   trace commands bound to a key
+          --trace-setting=NAME  trace where named setting is set
+          --window-size=SIZE    initial window size (height x width)
+          --window-spot=SPOT    initial window position (top x left)
+          -v, --version         print version number and exit
+        """)
     #@+node:ekr.20210927034148.4: *6* LM.doGuiOption
     def doGuiOption(self) -> str:
         """Handle --gui option. Default to 'qt'"""

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2617,10 +2617,10 @@ class LoadManager:
         if any(z in sys.argv for z in ('-h', '-?', '--help')):
             print(usage_message)
             sys.exit()
-        obsolete_options = (
+        obsolete_options = [
             '--dock', '--global-docks', '--init-docks', '--no-cache',
             '--no-dock', '--session-restore', '--session-save', '--use-docks',
-        )
+        ]
         valid_options = g.computeValidOptions(usage_message)
         g.checkOptions(obsolete_options, valid_options)
         self.doSimpleOptions()
@@ -2661,7 +2661,7 @@ class LoadManager:
     #@+node:ekr.20230615062931.1: *6* LM.defineUsage
     # g.computeValidOptions uses this message to compute the list of valid options!
     # Abbreviations (-whatever) must appear before full options (--whatever).
-    def defineUsage(self):
+    def defineUsage(self) -> str:
         return textwrap.dedent(
         """
         usage: launchLeo.py [options] file1, file2, ...

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2792,7 +2792,7 @@ class LoadManager:
     #@+node:ekr.20210927034148.10: *7* LM.doWindowSizeOption
     def doWindowSizeOption(self) -> Optional[tuple[int, int]]:
         """Handle --window-size"""
-        m = self.findComplexOption('--window-size=(\d+)x(\d+)')
+        m = self.findComplexOption(r'--window-size=(\d+)x(\d+)')
         if not m:
             return None
         try:
@@ -2939,7 +2939,6 @@ class LoadManager:
     def optionError(self, arg: str, message: str) -> None:
         """Print an error message and help message, then exit."""
         print(f"Invalid {arg!r} option: {message}")
-        ### print(self.usage_message)
         sys.exit(1)
     #@+node:ekr.20160718072648.1: *5* LM.setStdStreams
     def setStdStreams(self) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2700,7 +2700,7 @@ class LoadManager:
     def doGuiOption(self) -> str:
         """Handle --gui option. Default to 'qt'"""
         m = self.findComplexOption(r'--gui=(\w+)')
-        valid = ('console', 'curses', 'text', 'null', 'qt')
+        valid = ('console', 'curses', 'null', 'qt', 'text')
         if not m:
             g.app.guiArgName = 'qt'
             return 'qt'
@@ -2797,7 +2797,7 @@ class LoadManager:
             return None
         try:
             h, w = int(m.group(1)), int(m.group(2))
-        except Exception:
+        except ValueError:
             arg = m.group(0)
             self.optionError(arg, 'Invalid value: expected int x int')
         return h, w
@@ -2809,7 +2809,7 @@ class LoadManager:
             return None
         try:
             top, left = int(m.group(1)), int(m.group(2))
-        except Exception:
+        except ValueError:
             arg = m.group(0)
             self.optionError(arg, 'Invalid value: expected int x int')
         return top, left
@@ -2925,9 +2925,7 @@ class LoadManager:
         Exit if the option exists but contains no value.
         """
         assert '=' in regex, repr(regex)
-        i = regex.find('=')
-        prefix = regex[: i + 1]
-        assert '=' in prefix, repr(prefix)
+        prefix = regex.split('=')[0]
         for arg in sys.argv:
             if arg.startswith(prefix):
                 m = re.match(regex, arg)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6344,7 +6344,7 @@ def windows() -> Optional[list]:
 
 # LM.scanOptions uses these functions.
 #@+node:ekr.20230615034937.1: *3* g.checkOptions
-def checkOptions(obsolete_options: list[str], valid_options: list[str]) -> None:
+def checkOptions(obsolete_options: list[str], valid_options: list[str], usage: str) -> None:
     """Make sure all command-line options pass sanity checks."""
     option_prefixes = [z[:-1] for z in valid_options if z.endswith('=')]
     for arg in sys.argv:
@@ -6357,12 +6357,12 @@ def checkOptions(obsolete_options: list[str], valid_options: list[str]) -> None:
             else:
                 for prefix in option_prefixes:
                     if arg.startswith(prefix):
-                        g.optionError(arg, 'Missing value')
-                g.optionError(arg, 'Unknown option')
+                        g.optionError(arg, 'Missing value', usage)
+                g.optionError(arg, 'Unknown option', usage)
         else:
             # Do a simple check for file arguments.
             if any(z in arg for z in ',='):
-                g.optionError(arg, 'Invalid file arg')
+                g.optionError(arg, 'Invalid file arg', usage)
 #@+node:ekr.20230615062610.1: *3* g.computeValidOptions
 def computeValidOptions(usage_message: str) -> list[str]:
     """
@@ -6381,7 +6381,7 @@ def computeValidOptions(usage_message: str) -> list[str]:
                 valid.append(m.group(2))
     return list(sorted(list(set(valid))))
 #@+node:ekr.20230615084117.1: *3* g.findComplexOption
-def findComplexOption(regex: str) -> Optional[re.Match]:
+def findComplexOption(regex: str, usage: str) -> Optional[re.Match]:
     # """Return the complex argument starting with the given prefix."""
     """
     Handle the common portion of complex arguments.
@@ -6395,12 +6395,13 @@ def findComplexOption(regex: str) -> Optional[re.Match]:
             m = re.match(regex, arg)
             if m:
                 return m
-            g.optionError(arg, 'Missing or erroneous value')
+            g.optionError(arg, 'Missing or erroneous value', usage)
     return None
 #@+node:ekr.20230616075049.1: *3* g.optionError
-def optionError(arg: str, message: str) -> None:
+def optionError(arg: str, message: str, usage: str) -> None:
     """Print an error message and help message, then exit."""
     print(f"Invalid {arg!r} option: {message}")
+    print(usage)
     sys.exit(1)
 #@+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers
 #@+at Note: all these methods return Unicode strings. It is up to the user to

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6339,6 +6339,69 @@ def truncate(s: str, n: int) -> str:
 #@+node:ekr.20031218072017.3150: *3* g.windows
 def windows() -> Optional[list]:
     return app and app.windowList
+#@+node:ekr.20230616134732.1: ** g.Options
+# stateless utility functions for handling command-line options.
+
+# LM.scanOptions uses these functions.
+#@+node:ekr.20230615034937.1: *3* g.checkOptions
+def checkOptions(obsolete_options: list[str], valid_options: list[str]) -> None:
+    """Make sure all command-line options pass sanity checks."""
+    option_prefixes = [z[:-1] for z in valid_options if z.endswith('=')]
+    for arg in sys.argv:
+        if arg in obsolete_options:
+            print(f"Ignoring obsolete option: {arg!r}")
+        elif arg.startswith('-'):
+            for option in valid_options:
+                if arg.startswith(option):
+                    break
+            else:
+                for prefix in option_prefixes:
+                    if arg.startswith(prefix):
+                        g.optionError(arg, 'Missing value')
+                g.optionError(arg, 'Unknown option')
+        else:
+            # Do a simple check for file arguments.
+            if any(z in arg for z in ',='):
+                g.optionError(arg, 'Invalid file arg')
+#@+node:ekr.20230615062610.1: *3* g.computeValidOptions
+def computeValidOptions(usage_message: str) -> list(str):
+    """
+    Return a list of valid options.
+    Options requiring an argument end with '='.
+    """
+    # Abbreviations (-whatever) must appear before full options (--whatever).
+    option_pattern = re.compile(r'\s*(-\w)?,?\s*(--[\w-]+=?)')
+    valid = ['-?']
+    for line in g.splitLines(usage_message):
+        m = option_pattern.match(line)
+        if m:
+            if m.group(1):
+                valid.append(m.group(1))
+            if m.group(2):
+                valid.append(m.group(2))
+    return list(sorted(list(set(valid))))
+#@+node:ekr.20230615084117.1: *3* g.findComplexOption
+def findComplexOption(regex: str) -> Optional[re.Match]:
+    # """Return the complex argument starting with the given prefix."""
+    """
+    Handle the common portion of complex arguments.
+
+    Exit if the option exists but contains no value.
+    """
+    assert '=' in regex, repr(regex)
+    prefix = regex.split('=')[0]
+    for arg in sys.argv:
+        if arg.startswith(prefix):
+            m = re.match(regex, arg)
+            if m:
+                return m
+            g.optionError(arg, 'Missing or erroneous value')
+    return None
+#@+node:ekr.20230616075049.1: *3* g.optionError
+def optionError(arg: str, message: str) -> None:
+    """Print an error message and help message, then exit."""
+    print(f"Invalid {arg!r} option: {message}")
+    sys.exit(1)
 #@+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers
 #@+at Note: all these methods return Unicode strings. It is up to the user to
 # convert to an encoded string as needed, say when opening a file.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6364,7 +6364,7 @@ def checkOptions(obsolete_options: list[str], valid_options: list[str]) -> None:
             if any(z in arg for z in ',='):
                 g.optionError(arg, 'Invalid file arg')
 #@+node:ekr.20230615062610.1: *3* g.computeValidOptions
-def computeValidOptions(usage_message: str) -> list(str):
+def computeValidOptions(usage_message: str) -> list[str]:
     """
     Return a list of valid options.
     Options requiring an argument end with '='.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6364,15 +6364,15 @@ def checkOptions(obsolete_options: list[str], valid_options: list[str], usage: s
             if any(z in arg for z in ',='):
                 g.optionError(arg, 'Invalid file arg', usage)
 #@+node:ekr.20230615062610.1: *3* g.computeValidOptions
-def computeValidOptions(usage_message: str) -> list[str]:
+def computeValidOptions(usage: str) -> list[str]:
     """
-    Return a list of valid options.
+    Return a list of valid options by parsing the given usage message.
     Options requiring an argument end with '='.
     """
     # Abbreviations (-whatever) must appear before full options (--whatever).
     option_pattern = re.compile(r'\s*(-\w)?,?\s*(--[\w-]+=?)')
     valid = ['-?']
-    for line in g.splitLines(usage_message):
+    for line in g.splitLines(usage):
         m = option_pattern.match(line)
         if m:
             if m.group(1):


### PR DESCRIPTION
- [x] `findComplexOption` calls `optionError` if the regex doesn't match.
    This change simplifies all the handlers for complex arguments.
- [x] `optionError` calls `sys.exit(1)`
- [x] Improve help message.
- [x] Remove cruft.
- [x] Convert four `LoadManager` methods to functions in `leoGlobals.py`.
    Surprisingly, doing so simplifies `LM.scanOptions` a bit.