### PR TITLE
PR: Fix misspellings in Leo's core

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -467,7 +467,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             re.escape(c.abbrev_subst_end),
         ))
         changed = False
-        # Perform at most one scripting substition.
+        # Perform at most one scripting substitution.
         m = pattern.match(p.h)
         if m:
             content = m.group(2)

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -63,7 +63,7 @@ def check_nodes(event: Event) -> None:
     Especially useful when using @clean nodes in a collaborative
     environment. Leo's @clean update algorithm will update @clean nodes
     when others have added, deleted or moved code, but the update algorithm
-    won't assign changed code to the optimal nodes. This script highligts
+    won't assign changed code to the optimal nodes. This script highlights
     nodes that needed attention.
 
     Settings: You can customize the behavior of this command with @data nodes:
@@ -79,7 +79,7 @@ def check_nodes(event: Event) -> None:
 
     - @data check-nodes-ok-prefixes
 
-      The body ot the @data node contains a list of strings, one per line.
+      The body of the @data node contains a list of strings, one per line.
       Headlines starting with any of these strings are not considered dubious.
       The defaults ignore top-level @<file> nodes and marker nodes::
 
@@ -90,7 +90,7 @@ def check_nodes(event: Event) -> None:
 
     - @data check-nodes-suppressions
 
-      The body ot the @data node contains a list of strings, one per line.
+      The body of the @data node contains a list of strings, one per line.
       Headlines that match these suppressions *exactly* are not considered dubious.
       Default: None.
     """

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -205,7 +205,7 @@ def new(self: Self, event: Event = None, gui: LeoGui = None) -> Cmdr:
     old_c = self
     # Clean out the update queue so it won't interfere with the new window.
     self.outerUpdate()
-    # Supress redraws until later.
+    # Suppress redraws until later.
     g.app.disable_redraw = True
     # Send all log messages to the new frame.
     g.app.setLog(None)

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1093,7 +1093,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 if self.is_string_or_comment(body, i):
                     j = self.skip_string_or_comment(body, i)
                 elif ch in '{};':
-                    # Look ahead ofr '{'
+                    # Look ahead for '{'
                     j += 1
                     while True:
                         k = j
@@ -2153,7 +2153,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             # Suppression table.
             # Missing elements are likely to cause this method to generate '= ='.
             table = (
-                ',',  # Tuple assignment or  mutli-line argument lists.
+                ',',  # Tuple assignment or  multi-line argument lists.
                 '*',  # A converted docstring.
                 '`',  # f-string.
                 '//',  # Comment.
@@ -2635,7 +2635,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     if self.is_string_or_comment(body, i):
                         j = self.skip_string_or_comment(body, i)
                     elif ch in '{};':
-                        # Look ahead ofr '{'
+                        # Look ahead for '{'
                         j += 1
                         while True:
                             k = j

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -238,7 +238,7 @@ class To_Python:  # pragma: no cover
     #@+node:ekr.20150514063305.146: *5* replace
     def replace(self, lines: list[str], findString: str, changeString: str) -> None:
         """
-        Replaces all occurances of findString by changeString.
+        Replaces all occurrences of findString by changeString.
         changeString may be the empty string, but not None.
         """
         if not findString:
@@ -325,7 +325,7 @@ class To_Python:  # pragma: no cover
     #@+node:ekr.20150514063305.150: *5* safe_replace
     def safe_replace(self, lines: list[str], findString: str, changeString: str) -> None:
         """
