### PR TITLE
PR for #3240: fix insert-headline-time

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -549,7 +549,7 @@
 </v>
 <v t="ekr.20110611092035.16482"><vh>Headline commands settings</vh>
 <v t="ekr.20181018105904.1"><vh>@bool headline-gmt-time = False</vh></v>
-<v t="ekr.20041119050749.10"><vh>@string headline-time-format-string = %m/%d</vh></v>
+<v t="ekr.20041119050749.10"><vh>@string headline-time-format-string = %m/%d/%Y %H:%M:%S</vh></v>
 </v>
 <v t="ekr.20160127043440.1"><vh>make-stub-files settings</vh>
 <v t="ekr.20160127051552.1"><vh>@bool stub-overwrite = False</vh></v>


### PR DESCRIPTION
See #3240.

The settings for `insert-body-time` and `insert-headline-time` are now the same.

It's possible that the previous difference was intentional, but I doubt it.