### PR TITLE
PR: More spell-checking tweaks

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -143,7 +143,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             try:
                 exec(script, c.abbrev_subst_env, c.abbrev_subst_env)  # type:ignore
             except Exception:
-                g.es('Error exec\'ing @data abbreviations-subst-env')
+                g.es('Error executing @data abbreviations-subst-env')
                 g.es_exception()
         else:
             c.abbrev_subst_start = ''  # Was False.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -644,8 +644,7 @@ class SpellTabHandler:
     #@+node:ekr.20150514063305.501: *3* SpellTabHandler.__init__
     def __init__(self, c: Cmdr, tabName: Any) -> None:
         """Ctor for SpellTabHandler class."""
-        if g.app.gui.isNullGui:
-            return
+        # New in Leo 6.7.5: This class works in a null gui.
         self.c = c
         self.body = c.frame.body
         self.currentWord: str = None
@@ -734,6 +733,8 @@ class SpellTabHandler:
             for m in self.re_word.finditer(s[ins:]):
                 start, word = m.start(0), m.group(0)
 
+                g.trace(start, word)  ###
+
                 # Strip leading and trailing underscores.
                 # sc.process_word throw ValueError otherwise.
                 while word and word.startswith(('_', '`')):
@@ -811,6 +812,7 @@ class SpellTabHandler:
 
                 # Look up word and alt_word.
                 try:
+                    # Note: sc.process_word munges the word!
                     alts: list[str] = sc.process_word(word)
 
                     # Look up the alternate word if the word was not found.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -823,9 +823,14 @@ class SpellTabHandler:
                         alts2 = sc.process_word(alt_word)
                         # g.trace('alt_word', alt_word, 'alts2', alts2)
                         if alts2:
-                            # Add the alt word to the top of alts.
+                            # Add the top three *new* suggestions to the top of alts.
                             # g.trace(f"alt word not found: {alt_word}")
-                            alts.insert(0, alts2[0])
+                            new_alts = [alts2[i] for i in range(3)
+                                if i < len(alts2) and alts2[i] not in alts
+                            ]
+                            for z in reversed(new_alts):
+                                # g.trace(f"new alt: {z}")
+                                alts.insert(0, z)
                         else:
                             # g.trace(f"Alt word found: {alt_word}")
                             alts = []  # Done.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -748,6 +748,7 @@ class SpellTabHandler:
 
     re_word = re.compile(r"(\w+(['`]\w+)?)", flags=re.UNICODE)
     re_part = re.compile(r'[a-zA-z]+')
+    re_http = re.compile(r'.*?(http|https)://(.*?)$')
 
     def find(self, event: Event = None) -> None:
         """Find the next unknown word."""
@@ -819,15 +820,14 @@ class SpellTabHandler:
                 if len(word) < 3:
                     # g.trace('Skip short word', repr(word))
                     continue
-
-                # Ignore non-alpha words in lines containing http.
-                if not word.isalpha():
-                    # g.trace(f"Check non-alpha http word: {word!r}")
-                    i, j = g.getLine(s, ins + start)
-                    line = s[i:j]
-                    if 'http' in line:
-                        # g.trace(f"Skip url {word:>20} {line[:50]!r}")
-                        continue
+                    
+                # Don't check words following `(http|https)://`.
+                i, j = g.getLine(s, ins + start)
+                line = s[i:j]
+                m = self.re_http.match(line)
+                if m and word in m.group(2):
+                    # g.trace(f"Skip url word {word:>20} {line[:50]!r}")
+                    continue
 
                 # Last checks.
                 k2 = ins + start + len(word)

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -762,7 +762,6 @@ class SpellTabHandler:
                 else:
                     parts = [word]
                     if not self.re_part.match(word):
-                        # g.trace('Skip non-word', repr(word))
                         continue
 
                 # Ignore the word if numbers precede or follow it.
@@ -781,7 +780,6 @@ class SpellTabHandler:
 
                 # Don't check short words.
                 if len(word) < 3:
-                    # g.trace('Skip short word', repr(word))
                     continue
 
                 # Don't check words following `(http|https)://`.
@@ -789,7 +787,6 @@ class SpellTabHandler:
                 line = s[i:j]
                 m = self.re_http.match(line)
                 if m and word in m.group(2):
