### PR TITLE
Fixed "compareAnyTwoFiles" by calling "recreateGnxDict" when its done.  Also fixed "recreateGnxDict", which now updates c.fileCommands.gnxDict properly, by including the hiddenRootNode.

### DIFF
--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -293,6 +293,8 @@ class EditFileCommandsClass(BaseEditCommandsClass):
             g.app.forgetOpenFile(fn=c2.fileName())
             c2.frame.destroySelf()
             g.app.gui.set_focus(c, w)
+        # The inserted, deleted and changed dicts nodes may come from c2, a different Commander.
+        c.recreateGnxDict()  # So update c.fileCommands.gnxDict.
     #@+node:ekr.20170806094317.9: *4* efc.computeChangeDicts
     def computeChangeDicts(self, d1: dict, d2: dict) -> tuple[dict, dict, dict]:
         """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3304,6 +3304,10 @@ class Commands:
     def recreateGnxDict(self) -> None:
         """Recreate the gnx dict prior to refreshing nodes from disk."""
         c, d = self, {}
+        # Start with the hidden-root-vnode
+        vHiddenRoot = c.hiddenRootNode
+        d[vHiddenRoot.gnx] = vHiddenRoot
+        # And fill up the with rest of the commander's VNodes.
         for v in c.all_unique_nodes():
             gnxString = v.fileIndex
             if isinstance(gnxString, str):


### PR DESCRIPTION
Small corrections that fix two methods. (compareAnyTwoFiles and recreateGnxDict) I made sure all unittests still pass.
Fixes #3470