### PR TITLE
PR for #3447: show-file-line

### DIFF
--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1514,7 +1514,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 Strip s of all sentinel lines.
                 This may be dubious because it destroys outline structure.
                 """
-                delims = ['#', None, None]
+                delims = ('#', None, None)
                 return ''.join(
                     [z for z in g.splitLines(s) if not g.is_sentinel(z, delims)])
             #@-others

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -992,7 +992,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         k.clearState()
         c.widgetWantsFocus(w)
     #@+node:ekr.20150514063305.225: *3* ec: goto node
-    #@+node:ekr.20170411065920.1: *4* ec.gotoAnyClone
+    #@+node:ekr.20170411065920.1: *4* goto-any-clone
     @cmd('goto-any-clone')
     def gotoAnyClone(self, event: Event = None) -> None:
         """Select then next cloned node, regardless of whether c.p is a clone."""
@@ -1004,7 +1004,7 @@ class EditCommandsClass(BaseEditCommandsClass):
                 return
             p.moveToThreadNext()
         g.es('no clones found after', c.p.h)
-    #@+node:ekr.20150514063305.226: *4* ec.gotoCharacter
+    #@+node:ekr.20150514063305.226: *4* goto-char
     @cmd('goto-char')
     def gotoCharacter(self, event: Event) -> None:
         """Put the cursor at the n'th character of the buffer."""
@@ -1030,7 +1030,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         k.resetLabel()
         k.clearState()
         c.widgetWantsFocus(w)
-    #@+node:ekr.20150514063305.227: *4* ec.gotoGlobalLine
+    #@+node:ekr.20150514063305.227: *4* goto-global-line
     @cmd('goto-global-line')
     def gotoGlobalLine(self, event: Event) -> None:
         """
@@ -1058,7 +1058,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         if n.isdigit():
             # Very important: n is one-based.
             c.gotoCommands.find_file_line(n=int(n))
-    #@+node:ekr.20150514063305.228: *4* ec.gotoLine
+    #@+node:ekr.20150514063305.228: *4* goto-line
     @cmd('goto-line')
     def gotoLine(self, event: Event) -> None:
         """Put the cursor at the n'th line of the buffer."""

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -102,7 +102,7 @@ class GoToCommands:
                     n = self.prev_hidden_lines(delims, contents, i)
                     if n is None:
                         return i + 1
-                    return max(0, i - n + 1)
+                    return max(1, i - n + 1)
                 return i + 1
 
         # #3010: Special case for .vue files.

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -27,6 +27,8 @@ class GoToCommands:
     #@+node:ekr.20100216141722.5622: *3* goto.find_file_line & helper
     def find_file_line(self, n: int, p: Position = None) -> tuple[Position, int]:
         """
+        Helper for goto-global-line command.
+
         Place the cursor on the n'th line (1-based) of an external file.
 
         Return (p, offset) if found or (None, -1) if not found.
@@ -75,7 +77,11 @@ class GoToCommands:
         return None, -1
     #@+node:ekr.20160921210529.1: *3* goto.find_node_start & helper
     def find_node_start(self, p: Position, s: str = None) -> Optional[int]:
-        """Return the 1-based global line number of the first line of p.b"""
+        """
+        Helper for show-file-line command.
+
+        Return the 1-based global line number of the first line of p.b.
+        """
         root, fileName = self.find_root(p)
         if not root:
             return None
@@ -459,6 +465,6 @@ def show_file_line(event: Event) -> None:
     i = w.getInsertPoint()
     s = w.getAllText()
     row, col = g.convertPythonIndexToRowCol(s, i)
-    g.es_print('line', n0 + row)
+    g.es_print('line', n0 + row + 1)  # Returns the same as goto-global-line.
 #@-others
 #@-leo

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -75,7 +75,7 @@ class GoToCommands:
         return None, -1
     #@+node:ekr.20160921210529.1: *3* goto.find_node_start & helper
     def find_node_start(self, p: Position, s: str = None) -> Optional[int]:
-        """Return the one-based global line number of the first line of p.b"""
+        """Return the 1-based global line number of the first line of p.b"""
         # See #283.
         root, fileName = self.find_root(p)
         if not root:
@@ -96,10 +96,8 @@ class GoToCommands:
                 if remove_sentinels:
                     n = self.prev_hidden_lines(delims, contents, i)
                     if n is None:
-                        # g.trace(f"Not found '{p.h}' {i}")
-                        return i
+                        return i + 1
                     else:
-                        # g.trace(f"Found '{p.h}' {i} -> {n + 1}")
                         return max(0, i - n + 1)
                 return i + 1
         # #3010: Special case for .vue files.
@@ -109,7 +107,7 @@ class GoToCommands:
             re.escape('//'), re.escape(p.gnx)))
         for i, s in enumerate(contents):
             if node_pat2.match(s):
-                return i + 1  # Convert to one-based.
+                return i + 1
         return None
     #@+node:ekr.20230803073950.1: *4* goto.prev_hidden_lines
     def prev_hidden_lines(self,

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -96,8 +96,7 @@ class GoToCommands:
                     n = self.prev_hidden_lines(delims, contents, i)
                     if n is None:
                         return i + 1
-                    else:
-                        return max(0, i - n + 1)
+                    return max(0, i - n + 1)
                 return i + 1
 
         # #3010: Special case for .vue files.
@@ -198,16 +197,12 @@ class GoToCommands:
         h:      the headline of the #@+node
         offset: the offset of line n within the node.
         """