-                    # g.trace(f"Skip url word {word:>20} {line[:50]!r}")
                     continue
 
                 # Special case: \b, \n, and \t delimit words.
@@ -816,29 +813,23 @@ class SpellTabHandler:
                 try:
                     # Note: sc.process_word munges the word!
                     alts: list[str] = sc.process_word(word)
-                    # g.trace('alts', alts)
 
                     # Look up the alternate word if the word was not found.
                     if alts and alt_word:
                         alts2 = sc.process_word(alt_word)
-                        # g.trace('alt_word', alt_word, 'alts2', alts2)
                         if alts2:
                             # Add the top three *new* suggestions to the top of alts.
-                            # g.trace(f"alt word not found: {alt_word}")
                             new_alts = [alts2[i] for i in range(3)
                                 if i < len(alts2) and alts2[i] not in alts
                             ]
                             for z in reversed(new_alts):
-                                # g.trace(f"new alt: {z}")
                                 alts.insert(0, z)
                         else:
-                            # g.trace(f"Alt word found: {alt_word}")
                             alts = []  # Done.
                 except ValueError:
                     g.printObj(parts, tag=f"Fail: word: {word!r}")
                     continue
                 if alts:
-                    # g.trace('UPDATE', word, self.tab.__class__.__name__)
                     self.currentWord = word
                     i = ins + start
                     j = i + len(word)

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -2060,7 +2060,7 @@ class Orange:
             # '==','+=','-=','*=','**=','/=','//=','%=','!=','<=','>=','<','>',
             # '^','~','*','**','&','|','/','//',
             # Pep 8: If operators with different priorities are used,
-            # consider adding whitespace around the operators with the lowest priority(ies).
+            # consider adding whitespace around the operators with the lowest priorities.
             self.blank()
             self.add_token('op', val)
             self.blank()

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1207,7 +1207,7 @@ class GlobalConfigManager:
         self.default_derived_file_encoding = 'utf-8'
         self.enabledPluginsFileName = None
         self.enabledPluginsString = ''
-        self.menusList: list[Any] = []  # pbc.doMenu comment: likely buggy.
+        self.menusList: list[Any] = []
         self.menusFileName = ''
         self.modeCommandsDict: dict[str, g.SettingsDict] = g.SettingsDict('modeCommandsDict')
         self.panes = None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1864,11 +1864,6 @@ def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> C
 #@@nobeautify
 
 tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
-### tracing_vars: dict[int, list[str]] = {}  # Keys are id's, values are names of ivars.
-
-# Keys are signatures: '%s.%s:%s' % (tag, attr, callers). Values not important.
-tracing_signatures: dict[str, Any] = {}  # Trace the callers once.
-
 class NullObject:
     """An object that does nothing, and does it very well."""
     def __init__(self, ivars: list[str]=None, *args: Any, **kwargs: Any) -> None:
@@ -1950,19 +1945,13 @@ class TracingNullObject:
 def null_object_print(id_: int, kind: Any, *args: Any) -> None:
     tag = tracing_tags.get(id_, "<NO TAG>")
     callers = g.callers(3).split(',')
-    callers = ','.join(callers[:-1])
+    callers_s = ','.join(callers[:-1])
     s = f"{kind}.{tag}"
-    signature = f"{s}:{callers}"
-    if 1:  # Always print.
-        if args:
-            args_s = ', '.join([repr(z) for z in args])
-            g.pr(f"{s:40} {callers}\n\t\t\targs: {args_s}")
-        else:
-            g.pr(f"{s:40} {callers}")
-    elif signature not in tracing_signatures:
-        # Print each signature once.
-        tracing_signatures[signature] = True
-        g.pr(f"{s:40} {callers}")
+    if args:
+        args_s = ', '.join([repr(z) for z in args])
+        g.pr(f"{s:40} {callers_s}\n\t\t\targs: {args_s}")
+    else:
+        g.pr(f"{s:40} {callers_s}")
 #@+node:ville.20090827174345.9963: *3* class g.UiTypeException & g.assertui
 class UiTypeException(Exception):
     pass

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1864,16 +1864,15 @@ def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> C
 #@@nobeautify
 
 tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
