### PR TITLE
PR for #3590: path-related problems

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -404,7 +404,6 @@ def save(self: Self, event: Event = None, fileName: str = None) -> None:
             c.mFileName = g.ensure_extension(fileName, g.defaultLeoFileExtension(c))
             c.frame.title = c.computeWindowTitle(c.mFileName)
             c.frame.setTitle(c.computeWindowTitle(c.mFileName))
-            c.openDirectory = c.frame.openDirectory = g.os_path_dirname(c.mFileName)
             if hasattr(c.frame, 'top'):
                 c.frame.top.leo_master.setTabName(c, c.mFileName)
             c.fileCommands.save(c.mFileName)
@@ -480,7 +479,6 @@ def saveAs(self: Self, event: Event = None, fileName: str = None) -> None:
         # Part of the fix for https://bugs.launchpad.net/leo-editor/+bug/1194209
         c.frame.title = title = c.computeWindowTitle(c.mFileName)
         c.frame.setTitle(title)
-        c.openDirectory = c.frame.openDirectory = g.os_path_dirname(c.mFileName)
         # Calls c.clearChanged() if no error.
         if hasattr(c.frame, 'top'):
             c.frame.top.leo_master.setTabName(c, c.mFileName)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2115,7 +2115,6 @@ class LoadManager:
         finally:
             # Never put a return in a finally clause.
             g.app.unlockLog()
-            c.openDirectory = frame.openDirectory = g.os_path_dirname(fn)
             g.app.gui = oldGui
     #@+node:ekr.20120213081706.10382: *4* LM.readGlobalSettingsFiles
     def readGlobalSettingsFiles(self) -> None:
@@ -2363,7 +2362,6 @@ class LoadManager:
         # Create the outline with workbook's name.
         c.frame.title = title = c.computeWindowTitle(fn)
         c.frame.setTitle(title)
-        c.openDirectory = c.frame.openDirectory = g.os_path_dirname(fn)
         if hasattr(c.frame, 'top'):
             c.frame.top.leo_master.setTabName(c, fn)
         # Finish: Do *not* save the file!

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1120,7 +1120,7 @@ class Commands:
         rewrite_asserts(tree, script, config=cfg)  # type:ignore
         co = compile(tree, fname, "exec", dont_inherit=True)
         sys.path.insert(0, os.getcwd())
-        sys.path.insert(0, os.path.dirname(c.fileName()))  # per SegundoBob
+        sys.path.insert(0, g.os_path_dirname(c.fileName()))  # per SegundoBob
         try:
             exec(co, {'c': c, 'g': g, 'p': p})
         except KeyboardInterrupt:
@@ -1182,7 +1182,7 @@ class Commands:
             g.app.log = log
             if script.strip():
                 sys.path.insert(0, os.getcwd())
-                sys.path.insert(0, os.path.dirname(c.fileName()))  # per SegundoBob
+                sys.path.insert(0, g.os_path_dirname(c.fileName()))  # per SegundoBob
                 script += '\n'  # Make sure we end the script properly.
                 try:
                     if not namespace or namespace.get('script_gnx') is None:
@@ -2610,7 +2610,7 @@ class Commands:
         c = self
         c.scanAtPathDirectivesCount += 1  # An important statistic.
         if c.fileName():
-            absbase = os.path.dirname(c.fileName())
+            absbase = g.os_path_dirname(c.fileName())
         else:
             absbase = os.getcwd()
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2348,20 +2348,15 @@ class Commands:
             raise
     #@+node:ekr.20171123200644.1: *3* c.Convenience methods
     #@+node:ekr.20230402232100.1: *4* c.fullPath
-    def fullPath(self, p: Position, simulate: bool = False) -> str:
+    def fullPath(self, p: Position) -> str:
         """
         Return the full path (including fileName) in effect at p. Neither the
         path nor the fileName will be created if it does not exist.
         """
         c = self
