### PR TITLE
PR: for #3479: Support @bool search-links-backwards

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1456,6 +1456,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             return
         url = p.get_UNL()
         g.app.gui.replaceClipboardWith(url)
+        print('gnx:', url)
         status_line = getattr(c.frame, "statusLine", None)
         if status_line:
             status_line.put(url)

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -514,6 +514,7 @@
 <v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20220624062948.1"><vh>@bool redirect-execute-script-output-to-log_pane = False</vh></v>
+<v t="ekr.20230804112912.1"><vh>@bool search-links-backwards=True</vh></v>
 <v t="ekr.20180117074230.1"><vh>@bool show-tips = True</vh></v>
 <v t="ekr.20060323131801"><vh>@bool warn-about-missing-settings = False</vh></v>
 <v t="ekr.20220105172501.1"><vh>@data add-mypy-annotations</vh></v>
@@ -11675,6 +11676,11 @@ False:          Display only the .leo file's name in the status area.
 
 # test.leo:    c:/Repos/leo-editor/leo/test
 # LeoDocs.leo: c:/Repos/leo-editor/leo/doc</t>
+<t tx="ekr.20230804112912.1">This setting tells how Leo should search when the user clicks a clickable link.
+
+True:  (Recommended) Search backwards from the end of the outline.
+False: (Legacy)      Search forwards from the start of the outline.
+</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7323,10 +7323,8 @@ def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
             n = int(m.group(2))
         except(TypeError, ValueError):
             pass
-    positions: Any = c.all_unique_positions()
-    if c.config.getBool('search-links-backwards', default=True):
-        positions = reversed(list(positions))
-    for p in positions:
+    # Search forwards, setting p2.
+    for p in c.all_unique_positions():
         if p.gnx == gnx:
             if n is None:
                 return p

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7323,7 +7323,10 @@ def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
             n = int(m.group(2))
         except(TypeError, ValueError):
             pass
-    for p in c.all_unique_positions():
+    positions: Any = c.all_unique_positions()
+    if c.config.getBool('search-links-backwards', default=True):
+        positions = reversed(list(positions))
+    for p in positions:
         if p.gnx == gnx:
             if n is None:
                 return p


### PR DESCRIPTION
See #3479. 

**Important changes**

- [x] `goto.find_gnx2` always tests `c.p` first, regardless of search direction.
- [x] Support `@bool search-links-backwards` in `goto.find_gnx2`.
- [x] Add `@bool search-links-backwards=True` to `leoSettings.leo`.

**Other changes**

- [x] Remove two unused kwargs from `goto.find_gnx2`.
- [x] Add print statement to `show-gnx`.