-tracing_vars: dict[int, list[str]] = {}  # Keys are id's, values are names of ivars.
+### tracing_vars: dict[int, list[str]] = {}  # Keys are id's, values are names of ivars.
+
 # Keys are signatures: '%s.%s:%s' % (tag, attr, callers). Values not important.
-tracing_signatures: dict[str, Any] = {}
+tracing_signatures: dict[str, Any] = {}  # Trace the callers once.
 
 class NullObject:
     """An object that does nothing, and does it very well."""
     def __init__(self, ivars: list[str]=None, *args: Any, **kwargs: Any) -> None:
-        if isinstance(ivars, str):
-            ivars = [ivars]
-        tracing_vars [id(self)] = ivars or []
+        pass
     def __call__(self, *args: Any, **keys: Any) -> "NullObject":
         return self
     def __repr__(self) -> str:
@@ -1884,12 +1883,9 @@ class NullObject:
     def __delattr__(self, attr: str) -> None:
         return None
     def __getattr__(self, attr: str) -> Any:
-        if attr in tracing_vars.get(id(self), []):
-            return getattr(self, attr, None)
         return self # Required.
     def __setattr__(self, attr: str, val: Any) -> None:
-        if attr in tracing_vars.get(id(self), []):
-            object.__setattr__(self, attr, val)
+        return None
     # Container methods..
     def __bool__(self) -> bool:
         return False
@@ -1912,36 +1908,25 @@ class TracingNullObject:
     """Tracing NullObject."""
     def __init__(self, tag: str, ivars: list[str]=None, *args: Any, **kwargs: Any) -> None:
         tracing_tags [id(self)] = tag
-        if isinstance(ivars, str):
-            ivars = [ivars]
-        tracing_vars [id(self)] = ivars or []
     def __call__(self, *args: Any, **kwargs: Any) -> "TracingNullObject":
         return self
     def __repr__(self) -> str:
         return f'TracingNullObject: {tracing_tags.get(id(self), "<NO TAG>")}'
     def __str__(self) -> str:
         return f'TracingNullObject: {tracing_tags.get(id(self), "<NO TAG>")}'
-    #
+
     # Attribute access...
     def __delattr__(self, attr: str) -> None:
         return None
     def __getattr__(self, attr: str) -> "TracingNullObject":
-        null_object_print_attr(id(self), attr)
-        if attr in tracing_vars.get(id(self), []):
-            return getattr(self, attr, None)
+        g.null_object_print(id(self), f"attr: {attr}")
         return self # Required.
     def __setattr__(self, attr: str, val: Any) -> None:
-        g.null_object_print(id(self), '__setattr__', attr, val)
-        if attr in tracing_vars.get(id(self), []):
-            object.__setattr__(self, attr, val)
-    #
+        g.null_object_print(id(self), f"__setattr__: {attr} {val!r}")
+
     # All other methods...
     def __bool__(self) -> bool:
-        if 0: # To do: print only once.
-            suppress = ('getShortcut','on_idle', 'setItemText')
-            callers = g.callers(2)
-            if not callers.endswith(suppress):
-                g.null_object_print(id(self), '__bool__')
+        g.null_object_print(id(self), '__bool__')
         return False
     def __contains__(self, item: Any) -> bool:
         g.null_object_print(id(self), '__contains__')
@@ -1961,57 +1946,6 @@ class TracingNullObject:
     def __setitem__(self, key: str, val: Any) -> None:
         g.null_object_print(id(self), '__setitem__')
         # pylint doesn't like trailing return None.