-        # Search p and p's parents.
-        for p in p.self_and_parents(copy=False):
-            aList = g.get_directives_dict_list(p)
-            path = c.scanAtPathDirectives(aList)
-            fn = p.h if simulate else p.anyAtFileNodeName()  # Use p.h for unit tests.
-            if fn:
-                return g.finalize_join(path, fn)
-        return ''
+        aList = g.get_directives_dict_list(p)
+        path = c.scanAtPathDirectives(aList)
+        return g.finalize_join(path, p.anyAtFileNodeName())
     #@+node:ekr.20171123135625.39: *4* c.getTime
     def getTime(self, body: bool = True) -> str:
         c = self
@@ -2615,8 +2610,10 @@ class Commands:
         """
         c = self
         c.scanAtPathDirectivesCount += 1  # An important statistic.
-        base = c.openDirectory
-        absbase = g.finalize_join(g.app.loadDir, base)
+        if c.fileName():
+            absbase = os.path.dirname(c.fileName())
+        else:
+            absbase = os.getcwd()
 
         # Look for @path directives.
         paths = []

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -227,7 +227,6 @@ class Commands:
         self.last_dir: str = None  # The last used directory.
         self.mFileName: str = fileName or ''  # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
         self.mRelativeFileName = relativeFileName or ''  #
-        self.openDirectory: Optional[str] = None  #
         self.orphan_at_file_nodes: list[Position] = []  # List of orphaned nodes for c.raise_error_dialogs.
         self.wrappedFileName: Optional[str] = None  # The name of the wrapped file, for wrapper commanders.
 
@@ -1120,8 +1119,8 @@ class Commands:
         # A mypy bug? the script can be str.
         rewrite_asserts(tree, script, config=cfg)  # type:ignore
         co = compile(tree, fname, "exec", dont_inherit=True)
-        sys.path.insert(0, '.')
-        sys.path.insert(0, c.frame.openDirectory)
+        sys.path.insert(0, os.getcwd())
+        sys.path.insert(0, os.path.dirname(c.fileName()))  # per SegundoBob
         try:
             exec(co, {'c': c, 'g': g, 'p': p})
         except KeyboardInterrupt:
@@ -1182,8 +1181,8 @@ class Commands:
             log = c.frame.log
             g.app.log = log
             if script.strip():
-                sys.path.insert(0, '.')  # New in Leo 5.0
-                sys.path.insert(0, c.frame.openDirectory)  # per SegundoBob
+                sys.path.insert(0, os.getcwd())
+                sys.path.insert(0, os.path.dirname(c.fileName()))  # per SegundoBob
                 script += '\n'  # Make sure we end the script properly.
                 try:
                     if not namespace or namespace.get('script_gnx') is None:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -607,7 +607,6 @@ class FileCommands:
         self.read_only = False
         self.rootPosition: Position = None
         self.outputFile: io.StringIO = None
-        self.openDirectory: str = None
         self.usingClipboard = False
         self.currentPosition: Position = None
         # New in 3.12...
@@ -766,14 +765,6 @@ class FileCommands:
             except Exception:
                 pass  # os.access() may not exist on all platforms.
         return False
-    #@+node:ekr.20031218072017.3045: *4* fc.setDefaultDirectoryForNewFiles
-    def setDefaultDirectoryForNewFiles(self, fileName: str) -> None:
-        """Set c.openDirectory for new files for the benefit of leoAtFile.scanAllDirectives."""
-        c = self.c
-        if not c.openDirectory:
-            theDir = g.os_path_dirname(fileName)
-            if theDir and g.os_path_isabs(theDir) and g.os_path_exists(theDir):
-                c.openDirectory = c.frame.openDirectory = theDir
     #@+node:ekr.20031218072017.1554: *4* fc.warnOnReadOnlyFiles
     def warnOnReadOnlyFiles(self, fileName: str) -> None:
         # os.access may not exist on all platforms.
@@ -1338,7 +1329,6 @@ class FileCommands:
         ok = g.doHook("save1", c=c, p=p, fileName=fileName)
         if ok is None:
             c.endEditing()  # Set the current headline text.
-            self.setDefaultDirectoryForNewFiles(fileName)
             g.app.commander_cacher.save(c, fileName)
             ok = c.checkFileTimeStamp(fileName)
             if ok:
@@ -1359,7 +1349,6 @@ class FileCommands:
         p = c.p
         if not g.doHook("save1", c=c, p=p, fileName=fileName):
             c.endEditing()  # Set the current headline text.
-            self.setDefaultDirectoryForNewFiles(fileName)
             g.app.commander_cacher.save(c, fileName)
             # Disable path-changed messages in writeAllHelper.
             try:
@@ -1377,7 +1366,6 @@ class FileCommands:
         p = c.p
         if not g.doHook("save1", c=c, p=p, fileName=fileName):
             c.endEditing()  # Set the current headline text.
-            self.setDefaultDirectoryForNewFiles(fileName)
             g.app.commander_cacher.commit()  # Commit, but don't save file name.
 
             # Disable path-changed messages in writeAllHelper.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -720,7 +720,6 @@ class LeoFrame:
         self.cursorStay = True  # May be overridden in subclass.reloadSettings.
         self.es_newlines = 0  # newline count for this log stream.
         self.isNullFrame = False
-        self.openDirectory = ""
         self.saved = False  # True if ever saved
         self.splitVerticalFlag = True  # Set by initialRatios later.
         self.stylesheet: str = None  # The contents of <?xml-stylesheet...?> line.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6771,9 +6771,9 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
         else:
             path = url
         # Handle ancestor @path directives.
-        if c and c.openDirectory:
+        if c and c.fileName():
             base = c.getNodePath(p)
-            path = g.finalize_join(c.openDirectory, base, path)
+            path = g.finalize_join(os.path.dirname(c.fileName()), base, path)
         else:
             path = g.finalize(path)
         url = f"{tag}{path}"

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6773,7 +6773,7 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
         # Handle ancestor @path directives.
         if c and c.fileName():
             base = c.getNodePath(p)
-            path = g.finalize_join(os.path.dirname(c.fileName()), base, path)
+            path = g.finalize_join(g.os_path_dirname(c.fileName()), base, path)
         else:
             path = g.finalize(path)
         url = f"{tag}{path}"

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3074,7 +3074,7 @@ def ensure_extension(name: str, ext: str) -> str:
         return name
     return name + ext
 #@+node:ekr.20150403150655.1: *3* g.fullPath (deprecated)
-def fullPath(c: Cmdr, p: Position, simulate: bool = False) -> str:
+def fullPath(c: Cmdr, p: Position) -> str:
     """
     Return the full path (including fileName) in effect at p.
 
