### PR TITLE
PR: add auto link correction

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2134,7 +2134,7 @@ class Commands:
                 for child_v in parent_v.children:
                     children_n = parent_v.children.count(child_v)
                     parents_n = child_v.parents.count(parent_v)
-                    if children_n != parents_n:
+                    if children_n != parents_n:  # pragma: no cover
                         error_list.append((parent_v, child_v))
                         messages.append(
                             'Error recovery failed!'
@@ -2150,7 +2150,7 @@ class Commands:
         error_list, messages, n = find_errors()
         if n == 0:
             return 0
-        if verbose:
+        if verbose:  # pragma: no cover
             print('\n')
             g.trace(f"{len(messages)} link error{g.plural(len(messages))}:\n")
             print('\n'.join(messages) + '\n')
@@ -2160,10 +2160,10 @@ class Commands:
         fix_errors(error_list)
         undelete_nodes(error_list)
         error_list, messages, n = recheck()
-        if n:
+        if n:  # pragma: no cover
             # Report the *failure* to fix links!
             print('\n'.join(messages))
-        elif verbose:
+        elif verbose:  # pragma: no cover
             g.trace(f"Fixed {old_n} link error{g.plural(old_n)}")
         return n
     #@+node:ekr.20031218072017.1760: *4* c.checkMoveWithParentWithWarning & c.checkDrag

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2093,7 +2093,7 @@ class Commands:
                 children_n = parent_v.children.count(child_v)
                 parents_n = child_v.parents.count(parent_v)
                 if parents_n == children_n:
-                    g.trace('Can not happen: parents_n == children_n')
+                    pass  # Already fixed.
                 elif parents_n < children_n:
                     while parents_n < children_n:
                         # Safe.
@@ -2152,7 +2152,7 @@ class Commands:
             return 0
         if verbose:
             print('\n')
-            g.trace(f"{len(messages)} link errors:\n")
+            g.trace(f"{len(messages)} link error{g.plural(len(messages))}:\n")
             print('\n'.join(messages) + '\n')
         if strict:
             return n

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2160,11 +2160,11 @@ class Commands:
         fix_errors(error_list)
         undelete_nodes(error_list)
         error_list, messages, n = recheck()
-        if verbose:
-            if n:
-                print('\n'.join(messages))
-            else:
-                g.trace(f"Fixed {old_n} link error{g.plural(old_n)}")
+        if n:
+            # Report the *failure* to fix links!
+            print('\n'.join(messages))
+        elif verbose:
+            g.trace(f"Fixed {old_n} link error{g.plural(old_n)}")
         return n
     #@+node:ekr.20031218072017.1760: *4* c.checkMoveWithParentWithWarning & c.checkDrag
     #@+node:ekr.20070910105044: *5* c.checkMoveWithParentWithWarning

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2105,7 +2105,7 @@ class Commands:
                             # Safe.
                             child_v.parents.remove(parent_v)
                             children_n += 1
-                        else:
+                        else:  # pragma: no cover
                             # This could delete the child.
                             parent_v.children.remove(child_v)
                             parents_n += 1
@@ -2115,7 +2115,7 @@ class Commands:
             """Restore a parent link to any node that would otherwise be deleted."""
             seen: list[VNode] = []
             for parent_v, child_v in error_list:
-                if not child_v.parents and child_v not in seen:
+                if not child_v.parents and child_v not in seen:  # pragma: no cover
                     # Add child_v to *one* parent.
                     seen.append(child_v)
                     parent_v.children.append(child_v)
@@ -2154,7 +2154,7 @@ class Commands:
             print('\n')
             g.trace(f"{len(messages)} link error{g.plural(len(messages))}:\n")
             print('\n'.join(messages) + '\n')
-        if strict:
+        if strict:  # pragma: no cover
             return n
         old_n = n
         fix_errors(error_list)
@@ -2182,7 +2182,7 @@ class Commands:
                 clonedVnodes[v] = v
         if not clonedVnodes:
             return True
-        for p in root.self_and_subtree(copy=False):
+        for p in root.self_and_subtree(copy=False):  # pragma: no cover
             if p.isCloned() and clonedVnodes.get(p.v):
                 if not g.unitTesting and warningFlag:
                     c.alert(message)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2137,27 +2137,27 @@ class Commands:
             return error_list, messages, n
         #@-others
 
+        # For unit testing.
+        silent = 'silent' in g.app.debug
+        strict = 'strict' in g.app.debug
+        verbose = not silent
+
         error_list, messages, n = find_errors()
         if n == 0:
             return 0
-        if 'strict' in g.app.debug:  # For unit testing.
+        if strict:
             return n
-        if False:  ### not g.unitTesting:
+        if verbose:
             print('\n'.join(messages))
         old_n = n
-        if 1:  # To be tested!
-            fix_errors(error_list)
-            undelete_nodes(error_list)
-            error_list, messages, n = recheck()
+        fix_errors(error_list)
+        undelete_nodes(error_list)
+        error_list, messages, n = recheck()
+        if verbose:
             if n:
                 print('\n'.join(messages))
             else:
                 g.trace(f"Fixed {old_n} link error{g.plural(old_n)}")
-        else:
-            g.trace(f"{old_n} link error{g.plural(old_n)}")
-            g.trace(g.callers(2))
-            print('')
-            print('\n'.join(messages))
         return n
     #@+node:ekr.20031218072017.1760: *4* c.checkMoveWithParentWithWarning & c.checkDrag
     #@+node:ekr.20070910105044: *5* c.checkMoveWithParentWithWarning

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -895,22 +895,13 @@ class FileCommands:
                 return None
             p._linkCopiedAfter(current)
 
-        # Fix #862: paste-retaining-clones can corrupt the outline.
-        self.linkChildrenToParents(p)
+        # Automatically correct any link errors!
         errors = c.checkOutline()
         if errors > 0:
             return None
         c.selectPosition(p)
         self.initReadIvars()
         return p
-    #@+node:ekr.20180424123010.1: *5* fc.linkChildrenToParents
-    def linkChildrenToParents(self, p: Position) -> None:
-        """
-        Populate the parent links in all children of p.
-        """
-        for child in p.children():
-            child.v.parents.append(p.v)
-            self.linkChildrenToParents(child)
     #@+node:ekr.20180425034856.1: *5* fc.reassignAllIndices
     def reassignAllIndices(self, p: Position) -> None:
         """Reassign all indices in p's subtree."""

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -325,21 +325,32 @@ class Position:
     def archive(self) -> dict[str, Any]:
         """Return a json-like archival dictionary for p/v.unarchive."""
         p = self
+        c = p.v.context
 
-        # Create a list of all vnodes in p.self_and_subtree.
+        # Create an *initial* list of all vnodes in p.self_and_subtree.
         all_unique_vnodes: list[VNode] = []
         for p in p.self_and_subtree():
             if p.v not in all_unique_vnodes:
-                all_unique_vnodes.append(p.b)
+                all_unique_vnodes.append(p.v)
 
-        # Create an archive of all_vnodes.
+        def ref(v: VNode) -> Optional[str]:
+            if v == c.hiddenRootNode:
+                return None
+            if v.gnx not in all_unique_vnodes:
+                all_unique_vnodes.append(v.gnx)
+            return v.gnx
+
         parents_dict: dict[str, list[str]] = {}
-        for v in all_unique_vnodes:
-            parents_dict[v.gnx] = [z.gnx for z in v.parents]
+        for p2 in p.self_and_subtree():
+            v = p2.v
+            parents_list = [ref(z) for z in v.parents]
+            parents_dict[v.gnx] = [z for z in parents_list if z]
 
         children_dict: dict[str, list[str]] = {}
-        for v in all_unique_vnodes:
-            children_dict[v.gnx] = [z.gnx for z in v.children]
+        for p2 in p.self_and_subtree():
+            v = p2.v
+            childrens_list = [ref(z.gnx) for z in v.children]
+            children_dict[v.gnx] = [z for z in childrens_list if z]
 
         marks_dict: dict[str, str] = {}
         for v in all_unique_vnodes:

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -10790,7 +10790,7 @@ def interactive_change_all_unique_regex2(self, event: Event) -> None:  # pragma:
     k.showStateAndMode()
     c.widgetWantsFocusNow(w)
     self.do_change_all(settings)
-#@+node:ekr.20210907103011.1: *3* leo/commands/testCommands.py
+#@+node:ekr.20210907103011.1: *3* coverage commands from leo/commands/testCommands.py
 @first # -*- coding: utf-8 -*-
 """Unit test commands"""
 import os

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -355,7 +355,7 @@ class TestOutlineCommands(LeoUnitTest):
         c = self.c
         p = c.p
         u = c.undoer
-        
+
         # Set flags for checkVnodeLinks.
         # g.app.debug.extend(['test:strict', 'test:verbose'])
 

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -491,8 +491,7 @@ class TestOutlineCommands(LeoUnitTest):
         #@+node:ekr.20230729124541.1: *4* function: do_defect
         def do_defect(parent: Position, child: Position, defect: str) -> bool:
             """
-            Create the defect if possible.
-            Return True if the defect was in fact created.
+            Create the defect if possible. Return True if the defect was created.
             """
             if defect == 'parents:insert':
                 # Insert one for parent_v in child_v.parents.
@@ -521,7 +520,7 @@ class TestOutlineCommands(LeoUnitTest):
         def test(headline: str, parent: Position, child: Position, defect: str) -> int:
             """
             Run all tests on all positions with the given headline with all possible defects.
-            
+
             Return the number of tests actually run.
             """
             # Re-create the tree.
@@ -555,12 +554,12 @@ class TestOutlineCommands(LeoUnitTest):
         def equivalent(p1: Position, p2: Position) -> bool:
             """
             Return True if two positions are structurally equivalent.
-            
+
             Use headlines as proxies for gnx's.
             """
             assert p1 and isinstance(p1, Position), repr(p1)
             assert p2 and isinstance(p2, Position), repr(p2)
-            
+
             # Actual stack entries are tuples (v, childIndex).
             # Create proxy stacks of tuples (headline, childIndex).
             stack1 = [(v.h, index) for (v, index) in p1.stack]

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -515,10 +515,16 @@ class TestOutlineCommands(LeoUnitTest):
                 child.v.parents.append(parent.v)
             elif defect == 'parents:delete':
                 child.v.parents.remove(parent.v)
+            elif defect == 'parents:delete-all':
+                while parent.v in child.v.parents:
+                    child.v.parents.remove(parent.v)
             elif defect == 'children:insert':
                 parent.v.children.append(child.v)
             elif defect == 'children:delete':
                 parent.v.children.remove(child.v)
+            elif defect == 'children:delete-all':
+                while child.v in parent.v.children:
+                    parent.v.children.remove(child.v)
             else:
                 assert False, defect
         #@+node:ekr.20230729124819.1: *4* function: enable_options
@@ -562,6 +568,7 @@ class TestOutlineCommands(LeoUnitTest):
 
         init_dicts()
 
+        # Set options for enable_options().
         # Options: a tuple (selector, option):
         #          Selector: headline or 'all'
         #          Option: 's' for strict, 'v' for verbose or 'sv' for both.
@@ -570,7 +577,9 @@ class TestOutlineCommands(LeoUnitTest):
         )
 
         # The list of all possible defects. See do_defect.