-#@+node:ekr.20190330062625.1: *4* g.null_object_print_attr
-def null_object_print_attr(id_: int, attr: str) -> None:
-    suppress = True
-    suppress_callers: list[str] = []
-    suppress_attrs: list[str] = []
-    if suppress:
-        #@+<< define suppression lists >>
-        #@+node:ekr.20190330072026.1: *5* << define suppression lists >>
-        suppress_callers = [
-            'drawNode', 'drawTopTree', 'drawTree',
-            'contractItem', 'getCurrentItem',
-            'declutter_node',
-            'finishCreate',
-            'initAfterLoad',
-            'show_tips',
-            'writeWaitingLog',
-            # 'set_focus', 'show_tips',
-        ]
-        suppress_attrs = [
-            # Leo...
-            'c.frame.body.wrapper',
-            'c.frame.getIconBar.add',
-            'c.frame.log.createTab',
-            'c.frame.log.enable',
-            'c.frame.log.finishCreate',
-            'c.frame.menu.createMenuBar',
-            'c.frame.menu.finishCreate',
-            # 'c.frame.menu.getMenu',
-            'currentItem',
-            'dw.leo_master.windowTitle',
-            # Pyzo...
-            'pyzo.keyMapper.connect',
-            'pyzo.keyMapper.keyMappingChanged',
-            'pyzo.keyMapper.setShortcut',
-        ]
-        #@-<< define suppression lists >>
-    tag = tracing_tags.get(id_, "<NO TAG>")
-    callers = g.callers(3).split(',')
-    callers = ','.join(callers[:-1])
-    in_callers = any(z in callers for z in suppress_callers)
-    s = f"{tag}.{attr}"
-    if suppress:
-        # Filter traces.
-        if not in_callers and s not in suppress_attrs:
-            g.pr(f"{s:40} {callers}")
-    else:
-        # Print each signature once.  No need to filter!
-        signature = f"{tag}.{attr}:{callers}"
-        if signature not in tracing_signatures:
-            tracing_signatures[signature] = True
-            g.pr(f"{s:40} {callers}")
 #@+node:ekr.20190330072832.1: *4* g.null_object_print
 def null_object_print(id_: int, kind: Any, *args: Any) -> None:
     tag = tracing_tags.get(id_, "<NO TAG>")
@@ -2019,8 +1953,7 @@ def null_object_print(id_: int, kind: Any, *args: Any) -> None:
     callers = ','.join(callers[:-1])
     s = f"{kind}.{tag}"
     signature = f"{s}:{callers}"
-    if 1:
-        # Always print:
+    if 1:  # Always print.
         if args:
             args_s = ', '.join([repr(z) for z in args])
             g.pr(f"{s:40} {callers}\n\t\t\targs: {args_s}")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1864,7 +1864,7 @@ def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> C
 #@@nobeautify
 
 tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
-tracing_vars: dict[int, list] = {}  # Keys are id's, values are names of ivars.
+tracing_vars: dict[int, list[str]] = {}  # Keys are id's, values are names of ivars.
 # Keys are signatures: '%s.%s:%s' % (tag, attr, callers). Values not important.
 tracing_signatures: dict[str, Any] = {}
 
@@ -1910,7 +1910,7 @@ class NullObject:
 
 class TracingNullObject:
     """Tracing NullObject."""
-    def __init__(self, tag: str, ivars: list[Any]=None, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, tag: str, ivars: list[str]=None, *args: Any, **kwargs: Any) -> None:
         tracing_tags [id(self)] = tag
         if isinstance(ivars, str):
             ivars = [ivars]

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -355,13 +355,15 @@ class NullGui(LeoGui):
     #@+node:ekr.20031218072017.2225: *3* NullGui.__init__
     def __init__(self, guiName: str = 'nullGui') -> None:
         """ctor for the NullGui class."""
+        from leo.plugins.qt_text import QTextEditWrapper
         super().__init__(guiName)
         self.clipboardContents = ''
         self.focusWidget: Widget = None
-        self.script = None
-        self.lastFrame: Widget = None  # The outer frame, to set g.app.log in runMainLoop.
         self.isNullGui = True
         self.idleTimeClass: Any = g.NullObject
+        self.lastFrame: Widget = None  # The outer frame, to set g.app.log in runMainLoop.
+        self.plainTextWidget: Widget = QTextEditWrapper  # For SpellTabHandler class.
+        self.script = None
     #@+node:ekr.20031218072017.3744: *3* NullGui.dialogs
     def runAboutLeoDialog(self, c: Cmdr, version: str, theCopyright: str, url: str, email: str) -> str:
         return self.simulateDialog("aboutLeoDialog", None)
@@ -448,6 +450,18 @@ class NullGui(LeoGui):
 
     def set_focus(self, commander: str, widget: str) -> None:
         self.focusWidget = widget