-        Replaces occurances of findString by changeString,
+        Replaces occurrences of findString by changeString,
         but only outside of C comments and strings.
         changeString may be the empty string, but not None.
         """

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2299,7 +2299,7 @@ class EditCommandsClass(BaseEditCommandsClass):
             c.indentBody(event)
             return
         tab_width = c.getTabWidth(p)
-        # Get the preceeding characters.
+        # Get the preceding characters.
         s = w.getAllText()
         start, end = g.getLine(s, i)
         after = s[i:end]

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -353,7 +353,7 @@ class KillBufferCommandsClass(BaseEditCommandsClass):
                     w.delete(i2, k)
                     i = i2
             w.insert(i, s)
-            # Fix bug 1099035: Leo yank and kill behaviour not quite the same as emacs.
+            # Fix bug 1099035: Leo yank and kill behavior not quite the same as emacs.
             # w.setSelectionRange(i,i+len(s),insert=i+len(s))
             w.setInsertPoint(i + len(s))
             self.lastYankP = current.copy()

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -759,9 +759,9 @@ class SpellTabHandler:
         c.selectPosition(p)
         s = w.getAllText().rstrip()
         ins = w.getInsertPoint()
-        # New in Leo 5.3: use regex to find words.
         last_p = p.copy()
         while True:
+            # Note: despite the tests below, finditer is a crucial speed boost.
             for m in self.re_word.finditer(s[ins:]):
                 start, word = m.start(0), m.group(0)
 
@@ -838,6 +838,7 @@ class SpellTabHandler:
                     k = g.see_more_lines(s, j, 4)
                     w.see(k)
                     return
+                # Don't add misspellings.
                 self.seen.add(word)
             # No more misspellings in p
             p.moveToThreadNext()

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -772,14 +772,16 @@ class SpellTabHandler:
                 if word in self.seen:
                     continue
                 n += 1
+
                 # Ignore the word if numbers precede or follow it.
                 # Seems difficult to do this in the regex itself.
                 k1 = ins + start - 1
                 if k1 >= 0 and s[k1].isdigit():
                     continue
-                # Special case: \n and \t delimit words.
+
+                # Special case: \b, \n, and \t delimit words.
                 #               It seems impossible to do this in the regex.
-                if word.startswith(('t', 'n')) and k1 >= 0 and s[k1] == '\\':
+                if word.startswith(('b', 'n', 't')) and k1 >= 0 and s[k1] == '\\':
                     word = word[1:]
                     start += 1
                     if not word:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -794,7 +794,7 @@ class SpellTabHandler:
                 else:
                     # A special case to handle non-fstring contractions.
                     i = word.find("'")
-                    if i > -1 and i + 2 < len(word):
+                    if i > -1 and i + 3 < len(word):
                         # The supposed contraction ends with more than 2 characters.
                         g.trace('too-long contraction', repr(word))  ### Temp.
                         continue

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -681,9 +681,6 @@ class SpellTabHandler:
         self.c = c
         self.body = c.frame.body
         self.currentWord: str = None
-        # Don't include underscores in words. It just complicates things.
-        # [^\W\d_] means any unicode char except underscore or digit.
-        self.re_word = re.compile(r"([^\W\d_]+)(['`][^\W\d_]+)?", flags=re.UNICODE)
         self.outerScrolledFrame = None
         self.seen: set[str] = set()  # Adding a word to seen will ignore it until restart.
         # A text widget for scanning. Must have a parent frame.
@@ -703,7 +700,7 @@ class SpellTabHandler:
             # g.es_print('No main dictionary')
             self.tab = None
     #@+node:ekr.20150514063305.502: *3* Commands
-    #@+node:ekr.20150514063305.503: *4* add (spellTab)
+    #@+node:ekr.20150514063305.503: *4* SpellTabHandler.add
     def add(self, event: Event = None) -> None:
         """Add the selected suggestion to the dictionary."""
         if self.loaded:
@@ -711,7 +708,7 @@ class SpellTabHandler:
             if w:
                 self.spellController.add(w)
                 self.tab.onFindButton()
-    #@+node:ekr.20150514063305.504: *4* change (spellTab)
+    #@+node:ekr.20150514063305.504: *4* SpellTabHandler.change
     def change(self, event: Event = None) -> bool:
         """Make the selected change to the text"""
         if not self.loaded:
@@ -743,7 +740,15 @@ class SpellTabHandler:
         c.invalidateFocus()
         c.bodyWantsFocus()
         return False
-    #@+node:ekr.20150514063305.505: *4* find & helper
+    #@+node:ekr.20150514063305.505: *4* SpellTabHandler.find & helper
+    # Create a pattern that matches words, including contractions.
+
+    # Do *not* include underscores in words. The spell checker will barf!
+
+    # [^\W\d_] means any unicode char except underscore or digit.
+
+    re_word = re.compile(r"([^\W\d_]+(['`][^\W\d_]{1,2})?)", flags=re.UNICODE)
+
     def find(self, event: Event = None) -> None:
         """Find the next unknown word."""
         if not self.loaded:
@@ -803,7 +808,7 @@ class SpellTabHandler:
                 c.invalidateFocus()
                 c.bodyWantsFocus()
                 return
-    #@+node:ekr.20160415033936.1: *5* showMisspelled
+    #@+node:ekr.20160415033936.1: *5* SpellTabHandler.showMisspelled
     def showMisspelled(self, p: Position) -> None:
         """Show the position p, contracting the tree as needed."""
         c = self.c
@@ -821,10 +826,10 @@ class SpellTabHandler:
             c.redraw(p)
         else:
             c.selectPosition(p)
-    #@+node:ekr.20150514063305.508: *4* hide
+    #@+node:ekr.20150514063305.508: *4* SpellTabHandler.hide
     def hide(self, event: Event = None) -> None:
         self.c.frame.log.selectTab('Log')
-    #@+node:ekr.20150514063305.509: *4* ignore
+    #@+node:ekr.20150514063305.509: *4* SpellTabHandler.ignore
     def ignore(self, event: Event = None) -> None:
         """Ignore the incorrect word for the duration of this spell check session."""
         if self.loaded:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -377,7 +377,7 @@ class EnchantWrapper(BaseSpellWrapper):
                 d = enchant.Dict(language)
             except Exception:
                 d = {}
-        # Commen exit, for traces.
+        # Common exit, for traces.
         return d
 
     #@+node:ekr.20150514063305.515: *3* spell.ignore

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -767,6 +767,13 @@ class SpellTabHandler:
                 k1 = ins + start - 1
                 if k1 >= 0 and s[k1].isdigit():
                     continue
+                # Special case: \n and \t delimit words.
+                #               It seems impossible to do this in the regex.
+                if word.startswith(('t', 'n')) and k1 >= 0 and s[k1] == '\\':
+                    word = word[1:]
+                    start += 1
+                    if not word:
+                        continue
                 k2 = ins + start + len(word)
                 if k2 < len(s) and s[k2].isdigit():
                     continue

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -803,7 +803,7 @@ class SpellTabHandler:
                         continue
 
                 # Special case: f-strings delimited by single quotes.
-                #               Don't bother testing for the obsolute u'xxx' syntax.
+                #               Don't bother testing for the obsolete u'xxx' syntax.
                 if word.startswith("f'"):
                     word = word[2:]
                     start += 2

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -743,22 +743,17 @@ class SpellTabHandler:
     #@+node:ekr.20150514063305.505: *4* SpellTabHandler.find & helper
     # Create a pattern that matches words, including contractions.
 
-    # Do *not* include underscores in words. The spell checker will barf!
+    # The following pattern below is only approximate!
+    # The find method checks and modifies its results.
 
-    # The pattern below doesn't limit the length of contractions
-    # because f-strings starting with a single quote looks like a contraction.
-
-    # Special cases below handle the details.
-
-    # [^\W\d_] means any unicode char except underscore or digit.
-
-    re_word = re.compile(r"([^\W\d_]+(['`][^\W\d_]+)?)", flags=re.UNICODE)
+    re_word = re.compile(r"(\w+(['`]\w+)?)", flags=re.UNICODE)
+    re_part = re.compile(r'[a-zA-z]+')
 
     def find(self, event: Event = None) -> None:
         """Find the next unknown word."""
         if not self.loaded:
             return
-        c, n, p = self.c, 0, self.c.p
+        c, p = self.c, self.c.p
         sc = self.spellController
         w = c.frame.body.wrapper
         c.selectPosition(p)
@@ -769,9 +764,29 @@ class SpellTabHandler:
         while True:
             for m in self.re_word.finditer(s[ins:]):
                 start, word = m.start(0), m.group(0)
-                if word in self.seen:
+
+                # Strip leading and trailing underscores.
+                # sc.process_word throw ValueError otherwise.
+                while word and word.startswith('_'):
+                    word = word[1:]
+                    start += 1
+                if not word:
                     continue
-                n += 1
+                while word and word.endswith('_'):
+                    word = word[:-1]
+                if not word:
+                    continue
+
+                # Make sure the spell checker won't throw ValueError.
+                if '_' in word:
+                    # Only check up to those parts containing word characters.
+                    parts = word.split('_')
+                    parts = [z for z in parts if z]  # Handle '__'.
+                    for i, part in enumerate(parts):
+                        if not self.re_part.match(part):
+                            word = '_'.join(parts[:i])
+                            if not word:
+                                continue
 
                 # Ignore the word if numbers precede or follow it.
                 # Seems difficult to do this in the regex itself.
@@ -780,7 +795,7 @@ class SpellTabHandler:
                     continue
 
                 # Special case: \b, \n, and \t delimit words.
-                #               It seems impossible to do this in the regex.
+                #               It's hard to test for this in the regex.
                 if word.startswith(('b', 'n', 't')) and k1 >= 0 and s[k1] == '\\':
                     word = word[1:]
                     start += 1
@@ -788,29 +803,29 @@ class SpellTabHandler:
                         continue
 
                 # Special case: f-strings delimited by single quotes.
+                #               Don't bother testing for the obsolute u'xxx' syntax.
                 if word.startswith("f'"):
                     word = word[2:]
                     start += 2
                     if not word:
-                        continue
-                else:
-                    # A special case to handle non-fstring contractions.
-                    i = word.find("'")
-                    if i > -1 and i + 3 < len(word):
-                        # The supposed contraction ends with more than 2 characters.
-                        g.trace('too-long contraction', repr(word))  ### Temp.
                         continue
 
                 # Last checks.
                 k2 = ins + start + len(word)
                 if k2 < len(s) and s[k2].isdigit():
                     continue
-                if '_' in word:
+                if word.startswith('_') or word.endswith('_'):
                     g.trace('Can not happen: underscore in word', repr(word))
+                    continue
+                if word in self.seen:
                     continue
 
                 # Look up the word!
-                alts: list[str] = sc.process_word(word)
+                try:
+                    alts: list[str] = sc.process_word(word)
+                except ValueError:
+                    g.trace('Fail:', repr(word))
+                    continue
                 if alts:
                     self.currentWord = word
                     i = ins + start

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -774,7 +774,7 @@ class LeoApp:
             "pl1"           : "pl1",
             "plain"         : "txt",
             "plsql"         : "sql", # qt02537 2005-05-27
-            # "pop11"       : "p", # Conflicts with pascall.
+            # "pop11"       : "p", # Conflicts with pascal.
             "postscript"    : "ps",
             "povray"        : "pov",
             "prolog"        : "pro",
@@ -1946,7 +1946,7 @@ class LoadManager:
         isLeoSettings = fn and g.shortFileName(fn).lower() == 'leosettings.leo'
         exists = g.os_path_exists(fn)
         if fn and exists and lm.isLeoFile(fn) and not isLeoSettings:
-            # Open the file usinging a null gui.
+            # Open the file using a null gui.
             try:
                 g.app.preReadFlag = True
                 c = lm.openSettingsFile(fn)
@@ -2151,7 +2151,7 @@ class LoadManager:
         lm.globalSettingsDict = settings_d
         lm.globalBindingsDict = bindings_d
         # Add settings from --theme or @string theme-name files.
-        # This must be done *after* reading myLeoSettigns.leo.
+        # This must be done *after* reading myLeoSettings.leo.
         lm.theme_path = lm.computeThemeFilePath()
         if lm.theme_path and lm.theme_path != LoadManager.LM_NOTHEME_FLAG:
             lm.theme_c = lm.openSettingsFile(lm.theme_path)
@@ -2361,7 +2361,7 @@ class LoadManager:
             c = self.openEmptyLeoFile(gui=g.app.gui, old_c=None)
             c.rootPosition().h = 'Workbook'
         else:
-            # Open the workboook or create an empty file.
+            # Open the workbook or create an empty file.
             c = self.loadLocalFile(fn, gui=g.app.gui, old_c=None)
             if not exists:
                 c.rootPosition().h = 'Workbook'
@@ -2984,7 +2984,7 @@ class LoadManager:
             return False
     #@+node:ekr.20120223062418.10393: *4* LM.loadLocalFile & helpers
     def loadLocalFile(self, fn: str, gui: Optional[LeoGui], old_c: Optional[Cmdr]) -> Optional[Cmdr]:
-        """Completely read a file, creating the corresonding outline.
+        """Completely read a file, creating the corresponding outline.
 
         1. If fn is an existing .leo, .db or .leojs file, read it twice:
         the first time with a NullGui to discover settings,
@@ -2992,7 +2992,7 @@ class LoadManager:
 
         2. If fn is an external file:
         get settings from the leoSettings.leo and myLeoSetting.leo, then
-        create a "wrapper" outline continain an @file node for the external file.
+        create a "wrapper" outline containing an @file node for the external file.
 
         3. If fn is empty:
         get settings from the leoSettings.leo and myLeoSetting.leo or default settings,
@@ -3446,7 +3446,7 @@ class RecentFilesManager:
                         # acts as a flag for the need to create the menu
                     c.add_command(menu.getMenu(baseName), label=dirName,
                         command=recentFilesCallback, underline=0)
-                else:  # single occurence, no submenu
+                else:  # single occurrence, no submenu
                     c.add_command(recentFilesMenu, label=baseName,
                         command=recentFilesCallback, underline=0)
             else:  # original behavior
@@ -3474,7 +3474,7 @@ class RecentFilesManager:
         c.selectPosition(p1)
         c.redraw()
         c.bodyWantsFocusNow()
-        g.es('edit list and run write-rff to save recentFiles')
+        g.es('edit list and run write-edited-recent-files to save recentFiles')
     #@+node:ekr.20120225072226.10286: *3* rf.getRecentFiles
     def getRecentFiles(self) -> list[str]:
         # Fix #299: Leo loads a deleted file.
@@ -3607,7 +3607,7 @@ class RecentFilesManager:
     def writeEditedRecentFiles(self, c: Cmdr) -> None:
         """
         Write content of "edit_headline" node as recentFiles and recreates
