### PR TITLE
PR for #3531: create move-outline-to-first/last-child

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -410,7 +410,7 @@ def editHeadline(self: Self, event: Event = None) -> tuple[Any, Any]:
         k.setEditingState()
         k.showStateAndMode(w=wrapper)
     return e, wrapper  # Neither of these is used by any caller.
-#@+node:ekr.20171123135625.23: ** c_ec.extract & helpers
+#@+node:ekr.20171123135625.23: ** c_ec.extract
 @g.commander_command('extract')
 def extract(self: Self, event: Event = None) -> None:
     #@+<< docstring for extract command >>
@@ -460,7 +460,7 @@ def extract(self: Self, event: Event = None) -> None:
     # Start the outer undo group.
     u.beforeChangeGroup(c.p, undoType)
     undoData = u.beforeInsertNode(c.p)
-    p = createLastChildNode(c, c.p, h, ''.join(b))
+    p = createFirstChildNode(c, c.p, h, ''.join(b))
     u.afterInsertNode(p, undoType, undoData)
     #
     # Start inner undo.
@@ -495,19 +495,19 @@ def extract(self: Self, event: Event = None) -> None:
 
 g.command_alias('extractSection', extract)
 g.command_alias('extractPythonMethod', extract)
-#@+node:ekr.20171123135625.20: *3* def createLastChildNode
-def createLastChildNode(c: Cmdr, parent: Position, headline: str, body: str) -> Position:
+#@+node:ekr.20171123135625.20: *3* function: createFirstChildNode
+def createFirstChildNode(c: Cmdr, parent: Position, headline: str, body: str) -> Position:
     """A helper function for the three extract commands."""
     # #1955: don't strip trailing lines.
     if not body:
         body = ""
-    p = parent.insertAsLastChild()
+    p = parent.insertAsNthChild(0)
     p.initHeadString(headline)
     p.setBodyString(body)
     p.setDirty()
     c.checkOutline()
     return p
