### PR TITLE
PR for #3517: various importer bugs

### DIFF
--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1726,7 +1726,7 @@ class RecursiveImportController:
             return path
 
          # The paths of all @<file> nodes should start with outline_dir.
-        p.h = norm(p.h.replace('\\', '/'))  # Defensive.
+        p.h = p.h.replace('\\', '/')  # Defensive.
         outline_dir = norm(self.outline_directory.replace('\\', '/'))
         len_outline_dir = len(outline_dir)
 
@@ -1734,8 +1734,8 @@ class RecursiveImportController:
         if m:
             # p is an @file node of some kind.
             kind = m.group(0)
-            path = norm(p.h[len(kind) :].strip())
-            if path.startswith(outline_dir):
+            path = p.h[len(kind) :].strip()
+            if norm(path).startswith(outline_dir):
                 file_name = os.path.basename(path)
                 dir_name = os.path.dirname(path)
                 r_path = rel_path(dir_name)
@@ -1745,7 +1745,7 @@ class RecursiveImportController:
             return
 
         # Handle everything else.
-        if p.h.startswith(outline_dir):
+        if norm(p.h).startswith(outline_dir):
             r_path = rel_path(p.h)
             if r_path:
                 p.h = f"path: {r_path}"

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1683,6 +1683,7 @@ class RecursiveImportController:
             self.minimize_headline(p2)
         if self.kind not in ('@auto', '@edit'):
             self.remove_empty_nodes(p)
+            self.move_leading_blank_lines(p)
         self.clear_dirty_bits(p)
     #@+node:ekr.20130823083943.12608: *4* ric.clear_dirty_bits
     def clear_dirty_bits(self, p: Position) -> None:
@@ -1749,6 +1750,17 @@ class RecursiveImportController:
             r_path = rel_path(p.h)
             if r_path:
                 p.h = f"path: {r_path}"
+    #@+node:ekr.20230831011155.1: *4* ric.move_leading_blank_lines
+    def move_leading_blank_lines(self, parent: Position) -> None:
+        """
+        Move leading blank lines from one node to its previous sibling.
+        """
+        for p in parent.subtree():
+            if p.hasBack() and p.b.startswith('\n'):
+                back = p.back()
+                while p.b.startswith('\n'):
+                    p.b = p.b[1:]
+                    back.b = back.b + '\n'
     #@+node:ekr.20130823083943.12612: *4* ric.remove_empty_nodes
     def remove_empty_nodes(self, p: Position) -> None:
         """Remove empty nodes. Not called for @auto or @edit trees."""

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -22,8 +22,8 @@ class C_Importer(Importer):
     block_patterns = (
         ('class', re.compile(r'.*?\bclass\s+(\w+)\s*\{')),
         ('func', re.compile(r'.*?\b(\w+)\s*\(.*?\)\s*(const)?\s*{')),
-        ('namespace', re.compile(r'.*?\bnamespace\s*(\w+)?\s*\{')),
-        ('struct', re.compile(r'.*?\bstruct\s*(\w+)?\s*(:.*?)?\{')),
+        ('namespace', re.compile(r'.*?\bnamespace\s+(\w+)?\s*\{')),
+        ('struct', re.compile(r'.*?\bstruct\s+(\w+)?\s*(:.*?)?\{')),
     )
 
     #@+others

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -24,9 +24,9 @@ class Python_Importer(Importer):
 
     # The default patterns. Overridden in the Cython_Importer class.
     # Group 1 matches the name of the class/def.
