### PR TITLE
PR: tweaks to Leo's new unls code

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -11667,11 +11667,7 @@ False: do nothing when the mouse hovers over nodes.</t>
 <t tx="ekr.20230627130611.1">gnx:    Show gnx-based unls in the status area.
 legacy: Show legacy (headline-based) uns in the status area.</t>
 <t tx="ekr.20230627131213.1"></t>
-<t tx="ekr.20230627131227.1">This setting has effect only when `@string unl-status-kind = legacy`.
-
-Regardless of this setting, Leo will resolve unls using `@data unl-path-prefixes`.
-
-True: (legacy): Display full path names in the status area.
+<t tx="ekr.20230627131227.1">True: (legacy): Display full path names in the status area.
 False:          Display only the .leo file's name in the status area.
 </t>
 <t tx="ekr.20230627202839.1"># lines have the form:

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -11667,9 +11667,12 @@ False: do nothing when the mouse hovers over nodes.</t>
 <t tx="ekr.20230627130611.1">gnx:    Show gnx-based unls in the status area.
 legacy: Show legacy (headline-based) uns in the status area.</t>
 <t tx="ekr.20230627131213.1"></t>
-<t tx="ekr.20230627131227.1">True: (legacy): Display full path names in the status area.
+<t tx="ekr.20230627131227.1">This setting has effect only when `@string unl-status-kind = legacy`.
+
+Regardless of this setting, Leo will resolve unls using `@data unl-path-prefixes`.
+
+True: (legacy): Display full path names in the status area.
 False:          Display only the .leo file's name in the status area.
-                Use @data unl-path-prefixes to resolve names.
 </t>
 <t tx="ekr.20230627202839.1"># lines have the form:
 # x.leo: &lt;absolute path to x.leo&gt;

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -2197,8 +2197,8 @@
 </v>
 </v>
 <v t="ekr.20230627131213.1"><vh>UNLs</vh>
-<v t="ekr.20230627130611.1"><vh>@string unl-status-kind = legacy</vh></v>
-<v t="ekr.20230627131227.1"><vh>@bool full-unl-paths = True</vh></v>
+<v t="ekr.20230627130611.1"><vh>@string unl-status-kind = gnx</vh></v>
+<v t="ekr.20230627131227.1"><vh>@bool full-unl-paths = False</vh></v>
 <v t="ekr.20230627202839.1"><vh>@data unl-path-prefixes</vh></v>
 </v>
 <v t="ekr.20110611092035.16471"><vh>Widget colors</vh>

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7752,6 +7752,9 @@ def openUNLFile(c: Cmdr, s: str) -> Cmdr:
         s = s[2:-1]
     if not s.strip():
         return c
+    # Always match within the present file.
+    if os.path.basename(s) == os.path.basename(c.fileName()):
+        return c
     if os.path.isabs(s):
         path = os.path.normpath(s).lower()
     else:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7757,7 +7757,6 @@ def openUNLFile(c: Cmdr, s: str) -> Cmdr:
         """Standardize the path for easy comparison."""
         return norm(path).lower()
 
-    trace = False and not g.unitTesting
     if not s.strip():
         return None
     if s.startswith('//') and s.endswith('#'):
@@ -7766,52 +7765,31 @@ def openUNLFile(c: Cmdr, s: str) -> Cmdr:
         return None
     # Always match within the present file.
     if os.path.isabs(s) and standard(s) == standard(c_name):
-        if trace:
-            g.trace('Quick full match:', s)
         return c
     if not os.path.isabs(s) and standard(s) == standard(base(c_name)):
-        if trace:
-            g.trace('Quick short match:', s, base(c_name))
         return c
-    if trace:
-        g.trace('No quick match', s)
     if os.path.isabs(s):
         path = standard(s)
     else:
         # Values of d should be directories.
         d = g.parsePathData(c)
-        if trace:
-            print('')
-            g.printObj(d, tag='d')
         base_s = base(s)
         directory = d.get(base_s)
         if not directory:
-            g.trace(f"No directory for {s!r}")
             return None
         if not os.path.exists(directory):
-            g.trace(f"Directory found: {directory!r}")
             return None
         path = standard(os.path.join(directory, base_s))
