### PR TITLE
PR for #3567: word boundaries

### DIFF
--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -798,7 +798,7 @@ class SpellTabHandler:
                     i = word.find("'")
                     if i > -1 and i + 3 < len(word):
                         # The supposed contraction ends with more than 2 characters.
-                        g.trace('too-long contraction', repr(word))  ### Temp.
+                        # g.trace('too-long contraction', repr(word))
                         continue
 
                 # Last checks.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -759,9 +759,9 @@ class SpellTabHandler:
         c.selectPosition(p)
         s = w.getAllText().rstrip()
         ins = w.getInsertPoint()
-        # New in Leo 5.3: use regex to find words.
         last_p = p.copy()
         while True:
+            # Note: despite the tests below, finditer is a crucial speed boost.
             for m in self.re_word.finditer(s[ins:]):
                 start, word = m.start(0), m.group(0)
 
@@ -838,6 +838,7 @@ class SpellTabHandler:
                     k = g.see_more_lines(s, j, 4)
                     w.see(k)
                     return
+                # Don't add misspellings.
                 self.seen.add(word)
             # No more misspellings in p
             p.moveToThreadNext()

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -772,14 +772,16 @@ class SpellTabHandler:
                 if word in self.seen:
                     continue
                 n += 1
+
                 # Ignore the word if numbers precede or follow it.
                 # Seems difficult to do this in the regex itself.
                 k1 = ins + start - 1
                 if k1 >= 0 and s[k1].isdigit():
                     continue
-                # Special case: \n and \t delimit words.
+
+                # Special case: \b, \n, and \t delimit words.
                 #               It seems impossible to do this in the regex.
-                if word.startswith(('t', 'n')) and k1 >= 0 and s[k1] == '\\':
+                if word.startswith(('b', 'n', 't')) and k1 >= 0 and s[k1] == '\\':
                     word = word[1:]
                     start += 1
                     if not word:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -794,7 +794,7 @@ class SpellTabHandler:
                 else:
                     # A special case to handle non-fstring contractions.
                     i = word.find("'")
-                    if i > -1 and i + 2 < len(word):
+                    if i > -1 and i + 3 < len(word):
                         # The supposed contraction ends with more than 2 characters.
                         g.trace('too-long contraction', repr(word))  ### Temp.
                         continue

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -796,15 +796,18 @@ class SpellTabHandler:
                     i = word.find("'")
                     if i > -1 and i + 2 < len(word):
                         # The supposed contraction ends with more than 2 characters.
-                        g.trace('too-long contraction', repr(word))
+                        g.trace('too-long contraction', repr(word))  ### Temp.
                         continue
 
-                # Last check.
+                # Last checks.
                 k2 = ins + start + len(word)
                 if k2 < len(s) and s[k2].isdigit():
                     continue
+                if '_' in word:
+                    g.trace('Can not happen: underscore in word', repr(word))
+                    continue
 
-                # Look up the word! It must not contain an underscore!
+                # Look up the word!
                 alts: list[str] = sc.process_word(word)
                 if alts:
                     self.currentWord = word

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -681,9 +681,6 @@ class SpellTabHandler:
         self.c = c
         self.body = c.frame.body
         self.currentWord: str = None
-        # Don't include underscores in words. It just complicates things.
-        # [^\W\d_] means any unicode char except underscore or digit.
-        self.re_word = re.compile(r"([^\W\d_]+)(['`][^\W\d_]+)?", flags=re.UNICODE)
         self.outerScrolledFrame = None
         self.seen: set[str] = set()  # Adding a word to seen will ignore it until restart.
         # A text widget for scanning. Must have a parent frame.
@@ -703,7 +700,7 @@ class SpellTabHandler:
             # g.es_print('No main dictionary')
             self.tab = None
     #@+node:ekr.20150514063305.502: *3* Commands
-    #@+node:ekr.20150514063305.503: *4* add (spellTab)
+    #@+node:ekr.20150514063305.503: *4* SpellTabHandler.add
     def add(self, event: Event = None) -> None:
         """Add the selected suggestion to the dictionary."""
         if self.loaded:
@@ -711,7 +708,7 @@ class SpellTabHandler:
             if w:
                 self.spellController.add(w)
                 self.tab.onFindButton()