-        menues.
+        menus.
         """
         p, rf = c.p, self
         p = g.findNodeAnywhere(c, self.edit_headline)

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1425,7 +1425,7 @@ class Fstringify:
         """
         Return False if any backslash appears with an {} expression.
 
-        Tokens is a list of lokens on the RHS.
+        Tokens is a list of tokens on the RHS.
         """
         count = 0
         for z in tokens:
@@ -1666,7 +1666,7 @@ class Orange:
     Orange is the new black.
 
     This is a predominantly a *token-based* beautifier. However,
-    organge.do_op, orange.colon, and orange.possible_unary_op use the parse
+    orange.do_op, orange.colon, and orange.possible_unary_op use the parse
     tree to provide context that would otherwise be difficult to deduce.
     """
     # This switch is really a comment. It will always be false.
@@ -2975,7 +2975,7 @@ class TokenOrderGenerator:
                     f"    callers: {g.callers()}")
         # Assign newlines to the previous statement node, if any.
         if token.kind in ('newline', 'nl'):
-            # Set an *auxillary* link for the split/join logic.
+            # Set an *auxiliary* link for the split/join logic.
             # Do *not* set token.node!
             token.statement_node = self.last_statement_node
             return
@@ -3146,7 +3146,7 @@ class TokenOrderGenerator:
     def do_keyword(self, node: Node) -> None:  # pragma: no cover
         """A keyword arg in an ast.Call."""
         # This should never be called.
