### PR TITLE
PR for #3429: paste retains gnxs if possible

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -103,7 +103,7 @@ def pasteOutline(
         kind = 'allocating new' if clashes else 'retaining'
         g.es_print(f"paste-node: {kind} gnxs")
     if clashes:
-        pasted = fc.getLeoOutlineFromClipboard(s)
+        pasted = fc.getLeoOutlineFromClipboard(s)  # Reassigns gnxs.
     else:
         pasted = fc.getLeoOutlineFromClipboardRetainingClones(s)
     if not pasted:
@@ -131,7 +131,7 @@ def pasteOutline(
     c.recolor()
     return pasted
 #@+node:ekr.20230706192145.1: *3* c_oc.pasteOutlineAllocatingGnxs
-@g.commander_command('paste-node-allocating gnxs')
+@g.commander_command('paste-node-allocating-gnxs')
 def pasteOutlineAllocatingGnxs(
     self: Self,
     event: Event = None,
@@ -155,7 +155,7 @@ def pasteOutlineAllocatingGnxs(
     if not isLeo:
         return None
     # Get *position* to be pasted.
-    pasted = fc.getLeoOutlineFromClipboard(s)
+    pasted = fc.getLeoOutlineFromClipboard(s)  # Reassigns gnxs.
     if not pasted:
         return None
     # Validate.
@@ -190,7 +190,7 @@ def pasteOutlineRetainingClones(
 ) -> Optional[Position]:
     """
     Paste an outline into the present outline from the clipboard.
-    Nodes *retain* their original identify.
+    Do *not* reassign gnxs.
     """
     c = self
     if s is None:

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -57,7 +57,7 @@ def cutOutline(self: Self, event: Event = None) -> None:
         c.copyOutline()
         c.deleteOutline(op_name="Cut Node")
         c.recolor()
-#@+node:ekr.20031218072017.1551: *3* c_oc.pasteOutline (generalized) & helper 
+#@+node:ekr.20031218072017.1551: *3* c_oc.pasteOutline (generalized) & helper
 @g.commander_command('paste-node')
 def pasteOutline(
     self: Self,

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -97,29 +97,17 @@ def pasteOutline(
         return None
     # Pre-read the ouline.
     candidate = fc.preReadLeoOutlineFromClipboard(s)
-    clashes = anyGnxClashes(c, candidate)
-    print('')
-    g.trace('clashes', clashes, candidate.h)
-        # # # pasted.doDelete()  ### Experimental.
-        # # # pasted = c.fileCommands.getLeoOutlineFromClipboardRetainingClones(s)
-        # # # if not pasted:
-            # # # return None  # Should never happen.
-
     # Get *position* to be pasted.
-    pasted = fc.getLeoOutlineFromClipboard(s)
-    ### g.trace(c.positionExists(pasted), pasted.h)
+    if anyGnxClashes(c, candidate):
+        pasted = fc.getLeoOutlineFromClipboard(s)
+    else:
+        g.trace('No clashes', candidate.h)
+        pasted = fc.getLeoOutlineFromClipboard(s)
     if not pasted:
-        # Leo no longer supports MORE outlines. Use import-MORE-files instead.
         return None
     # Validate.
     c.validateOutline()
     c.checkOutline()
-    # Delete and retry retaining nodes if no nodes in the pasted outline exist within the outline.
-    if False and not anyGnxClashes(c, pasted):  ###
-        pasted.doDelete()  ### Experimental.
-        pasted = c.fileCommands.getLeoOutlineFromClipboardRetainingClones(s)
-        if not pasted:
-            return None  # Should never happen.
     # Handle the "before" data for undo.
     if undoFlag:
         undoData = c.undoer.beforeInsertNode(c.p,

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -102,7 +102,7 @@ def pasteOutline(
         pasted = fc.getLeoOutlineFromClipboard(s)
     else:
         g.trace('No clashes', candidate.h)
-        pasted = fc.getLeoOutlineFromClipboard(s)
+        pasted = fc.getLeoOutlineFromClipboardRetainingClones(s)
     if not pasted:
         return None
     # Validate.

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -104,7 +104,7 @@ def pasteOutline(
         # # # pasted = c.fileCommands.getLeoOutlineFromClipboardRetainingClones(s)
         # # # if not pasted:
             # # # return None  # Should never happen.
-    
+
     # Get *position* to be pasted.
     pasted = fc.getLeoOutlineFromClipboard(s)
     ### g.trace(c.positionExists(pasted), pasted.h)
@@ -115,7 +115,7 @@ def pasteOutline(
     c.validateOutline()
     c.checkOutline()
     # Delete and retry retaining nodes if no nodes in the pasted outline exist within the outline.
-    if False and not anyGnxClashes(c, pasted):   ###
+    if False and not anyGnxClashes(c, pasted):  ###
         pasted.doDelete()  ### Experimental.
         pasted = c.fileCommands.getLeoOutlineFromClipboardRetainingClones(s)
         if not pasted:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -856,7 +856,7 @@ class FileCommands:
     def getLeoOutlineFromClipboard(self, s: str) -> Optional[Position]:
         """
         Read a Leo outline from string s in clipboard format.
-        
+
         Reassign all gnxs.
         """
         c = self.c

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -854,7 +854,11 @@ class FileCommands:
 
     #@+node:ekr.20180709205603.1: *5* fc.getLeoOutlineFromClipBoard
     def getLeoOutlineFromClipboard(self, s: str) -> Optional[Position]:
-        """Read a Leo outline from string s in clipboard format."""
+        """
+        Read a Leo outline from string s in clipboard format.
+        
+        Reassign all gnxs.
+        """
         c = self.c
         current = c.p
         if not current:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -882,6 +882,7 @@ class FileCommands:
             return None
         # Create the position.
         p = leoNodes.Position(v)
+
         # Do *not* adjust links when linking v.
         if current.hasChildren() and current.isExpanded():
             p._linkCopiedAsNthChild(current, 0)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -837,7 +837,7 @@ class FileCommands:
         p = leoNodes.Position(v)
         self.gnxDict = oldGnxDict
         return p
-        
+
         ###
             # # Do *not* adjust links when linking v.
             # if current.hasChildren() and current.isExpanded():


### PR DESCRIPTION
See #3429.

- [x] Add `fc.preReadLeoOutlineFromClipboard`.
  This **preread method** contains the opening line from `fc.getLeoOutlineFromClipboard`.
  Duplicating code in this method minimizes changes everywhere else.
- [x] `c_oc.pasteOutline` looks ahead using the preread method, choosing its course of action accordingly.
- [x] Create a `paste-node-reallocating-gnxs` command to force reallocation.