### PR TITLE
PR: Ignore only non-alpha words in http lines

### DIFF
--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -822,7 +822,7 @@ class SpellTabHandler:
 
                 # Ignore non-alpha words in lines containing http.
                 if not word.isalpha():
-                    # g.trace(f"Check non-alpah http word: {word!r}")
+                    # g.trace(f"Check non-alpha http word: {word!r}")
                     i, j = g.getLine(s, ins + start)
                     line = s[i:j]
                     if 'http' in line:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -820,12 +820,14 @@ class SpellTabHandler:
                     # g.trace('Skip short word', repr(word))
                     continue
 
-                # Ignore all words in lines containing http.
-                i, j = g.getLine(s, ins + start)
-                line = s[i:j]
-                if 'http' in line:
-                    # g.trace(f"Skip url {word:>20} {line[:50]!r}")
-                    continue
+                # Ignore non-alpha words in lines containing http.
+                if not word.isalpha():
+                    # g.trace(f"Check non-alpah http word: {word!r}")
+                    i, j = g.getLine(s, ins + start)
+                    line = s[i:j]
+                    if 'http' in line:
+                        # g.trace(f"Skip url {word:>20} {line[:50]!r}")
+                        continue
 
                 # Last checks.
                 k2 = ins + start + len(word)


### PR DESCRIPTION
It's reasonable to check all-alpha words everywhere.

Traces and tests show this tweak makes sense.