### PR TITLE
PR for #3417: deprecate all session commands

### DIFF
--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -1,8 +1,6 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20120420054855.14241: * @file leoSessions.py
 """Support for sessions in Leo."""
-#@+<< leoSessions imports  & annotations >>
-#@+node:ekr.20120420054855.14344: ** << leoSessions imports & annotations >>
 from __future__ import annotations
 import json
 from typing import Optional, TYPE_CHECKING
@@ -11,35 +9,41 @@ from leo.core import leoGlobals as g
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
-#@-<< leoSessions imports  & annotations >>
-#@+<< leoSessions exception classes>>
-#@+node:ekr.20120420054855.14357: ** << leoSessions exception classes >>
-class LeoSessionException(Exception):
-    pass
-#@-<< leoSessions exception classes>>
+
 #@+others
 #@+node:ekr.20120420054855.14349: ** class SessionManager
-# These were top-level nodes of leotools.py
-
-
 class SessionManager:
+    """
+    Leo's core uses only the load_snapshot and save_snapshot methods.
+
+    All other methods support deprecated commands.
+    """
     #@+others
-    #@+node:ekr.20120420054855.14351: *3* SessionManager.ctor
+    #@+node:ekr.20120420054855.14351: *3* SessionManager.ctor & get_session_path
     def __init__(self) -> None:
         self.path: str = self.get_session_path()
+
+    def get_session_path(self) -> Optional[str]:
+        """Return the path to the session file."""
+        for path in (g.app.homeLeoDir, g.app.homeDir):
+            if g.os_path_exists(path):
+                return g.finalize_join(path, 'leo.session')
+        return None
     #@+node:ekr.20120420054855.14246: *3* SessionManager.clear_session
     def clear_session(self, c: Cmdr) -> None:
-        """Close all tabs except the presently selected tab."""
+        """
+        Support the deprecated session-clear command.
+
+        Close all tabs except the presently selected tab.
+        """
         for frame in g.app.windowList:
             if frame.c != c:
                 frame.c.close()
-    #@+node:ekr.20120420054855.14417: *3* SessionManager.error
-    # def error (self,s):
-        # # Do not use g.trace or g.es here.
-        # print(s)
     #@+node:ekr.20120420054855.14245: *3* SessionManager.get_session
     def get_session(self) -> list[str]:
-        """Return a list of UNLs for open tabs."""
+        """
+        Return a list of UNLs for open tabs.
+        """
         result: list[str] = []
         # Fix #1118, part 2.
         if not getattr(g.app.gui, 'frameFactory', None):
@@ -52,16 +56,11 @@ class SessionManager:
         for c in outlines:
             result.append(c.p.get_UNL())
         return result
-    #@+node:ekr.20120420054855.14416: *3* SessionManager.get_session_path
-    def get_session_path(self) -> Optional[str]:
-        """Return the path to the session file."""
-        for path in (g.app.homeLeoDir, g.app.homeDir):
-            if g.os_path_exists(path):
-                return g.finalize_join(path, 'leo.session')
-        return None
     #@+node:ekr.20120420054855.14247: *3* SessionManager.load_session
     def load_session(self, c: Cmdr = None, unls: list[str] = None) -> None:
-        """Open a tab for each item in UNLs & select the indicated node in each."""
+        """
+        Open a tab for each item in UNLs & select the indicated node in each.
+        """
         if not unls:
             return
         unls = [z.strip() for z in unls or [] if z.strip()]
@@ -89,7 +88,7 @@ class SessionManager:
         """
         Load a snapshot of a session from the leo.session file.
 
-        Called when --restore-session is in effect.
+        Leo calls this method at startup when no outlines appear on the command line.
         """
         fn = self.path
         if fn and g.os_path_exists(fn):
