### PR TITLE
rpcalc plugin: Add external file to LeoPyRef.leo; update one command/…

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -572,6 +572,7 @@
 <v t="ekr.20090622063842.5264"><vh>@file ../plugins/projectwizard.py</vh></v>
 <v t="ekr.20160928073518.1"><vh>@file ../plugins/pyplot_backend.py</vh></v>
 <v t="ville.20090314215508.4"><vh>@file ../plugins/quicksearch.py</vh></v>
+<v t="tom.20230424140347.1"><vh>@file ../plugins/rpcalc.py</vh></v>
 <v t="tbrown.20130420091241.44181"><vh>@file ../plugins/screen_capture.py</vh></v>
 <v t="ville.20090815203828.5235"><vh>@file ../plugins/spydershell.py</vh></v>
 <v t="ekr.20100103093121.5329"><vh>@file ../plugins/stickynotes.py</vh></v>

--- a/leo/plugins/rpcalc.py
+++ b/leo/plugins/rpcalc.py
@@ -88,7 +88,7 @@ if TYPE_CHECKING:  # pragma: no cover
     # from leo.core.leoGui import LeoKeyEvent as Event
     # Widget = Any
 #@+node:tom.20230428182922.1: ** declarations
-__version__ = 0.9
+__version__ = 0.91
 __author__ = 'Douglas W. Bell, Thomas B. Passin'
 
 TABNAME = 'RPCalc'
@@ -847,7 +847,7 @@ class CalcCore:
                 eqn = '({0})^{1}'.format(self.formatNum(self.stack[1]),
                                          self.formatNum(self.stack[0]))
                 self.stack.replaceXY(self.stack[1] ** self.stack[0])
-            elif cmdStr == 'XRT':          # x root of y
+            elif cmdStr == 'XRTY':          # x root of y
                 eqn = '({0})^(1/{1})'.format(self.formatNum(self.stack[1]),
                                              self.formatNum(self.stack[0]))
                 self.stack.replaceXY(self.stack[1] ** (1/self.stack[0]))
@@ -1004,7 +1004,7 @@ class CalcDlg(QWidget): # type: ignore
         self.addCmdButton('x^2', 0, 0)
         self.addCmdButton('sqRT', 0, 1)
         self.addCmdButton('y^X', 0, 2)
-        self.addCmdButton('xRT', 0, 3)
+        self.addCmdButton('xRTy', 0, 3)
         self.addCmdButton('RCIP', 0, 4)
         self.addCmdButton('SIN', 1, 0)
         self.addCmdButton('COS', 1, 1)
@@ -2613,8 +2613,8 @@ partially typed command.  Of course, the mouse may also be used to hit
 any key.</p>
 
 <p>A few keys have unusual labels to allow them to be typed:  "RCIP"
-is 1/X, "tn^X" is 10^X, "R&lt;" rolls the stack back (or down),
-"R&gt;" rolls the stack forward (or up), "x&lt;&gt;y" is exchange,
+is 1/X, "tn^X" is 10^X, "R^" rolls the stack forward (or up),
+"R&gt;" rolls the stack back (or down), "x&lt;&gt;y" is exchange,
 "CLR" clears the registers, and "&lt;-" is backspace.</p>
 
 <p>A few commands ("STO", "RCL" and "PLCS") prompt for a number from


### PR DESCRIPTION
-  Add external file to LeoPyRef.leo
- Update one command/key label;
- Correct errors in Help screen.

Somehow the rpcalc plugin escaped being added to LeoPyRef, although it has been in the plugins directory for months.