-        if trace:
-            g.trace('   directory:', directory.lower())
-            g.trace('        path:', path.lower())
-            g.trace('c.fileName():', standard(c_name))
     if path == standard(c_name):
         return c
     # Search all open commanders.
     # This is a good shortcut, and it helps unit tests.
     for c2 in g.app.commanders():
         if path == standard(c2.fileName()):
-            if trace:
-                g.trace(f"       Found: {norm(c2.fileName())}")
             return c2
     # Open the file if possible.
     if not os.path.exists(path):
-        if trace:
-            g.trace(f"   Not found: {path}")
         return None
-    if trace:
-        g.trace(f"Opening {path}")
     return g.openWithFileName(path)
 #@+node:ekr.20230630132341.1: *4* g.parsePathData
 path_data_pattern = re.compile(r'(.+?):\s*(.+)')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7765,7 +7765,10 @@ def openUNLFile(c: Cmdr, s: str) -> Cmdr:
         if trace:
             g.trace('Quick full match:', s)
         return c
-    if not os.path.isabs(s) and standardize(s) == standardize(c.fileName()):
+    if (
+        not os.path.isabs(s)
+        and standardize(s) == standardize(os.path.basename(c.fileName()))
+    ):
         if trace:
             g.trace('Quick short match:', s, os.path.basename(c.fileName()))
         return c

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7798,7 +7798,8 @@ path_data_pattern = re.compile(r'(.+?):\s*(.+)')
 
 def parsePathData(c: Cmdr) -> dict[str, str]:
     """
-    Return a dict giving path prefixes for the files given in @data unl-path-prefixes.
+    Return a dict giving path prefixes for the files given in @data
+    unl-path-prefixes.
     """
     lines = c.config.getData('unl-path-prefixes')
     d: dict[str, str] = {}

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -826,7 +826,7 @@ class Position:
         c = p.v.context
         file_part = c.fileName()
         return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
-    #@+node:ekr.20230628173542.2: *5* p.get_full_legacy_UNL
+    #@+node:tbrown.20111010104549.26758: *5* p.get_full_legacy_UNL
     def get_full_legacy_UNL(self) -> str:
         """
         Return a legacy unl with the full file-name component.
@@ -884,7 +884,8 @@ class Position:
         """
         p = self
         c = p.v.context
-        file_part = os.path.basename(c.fileName())
+        full = c.config.getBool('full-unl-paths', default=False)
+        file_part = c.fileName() if full else os.path.basename(c.fileName())
         return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
     #@+node:ekr.20080416161551.192: *4* p.hasBack/Next/Parent/ThreadBack
     def hasBack(self) -> bool:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -878,14 +878,13 @@ class Position:
     #@+node:ekr.20230624171452.1: *5* p.get_UNL
     def get_UNL(self) -> str:
         """
-        Return a gnx-oriented UNL whose file part depends on the @bool full-unl-paths setting.
+        Return a gnx-oriented UNL with a short file name.
 
-        LeoTree.set_status_line will call this method if gnx-based unls are in effect.
+        LeoTree.set_status_line calls this method if gnx-based unls are in effect.
         """
         p = self
         c = p.v.context
-        full = c.config.getBool('full-unl-paths', default=False)
-        file_part = c.fileName() if full else os.path.basename(c.fileName())
+        file_part = os.path.basename(c.fileName())
         return 'unl:gnx:' + f"//{file_part}#{self.gnx}"
     #@+node:ekr.20080416161551.192: *4* p.hasBack/Next/Parent/ThreadBack
     def hasBack(self) -> bool:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -842,7 +842,7 @@ class Position:
         """
         Return a headline-oriented UNL, as in legacy versions of p.get_UNL.
 
-        The file part of this UNL depends on the @bool full-unl-paths setting.
+        @bool full-unl-paths determines the size of the file part.
 
         LeoTree.set_status_line will call this method if legacy unls are in effect.
         """