-        defects = ['parents:insert', 'parents:delete', 'children:insert', 'children:delete']
+        defects = [
+            'parents:insert', 'parents:delete', 'parents:delete-all',
+            'children:insert', 'children:delete', 'children:delete-all']
 
         # Test all defects on all positions.
         n_tests, n_positions = 0, 0

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -478,24 +478,82 @@ class TestOutlineCommands(LeoUnitTest):
                     u.redo()
                     self.assertEqual(0, c.checkOutline())
                     test_tree(pasted_flag=True, tag=f"redo {i}")
-    #@+node:ekr.20230729042305.1: *3* TestOutlineCommands.test_c_checkVnodeLinks (To Do)
+    #@+node:ekr.20230729042305.1: *3* TestOutlineCommands.test_c_checkVnodeLinks
     def test_c_checkVnodeLinks(self):
 
         c = self.c
-        # p = c.p
-        # u = c.undoer
 
-        # Create the tree and gnx_dict.
+        # Resources.
+        # self.dump_clone_info(c)
+        # g.printObj(gnx_dict, tag='gnx_dict')
+        # g.printObj(vnodes_list, tag='vnodes_list')
+        # g.printObj([f"{z.gnx:30} {' '*z.level()}{z.h:10} {z.b!r}" for z in c.all_positions()], tag='bodies')
+
+        #@+others  # define helper
+        #@+node:ekr.20230729124541.1: *4* function: do_defect
+        def do_defect(p: Position, defect: str) -> None:
+            pass
+        #@+node:ekr.20230729124819.1: *4* function: enable_options
+        def enable_options(options: str) -> None:
+            """Enable options in g.app.debug."""
+            g.app.debug = []
+            if 's' in options:
+                g.app.debug.append('test:strict')
+            if 'v' in options:
+                g.app.debug.append('test:verbose')
+        #@+node:ekr.20230729124441.1: *4* function: test (test_c_checkVnodeLinks)
+        def test(p: Position, defect: str, options: str) -> None:
+            """Run the test give after creating the given defect."""
+            # Re-create the tree.
+            self.clean_tree()
+            cc = self.create_test_paste_outline()
+            assert cc.h == 'cc'
+
+            # Re-create the vnodes_list and gnx_dict for test_node.
+                # vnodes_list = list(set(list(c.all_nodes())))
+                # gnx_dict = {z.h: z.gnx for z in vnodes_list}
+                # assert gnx_dict
+
+            # Find the node.
+            p = g.findNodeAnywhere(c, headline)
+            self.assertTrue(p, msg=headline)
+
+            # Insert the defect into p or p's parent.
+            do_defect(p, defect)
+
+            # Enable options.
+            enable_options(options)
+
+            # Run the test.
+            self.assertEqual(0, c.checkOutline())
+        #@-others
+
+        # Create the initial tree.
         self.clean_tree()
         cc = self.create_test_paste_outline()
