### PR TITLE
PR for #3604: startup message

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -993,15 +993,10 @@ class LeoApp:
         app = self
         try:
             from leo.core.leoQt import Qt
+            from leo.plugins import qt_gui
             assert Qt
         except Exception:
-            return None
-        try:
-            from leo.plugins import qt_gui
-        except Exception:
-            g.es_exception()
-            print('can not import leo.plugins.qt_gui')
-            sys.exit(1)
+            return None  # Other methods will report startup problems.
         try:
             from leo.plugins.editpane.editpane import edit_pane_test_open, edit_pane_csv
             g.command('edit-pane-test-open')(edit_pane_test_open)

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -965,7 +965,20 @@ class LeoApp:
         elif argName == 'text':
             app.createTextGui()
         if not app.gui:
-            print('createDefaultGui: Leo requires Qt to be installed.')
+            # Raise an emergency dialog.
+            message = (
+                f"Can not load the requested gui: {argName}\n"
+                '*** Leo could not be started ***\n\n'
+                "Please verify you've installed the required dependencies:\n"
+                'https://leo-editor.github.io/leo-editor/installing.html\n'
+            )
+            try:
+                d = g.EmergencyDialog(title=message, message=message)
+                d.run()
+            except Exception:
+                g.es_exception()
+            # runLeo.py will catch the SystemExit exception and print the message.
+            sys.exit(message)
     #@+node:ekr.20031218072017.1938: *5* app.createNullGuiWithScript
     def createNullGuiWithScript(self, script: str = None) -> None:
         app = self
@@ -973,23 +986,16 @@ class LeoApp:
         app.gui = g.app.nullGui
         app.gui.setScript(script)
     #@+node:ekr.20090202191501.1: *5* app.createQtGui
+    # Do NOT omit fileName param: it is used in plugin code.
+
     def createQtGui(self, fileName: str = '', verbose: bool = False) -> None:
-        # Do NOT omit fileName param: it is used in plugin code.
         """A convenience routines for plugins to create the Qt gui class."""
         app = self
         try:
             from leo.core.leoQt import Qt
             assert Qt
         except Exception:
-            # #1215: Raise an emergency dialog.
-            message = 'Can not Import Qt'
-            print(message)
-            try:
-                d = g.EmergencyDialog(title=message, message=message)
-                d.run()
-            except Exception:
-                g.es_exception()
-            sys.exit(1)
+            return None
         try:
             from leo.plugins import qt_gui
         except Exception:
@@ -1001,9 +1007,8 @@ class LeoApp:
             g.command('edit-pane-test-open')(edit_pane_test_open)
             g.command('edit-pane-csv')(edit_pane_csv)
         except ImportError:
-            # g.es_exception()
             print('Failed to import editpane')
-        #
+
         # Complete the initialization.
         qt_gui.init()
         if app.gui and fileName and verbose:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -355,14 +355,13 @@ class NullGui(LeoGui):
     #@+node:ekr.20031218072017.2225: *3* NullGui.__init__
     def __init__(self, guiName: str = 'nullGui') -> None:
         """ctor for the NullGui class."""
-        from leo.plugins.qt_text import QTextEditWrapper
         super().__init__(guiName)
         self.clipboardContents = ''
         self.focusWidget: Widget = None
         self.isNullGui = True
         self.idleTimeClass: Any = g.NullObject
         self.lastFrame: Widget = None  # The outer frame, to set g.app.log in runMainLoop.
-        self.plainTextWidget: Widget = QTextEditWrapper  # For SpellTabHandler class.
+        self.plainTextWidget: Widget = g.NullObject
         self.script = None
     #@+node:ekr.20031218072017.3744: *3* NullGui.dialogs
     def runAboutLeoDialog(self, c: Cmdr, version: str, theCopyright: str, url: str, email: str) -> str:

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -54,7 +54,8 @@ if not g.in_bridge:
             isQt5 = True
             # print('\n===== Qt5 =====')
         except Exception:
-            # print('===== No Qt =====')
-            if g.app.gui.guiName() == 'qt':
-                print('Can not load pyQt5 or pyQt6')
+            # Don't print anything here.
+            # g.app.createQtGui will issue handle the error if the user wants Qt.
+            if 0:
+                print('Can not import pyQt5 or pyQt6')
 #@-leo

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -55,7 +55,7 @@ if not g.in_bridge:
             # print('\n===== Qt5 =====')
         except Exception:
             # Don't print anything here.
-            # g.app.createQtGui will issue handle the error if the user wants Qt.
+            # g.app.createQtGui will handle the error if the user wants Qt.
             if 0:
                 print('Can not import pyQt5 or pyQt6')
 #@-leo

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -49,7 +49,11 @@ def create_app(gui_name: str = 'null') -> Cmdr:
     from leo.core import leoCommands
     from leo.core.leoGui import NullGui
     if gui_name == 'qt':