@@ -878,7 +878,9 @@ class Position:
     #@+node:ekr.20230624171452.1: *5* p.get_UNL
     def get_UNL(self) -> str:
         """
-        Return a gnx-oriented UNL with a short file name.
+        Return a gnx-oriented UNL.
+
+        @bool full-unl-paths determines the size of the file part.
 
         LeoTree.set_status_line calls this method if gnx-based unls are in effect.
         """

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -69,7 +69,8 @@
 <v t="ekr.20230625084119.1"><vh>Legacy UNLs: in this file</vh></v>
 <v t="ekr.20230628090119.1"><vh>Legacy UNLs: other files</vh></v>
 <v t="ekr.20230623141357.1"><vh>URLs and UNLs: </vh></v>
-<v t="ekr.20230627150454.1"><vh>New UNLs with file parts</vh></v>
+<v t="ekr.20230627150454.1"><vh>New UNLs with short file parts</vh></v>
+<v t="ekr.20230707065449.1"><vh>New UNLS with long(absolute) file parts</vh></v>
 </vnodes>
 <tnodes>
 <t tx="ekr.20180311131353.1" str_leo_pos="3,11"></t>
@@ -1046,5 +1047,25 @@ unl://LeoDocs.leo#Release Notes--&gt;Leo 6.7.3 release notes
 # In LeoDocs.leo
 unl://LeoDocs.leo#Web pages
 </t>
+<t tx="ekr.20230707065449.1"># These unls will work only on EKR's machine.
+# They are a test of absolute matches in g.openUNLFile.
+
+# Exists: Recent
+unl:gnx://c:\Repos\leo-editor\leo\test\test.leo#ekr.20180311131424.1
+
+# Error mssages (copy to log)
+unl:gnx://c:\Repos\leo-editor\leo\test\test.leo#ekr.20230622112649.1
+
+# Should fail
+unl:gnx://c:\Repos\leo-editor\leo\doc\test.leo#ekr.20230622112649.1
+
+# In LeoDocs.leo: Leo 6.7.3 release notes
+unl:gnx://c:\Repos\leo-editor\leo\doc\LeoDocs.leo#ekr.20230409052507.1
+
+# In LeoDocs.leo: ** Read me first **
+unl:gnx://c:\Repos\leo-editor\leo\doc\LeoDocs.leo#ekr.20050831195449
+
+# Bad gnx: xyzzy.leo does not exist.
+unl:gnx://xyzzy.leo#.20230622112649.1</t>
 </tnodes>
 </leo_file>

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -1100,7 +1100,13 @@ class TestGlobals(LeoUnitTest):
             c.config.set(p=None, kind='bool', name='full-unl-paths', val=full)
             self.assertEqual(full, getBool('full-unl-paths'), msg=full)
             self.assertEqual(kind, getString('unl-status-kind'), msg=kind)
