### PR TITLE
PR for #3336: edit-settings

### DIFF
--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -36,8 +36,10 @@ def about(self: Self, event: Event = None) -> None:
 #@+node:vitalije.20170713174950.1: ** c_help.editOneSetting
 @g.commander_command('edit-setting')
 def editOneSetting(self: Self, event: Event = None) -> None:
-    """Opens correct dialog for selected setting type"""
-    c, p = self, self.c.p
+    """
+    Opens dialog for editing @button, @command, @color, @font, or @shortcuts nodes.
+    """
+    c, p = self, self.p
     func = None
     if p.h.startswith('@font'):
         func = c.commandsDict.get('show-fonts')
@@ -47,7 +49,7 @@ def editOneSetting(self: Self, event: Event = None) -> None:
         c.editShortcut()
         return
     else:
-        g.es('not in a setting node')
+        g.es('Please select an @button, @command, @color, @font, or @shortcuts node')
         return
     if func:
         event = g.app.gui.create_key_event(c)

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -149,10 +149,15 @@ def showFonts(self, event=None):
             font.setFamily(family)
         font.setBold(weight)
         font.setItalic(slant)
-        font.setPointSize(size)
+        try:
+            font.setPointSizeF(float(size))
+        except TypeError:
+            font.setPointSize(int(size))
         picker.setCurrentFont(font)
     except ValueError:
         pass
+    except Exception:
+        g.es_exception()
     result = picker.exec_()
     if not result:
         g.es("No font selected")


### PR DESCRIPTION
See #3336.

- [x] Fix crash in `edit-settings` command.
- [x] Improve docstring of `edit-settings` command.
- [x] Fix crash in `showFonts`:

<details>

```console
Traceback (most recent call last):
  File "C:\Repos\leo-editor\leo\core\leoKeys.py", line 2507, in callAltXFunction
    func(event)
  File "C:\Repos\leo-editor\leo\core\leoGlobals.py", line 244, in commander_command_wrapper
    method(event=event)
  File "C:\Repos\leo-editor\leo\commands\commanderHelpCommands.py", line 56, in editOneSetting
    func(event)
  File "C:\Repos\leo-editor\leo\plugins\qt_commands.py", line 152, in showFonts
    font.setPointSize(size)
TypeError: setPointSize(self, a0: int): argument 1 has unexpected type 'float'
```

</details>