### PR TITLE
PR for #3514: improve python importer

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4379,13 +4379,7 @@ class Commands:
         """
         #@-<< docstring >>
         c = self
-        ###
-            # if not dir_:
-                # g.es_print('Missing dir_ argument')
-                # return
-            # if not g.os_path_exists(dir_):
-                # g.es_print(f"Directory/file does not exist: {dir_}")
-                # return
+
         # Import all files in dir_ after c.p.
         try:
             from leo.core import leoImport

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4377,12 +4377,13 @@ class Commands:
         """
         #@-<< docstring >>
         c = self
-        if not dir_:
-            g.es_print('Missing dir_ argument')
-            return
-        if not g.os_path_exists(dir_):
-            g.es_print(f"Directory/file does not exist: {dir_}")
-            return
+        ###
+            # if not dir_:
+                # g.es_print('Missing dir_ argument')
+                # return
+            # if not g.os_path_exists(dir_):
+                # g.es_print(f"Directory/file does not exist: {dir_}")
+                # return
         # Import all files in dir_ after c.p.
         try:
             from leo.core import leoImport

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1823,7 +1823,7 @@ class Commands:
                 raise ValueError(f"Invalid position: {p!r}")
             c._currentPosition = c.rootPosition()
             g.trace('Invalid position', repr(p), repr(c))
-            g.trace(g.callers())
+            g.printObj(g.callers(20).split(','), tag='Callers')
 
     # For compatibility with old scripts.
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4361,12 +4361,14 @@ class Commands:
         Recursively import all python files in a directory and clean the results.
 
         Parameters::
-            dir_              The root directory or file to import.
+            dir_              The path to a directory or file.
+                              Relative paths must exist relative to the outline's directory.
             kind              One of ('@clean','@edit','@file','@nosent').
             recursive=True    True: recurse into subdirectories.
             safe_at_file=True True: produce @@file nodes instead of @file nodes.
             theTypes=None     A list of file extensions to import.
                               None is equivalent to ['.py']
+            verbose=False     True: report imported directories.
 
         This method cleans imported files as follows:
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1719,42 +1719,6 @@ class RecursiveImportController:
         if self.kind not in ('@auto', '@edit'):
             self.remove_empty_nodes(p)
         self.clear_dirty_bits(p)
-        ### self.add_class_names(p)
-    #@+node:ekr.20180524100258.1: *5* ric.add_class_names
-    def add_class_names(self, p: Position) -> None:
-        """Add class names to headlines for all descendant nodes."""
-        return  #########
-        after, class_name = None, None
-        class_paren_pattern = re.compile(r'(.*)\(.*\)\.(.*)')
-        paren_pattern = re.compile(r'(.*)\(.*\.py\)')
-        for p in p.self_and_subtree(copy=False):
-            # Part 1: update the status.
-            m = self.file_pattern.match(p.h)
-            if m:
-                after, class_name = None, None
-                continue
-            if p.h.startswith('@path '):
-                after, class_name = None, None
-            elif p.h.startswith('class '):
-                class_name = p.h[5:].strip()
-                if class_name:
-                    after = p.nodeAfterTree()
-                    continue
-            elif p == after:
-                after, class_name = None, None
-
-            # Part 2: update the headline.
-            if class_name:
-                if p.h.startswith(class_name):
-                    m = class_paren_pattern.match(p.h)
-                    if m:
-                        p.h = f"{m.group(1)}.{m.group(2).lstrip()}".rstrip()
-                else:
-                    p.h = f"{class_name}.{p.h.lstrip()}"
-            else:
-                m = paren_pattern.match(p.h)
-                if m:
-                    p.h = m.group(1).rstrip()
     #@+node:ekr.20130823083943.12608: *5* ric.clear_dirty_bits
     def clear_dirty_bits(self, p: Position) -> None:
         c = self.c

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1599,7 +1599,7 @@ class RecursiveImportController:
         self.n_files: int = 0
         self.recursive = recursive
         self.root: Position = None
-        self.root_directory: str = None  # Set by ric.run.
+        self.outline_directory: str = None  # Set by ric.run.
         self.safe_at_file = safe_at_file
         self.theTypes = theTypes
         self.verbose = verbose
@@ -1635,7 +1635,7 @@ class RecursiveImportController:
     def error(self, message: str) -> None:
         """Print an error message."""
         g.es_print(message, color='red')
-    #@+node:ekr.20130823083943.12613: *3* ric.run & helpers
+    #@+node:ekr.20130823083943.12613: *3* ric.run
     def run(self, dir_: Optional[str]) -> None:
         """
         dir_ can be None, a directory contained in the outline's directory, or a single file.
@@ -1651,15 +1651,15 @@ class RecursiveImportController:
         # All computations use forward slashes.
         if dir_ is not None:
             dir_ = dir_.replace('\\', '/')
-        self.root_directory = self.compute_root_directory(dir_)
-        if not self.root_directory:
+        self.outline_directory = self.compute_root_directory(dir_)
+        if not self.outline_directory:
             self.error(f"{dir_!r} is outside of the outline's directory")
             return
         if dir_ is None:
-            dir_ = self.root_directory
+            dir_ = self.outline_directory
         # All computations use forward slashes.
         assert '\\' not in dir_, repr(dir_)
-        assert '\\' not in self.root_directory, repr(self.root_directory)
+        assert '\\' not in self.outline_directory, repr(self.outline_directory)
         try:
             c, u = self.c, self.c.undoer
             t1 = time.time()
@@ -1701,7 +1701,8 @@ class RecursiveImportController:
         files = []
         if not os.path.exists(dir_):
             self.error(f"Not found: {dir_!r}")
-        elif g.os_path_isfile(dir_):
+            return  ###
+        if g.os_path_isfile(dir_):
             files = [dir_]
         else:
             if self.verbose:
@@ -1762,7 +1763,7 @@ class RecursiveImportController:
         Traverse p's tree, replacing all nodes that start with prefix
         by the smallest equivalent @path or @file node.
         """
