### PR TITLE
remove Screencast warning

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -8904,9 +8904,9 @@ QLabel#minibufferLabel {
 QPlainTextEdit#screencastcaption {
     background-color:   @screencast-bg;
     font-family:        @screencast-font-family;
-    font-size:          @screencaset-font-size;
+    font-size:          @screencast-font-size;
     font-weight:        @screencast-font-weight;
-    font-style:         @screencaset-font-style;
+    font-style:         @screencast-font-style;
 }
 </t>
 <t tx="ekr.20140915194122.19466">/*  ========== Dialogs (QLabel) ========== 
@@ -11649,7 +11649,7 @@ date;;={|{x=time.asctime()}|}
 <t tx="ekr.20230316031838.1">screencast_family = Times New Roman
 screencast_size = 18pt
 screencast_weight = normal
-screencaset_style = normal
+screencast_style = normal
 </t>
 <t tx="ekr.20230327033157.1">True: expand/contract nodes when the mouse hovers over the outline:
     &lt;CTRL-hover&gt;: expand.

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -11646,10 +11646,10 @@ date;;={|{x=time.asctime()}|}
 # hellow=hello
 
 </t>
-<t tx="ekr.20230316031838.1">screencast_family = Times New Roman
-screencast_size = 18pt
-screencast_weight = normal
-screencast_style = normal
+<t tx="ekr.20230316031838.1">screencast_font_family = Times New Roman
+screencast_font_size = 18pt
+screencast_font_weight = normal
+screencast_font_style = normal
 </t>
 <t tx="ekr.20230327033157.1">True: expand/contract nodes when the mouse hovers over the outline:
     &lt;CTRL-hover&gt;: expand.

--- a/leo/themes/old_themes.leo
+++ b/leo/themes/old_themes.leo
@@ -1167,9 +1167,9 @@ QTreeView::branch:open:has-children{
 QPlainTextEdit#screencastcaption {
     background-color:   @screencast-bg;
     font-family:        @screencast-font-family;
-    font-size:          @screencaset-font-size;
+    font-size:          @screencast-font-size;
     font-weight:        @screencast-font-weight;
-    font-style:         @screencaset-font-style;
+    font-style:         @screencast-font-style;
 }
 </t>
 <t tx="ekr.20180307015158.127">/* ========== interact.py plugin ========== */


### PR DESCRIPTION
when I start leo, there is a warning:

```
expand_css_constants Unresolved @constants
[
     0: '@screencast-font-family'
     1: '@screencast-font-weight'
     2: '@screencast-font-style'
     3: '@screencast-font-size'
]
```

after some research, I find some typo in the repo. 
1. screencaset -> screencast
2. screencast_size -> screencast_font_size

then the warning left one, but it beyond my ability to fix

```
expand_css_constants Unresolved @constants
[
     0: '@screencast-font-style'
]
```

Btw, I didn't enable screencast plugin...