-        # tog.hande_call_arguments calls self.visit(kwarg_arg.value) instead.
+        # tog.handle_call_arguments calls self.visit(kwarg_arg.value) instead.
         filename = getattr(self, 'filename', '<no file>')
         raise AssignLinksError(
             f"file: {filename}\n"

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1476,7 +1476,7 @@ class AtFile:
             #
             # Bug fix: Leo 4.5.1:
             # use x.markerFromFileName to force the delim to match
-            # what is used in x.propegate changes.
+            # what is used in x.propagate changes.
             marker = x.markerFromFileName(full_path)
             at.startSentinelComment, at.endSentinelComment = marker.getDelims()
             if g.unitTesting:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1476,7 +1476,7 @@ class AtFile:
             #
             # Bug fix: Leo 4.5.1:
             # use x.markerFromFileName to force the delim to match
-            # what is used in x.propagate changes.
+            # what is used in x.propagate_changes.
             marker = x.markerFromFileName(full_path)
             at.startSentinelComment, at.endSentinelComment = marker.getDelims()
             if g.unitTesting:

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -33,7 +33,7 @@ will return None.
 #@-<< leoColor docstring >>
 #@+<< define leo_color_database >>
 #@+node:bob.20080115070511.2: ** << define leo_color_database >>
-# Names should be lower case, without spaces or special characteres.
+# Names should be lower case, without spaces or special characters.
 # See BaseColorizer.normalize().
 leo_color_database = {
     # leo colors

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -299,7 +299,7 @@ class BaseColorizer:
         https://stackoverflow.com/questions/13027091/how-to-override-tab-width-in-qt
         assumes that QTextEdit's have only a single font(!).
 
-        This method probabably only works probably if the body text contains
+        This method probably only works probably if the body text contains
         a single @language directive, and it may not work properly even then.
         """
         c, widget = self.c, self.widget
@@ -645,7 +645,7 @@ class BaseColorizer:
         # This setting is used only in the LeoHighlighter class
         style_name = c.config.getString('pygments-style-name') or 'default'
         # Report everything if we are tracing.
-        show('@bool use-pytments-styles', self.use_pygments_styles)
+        show('@bool use-pygments-styles', self.use_pygments_styles)
         show('@string pygments-style-name', style_name)
         # Report changes to @bool use-pygments-style
         if self.prev_use_styles is None:
@@ -886,7 +886,7 @@ class JEditColorizer(BaseColorizer):
         self.after_doc_language: str = None
         self.initialStateNumber = -1
         self.old_v: VNode = None
-        self.nextState = 1  # Dont use 0.
+        self.nextState = 1  # Don't use 0.
         self.n2languageDict: dict[int, str] = {-1: c.target_language}
         self.prev: tuple[int, int, str] = None
         self.restartDict: dict[int, Callable] = {}  # Keys are state numbers, values are restart functions.
@@ -906,7 +906,7 @@ class JEditColorizer(BaseColorizer):
         self.initialStateNumber = self.setInitialStateNumber()
         #
         # Fix #389. Do *not* change these.
-            # self.nextState = 1 # Dont use 0.
+            # self.nextState = 1 # Don't use 0.
             # self.stateDict = {}
             # self.stateNameDict = {}
             # self.restartDict = {}
@@ -922,7 +922,7 @@ class JEditColorizer(BaseColorizer):
         assert self.language, g.callers(8)
         self.old_v = v
         self.n2languageDict = {-1: self.language}
-        self.nextState = 1  # Dont use 0.
+        self.nextState = 1  # Don't use 0.
         self.restartDict = {}
         self.stateDict = {}
         self.stateNameDict = {}
@@ -1580,7 +1580,7 @@ class JEditColorizer(BaseColorizer):
         self.colorRangeWithTag(s, 0, j, 'leokeyword')
         # New in Leo 5.5: optionally colorize doc parts using reStructuredText
         if c.config.getBool('color-doc-parts-as-rest'):
-            # Switch langauges.
+            # Switch languages.
             self.after_doc_language = self.language
             self.language = 'rest'
             self.clearState()
@@ -1596,7 +1596,7 @@ class JEditColorizer(BaseColorizer):
     #@+node:ekr.20110605121601.18603: *6* jedit.restartDocPart
     def restartDocPart(self, s: str) -> int:
         """
-        Restarter for @ and @ contructs.
+        Restarter for @ and @ constructs.
         Continue until an @c, @code or @language at the start of the line.
         """
         for tag in ('@c', '@code', '@language'):
@@ -2034,7 +2034,7 @@ class JEditColorizer(BaseColorizer):
         at_word_start: bool = False,
         delegate: str = '',
     ) -> int:
-        """Succeed if s[:] mathces seq."""
+        """Succeed if s[:] matches seq."""
         if at_line_start and i != 0 and s[i - 1] != '\n':
             j = i
         elif at_whitespace_end and i != g.skip_ws(s, 0):
@@ -2250,7 +2250,7 @@ class JEditColorizer(BaseColorizer):
 
             def span(s: str) -> int:
                 return self.restart_match_span(s, kind,
-                    # Must be kword arguments.
+                    # Must be keyword arguments.
                     delegate=delegate,
                     end=end,
                     exclude_match=exclude_match,
@@ -2260,7 +2260,7 @@ class JEditColorizer(BaseColorizer):
                 )
 
             self.setRestart(span,
-                # Must be kword arguments.
+                # Must be keyword arguments.
                 delegate=delegate,
                 end=end,
                 kind=kind,
@@ -2344,7 +2344,7 @@ class JEditColorizer(BaseColorizer):
         """
         Match the tex s[i:].
 
-        (Conventional) acro names are a backslashe followed by either:
+        (Conventional) macro names are a backslash followed by either:
         1. One or more ascii letters, or
         2. Exactly one character, of any kind.
         """
@@ -2637,7 +2637,7 @@ if QtGui:
 
         All actual syntax coloring is done in the highlighter class.
 
-        Used by both the JeditColorizer and PYgmentsColorizer classes.
+        Used by both the JeditColorizer and PygmentsColorizer classes.
         """
         # This is c.frame.body.colorizer.highlighter
         #@+others
@@ -2852,7 +2852,7 @@ class PygmentsColorizer(BaseColorizer):
         # Tables and setTag assume lower-case.
         r = repr(token).lstrip('Token.').lstrip('Literal.').lower()
         if r == 'name':
-            # Avoid a colision with existing Leo tag.
+            # Avoid a collision with existing Leo tag.
             r = 'name.pygments'
         return r
 
@@ -3247,7 +3247,7 @@ if pygments:
         """
         Split ``text`` into (tokentype, text) pairs.
 
-        Monkeypatched to store the final stack on the object itself.
+        Monkey patched to store the final stack on the object itself.
 
         The `text` parameter this gets passed is only the current line, so to
         highlight things like multiline strings correctly, we need to retrieve

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2713,7 +2713,7 @@ if QtGui:
             """
             # Modified by EKR.
             # These lines cause unbounded recursion.
-                # code, html = next(self._formatter._format_lines([(token, u'dummy')]))
+                # code, html = next(self._formatter._format_lines([(token, 'dummy')]))
                 # self._document.setHtml(html)
             return QtGui.QTextCursor(self._document).charFormat()
         #@+node:ekr.20190320153716.1: *5* leo_h._get_format_from_style

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -477,7 +477,7 @@ class Commands:
     idle_focus_count = 0
 
     def idle_focus_helper(self, tag: str, keys: Any) -> None:
-        """An idle-tme handler that ensures that focus is *somewhere*."""
+        """An idle-time handler that ensures that focus is *somewhere*."""
         trace = 'focus' in g.app.debug
         trace_inactive_focus = False  # Too disruptive for --trace-focus
         trace_in_dialog = False  # Not useful enough for --trace-focus
@@ -3721,7 +3721,7 @@ class Commands:
         """
         Navigate to the next headline starting with ch = event.char.
         If ch is uppercase, search all headlines; otherwise search only visible headlines.
-        This is modelled on Windows explorer.
+        This is modeled on Windows explorer.
         """
         if not event or not event.char or not event.char.isalnum():
             return

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1000,7 +1000,7 @@ class FileCommands:
         recoveryNode = fc.handleNodeConflicts()
         #
         # Do this after reading external files.
-        # The descendent nodes won't exist unless we have read
+        # The descendant nodes won't exist unless we have read
         # the @thin nodes!
         fc.restoreDescendentAttributes()
         fc.setPositionsFromVnodes()
@@ -1865,7 +1865,7 @@ class FileCommands:
     #@+node:ekr.20080805071954.2: *5* fc.putDescendentVnodeUas & helper
     def putDescendentVnodeUas(self, p: Position) -> str:
         """
-        Return the a uA field for descendent VNode attributes,
+        Return the a uA field for descendant VNode attributes,
         suitable for reconstituting uA's for anonymous vnodes.
         """
         # Create aList of tuples (p,v) having a valid unknownAttributes dict.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2394,18 +2394,7 @@ class LeoFind:
     def _inner_search_match_word(self, s: str, i: int, pattern: str) -> bool:
         """Do a whole-word search."""
         pattern = self.replace_back_slashes(pattern)
-        if not s or not pattern or not g.match(s, i, pattern):
-            return False
-        pat1, pat2 = pattern[0], pattern[-1]
-        n = len(pattern)
-        ch1 = s[i - 1] if 0 <= i - 1 < len(s) else '.'
-        ch2 = s[i + n] if 0 <= i + n < len(s) else '.'
-        isWordPat1 = g.isWordChar(pat1)
-        isWordPat2 = g.isWordChar(pat2)
-        isWordCh1 = g.isWordChar(ch1)
-        isWordCh2 = g.isWordChar(ch2)
-        inWord = isWordPat1 and isWordCh1 or isWordPat2 and isWordCh2
-        return not inWord
+        return bool(s and pattern and g.match_word(s, i, pattern))
     #@+node:ekr.20210110073117.46: *5* find._inner_search_plain
     def _inner_search_plain(self,
         s: str,

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -414,7 +414,7 @@ class LeoBody:
     def deleteEditor(self, event: Event = None) -> None:
         """Delete the presently selected body text editor."""
         c = self.c
-        w = c.frame.body.wapper
+        w = c.frame.body.wrapper
         d = self.editorWrappers
         if len(list(d.keys())) == 1:
             return
@@ -786,7 +786,7 @@ class LeoFrame:
     def promptForSave(self) -> bool:
         """
         Prompt the user to save changes.
-        Return True if the user vetos the quit or save operation.
+        Return True if the user vetoes the quit or save operation.
         """
         c = self.c
         theType = "quitting?" if g.app.quitting else "closing?"

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3190,7 +3190,7 @@ def get_files_in_directory(directory: str, kinds: list = None, recursive: bool =
 #@+node:ekr.20031218072017.1264: *3* g.getBaseDirectory
 def getBaseDirectory(c: Cmdr) -> str:
     """
-    This function is deprectated.
+    This function is deprecated.
 
     Previously it convert '!' or '.' to proper directory references using
     @string relative-path-base-directory.
@@ -5971,7 +5971,7 @@ def finalize(path: str) -> str:
     path = os.path.abspath(path)
     path = os.path.normpath(path)
 
-    # Convert backslashes to forward slashes, regradless of platform.
+    # Convert backslashes to forward slashes, regardless of platform.
     path = g.os_path_normslashes(path)
     return path
 
@@ -6000,7 +6000,7 @@ def finalize_join(*args: Any) -> str:
     path = os.path.abspath(path)
     path = os.path.normpath(path)
 
-    # Convert backslashes to forward slashes, regradless of platform.
+    # Convert backslashes to forward slashes, regardless of platform.
     path = g.os_path_normslashes(path)
     return path
 
@@ -6231,7 +6231,7 @@ def os_startfile(fname: str) -> None:
 #@+node:ekr.20111115155710.9859: ** g.Parsing & Tokenizing
 #@+node:ekr.20031218072017.822: *3* g.createTopologyList
 def createTopologyList(c: Cmdr, root: Position = None, useHeadlines: bool = False) -> list:
-    """Creates a list describing a node and all its descendents"""
+    """Creates a list describing a node and all its descendants"""
     if not root:
         root = c.rootPosition()
     v = root
@@ -6430,7 +6430,7 @@ def executeFile(filename: str, options: str = '') -> None:
     if not os.access(filename, os.R_OK):
         return
     fdir, fname = g.os_path_split(filename)
-    # New in Leo 4.10: alway use subprocess.
+    # New in Leo 4.10: always use subprocess.
 
     def subprocess_wrapper(cmdlst: str) -> tuple:
 
@@ -6690,7 +6690,7 @@ def is_invisible_sentinel(delims: tuple[str, str, str], contents: list[str], i: 
         return True
     if s2.startswith(('@+others', '@+<<')):
         #@verbatim
-        # @others and section references are visibible everywhere.
+        # @others and section references are visible everywhere.
         return True
     # Not visible anywhere. For example, @+leo, @-leo, @-others, @+node, @-node.
     return True

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3997,22 +3997,30 @@ def match_ignoring_case(s1: str, s2: str) -> bool:
     return bool(s1 and s2 and s1.lower() == s2.lower())
 #@+node:ekr.20031218072017.3184: *4* g.match_word & g.match_words
 def match_word(s: str, i: int, pattern: str) -> bool:
-
+    """Return True if s[i] starts a word."""
     # Using a regex is surprisingly tricky.
+
+    # Check the pattern and set j.
     if pattern is None:
         return False
     j = len(pattern)
     if j == 0:
         return False
+
+    # Check the start of the word.
     # Special case: \t or \n delimit words!
     if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'tn':
         return True
     if i > 0 and g.isWordChar(s[i - 1]):
         return False
+
+    # Check that the pattern matches.
     if s.find(pattern, i, i + j) != i:
         return False
     if i + j >= len(s):
         return True
+
+    # Check the end of the word.
     ch = s[i + j]
     return not g.isWordChar(ch)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4008,8 +4008,8 @@ def match_word(s: str, i: int, pattern: str) -> bool:
         return False
 
     # Check the start of the word.
-    # Special case: \t or \n delimit words!
-    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'tn':
+    # Special cases: \b or \t or \n delimit words!
+    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'bnt':
         return True
     if i > 0 and g.isWordChar(s[i - 1]):
         return False

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5518,7 +5518,7 @@ def getLastTracebackFileAndLineNumber() -> tuple[str, int]:
         return val.filename, val.lineno
     #
     # Data is a list of tuples, one per stack entry.
-    # Tupls have the form (filename,lineNumber,functionName,text).
+    # Tuples have the form (filename,lineNumber,functionName,text).
     data = traceback.extract_tb(tb)
     if data:
         item = data[-1]  # Get the item at the top of the stack.
@@ -5545,7 +5545,7 @@ def goto_last_exception(c: Cmdr) -> None:
         g.trace('No previous exception')
 #@+node:ekr.20100126062623.6240: *3* g.internalError
 def internalError(*args: Any) -> None:
-    """Report a serious interal error in Leo."""
+    """Report a serious internal error in Leo."""
     callers = g.callers(20).split(',')
     caller = callers[-1]
     g.error('\nInternal Leo error in', caller)
@@ -6584,7 +6584,7 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
     #
     # Rewritten to fix #1071.
     if g.unitTesting:
-        return s  # Regretable, but necessary.
+        return s  # Regrettable, but necessary.
     #
     # Return s if no @language in effect. Should never happen.
     language = g.scanForAtLanguage(c, p)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4001,10 +4001,13 @@ def match_word(s: str, i: int, pattern: str) -> bool:
     # Using a regex is surprisingly tricky.
     if pattern is None:
         return False
-    if i > 0 and g.isWordChar(s[i - 1]):  # Bug fix: 2017/06/01.
-        return False
     j = len(pattern)
     if j == 0:
+        return False
+    # Special case: \t or \n delimit words!
+    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'tn':
+        return True
+    if i > 0 and g.isWordChar(s[i - 1]):
         return False
     if s.find(pattern, i, i + j) != i:
         return False

--- a/leo/core/leoHistory.py
+++ b/leo/core/leoHistory.py
@@ -33,7 +33,7 @@ class NodeHistory:
         c = self.c
         if g.unitTesting or not self.beadList:
             return
-        print(f"NodeHisory.beadList: {c.shortFileName()}:")
+        print(f"NodeHistory.beadList: {c.shortFileName()}:")
         for i, data in enumerate(self.beadList):
             p, chapter = data
             p_s = p.h if p else 'no p'

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -368,7 +368,7 @@ class AutoCompleterClass:
 
         Evaluates s using eval(s,namespace)
 
-        Assuming the text is of the form NAME.NAME....[NAME], and is evaluatable in
+        Assuming the text is of the form NAME.NAME....[NAME], and can be evaluated in
         the namespace, it will be evaluated and its attributes (as revealed by
         dir()) are used as possible completions.
 

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -72,7 +72,7 @@ def adoc_command(event: Event = None, verbose: bool = True) -> File_List:
 
     Scripts may invoke the adoc command as follows::
 
-        event = g.Bunch(base_dicrectory=my_directory, p=some_node)
+        event = g.Bunch(base_directory=my_directory, p=some_node)
         c.markupCommands.adoc_command(event=event)
 
     This @button node runs the adoc command and coverts all results to .html::
@@ -131,7 +131,7 @@ def pandoc_command(event: Event, verbose: bool = True) -> File_List:
 
     Scripts may invoke the adoc command as follows::
 
-        event = g.Bunch(base_dicrectory=my_directory, p=some_node)
+        event = g.Bunch(base_directory=my_directory, p=some_node)
         c.markupCommands.pandoc_command(event=event)
 
     This @button node runs the adoc command and coverts all results to .html::
@@ -190,7 +190,7 @@ def sphinx_command(event: Event, verbose: bool = True) -> File_List:
 
     Scripts may invoke the sphinx command as follows::
 
-        event = g.Bunch(base_dicrectory=my_directory, p=some_node)
+        event = g.Bunch(base_directory=my_directory, p=some_node)
         c.markupCommands.sphinx_command(event=event)
 
     This @button node runs the sphinx command and coverts all results to .html::
@@ -320,7 +320,7 @@ class MarkupCommands:
     #@+node:ekr.20191007053522.1: *4* markup.compute_opath
     def compute_opath(self, i_path: str) -> str:
         """
-        Neither asciidoctor nor pandoc handles extra extentions well.
+        Neither asciidoctor nor pandoc handles extra extensions well.
         """
         c = self.c
         for _i in range(3):

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -103,7 +103,7 @@ class NodeIndices:
 
         # Leo will continue to work when gnxs are UUIDs or KSUIDs:
         # 1. The FastAtRead.node_start regex uses `([^:]+):` to find gnxs.
-        #    In other words, the gnx is everthing up to the first colon.
+        #    In other words, the gnx is everything up to the first colon.
         #    Neither UUIDs nor KSUIDs contain colons, so the read code will
         #    parse all forms of gnx properly.
         # 2. NodeIndicds.compute_last_index ignores UUIDs and KSUIDs,

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoPlugins imports & annotations >>
 
 # Define modules that may be enabled by default
-# but that mignt not load because imports may fail.
+# but that might not load because imports may fail.
 optional_modules = [
     'leo.plugins.livecode',
     'leo.plugins.cursesGui2',

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -215,7 +215,7 @@ class ShadowController:
         """
         The Mulder update algorithm, revised by EKR.
 
-        Use the diff between the old and new public lines to insperse sentinels
+        Use the diff between the old and new public lines to intersperse sentinels
         from old_private_lines into the result.
 
         The algorithm never deletes or rearranges sentinels. However, verbatim

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -405,7 +405,7 @@ class VimCommands:
             if c.config.getBool('vim-trainer-mode', default=False):
                 self.toggle_vim_trainer_mode()
     #@+node:ekr.20140803220119.18103: *4* vc.init helpers
-    # Every ivar of this class must be initied in exactly one init helper.
+    # Every ivar of this class must be inited in exactly one init helper.
     #@+node:ekr.20140803220119.18104: *5* vc.init_dot_ivars
     def init_dot_ivars(self) -> None:
         """Init all dot-related ivars."""
@@ -1366,7 +1366,7 @@ class VimCommands:
             self.quit()
     #@+node:ekr.20140808173212.18070: *5* vc.vim_pound
     def vim_pound(self) -> None:
-        """Find previous occurance of word under the cursor."""
+        """Find previous occurrence of word under the cursor."""
         # ec = self.c.editCommands
         w = self.w
         if self.is_text_wrapper(w):
@@ -1461,7 +1461,7 @@ class VimCommands:
             self.quit()
     #@+node:ekr.20140810210411.18239: *5* vc.vim_star
     def vim_star(self) -> None:
-        """Find previous occurance of word under the cursor."""
+        """Find previous occurrence of word under the cursor."""
         # ec = self.c.editCommands
         w = self.w
         if self.is_text_wrapper(w):

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -101,7 +101,7 @@ class SetEncoder(json.JSONEncoder):
         # Sets become basic javascript arrays
         if isinstance(obj, set):
             return list(obj)
-        # Leo Positions get converted with same simple algo as p_to_ap
+        # Leo Positions get converted with same simple algorithm as p_to_ap
         if isinstance(obj, Position):
             stack = [{'gnx': v.gnx, 'childIndex': childIndex}
                 for (v, childIndex) in obj.stack]
@@ -4867,7 +4867,7 @@ class LeoServer:
             selRange = gui_w.getSelectionRange()
             return selRange
         except Exception:
-            print("Error retrieving current focussed widget selection range.")
+            print("Error retrieving current focused widget selection range.")
             return 0, 0
     #@+node:felix.20210705211625.1: *4* server._is_jsonable
     def _is_jsonable(self, x: Any) -> bool:

--- a/leo/external/codewise.py
+++ b/leo/external/codewise.py
@@ -78,7 +78,7 @@ FUNCTION, the most important one, contains functions/methods, along with CLASS
  used to give calltips, or used as a regexp to find the method from file
  quickly.
 
-You can browse the data by installing sqlitebrovser and doing 'sqlitebrowser
+You can browse the data by installing sqlitebrowser and doing 'sqlitebrowser
 ~/codewise.db'
 
 If you know the class name you want to find the methods for,
@@ -117,7 +117,7 @@ codewise m MyClass
  Show all methods in MyClass
 
 codewise f PREFIX
- Show all symbols (also nonmember functiosn) starting with PREFIX.
+ Show all symbols (also nonmember functions) starting with PREFIX.
  PREFIX can be omitted to get a list of all symbols
 
 codewise parseall

--- a/leo/external/leosax.py
+++ b/leo/external/leosax.py
@@ -51,7 +51,7 @@ class LeoNode:
     #@+node:ekr.20120519121124.9923: *3* __str__
     def __str__(self, level=0):
         """Return long text representation of node and
-        descendents with indentation"""
+        descendants with indentation"""
         ans = [("%s%s (%s)" % ('  ' * (level - 1), self.h, self.gnx))[:78]]
         for k in self.u:
             s = self.u[k]
@@ -65,7 +65,7 @@ class LeoNode:
     #@+node:ekr.20120519121124.9924: *3* UNL (leosax.py)
     def node_pos_count(self, node):
         """node_pos_count - return the position (index) and count of
-        preceeding siblings with the same name, also return headline
+        preceding siblings with the same name, also return headline
 
         :param LeoNode node: node to characterize
         :return: h, pos, count
@@ -109,7 +109,7 @@ class LeoReader(ContentHandler):
         `in_`
           name of XML element we're current in, used for SAX read
         in_attr
-          attributes of element tag we're currentl in, used for SAX read
+          attributes of element tag we're currently in, used for SAX read
         path
           list of nodes leading to current node
 
@@ -190,7 +190,7 @@ class LeoReader(ContentHandler):
     #@-others
 #@+node:ekr.20120519121124.9931: ** get_leo_data
 def get_leo_data(source):
-    """Return the root node for the specificed .leo file (path or file)"""
+    """Return the root node for the specified .leo file (path or file)"""
     parser = LeoReader()
     if g.os_path_isfile(source):
         source = g.readFileIntoEncodedString(source)

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -112,7 +112,7 @@ def unit_test(raise_on_fail=True):
         'FunctionType', 'NamedExpr', 'TypeIgnore',
     ]
     aList = [z for z in aList if not z[0].islower()]
-        # Remove base classe
+        # Remove base class.
     aList = [z for z in aList if not z.startswith('_') and not z in remove]
     # Now test them.
     table = (
@@ -886,7 +886,7 @@ class AstFormatter:
         result.append(self.indent('%swith ' % 'async ' if async_flag else ''))
         vars_list = []
         if getattr(node, 'context_expression', None):
-            result.append(self.visit(node.context_expresssion))
+            result.append(self.visit(node.context_expression))
         if getattr(node, 'optional_vars', None):
             try:
                 for z in node.optional_vars:
@@ -1429,7 +1429,7 @@ class ReduceTypes:
             if s2 == s:
                 return True
             else:
-                # Don't look inside bracketss.
+                # Don't look inside brackets.
                 pattern = Pattern(s2 + '[*]', s)
                 if pattern.match_entire_string(s):
                     return True
@@ -2274,7 +2274,7 @@ class StubFormatter(AstFormatter):
     #@+node:ekr.20160317054700.161: *3* sf.Return
     def do_Return(self, node):
         '''
-        StubFormatter ast.Return vsitor.
+        StubFormatter ast.Return visitor.
         Return only the return expression itself.
         '''
         s = AstFormatter.do_Return(self, node)
@@ -2802,7 +2802,7 @@ class StubTraverser(ast.NodeVisitor):
             return s + ': ...'
     #@+node:ekr.20160317054700.185: *5* st.get_def_name
     def get_def_name(self, node):
-        '''Return the representaion of a function or method name.'''
+        '''Return the representation of a function or method name.'''
         if self.class_name_stack:
             name = '%s.%s' % (self.class_name_stack[-1], node.name)
             # All ctors should return None

--- a/leo/external/py2cs.py
+++ b/leo/external/py2cs.py
@@ -88,7 +88,7 @@ def unit_test(raise_on_fail=True):
         'FunctionType', 'NamedExpr', 'TypeIgnore',
     ]
     aList = [z for z in aList if not z[0].islower()]
-        # Remove base classe
+        # Remove base class.
     aList = [z for z in aList if not z.startswith('_') and not z in remove]
     # Now test them.
     traverser = CoffeeScriptTraverser(controller=None)
@@ -222,7 +222,7 @@ class CoffeeScriptTraverser:
         self.last_node = sync.last_node
         self.leading_lines = sync.leading_lines
         self.leading_string = sync.leading_string
-        self.tokens_for_statment = sync.tokens_for_statement
+        self.tokens_for_statement = sync.tokens_for_statement
         self.trailing_comment = sync.trailing_comment
         self.trailing_comment_at_lineno = sync.trailing_comment_at_lineno
         # Compute the result.

--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -77,7 +77,7 @@ class ListTable(QtCore.QAbstractTableModel):
         if delim is None:
             delim = DEFAULTDELIM
 
-        # look for seperator not in text
+        # look for separator not in text
         sep_i = 0
         while SEPS[sep_i] in text and sep_i < len(SEPS) - 1:
             sep_i += 1
@@ -141,7 +141,7 @@ class ListTable(QtCore.QAbstractTableModel):
     #@+node:ekr.20211210174103.9: *3* get_text
     def get_text(self):
 
-        # look for seperator not in text
+        # look for separator not in text
         sep_i = 0
         tmp = ''.join([''.join(i) for i in self._data])
         while SEPS[sep_i] in tmp and sep_i < len(SEPS) - 1:

--- a/leo/plugins/editpane/plaintextedit.py
+++ b/leo/plugins/editpane/plaintextedit.py
@@ -69,7 +69,7 @@ class LEP_PlainTextEdit(QtWidgets.QTextEdit):
 #@+node:tbrown.20171028115504.10: ** class LEP_PlainTextEditB
 class LEP_PlainTextEditB(LEP_PlainTextEdit):
     """LEP_PlainTextEditB - copy of LEP_PlainTextEdit with different
-    background color to test multiple edtitors
+    background color to test multiple editors
     """
     lep_name = "Plain Text Edit 'B'"
     #@+others

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -120,7 +120,7 @@ class FreeLayoutController:
           (tree, body, log-window-tabs) and
 
         - tag the log-window-tabs widget as the place to put widgets
-          from free-laout panes which are closed
+          from free-layout panes which are closed
 
         - register this FreeLayoutController as a provider of menu items
           for NestedSplitter
@@ -238,7 +238,7 @@ class FreeLayoutController:
         - `reloading`: True if this is not the initial load, see below
 
         When called from the `after-create-leo-frame2` hook this defaults
-        to False.  When called from the `resotre-layout` command, this is set
+        to False.  When called from the `restore-layout` command, this is set
         True, and the layout the outline had *when first loaded* is restored.
         Useful if you want to temporarily switch to a different layout and then
         back, without having to remember the original layouts name.

--- a/leo/plugins/leo_pdf.py
+++ b/leo/plugins/leo_pdf.py
@@ -939,7 +939,7 @@ if docutils:  # NOQA
                 'footnote_refs'
                 'footnotes'
                 'id_start'
-                'ids'  # keys are sectinon names, values are section objects or reference objects.
+                'ids'  # keys are section names, values are section objects or reference objects.
                 'indirect_targets'
                 'nameids'  # This might be what we want: keys are section names, values are munged names.
                 # 'nametypes'

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -69,7 +69,7 @@ class NestedSplitterTopLevel(QtWidgets.QWidget):  # type:ignore
 #@+node:ekr.20110605121601.17959: ** class NestedSplitterChoice (QWidget)
 class NestedSplitterChoice(QtWidgets.QWidget):  # type:ignore
     """When a new pane is opened in a nested splitter layout, this widget
-    presents a button, labled 'Action', which provides a popup menu
+    presents a button, labeled 'Action', which provides a popup menu
     for the user to select what to do in the new pane"""
     #@+others
     #@+node:ekr.20110605121601.17960: *3* __init__ (NestedSplitterChoice)
@@ -407,7 +407,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
             # actual splitters, current and future
             root._splitterClickedArgs = []  # save for future added splitters
         for args in root._splitterClickedArgs:
-            # apply any .connect() calls that occured earlier
+            # apply any .connect() calls that occurred earlier
             self._splitterClickedSignal.connect(*args)
 
         self.root = root
@@ -528,7 +528,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
             orient == vertical and side in ('above', 'below')
         ):
             # easy case, just insert the new thing, what,
-            # either side of old, in existng splitter
+            # either side of old, in existing splitter
             if side in ('right-of', 'below'):
                 pos += 1
             layout['splitter'].insert(pos, what)
@@ -606,7 +606,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
                     break
     #@+node:ekr.20110605121601.17973: *3* ns.contains
     def contains(self, widget):
-        """check if widget is a descendent of self"""
+        """check if widget is a descendant of self"""
         for i in range(self.count()):
             if widget == self.widget(i):
                 return True
@@ -640,7 +640,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
           if the neighbours are not NestedSplitters, i.e.
           [ns0, ns1] or [None, ns1] or [ns0, None] or [None, None]
         count
-          the pair of nested counts of widgets / spliters around the handle
+          the pair of nested counts of widgets / splitters around the handle
         """
         widget = [self.widget(index - 1), self.widget(index)]
         neighbour = [(i if isinstance(i, NestedSplitter) else None) for i in widget]
@@ -678,7 +678,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
         return w
     #@+node:ekr.20110605121601.17976: *3* ns.invalid_swap
     def invalid_swap(self, w0, w1):
-        """check for swap violating hierachy"""
+        """check for swap violating hierarchy"""
         return (
             w0 == w1 or
             isinstance(w0, NestedSplitter) and w0.contains(w1) or
@@ -836,7 +836,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
             self.setSizes(sizes)
     #@+node:ekr.20110605121601.17983: *3* ns.rotate
     def rotate(self, descending=False):
-        """Change orientation - current rotates entire hierachy, doing less
+        """Change orientation - current rotates entire hierarchy, doing less
         is visually confusing because you end up with nested splitters with
         the same orientation - avoiding that would mean doing rotation by
         inserting out widgets into our ancestors, etc.
@@ -848,7 +848,7 @@ class NestedSplitter(QtWidgets.QSplitter):  # type:ignore
                 i.setOrientation(Orientation.Vertical)
     #@+node:vitalije.20170713085342.1: *3* ns.rotateOne
     def rotateOne(self, index):
-        """Change orientation - only of splithandle at index."""
+        """Change orientation - only of splitter handle at index."""
         psp = self.parent()
         if self.count() == 2 and isinstance(psp, NestedSplitter):
             i = psp.indexOf(self)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -750,7 +750,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         ftm = fc.ftm
 
         def mungeName(kind: str, label: str) -> str:
-            # The returned value is the namve of an ivar.
+            # The returned value is the name of an ivar.
             kind = 'check_box_' if kind == 'box' else 'radio_button_'
             name = label.replace(' ', '_').replace('&', '').lower()
             return f"{kind}{name}"
@@ -946,7 +946,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
                     return True
                 binding, ch, lossage = self.eventFilter.toBinding(event)
                 # #2094: Use code similar to the end of LeoQtEventFilter.eventFilter.
-                #        The ctor converts <Alt-X> to <Atl-x> !!
+                #        The ctor converts <Alt-X> to <Alt-x> !!
                 #        That is, we must use the stroke, not the binding.
                 key_event = leoGui.LeoKeyEvent(
                     c=self.c, char=ch, event=event, binding=binding, w=self.w)
@@ -3532,7 +3532,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):  # type:ignore
         based on the file's name fn and contents s.
 
         If the file is an thin file, create an @file tree.
-        Othewise, create an @auto tree.
+        Otherwise, create an @auto tree.
         If all else fails, create an @edit node.
 
         Give a warning if a node with the same headline already exists.
@@ -4253,7 +4253,7 @@ class QtMenuWrapper(LeoQtMenu, QtWidgets.QMenu):  # type:ignore
                     if not bi.isModeBinding():
                         accel = k.prettyPrintKey(bi.stroke)
                         result.append(accel)
-                        # Break here if we want to show only one accerator.
+                        # Break here if we want to show only one accelerator.
                 action.setText(f"{s}\t{', '.join(result)}")
             else:
                 action.setText(s)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -664,7 +664,7 @@ class LeoQtGui(leoGui.LeoGui):
         callback: Callable=None,
         buttons: list[str]=None,
     ) -> tuple[str, dict]:
-        """Dispay a modal TkPropertiesDialog"""
+        """Display a modal TkPropertiesDialog"""
         if not g.unitTesting:
             g.warning('Properties menu not supported for Qt gui')
         return 'Cancel', {}
@@ -830,7 +830,7 @@ class LeoQtGui(leoGui.LeoGui):
         w_name = w and w.objectName()
         # Fix #270: Vim keys don't always work after double Alt+Tab.
         # Fix #359: Leo hangs in LeoQtEventFilter.eventFilter
-        # #1273: add teest on c.vim_mode.
+        # #1273: add test on c.vim_mode.
         if c.exists and c.vim_mode and c.vimCommands and not self.active and not g.app.killed:
             c.vimCommands.on_activate()
         self.active = True  # Used only by c.idle_focus_helper.
@@ -1375,12 +1375,12 @@ class LeoQtGui(leoGui.LeoGui):
         splash = None
         for fn in (
             'SplashScreen.svg',  # Leo's licensed .svg logo.
-            'Leosplash.GIF',  # Leo's public domain bitmaped image.
+            'Leosplash.GIF',  # Leo's public domain bitmapped image.
         ):
             path = g.finalize_join(g.app.loadDir, '..', 'Icons', fn)
             if g.os_path_exists(path):
                 if fn.endswith('svg'):
-                    # Convert SVG to un-pixelated pixmap
+                    # Convert SVG to un-pixilated pixmap
                     renderer = QSvgRenderer(path)
                     size = renderer.defaultSize()
                     svg_height, svg_width = size.height(), size.width()
@@ -1598,7 +1598,7 @@ class StyleClassManager:
     def update_view(self, w: Wrapper) -> None:
         """update_view - Make Qt apply w's style
 
-        :param QWidgit w: widgit to style
+        :param QWidgit w: widget to style
         """
 
         w.setStyleSheet("/* */")  # forces visual update
@@ -1826,7 +1826,7 @@ class StyleSheetManager:
                 w = self.get_master_widget(top)
             w.setStyleSheet(sheet)
     #@+node:ekr.20180316091943.1: *3* ssm.Stylesheet
-    # Computations on stylesheets themeselves.
+    # Computations on stylesheets themselves.
     #@+node:ekr.20140915062551.19510: *4* ssm.expand_css_constants & helpers
     css_warning_given = False  # For do_pass.
 
@@ -1916,7 +1916,7 @@ class StyleSheetManager:
             if value:
                 # Partial fix for #780.
                 try:
-                    # Don't replace shorter constants occuring in larger.
+                    # Don't replace shorter constants occurring in larger.
                     sheet = re.sub(
                         const + "(?![-A-Za-z0-9_])",
                         value,

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1075,7 +1075,7 @@ class NumberBar(QtWidgets.QFrame):  # type:ignore
         self.image = QtGui.QImage(g.app.gui.getImageImage(
             g.finalize_join(g.app.loadDir,
             '..', 'Icons', 'Tango', '16x16', 'actions', 'stop.png')))
-        self.highest_line = 0  # The highest line that is currently visibile.
+        self.highest_line = 0  # The highest line that is currently visible.
         # Set the name to gutter so that the QFrame#gutter style sheet applies.
         self.offsets: list[tuple[int, Any]] = []
         self.setObjectName('gutter')
@@ -1789,7 +1789,7 @@ class QTextEditWrapper(QTextMixin):
     def pageUpDown(self, op: Any, moveMode: Any) -> None:
         """
         The QTextEdit PageUp/PageDown functionality seems to be "baked-in"
-        and not externally accessible. Since Leo has its own keyhandling
+        and not externally accessible. Since Leo has its own key handling
         functionality, this code emulates the QTextEdit paging. This is a
         straight port of the C++ code found in the pageUpDown method of
         gui/widgets/qtextedit.cpp.
@@ -1952,7 +1952,7 @@ class QTextEditWrapper(QTextMixin):
         v.scrollBarSpot = w.verticalScrollBar().value()
     #@+node:ekr.20141103061944.40: *4* qtew.setXScrollPosition
     def setXScrollPosition(self, pos: int) -> None:
-        """Set the position of the horizonatl scrollbar."""
+        """Set the position of the horizontal scrollbar."""
         if pos is not None:
             w = self.widget
             sb = w.horizontalScrollBar()

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -246,7 +246,7 @@ class LeoQtTree(leoFrame.LeoTree):
             elif cmd == 'REPLACE-REST':
                 s = (text[:m.start()] + text[m.end() :]).strip()
 
-            # 's' is string when 'cmd' is recognised
+            # 's' is string when 'cmd' is recognized
             # and is None otherwise
             if isinstance(s, str):
                 # Save the operation
@@ -693,7 +693,7 @@ class LeoQtTree(leoFrame.LeoTree):
         if not p:
             self.error('no p')
             return
-        # 2014/02/21: generate headddlick1/2 instead of icondclick1/2.
+        # 2014/02/21: generate headdlick1/2 instead of icondclick1/2.
         if g.doHook("headdclick1", c=c, p=p, event=None) is None:
             c.frame.tree.OnIconDoubleClick(p)  # Call the base class method.
         g.doHook("headclick2", c=c, p=p, event=None)

--- a/leo/scripts/remove_duplicate_pictures.py
+++ b/leo/scripts/remove_duplicate_pictures.py
@@ -343,7 +343,7 @@ class RemoveDuplicates:
         starting_directory=None,  # Starting directory for file dialog if no path given.
     ):
         """
-        Preprecess the files and show the first duplicates.
+        Preprocess the files and show the first duplicates.
         Return True if any duplicates were found.
         """
         # Init ivars.


### PR DESCRIPTION
Most misspellings are in docstrings or comments. Other misspellings are more serious.

*Note*: The diffs include changes from PR #3568 (word boundaries) because that PR helps spell-checking.

~~This PR will be deferred until Leo 6.7.6 so as not to interfere with leoJS.~~

**Fix real bugs**

- `leoFrame.py: deleteEditor`: Change `c.frame.body.wapper` to `c.frame.body.wrapper`!
- `make_stub_files.py: do_With`:
  Change `result.append(self.visit(node.context_expresssion))`  (3 s's)
  to `result.append(self.visit(node.context_expression))`
- `py2cs.py: format`: Change `self.tokens_for_statment` to `self.tokens_for_statement`.

**Other non-trivial changes**

- `writeOneAtShadowNode`: Check that `x.propagate changes` exists.
-  `configure_hard_tab_width`: Change the code to `show('@bool use-pygments-styles', self.use_pygments_styles)`.