-    async_def_pat = re.compile(r'\s*async\s+def\b\s*(\w+)\s*\(')
-    def_pat = re.compile(r'\s*def\b\s*(\w+)\s*\(')
-    class_pat = re.compile(r'\s*class\b\s*(\w+)')
+    async_def_pat = re.compile(r'\s*async\s+def\s+(\w+)\s*\(')
+    def_pat = re.compile(r'\s*def\s+(\w+)\s*\(')
+    class_pat = re.compile(r'\s*class\s+(\w+)')
 
     block_patterns: tuple = (
         ('class', class_pat),

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -133,17 +133,6 @@ class Python_Importer(Importer):
             result.append(''.join(result_line))
         assert len(result) == len(lines)  # A crucial invariant.
         return result
-    #@+node:ekr.20230831011155.1: *3* python_i.move_leading_blank_lines
-    def move_leading_blank_lines(self, parent: Position) -> None:
-        """
-        Move leading blank lines from one node to its previous sibling.
-        """
-        for p in parent.subtree():
-            if p.hasBack() and p.b.startswith('\n'):
-                back = p.back()
-                while p.b.startswith('\n'):
-                    p.b = p.b[1:]
-                    back.b = back.b + '\n'
     #@+node:ekr.20230612171619.1: *3* python_i.create_preamble
     def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
@@ -350,7 +339,6 @@ class Python_Importer(Importer):
         self.adjust_headlines(parent)
         self.move_docstrings(parent)
         self.adjust_at_others(parent)
-        self.move_leading_blank_lines(parent)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -55,6 +55,21 @@ class Python_Importer(Importer):
                 else:
                     if self.language == 'python':
                         p.h = f"function: {p.h[4:].strip()}"
+    #@+node:ekr.20230830113521.1: *3* python_i.adjust_at_others
+    def adjust_at_others(self, parent: Position) -> None:
+        """
+        Add a blank line before @others, and remove the leading blank line in the first child.
+        """
+        for p in parent.subtree():
+            if p.h.startswith('class') and p.hasChildren():
+                child = p.firstChild()
+                lines = g.splitLines(p.b)
+                for i, line in enumerate(lines):
+                    if line == ' ' * 4 + '@others\n' and child.b.startswith('\n'):
+                        p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
+                        child = p.firstChild()
+                        child.b = child.b[1:]
+                        break
     #@+node:ekr.20230830051934.1: *3* python_i.delete_comments_and_strings
     string_pat1 = re.compile(r'([fFrR]*)("""|")')
     string_pat2 = re.compile(r"([fFrR]*)('''|')")
@@ -322,6 +337,7 @@ class Python_Importer(Importer):
         # See #3514.
         self.adjust_headlines(parent)
         self.move_docstrings(parent)
+        self.adjust_at_others(parent)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -178,19 +178,13 @@ class Python_Importer(Importer):
         Return a list of Blocks, that is, tuples(name, start, start_body, end).
         """
         i, prev_i, results = i1, i1, []
-        ### g.printObj(self.lines[max(0, i1-1):i2+1], tag=f"Entry: {i1}:{i2}")
 
         def lws_n(s: str) -> int:
             """Return the length of the leading whitespace for s."""
             return len(s) - len(s.lstrip())
 
         # Look behind to see what the previous block was.
-        if i1 > 0:
-            prev_block_line = self.guide_lines[i1 - 1]
-            ### g.trace('prev_block_line', repr(prev_block_line))
-        else:
-            prev_block_line = ''
-
+        prev_block_line = self.guide_lines[i1 - 1] if i1 > 0 else ''
         while i < i2:
             s = self.guide_lines[i]
             i += 1
@@ -201,11 +195,9 @@ class Python_Importer(Importer):
                     name = m.group(1).strip()
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
-                    ### g.trace(i, end, name, 'kind', kind, 'prev_block_line', repr(prev_block_line))
 
                     # #3517: Don't generated nested defs.
-                    if (
-                        kind == 'def'
+                    if (kind == 'def'
                         and prev_block_line.strip().startswith('def ')
                         and lws_n(prev_block_line) < lws_n(s)
                     ):
@@ -214,7 +206,6 @@ class Python_Importer(Importer):
                         results.append((kind, name, prev_i, i, end))
                         i = prev_i = end
                     break
-        ### g.printObj(results, tag=f"Results: {i1}:{i2}")
         return results
     #@+node:ekr.20230514140918.4: *3* python_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -133,6 +133,17 @@ class Python_Importer(Importer):
             result.append(''.join(result_line))
         assert len(result) == len(lines)  # A crucial invariant.
         return result
+    #@+node:ekr.20230831011155.1: *3* python_i.move_leading_blank_lines
+    def move_leading_blank_lines(self, parent: Position) -> None:
+        """
+        Move leading blank lines from one node to its previous sibling.
+        """
+        for p in parent.subtree():
+            if p.hasBack() and p.b.startswith('\n'):
+                back = p.back()
+                while p.b.startswith('\n'):
+                    p.b = p.b[1:]
+                    back.b = back.b + '\n'
     #@+node:ekr.20230612171619.1: *3* python_i.create_preamble
     def create_preamble(self, blocks: list[Block], parent: Position, result_list: list[str]) -> None:
         """
@@ -339,6 +350,7 @@ class Python_Importer(Importer):
         self.adjust_headlines(parent)
         self.move_docstrings(parent)
         self.adjust_at_others(parent)
+        self.move_leading_blank_lines(parent)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -82,7 +82,6 @@ class Python_Importer(Importer):
                     i += 2
                     continue
                 if delim_pat.match(line, i):
-                ### if line[i:].startswith(delim):  ###  Temp!
                     return '', i + len(delim)
                 i += 1
             return delim, i
@@ -103,10 +102,8 @@ class Python_Importer(Importer):
                     self.string_pat2.match(line, i)
                 )
                 if m:
-                    ### g.trace(line_i, i, m.group(0), repr(line))
                     # Start skipping the string.
                     prefix, delim = m.group(1), m.group(2)
-                    ### g.trace(repr(prefix), repr(delim))
                     i += len(prefix)
                     i += len(delim)
                     if i < len(line):
@@ -191,7 +188,6 @@ class Python_Importer(Importer):
                     name = m.group(1).strip()
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
-                    ### g.trace(f"{i:4} {end:4} {s!r}")
                     results.append((kind, name, prev_i, i, end))
                     i = prev_i = end
                     break

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -62,14 +62,14 @@ class Python_Importer(Importer):
     def delete_comments_and_strings(self, lines: list[str]) -> list[str]:
         """
         Python_i.delete_comments_and_strings.
-        
+
         This method handles f-strings properly.
         """
-        
+
         def skip_string(delim: str, i: int, line: str) -> tuple[str, int]:
             """
             Skip the remainder of a string.
-            
+
             Sring ends:       return ('', i)
             String continues: return (delim, len(line))
             """
@@ -88,7 +88,7 @@ class Python_Importer(Importer):
             return delim, i
 
         delim: str = ''  # The open string delim.
-        result: list[str] = [] 
+        result: list[str] = []
         for line_i, line in enumerate(lines):
             i, result_line = 0, []
             while i < len(line):
@@ -210,18 +210,13 @@ class Python_Importer(Importer):
             return len(s) - len(s.lstrip())
 
         prev_line = self.guide_lines[i - 1]
-        trace = False and 'load_plugins_from_config' in prev_line ###
         kinds = ('class', 'def', '->')  # '->' denotes a coffeescript function.
         assert any(z in prev_line for z in kinds), (i, repr(prev_line))
+
         # Handle multi-line def's. Scan to the line containing a close parenthesis.
-        if trace:
-            g.trace('***********')
-            print(i, i2, 'prev_line', repr(prev_line))
         if prev_line.strip().startswith('def ') and ')' not in prev_line:
             while i < i2:
                 i += 1
-                if trace:
-                    print('     LOOK', repr(self.guide_lines[i - 1]))
                 if ')' in self.guide_lines[i - 1]:
                     break
         tail_lines = 0
@@ -229,17 +224,13 @@ class Python_Importer(Importer):
             lws1 = lws_n(prev_line)
             while i < i2:
                 s = self.guide_lines[i]