-        assert self.root_directory
+        assert self.outline_directory
         self.fix_back_slashes(p)
         for p2 in p.subtree():
             self.minimize_headline(p2)
@@ -1794,11 +1795,11 @@ class RecursiveImportController:
         Create an @path directive in  @<file> nodes.
         """
 
-        # The root_directory is the outline's directory.
-        assert os.path.isabs(self.root_directory), repr(self.root_directory)
+        # The outline_directory is the outline's directory.
+        assert os.path.isabs(self.outline_directory), repr(self.outline_directory)
 
         # The paths of all @<file> nodes should start with root_dir.
-        root_dir = self.root_directory.replace('\\', '/')
+        root_dir = self.outline_directory.replace('\\', '/')
         len_root_dir = len(root_dir)
 
         def rel_path(path: str) -> str:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1690,7 +1690,7 @@ class RecursiveImportController:
             c.redraw(parent)
         if not g.unitTesting:
             t2 = time.time()
-            n = len(list(parent.self_and_subtree()))
+            n = len(list(parent.subtree()))
             g.es_print(
                 f"imported {n} node{g.plural(n)} "
                 f"in {self.n_files} file{g.plural(self.n_files)} "
@@ -1701,7 +1701,7 @@ class RecursiveImportController:
         files = []
         if not os.path.exists(dir_):
             self.error(f"Not found: {dir_!r}")
-            return  ###
+            return
         if g.os_path_isfile(dir_):
             files = [dir_]
         else:
@@ -1843,8 +1843,9 @@ class RecursiveImportController:
                     return True
             return False
 
+        # Never remove p itself!
         aList = [
-            p2 for p2 in p.self_and_subtree()
+            p2 for p2 in p.subtree()
                 if not p2.b.strip() and not has_significant_children(p2)]
         if aList:
             c.deletePositionsInList(aList)  # Don't redraw.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1719,11 +1719,11 @@ class RecursiveImportController:
         if self.kind not in ('@auto', '@edit'):
             self.remove_empty_nodes(p)
         self.clear_dirty_bits(p)
-        self.add_class_names(p)
+        ### self.add_class_names(p)
     #@+node:ekr.20180524100258.1: *5* ric.add_class_names
     def add_class_names(self, p: Position) -> None:
         """Add class names to headlines for all descendant nodes."""
-        # pylint: disable=no-else-continue
+        return  #########
         after, class_name = None, None
         class_paren_pattern = re.compile(r'(.*)\(.*\)\.(.*)')
         paren_pattern = re.compile(r'(.*)\(.*\.py\)')
@@ -1731,11 +1731,9 @@ class RecursiveImportController:
             # Part 1: update the status.
             m = self.file_pattern.match(p.h)
             if m:
-                # prefix = m.group(1)
-                # fn = g.shortFileName(p.h[len(prefix):].strip())
                 after, class_name = None, None
                 continue
-            elif p.h.startswith('@path '):
+            if p.h.startswith('@path '):
                 after, class_name = None, None
             elif p.h.startswith('class '):
                 class_name = p.h[5:].strip()
@@ -1744,22 +1742,19 @@ class RecursiveImportController:
                     continue
             elif p == after:
                 after, class_name = None, None
+
             # Part 2: update the headline.
             if class_name:
                 if p.h.startswith(class_name):
                     m = class_paren_pattern.match(p.h)
                     if m:
-                        p.h = f"{m.group(1)}.{m.group(2)}".rstrip()
+                        p.h = f"{m.group(1)}.{m.group(2).lstrip()}".rstrip()
                 else:
-                    p.h = f"{class_name}.{p.h}"
+                    p.h = f"{class_name}.{p.h.lstrip()}"
             else:
                 m = paren_pattern.match(p.h)
                 if m:
                     p.h = m.group(1).rstrip()
-            # elif fn:
-                # tag = ' (%s)' % fn
-                # if not p.h.endswith(tag):
-                    # p.h += tag
     #@+node:ekr.20130823083943.12608: *5* ric.clear_dirty_bits
     def clear_dirty_bits(self, p: Position) -> None:
         c = self.c

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1737,9 +1737,10 @@ class RecursiveImportController:
             path = norm(p.h[len(kind) :].strip())
             if path.startswith(outline_dir):
                 file_name = os.path.basename(path)
-                r_path = rel_path(path)
+                dir_name = os.path.dirname(path)
+                r_path = rel_path(dir_name)
                 p.h = f"{kind} {file_name}"
-                if r_path and '/' in r_path:
+                if r_path: ###  and '/' in r_path:
                     p.b = f"@path {r_path}\n{p.b}"
             return
 
@@ -1845,7 +1846,7 @@ class RecursiveImportController:
             self.n_files = 0
             if g.os_path_isfile(dir_):
                 if self.verbose:
-                    g.es_print(f"\nimporting file: {dir!r}")
+                    g.es_print(f"\nimporting file: {dir_!r}")
                 self.import_one_file(dir_, parent)
             else:
                 self.import_dir(dir_, parent)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1740,7 +1740,7 @@ class RecursiveImportController:
                 dir_name = os.path.dirname(path)
                 r_path = rel_path(dir_name)
                 p.h = f"{kind} {file_name}"
-                if r_path: ###  and '/' in r_path:
+                if r_path:
                     p.b = f"@path {r_path}\n{p.b}"
             return
 
@@ -1846,6 +1846,7 @@ class RecursiveImportController:
             self.n_files = 0
             if g.os_path_isfile(dir_):
                 if self.verbose:
+                    # Only print this message if importing a *single* file.
                     print('')
                     g.es_print(f"importing file: {os.path.normpath(dir_)}")
                 self.import_one_file(dir_, parent)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1577,7 +1577,7 @@ class MORE_Importer:
 #@+node:ekr.20130823083943.12596: ** class RecursiveImportController
 class RecursiveImportController:
     """Recursively import all python files in a directory and clean the result."""
-    
+
     # Similar to p.isAnyAtFileNode, but not the same.
     file_pattern = re.compile(r'^(@@|@)(auto|clean|edit|file|nosent)')
 
@@ -1620,7 +1620,7 @@ class RecursiveImportController:
             files = [dir_]
         else:
             if self.verbose:
-                g.es_print(f"importing directory: {dir_}")
+                g.es_print(f"importing directory: {os.path.normpath(dir_)}")
             files = list(sorted(os.listdir(dir_)))
         dirs, files2 = [], []
         for path in files:
@@ -1711,7 +1711,6 @@ class RecursiveImportController:
 
         fix_back_slashes has converted backslashes to forward slashes.
         """