@@ -3082,7 +3082,7 @@ def fullPath(c: Cmdr, p: Position, simulate: bool = False) -> str:
 
     This function is deprecated. Use c.fullPath(p) instead.
     """
-    return c.fullPath(p, simulate)
+    return c.fullPath(p)
 #@+node:ekr.20190327192721.1: *3* g.get_files_in_directory
 def get_files_in_directory(directory: str, kinds: list = None, recursive: bool = True) -> list[str]:
     """

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -393,7 +393,7 @@ class RstCommands:
     def computeOutputFileName(self, fn: str) -> str:
         """Return the full path to the output file."""
         c = self.c
-        openDirectory = os.path.dirname(c.fileName())
+        openDirectory = g.os_path_dirname(c.fileName())
         if self.default_path:
             path = g.finalize_join(self.path, self.default_path, fn)
         elif self.path:
@@ -453,7 +453,7 @@ class RstCommands:
             g.error('writeToDocutils: docutils not present')
             return None
         join = g.finalize_join
-        openDirectory = os.path.dirname(c.fileName())
+        openDirectory = g.os_path_dirname(c.fileName())
         overrides = {'output_encoding': self.encoding}
         #
         # Compute the args list if the stylesheet path does not exist.

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -393,7 +393,7 @@ class RstCommands:
     def computeOutputFileName(self, fn: str) -> str:
         """Return the full path to the output file."""
         c = self.c