-    #@+node:ekr.20150514063305.504: *4* change (spellTab)
+    #@+node:ekr.20150514063305.504: *4* SpellTabHandler.change
     def change(self, event: Event = None) -> bool:
         """Make the selected change to the text"""
         if not self.loaded:
@@ -743,7 +740,15 @@ class SpellTabHandler:
         c.invalidateFocus()
         c.bodyWantsFocus()
         return False
-    #@+node:ekr.20150514063305.505: *4* find & helper
+    #@+node:ekr.20150514063305.505: *4* SpellTabHandler.find & helper
+    # Create a pattern that matches words, including contractions.
+
+    # Do *not* include underscores in words. The spell checker will barf!
+
+    # [^\W\d_] means any unicode char except underscore or digit.
+
+    re_word = re.compile(r"([^\W\d_]+(['`][^\W\d_]{1,2})?)", flags=re.UNICODE)
+
     def find(self, event: Event = None) -> None:
         """Find the next unknown word."""
         if not self.loaded:
@@ -803,7 +808,7 @@ class SpellTabHandler:
                 c.invalidateFocus()
                 c.bodyWantsFocus()
                 return
-    #@+node:ekr.20160415033936.1: *5* showMisspelled
+    #@+node:ekr.20160415033936.1: *5* SpellTabHandler.showMisspelled
     def showMisspelled(self, p: Position) -> None:
         """Show the position p, contracting the tree as needed."""
         c = self.c
@@ -821,10 +826,10 @@ class SpellTabHandler:
             c.redraw(p)
         else:
             c.selectPosition(p)
-    #@+node:ekr.20150514063305.508: *4* hide
+    #@+node:ekr.20150514063305.508: *4* SpellTabHandler.hide
     def hide(self, event: Event = None) -> None:
         self.c.frame.log.selectTab('Log')
-    #@+node:ekr.20150514063305.509: *4* ignore
+    #@+node:ekr.20150514063305.509: *4* SpellTabHandler.ignore
     def ignore(self, event: Event = None) -> None:
         """Ignore the incorrect word for the duration of this spell check session."""
         if self.loaded:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -776,11 +776,12 @@ class SpellTabHandler:
                     word = word[:-1]
                 if not word:
                     continue
-                    
+
                 # Make sure the spell checker won't throw ValueError.
                 if '_' in word:
                     # Only check up to those parts containing word characters.
                     parts = word.split('_')
+                    parts = [z for z in parts if z]  # Handle '__'.
                     for i, part in enumerate(parts):
                         if not self.re_part.match(part):
                             word = '_'.join(parts[:i])

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -767,6 +767,13 @@ class SpellTabHandler:
                 k1 = ins + start - 1
                 if k1 >= 0 and s[k1].isdigit():
                     continue
+                # Special case: \n and \t delimit words.
+                #               It seems impossible to do this in the regex.
+                if word.startswith(('t', 'n')) and k1 >= 0 and s[k1] == '\\':
+                    word = word[1:]
+                    start += 1
+                    if not word:
+                        continue
                 k2 = ins + start + len(word)
                 if k2 < len(s) and s[k2].isdigit():
                     continue

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -745,9 +745,14 @@ class SpellTabHandler:
 
     # Do *not* include underscores in words. The spell checker will barf!
 
+    # The pattern below doesn't limit the length of contractions
+    # because f-strings starting with a single quote looks like a contraction.
+
+    # Special cases below handle the details.
+
     # [^\W\d_] means any unicode char except underscore or digit.
 
-    re_word = re.compile(r"([^\W\d_]+(['`][^\W\d_]{1,2})?)", flags=re.UNICODE)
+    re_word = re.compile(r"([^\W\d_]+(['`][^\W\d_]+)?)", flags=re.UNICODE)
 
     def find(self, event: Event = None) -> None:
         """Find the next unknown word."""
@@ -779,9 +784,27 @@ class SpellTabHandler:
                     start += 1
                     if not word:
                         continue
