### PR TITLE
PR 2 for #3592: xml headlines

### DIFF
--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -50,16 +50,13 @@ class Xml_Importer(Importer):
         self.end_patterns = tuple(re.compile(fr"\s*</({tag})>") for tag in tags)
         return tags
     #@+node:ekr.20230519053541.1: *3* xml_i.compute_headline
-    tag_pattern = re.compile(r'<.*?>')
-
     def compute_headline(self, block: Block) -> str:
         """Xml_Importer.compute_headline."""
         n = max(block.start, block.start_body - 1)
         s = block.lines[n].strip()
 
         # Truncate the headline if necessary.
-        m = self.tag_pattern.match(s)
-        return m.group(0) if m else s[:50]
+        return g.truncate(s, 120)
     #@+node:ekr.20230518081757.1: *3* xml_i.find_end_of_block
     def find_end_of_block(self, i1: int, i2: int) -> int:
         """

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -999,7 +999,7 @@ class TestHtml(BaseTestImporter):
                     '\n'
                     '</body>\n'
             ),
-            (2, '<div id="D666">',
+            (2, '<div id="D666">Paragraph</p> <!-- P1 -->',
                     '<!-- OOPS: the div and p elements not properly nested.-->\n'
                     '<!-- OOPS: this table got generated twice. -->\n'
                     '\n'
@@ -1008,7 +1008,7 @@ class TestHtml(BaseTestImporter):
                     '@others\n'
                     '</div>\n'
             ),
-            (3, '<TABLE id="T666">',
+            (3, '<TABLE id="T666"></TABLE></p> <!-- P2 -->',
                     '<p id="P2">\n'
                     '\n'
                     '<TABLE id="T666"></TABLE></p> <!-- P2 -->\n'


### PR DESCRIPTION
See #3592. This PR mostly reverts PR #3593. Keeping only the opening tag hides too much.

This PR has been tested on a long, strange, html file.