-#@+node:ekr.20171123135625.24: *3* def extractDef
+#@+node:ekr.20171123135625.24: *3* function: extractDef
 extractDef_patterns = (
     re.compile(
     r'\((?:def|defn|defui|deftype|defrecord|defonce)\s+(\S+)'),  # clojure definition
@@ -542,14 +542,14 @@ def extractDef(c: Cmdr, s: str) -> str:
         if m:
             return m.group(1)
     return ''
-#@+node:ekr.20171123135625.26: *3* def extractDef_find
+#@+node:ekr.20171123135625.26: *3* function: extractDef_find
 def extractDef_find(c: Cmdr, lines: list[str]) -> Optional[str]:
     for line in lines:
         def_h = extractDef(c, line.strip())
         if def_h:
             return def_h
     return None
-#@+node:ekr.20171123135625.25: *3* def extractRef
+#@+node:ekr.20171123135625.25: *3* function: extractRef
 def extractRef(c: Cmdr, s: str) -> str:
     """Return s if it starts with a section name."""
     i = s.find('<<')
@@ -561,7 +561,7 @@ def extractRef(c: Cmdr, s: str) -> str:
     if -1 < i < j:
         return s
     return ''
-#@+node:ekr.20171123135625.27: ** c_ec.extractSectionNames & helper
+#@+node:ekr.20171123135625.27: ** c_ec.extractSectionNames
 @g.commander_command('extract-names')
 def extractSectionNames(self: Self, event: Event = None) -> None:
     """
@@ -585,7 +585,7 @@ def extractSectionNames(self: Self, event: Event = None) -> None:
             if not found:
                 u.beforeChangeGroup(current, undoType)  # first one!
             undoData = u.beforeInsertNode(current)
-            p = createLastChildNode(c, current, name, None)
+            p = createFirstChildNode(c, current, name, None)
             u.afterInsertNode(p, undoType, undoData)
             found = True
     c.checkOutline()
@@ -600,7 +600,7 @@ def extractSectionNames(self: Self, event: Event = None) -> None:
     if w:
         w.setSelectionRange(i, j)
         w.setFocus()
-#@+node:ekr.20171123135625.28: *3* def findSectionName
+#@+node:ekr.20171123135625.28: *3* function: findSectionName
 def findSectionName(self: Self, s: str) -> Optional[str]:
     head1 = s.find("<<")
     if head1 > -1:

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1691,7 +1691,11 @@ def moveOutlineUp(self: Cmdr, event: Event = None) -> None:
 #@+node:ekr.20230902051130.1: *3* c_oc.moveOutlineToFirstChild
 @g.commander_command('move-outline-to-first-child')
 def moveOutlineToFirstChild(self: Cmdr, event: Event = None) -> None:
-    """Move the selected node so that it is the first child of its parent."""
+    """
+    Move the selected node so that it is the first child of its parent.
+
+    Do nothing if a hoist is in effect.
+    """
     c, p, u = self, self.p, self.undoer
     if not p:
         return
@@ -1709,11 +1713,14 @@ def moveOutlineToFirstChild(self: Cmdr, event: Event = None) -> None:
     c.setChanged()
     u.afterMoveNode(p, 'Move To First Child', undoData)
     c.redraw(p)
-    c.updateSyntaxColorer(p)  # Moving can change syntax coloring.
 #@+node:ekr.20230902051833.1: *3* c_oc.moveOutlineToLastChild
 @g.commander_command('move-outline-to-last-child')
 def moveOutlineToLastChild(self: Cmdr, event: Event = None) -> None:
-    """Move the selected node so that it is the first child of its parent."""
+    """
+    Move the selected node so that it is the last child of its parent.
+
+    Do nothing if a hoist is in effect.
+    """
     c, p, u = self, self.p, self.undoer
     if not p:
         return
@@ -1726,12 +1733,11 @@ def moveOutlineToLastChild(self: Cmdr, event: Event = None) -> None:
         return
     c.endEditing()
     undoData = u.beforeMoveNode(p)
-    p.moveToNthChildOf(parent, len(parent.v.children))
+    p.moveToNthChildOf(parent, len(parent.v.children) - 1)
     p.setDirty()
     c.setChanged()
     u.afterMoveNode(p, 'Move To Last Child', undoData)
     c.redraw(p)
-    c.updateSyntaxColorer(p)  # Moving can change syntax coloring.
 #@+node:ekr.20031218072017.1774: *3* c_oc.promote
 @g.commander_command('promote')
 def promote(self: Cmdr, event: Event = None, undoFlag: bool = True) -> None:

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1688,6 +1688,50 @@ def moveOutlineUp(self: Cmdr, event: Event = None) -> None:
         u.afterMoveNode(p, 'Move Up', undoData)
     c.redraw(p)
     c.updateSyntaxColorer(p)  # Moving can change syntax coloring.
+#@+node:ekr.20230902051130.1: *3* c_oc.moveOutlineToFirstChild
+@g.commander_command('move-outline-to-first-child')
+def moveOutlineToFirstChild(self: Cmdr, event: Event = None) -> None:
+    """Move the selected node so that it is the first child of its parent."""
+    c, p, u = self, self.p, self.undoer
+    if not p:
+        return
+    if c.hoistStack:
+        return
+    if not p.hasBack():
+        return
+    parent = p.parent()
+    if not parent:
+        return
+    c.endEditing()
+    undoData = u.beforeMoveNode(p)
+    p.moveToNthChildOf(p.parent(), 0)
+    p.setDirty()
+    c.setChanged()
+    u.afterMoveNode(p, 'Move To First Child', undoData)
+    c.redraw(p)
+    c.updateSyntaxColorer(p)  # Moving can change syntax coloring.
+#@+node:ekr.20230902051833.1: *3* c_oc.moveOutlineToLastChild
+@g.commander_command('move-outline-to-last-child')
+def moveOutlineToLastChild(self: Cmdr, event: Event = None) -> None:
+    """Move the selected node so that it is the first child of its parent."""
+    c, p, u = self, self.p, self.undoer
+    if not p:
+        return
+    if c.hoistStack:
+        return
+    if not p.hasNext():
+        return
+    parent = p.parent()
+    if not parent:
+        return
+    c.endEditing()
+    undoData = u.beforeMoveNode(p)
+    p.moveToNthChildOf(parent, len(parent.v.children))
+    p.setDirty()
+    c.setChanged()
+    u.afterMoveNode(p, 'Move To Last Child', undoData)
+    c.redraw(p)
+    c.updateSyntaxColorer(p)  # Moving can change syntax coloring.
 #@+node:ekr.20031218072017.1774: *3* c_oc.promote
 @g.commander_command('promote')
 def promote(self: Cmdr, event: Event = None, undoFlag: bool = True) -> None:

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -605,6 +605,65 @@ class TestOutlineCommands(LeoUnitTest):
         u.undo()
         result_children = [z.h for z in self.root_p.v.children]
         self.assertEqual(result_children, original_children)
+    #@+node:ekr.20230902053728.1: *3* TestOutlineCommands.test_move_outline_to_first_child
+    def test_move_outline_to_first_child(self):
+        # Setup.
+        c, u = self.c, self.c.undoer
+        root = self.root_p
+        assert root.h == 'root'
+        self.create_test_outline()
+        original_children = root.v.children[:]
+        last_child = root.lastChild()
+        assert last_child
+        last_gnx = last_child.gnx
+        # Move.
+        c.selectPosition(last_child)
+        c.moveOutlineToFirstChild()
+        # Tests.
+        assert c.checkOutline() == 0
+        first_child = root.firstChild()
+        assert first_child
+        first_gnx = first_child.gnx
+        assert first_gnx == last_gnx, (first_gnx, last_gnx)
+        u.undo()
+        assert c.checkOutline() == 0
+        assert root.v.children == original_children
+        u.redo()
+        assert c.checkOutline() == 0
+        u.undo()
+        assert c.checkOutline() == 0
+        assert root.v.children == original_children
+
+    #@+node:ekr.20230902053751.1: *3* TestOutlineCommands.test_move_outline_to_last_child
+    def test_move_outline_to_last_child(self):
+        # Setup.
+        c, u = self.c, self.c.undoer
+        root = self.root_p
+        assert root.h == 'root'
+        self.create_test_outline()
+        original_children = root.v.children[:]
+        first_child = root.firstChild()
+        assert first_child
+        first_gnx = first_child.gnx
+        # Move.
+        # c.selectPosition(first_child)
+        c.selectPosition(first_child)
+        c.moveOutlineToLastChild()
+        # Tests.
+        assert c.checkOutline() == 0
+        last_child = root.lastChild()
+        assert first_child
+        last_gnx = last_child.gnx
+        assert first_gnx == last_gnx, (first_gnx, last_gnx)
+        u.undo()
+        assert c.checkOutline() == 0
+        assert root.v.children == original_children
+        u.redo()
+        assert c.checkOutline() == 0
+        u.undo()
+        assert c.checkOutline() == 0
+        assert root.v.children == original_children
+
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
See #3531.

- [x] Create the commands.
- [x] Create new unit tests.
- [x] Extract commands create section definitions as the *first* child.