-        trace = False
         delim1, delim2 = self.get_delims(root)
         count, gnx, h, offset = 0, root.gnx, root.h, 0
         stack = [(gnx, h, offset),]
-        if trace:
-            g.trace(n, root.h)
         for s in lines:
             is_sentinel = self.is_sentinel(delim1, delim2, s)
-            if trace:
-                print(f"count: {count:2} offset: {offset} {s!r}")
+            # print(f"count: {count:2} offset: {offset} {s!r}")
             if is_sentinel:
                 s2 = s.strip()[len(delim1) :]  # Works for blackened sentinels.
                 if s2.startswith('@+node'):

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -462,6 +462,6 @@ def show_file_line(event: Event) -> None:
     i = w.getInsertPoint()
     s = w.getAllText()
     row, col = g.convertPythonIndexToRowCol(s, i)
-    g.es_print('line', n0 + row)  ### 1 + n0 + row)
+    g.es_print('line', n0 + row)
 #@-others
 #@-leo

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -345,7 +345,7 @@ class GoToCommands:
                         if fileName:
                             return p2.copy(), fileName
         return None, None
-    #@+node:ekr.20150625123747.1: *4* goto.get_delims & goto.get_3_delims
+    #@+node:ekr.20150625123747.1: *4* goto.get_delims
     def get_delims(self, root: Position) -> tuple[str, str]:
         """Return the two start/end delimiters in effect at root."""
         c = self.c
@@ -359,7 +359,7 @@ class GoToCommands:
         if delims1:
             return delims1, None
         return delims2, delims3
-
+    #@+node:ekr.20230804034631.1: *4* goto.get_3_delims
     def get_3_delims(self, root: Position) -> tuple[str, str, str]:
         """Return all three comment delimiters in effect at root."""
         c = self.c

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1562,6 +1562,20 @@ class AtFile:
         except Exception:
             at.writeException(fileName, root)
             return ''
+    #@+node:ekr.20230804025627.1: *6* at.AtCleanToString
+    def atCleanToString(self, root: Position) -> str:  # pragma: no cover
+        """Write one @clean node to a string."""
+        at, c = self, self.c
+        try:
+            c.endEditing()
+            fileName = at.initWriteIvars(root)
+            at.sentinels = False
+            at.outputList = []
+            at.putFile(root, sentinels=False)
+            return '' if at.errors else ''.join(at.outputList)
+        except Exception:
+            at.writeException(fileName, root)
+            return ''
     #@+node:ekr.20190109160056.3: *6* at.atEditToString
     def atEditToString(self, root: Position) -> str:  # pragma: no cover
         """Write one @edit node."""

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1562,7 +1562,7 @@ class AtFile:
         except Exception:
             at.writeException(fileName, root)
             return ''
