### PR TITLE
PR for #3476: diff-marked-nodes

### DIFF
--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -688,7 +688,6 @@ def diffMarkedNodes(event: Event) -> None:
         p = root.insertAsLastChild()
         p.h = f"diff {n}"
         p.b = f"1: {p1.h}\n2: {p2.h}\n{''.join(list(lines))}"
-        u.afterInsertNode(p, undoType, undoData)
         for p3 in (p1, p2):
             clone = p3.clone()
             clone.moveToLastChildOf(p)

--- a/leo/unittests/core/test_leoCompare.py
+++ b/leo/unittests/core/test_leoCompare.py
@@ -47,15 +47,23 @@ class TestCompare(LeoUnitTest):
         for p, h, b in table:
             p.h = h
             p.b = b
+            
+        self.assertEqual(0, len(u.beads))  # #3476.
         self.assertEqual(c.lastTopLevel(), root)
+        self.assertEqual(0, c.checkOutline())
 
         # Run the command.
         diffMarkedNodes(event={'c': c})
-        self.assertEqual(c.lastTopLevel().h, 'diff marked nodes')
-        u.undo()
-        self.assertEqual(c.lastTopLevel(), root)
-        u.redo()
-        self.assertEqual(c.lastTopLevel().h, 'diff marked nodes')
+        for i in range(3):
+            self.assertEqual(1, len(u.beads))  # #3476.
+            self.assertEqual(0, c.checkOutline())
+            self.assertEqual(c.lastTopLevel().h, 'diff marked nodes')
+            u.undo()
+            self.assertEqual(0, c.checkOutline())
+            self.assertEqual(c.lastTopLevel(), root)
+            u.redo()
+            self.assertEqual(0, c.checkOutline())
+            self.assertEqual(c.lastTopLevel().h, 'diff marked nodes')
     #@+node:ekr.20230714160900.1: *3* TestCompare.test_diff_list_of_files
     def test_diff_list_of_files(self):
 

--- a/leo/unittests/core/test_leoCompare.py
+++ b/leo/unittests/core/test_leoCompare.py
@@ -47,7 +47,7 @@ class TestCompare(LeoUnitTest):
         for p, h, b in table:
             p.h = h
             p.b = b
-            
+
         self.assertEqual(0, len(u.beads))  # #3476.
         self.assertEqual(c.lastTopLevel(), root)
         self.assertEqual(0, c.checkOutline())


### PR DESCRIPTION
See #3476.

- [x] Modify an existing unit test for `diff-marked-nodes` so it fails with legacy code and passes with the new code.
- [x] Remove redundant call to `u.afterInsertNode`.