-
 
         # The outline_directory is the outline's directory.
         assert os.path.isabs(self.outline_directory), repr(self.outline_directory)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1846,7 +1846,8 @@ class RecursiveImportController:
             self.n_files = 0
             if g.os_path_isfile(dir_):
                 if self.verbose:
-                    g.es_print(f"\nimporting file: {dir_!r}")
+                    print('')
+                    g.es_print(f"importing file: {os.path.normpath(dir_)}")
                 self.import_one_file(dir_, parent)
             else:
                 self.import_dir(dir_, parent)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1830,10 +1830,6 @@ class RecursiveImportController:
             self.error(f"invalid 'dir_' argument: {dir_1!r}")
             return
 
-        # All computations from here on use forward slashes.
-        ### dir_ = dir_.replace('\\', '/')
-        ### self.outline_directory = self.outline_directory.replace('\\', '/')
-
         # Import all requested files.
         try:
             c, u = self.c, self.c.undoer

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1596,17 +1596,10 @@ class RecursiveImportController:
         self.file_pattern = re.compile(r'^(@@|@)(auto|clean|edit|file|nosent)')
         self.ignore_pattern = ignore_pattern or re.compile(r'\.git|node_modules')
         self.kind = kind  # in ('@auto', '@clean', '@edit', '@file', '@nosent')
+        self.n_files: int = 0
         self.recursive = recursive
         self.root: Position = None
-        self.root_directory = None  # Set by ric.run.
-
-        ###
-        # self.root_directory = dir_ if os.path.isdir(dir_) else os.path.dirname(dir_)
-        # # Adjust the root directory.
-        # assert dir_ and self.root_directory, dir_
-        # self.root_directory = self.root_directory.replace('\\', '/')
-        # if self.root_directory.endswith('/'):
-            # self.root_directory = self.root_directory[:-1]
+        self.root_directory: str = None  # Set by ric.run.
         self.safe_at_file = safe_at_file
         self.theTypes = theTypes
         self.verbose = verbose
@@ -1615,10 +1608,10 @@ class RecursiveImportController:
         """
         dir_ can be None, a directory contained in the outline's directory, or
         a single file.
-        
+
         Return leo's directory if dir_'s directory is the outline's directory
         or a subdirectory.
-        
+
         There is no need to call os.path.relpath in this class. The paths of
         all imported files start with the outline's directory.
         """
@@ -1643,7 +1636,7 @@ class RecursiveImportController:
         dir_ can be None, a directory contained in the outline's directory, or a single file.
 
         Import all files in the dir_ directory, or the outline's directory if dir_ is None.
-        
+
         Import all files whose extension matches self.theTypes in dir_.
         In fact, dir_ can be a path to a single file.
         """
@@ -1802,8 +1795,8 @@ class RecursiveImportController:
         # The paths of all @<file> nodes should start with root_dir.
         root_dir = self.root_directory.replace('\\', '/')
         len_root_dir = len(root_dir)
-        
-        def rel_path(path):
+
+        def rel_path(path: str) -> str:
             path = path[len_root_dir:].strip()
             if path.startswith('/'):
                 path = path[1:]

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -775,8 +775,6 @@ class LeoImportCommands:
                 u.afterInsertNode(p, 'Import', undoData)
                 p = self.createOutline(parent=p)
                 if p:  # createOutline may fail.
-                    if self.verbose and not g.unitTesting:
-                        g.blue("imported", g.shortFileName(fn) if shortFn else fn)
                     p.contract()
                     p.setDirty()
                     c.setChanged()
@@ -1579,6 +1577,10 @@ class MORE_Importer:
 #@+node:ekr.20130823083943.12596: ** class RecursiveImportController
 class RecursiveImportController:
     """Recursively import all python files in a directory and clean the result."""
+    
+    # Similar to p.isAnyAtFileNode, but not the same.
+    file_pattern = re.compile(r'^(@@|@)(auto|clean|edit|file|nosent)')
+
     #@+others
     #@+node:ekr.20130823083943.12615: *3*  ric.ctor
     def __init__(self, c: Cmdr,
@@ -1593,7 +1595,6 @@ class RecursiveImportController:
     ) -> None:
         """Ctor for RecursiveImportController class."""
         self.c = c
-        self.file_pattern = re.compile(r'^(@@|@)(auto|clean|edit|file|nosent)')
         self.ignore_pattern = ignore_pattern or re.compile(r'\.git|node_modules')
         self.kind = kind  # in ('@auto', '@clean', '@edit', '@file', '@nosent')
         self.n_files: int = 0
@@ -1619,7 +1620,7 @@ class RecursiveImportController:
             files = [dir_]
         else:
             if self.verbose:
-                g.es_print(f"importing directory: {dir!r}")
+                g.es_print(f"importing directory: {dir_}")
             files = list(sorted(os.listdir(dir_)))
         dirs, files2 = [], []
         for path in files:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -585,8 +585,11 @@ class LeoImportCommands:
         ext, s = self.init_import(ext, fileName, s)
         if s is None:
             return None
-        # The so-called scanning func is a callback. It must have a c argument.
-        func = self.dispatch(ext, p)
+
+        # Each importer file defines `do_import` at the top level with this signature:
+        # def do_import(c: Cmdr, parent: Position, s: str) -> None:
+
+        func = self.dispatch(ext, p)  # The do_import callback.
         # Call the scanning function.
         if g.unitTesting:
             assert func or ext in ('.txt', '.w', '.xxx'), (repr(func), ext, p.h)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -274,6 +274,7 @@ class Importer:
         Importer.import_from_string.
 
         parent: An @<file> node containing the absolute path to the to-be-imported file.
+
         s: The contents of the file.
 
         The top-level code for almost all importers.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -326,9 +326,10 @@ class Importer:
     #@+node:ekr.20230825095756.1: *4* i.postprocess
     def postprocess(self, parent: Position) -> None:
         """