-        assert cc.h == 'cc'
+        self.assertEqual(cc.h, 'cc')
+        headlines = [p.h for p in c.all_unique_positions()]
 
-        # Calculate vnodes and gnx_dict for test_node, before any changes.
-        vnodes = list(set(list(c.all_nodes())))
-        gnx_dict = {z.h: z.gnx for z in vnodes}
-        assert gnx_dict
+        # Options: a tuple (selector, option):
+        #          Selector: headline or 'all'
+        #          Option: 's' for strict, 'v' for verbose or 'sv' for both.
+        options: tuple[tuple[str, str]] = (
+            ('all', 'v'),
+        )
 
-        self.assertEqual(0, c.checkOutline())
+        # Create the list of all possible defects.
+        defects = []
+
+        # Test all actions on all positions for all headlines.
+        n, n_positions = 0, 0
+        for headline in headlines:
+            positions = [z for z in c.all_positions() if z.h == headline]
+            n_positions += len(positions)
+            for p in positions:
+                for defect in defects:
+                    n += 1
+                    test(p, defect, options)
+        # g.trace('Done', n, 'tests', n_positions, 'positions')
     #@+node:ekr.20230722083123.1: *3* TestOutlineCommands.test_restoreFromCopiedTree
     def test_restoreFromCopiedTree(self):
 

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -356,8 +356,11 @@ class TestOutlineCommands(LeoUnitTest):
         p = c.p
         u = c.undoer
 
