### PR TITLE
PR: Don't run LeoUnitTest.verbose_test_set_setting by default

### DIFF
--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -145,17 +145,8 @@ class LeoUnitTest(unittest.TestCase):
             c.config.set(p=None, kind=kind, name=name, val=val)
         finally:
             sys.stdout = old_stdout
-    #@+node:ekr.20230703103514.1: *4* LeoUnitTest.test_set_setting
-    def test_set_setting(self) -> None:
-
-        class_name = self.__class__.__name__
-
-        if class_name != 'LeoUnitTest':
-            self.skipTest(f"{class_name} is not 'LeoUnitTest'")
-
-        if not hasattr(self, 'c'):
-            # TestLeoServer.
-            self.skipTest(f"{self.__class__.__name__} has no 'c' ivar")
+    #@+node:ekr.20230703103514.1: *4* LeoUnitTest.verbose_test_set_setting
+    def verbose_test_set_setting(self) -> None:
 
         c = self.c
         val: Any

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -147,7 +147,8 @@ class LeoUnitTest(unittest.TestCase):
             sys.stdout = old_stdout
     #@+node:ekr.20230703103514.1: *4* LeoUnitTest.verbose_test_set_setting
     def verbose_test_set_setting(self) -> None:
-
+        # Not run by default. To run:
+        # python -m unittest leo.core.leoTest2.LeoUnitTest.verbose_test_set_setting
         c = self.c
         val: Any
         for val in (True, False):


### PR DESCRIPTION
`LeoUnitTest` is the base of almost all of Leo's unit tests. It was mistake to include `test_set_setting` in this class.

- [x] Change `LeoUnitTest.test_set_setting` to `verbose_test_set_setting` to prevent running the test by default.