### PR TITLE
PR for #3446: paste-retaining-clone bug

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -897,7 +897,8 @@ class FileCommands:
         Populate the parent links in all children of p.
         """
         for child in p.children():
-            if not child.v.parents:
+            ### if not child.v.parents:
+            if p.v not in child.v.parents:  ### Experimental.
                 child.v.parents.append(p.v)
             self.linkChildrenToParents(child)
     #@+node:ekr.20180425034856.1: *5* fc.reassignAllIndices

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -897,8 +897,7 @@ class FileCommands:
         Populate the parent links in all children of p.
         """
         for child in p.children():
-            ### if not child.v.parents:
-            if p.v not in child.v.parents:  ### Experimental.
+            if p.v not in child.v.parents:
                 child.v.parents.append(p.v)
             self.linkChildrenToParents(child)
     #@+node:ekr.20180425034856.1: *5* fc.reassignAllIndices

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -149,7 +149,10 @@ class LeoUnitTest(unittest.TestCase):
         print('')
         for p in c.all_positions():
             head_s = f"{' '*p.level()}{p.h}"
-            print(f"clone? {int(p.isCloned())} {p.gnx:10}: {head_s:<10} parents: {p.v.parents}")
+            print(
+                f"clone? {int(p.isCloned())} id(v): {id(p.v)} gnx: {p.gnx:10}: "
+                f"{head_s:<10} parents: {p.v.parents}"
+            )
     #@+node:ekr.20220805071838.1: *3* LeoUnitTest.dump_headlines
     def dump_headlines(self, c: Cmdr) -> None:  # pragma: no cover
         """Dump all headlines."""

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -98,6 +98,85 @@ class LeoUnitTest(unittest.TestCase):
     Contains setUp/tearDown methods and various utilites.
     """
     #@+others
+    #@+node:ekr.20210830151601.1: *3* LeoUnitTest.create_test_outline
+    def create_test_outline(self) -> None:
+        p = self.c.p
+        # Create the following outline:
+        #
+        # root
+        #   child clone a
+        #     node clone 1
+        #   child b
+        #     child clone a
+        #       node clone 1
+        #   child c
+        #     node clone 1
+        #   child clone a
+        #     node clone 1
+        #   child b
+        #     child clone a
+        #       node clone 1
+        assert p == self.root_p
+        assert p.h == 'root'
+        # Child a
+        child_clone_a = p.insertAsLastChild()
+        child_clone_a.h = 'child clone a'
+        node_clone_1 = child_clone_a.insertAsLastChild()
+        node_clone_1.h = 'node clone 1'
+        # Child b
+        child_b = p.insertAsLastChild()
+        child_b.h = 'child b'
+        # Clone 'child clone a'
+        clone = child_clone_a.clone()
+        clone.moveToLastChildOf(child_b)
+        # Child c
+        child_c = p.insertAsLastChild()
+        child_c.h = 'child c'
+        # Clone 'node clone 1'
+        clone = node_clone_1.clone()
+        clone.moveToLastChildOf(child_c)
+        # Clone 'child clone a'
+        clone = child_clone_a.clone()
+        clone.moveToLastChildOf(p)
+        # Clone 'child b'
+        clone = child_b.clone()
+        clone.moveToLastChildOf(p)
+    #@+node:ekr.20230720210931.1: *3* LeoUnitTest.dump_clone_info
+    def dump_clone_info(self, c: Cmdr) -> None:
+        """Dump all clone info."""
+        print('')
+        g.trace(c.fileName())
+        print('')
+        for p in c.all_positions():
+            head_s = f"{' '*p.level()}{p.h}"
+            print(f"clone? {int(p.isCloned())} {p.gnx:10}: {head_s:<20} parents: {p.v.parents}")
+    #@+node:ekr.20220805071838.1: *3* LeoUnitTest.dump_headlines
+    def dump_headlines(self, c: Cmdr) -> None:  # pragma: no cover
+        """Dump all headlines."""
+        print('')
+        g.trace(c.fileName())
+        print('')
+        for p in c.all_positions():
+            print(f"{p.gnx:10}: {' '*p.level()}{p.h}")
+
+    #@+node:ekr.20220806170537.1: *3* LeoUnitTest.dump_string
+    def dump_string(self, s: str, tag: str = None) -> None:
+        if tag:
+            print(tag)
+        g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
+    #@+node:ekr.20211129062220.1: *3* LeoUnitTest.dump_tree
+    def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
+        """
+        Dump root's tree, or the entire tree if root is None.
+        """
+        print('')
+        if tag:
+            print(tag)
+        _iter = root.self_and_subtree if root else self.c.all_positions
+        for p in _iter():
+            print('')
+            print('level:', p.level(), p.h)
+            g.printObj(g.splitLines(p.v.b))
     #@+node:ekr.20210901140855.2: *3* LeoUnitTest.setUp, tearDown & setUpClass
     @classmethod
     def setUpClass(cls: Any) -> None:
@@ -158,77 +237,6 @@ class LeoUnitTest(unittest.TestCase):
         val = 'aString'
         self._set_setting(c, kind='string', name=name, val=val)
         self.assertTrue(c.config.getString(name) == val)
-    #@+node:ekr.20210830151601.1: *3* LeoUnitTest.create_test_outline
-    def create_test_outline(self) -> None:
-        p = self.c.p
-        # Create the following outline:
-        #
-        # root
-        #   child clone a
-        #     node clone 1
-        #   child b
-        #     child clone a
-        #       node clone 1
-        #   child c
-        #     node clone 1
-        #   child clone a
-        #     node clone 1
-        #   child b
-        #     child clone a
-        #       node clone 1
-        assert p == self.root_p
-        assert p.h == 'root'
-        # Child a
-        child_clone_a = p.insertAsLastChild()
-        child_clone_a.h = 'child clone a'
-        node_clone_1 = child_clone_a.insertAsLastChild()
-        node_clone_1.h = 'node clone 1'
-        # Child b
-        child_b = p.insertAsLastChild()
-        child_b.h = 'child b'
-        # Clone 'child clone a'
-        clone = child_clone_a.clone()
-        clone.moveToLastChildOf(child_b)
-        # Child c
-        child_c = p.insertAsLastChild()
-        child_c.h = 'child c'
-        # Clone 'node clone 1'
-        clone = node_clone_1.clone()
-        clone.moveToLastChildOf(child_c)
-        # Clone 'child clone a'
-        clone = child_clone_a.clone()
-        clone.moveToLastChildOf(p)
-        # Clone 'child b'
-        clone = child_b.clone()
-        clone.moveToLastChildOf(p)
-    #@+node:ekr.20220806170537.1: *3* LeoUnitTest.dump_string
-    def dump_string(self, s: str, tag: str = None) -> None:
-        if tag:
-            print(tag)
-        g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
-    #@+node:ekr.20220805071838.1: *3* LeoUnitTest._dump_headlines
-    def _dump_headlines(self, c: Cmdr) -> None:  # pragma: no cover
-        """
-        Dump root's headlines, or all headlines if root is None.
-        """
-        print('')
-        g.trace(c.fileName())
-        print('')
-        for p in c.all_positions():
-            print(f"{p.gnx:10}: {' '*p.level()}{p.h}")
-    #@+node:ekr.20211129062220.1: *3* LeoUnitTest.dump_tree
-    def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
-        """
-        Dump root's tree, or the entire tree if root is None.
-        """
-        print('')
-        if tag:
-            print(tag)
-        _iter = root.self_and_subtree if root else self.c.all_positions
-        for p in _iter():
-            print('')
-            print('level:', p.level(), p.h)
-            g.printObj(g.splitLines(p.v.b))
     #@-others
 #@-others
 #@-leo

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -149,7 +149,7 @@ class LeoUnitTest(unittest.TestCase):
         print('')
         for p in c.all_positions():
             head_s = f"{' '*p.level()}{p.h}"
-            print(f"clone? {int(p.isCloned())} {p.gnx:10}: {head_s:<20} parents: {p.v.parents}")
+            print(f"clone? {int(p.isCloned())} {p.gnx:10}: {head_s:<10} parents: {p.v.parents}")
     #@+node:ekr.20220805071838.1: *3* LeoUnitTest.dump_headlines
     def dump_headlines(self, c: Cmdr) -> None:  # pragma: no cover
         """Dump all headlines."""

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -73,13 +73,13 @@
 <v t="ekr.20230713145509.1"><vh>test of parse-body</vh></v>
 <v t="ekr.20230713173540.1"><vh>test of tree abbreviations</vh></v>
 <v t="ekr.20230714023025.1"><vh>script: diff-branches/revs (one file)</vh></v>
-</v>
 <v t="ekr.20230713144259.1"><vh>test of diff-marked-nodes</vh>
 <v t="ekr.20230713144317.1"><vh>node 1</vh>
 <v t="ekr.20230713144328.1"><vh>child 1</vh></v>
 </v>
 <v t="ekr.20230713144405.1"><vh>node 1a</vh>
 <v t="ekr.20230713144405.2"><vh>child 1</vh></v>
+</v>
 </v>
 </v>
 </vnodes>

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -73,13 +73,13 @@
 <v t="ekr.20230713145509.1"><vh>test of parse-body</vh></v>
 <v t="ekr.20230713173540.1"><vh>test of tree abbreviations</vh></v>
 <v t="ekr.20230714023025.1"><vh>script: diff-branches/revs (one file)</vh></v>
+</v>
 <v t="ekr.20230713144259.1"><vh>test of diff-marked-nodes</vh>
 <v t="ekr.20230713144317.1"><vh>node 1</vh>
 <v t="ekr.20230713144328.1"><vh>child 1</vh></v>
 </v>
 <v t="ekr.20230713144405.1"><vh>node 1a</vh>
 <v t="ekr.20230713144405.2"><vh>child 1</vh></v>
-</v>
 </v>
 </v>
 </vnodes>

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -146,24 +146,27 @@ class TestOutlineCommands(LeoUnitTest):
         assert clone.isCloned()  # Fails.
         assert cc.firstChild().isCloned()
         
-        # Undo paste-retaining.clones
-        u.undo()
-        for p in c.all_positions():
-            assert not p.isCloned(), p.h
-            if p.h == 'child1':
-                # The vnode never changes!
-                assert p.v == clone_v, p.h
-            
-        # Redo paste-retaining-clones.
-        u.redo()
-        # self.dump_clone_info(c)
-        for p in c.all_positions():
-            if p.h == 'child1':
-                assert p.isCloned(), p.h
-                # The vnode never changes *and* all positions share the same vnode.
-                assert p.v == clone_v, p.h
-            else:
+        # Test multiple undo/redo cycles.
+        for i in range(3):
+
+            # Undo paste-retaining-clones.
+            u.undo()
+            for p in c.all_positions():
                 assert not p.isCloned(), p.h
+                if p.h == 'child1':
+                    # The vnode never changes!
+                    assert p.v == clone_v, p.h
+
+            # Redo paste-retaining-clones.
+            u.redo()
+            # self.dump_clone_info(c)
+            for p in c.all_positions():
+                if p.h == 'child1':
+                    assert p.isCloned(), p.h
+                    # The vnode never changes *and* all positions share the same vnode.
+                    assert p.v == clone_v, p.h
+                else:
+                    assert not p.isCloned(), p.h
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -13,12 +13,6 @@ class TestOutlineCommands(LeoUnitTest):
     Unit tests for Leo's outline commands.
     """
 