-        from leo.plugins.qt_gui import LeoQtGui
+        # Don't fail if Qt has not been installed.
+        try:
+            from leo.plugins.qt_gui import LeoQtGui
+        except Exception:
+            gui_name = 'null'
     t2 = time.process_time()
     g.app.recentFilesManager = leoApp.RecentFilesManager()
     g.app.loadManager = lm = leoApp.LoadManager()

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -8,7 +8,7 @@
 import os
 import sys
 import traceback
-#
+
 # Override sys.excepthook
 def leo_excepthook(typ, val, tb):
     # Like g.es_exception.
@@ -22,7 +22,7 @@ def leo_excepthook(typ, val, tb):
     print('')
 
 sys.excepthook = leo_excepthook
-#
+
 # Partial fix for #541.
 # See https://stackoverflow.com/questions/24835155/
 if sys.executable.endswith("pythonw.exe"):
@@ -39,12 +39,17 @@ try:
     from leo.core import leoGlobals as g
     from leo.core import leoApp
     g.app = leoApp.LeoApp()
+
 except Exception as e:
+    # Printing the exception would be confusing.
+    # Note: app.createDefaultGui reports problems importing Qt.
     print(e)
-    msg = "\n*** Leo could not be started ***\n"
-    msg += "Please verify you've installed the required dependencies:\n"
-    msg += "https://leo-editor.github.io/leo-editor/installing.html"
-    sys.exit(msg)
+    print(
+        '*** Leo could not be started ***\n'
+        "Please verify you've installed the required dependencies:\n"
+        'https://leo-editor.github.io/leo-editor/installing.html'
+    )
+    sys.exit(1)
 #@-<< imports and inits >>
 #@+others
 #@+node:ekr.20031218072017.2607: ** profile_leo (runLeo.py)

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -41,15 +41,16 @@ try:
     g.app = leoApp.LeoApp()
 
 except Exception as e:
-    # Printing the exception would be confusing.
+    # The full traceback would alarm users!
     # Note: app.createDefaultGui reports problems importing Qt.
     print(e)
-    print(
+    message = (
         '*** Leo could not be started ***\n'
         "Please verify you've installed the required dependencies:\n"
         'https://leo-editor.github.io/leo-editor/installing.html'
     )
-    sys.exit(1)
+    print(message)
+    sys.exit(message)
 #@-<< imports and inits >>
 #@+others
 #@+node:ekr.20031218072017.2607: ** profile_leo (runLeo.py)

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -102,8 +102,11 @@ import re
 from typing import Any, Generator, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoNodes
-from leo.core.leoQt import QtCore, QtWidgets
-from leo.core.leoQt import MouseButton
+try:
+    from leo.core.leoQt import QtCore, QtWidgets
+    from leo.core.leoQt import MouseButton
+except Exception:
+    QtCore = QtWidgets = None
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -5,6 +5,7 @@
 import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
+from leo.core.leoQt import Qt
 import leo.core.leoColorizer as leoColorizer
 
 #@+others
@@ -37,6 +38,8 @@ class TestColorizer(LeoUnitTest):
         self.color('plain', text)
     #@+node:ekr.20210905170507.3: *3* TestColorizer.test_bc_scanLanguageDirectives
     def test_bc_scanLanguageDirectives(self):
+        if not Qt:
+            self.skipTest('Requires Qt')
         c = self.c
         c.target_language = 'python'  # Set the default.
         widget = c.frame.body.widget
@@ -56,6 +59,8 @@ class TestColorizer(LeoUnitTest):
             self.assertEqual(got, language, msg=f"i: {i} {language}")
     #@+node:ekr.20210905170507.4: *3* TestColorizer.test_bc_useSyntaxColoring
     def test_bc_useSyntaxColoring(self):
+        if not Qt:
+            self.skipTest('Requires Qt')
         c = self.c
         widget = c.frame.body.widget
         x = leoColorizer.JEditColorizer(c, widget)


### PR DESCRIPTION
None of these changes are likely to affect leoJS.

- [x] Improve messages issued when the requested gui (usually Qt) was not imported.
- [x] Fix bug that prevented the emergency (Tk) dialog from being shown.

**Bonus**

Remove dependencies on Qt in various places:

- [x] The `NullGui` class no longer depends on Qt!
- [x] The `nodetags` plugins no longer depends on Qt.  Previously, it had said it didn't, but it did :-)
- [x] Improve unit testing framework. All tests pass (skipping Qt-related tests) when Qt is not available.