### PR TITLE
PR: Remove updateBodies

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -330,8 +330,6 @@ def pasteAsTemplate(self: Cmdr, event: Event = None) -> None:
         xvelements = xroot.find('vnodes')  # <v> elements.
         xtelements = xroot.find('tnodes')  # <t> elements.
         bodies, uas = x.scanTnodes(xtelements)
-        # g.printObj(bodies, tag='bodies/gnx2body')
-        x.updateBodies(bodies, x.gnx2vnode)
         root_gnx = xvelements[0].attrib.get('t')  # the gnx of copied node
     else:
         xroot = json.loads(s)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -172,7 +172,6 @@ class FastRead:
         t_elements = xroot.find('tnodes')
         gnx2body, gnx2ua = self.scanTnodes(t_elements)
         hidden_v = self.scanVnodes(gnx2body, self.gnx2vnode, gnx2ua, v_elements)
-        self.updateBodies(gnx2body, self.gnx2vnode)
         self.handleBits()
         return hidden_v, g_element
     #@+node:ekr.20180624125321.1: *4* fast.handleBits (reads c.db)
@@ -302,7 +301,7 @@ class FastRead:
                     if s:
                         gnx2ua[gnx][key] = s
         return gnx2body, gnx2ua
-    #@+node:ekr.20180602062323.9: *4* fast.scanVnodes & helper
+    #@+node:ekr.20180602062323.9: *4* fast.scanVnodes
     def scanVnodes(self,
         gnx2body: dict[str, str],
         gnx2vnode: dict[str, VNode],
@@ -386,16 +385,6 @@ class FastRead:
         # Traverse the tree of v elements.
         v_element_visitor(v_elements, hidden_v)
         return hidden_v
-    #@+node:ekr.20230724092804.1: *4* fast.updateBodies
-    def updateBodies(self, gnx2body: dict[str, str], gnx2vnode: dict[str, VNode]) -> None:
-        """Update bodies to enforce the "pasted wins" policy."""
-        for gnx in gnx2body:
-            body = gnx2body[gnx]
-            try:
-                v = gnx2vnode[gnx]
-                v.b = body
-            except KeyError:
-                pass
     #@+node:felix.20220621221215.1: *3* fast.readFileFromJsonClipboard
     def readFileFromJsonClipboard(self, s: str) -> VNode:
         """
@@ -428,7 +417,6 @@ class FastRead:
             gnx2ua.update(d.get('uas', {}))  # User attributes in their own dict for leojs files
             gnx2body = self.scanJsonTnodes(t_elements)
             hidden_v = self.scanJsonVnodes(gnx2body, self.gnx2vnode, gnx2ua, v_elements)
-            self.updateBodies(gnx2body, self.gnx2vnode)
             self.handleBits()
         except Exception:
             g.trace(f"Error .leojs JSON is not valid: {path}")

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -96,7 +96,7 @@ class LeoUnitTest(unittest.TestCase):
     The base class for all unit tests in Leo.
 
     Contains setUp/tearDown methods and various utilites.
-    
+
     This class must not contain any  test_* methods!
     """
 

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -96,6 +96,8 @@ class LeoUnitTest(unittest.TestCase):
     The base class for all unit tests in Leo.
 
     Contains setUp/tearDown methods and various utilites.
+    
+    This class must not contain any  test_* methods!
     """
 
     @classmethod

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -144,7 +144,7 @@ class LeoUnitTest(unittest.TestCase):
         while p.hasNext():
             p.next().doDelete()
     #@+node:ekr.20230724141139.1: *4* LeoUnitTest.copy_node
-    def copy_node(self, is_json=False) -> str:
+    def copy_node(self, is_json: bool = False) -> str:
         """Copy c.p to the clipboard."""
         c = self.c
         if is_json:

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -134,18 +134,26 @@ class LeoUnitTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.c = None
-    #@+node:ekr.20230703103458.1: *3* LeoUnitTest._set_setting
-    def _set_setting(self, c: Cmdr, kind: str, name: str, val: Any) -> None:
-        """
-        Call c.config.set with the given args, suppressing stdout.
-        """
-        try:
-            old_stdout = sys.stdout
-            sys.stdout = open(os.devnull, 'w')
-            c.config.set(p=None, kind=kind, name=name, val=val)
-        finally:
-            sys.stdout = old_stdout
-    #@+node:ekr.20210830151601.1: *3* LeoUnitTest.create_test_outline
+    #@+node:ekr.20230808113454.1: *3* LeoUnitTest: setup utils
+    #@+node:ekr.20230724140745.1: *4* LeoUnitTest.clean_tree
+    def clean_tree(self) -> None:
+        """Clear everything but the root node."""
+        p = self.root_p
+        assert p.h == 'root'
+        p.deleteAllChildren()
+        while p.hasNext():
+            p.next().doDelete()
+    #@+node:ekr.20230724141139.1: *4* LeoUnitTest.copy_node
+    def copy_node(self, is_json=False) -> str:
+        """Copy c.p to the clipboard."""
+        c = self.c
+        if is_json:
+            s = c.fileCommands.outline_to_clipboard_json_string()
+        else:
+            s = c.fileCommands.outline_to_clipboard_string()
+        g.app.gui.replaceClipboardWith(s)
+        return s
+    #@+node:ekr.20210830151601.1: *4* LeoUnitTest.create_test_outline
     def create_test_outline(self) -> None:
         p = self.c.p
         # Create the following outline:
@@ -188,7 +196,104 @@ class LeoUnitTest(unittest.TestCase):
         # Clone 'child b'
         clone = child_b.clone()
         clone.moveToLastChildOf(p)
-    #@+node:ekr.20230720210931.1: *3* LeoUnitTest.dump_clone_info
+    #@+node:ekr.20230724140451.1: *4* LeoUnitTest.create_test_paste_outline
+    def create_test_paste_outline(self) -> Position:
+        """
+        Create the following tree:
+
+            aa
+                aa:child1
+            bb
+            cc:child1 (clone)
+            cc
+              cc:child1 (clone)
+              cc:child2
+            dd
+              dd:child1
+                dd:child1:child1
+              dd:child2
+            ee
+
+        return cc.
+        """
+        c = self.c
+        root = c.rootPosition()
+        aa = root.insertAfter()
+        aa.h = 'aa'
+        aa_child1 = aa.insertAsLastChild()
+        aa_child1.h = 'aa:child1'
+        bb = aa.insertAfter()
+        bb.h = 'bb'
+        cc = bb.insertAfter()
+        cc.h = 'cc'
+        cc_child1 = cc.insertAsLastChild()
+        cc_child1.h = 'cc:child1'
+        cc_child2 = cc_child1.insertAfter()
+        cc_child2.h = 'cc:child2'
+        dd = cc.insertAfter()
+        dd.h = 'dd'
+        dd_child1 = dd.insertAsLastChild()
+        dd_child1.h = 'dd:child1'
+        dd_child2 = dd.insertAsLastChild()
+        dd_child2.h = 'dd:child2'
+        dd_child1_child1 = dd_child1.insertAsLastChild()
+        dd_child1_child1.h = 'dd:child1:child1'
+        ee = dd.insertAfter()
+        ee.h = 'ee'
+        clone = cc_child1.clone()
+        clone.moveAfter(bb)
+        assert clone.v == cc_child1.v
+        # Careful: position cc has changed.
+        cc = clone.next().copy()
+        # Initial checks.
+        assert cc.h == 'cc'
+        # Make *sure* clones are as expected.
+        for p in c.all_positions():
+            if p.h == 'cc:child1':
+                assert p.isCloned(), p.h
+            else:
+                assert not p.isCloned(), p.h
+        return cc
+    #@+node:ekr.20221113064908.1: *4* LeoUnitTest.create_test_sort_outline
+    def create_test_sort_outline(self) -> None:
+        """Create a test outline suitable for sort commands."""
+        p = self.c.p
+        assert p == self.root_p
+        assert p.h == 'root'
+        table = (
+            'child a',
+            'child z',
+            'child b',
+            'child w',
+        )
+        for h in table:
+            child = p.insertAsLastChild()
+            child.h = h
+
+
+    #@+node:ekr.20230703103458.1: *3* LeoUnitTest._set_setting
+    def _set_setting(self, c: Cmdr, kind: str, name: str, val: Any) -> None:
+        """
+        Call c.config.set with the given args, suppressing stdout.
+        """
+        try:
+            old_stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            c.config.set(p=None, kind=kind, name=name, val=val)
+        finally:
+            sys.stdout = old_stdout
+    #@+node:ekr.20230808113542.1: *3* LeoUnitTest: dumps
+    #@+node:ekr.20230724174102.1: *4* LeoUnitTest.dump_bodies
+    def dump_bodies(self, c: Cmdr) -> None:  # pragma: no cover
+        """Dump all headlines."""
+        print('')
+        g.trace(c.fileName())
+        print('')
+        for p in c.all_positions():
+            head_s = f"{' '*p.level()} {p.h}"
+            print(f"{p.gnx:<28} {head_s:<20} body: {p.b!r}")
+
+    #@+node:ekr.20230720210931.1: *4* LeoUnitTest.dump_clone_info
     def dump_clone_info(self, c: Cmdr, tag: str = None) -> None:
         """Dump all clone info."""
         print('')
@@ -200,17 +305,7 @@ class LeoUnitTest(unittest.TestCase):
                 f"clone? {int(p.isCloned())} id(v): {id(p.v)} gnx: {p.gnx:30}: "
                 f"{head_s:<10} parents: {p.v.parents}"
             )
-    #@+node:ekr.20230724174102.1: *3* LeoUnitTest.dump_bodies
-    def dump_bodies(self, c: Cmdr) -> None:  # pragma: no cover
-        """Dump all headlines."""
-        print('')
-        g.trace(c.fileName())
-        print('')
-        for p in c.all_positions():
-            head_s = f"{' '*p.level()} {p.h}"
-            print(f"{p.gnx:<28} {head_s:<20} body: {p.b!r}")
-
-    #@+node:ekr.20220805071838.1: *3* LeoUnitTest.dump_headlines
+    #@+node:ekr.20220805071838.1: *4* LeoUnitTest.dump_headlines
     def dump_headlines(self, c: Cmdr, tag: str = None) -> None:  # pragma: no cover
         """Dump all headlines."""
         print('')
@@ -218,12 +313,12 @@ class LeoUnitTest(unittest.TestCase):
         print('')
         for p in c.all_positions():
             print(f"{p.gnx:25}: {' '*p.level()}{p.h}")
-    #@+node:ekr.20220806170537.1: *3* LeoUnitTest.dump_string
+    #@+node:ekr.20220806170537.1: *4* LeoUnitTest.dump_string
     def dump_string(self, s: str, tag: str = None) -> None:
         if tag:
             print(tag)
         g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
-    #@+node:ekr.20211129062220.1: *3* LeoUnitTest.dump_tree
+    #@+node:ekr.20211129062220.1: *4* LeoUnitTest.dump_tree
     def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
         """
         Dump root's tree, or the entire tree if root is None.

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -2,14 +2,13 @@
 #@+node:ekr.20230802060212.1: * @file ../unittests/commands/test_gotoCommands.py
 """Tests of leo.commands.gotoCommands."""
 from leo.core import leoGlobals as g
-# from leo.core.leoTest2 import LeoUnitTest
+from leo.core.leoTest2 import LeoUnitTest
 from leo.commands.gotoCommands import GoToCommands
-from leo.unittests.commands.test_outlineCommands import TestOutlineCommands
 assert g
 
 #@+others
-#@+node:ekr.20230802060212.2: ** class TestGotoCommands(TestOutlineCommands)
-class TestGotoCommands(TestOutlineCommands):
+#@+node:ekr.20230802060212.2: ** class TestGotoCommands(LeoUnitTest)
+class TestGotoCommands(LeoUnitTest):
     """Unit tests for leo/commands/gotoCommands.py."""
 
     #@+others

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -356,6 +356,8 @@ class TestOutlineCommands(LeoUnitTest):
         p = c.p
         u = c.undoer
 
+        g.trace(g.callers(20))
+
         # This test fails with these flags for checkVnodeLinks.
         # g.app.debug.extend(['test:strict', 'test:verbose'])
 

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -20,99 +20,6 @@ class TestOutlineCommands(LeoUnitTest):
     """
 
     #@+others
-    #@+node:ekr.20230724140745.1: *3* TestOutlineCommands.clean_tree
-    def clean_tree(self) -> None:
-        """Clear everything but the root node."""
-        p = self.root_p
-        assert p.h == 'root'
-        p.deleteAllChildren()
-        while p.hasNext():
-            p.next().doDelete()
-    #@+node:ekr.20230724141139.1: *3* TestOutlineCommands.copy_node
-    def copy_node(self, is_json=False) -> str:
-        """Copy c.p to the clipboard."""
-        c = self.c
-        if is_json:
-            s = c.fileCommands.outline_to_clipboard_json_string()
-        else:
-            s = c.fileCommands.outline_to_clipboard_string()
-        g.app.gui.replaceClipboardWith(s)
-        return s
-    #@+node:ekr.20230724140451.1: *3* TestOutlineCommands.create_test_paste_outline
-    def create_test_paste_outline(self) -> Position:
-        """
-        Create the following tree:
-
-            aa
-                aa:child1
-            bb
-            cc:child1 (clone)
-            cc
-              cc:child1 (clone)
-              cc:child2
-            dd
-              dd:child1
-                dd:child1:child1
-              dd:child2
-            ee
-
-        return cc.
-        """
-        c = self.c
-        root = c.rootPosition()
-        aa = root.insertAfter()
-        aa.h = 'aa'
-        aa_child1 = aa.insertAsLastChild()
-        aa_child1.h = 'aa:child1'
-        bb = aa.insertAfter()
-        bb.h = 'bb'
-        cc = bb.insertAfter()
-        cc.h = 'cc'
-        cc_child1 = cc.insertAsLastChild()
-        cc_child1.h = 'cc:child1'
-        cc_child2 = cc_child1.insertAfter()
-        cc_child2.h = 'cc:child2'
-        dd = cc.insertAfter()
-        dd.h = 'dd'
-        dd_child1 = dd.insertAsLastChild()
-        dd_child1.h = 'dd:child1'
-        dd_child2 = dd.insertAsLastChild()
-        dd_child2.h = 'dd:child2'
-        dd_child1_child1 = dd_child1.insertAsLastChild()
-        dd_child1_child1.h = 'dd:child1:child1'
-        ee = dd.insertAfter()
-        ee.h = 'ee'
-        clone = cc_child1.clone()
-        clone.moveAfter(bb)
-        assert clone.v == cc_child1.v
-        # Careful: position cc has changed.
-        cc = clone.next().copy()
-        # Initial checks.
-        assert cc.h == 'cc'
-        # Make *sure* clones are as expected.
-        for p in c.all_positions():
-            if p.h == 'cc:child1':
-                assert p.isCloned(), p.h
-            else:
-                assert not p.isCloned(), p.h
-        return cc
-    #@+node:ekr.20221113064908.1: *3* TestOutlineCommands.create_test_sort_outline
-    def create_test_sort_outline(self) -> None:
-        """Create a test outline suitable for sort commands."""
-        p = self.c.p
-        assert p == self.root_p
-        assert p.h == 'root'
-        table = (
-            'child a',
-            'child z',
-            'child b',
-            'child w',
-        )
-        for h in table:
-            child = p.insertAsLastChild()
-            child.h = h
-
-
     #@+node:ekr.20230724130924.1: *3* TestOutlineCommands.test_paste_as_template
     def test_paste_as_template(self):
 
@@ -355,8 +262,8 @@ class TestOutlineCommands(LeoUnitTest):
         c = self.c
         p = c.p
         u = c.undoer
-
-        g.trace(g.callers(20))
+        self.skipTest('not ready yet')  ###
+        return  ###
 
         # This test fails with these flags for checkVnodeLinks.
         # g.app.debug.extend(['test:strict', 'test:verbose'])

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -262,8 +262,6 @@ class TestOutlineCommands(LeoUnitTest):
         c = self.c
         p = c.p
         u = c.undoer
-        self.skipTest('not ready yet')  ###
-        return  ###
 
         # This test fails with these flags for checkVnodeLinks.
         # g.app.debug.extend(['test:strict', 'test:verbose'])
@@ -286,7 +284,7 @@ class TestOutlineCommands(LeoUnitTest):
                     seen.add(p.v)
                     if p.h in cloned_headlines:
                         assert p.isCloned(), f"{tag_s}: not cloned: {p.h}"
-                        assert p.b, f"{tag_s} {p.h}: unexpected empty body text: {p.b!r}"
+                        # assert p.b, f"{tag_s} {p.h}: unexpected empty body text: {p.b!r}"
                     else:
                         assert not p.isCloned(), f"{tag_s}: is cloned: {p.h}"
                     message = f"{tag}: p.gnx: {p.gnx} != expected {gnx_dict.get(p.h)}"

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -263,11 +263,9 @@ class TestOutlineCommands(LeoUnitTest):
         p = c.p
         u = c.undoer
 
-        # This test fails with these flags for checkVnodeLinks.
-        # g.app.debug.extend(['test:strict', 'test:verbose'])
-
-        # This test passes (with messages) with this flag:
-        # g.app.debug.append('test:strict')
+        # These tests fail in Leo 6.7.4. To be corrected in Leo 6.7.5.
+        # g.app.debug.extend(['test:strict'])
+        # g.app.debug.extend(['test:verbose'])
 
         #@+others  # Define test_tree function.
         #@+node:ekr.20230723160812.1: *4* function: test_tree (test_paste_retaining_clones)
@@ -284,14 +282,14 @@ class TestOutlineCommands(LeoUnitTest):
                     seen.add(p.v)
                     if p.h in cloned_headlines:
                         assert p.isCloned(), f"{tag_s}: not cloned: {p.h}"
-                        # assert p.b, f"{tag_s} {p.h}: unexpected empty body text: {p.b!r}"
+                        assert p.b, f"{tag_s} {p.h}: unexpected empty body text: {p.b!r}"
                     else:
                         assert not p.isCloned(), f"{tag_s}: is cloned: {p.h}"
                     message = f"{tag}: p.gnx: {p.gnx} != expected {gnx_dict.get(p.h)}"
                     assert gnx_dict.get(p.h) == p.gnx, message
 
                 # Test that all and *only* the expected nodes exist.
-                if test_kind == 'copy' or tag.startswith(('redo', 'paste-')):
+                if test_kind == 'copy' or tag.startswith(('redo', 'paste')):
                     for z in seen:
                         assert z in vnodes, f"p.v not in vnodes: {z.gnx}, {z.h}"
                     for z in vnodes:
@@ -322,6 +320,9 @@ class TestOutlineCommands(LeoUnitTest):
             'root', 'aa', 'aa:child1', 'bb', 'dd', 'dd:child1', 'dd:child1:child1', 'dd:child2', 'ee',
         )
         for target_headline in valid_target_headlines:
+
+            # print(f"\nTarget headline: {target_headline}\n")
+
             for test_kind, is_json in (
                 ('cut', True), ('cut', False), ('copy', True), ('copy', False),
             ):
@@ -356,9 +357,6 @@ class TestOutlineCommands(LeoUnitTest):
                     c.selectPosition(cc)
                     self.copy_node(is_json)
 
-                    # Restore the empty bodies of cc and cc:child1 before the paste.
-                    cc.b = cc_child1.b = ''  # Copy does not change these positions.
-
                 self.assertEqual(0, c.checkOutline())
 
                 # Pretest: select all positions in the tree.
@@ -375,7 +373,7 @@ class TestOutlineCommands(LeoUnitTest):
 
                 # Check the paste.
                 self.assertEqual(0, c.checkOutline())
-                test_tree(pasted_flag=True, tag='paste-retaining-clones')
+                test_tree(pasted_flag=True, tag='paste')
 
                 # Check multiple undo/redo cycles.
                 for i in range(3):


### PR DESCRIPTION
- [x] Remove `updateBodies`.
- [x] Reorganize test classes.
  - All test classes should be subclasses of either `unittest.TestCase` or `LeoUnitTest`.
  - `LeoUnitTest` should contain all setup utilities.
- [x] Fix failing unit test by disabling dubious test code.