-    def setUp(self) -> None:
-        super().setUp()
-        c = self.c
-        self.create_test_sort_outline()
-        c.selectPosition(c.rootPosition())
-
     #@+others
     #@+node:ekr.20221113064908.1: *3* TestOutlineCommands.create_test_sort_outline
     def create_test_sort_outline(self) -> None:
@@ -41,6 +35,7 @@ class TestOutlineCommands(LeoUnitTest):
     def test_sort_children(self):
         c, u = self.c, self.c.undoer
         assert self.root_p.h == 'root'
+        self.create_test_sort_outline()  ###
         original_children = [z.h for z in self.root_p.v.children]
         sorted_children = sorted(original_children)
         c.sortChildren()
@@ -59,6 +54,7 @@ class TestOutlineCommands(LeoUnitTest):
     def test_sort_siblings(self):
         c, u = self.c, self.c.undoer
         assert self.root_p.h == 'root'
+        self.create_test_sort_outline()  ###
         original_children = [z.h for z in self.root_p.v.children]
         sorted_children = sorted(original_children)
         c.selectPosition(self.root_p.firstChild())
@@ -74,6 +70,60 @@ class TestOutlineCommands(LeoUnitTest):
         u.undo()
         result_children = [z.h for z in self.root_p.v.children]
         self.assertEqual(result_children, original_children)