-        # Set flags for checkVnodeLinks.
+        # This test fails with these flags for checkVnodeLinks.
         # g.app.debug.extend(['test:strict', 'test:verbose'])
+
+        # This test passes (with messages) with this flag:
+        # g.app.debug.append('test:strict')
 
         #@+others  # Define test_tree function.
         #@+node:ekr.20230723160812.1: *4* function: test_tree (test_paste_retaining_clones)
@@ -475,7 +478,7 @@ class TestOutlineCommands(LeoUnitTest):
                     u.redo()
                     self.assertEqual(0, c.checkOutline())
                     test_tree(pasted_flag=True, tag=f"redo {i}")
-    #@+node:ekr.20230729042305.1: *3* TestOutlineCommands.test_c_checkVnodeLinks
+    #@+node:ekr.20230729042305.1: *3* TestOutlineCommands.test_c_checkVnodeLinks (To Do)
     def test_c_checkVnodeLinks(self):
 
         c = self.c

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -490,6 +490,24 @@ class TestOutlineCommands(LeoUnitTest):
                     u.redo()
                     self.assertEqual(0, c.checkOutline())
                     test_tree(pasted_flag=True, tag=f"redo {i}")
+    #@+node:ekr.20230729042305.1: *3* TestOutlineCommands.test_c_checkVnodeLinks
+    def test_c_checkVnodeLinks(self):
+
+        c = self.c
+        # p = c.p
+        # u = c.undoer
+
+        # Create the tree and gnx_dict.
+        self.clean_tree()
+        cc = self.create_test_paste_outline()
+        assert cc.h == 'cc'
+
+        # Calculate vnodes and gnx_dict for test_node, before any changes.
+        vnodes = list(set(list(c.all_nodes())))
+        gnx_dict = {z.h: z.gnx for z in vnodes}
+        assert gnx_dict
+
+        self.assertEqual(0, c.checkOutline())
     #@+node:ekr.20230722083123.1: *3* TestOutlineCommands.test_restoreFromCopiedTree
     def test_restoreFromCopiedTree(self):
 

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -113,22 +113,6 @@ class TestOutlineCommands(LeoUnitTest):
             child.h = h
 
 