-                if trace: print('NEXT', i, repr(s))
                 i += 1
                 if s.strip():
                     if lws_n(s) <= lws1:
                         # A non-comment line that ends the block.
                         # Exclude all tail lines.
-                        if trace:
-                            print('DONE', i, 'tail_lines', tail_lines - 1, repr(s))
                         return i - tail_lines - 1
                     # A non-comment line that does not end the block.
-                    ### if trace: print('Non-comment', i, repr(s))
                     tail_lines = 0
                 else:
                     # A comment line.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -292,8 +292,8 @@ class Python_Importer(Importer):
 
         #@+node:ekr.20230825164234.1: *4* function: move_docstring
         def move_docstring(parent: Position) -> None:
-            """Move a docstring from the child to the parent."""
-            child = parent.firstChild()
+            """Move a docstring from the child (or next sibling) to the parent."""
+            child = parent.firstChild() or parent.next()
             if not child:
                 return
             docstring = find_docstring(child)
@@ -308,11 +308,12 @@ class Python_Importer(Importer):
                 while n < len(parent_lines):
                     line = parent_lines[n]
                     n += 1
-                    if line.strip().startswith('class'):
+                    if line.strip().startswith('class '):
                         break
-                if n >= len(parent_lines):
-                    g.trace('NO CLASS LINE')
+                if n > len(parent_lines):
+                    g.printObj(g.splitLines(parent.b), tag=f"Noclass line: {p.h}")
                     return
+                # This isn't perfect in some situations.
                 docstring_list = [f"{' '*4}{z}" for z in g.splitLines(docstring)]
                 parent.b = ''.join(parent_lines[:n] + docstring_list + parent_lines[n:])
             else:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -24,9 +24,9 @@ class Python_Importer(Importer):
 
     # The default patterns. Overridden in the Cython_Importer class.
     # Group 1 matches the name of the class/def.
-    async_def_pat = re.compile(r'\s*async\s+def\s*(\w+)\s*\(')
-    def_pat = re.compile(r'\s*def\s*(\w+)\s*\(')
-    class_pat = re.compile(r'\s*class\s*(\w+)')
+    async_def_pat = re.compile(r'\s*async\s+def\b\s*(\w+)\s*\(')
+    def_pat = re.compile(r'\s*def\b\s*(\w+)\s*\(')
+    class_pat = re.compile(r'\s*class\b\s*(\w+)')
 
     block_patterns: tuple = (
         ('class', class_pat),

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -21,8 +21,8 @@ class Rust_Importer(Importer):
 
     block_patterns = (
         ('impl', re.compile(r'\bimpl\b(.*?)\s*{')),  # Use most of the line.
-        ('fn', re.compile(r'\s*fn\s*(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s+fn\s*(\w+)\s*\(')),
+        ('fn', re.compile(r'\s*fn\s+(\w+)\s*\(')),
+        ('fn', re.compile(r'\s*pub\s+fn\s+(\w+)\s*\(')),
     )
 #@-others
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -76,11 +76,8 @@ class TestLeoImport(BaseTestImporter):
             ),
             (1, 'function: macro',
                 'def macro(func):\n'
-                '    @others\n'
-            ),
-            (2, 'function: new_func',
-                'def new_func(*args, **kwds):\n'
-                "    raise RuntimeError('blah blah blah')\n"
+                '    def new_func(*args, **kwds):\n'
+                "        raise RuntimeError('blah blah blah')\n"
             ),
         )
         # Don't call run_test.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3434,10 +3434,10 @@ class TestPython(BaseTestImporter):
             (1, 'class C1',
                     'class C1:\n'
                     '    """Class docstring"""\n'
+                    '\n'
                     '    @others\n'
             ),
             (2, 'C1.__init__',
-                    '\n'
                     'def __init__(self):\n'
                     '    pass\n'
             ),

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3547,6 +3547,7 @@ class TestPython(BaseTestImporter):
     def test_nested_defs(self):
         # See #3517
 
