### PR TITLE
PR for #3416: quirps in refresh-from-disk and two other methods

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -310,8 +310,8 @@ def refreshFromDisk(self: Self, event: Event = None) -> None:
     if not fn:
         g.warning(f"not an @<file> node: {p.h!r}")
         return
-    # #1603.
-    if os.path.isdir(fn):
+    full_path = c.fullPath(p)
+    if os.path.isdir(full_path):
         g.warning(f"not a file: {fn!r}")
         return
     b = u.beforeChangeTree(p)
@@ -343,10 +343,10 @@ def refreshFromDisk(self: Self, event: Event = None) -> None:
             p.v._deleteAllChildren()
         at.read(p)
     elif word == '@edit':
-        at.readOneAtEditNode(fn, p)  # Always deletes children.
+        at.readOneAtEditNode(p)  # Always deletes children.
     elif word == '@asis':
         # Fix #1067.
-        at.readOneAtAsisNode(fn, p)  # Always deletes children.
+        at.readOneAtAsisNode(p)  # Always deletes children.
     else:
         g.es_print(f"can not refresh from disk\n{p.h!r}")
         redraw_flag = False

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -305,14 +305,13 @@ def refreshFromDisk(self: Self, event: Event = None) -> None:
     """Refresh an @<file> node from disk."""
     c, p, u = self, self.p, self.undoer
     c.nodeConflictList = []
-    fn = p.anyAtFileNodeName()
     shouldDelete = c.sqlite_connection is None
-    if not fn:
+    if not p.isAnyAtFileNode():
         g.warning(f"not an @<file> node: {p.h!r}")
         return
     full_path = c.fullPath(p)
     if os.path.isdir(full_path):
-        g.warning(f"not a file: {fn!r}")
+        g.warning(f"not a file: {full_path!r}")
         return
     b = u.beforeChangeTree(p)
     redraw_flag = True

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -396,7 +396,7 @@ class AtFile:
         elif p.isAtAutoNode():
             at.readOneAtAutoNode(p)
         elif p.isAtEditNode():
-            at.readOneAtEditNode(fileName, p)
+            at.readOneAtEditNode(p)
         elif p.isAtShadowFileNode():
             at.readOneAtShadowNode(fileName, p)
         elif p.isAtAsisFileNode() or p.isAtNoSentFileNode():
@@ -471,11 +471,10 @@ class AtFile:
             g.doHook('after-auto', c=c, p=p)
         return p  # For #451: return p.
     #@+node:ekr.20090225080846.3: *5* at.readOneAtEditNode
-    def readOneAtEditNode(self, fn: str, p: Position) -> None:  # pragma: no cover
+    def readOneAtEditNode(self, p: Position) -> None:  # pragma: no cover
         at = self
         c = at.c
         ic = c.importCommands
-        # #1521
         fn = c.fullPath(p)
         junk, ext = g.os_path_splitext(fn)
         # Fix bug 889175: Remember the full fileName.
@@ -503,7 +502,7 @@ class AtFile:
         p.b = head + g.toUnicode(s, encoding=encoding, reportErrors=True)
         g.doHook('after-edit', p=p)
     #@+node:ekr.20190201104956.1: *5* at.readOneAtAsisNode
-    def readOneAtAsisNode(self, fn: str, p: Position) -> None:  # pragma: no cover
+    def readOneAtAsisNode(self, p: Position) -> None:  # pragma: no cover
         """Read one @asis node. Used only by refresh-from-disk"""
         at, c = self, self.c
         fn = c.fullPath(p)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3569,7 +3569,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):  # type:ignore
         at = c.atFileCommands
         # Use the full @edit logic, so dragging will be
         # exactly the same as reading.
-        at.readOneAtEditNode(fn, p)
+        at.readOneAtEditNode(p)
         fn2 = fn.replace('\\', '/')
         p.h = f"@edit {fn2}"
         p.clearDirty()  # Don't automatically rewrite this node.


### PR DESCRIPTION
See #3416.

- [x] Check `c.fullPath(p)` when checking to see if `p` (an `@<file>` node) refers to a file.
- [x] Remove the `fn` var completely. Check `p.isAnyAtFileNode()` instead.
- [x] Remove the unused `fn` *positional* arguments in `at.readOneAtEditNode` and `at.readOneAtAsisNode`.
   In both methods, `fn = c.fullPath(p)` immediately replaces the `fn` arg!