-        openDirectory = c.frame.openDirectory
+        openDirectory = os.path.dirname(c.fileName())
         if self.default_path:
             path = g.finalize_join(self.path, self.default_path, fn)
         elif self.path:
@@ -448,11 +448,12 @@ class RstCommands:
     #@+node:ekr.20090502071837.65: *5* rst.writeToDocutils & helper
     def writeToDocutils(self, s: str, ext: str) -> Optional[str]:
         """Send s to docutils using the writer implied by ext and return the result."""
+        c = self.c
         if not docutils:
             g.error('writeToDocutils: docutils not present')
             return None
         join = g.finalize_join
-        openDirectory = self.c.frame.openDirectory
+        openDirectory = os.path.dirname(c.fileName())
         overrides = {'output_encoding': self.encoding}
         #
         # Compute the args list if the stylesheet path does not exist.

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -127,7 +127,7 @@ def applyFileAction(p, filename, c):
     redirect = c.config.getBool('redirect-execute-script-output-to-log_pane')
     if script:
         working_directory = os.getcwd()
-        file_directory = os.path.dirname(filename)
+        file_directory = g.os_path_dirname(filename)
         os.chdir(file_directory)
         script += '\n'
         if redirect:

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -127,7 +127,7 @@ def applyFileAction(p, filename, c):
     redirect = c.config.getBool('redirect-execute-script-output-to-log_pane')
     if script:
         working_directory = os.getcwd()
-        file_directory = c.frame.openDirectory
+        file_directory = os.path.dirname(filename)
         os.chdir(file_directory)
         script += '\n'
         if redirect:

--- a/leo/plugins/nodeActions.py
+++ b/leo/plugins/nodeActions.py
@@ -375,7 +375,7 @@ def applyNodeAction(pScript, pClicked, c):
     redirect = c.config.getBool('redirect-execute-script-output-to-log_pane')
     if script:
         working_directory = os.getcwd()
-        file_directory = c.frame.openDirectory
+        file_directory = os.path.dirname(c.fileName())
         os.chdir(file_directory)
         script += '\n'
         # Redirect output

--- a/leo/plugins/nodeActions.py
+++ b/leo/plugins/nodeActions.py
@@ -375,7 +375,7 @@ def applyNodeAction(pScript, pClicked, c):
     redirect = c.config.getBool('redirect-execute-script-output-to-log_pane')
     if script:
         working_directory = os.getcwd()
-        file_directory = os.path.dirname(c.fileName())
+        file_directory = g.os_path_dirname(c.fileName())
         os.chdir(file_directory)
         script += '\n'
         # Redirect output

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1695,9 +1695,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             fn = g.finalize(fn)
         else:
             # Handle ancestor @path directives.
-            if c and c.openDirectory:
+            if c and c.fileName():
                 base = c.getNodePath(c.p)
-                fn = g.finalize_join(c.openDirectory, base, fn)
+                fn = g.finalize_join(os.path.dirname(c.fileName()), base, fn)
             else:
                 fn = g.finalize(fn)
         ok = g.os_path_exists(fn)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1697,7 +1697,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             # Handle ancestor @path directives.
             if c and c.fileName():
                 base = c.getNodePath(c.p)
-                fn = g.finalize_join(os.path.dirname(c.fileName()), base, fn)
+                fn = g.finalize_join(g.os_path_dirname(c.fileName()), base, fn)
             else:
                 fn = g.finalize(fn)
         ok = g.os_path_exists(fn)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4554,9 +4554,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
             fn = g.finalize(fn)
         else:
             # Handle ancestor @path directives.
-            if c and c.openDirectory:
+            if c and c.fileName():
                 base = c.getNodePath(c.p)