+        # A simplified version of code in mypy/build.py.
         s = (
         '''
             def load_plugins_from_config(

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3099,7 +3099,10 @@ class TestPython(BaseTestImporter):
             "'''\n",
             '    if 2: a = 2\n',
             "'''\n",
-            'i = 2\n'
+            'i = 2\n',
+            # #3517: f-strings.
+            # mypy/build.py line 430.
+            r"""plugin_error(f'Can\'t find plugin "{plugin_path}"')""" + '\n',
         ]
         expected_lines = [
             'i = 1 \n',
@@ -3113,7 +3116,8 @@ class TestPython(BaseTestImporter):
             '\n',
             '\n',
             '\n',
-            'i = 2\n'
+            'i = 2\n',
+            'plugin_error()\n',
         ]
         result = importer.delete_comments_and_strings(lines)
         self.assertEqual(len(result), len(expected_lines))

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3543,6 +3543,49 @@ class TestPython(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
+    #@+node:ekr.20230830100457.1: *3* TestPython.test_nested_defs
+    def test_nested_defs(self):
+        # See #3517
+
+        s = (
+        '''
+            def load_plugins_from_config(
+                options: Options, errors: Errors, stdout: TextIO
+            ) -> tuple[list[Plugin], dict[str, str]]:
+                """Load all configured plugins."""
+
+                snapshot: dict[str, str] = {}
+
+                def plugin_error(message: str) -> NoReturn:
+                    errors.report(line, 0, message)
+                    errors.raise_error(use_stdout=False)
+
+                custom_plugins: list[Plugin] = []
+        ''')
+
+
+        expected_results = (
+            (0, '',  # Ignore the first headline.
+                '@others\n'
+                '@language python\n'
+                '@tabwidth -4\n'
+            ),
+            (1, 'function: load_plugins_from_config',
+                'def load_plugins_from_config(\n'
+                '    options: Options, errors: Errors, stdout: TextIO\n'
+                ') -> tuple[list[Plugin], dict[str, str]]:\n'
+                '    """Load all configured plugins."""\n'
+                '\n'
+                '    snapshot: dict[str, str] = {}\n'
+                '\n'
+                '    def plugin_error(message: str) -> NoReturn:\n'
+                '        errors.report(line, 0, message)\n'
+                '        errors.raise_error(use_stdout=False)\n'
+                '\n'
+                '    custom_plugins: list[Plugin] = []\n'
+            ),
+        )
+        self.new_run_test(s, expected_results)
     #@-others
 #@+node:ekr.20211108050827.1: ** class TestRst (BaseTestImporter)
 class TestRst(BaseTestImporter):

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3564,7 +3564,6 @@ class TestPython(BaseTestImporter):
                 custom_plugins: list[Plugin] = []
         ''')
 
-
         expected_results = (
             (0, '',  # Ignore the first headline.
                 '@others\n'


### PR DESCRIPTION
See #3517.

All files in the `mypy` folder import correctly and all unit tests pass.

- [x] (New) `python_i.delete_comments_and_strings`: handle f-strings properly.
- [x] (Bug fix) `ric.minimize_headline`: don't lowercase headlines.
- [x] (Bug fix) Fix keyword regexes in `Python_Importer` to ensure that keywords really are keywords.
    Use `\s+` to delimit the end language keywords in most importers.
- [x] (New) `python_i. adjust_at_others`: add a blank line before `@others` for classes.
- [x] (New) `python_i.move_docstring`: move docstrings from next sibling if there is no first child.
- [x] (Change) `python_i.find_blocks`: don't create nodes for nested functions.
- [x] (New) `ric.ric.move_leading_blank_lines`: move leading blank lines to the previous sibling.

**Testing**

- [x] Add test case to `TestPython.test_delete_comments_and_strings` to test f-string.
- [x] Create unit test for nested `def` statements.