### PR TITLE
Fix message in the 'ask' method of leoserver for .leojs files when change is detected.

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -337,7 +337,7 @@ class ServerExternalFilesController(ExternalFilesController):
         else:
             where = p.h
 
-        _is_leo = path.endswith(('.leo', '.db'))
+        _is_leo = path.endswith(('.leo', '.db', '.leojs'))
 
         if _is_leo:
             s = '\n'.join([

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -64,7 +64,7 @@ Socket = Any
 #@-<< leoserver annotations >>
 #@+<< leoserver version >>
 #@+node:ekr.20220820160619.1: ** << leoserver version >>
-version_tuple = (1, 0, 6)
+version_tuple = (1, 0, 7)
 # Version History
 # 1.0.1 Initial commit.
 # 1.0.2 July 2022: Adding ui-scroll, undo/redo, chapters, ua's & node_tags info.
@@ -72,6 +72,7 @@ version_tuple = (1, 0, 6)
 # 1.0.4 September 2022: Full type checking.
 # 1.0.5 October 2022: Fixed node commands when used from client's context menu.
 # 1.0.6 February 2023: Fixed JSON serialization, improved search commands and syntax-coloring.
+# 1.0.7 September 2023: Fixed message for file change detection.
 v1, v2, v3 = version_tuple
 __version__ = f"leoserver.py version {v1}.{v2}.{v3}"
 #@-<< leoserver version >>


### PR DESCRIPTION
Fixed the condition to look for .leojs alongside .leo and .db extensions.
Fixes #3548