+    #@+node:ekr.20230720202352.1: *3* TestOutlineCommands.test_paste_retaining_clones
+    def test_paste_retaining_clones(self):
+
+        c = self.c
+        p = c.p
+        assert p == self.root_p
+        assert p.h == 'root'
+        p.deleteAllChildren()
+        while p.hasNext():
+            p.next().doDelete()
+        # cut cc and paste-as-clone again. cc's child1 is surprisingly not a clone!
+        # aa
+        # bb
+        # child1 (clone)
+        # cc
+        #   child1 (clone)
+        #   child2
+        aa = p.insertAfter()
+        aa.h = 'aa'
+        bb = aa.insertAfter()
+        bb.h = 'bb'
+        cc = bb.insertAfter()
+        cc.h = 'cc'
+        child1 = cc.insertAsLastChild()
+        child1.h = 'child1'
+        child1_gnx = child1.gnx
+        child2 = child1.insertAfter()
+        child2.h = 'child2'
+        child2_gnx = child2.gnx
+        clone = child1.clone()
+        clone.moveAfter(bb)
+        assert clone.v == child1.v
+        # Careful: position cc has changed.
+        cc = clone.next()
+        cc_gnx = cc.gnx
+        assert cc.h == 'cc'
+        self.dump_headlines(c)
+        # Cut node cc
+        c.selectPosition(cc)
+        c.cutOutline()
+        self.dump_headlines(c)
+        assert not clone.isCloned()
+        assert c.p == clone
+        assert c.p.h == 'child1'
+        # paste-retaining-clones
+        c.pasteOutlineRetainingClones()
+        self.dump_headlines(c)
+        self.dump_clone_info(c)
+        cc = clone.next()
+        assert cc.gnx == cc_gnx
+        assert cc.firstChild().gnx == child1_gnx
+        assert cc.firstChild().next().gnx == child2_gnx
+        assert clone.isCloned()
+        assert cc.firstChild().isCloned()
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -109,20 +109,24 @@ class TestOutlineCommands(LeoUnitTest):
         self.dump_headlines(c)
         # Cut node cc
         c.selectPosition(cc)