-    #@+node:ekr.20230725111522.1: *3* TestOutlineCommands.test_p_v_archive
-    def test_p_v_archive(self):
-
-        self.skipTest('not ready yet')
-        c = self.c
-        p = c.p
-        v = p.v
-        ### Add uAs.
-        p.archive()
-        v.archive()
-        if 0:
-            print('p.archive:')
-            g.printObj(p.archive())
-        if 0:
-            print('v.archive:')
-            g.printObj(v.archive())
     #@+node:ekr.20230724130924.1: *3* TestOutlineCommands.test_paste_as_template
     def test_paste_as_template(self):
 
@@ -368,11 +352,12 @@ class TestOutlineCommands(LeoUnitTest):
     #@+node:ekr.20230722104508.1: *3* TestOutlineCommands.test_paste_retaining_clones
     def test_paste_retaining_clones(self):
 
-        self.skipTest('not ready yet')
-
         c = self.c
         p = c.p
         u = c.undoer
+        
+        # Set flags for checkVnodeLinks.
+        # g.app.debug.extend(['test:strict', 'test:verbose'])
 
         #@+others  # Define test_tree function.
         #@+node:ekr.20230723160812.1: *4* function: test_tree (test_paste_retaining_clones)

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -637,23 +637,6 @@ class TestNodes(LeoUnitTest):
         c.undoer.redo()
         c.undoer.undo()
         c.undoer.redo()
-    #@+node:ekr.20210830095545.52: *4* TestNodes.test_paste_retaining_clones
-    def test_paste_retaining_clones(self):
-        c, p = self.c, self.c.p
-        child = p.insertAsNthChild(0)
-        child.setHeadString('child')
-        self.assertTrue(child)
-        grandChild = child.insertAsNthChild(0)
-        grandChild.setHeadString('grand child')
-        c.selectPosition(child)
-        c.copyOutline()
-        oldVnodes = [p2.v for p2 in child.self_and_subtree()]
-        c.p.contract()  # Essential
-        c.pasteOutlineRetainingClones()
-        self.assertNotEqual(c.p, child)
-        newVnodes = [p2.v for p2 in c.p.self_and_subtree()]
-        for v in newVnodes:
-            self.assertTrue(v in oldVnodes)
     #@+node:ekr.20210830095545.53: *4* TestNodes.test_promote
     def test_promote(self):
         c, p = self.c, self.c.p


### PR DESCRIPTION
See #1183 and #3446.

**Summary**

- Use `c.checkOutline` to fix problems with paste-retaining-clones.
- `c.checkOutline` calls `c.checkVnodeLinks` to check and parent/child links and *recover* from all such errors!

**Details**

- [x] Retire `TestNodes.test_paste_retaining_clones`.
- [x] Enable link correction.
- [x] Always report any failure to fix links.
- [x] Set switches for `c.checkVnodeLinks` via `g.app.debug` using any of the following: 
   `'test:verbose'`, `gnx'`, `'shutdown'`, `'startup'`, `'verbose'`.
   Users can set all but the first of these using the `--trace=xxx` command-line options.
- [x] Hurray! `Replace fc.linkChildrenToParents` with `c.checkOutline`. All tests pass with this change.
- [x] Complete `TestOutlineCommands.test_c_checkVnodeLinks`.
- [x] Bonus: improve `p.archive` :-)