+    #@+node:ekr.20230916153234.1: *3* NullGui.createSpellTab (NEW)
+    def createSpellTab(self, c: Cmdr, spellHandler: Any, tabName: str) -> Any:
+
+        class NullSpellTab:
+
+            def __init__(self, c: Cmdr, spellHandler: Any, tabName: str) -> None:
+                self.c = c
+                self.fillbox = g.TracingNullObject('NullSpellTab.fillbox')
+                self.spellHandler = spellHandler
+                self.tabName = tabName
+
+        return NullSpellTab(c, spellHandler, tabName)
     #@+node:ekr.20070301171901: *3* NullGui.do nothings
     def alert(self, c: Cmdr, message: str) -> None:
         pass
@@ -800,8 +814,9 @@ class UnitTestGui(NullGui):
     def destroySelf(self) -> None:
         g.app.gui = self.oldGui
     #@+node:ekr.20071128094234.1: *3* UnitTestGui.createSpellTab
-    def createSpellTab(self, c: Cmdr, spellHandler: str, tabName: str) -> None:
+    def createSpellTab(self, c: Cmdr, spellHandler: Any, tabName: str) -> None:
         pass  # This method keeps pylint happy.
+
     #@+node:ekr.20111001155050.15484: *3* UnitTestGui.runAtIdle
     if 1:  # Huh?
 

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -450,16 +450,18 @@ class NullGui(LeoGui):
 
     def set_focus(self, commander: str, widget: str) -> None:
         self.focusWidget = widget
-    #@+node:ekr.20230916153234.1: *3* NullGui.createSpellTab (NEW)
+    #@+node:ekr.20230916153234.1: *3* NullGui.createSpellTab
     def createSpellTab(self, c: Cmdr, spellHandler: Any, tabName: str) -> Any:
 
         class NullSpellTab:
 
             def __init__(self, c: Cmdr, spellHandler: Any, tabName: str) -> None:
                 self.c = c
-                self.fillbox = g.TracingNullObject('NullSpellTab.fillbox')
                 self.spellHandler = spellHandler
                 self.tabName = tabName
+
+            def fillbox(self, alts: list[str], word: str) -> None:
+                pass  # g.trace('alts:', alts, 'word:', word)
 
         return NullSpellTab(c, spellHandler, tabName)
     #@+node:ekr.20070301171901: *3* NullGui.do nothings

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -461,7 +461,7 @@ class NullGui(LeoGui):
                 self.tabName = tabName
 
             def fillbox(self, alts: list[str], word: str) -> None:
-                pass  # g.trace('alts:', alts, 'word:', word)
+                pass
 
         return NullSpellTab(c, spellHandler, tabName)
     #@+node:ekr.20070301171901: *3* NullGui.do nothings

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -1673,7 +1673,7 @@ class LeoBrowserTree(leoFrame.NullTree):
         w = self.root.main_window
         w.tree.set_focus()
     #@-others
-#@+node:ekr.20181119094122.1: *3* class TracingNullObject
+#@+node:ekr.20181119094122.1: *3* class TracingNullObject (leoflexx.py)
 #@@nobeautify
 
 class TracingNullObject:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1530,7 +1530,7 @@ class QTextEditWrapper(QTextMixin):
     """A wrapper for a QTextEdit/QTextBrowser supporting the high-level interface."""
     #@+others
     #@+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
-    def __init__(self, widget: Widget, name: str, c: Cmdr=None) -> None:
+    def __init__(self, widget: Widget, name: str='TestWrapper', c: Cmdr=None) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
         # Make sure all ivars are set.

--- a/leo/unittests/commands/test_spellCommands.py
+++ b/leo/unittests/commands/test_spellCommands.py
@@ -72,7 +72,7 @@ class TestSpellCommands(LeoUnitTest):
         for line, expected in table:
             p.b = line + '\n'
             result = handler.find()
-            assert result == expected, (result, expected)
+            assert result == expected, (repr(result), repr(expected))
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_spellCommands.py
+++ b/leo/unittests/commands/test_spellCommands.py
@@ -20,8 +20,22 @@ class TestSpellCommands(LeoUnitTest):
     #@+node:ekr.20230916141635.3: *3* TestSpellCommands.test_SpellTabHandler_find
     def test_SpellTabHandler_find(self):
 