-        A hook to enable post-processing of all nodes.
+        Importer.postprocess.
 
-        Python_Importer uses this hook.
+        New in Leo 6.7.5. The Importer class handles all the post-processing
+                          instead of the RecursiveImportController class.
         """
 
     #@+node:ekr.20230529075138.39: *4* i.regularize_whitespace

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -294,7 +294,7 @@ class Importer:
 
         # Generate all nodes.
         self.gen_lines(lines, parent)
-        
+
         # A hook for python importer.
         self.postprocess(parent)
 
@@ -324,7 +324,7 @@ class Importer:
         """
         return lines
     #@+node:ekr.20230825095756.1: *4* i.postprocess
-    def preprocess(self, parent: Position) -> None:
+    def postprocess(self, parent: Position) -> None:
         """
         A hook to enable post-processing of all nodes.
 

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -3,7 +3,6 @@
 """base_importer.py: The base Importer class used by almost all importers."""
 from __future__ import annotations
 import io
-import os
 import re
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
@@ -62,8 +61,6 @@ class Importer:
         assert self.language, g.callers()  # Do not remove.
         self.c = c  # May be None.
         self.root: Position = None
-        file_name = c.fileName()
-        self.outline_directory = os.path.dirname(file_name) if file_name else None
         delims = g.set_delims_from_language(self.language)
         self.single_comment, self.block1, self.block2 = delims
         self.tab_width = 0  # Must be set later.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -3,6 +3,7 @@
 """base_importer.py: The base Importer class used by almost all importers."""
 from __future__ import annotations
 import io
+import os
 import re
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
@@ -61,6 +62,8 @@ class Importer:
         assert self.language, g.callers()  # Do not remove.
         self.c = c  # May be None.
         self.root: Position = None
+        file_name = c.fileName()
+        self.root_directory = os.path.dirname(file_name) if file_name else None
         delims = g.set_delims_from_language(self.language)
         self.single_comment, self.block1, self.block2 = delims
         self.tab_width = 0  # Must be set later.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -294,6 +294,9 @@ class Importer:
 
         # Generate all nodes.
         self.gen_lines(lines, parent)
+        
+        # A hook for python importer.
+        self.postprocess(parent)
 
         # Importers should never dirty the outline.
         # #1451: Do not change the outline's change status.
@@ -320,6 +323,14 @@ class Importer:
         Xml_Importer uses this hook to split lines.
         """
         return lines
+    #@+node:ekr.20230825095756.1: *4* i.postprocess
+    def preprocess(self, parent: Position) -> None:
+        """
+        A hook to enable post-processing of all nodes.
+
+        Python_Importer uses this hook.
+        """
+
     #@+node:ekr.20230529075138.39: *4* i.regularize_whitespace
     def regularize_whitespace(self, lines: list[str]) -> list[str]:  # pragma: no cover (missing test)
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -282,7 +282,7 @@ class Importer:
         Overriding this method gives the subclass completed control.
         """
         c = self.c
-        ### g.trace(f"{len(s):>6} {parent.h}")  ###
+
         # Fix #449: Cloned @auto nodes duplicates section references.
         if parent.isCloned() and parent.hasChildren():  # pragma: no cover (missing test)
             return

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -272,7 +272,7 @@ class Importer:
     def import_from_string(self, parent: Position, s: str) -> None:
         """
         Importer.import_from_string.
-        
+
         parent: An @<file> node containing the absolute path to the to-be-imported file.
         s: The contents of the file.
 
@@ -281,7 +281,7 @@ class Importer:
         Overriding this method gives the subclass completed control.
         """
         c = self.c
-        g.trace(f"{len(s):>6} {parent.h}")  ###
+        ### g.trace(f"{len(s):>6} {parent.h}")  ###
         # Fix #449: Cloned @auto nodes duplicates section references.
         if parent.isCloned() and parent.hasChildren():  # pragma: no cover (missing test)
             return

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -295,9 +295,6 @@ class Importer:
         # Generate all nodes.
         self.gen_lines(lines, parent)
 
-        # A hook for last-minute adjustments.
-        self.post_process(parent)
-
         # Importers should never dirty the outline.
         # #1451: Do not change the outline's change status.
         for p in root.self_and_subtree():
@@ -315,13 +312,6 @@ class Importer:
         as comments and strings.
         """
         return self.delete_comments_and_strings(lines[:])
-    #@+node:ekr.20230825065418.1: *4* i.post_process
-    def post_process(self, parent: Position) -> None:
-        """
-       A hook to allow last-minute adjustments to all generated nodes.
-
-       The Python_Importer uses this hook.
-       """
     #@+node:ekr.20230529075138.38: *4* i.preprocess_lines
     def preprocess_lines(self, lines: list[str]) -> list[str]:
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -333,12 +333,14 @@ class Importer:
     #@+node:ekr.20230825095756.1: *4* i.postprocess
     def postprocess(self, parent: Position) -> None:
         """
-        Importer.postprocess.
+        Importer.postprocess.  A hook for language-specific post-processing.
 
-        New in Leo 6.7.5. The Importer class handles all the post-processing
-                          instead of the RecursiveImportController class.
+        Python_Importer overrides this method.
+
+        **Important**: The RecursiveImportController (RIC) class contains a
+                       language-independent postpass that adjusts headlines of
+                       *all* imported nodes.
         """
-
     #@+node:ekr.20230529075138.39: *4* i.regularize_whitespace
     def regularize_whitespace(self, lines: list[str]) -> list[str]:  # pragma: no cover (missing test)
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -63,7 +63,7 @@ class Importer:
         self.c = c  # May be None.
         self.root: Position = None
         file_name = c.fileName()
-        self.root_directory = os.path.dirname(file_name) if file_name else None
+        self.outline_directory = os.path.dirname(file_name) if file_name else None
         delims = g.set_delims_from_language(self.language)
         self.single_comment, self.block1, self.block2 = delims
         self.tab_width = 0  # Must be set later.
