### PR TITLE
PR for #3482: check-uas command

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -40,6 +40,7 @@ except Exception:
 #
 # Leo imports.
 from leo.core import leoGlobals as g
+from leo.core import leoNodes
 #@-<< checkerCommands imports >>
 #@+<< checkerCommands annotations >>
 #@+node:ekr.20220826075856.1: ** << checkerCommands annotations >>
@@ -95,6 +96,23 @@ def check_nodes(event: Event) -> None:
       Default: None.
     """
     CheckNodes().check(event)
+#@+node:ekr.20230807081137.1: *3* check-uas
+@g.command('check-uas')
+@g.command('show-uas')
+@g.command('uas-check')
+def check_uas(event: Event) -> None:
+    c = event and event.get('c')
+    if not c:
+        return
+    old_debug = g.app.debug
+    g.app.debug = ['uas']  # Enable traces in v.archive_uas.
+    try:
+        for v in c.all_unique_nodes():
+            d = v.archive_uas()
+            if d:
+                leoNodes.dump_archive(d, tag=f"uAs for {v.h}...")
+    finally:
+        g.app.debug = old_debug
 #@+node:ekr.20190608084751.1: *3* find-long-lines
 @g.command('find-long-lines')
 def find_long_lines(event: Event) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2678,7 +2678,7 @@ class LoadManager:
                 A comma-separated list. Valid values are:
                 abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
                 importers, ipython, keys, layouts, plugins, save, select, sections,
-                shutdown, size, speed, startup, themes, undo, verbose, zoom.
+                shutdown, size, speed, startup, themes, uas, undo, verbose, zoom.
 
           --trace-binding=KEY   trace commands bound to a key
           --trace-setting=NAME  trace where named setting is set
@@ -2821,7 +2821,7 @@ class LoadManager:
                 'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
                 'focus', 'git', 'gnx', 'importers', 'ipython', 'keys',
                 'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
-                'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
+                'size', 'speed', 'startup', 'themes', 'uas', 'undo', 'verbose', 'zoom',
             ]
             m = utils.find_complex_option(r'--trace=([\w\,]+)')
             if not m:


### PR DESCRIPTION
See #3482.

- [x] Add `check-uas` commands and two aliases to `checkerCommands.py`.
- [x] Add support for `--trace-uas` to `leoApp.py`.
- [x] Add `v.archive_uas` and archive-related functions to `leoNodes.py`.