### PR TITLE
PR: Fix undo annotations and other quirps

### DIFF
--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -683,7 +683,7 @@ class Undoer:
         u.setUndoTypes()
     #@+node:ekr.20050318085432.3: *4* u.beforeX...
     #@+node:ekr.20201109074740.1: *5* u.beforeChangeBody
-    def beforeChangeBody(self, p: Position) -> None:
+    def beforeChangeBody(self, p: Position) -> g.Bunch:
         """Return data that gets passed to afterChangeBody."""
         w = self.c.frame.body.wrapper
         bunch = self.createCommonBunch(p)  # Sets u.oldMarked, u.oldSel, u.p
@@ -716,7 +716,7 @@ class Undoer:
         u.bead += 1
         u.beads[u.bead:] = [bunch]
     #@+node:ekr.20201107145859.1: *5* u.beforeChangeHeadline
-    def beforeChangeHeadline(self, p: Position) -> None:
+    def beforeChangeHeadline(self, p: Position) -> g.Bunch:
         """
         Return data that gets passed to afterChangeNode.
 
@@ -729,7 +729,7 @@ class Undoer:
 
     beforeChangeHead = beforeChangeHeadline
     #@+node:felix.20230326230839.1: *5* u.beforeChangeMultiHeadline
-    def beforeChangeMultiHeadline(self, p: Position) -> None:
+    def beforeChangeMultiHeadline(self, p: Position) -> g.Bunch:
         """
         Return data that gets passed to afterChangeMultiHeadline.
         p is used to select position after undo/redo multiple headline changes is done
@@ -745,7 +745,7 @@ class Undoer:
 
     beforeChangeMultiHead = beforeChangeMultiHeadline
     #@+node:ekr.20050315133212.2: *5* u.beforeChangeNodeContents
-    def beforeChangeNodeContents(self, p: Position) -> None:
+    def beforeChangeNodeContents(self, p: Position) -> g.Bunch:
         """Return data that gets passed to afterChangeNode."""
         c, u = self.c, self
         w = c.frame.body.wrapper
@@ -756,19 +756,19 @@ class Undoer:
         bunch.oldYScroll = w.getYScrollPosition() if w else 0
         return bunch
     #@+node:ekr.20050424161505.1: *5* u.beforeClearRecentFiles
-    def beforeClearRecentFiles(self) -> None:
+    def beforeClearRecentFiles(self) -> g.Bunch:
         u = self
         p = u.c.p
         bunch = u.createCommonBunch(p)
         bunch.oldRecentFiles = g.app.config.recentFiles[:]
         return bunch
     #@+node:ekr.20050412080354: *5* u.beforeCloneNode
-    def beforeCloneNode(self, p: Position) -> None:
+    def beforeCloneNode(self, p: Position) -> g.Bunch:
         u = self
         bunch = u.createCommonBunch(p)
         return bunch
     #@+node:ekr.20050411193627.3: *5* u.beforeDeleteNode
-    def beforeDeleteNode(self, p: Position) -> None:
+    def beforeDeleteNode(self, p: Position) -> g.Bunch:
         u = self
         bunch = u.createCommonBunch(p)
         bunch.oldBack = p.back()
@@ -779,7 +779,7 @@ class Undoer:
         p: Position,
         pasteAsClone: bool = False,
         copiedBunchList: list[g.Bunch] = None,
-    ) -> None:
+    ) -> g.Bunch:
         u = self
         if copiedBunchList is None:
             copiedBunchList = []
@@ -790,21 +790,21 @@ class Undoer:
             bunch.beforeTree = copiedBunchList
         return bunch
     #@+node:ekr.20050526131252: *5* u.beforeMark
-    def beforeMark(self, p: Position, command: str) -> None:
+    def beforeMark(self, p: Position, command: str) -> g.Bunch:
         u = self
         bunch = u.createCommonBunch(p)
         bunch.kind = 'mark'
         bunch.undoType = command
         return bunch
     #@+node:ekr.20050410110215: *5* u.beforeMoveNode
-    def beforeMoveNode(self, p: Position) -> None:
+    def beforeMoveNode(self, p: Position) -> g.Bunch:
         u = self
         bunch = u.createCommonBunch(p)
         bunch.oldN = p.childIndex()
         bunch.oldParent_v = p._parentVnode()
         return bunch
     #@+node:ekr.20230713145834.1: *5* u.beforeParseBody
-    def beforeParseBody(self, p: Position) -> None:
+    def beforeParseBody(self, p: Position) -> g.Bunch:
         u = self
         bunch = u.createCommonBunch(p)
         bunch.oldBody = p.b
@@ -816,7 +816,7 @@ class Undoer:
         oldChildren: list[VNode],
         newChildren: list[VNode],
         sortChildren: bool,
-    ) -> None:
+    ) -> g.Bunch:
         """Create an undo node for sort operations."""
         u = self
         if sortChildren:
@@ -836,7 +836,7 @@ class Undoer:
         u.beads[u.bead:] = [bunch]
         return bunch
     #@+node:ekr.20050318085432.2: *5* u.createCommonBunch
-    def createCommonBunch(self, p: Position) -> None:
+    def createCommonBunch(self, p: Position) -> g.Bunch:
         """Return a bunch containing all common undo info.
         This is mostly the info for recreating an empty node at position p."""
         c = self.c

--- a/leo/unittests/commands/test_editFileCommands.py
+++ b/leo/unittests/commands/test_editFileCommands.py
@@ -10,7 +10,7 @@ from leo.core.leoTest2 import LeoUnitTest
 #@+others
 #@+node:ekr.20230714143317.2: ** class TestEditFileCommands(LeoUnitTest)
 class TestEditFileCommands(LeoUnitTest):
-    """Unit tests for leo/commands/editCommands.py."""
+    """Unit tests for leo/commands/editFileCommands.py."""
 
     #@+others
     #@+node:ekr.20230714143317.3: *3* TestEditFileCommands.slow_test_gdc_node_history


### PR DESCRIPTION
- [x] Change annotations of all `u.before*` methods except `u.beforeChangeGroup`.
- [x] Fix docstring for `TestEditFileCommands` class.
- [x] Reduce visual impact `u.clearAndWarn`:
  - Remove the log messages. They quickly become annoying.
  - (In Leo's `Edit` menu) For undoable commands, replace `Can't Undo` by `Can't Undo <command-name>`.