@@ -272,12 +272,16 @@ class Importer:
     def import_from_string(self, parent: Position, s: str) -> None:
         """
         Importer.import_from_string.
+        
+        parent: An @<file> node containing the absolute path to the to-be-imported file.
+        s: The contents of the file.
 
         The top-level code for almost all importers.
 
         Overriding this method gives the subclass completed control.
         """
         c = self.c
+        g.trace(f"{len(s):>6} {parent.h}")  ###
         # Fix #449: Cloned @auto nodes duplicates section references.
         if parent.isCloned() and parent.hasChildren():  # pragma: no cover (missing test)
             return

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -295,6 +295,9 @@ class Importer:
         # Generate all nodes.
         self.gen_lines(lines, parent)
 
+        # A hook for last-minute adjustments.
+        self.post_process(parent)
+
         # Importers should never dirty the outline.
         # #1451: Do not change the outline's change status.
         for p in root.self_and_subtree():
@@ -312,6 +315,13 @@ class Importer:
         as comments and strings.
         """
         return self.delete_comments_and_strings(lines[:])
+    #@+node:ekr.20230825065418.1: *4* i.post_process
+    def post_process(self, parent: Position) -> None:
+        """
+       A hook to allow last-minute adjustments to all generated nodes.
+
+       The Python_Importer uses this hook.
+       """
     #@+node:ekr.20230529075138.38: *4* i.preprocess_lines
     def preprocess_lines(self, lines: list[str]) -> list[str]:
         """

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -35,6 +35,20 @@ class Python_Importer(Importer):
     )
 
     #@+others
+    #@+node:ekr.20230825094632.1: *3* python_i.compute_headline
+    def compute_headline(self, block: Block) -> str:
+        """
+        Importer.compute_headline.
+
+        Return the headline for the given block.
+
+        Subclasses may override this method as necessary.
+        """
+        child_kind, child_name, child_start, child_start_body, child_end = block
+        if child_kind == 'def':
+            return child_name
+        return f"{child_kind} {child_name}" if child_name else f"unnamed {child_kind}"
+
     #@+node:ekr.20230612171619.1: *3* python_i.create_preamble
     def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
@@ -148,6 +162,51 @@ class Python_Importer(Importer):
                     # A comment line.
                     tail_lines += 1
         return i2 - tail_lines
+    #@+node:ekr.20230825095926.1: *3* python_i.postprocess (do do)
+    def postprocess(self, parent: Position) -> None:
+        """
+        Post-process all nodes:
+            
+        - Add class names to headlines.
+        - Move docstrings to their natural places.
+        """
+        # This code used to be in RecursiveImportController.
+        g.trace(parent.h)
+
+    #@+node:ekr.20230825100219.1: *3* python_i.add_class_names (to do)
+    def add_class_names(self, p: Position) -> None:
+        """Add class names to headlines for all descendant nodes."""
+        after, class_name = None, None
+        class_paren_pattern = re.compile(r'(.*)\(.*\)\.(.*)')
+        paren_pattern = re.compile(r'(.*)\(.*\.py\)')
+        for p in p.self_and_subtree(copy=False):
+            # Part 1: update the status.
+            m = self.file_pattern.match(p.h)
+            if m:
+                after, class_name = None, None
+                continue
+            if p.h.startswith('@path '):
+                after, class_name = None, None
+            elif p.h.startswith('class '):
+                class_name = p.h[5:].strip()
+                if class_name:
+                    after = p.nodeAfterTree()
+                    continue
+            elif p == after:
+                after, class_name = None, None
+
+            # Part 2: update the headline.
+            if class_name:
+                if p.h.startswith(class_name):
+                    m = class_paren_pattern.match(p.h)
+                    if m:
+                        p.h = f"{m.group(1)}.{m.group(2).lstrip()}".rstrip()
+                else:
+                    p.h = f"{class_name}.{p.h.lstrip()}"
+            else:
+                m = paren_pattern.match(p.h)
+                if m:
+                    p.h = m.group(1).rstrip()
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -148,17 +148,6 @@ class Python_Importer(Importer):
                     # A comment line.
                     tail_lines += 1
         return i2 - tail_lines
-    #@+node:ekr.20230825065619.1: *3* python_i.post_process
-    def post_process(self, parent: Position) -> None:
-        """
-        Python_Importer.post_process.
-
-        - Move module-level docstrings to the top level.
-        - Move class docstrings right after the `class` line.
-        - Remove `def ` from all headlines. Use `function: ` for true functions.
-        """
-        if not g.unitTesting:  ###
-            g.trace(parent.h)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -35,20 +35,6 @@ class Python_Importer(Importer):
     )
 
     #@+others
-    #@+node:ekr.20230825094632.1: *3* python_i.compute_headline
-    def compute_headline(self, block: Block) -> str:
-        """
-        Importer.compute_headline.
-
-        Return the headline for the given block.
-
-        Subclasses may override this method as necessary.
-        """
-        child_kind, child_name, child_start, child_start_body, child_end = block
-        if child_kind == 'def':
-            return child_name
-        return f"{child_kind} {child_name}" if child_name else f"unnamed {child_kind}"
-
     #@+node:ekr.20230612171619.1: *3* python_i.create_preamble
     def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
@@ -166,16 +152,22 @@ class Python_Importer(Importer):
     def postprocess(self, parent: Position) -> None:
         """
         Post-process all nodes:
-            
+
         - Add class names to headlines.
         - Move docstrings to their natural places.
         """
         # This code used to be in RecursiveImportController.
-        g.trace(parent.h)
+        ### g.trace(parent.h)
+
+        for p in parent.subtree():
+            if p.h.startswith('class'):
+                self.add_class_names(p)
 
     #@+node:ekr.20230825100219.1: *3* python_i.add_class_names (to do)
     def add_class_names(self, p: Position) -> None:
         """Add class names to headlines for all descendant nodes."""