-        # g.trace('***')
-        pass
+        c = self.c
+
+        # Create test classes.
+        class TestEnchantWrapper:
+
+            def __init__(self, c):
+                self.c = c
+                self.language = 'en_US'
+                self.d: dict[str, str] = {}
+                g.app.spellDict = self.d
+
+        x = TestEnchantWrapper(c)
+        if 0:
+            g.trace(x)
+
+
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_spellCommands.py
+++ b/leo/unittests/commands/test_spellCommands.py
@@ -1,0 +1,27 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20230916141635.1: * @file ../unittests/commands/test_spellCommands.py
+"""
+New unit tests for Leo's outline commands.
+
+Older tests are in unittests/core/test_leoNodes.py
+"""
+from leo.core.leoTest2 import LeoUnitTest
+from leo.core import leoGlobals as g
+assert g
+
+#@+others
+#@+node:ekr.20230916141635.2: ** class TestSpellCommands(LeoUnitTest)
+class TestSpellCommands(LeoUnitTest):
+    """
+    Unit tests for Leo's outline commands.
+    """
+
+    #@+others
+    #@+node:ekr.20230916141635.3: *3* TestSpellCommands.test_SpellTabHandler_find
+    def test_SpellTabHandler_find(self):
+
+        # g.trace('***')
+        pass
+    #@-others
+#@-others
+#@-leo

--- a/leo/unittests/commands/test_spellCommands.py
+++ b/leo/unittests/commands/test_spellCommands.py
@@ -9,6 +9,7 @@ from leo.core.leoTest2 import LeoUnitTest
 from leo.core import leoGlobals as g
 assert g
 
+
 #@+others
 #@+node:ekr.20230916141635.2: ** class TestSpellCommands(LeoUnitTest)
 class TestSpellCommands(LeoUnitTest):
@@ -20,22 +21,50 @@ class TestSpellCommands(LeoUnitTest):
     #@+node:ekr.20230916141635.3: *3* TestSpellCommands.test_SpellTabHandler_find
     def test_SpellTabHandler_find(self):
 
+        from leo.core.leoCommands import Commands as Cmdr
+        from leo.commands.spellCommands import SpellTabHandler
+
         c = self.c
+        p = c.p
 
         # Create test classes.
         class TestEnchantWrapper:
 
-            def __init__(self, c):
+            def __init__(self, c: Cmdr) -> None:
                 self.c = c
-                self.language = 'en_US'
                 self.d: dict[str, str] = {}
-                g.app.spellDict = self.d
+                ### self.language = 'en_US'
+                ### g.app.spellDict = self.d
 
-        x = TestEnchantWrapper(c)
-        if 0:
-            g.trace(x)
+            def process_word(self, word: str) -> list[str]:
+                g.trace(word)
+                return [word]
 
+        handler = SpellTabHandler(c, tabName='Test Spell Tab')
+        handler.loaded = True
+        handler.spellController = TestEnchantWrapper(c)
 
+        # \beginx
+        # \begin
+        # \bibliographystyle{acm}
+        # \bibliography{myBibliography}
+
+        # `PR #3509`: Improve rust importer.
+        # _Insert_indexterm__140664580.txt
+
+        # we'lll we're we'll
+        # sel_1  selll_1
+        # a_b_c
+
+        table = (
+             # Should not be checked.
+            'abc9: https://test1',
+            # Should be checked.
+            "Leo's: https://test2",
+        )
+        for word in table:
+            p.b = word + '\n'
+            handler.find()
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
More tweaks to `SpellTabHandler.find`.

Tested with traces while spell-checking `LeoDocs.leo` and by spell-checking a private test file.

- [x] Don't check words following `http://` or `https://` on a line. Call `g.getLine` for *all* words.
- [x] Look up an **alternate word** if the word starts with `\b`, `\n`, or `\t`.
   For example, this change allows the user to enter `tex` macro names.

Both these tweaks significantly speed up spell-checking. Spell-checking `LeoDocs.leo` is much more convenient.

- [x] Fixed (by revising text) several annoying misspellings.
   I didn't want to enter the original spellings into the dictionary!

**Unit testing**

Hah. The new unit test found a bug!

- [x] Improve annotations related to `g.TracingNullObject` class.
- [x] Move methods from `BaseSpellWrapper` class to `EnchantWrapper` class.
- [x] Add infrastructure for testing `SpellTabHandler.find` using a null gui.
- [x] Add a unit test that runs non-interactively.