-
+            
+        expected_get_UNL = {
+            'legacy:0': short_gnx,
+            'legacy:1': full_gnx,
+            'gnx:0': short_gnx,
+            'gnx:1': full_gnx,
+        }
         expected_get_legacy_UNL = {
             'legacy:0': short_legacy,
             'legacy:1': full_legacy,
@@ -1111,6 +1117,7 @@ class TestGlobals(LeoUnitTest):
             for full in (True, False):
                 set_config(kind, full)
                 for d, f in (
+                    (expected_get_UNL, p.get_UNL),
                     (expected_get_legacy_UNL, p.get_legacy_UNL),
                 ):
                     expected = d[f"{kind}:{str(int(full))}"]
@@ -1122,8 +1129,6 @@ class TestGlobals(LeoUnitTest):
             for full in (True, False):
                 set_config(kind, full)
                 for expected, f in (
-                    # Test g.getUnl.
-                    (short_gnx, p.get_UNL),
                     # Test g.get_full/short_gnx_UNL.
                     (full_gnx, p.get_full_gnx_UNL),
                     (short_gnx, p.get_short_gnx_UNL),

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -1102,7 +1102,6 @@ class TestGlobals(LeoUnitTest):
             self.assertEqual(kind, getString('unl-status-kind'), msg=kind)
 
         # Test g.get_UNL and g.get_legacy_UNL.
-
         expected_get_UNL = {
             'legacy:0': short_gnx,
             'legacy:1': full_gnx,

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -1100,7 +1100,9 @@ class TestGlobals(LeoUnitTest):
             c.config.set(p=None, kind='bool', name='full-unl-paths', val=full)
             self.assertEqual(full, getBool('full-unl-paths'), msg=full)
             self.assertEqual(kind, getString('unl-status-kind'), msg=kind)
-            
+
+        # Test g.get_UNL and g.get_legacy_UNL.
+
         expected_get_UNL = {
             'legacy:0': short_gnx,
             'legacy:1': full_gnx,

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -1101,13 +1101,6 @@ class TestGlobals(LeoUnitTest):
             self.assertEqual(full, getBool('full-unl-paths'), msg=full)
             self.assertEqual(kind, getString('unl-status-kind'), msg=kind)
 
-        # Test g.get_UNL and g.get_legacy_UNL.
-        expected_get_UNL = {
-            'legacy:0': short_gnx,
-            'legacy:1': full_gnx,
-            'gnx:0': short_gnx,
-            'gnx:1': full_gnx,
-        }
         expected_get_legacy_UNL = {
             'legacy:0': short_legacy,
             'legacy:1': full_legacy,
@@ -1118,7 +1111,6 @@ class TestGlobals(LeoUnitTest):
             for full in (True, False):
                 set_config(kind, full)
                 for d, f in (
-                    (expected_get_UNL, p.get_UNL),
                     (expected_get_legacy_UNL, p.get_legacy_UNL),
                 ):
                     expected = d[f"{kind}:{str(int(full))}"]
@@ -1130,6 +1122,8 @@ class TestGlobals(LeoUnitTest):
             for full in (True, False):
                 set_config(kind, full)
                 for expected, f in (
+                    # Test g.getUnl.
+                    (short_gnx, p.get_UNL),
                     # Test g.get_full/short_gnx_UNL.
                     (full_gnx, p.get_full_gnx_UNL),
                     (short_gnx, p.get_short_gnx_UNL),


### PR DESCRIPTION
Small changes to PR #3215.

**Compatibility Guide**

`p.get_UNL` previously returned path-based unls. It now returns gnx-based unls:
**Pros**: existing code will start using gnx-based unls automatically.
**Cons**: Plugins that must use path-based unls will have to change. See below.

Plugins writers should do the following to adapt to the changes made in PR #3215 (and this PR). 

**Case 1**: The plugin will create and read (support) only legacy unls:

Instead of calling `p.get_UNL`, call one of `p.get_legacy_UNL`, `p.get_full_legacy_UNL`, or `p.get_short_legacy_UNL`.
That's all. There is no need to call `g.findAnyUnl` instead of `g.findUnl`.

**Case 2**: The plugin will *create* gnx-based unls, but will *read* all kinds of unls:

Call `g.findAnyUnl` instead of `g.findUnl`.
That's all. There is no need to change calls to `p.get_UNL`.

<details><summary>Summary of <em>this</em> PR</summary>
<br>
This PR makes *no* substantive changes to `leoNodes.py`.

- [x] `g.openUNLFile` does a quick test to match within c.
- [x] `g.openUNLFile` returns None if no match was found.
- [x] Change default: `@string unl-status-kind = gnx`.
- [x] Change default: `@bool full-unl-paths = False`.
- [x] Apply tbrown gnx `#@+node:tbrown.20111010104549.26758: *4* p.get_UNL` to `p.get_full_legacy_UNL`. See below.

Terry's Original Code

Here is the node from the `master` branch. The gnx originally applied to `p.get_UNL`, but `p.get_full_legacy_UNL` now corresponds most closely to Terry's original code. I moved the code because `p.get_UNL` now returns gnx-based unls. 

```python
#@+node:tbrown.20111010104549.26758: *4* p.get_UNL
    def get_UNL(self) -> str:
        """
        Return a UNL representing a clickable link.
        See the section < define global error regexs > for the regexes.

        New in Leo 6.6: Use a single, simplified format for UNL's:

        - unl: //
        - self.v.context.fileName() #
        - a list of headlines separated by '-->'

        New in Leo 6.6:
        - Always add unl: // and file name.
        - Never translate '-->' to '--%3E'.
        - Never generate child indices.
        """
        base_unl = (self.v.context.fileName() + '#'
            + '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
                    )
        encoded = base_unl.replace("'", "%27")
        return 'unl://' + encoded
```

</details>