+        g.trace(p.h)  ###
+        return  ###
         after, class_name = None, None
         class_paren_pattern = re.compile(r'(.*)\(.*\)\.(.*)')
         paren_pattern = re.compile(r'(.*)\(.*\.py\)')

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -148,7 +148,7 @@ class Python_Importer(Importer):
                     # A comment line.
                     tail_lines += 1
         return i2 - tail_lines
-    #@+node:ekr.20230825095926.1: *3* python_i.postprocess (do do)
+    #@+node:ekr.20230825095926.1: *3* python_i.postprocess (to do)
     def postprocess(self, parent: Position) -> None:
         """
         Post-process all nodes:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -148,6 +148,17 @@ class Python_Importer(Importer):
                     # A comment line.
                     tail_lines += 1
         return i2 - tail_lines
+    #@+node:ekr.20230825065619.1: *3* python_i.post_process
+    def post_process(self, parent: Position) -> None:
+        """
+        Python_Importer.post_process.
+
+        - Move module-level docstrings to the top level.
+        - Move class docstrings right after the `class` line.
+        - Remove `def ` from all headlines. Use `function: ` for true functions.
+        """
+        if not g.unitTesting:  ###
+            g.trace(parent.h)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -53,7 +53,8 @@ class Python_Importer(Importer):
                         p.h = f"{m.group(1)}.{p.h[4:].strip()}"
                         break
                 else:
-                    p.h = f"function: {p.h[4:].strip()}"
+                    if self.language == 'python':
+                        p.h = f"function: {p.h[4:].strip()}"
     #@+node:ekr.20230612171619.1: *3* python_i.create_preamble
     def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
@@ -216,7 +217,6 @@ class Python_Importer(Importer):
         # Move class docstrings.
         for p in parent.subtree():
             if p.h.startswith('class '):
-                g.trace(p.h)
                 move_docstring(p)
     #@+node:ekr.20230825095926.1: *3* python_i.postprocess
     def postprocess(self, parent: Position) -> None:

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -112,7 +112,7 @@ class TestLeoImport(BaseTestImporter):
         )
         x = leoImport.RecursiveImportController(c,
             ### dir_=dir_,
-            dir_=None,  ####
+            dir_=None,  ###
             kind='@clean',
             recursive=True,
             safe_at_file = False,

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -4,7 +4,7 @@
 
 import io
 import os
-import sys
+### import sys
 import textwrap
 from leo.unittests.test_importers import BaseTestImporter
 from leo.core import leoImport
@@ -97,20 +97,26 @@ class TestLeoImport(BaseTestImporter):
     #@+node:ekr.20230613235653.1: *3* TestLeoImport.test_ric_minimize_headlines
     def test_ric_minimize_headlines(self):
         c, root = self.c, self.c.rootPosition()
-        if sys.platform.startswith('win'):
-            dir_ = 'C:/Repos/non-existent-directory/mypy'
-        else:
-            dir_ = '/Repos/non-existent-directory/mypy'
+        ###
+            # if sys.platform.startswith('win'):
+                # dir_ = 'C:/Repos/non-existent-directory/mypy'
+            # else:
+                # dir_ = '/Repos/non-existent-directory/mypy'
+
         # minimize_headlines changes only headlines that start with dir_ or @<file> dir_.
+
+        dir_ = os.path.dirname(c.fileName())  ###
+
         table = (
             ('root', 'root'),
             (dir_, 'path: mypy'),
-            (f"{dir_}/test", 'path: mypy/test'),
-            (f"{dir_}/xyzzy/test2", 'path: mypy/xyzzy/test2'),
-            (f"@clean {dir_}/x.py", '@clean x.py'),
+            # (f"{dir_}/test", 'path: mypy/test'),
+            # (f"{dir_}/xyzzy/test2", 'path: mypy/xyzzy/test2'),
+            # (f"@clean {dir_}/x.py", '@clean x.py'),
         )
         x = leoImport.RecursiveImportController(c,
-            dir_=dir_,
+            ### dir_=dir_,
+            dir_=None,  ####
             kind='@clean',
             recursive=True,
             safe_at_file = False,
@@ -119,6 +125,7 @@ class TestLeoImport(BaseTestImporter):
         )
         for h, expected in table:
             root.h = h
+            x.root_directory = x.compute_root_directory(None)  ### Experimental.
             x.minimize_headline(root)
             self.assertEqual(root.h, expected, msg=h)
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -75,11 +75,11 @@ class TestLeoImport(BaseTestImporter):
                 'import os\n'
                 '\n'
             ),
-            (1, 'def macro',
+            (1, 'function: macro',
                 'def macro(func):\n'
                 '    @others\n'
             ),
-            (2, 'def new_func',
+            (2, 'function: new_func',
                 'def new_func(*args, **kwds):\n'
                 "    raise RuntimeError('blah blah blah')\n"
             ),

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-### import sys
 import textwrap
 from leo.unittests.test_importers import BaseTestImporter
 from leo.core import leoImport

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -105,7 +105,7 @@ class TestLeoImport(BaseTestImporter):
 
         table = (
             ('root', 'root'),
-            (dir_, 'path: mypy'),
+            (leo_dir, 'path: mypy'),
             # (f"{dir_}/test", 'path: mypy/test'),
             # (f"{dir_}/xyzzy/test2", 'path: mypy/xyzzy/test2'),
             # (f"@clean {dir_}/x.py", '@clean x.py'),

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -97,7 +97,7 @@ class TestLeoImport(BaseTestImporter):
     #@+node:ekr.20230613235653.1: *3* TestLeoImport.test_ric_minimize_headlines
     def test_ric_minimize_headlines(self):
         c, root = self.c, self.c.rootPosition()
-        
+
 
         # minimize_headlines changes only headlines that start with dir_ or @<file> dir_.
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -97,15 +97,11 @@ class TestLeoImport(BaseTestImporter):
     #@+node:ekr.20230613235653.1: *3* TestLeoImport.test_ric_minimize_headlines
     def test_ric_minimize_headlines(self):
         c, root = self.c, self.c.rootPosition()
-        ###
-            # if sys.platform.startswith('win'):
-                # dir_ = 'C:/Repos/non-existent-directory/mypy'
-            # else:
-                # dir_ = '/Repos/non-existent-directory/mypy'
+        
 
         # minimize_headlines changes only headlines that start with dir_ or @<file> dir_.
 
-        dir_ = os.path.dirname(c.fileName())  ###
+        leo_dir = os.path.dirname(c.fileName())
 
         table = (
             ('root', 'root'),

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -98,14 +98,14 @@ class TestLeoImport(BaseTestImporter):
     def test_ric_minimize_headlines(self):
         c, root = self.c, self.c.rootPosition()
 
-
         # minimize_headlines changes only headlines that start with dir_ or @<file> dir_.
 
-        leo_dir = os.path.dirname(c.fileName())
+        outline_dir = os.path.dirname(c.fileName())
+        assert os.path.exists(outline_dir), outline_dir
 
         table = (
-            ('root', 'root'),
-            (leo_dir, 'path: mypy'),
+            # ('root', 'root'),
+            # (outline_dir, 'path: mypy'),
             # (f"{dir_}/test", 'path: mypy/test'),
             # (f"{dir_}/xyzzy/test2", 'path: mypy/xyzzy/test2'),
             # (f"@clean {dir_}/x.py", '@clean x.py'),
@@ -121,15 +121,16 @@ class TestLeoImport(BaseTestImporter):
         )
         for h, expected in table:
             root.h = h
-            x.root_directory = x.compute_root_directory(None)  ### Experimental.
+            assert x.outline_directory
             x.minimize_headline(root)
             self.assertEqual(root.h, expected, msg=h)
 
         # Test that the recursive import only generates @<file> nodes containing absolute paths.
-        for h in ('@file bad1.py', '@edit bad2.py'):
-            with self.assertRaises(AssertionError, msg=h):
-                root.h = h
-                x.minimize_headline(root)
+        if 0:  ###
+            for h in ('@file bad1.py', '@edit bad2.py'):
+                with self.assertRaises(AssertionError, msg=h):
+                    root.h = h
+                    x.minimize_headline(root)
     #@+node:ekr.20230715004610.1: *3* TestLeoImport.slow_test_ric_run
     def slow_test_ric_run(self):
         c = self.c

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -94,43 +94,6 @@ class TestLeoImport(BaseTestImporter):
         # Test redo
         u.redo()
         self.check_outline(target, expected_results)
-    #@+node:ekr.20230613235653.1: *3* TestLeoImport.test_ric_minimize_headlines
-    def test_ric_minimize_headlines(self):
-        c, root = self.c, self.c.rootPosition()
-
-        # minimize_headlines changes only headlines that start with dir_ or @<file> dir_.
-
-        outline_dir = os.path.dirname(c.fileName())
-        assert os.path.exists(outline_dir), outline_dir
-
-        table = (
-            # ('root', 'root'),
-            # (outline_dir, 'path: mypy'),
-            # (f"{dir_}/test", 'path: mypy/test'),
-            # (f"{dir_}/xyzzy/test2", 'path: mypy/xyzzy/test2'),
-            # (f"@clean {dir_}/x.py", '@clean x.py'),
-        )
-        x = leoImport.RecursiveImportController(c,
-            ### dir_=dir_,
-            dir_=None,  ###
-            kind='@clean',
-            recursive=True,
-            safe_at_file = False,
-            theTypes=['.py'],
-            verbose=False,
-        )
-        for h, expected in table:
-            root.h = h
-            assert x.outline_directory
-            x.minimize_headline(root)
-            self.assertEqual(root.h, expected, msg=h)
-
-        # Test that the recursive import only generates @<file> nodes containing absolute paths.
-        if 0:  ###
-            for h in ('@file bad1.py', '@edit bad2.py'):
-                with self.assertRaises(AssertionError, msg=h):
-                    root.h = h
-                    x.minimize_headline(root)
     #@+node:ekr.20230715004610.1: *3* TestLeoImport.slow_test_ric_run
     def slow_test_ric_run(self):
         c = self.c

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1558,6 +1558,11 @@ class TestHtml(BaseTestImporter):
         )
         self.new_run_test(s, expected_results)
     #@-others
+#@+node:ekr.20230826053559.1: ** class TestImporter(LeoUnitTest)
+class TestImporter(LeoUnitTest):
+    """General tests of the Importer class."""
+    #@+others
+    #@-others
 #@+node:ekr.20211108062617.1: ** class TestIni (BaseTestImporter)
 class TestIni(BaseTestImporter):
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -639,11 +639,11 @@ class TestCoffeescript(BaseTestImporter):
                 'class Builder\n'
                 '  @others\n'
           ),
-          (2, 'def constructor',
+          (2, 'Builder.constructor',
               'constructor: ->\n'
               '  @transformer = new Transformer\n'
           ),
-          (2, 'def build',
+          (2, 'Builder.build',
                 '# `build()`\n'
                 '\n'
                 'build: (args...) ->\n'
@@ -658,13 +658,13 @@ class TestCoffeescript(BaseTestImporter):
                 '\n'
                 '  if node.parenthesized then paren(out) else out\n'
           ),
-          (2, 'def transform',
+          (2, 'Builder.transform',
               '# `transform()`\n'
               '\n'
               'transform: (args...) ->\n'
               '  @transformer.transform.apply(@transformer, args)\n'
           ),
-          (2, 'def body',
+          (2, 'Builder.body',
               '# `body()`\n'
               '\n'
               'body: (node, opts={}) ->\n'
@@ -3176,7 +3176,7 @@ class TestPython(BaseTestImporter):
             (1, '<< TestPython.test_general_test_1: preamble >>',
                     'import sys\n'
             ),
-            (1, 'def f1',
+            (1, 'function: f1',
                     'def f1():\n'
                     '    pass\n'
             ),
@@ -3184,15 +3184,15 @@ class TestPython(BaseTestImporter):
                        'class Class1:\n'
                        '    @others\n'
             ),
-            (2, 'def method11',
+            (2, 'Class1.method11',
                        'def method11():\n'
                        '    pass\n'
             ),
-            (2, 'def method12',
+            (2, 'Class1.method12',
                        'def method12():\n'
                        '    pass\n'
             ),
-            (1, 'def f2',
+            (1, 'function: f2',
                        '#\n'
                        '# Define a = 2\n'
                        'a = 2\n'
@@ -3206,18 +3206,18 @@ class TestPython(BaseTestImporter):
                        'class Class2:\n'
                        '    @others\n'
             ),
-            (2, 'def method21',
+            (2, 'Class2.method21',
                        'def method21():\n'
                        '    print(1)\n'
                        '    print(2)\n'
                        '    print(3)\n'
             ),
-            (2, 'def method22',
+            (2, 'Class2.method22',
                        '@myDecorator\n'
                        'def method22():\n'
                        '    pass\n'
             ),
-            (2, 'def method23',
+            (2, 'Class2.method23',
                        'def method23():\n'
                        '    pass\n'
             ),
@@ -3225,13 +3225,13 @@ class TestPython(BaseTestImporter):
                 'class UnderindentedComment:\n'
                 '@others\n'  # The underindented comments prevents indentaion
             ),
-            (2, 'def u1',
+            (2, 'UnderindentedComment.u1',
                     '# Outer underindented comment\n'
                     '    def u1():\n'
                     '    # Underindented comment in u1.\n'
                     '        pass\n'
             ),
-            (1, 'def main',
+            (1, 'function: main',
                        '# About main.\n'
                        '\n'
                        'def main():\n'
@@ -3264,7 +3264,7 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'def get_target_type',
+            (1, 'function: get_target_type',
                     'def get_target_type(\n'
                     '    tvar: TypeVarLikeType,\n'
                     '    type: Type,\n'
@@ -3369,14 +3369,14 @@ class TestPython(BaseTestImporter):
             (1, '<< TestPython.test_oneliners: preamble >>',
                     'import sys\n'
             ),
-            (1, 'def f1',
+            (1, 'function: f1',
                     'def f1():\n'
                     '    pass\n'
             ),
             (1, 'class Class1',
                     'class Class1:pass\n'
             ),
-            (1, 'def f2',
+            (1, 'function: f2',
                     'a = 2\n'
                     '@dec_for_f2\n'
                     'def f2(): pass\n'
@@ -3384,7 +3384,7 @@ class TestPython(BaseTestImporter):
             (1, 'class A',
                     'class A: pass\n'
             ),
-            (1, 'def main',
+            (1, 'function: main',
                        '# About main.\n'
                        'def main():\n'
                        '    pass\n'
@@ -3417,14 +3417,13 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, '<< TestPython.test_preamble: preamble >>',
+            (1, '<< TestPython.test_post_process: preamble >>',
                     '\n'
                     'from __future__ import annotations\n'
                     '\n'
-
             ),
             (1, 'class C1',
-                    'class C1:\n',
+                    'class C1:\n'
                     '    """Class docstring"""\n'
                     '    @others\n'
             ),
@@ -3434,9 +3433,9 @@ class TestPython(BaseTestImporter):
                     '    pass\n'
             ),
             (1, 'function: f1',
-                   'def f():\n'
-                   '    g.trace()\n'
-            )
+                   'def f1():\n'
+                   '    pass\n'
+            ),
         )
         self.new_run_test(s, expected_results)
     #@+node:ekr.20230612085239.1: *3* TestPython.test_preamble
@@ -3472,7 +3471,7 @@ class TestPython(BaseTestImporter):
                     'from leo.core import leoGlobals as g\n'
                     '\n'
             ),
-            (1, 'def f',
+            (1, 'function: f',
                    'def f():\n'
                    '    g.trace()\n'
             )

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3391,6 +3391,54 @@ class TestPython(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
+    #@+node:ekr.20230825071437.1: *3* TestPython.test_post_process
+    def test_post_process(self):
+
+        s = '''
+            """Module-level docstring"""
+
+            from __future__ import annotations
+
+            class C1:
+                """Class docstring"""
+
+                def __init__(self):
+                    pass
+
+            def f1():
+                pass
+
+            '''
+        expected_results = (
+            (0, '',  # Ignore the first headline.
+                    '"""Module-level docstring"""\n'
+                    '<< TestPython.test_post_process: preamble >>\n'
+                    '@others\n'
+                    '@language python\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, '<< TestPython.test_preamble: preamble >>',
+                    '\n'
+                    'from __future__ import annotations\n'
+                    '\n'
+
+            ),
+            (1, 'class C1',
+                    'class C1:\n',
+                    '    """Class docstring"""\n'
+                    '    @others\n'
+            ),
+            (2, 'C1.__init__',
+                    '\n'
+                    'def __init__(self):\n'
+                    '    pass\n'
+            ),
+            (1, 'function: f1',
+                   'def f():\n'
+                   '    g.trace()\n'
+            )
+        )
+        self.new_run_test(s, expected_results)
     #@+node:ekr.20230612085239.1: *3* TestPython.test_preamble
     def test_preamble(self):
 


### PR DESCRIPTION
See #3514.

**Summary**

- `python_i.postpass` moves docstrings to more convenient locations and adds class names to all methods.
- The `dir_` kwarg of `c.recursiveImport` may be relative and must refer to the outline's directory or a subdirectory thereof.
- The recursive import logic has been simplified in various places. Many checks have been added.
- `RIC.postpass` should stay were it is.

<details>
<br>

- [x] Add `Importer.postpass` and `Python_Importer.postpass`.
   - Add `Python_Importer.adjust_headlines` and `Python_Importer.move_docstrings`.
   - The docstring for `Importer.postpass` mentions `RIC.postpass`.
- [x] Add new unit test and adjust existing unit tests.
- [x] Ensure that importer generates `@path` statements.
- [x] Allow the `dir_` kwarg to `c.recursiveImport` to be a path relative to the outline's directory.
- [x] Add more checks to the 'RIC' class.
- [x] Improve error trace in `c.setCurrentPosition`.
- [x] Remove `test_ric_minimize_headlines`.

</details>