+        self.dump_clone_info(c)
         c.cutOutline()
-        self.dump_headlines(c)
         assert not clone.isCloned()
         assert c.p == clone
         assert c.p.h == 'child1'
         # paste-retaining-clones
         c.pasteOutlineRetainingClones()
-        self.dump_headlines(c)
         self.dump_clone_info(c)
+        # Recreate the positions.
+        clone = bb.next()
         cc = clone.next()
+        child1 = cc.firstChild()
         assert cc.gnx == cc_gnx
+        assert child1.gnx == clone.gnx
+        self.assertEqual(id(child1.v), id(clone.v))
         assert cc.firstChild().gnx == child1_gnx
         assert cc.firstChild().next().gnx == child2_gnx
-        assert clone.isCloned()
+        assert clone.isCloned()  # Fails.
         assert cc.firstChild().isCloned()
     #@-others
 #@-others

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -35,7 +35,7 @@ class TestOutlineCommands(LeoUnitTest):
     def test_sort_children(self):
         c, u = self.c, self.c.undoer
         assert self.root_p.h == 'root'
-        self.create_test_sort_outline()  ###
+        self.create_test_sort_outline()
         original_children = [z.h for z in self.root_p.v.children]
         sorted_children = sorted(original_children)
         c.sortChildren()
@@ -54,7 +54,7 @@ class TestOutlineCommands(LeoUnitTest):
     def test_sort_siblings(self):
         c, u = self.c, self.c.undoer
         assert self.root_p.h == 'root'
-        self.create_test_sort_outline()  ###
+        self.create_test_sort_outline()
         original_children = [z.h for z in self.root_p.v.children]
         sorted_children = sorted(original_children)
         c.selectPosition(self.root_p.firstChild())

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -106,17 +106,20 @@ class TestOutlineCommands(LeoUnitTest):
         cc = clone.next()
         cc_gnx = cc.gnx
         assert cc.h == 'cc'
-        self.dump_headlines(c)
+
         # Cut node cc
+        # self.dump_headlines(c)
+        # self.dump_clone_info(c)
         c.selectPosition(cc)
-        self.dump_clone_info(c)
         c.cutOutline()
         assert not clone.isCloned()
         assert c.p == clone
         assert c.p.h == 'child1'
-        # paste-retaining-clones
+
+        # Execute paste-retaining-clones
         c.pasteOutlineRetainingClones()
-        self.dump_clone_info(c)
+        # self.dump_clone_info(c)
+
         # Recreate the positions.
         clone = bb.next()
         cc = clone.next()


### PR DESCRIPTION
See #3446. Closed in favor of PR #3455.

**Summary**

A blunder in `fc.linkChildrenToParents` has been fixed. This blunder may have affected paste-node as well as paste-retaining-clones.

**Analysis**

Both `child1` positions refer to a clone after `paste-retaining-clones` because both positions refer to the same vnode. But `child1` isn't *shown* as a clone after `paste-retaining-clones` because `child1.parents` has only one entry. 

Leo's drawing code writes a clone mark for `p` if  `p.isCloned()` is `True`.
`p.isCloned()` returns `bool(len(p.v.parents) > 1)`.

**The fix**

`paste-retaining-clones` must set the `v.parents` array correctly.

