### PR TITLE
PR: Change scripts to use ruff instead of flake8 and pylint

### DIFF
--- a/leo/scripts/beautify-leo.cmd
+++ b/leo/scripts/beautify-leo.cmd
@@ -1,5 +1,5 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 echo beautify-leo
 call py -m leo.core.leoAst --orange --recursive leo\core

--- a/leo/scripts/blacken-leo.cmd
+++ b/leo/scripts/blacken-leo.cmd
@@ -3,7 +3,3 @@ cd %~dp0..\..
 
 echo black leo.core
 call py -m black --skip-string-normalization leo\core
-
-rem echo.
-rem echo black leo.commands
-rem call python -m black --skip-string-normalization leo\commands

--- a/leo/scripts/blacken-leo.cmd
+++ b/leo/scripts/blacken-leo.cmd
@@ -1,5 +1,5 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 echo black leo.core
 call py -m black --skip-string-normalization leo\core

--- a/leo/scripts/flake8-leo.cmd
+++ b/leo/scripts/flake8-leo.cmd
@@ -1,5 +1,5 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 rem: See leo-editor/setup.cfg for defaults.
 

--- a/leo/scripts/full-test-leo.cmd
+++ b/leo/scripts/full-test-leo.cmd
@@ -1,15 +1,15 @@
 @echo off
 cls
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 echo full-test-leo
-call reindent-leo.cmd
-call beautify-leo.cmd
+rem call reindent-leo.cmd
+rem call beautify-leo.cmd
 call test-leo.cmd
-echo.
+rem echo.
+call ruff-leo.cmd
 call mypy-leo.cmd
-echo.
-call flake8-leo.cmd
-call pylint-leo.cmd
-echo.
+rem call flake8-leo.cmd
+rem call pylint-leo.cmd
+rem echo.
 echo Done!

--- a/leo/scripts/make-leo.cmd
+++ b/leo/scripts/make-leo.cmd
@@ -1,7 +1,7 @@
 @echo off
 cls
 rem -a: write all files  (make clean)
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 cd leo\doc\html
 
 echo.

--- a/leo/scripts/mypy-leo.cmd
+++ b/leo/scripts/mypy-leo.cmd
@@ -1,5 +1,5 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 rem See leo-editor/.mypy.ini for exclusions!
 rem Always use the fast (official) version of mypy.

--- a/leo/scripts/pylint-leo.cmd
+++ b/leo/scripts/pylint-leo.cmd
@@ -1,5 +1,5 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 echo pylint-leo
 time /T

--- a/leo/scripts/reindent-leo.cmd
+++ b/leo/scripts/reindent-leo.cmd
@@ -1,5 +1,5 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 :: Save path to reindent.py to a file .leo\reindent-path.txt
 call py %~dp0\find-reindent.py
@@ -11,13 +11,15 @@ set /P "REINDENT_PATH="< %PATH_FILE%
 
 if "%REINDENT_PATH%"=="" goto no_reindent
 
-echo reindent leo/core
+echo reindent-leo
+
+rem echo reindent leo/core
 call py %REINDENT_PATH% -r leo\core
-echo reindent leo/commands
+rem echo reindent leo/commands
 call py %REINDENT_PATH% -r leo\commands
-echo reindent leo/plugins/importers
+rem echo reindent leo/plugins/importers
 call py %REINDENT_PATH% -r leo\plugins\importers
-echo reindent leo/plugins/writers
+rem echo reindent leo/plugins/writers
 call py %REINDENT_PATH% -r leo\plugins\writers
 goto done
 

--- a/leo/scripts/ruff-leo.cmd
+++ b/leo/scripts/ruff-leo.cmd
@@ -2,7 +2,7 @@
 cd %~dp0..\..
 
 echo ruff leo/core
-call python -m ruff leo/core
+call py -m ruff leo/core
 
 echo ruff leo/commands
-call python -m ruff leo/commands
+call py -m ruff leo/commands

--- a/leo/scripts/ruff-leo.cmd
+++ b/leo/scripts/ruff-leo.cmd
@@ -1,8 +1,8 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 echo ruff leo/core
-call ruff leo/core
+call python -m ruff leo/core
 
 echo ruff leo/commands
-call ruff leo/commands
+call python -m ruff leo/commands

--- a/leo/scripts/set-repo-dir.cmd
+++ b/leo/scripts/set-repo-dir.cmd
@@ -1,3 +1,0 @@
-:: Change directory from ...\leo-editor\leo\scripts to ...\leo-editor
-@echo off
-cd %~dp0..\..

--- a/leo/scripts/test-leo.cmd
+++ b/leo/scripts/test-leo.cmd
@@ -1,5 +1,7 @@
 @echo off
-call %~dp0\set-repo-dir
+cd %~dp0..\..
+
+call reindent-leo.cmd
 
 echo test-leo
 py -m unittest %*

--- a/leo/scripts/test-one-leo.cmd
+++ b/leo/scripts/test-one-leo.cmd
@@ -1,6 +1,6 @@
 @echo off
 cls
-call %~dp0\set-repo-dir
+cd %~dp0..\..
 
 echo test-one-leo
 call py -m unittest leo.unittests.core.test_leoGlobals.TestGlobals.test_g_handleScriptException


### PR DESCRIPTION
- [x] Delete set-repo-dir.cmd.
- [x] Replace `call %~dp0\set-repo-dir` with `cd %~dp0..\..`
- [x] Use `ruff` instead of `flake8` and `pylint`.
- [x] Run `reindent.cmd` from `test-leo.cmd`