@@ -108,7 +107,7 @@ class SessionManager:
         """
         Save a snapshot of the present session to the leo.session file.
 
-        Called automatically during shutdown when no files were given on the command line.
+        Leo always calls this method during shutdown.
         """
         if self.path:
             session = self.get_session()
@@ -124,10 +123,19 @@ class SessionManager:
             print('can not save session: no leo.session file')
     #@-others
 #@+node:ekr.20120420054855.14375: ** Commands (leoSession.py)
+# Leo 6.7.4: Leo's core handles sessions automatically.
+#            All session commands are deprecated.
 #@+node:ekr.20120420054855.14388: *3* session-clear
 @g.command('session-clear')
 def session_clear_command(event: Event) -> None:
-    """Close all tabs except the presently selected tab."""
+    """
+    Close all tabs except the presently selected tab.
+
+    *Note*: As of Leo 6.7.4, all session commands are deprecated.
+
+    When opening Leo without an outline name, Leo will automatically
+    restore the open outlines when Leo last closed.
+    """
     c = event.get('c')
     m = g.app.sessionManager
     if c and m:
@@ -135,7 +143,14 @@ def session_clear_command(event: Event) -> None:
 #@+node:ekr.20120420054855.14385: *3* session-create
 @g.command('session-create')
 def session_create_command(event: Event) -> None:
-    """Create a new @session node."""
+    """
+    Create a new @session node.
+
+    *Note*: As of Leo 6.7.4, all session commands are deprecated.
+
+    When opening Leo without an outline name, Leo will automatically
+    restore the open outlines when Leo last closed.
+    """
     c = event.get('c')
     m = g.app.sessionManager
     if c and m:
@@ -147,7 +162,14 @@ def session_create_command(event: Event) -> None:
 #@+node:ekr.20120420054855.14387: *3* session-refresh
 @g.command('session-refresh')
 def session_refresh_command(event: Event) -> None:
-    """Refresh the current @session node."""
+    """
+    Refresh the current @session node.
+
+    *Note*: As of Leo 6.7.4, all session commands are deprecated.
+
+    When opening Leo without an outline name, Leo will automatically
+    restore the open outlines when Leo last closed.
+    """
     c = event.get('c')
     m = g.app.sessionManager
     if c and m:
@@ -157,7 +179,14 @@ def session_refresh_command(event: Event) -> None:
 #@+node:ekr.20120420054855.14386: *3* session-restore
 @g.command('session-restore')
 def session_restore_command(event: Event) -> None:
-    """Open a tab for each item in the @session node & select the indicated node in each."""
+    """
+    Open a tab for each item in the @session node.
+
+    *Note*: As of Leo 6.7.4, all session commands are deprecated.
+
+    When opening Leo without an outline name, Leo will automatically
+    restore the open outlines when Leo last closed.
+    """
     c = event.get('c')
     m = g.app.sessionManager
     if c and m:
@@ -169,7 +198,14 @@ def session_restore_command(event: Event) -> None:
 #@+node:ekr.20120420054855.14390: *3* session-snapshot-load
 @g.command('session-snapshot-load')
 def session_snapshot_load_command(event: Event) -> None:
-    """Load a snapshot of a session from the leo.session file."""
+    """
+    Load a snapshot of a session from the leo.session file.
+
+    *Note*: As of Leo 6.7.4, all session commands are deprecated.
+
+    When opening Leo without an outline name, Leo will automatically
+    restore the open outlines when Leo last closed.
+    """
     c = event.get('c')
     m = g.app.sessionManager
     if c and m:
@@ -178,7 +214,14 @@ def session_snapshot_load_command(event: Event) -> None:
 #@+node:ekr.20120420054855.14389: *3* session-snapshot-save
 @g.command('session-snapshot-save')
 def session_snapshot_save_command(event: Event) -> None:
-    """Save a snapshot of the present session to the leo.session file."""
+    """
+    Save a snapshot of the present session to the leo.session file.
+
+    *Note*: As of Leo 6.7.4, all session commands are deprecated.
+
+    When opening Leo without an outline name, Leo will automatically
+    restore the open outlines when Leo last closed.
+    """
     m = g.app.sessionManager
     if m:
         m.save_snapshot()

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -1168,7 +1168,6 @@
 <v t="ekr.20150318110552.30"><vh>Loading, saving &amp; reverting files</vh></v>
 <v t="ekr.20150318110552.31"><vh>Closing outlines &amp; quitting Leo</vh></v>
 <v t="ekr.20150318110552.32"><vh>Importing &amp; exporting files</vh></v>
-<v t="ekr.20150318110552.33"><vh>Using sessions</vh></v>
 <v t="ekr.20150318110552.34"><vh>Communicating with external editors </vh></v>
 <v t="ekr.20150318110552.35"><vh>Creating &amp; deleting directories &amp; files</vh></v>
 <v t="ekr.20150318110552.36"><vh>Managing recent files</vh></v>
@@ -18429,21 +18428,6 @@ Leo preprocesses all scripts by simulating the writing of a external file to a s
     Formats the selected text and writes it to a file. 
 ``write-file-from-node``
     Writes the body text of the selected node to a file. The command prompts for a file name if the node is not an @&lt;file&gt; node.
-</t>
-<t tx="ekr.20150318110552.33">``session-clear``
-    Closes all tabs except the presently selected tab. 
-``session-create``
-    Creates a new @session node. 
-``session-refresh``
-    Refreshes the current @session node. 
-``session-restore``
-    Opens a tab for each item the selected @session node.
-``session-snapshot-load``
-    Loads a snapshot of a session from the leo.session file. 
-``session-snapshot-save``
-    Saves a snapshot of the present session to the leo.session file.
-
-A **session** specifies a list of .leo files that Leo opens automatically when Leo first starts.  Leo will reload the last session provided that command-line arguments *don't* contain any file names.
 </t>
 <t tx="ekr.20150318110552.34">.. _`Idle`: http://en.wikipedia.org/wiki/IDLE_%28Python%29
 .. _`Open Office`: https://www.openoffice.org/

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -10134,6 +10134,26 @@ def tupleToString(obj: Any, indent: str='', tag: str=None) -> str:
     result.append(')')
     s = ''.join(result)
     return f"{tag}...\n{s}\n" if tag else s
+#@+node:ekr.20230702203014.1: ** Old documentation
+#@+node:ekr.20230702203021.1: *3* Using sessions (deprecated)
+@language rest
+
+``session-clear``
+    Closes all tabs except the presently selected tab. 
+``session-create``
+    Creates a new @session node. 
+``session-refresh``
+    Refreshes the current @session node. 
+``session-restore``
+    Opens a tab for each item the selected @session node.
+``session-snapshot-load``
+    Loads a snapshot of a session from the leo.session file. 
+``session-snapshot-save``
+    Saves a snapshot of the present session to the leo.session file.
+
+A **session** specifies a list of .leo files that Leo opens automatically
+when Leo first starts. Leo will reload the last session provided that
+command-line arguments *don't* contain any file names.
 #@+node:ekr.20220917052540.1: ** Old commands
 #@+node:ekr.20150514063305.281: *3* ec.flushLines (doesn't work)
 @cmd('flush-lines')

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -10138,6 +10138,9 @@ def tupleToString(obj: Any, indent: str='', tag: str=None) -> str:
 #@+node:ekr.20230702203021.1: *3* Using sessions (deprecated)
 @language rest
 
+.. Note: All these commands are deprecated.
+..       Using these commands is no longer necessary.
+
 ``session-clear``
     Closes all tabs except the presently selected tab. 
 ``session-create``


### PR DESCRIPTION
See #3417.

- [x] Add deprecation comments to all appropriate docstrings.
- [x] Remove unnecessary error class.
- [x] Move the documentation for session commands from `LeoDocs.leo` to the attic.