-                fn = g.finalize_join(c.openDirectory, base, fn)
+                fn = g.finalize_join(os.path.dirname(c.fileName()), base, fn)
             else:
                 fn = g.finalize(fn)
 

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4556,7 +4556,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # Handle ancestor @path directives.
             if c and c.fileName():
                 base = c.getNodePath(c.p)
-                fn = g.finalize_join(os.path.dirname(c.fileName()), base, fn)
+                fn = g.finalize_join(g.os_path_dirname(c.fileName()), base, fn)
             else:
                 fn = g.finalize(fn)
 

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -291,6 +291,20 @@ class TestCommands(LeoUnitTest):
         path = c.scanAtPathDirectives(aList)
         endpath = g.os_path_normpath('one/two')
         assert path.endswith(endpath), f"expected '{endpath}' got '{path}'"
+
+        # Test 2: Create a commander for an outline outside of g.app.loadDir and its parents.
+        from leo.core.leoCommands import Commands
+        c = Commands(fileName='~/LeoPyRef.leo', gui=g.app.gui)
+        child = p.insertAfter()
+        child.h = '@path one'
+        grand = child.insertAsLastChild()
+        grand.h = '@path two'
+        great = grand.insertAsLastChild()
+        great.h = 'xyz'
+        aList = g.get_directives_dict_list(great)
+        path = c.scanAtPathDirectives(aList)
+        endpath = g.os_path_normpath('one/two')
+        assert path.endswith(endpath), f"expected '{endpath}' got '{path}'"
     #@+node:ekr.20210906075242.19: *3* TestCommands.test_c_scanAtPathDirectives_same_name_subdirs
     def test_c_scanAtPathDirectives_same_name_subdirs(self):
         c = self.c

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -441,8 +441,8 @@ class TestGlobals(LeoUnitTest):
         child = c.rootPosition().insertAfter()
         child.h = '@path abc'
         grand = child.insertAsLastChild()
-        grand.h = 'xyz'
-        path = g.fullPath(c, grand, simulate=True)
+        grand.h = '@file xyz'
+        path = g.fullPath(c, grand)
         end = g.os_path_normpath('abc/xyz')
         assert path.endswith(end), repr(path)
     #@+node:ekr.20210905203541.16: *4* TestGlobals.test_g_get_directives_dict

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -445,6 +445,17 @@ class TestGlobals(LeoUnitTest):
         path = g.fullPath(c, grand)
         end = g.os_path_normpath('abc/xyz')
         assert path.endswith(end), repr(path)
+
+        # Test 2: Create a commander for an outline outside of g.app.loadDir and its parents.
+        from leo.core.leoCommands import Commands
+        c = Commands(fileName='~/LeoPyRef.leo', gui=g.app.gui)
+        child = c.rootPosition().insertAfter()
+        child.h = '@path abc2'
+        grand = child.insertAsLastChild()
+        grand.h = '@file xyz2'
+        path = g.fullPath(c, grand)
+        end = g.os_path_normpath('abc2/xyz2')
+        assert path.endswith(end), repr(path)
     #@+node:ekr.20210905203541.16: *4* TestGlobals.test_g_get_directives_dict
     def test_g_get_directives_dict(self):
         c = self.c


### PR DESCRIPTION
See #3590.

- [x] Fix `c.scanAtPathDirectives`. `g.app.loadDir` *must not* be the base of relative paths!
- [x] Simplify `c.fullPath` and remove its `simulate` kwarg.
- [x] Remove the `simulate` kwarg from `g.fullPath` and `test_g_fullPath`
- [x] Remove the `x.openDirectory` ivars, replacing them with `g.os_path_dirname(c.fileName())`.
   *Note*: using `os.path.dirname` would probably work, but `g.os_path_dirname` normalizes slashes.
- [x] Remove `fc.setDefaultDirectoryForNewFiles`. 
- [x] Replace `sys.path.insert(0, '.')` with `sys.path.insert(0, os.getcwd())` in two places.
- [x] Test 'remote' outlines in `test_g_fullPath` and `test_c_scanAtPathDirectives`.