### PR TITLE
PR for #3404: Remove unls from sessions logic. Make sure workbook survives

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2374,7 +2374,7 @@ class LoadManager:
         verbose = script is None
         # Init the app.
         lm.initApp(verbose)
-        g.app.setGlobalDb()
+        ### g.app.setGlobalDb()
         if verbose:
             lm.reportDirectories()
         # Read settings *after* setting g.app.config and *before* opening plugins.
@@ -2599,6 +2599,9 @@ class LoadManager:
         g.app.recentFilesManager = RecentFilesManager()
         g.app.config = leoConfig.GlobalConfigManager()
         g.app.nodeIndices = leoNodes.NodeIndices(g.app.leoID)
+        ###
+        # Leo 7.6.4. Init the global db here, before the session manager.
+        g.app.setGlobalDb()
         g.app.sessionManager = leoSessions.SessionManager()
         # Complete the plugins class last.
         g.app.pluginsController.finishCreate()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2374,7 +2374,6 @@ class LoadManager:
         verbose = script is None
         # Init the app.
         lm.initApp(verbose)
-        ### g.app.setGlobalDb()
         if verbose:
             lm.reportDirectories()
         # Read settings *after* setting g.app.config and *before* opening plugins.
@@ -2599,7 +2598,6 @@ class LoadManager:
         g.app.recentFilesManager = RecentFilesManager()
         g.app.config = leoConfig.GlobalConfigManager()
         g.app.nodeIndices = leoNodes.NodeIndices(g.app.leoID)
-        ###
         # Leo 7.6.4. Init the global db here, before the session manager.
         g.app.setGlobalDb()
         g.app.sessionManager = leoSessions.SessionManager()

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -41,7 +41,7 @@ class SessionManager:
     # def error (self,s):
         # # Do not use g.trace or g.es here.
         # print(s)
-    #@+node:ekr.20120420054855.14245: *3* SessionManager.get_session
+    #@+node:ekr.20120420054855.14245: *3* SessionManager.get_session BUG?
     def get_session(self) -> list[str]:
         """Return a list of UNLs for open tabs."""
         result: list[str] = []
@@ -63,7 +63,7 @@ class SessionManager:
             if g.os_path_exists(path):
                 return g.finalize_join(path, 'leo.session')
         return None
-    #@+node:ekr.20120420054855.14247: *3* SessionManager.load_session
+    #@+node:ekr.20120420054855.14247: *3* SessionManager.load_session BUG!
     def load_session(self, c: Cmdr = None, unls: list[str] = None) -> None:
         """Open a tab for each item in UNLs & select the indicated node in each."""
         if not unls:

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -27,6 +27,10 @@ class SessionManager:
     #@+node:ekr.20120420054855.14351: *3* SessionManager.ctor
     def __init__(self) -> None:
         self.path: str = self.get_session_path()
+        if 'cache' in g.app.debug:
+            print('')
+            g.trace(f"(SessionManager) path: {self.path!r}")
+            print('')
     #@+node:ekr.20120420054855.14246: *3* SessionManager.clear_session
     def clear_session(self, c: Cmdr) -> None:
         """Close all tabs except the presently selected tab."""


### PR DESCRIPTION
**Won't Do**  I have deleted all of `leoSessions.py` instead.

- [ ] Ensure that Leo never overrides an existing notebook.
- [ ] Remove all unl-related code from the `SessionManager`.
- [ ] Use Leo's cache instead of `~/.leo/leo.session`.
- [ ] Maybe: Store both archived positions and gnxs in the cache.