### PR TITLE
Made 'file-diff-files' undoable.  Also made it insert it's diff result node at the end like other 'diff' & 'find-all' commands.

### DIFF
--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -481,7 +481,7 @@ class EditFileCommandsClass(BaseEditCommandsClass):
     @cmd('file-diff-files')
     def diff(self, event: Event = None) -> None:
         """Creates a node and puts the diff between 2 files into it."""
-        c = self.c
+        c, u = self.c, self.c.undoer
         fn = self.getReadableTextFile()
         if not fn:
             return
@@ -496,9 +496,13 @@ class EditFileCommandsClass(BaseEditCommandsClass):
             return
         lines1, lines2 = g.splitLines(s1), g.splitLines(s2)
         aList = difflib.ndiff(lines1, lines2)
+        # add as last top level like other 'diff' result nodes
+        c.selectPosition(c.lastTopLevel())  # pre-select to help undo-insert
+        undoData = u.beforeInsertNode(c.p)  # c.p is subject of 'insertAfter'
         p = c.p.insertAfter()
         p.h = 'diff'
         p.b = ''.join(aList)
+        u.afterInsertNode(p, 'file-diff-files', undoData)
         c.redraw()
     #@+node:ekr.20170806094318.6: *3* efc.getReadableTextFile
     def getReadableTextFile(self) -> str:


### PR DESCRIPTION
Fixes #3538