-    #@+node:ekr.20230804025627.1: *6* at.AtCleanToString
+    #@+node:ekr.20230804025627.1: *6* at.atCleanToString
     def atCleanToString(self, root: Position) -> str:  # pragma: no cover
         """Write one @clean node to a string."""
         at, c = self, self.c

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7142,11 +7142,13 @@ def is_invisible_sentinel(delims: tuple[str, str, str], contents: list[str], i: 
     s2 = line2.strip()[len(delim1) :]
     if s1.startswith('@verbatim'):
         return False  # *This* line is visible in the outline.
-    if s2.startswith(('@+others', '@+<<', '@@')):
+    if s2.startswith('@@'):
+        # Directives are visible in the outline, but not the external file.
+        return True
+    if s2.startswith(('@+others', '@+<<')):
         #@verbatim
-        # @others, section reference or Leo directive.
-        # Visibible in both the outline and external file.
-        return False
+        # @others and section references are visibible everywhere.
+        return True
     # Not visible anywhere. For example, @+leo, @-leo, @-others, @+node, @-node.
     return True
 #@+node:EKR.20040504154039: *3* g.is_sentinel

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7156,7 +7156,6 @@ def is_sentinel(line: str, delims: tuple[str, str, str]) -> bool:
 
     Leo 6.7.2: Support blackened sentinels.
     """
-    assert len(delims) == 3, (repr(delims), g.callers())  ###
     delim1, delim2, delim3 = delims
     # Defensive code. Make *sure* delim has no trailing space.
     if delim1:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7118,7 +7118,7 @@ def insertCodingLine(encoding: str, script: str) -> str:
             script = ''.join(lines)
     return script
 #@+node:ekr.20230803155851.1: ** g.Sentinels
-#@+node:ekr.20230803160315.1: *3* g.is_invisible_sentinel (new)
+#@+node:ekr.20230803160315.1: *3* g.is_invisible_sentinel
 def is_invisible_sentinel(delims: tuple[str, str, str], contents: list[str], i: int) -> bool:
     """
     delims are the comment delims in effect.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7130,11 +7130,13 @@ def is_invisible_sentinel(delims: tuple[str, str, str], contents: list[str], i: 
     but not the external file.
     """
     delim1 = delims[0] or delims[1]
+
     # Get previous line, to test for previous @verbatim sentinel.
     line1 = contents[i - 1] if i > 0 else ''  # previous line.
     line2 = contents[i]
     if not g.is_sentinel(line2, delims):
         return False  # Non-sentinels are visible everywhere.
+
     # Strip off the leading sentinel comment. Works for blackened sentinels.
     s1 = line1.strip()[len(delim1) :]
     s2 = line2.strip()[len(delim1) :]

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -62,13 +62,20 @@ class TestGotoCommands(TestOutlineCommands):
         clean_contents = [visible_line_in_outline(z) for z in contents if visible_line_in_outline(z)]
         assert clean_contents
 
+        # g.printObj(contents, tag='With sentinels')
+        # g.printObj(clean_contents, tag='No sentinels')
+
         # Test all lines of all nodes.
         for node_i, p in enumerate(c.all_positions()):
-            g.trace(p.h)
-            p_offset = x.find_node_start(p=p) - 1  # Convert to zero-based.
-            assert p_offset >= 0, p.h
 
-        g.printObj(clean_contents, tag='Clean contents')
+            p_offset = x.find_node_start(p) - 1
+            assert p_offset is not None, p.h
+            line = clean_contents[p_offset]
+            if p.h.startswith('@clean'):
+                assert line == '@language python\n', (p_offset, repr(p.h), repr(line))
+            else:
+                # print(f"{p.h:10} {p_offset:3} {line}")
+                assert p.h in line, (p_offset, repr(p.h), repr(line))
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -42,32 +42,23 @@ class TestGotoCommands(TestOutlineCommands):
         # self.dump_clone_info(c)
         delim1, delim2 = x.get_delims(root)
         assert (delim1, delim2) == ('#', None)
-
-        def visible_line_in_outline(line: str) -> bool:
-            """Return True if the line is visible in the outline."""
-            if not x.is_sentinel(delim1, delim2, line):
-                return line
-            s = line.lstrip()[len(delim1) :]
-            if s.startswith('@+others'):
-                return '@others\n'  # A small hack.
-            if s.startswith('@+<<'):
-                return s[2:]
-            if s.startswith('@@'):
-                return s[1:]
-            return None
+        delims = x.get_3_delims(root)
 
         # A shortcut. All body lines are unique.
         contents_s = x.get_external_file_with_sentinels(root)
         contents = g.splitLines(contents_s)
-        clean_contents = [visible_line_in_outline(z) for z in contents if visible_line_in_outline(z)]
-        assert clean_contents
-
+        # Remove invisible sentinels and convert visible sentinels to
+        # their corresponding line in the outline.
+        clean_contents = [
+            z.replace('#@', '').replace('+others', '@others')
+            for i, z in enumerate(contents)
+            if not g.is_invisible_sentinel(delims, contents, i)
+        ]
         # g.printObj(contents, tag='With sentinels')
         # g.printObj(clean_contents, tag='No sentinels')
 
         # Test all lines of all nodes.
         for node_i, p in enumerate(c.all_positions()):
-
             p_offset = x.find_node_start(p) - 1
             assert p_offset is not None, p.h
             line = clean_contents[p_offset]

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -74,7 +74,7 @@ class TestGotoCommands(TestOutlineCommands):
         # g.printObj(contents, tag='With sentinels')
         # g.printObj(clean_contents, tag='No sentinels')
 
-        # Test 1: A strong test of is_invisible_sentinel.
+        # Test 1: A strong test of g.is_invisible_sentinel.
         self.assertEqual(real_clean_contents, clean_contents)
         #@+<< Test 2: test the helper for show-file-line >>
         #@+node:ekr.20230804094419.1: *4* << Test 2: test the helper for show-file-line >>

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -15,63 +15,60 @@ class TestGotoCommands(TestOutlineCommands):
     #@+others
     #@+node:ekr.20230802060444.1: *3* TestGotoCommands.test_show_file_line
     def test_show_file_line(self):
-        
+
         c = self.c
         x = GoToCommands(c)
         self.clean_tree()
         self.create_test_paste_outline()
-        
+
+        # Demote all of the root's headlines!
+        c.demote()
+
         # Add body text to each node.
         root = c.rootPosition()
         assert root.h == 'root'
         root.h = '@clean test.py'  # Make the root an @clean node.
-        root.b = '@language python\n'
         for v in c.all_unique_nodes():
             for i in range(2):
-               v.b += f"{v.h} line {i}\n"
-        root.b += '@others\n'
-        
-        if 0:
-            for node_i, p in enumerate(c.all_positions()):
-                print(f"\nnode {node_i} {p.h}")
-                for body_i, line in enumerate(g.splitLines(p.b)):
-                    print(f"{body_i}: {line!r}")
-        
-        # Compute expected line numbers.
-        expected_lines: list[list[int]] = []
-        file_line_number = 0
-        for p in c.all_positions():
-            expected_node_lines = []
-            for line in g.splitLines(p.b):
-                if line.startswith('@'):
-                    expected_node_lines.append(max(0, file_line_number-1))
-                else:
-                    expected_node_lines.append(file_line_number)
-                    file_line_number += 1
-            expected_lines.append(expected_node_lines)
-            
-        self.assertEqual(len(expected_lines), len(list(c.all_positions())))
-            
-        # trace/test expected line numbers:
-        trace = True
+                v.b += f"{v.h} line {i}\n"
+        root.b = (
+            '@language python\n'
+            'before\n'
+            '@others\n'
+            'after\n'
+        )
+
+        # self.dump_headlines(c)
+        # self.dump_clone_info(c)
+        delim1, delim2 = x.get_delims(root)
+        assert (delim1, delim2) == ('#', None)
+
+        def visible_line_in_outline(line: str) -> bool:
+            """Return True if the line is visible in the outline."""
+            if not x.is_sentinel(delim1, delim2, line):
+                return line
+            s = line.lstrip()[len(delim1) :]
+            if s.startswith('@+others'):
+                return '@others\n'  # A small hack.
+            if s.startswith('@+<<'):
+                return s[2:]
+            if s.startswith('@@'):
+                return s[1:]
+            return None
+
+        # A shortcut. All body lines are unique.
+        contents_s = x.get_external_file_with_sentinels(root)
+        contents = g.splitLines(contents_s)
+        clean_contents = [visible_line_in_outline(z) for z in contents if visible_line_in_outline(z)]
+        assert clean_contents
+
+        # Test all lines of all nodes.
         for node_i, p in enumerate(c.all_positions()):
-            msg = f"node {node_i} {p.h}"
-            if trace:
-                print(f"\n{msg}")
-            p_offset = x.find_node_start(p=p)
-            self.assertFalse(p_offset is None, msg=msg)
-            node_lines = g.splitLines(p.b)
-            expected_node_lines = expected_lines[node_i]
-            self.assertEqual(len(node_lines), len(expected_node_lines), msg=f"\nnode {node_i} {p.h}")
-            for line_i, line in enumerate(node_lines):
-                expected_line = expected_node_lines[line_i]
-                msg = f"line {line_i}: file line: {expected_line} {line!r}"
-                if trace:
-                    print(msg)
-                self.assertEqual(p_offset + line_i, expected_line, msg=msg)
-                
-        # g.printObj(expected_lines)
-                    
+            g.trace(p.h)
+            p_offset = x.find_node_start(p=p) - 1  # Convert to zero-based.
+            assert p_offset >= 0, p.h
+
+        g.printObj(clean_contents, tag='Clean contents')
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -1,0 +1,21 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20230802060212.1: * @file ../unittests/commands/test_gotoCommands.py
+"""Tests of leo.commands.gotoCommands."""
+from leo.core import leoGlobals as g
+from leo.core.leoTest2 import LeoUnitTest
+assert g
+
+#@+others
+#@+node:ekr.20230802060212.2: ** class TestGotoCommands(LeoUnitTest)
+class TestGotoCommands(LeoUnitTest):
+    """Unit tests for leo/commands/gotoCommands.py."""
+
+    #@+others
+    #@+node:ekr.20230802060444.1: *3* TestGotoCommands.test_show_file_line
+    def test_show_file_line(self):
+        
+        self.fail('Not ready yet')
+    #@-others
+
+#@-others
+#@-leo

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -2,20 +2,76 @@
 #@+node:ekr.20230802060212.1: * @file ../unittests/commands/test_gotoCommands.py
 """Tests of leo.commands.gotoCommands."""
 from leo.core import leoGlobals as g
-from leo.core.leoTest2 import LeoUnitTest
+# from leo.core.leoTest2 import LeoUnitTest
+from leo.commands.gotoCommands import GoToCommands
+from leo.unittests.commands.test_outlineCommands import TestOutlineCommands
 assert g
 
 #@+others
-#@+node:ekr.20230802060212.2: ** class TestGotoCommands(LeoUnitTest)
-class TestGotoCommands(LeoUnitTest):
+#@+node:ekr.20230802060212.2: ** class TestGotoCommands(TestOutlineCommands)
+class TestGotoCommands(TestOutlineCommands):
     """Unit tests for leo/commands/gotoCommands.py."""
 
     #@+others
     #@+node:ekr.20230802060444.1: *3* TestGotoCommands.test_show_file_line
     def test_show_file_line(self):
         
-        self.fail('Not ready yet')
+        c = self.c
+        x = GoToCommands(c)
+        self.clean_tree()
+        self.create_test_paste_outline()
+        
+        # Add body text to each node.
+        root = c.rootPosition()
+        assert root.h == 'root'
+        root.h = '@clean test.py'  # Make the root an @clean node.
+        root.b = '@language python\n'
+        for v in c.all_unique_nodes():
+            for i in range(2):
+               v.b += f"{v.h} line {i}\n"
+        root.b += '@others\n'
+        
+        if 0:
+            for node_i, p in enumerate(c.all_positions()):
+                print(f"\nnode {node_i} {p.h}")
+                for body_i, line in enumerate(g.splitLines(p.b)):
+                    print(f"{body_i}: {line!r}")
+        
+        # Compute expected line numbers.
+        expected_lines: list[list[int]] = []
+        file_line_number = 0
+        for p in c.all_positions():
+            expected_node_lines = []
+            for line in g.splitLines(p.b):
+                if line.startswith('@'):
+                    expected_node_lines.append(max(0, file_line_number-1))
+                else:
+                    expected_node_lines.append(file_line_number)
+                    file_line_number += 1
+            expected_lines.append(expected_node_lines)
+            
+        self.assertEqual(len(expected_lines), len(list(c.all_positions())))
+            
+        # trace/test expected line numbers:
+        trace = True
+        for node_i, p in enumerate(c.all_positions()):
+            msg = f"node {node_i} {p.h}"
+            if trace:
+                print(f"\n{msg}")
+            p_offset = x.find_node_start(p=p)
+            self.assertFalse(p_offset is None, msg=msg)
+            node_lines = g.splitLines(p.b)
+            expected_node_lines = expected_lines[node_i]
+            self.assertEqual(len(node_lines), len(expected_node_lines), msg=f"\nnode {node_i} {p.h}")
+            for line_i, line in enumerate(node_lines):
+                expected_line = expected_node_lines[line_i]
+                msg = f"line {line_i}: file line: {expected_line} {line!r}"
+                if trace:
+                    print(msg)
+                self.assertEqual(p_offset + line_i, expected_line, msg=msg)
+                
+        # g.printObj(expected_lines)
+                    
     #@-others
-
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -118,8 +118,8 @@ class TestGotoCommands(TestOutlineCommands):
                     assert p.h in line, (p.h, line)
 
             # Test show-file-line.
-            show_offset = x.find_node_start(p) - 1
-            assert show_offset >= 0, (show_offset, p.h)
+            show_offset = x.find_node_start(p)
+            assert show_offset not in (None, -1), (show_offset, p.h)
 
             # Test goto-global-line.
             goto_p, goto_offset = x.find_file_line(global_i)

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -64,10 +64,10 @@ class TestGotoCommands(TestOutlineCommands):
         # g.printObj(contents, tag='With sentinels')
         # g.printObj(clean_contents, tag='No sentinels')
 
-        # A strong test of is_invisible_sentinel.
+        # Test 1: A strong test of is_invisible_sentinel.
         self.assertEqual(real_clean_contents, clean_contents)
 
-        # Test 1: x.find_node_start returns the 1-based index of the first line of each node.
+        # Test 2: x.find_node_start returns the 1-based index of the first line of each node.
         for node_i, p in enumerate(c.all_positions()):
             offset = x.find_node_start(p) - 1
             assert offset is not None, p.h
@@ -80,12 +80,10 @@ class TestGotoCommands(TestOutlineCommands):
                 # print(f"{p.h:10} {offset:3} {line}")
                 assert p.h in line, (offset, repr(p.h), repr(line))
 
-        # Test 2: x.find_file_line returns the expected node and offset.
+        # Test 3: x.find_file_line returns the expected node and offset.
         for i, clean_line in enumerate(clean_contents):
             p, offset = x.find_file_line(i)
-            if offset == -1:
-                g.trace('Not found', i, repr(clean_line))
-                continue
+            assert offset is not None, repr(p)
             assert offset > 0, (offset, repr(p))
             line = g.splitLines(p.b)[offset-1]
             # g.trace(f"{i:>2} {offset} {p.h:20} {line!r}")

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -496,7 +496,6 @@ class TestOutlineCommands(LeoUnitTest):
         #@+others  # define helpers
         #@+node:ekr.20230730070124.1: *4* function: init_dicts
         def init_dicts() -> None:
-            ### nonlocal vnodes_list, children_dict, parents_dict
             for z in vnodes_list:
                 children_dict [z.gnx] = z.children[:]
             for z in vnodes_list:


### PR DESCRIPTION
See #3447.

- This PR fixes several problems with the `show-file-line` command and adds an extensive new unit test.
- However, this command contains a bug that can not be fixed with any reasonable amount of work.
- The command is seldom used, but I see no urgent reason to retire it.
  Otoh, I see no reason for `show-file-line` to exist in leoJS.

<details><summary>Details</summary>
<br>

- [x] Add `g. is_invisible_sentinel`. This new resource handles all the details correctly.
- [x] Add `at.atCleanToString`, an independent check on `g. is_invisible_sentinel`.
- [x] Add `goto.prev_hidden_lines`.  It calls `g. is_invisible_sentinel`.
- [x] Add `goto.get_3_delims`. It simplifies calling `g.is_sentinels`.
- [x] Revise `goto.find_node_start`, fixing several bugs.
- [x] Add `TestGotoCommands.test_show_file_line`.
  - [x] Test equivalence of `at.atCleanToString` and `g. is_invisible_sentinel`.
  - [x] Test `goto.find_node_start`, the helper for `show-file-line`.
  - [x] Test `goto.find_file_line`, the helper for `goto-global-line`.

</details>
