### PR TITLE
git-diff now makes a diff tree for .leojs files, as it already does for .leo file.

### DIFF
--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -356,7 +356,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
             parent.setHeadString(kind)
             for key in d:
                 p = d.get(key)
-                if not kind.endswith('.leo') and p.isAnyAtFileNode():
+                if not kind.endswith(('.leo', '.leojs')) and p.isAnyAtFileNode():
                     # Don't make clones of @<file> nodes for wrapped files.
                     pass
                 elif p.v.context == c:

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -729,7 +729,7 @@ class GitDiffController:
         # Finish.
         path = g.finalize_join(directory, fn)  # #1781: bug fix.
         c1 = c2 = None
-        if fn.endswith('.leo'):
+        if fn.endswith(('.leo', '.leojs')):
             c1 = self.make_leo_outline(fn, path, s1, rev1)
             c2 = self.make_leo_outline(fn, path, s2, rev2)
         else:


### PR DESCRIPTION
Fixes #3536