+
+                # Special case: f-strings delimited by single quotes.
+                if word.startswith("f'"):
+                    word = word[2:]
+                    start += 2
+                    if not word:
+                        continue
+                else:
+                    # A special case to handle non-fstring contractions.
+                    i = word.find("'")
+                    if i > -1 and i + 2 < len(word):
+                        # The supposed contraction ends with more than 2 characters.
+                        g.trace('too-long contraction', repr(word))
+                        continue
+
+                # Last check.
                 k2 = ins + start + len(word)
                 if k2 < len(s) and s[k2].isdigit():
                     continue
+
+                # Look up the word! It must not contain an underscore!
                 alts: list[str] = sc.process_word(word)
                 if alts:
                     self.currentWord = word

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -803,7 +803,7 @@ class SpellTabHandler:
                         continue
 
                 # Special case: f-strings delimited by single quotes.
-                #               Don't bother testing for the obsolute u'xxx' syntax.
+                #               Don't bother testing for the obsolete u'xxx' syntax.
                 if word.startswith("f'"):
                     word = word[2:]
                     start += 2

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2394,18 +2394,7 @@ class LeoFind:
     def _inner_search_match_word(self, s: str, i: int, pattern: str) -> bool:
         """Do a whole-word search."""
         pattern = self.replace_back_slashes(pattern)
-        if not s or not pattern or not g.match(s, i, pattern):
-            return False
-        pat1, pat2 = pattern[0], pattern[-1]
-        n = len(pattern)
-        ch1 = s[i - 1] if 0 <= i - 1 < len(s) else '.'
-        ch2 = s[i + n] if 0 <= i + n < len(s) else '.'
-        isWordPat1 = g.isWordChar(pat1)
-        isWordPat2 = g.isWordChar(pat2)
-        isWordCh1 = g.isWordChar(ch1)
-        isWordCh2 = g.isWordChar(ch2)
-        inWord = isWordPat1 and isWordCh1 or isWordPat2 and isWordCh2
-        return not inWord
+        return bool(s and pattern and g.match_word(s, i, pattern))
     #@+node:ekr.20210110073117.46: *5* find._inner_search_plain
     def _inner_search_plain(self,
         s: str,

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3997,22 +3997,30 @@ def match_ignoring_case(s1: str, s2: str) -> bool:
     return bool(s1 and s2 and s1.lower() == s2.lower())
 #@+node:ekr.20031218072017.3184: *4* g.match_word & g.match_words
 def match_word(s: str, i: int, pattern: str) -> bool:
-
+    """Return True if s[i] starts a word."""
     # Using a regex is surprisingly tricky.
+
+    # Check the pattern and set j.
     if pattern is None:
         return False
     j = len(pattern)
     if j == 0:
         return False
+
+    # Check the start of the word.
     # Special case: \t or \n delimit words!
     if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'tn':
         return True
     if i > 0 and g.isWordChar(s[i - 1]):
         return False
+
+    # Check that the pattern matches.
     if s.find(pattern, i, i + j) != i:
         return False
     if i + j >= len(s):
         return True
+
+    # Check the end of the word.
     ch = s[i + j]
     return not g.isWordChar(ch)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4008,8 +4008,8 @@ def match_word(s: str, i: int, pattern: str) -> bool:
         return False
 
     # Check the start of the word.
-    # Special case: \t or \n delimit words!
-    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'tn':
+    # Special cases: \b or \t or \n delimit words!
+    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'bnt':
         return True
     if i > 0 and g.isWordChar(s[i - 1]):
         return False

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4001,10 +4001,13 @@ def match_word(s: str, i: int, pattern: str) -> bool:
     # Using a regex is surprisingly tricky.
     if pattern is None:
         return False
-    if i > 0 and g.isWordChar(s[i - 1]):  # Bug fix: 2017/06/01.
-        return False
     j = len(pattern)
     if j == 0:
+        return False
+    # Special case: \t or \n delimit words!
+    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'tn':
+        return True
+    if i > 0 and g.isWordChar(s[i - 1]):
         return False
     if s.find(pattern, i, i + j) != i:
         return False


### PR DESCRIPTION
See #3567. This PR allows improved spell checking of Leo's extended core. See PR #3566.

- [x] Change `SpellTabHandler.find` and its related regexes.
  Add several special cases to handle Python syntax.
- [x] Improve `g.match_word`.
- [x] Replace most of `find._inner_search_match_word` with a call to `g.match_word'.

There are no new unit tests, but several hand-checks pass.