### PR TITLE
PR for #3576: importer quirps

### DIFF
--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -65,7 +65,7 @@ class Python_Importer(Importer):
                 child = p.firstChild()
                 lines = g.splitLines(p.b)
                 for i, line in enumerate(lines):
-                    if line == ' ' * 4 + '@others\n' and child.b.startswith('\n'):
+                    if line.strip().startswith('@others') and child.b.startswith('\n'):
                         p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
                         child.b = child.b[1:]
                         break

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -67,7 +67,6 @@ class Python_Importer(Importer):
                 for i, line in enumerate(lines):
                     if line == ' ' * 4 + '@others\n' and child.b.startswith('\n'):
                         p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
-                        child = p.firstChild()
                         child.b = child.b[1:]
                         break
     #@+node:ekr.20230830051934.1: *3* python_i.delete_comments_and_strings

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -541,7 +541,7 @@ class TestC(BaseTestImporter):
         )
         self.new_run_test(s, expected_results)
     #@-others
-#@+node:ekr.20211108063520.1: ** class TestCoffeescript (BaseTextImporter)
+#@+node:ekr.20211108063520.1: ** class TestCoffeescript (BaseTestImporter)
 class TestCoffeescript(BaseTestImporter):
 
     ext = '.coffee'


### PR DESCRIPTION
See #3576.

- [x] Correct misspelling in a headline.
- [x] Remove redundant line: `child = p.firstChild()`.
- [x] Change the line:
     `if line == ' ' * 4 + '@others\n' and child.b.startswith('\n'):` to:
     `if line.strip().startswith('@others') and child.b.startswith('\n'):`.