- [x] Create initially-failing unit test: `TestOutlineCommands.test_paste_retaining_clones`.
   This strong test now passes. It tests multiple cycles of undo/redo.
- [x] Fix a blunder in `fc.linkChildrenToParents`.
  Change: ` if not child.v.parents:` to `if p.v not in child.v.parents:`.

<details><summary>Testing Changes</summary>
<br>

Changes to `leoTest2.py`:

- [x] Add `LeoUnitTest.dump_clone_info`.
  Despite the large diff, `git-diff-pr` shows that this is the only real change.

Changes to `testOutlineCommands.py`:

- [x] Remove `TestOutlineCommands.setUp`.
- [x] Two legacy tests now call `self.create_test_sort_outline()` themselves.

</details>

<details><summary>Test Output: Before Bug Fix</summary>
<br>

The "Before" Dump. Note `child1.parents`.

```console
dump_clone_info C:/Repos/leo-editor/leo/core/LeoPyRef.leo

clone? 0 id(v): 2501595111920 gnx: TestLeoId.20230721053740.2: root       parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112272 gnx: TestLeoId.20230721053740.4: aa         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112448 gnx: TestLeoId.20230721053740.5: bb         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 1 id(v): 2501595112800 gnx: TestLeoId.20230721053740.7: child1     parents: [<VNode TestLeoId.20230721053740.6 cc>, <VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112624 gnx: TestLeoId.20230721053740.6: cc         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 1 id(v): 2501595112800 gnx: TestLeoId.20230721053740.7:  child1    parents: [<VNode TestLeoId.20230721053740.6 cc>, <VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595113152 gnx: TestLeoId.20230721053740.8:  child2    parents: [<VNode TestLeoId.20230721053740.6 cc>]
```

The "after" dump.  gnxs are correct but `v.parents` are not.

```console
dump_clone_info C:/Repos/leo-editor/leo/core/LeoPyRef.leo

clone? 0 id(v): 2501595111920 gnx: TestLeoId.20230721053740.2: root       parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112272 gnx: TestLeoId.20230721053740.4: aa         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112448 gnx: TestLeoId.20230721053740.5: bb         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112800 gnx: TestLeoId.20230721053740.7: child1     parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112624 gnx: TestLeoId.20230721053740.6: cc         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595112800 gnx: TestLeoId.20230721053740.7:  child1    parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2501595113152 gnx: TestLeoId.20230721053740.8:  child2    parents: [<VNode TestLeoId.20230721053740.6 cc>]
```

</details>

<details><summary>Test Output: After Bug Fix</summary>
<br>

"Before" dump:

```console
dump_clone_info C:/Repos/leo-editor/leo/core/LeoPyRef.leo

clone? 0 id(v): 2600108433728 gnx: TestLeoId.20230721060702.2: root       parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2600108434080 gnx: TestLeoId.20230721060702.4: aa         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2600108434256 gnx: TestLeoId.20230721060702.5: bb         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 1 id(v): 2600108434608 gnx: TestLeoId.20230721060702.7: child1     parents: [<VNode TestLeoId.20230721060702.6 cc>, <VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2600108434432 gnx: TestLeoId.20230721060702.6: cc         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 1 id(v): 2600108434608 gnx: TestLeoId.20230721060702.7:  child1    parents: [<VNode TestLeoId.20230721060702.6 cc>, <VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2600108434960 gnx: TestLeoId.20230721060702.8:  child2    parents: [<VNode TestLeoId.20230721060702.6 cc>]
```

"After" Dump. Now all is well.

```console
dump_clone_info C:/Repos/leo-editor/leo/core/LeoPyRef.leo

clone? 0 id(v): 2600108433728 gnx: TestLeoId.20230721060702.2: root       parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2600108434080 gnx: TestLeoId.20230721060702.4: aa         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 0 id(v): 2600108434256 gnx: TestLeoId.20230721060702.5: bb         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 1 id(v): 2600108434608 gnx: TestLeoId.20230721060702.7: child1     parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>, <VNode TestLeoId.20230721060702.6 cc>]
clone? 0 id(v): 2600108434432 gnx: TestLeoId.20230721060702.6: cc         parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>]
clone? 1 id(v): 2600108434608 gnx: TestLeoId.20230721060702.7:  child1    parents: [<VNode hidden-root-vnode-gnx <hidden root vnode>>, <VNode TestLeoId.20230721060702.6 cc>]
clone? 0 id(v): 2600108434960 gnx: TestLeoId.20230721060702.8:  child2    parents: [<VNode TestLeoId.20230721060702.6 cc>]
```

</details>