### PR TITLE
PR for #3588: word-search

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2394,7 +2394,10 @@ class LeoFind:
     def _inner_search_match_word(self, s: str, i: int, pattern: str) -> bool:
         """Do a whole-word search."""
         pattern = self.replace_back_slashes(pattern)
-        return bool(s and pattern and g.match_word(s, i, pattern))
+        return bool(
+            s and pattern
+            and g.match_word(s, i, pattern, ignore_case=self.ignore_case)
+        )
     #@+node:ekr.20210110073117.46: *5* find._inner_search_plain
     def _inner_search_plain(self,
         s: str,

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3905,9 +3905,13 @@ def is_ws(ch: str) -> bool:
 def is_ws_or_nl(s: str, i: int) -> bool:
     return g.is_nl(s, i) or (i < len(s) and g.is_ws(s[i]))
 #@+node:ekr.20031218072017.3181: *4* g.match
-# Warning: this code makes no assumptions about what follows pattern.
-
 def match(s: str, i: int, pattern: str) -> bool:
+    """
+    Return True if the given pattern matches at s[i].
+
+    Warning: this method makes no assumptions about what precedes or
+    follows the pattern.
+    """
     return bool(s and pattern and s.find(pattern, i, i + len(pattern)) == i)
 #@+node:ekr.20031218072017.3182: *4* g.match_c_word
 def match_c_word(s: str, i: int, name: str) -> bool:
@@ -3921,36 +3925,32 @@ def match_c_word(s: str, i: int, name: str) -> bool:
 def match_ignoring_case(s1: str, s2: str) -> bool:
     return bool(s1 and s2 and s1.lower() == s2.lower())
 #@+node:ekr.20031218072017.3184: *4* g.match_word & g.match_words
-def match_word(s: str, i: int, pattern: str) -> bool:
-    """Return True if s[i] starts a word."""
-    # Using a regex is surprisingly tricky.
+def match_words(s: str, i: int, patterns: Sequence[str], *, ignore_case: bool = False) -> bool:
+    """Return true if any of the given patterns match at s[i]"""
+    return any(g.match_word(s, i, pattern, ignore_case=ignore_case) for pattern in patterns)
 
-    # Check the pattern and set j.
-    if pattern is None:
-        return False
-    j = len(pattern)
-    if j == 0:
+def match_word(s: str, i: int, pattern: str, *, ignore_case: bool = False) -> bool:
+    """Return True if s[i] starts the word given by pattern."""
+    if not pattern:
         return False
 
-    # Check the start of the word.
-    # Special cases: \b or \t or \n delimit words!
-    if i > 2 and s[i - 2] == '\\' and s[i - 1] in 'bnt':
-        return True
-    if i > 0 and g.isWordChar(s[i - 1]):
-        return False
+    # 1. Compute the required boundaries.
+    bound1 = g.isWordChar1(pattern[0])
+    bound2 = g.isWordChar(pattern[-1])
 
-    # Check that the pattern matches.
-    if s.find(pattern, i, i + j) != i:
-        return False
-    if i + j >= len(s):
-        return True
+    # 2. Add regex escapes.
+    pattern = re.escape(pattern)
 
-    # Check the end of the word.
-    ch = s[i + j]
-    return not g.isWordChar(ch)
+    # 3. Add the boundaries.
+    if bound1:
+        pattern = '\\b' + pattern
+    if bound2:
+        pattern = pattern + '\\b'
 
-def match_words(s: str, i: int, patterns: Sequence[str]) -> bool:
-    return any(g.match_word(s, i, pattern) for pattern in patterns)
+    # Compile the pattern so we can specify the starting position.
+    pat = re.compile(pattern, flags=re.I if ignore_case else 0)
+    return bool(pat.match(s, i))
+
 #@+node:ekr.20031218072017.3185: *4* g.skip_blank_lines
 # This routine differs from skip_ws_and_nl in that
 # it does not advance over whitespace at the start

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -560,11 +560,23 @@ class TestGlobals(LeoUnitTest):
             (False, 0, 'a', 'a_'),
             (True, 2, 'a', 'b a c'),
             (False, 0, 'a', 'b a c'),
+            # Tests of #3588.
+            (True, 4, '.lws', 'self.lws = 0'),
+            (True, 4, '.lws', 'self.lws=0'),
+            (False, 4, '.lws', 'self.lws2a=0'),
+            (False, 4, '.lws', 'self.lws0=0'),
+            (True, 2, '.lws', '  .lws  #comment'),
+            (False, 2, '.lws', '  .lws2  #comment'),
+            (True, 0, '###', '### comment'),
+            (True, 0, '###', '###comment'),
+            (True, 2, '###', '  ###comment'),
+            (True, 2, '###', '  ###.'),
+            (True, 1, '###', 'a###.'),
         )
-        for data in table:
-            expected, i, word, line = data
-            got = g.match_word(line + '\n', i, word)
-            self.assertEqual(expected, got)
+        for ignore_case in (True, False):
+            for expected, i, word, line in table:
+                got = g.match_word(line + '\n', i, word, ignore_case=ignore_case)
+                assert expected == got, (word, line[i:])
     #@+node:ekr.20230131234527.1: *4* TestGlobals.test_g_objToString
     def test_g_objToString(self):
 


### PR DESCRIPTION
See #3588.

This PR simplifies `g.match_word` using regular expressions, something I had long thought to be impossible.

The Aha! The method protects the start and the end of the pattern with `\b` only when protected character can begin or end the word.

- [x] Rewrite g.match_word, adding 'ignore_case' kwarg.
- [x] Set 'ignore_case' kwarg in `find. _inner_search_match_word`
- [x] Improve unit test.