### PR TITLE
PR for #3606: scheme importer

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -310,6 +310,7 @@ class LeoApp:
             "bib":      "bibtex",
             "c":        "c",
             "c++":      "cplusplus",
+            "cc":       "cplusplus",
             "cbl":      "cobol", # Only one extension is valid: .cob
             "cfg":      "config",
             "cfm":      "coldfusion",
@@ -338,6 +339,7 @@ class LeoApp:
             "go":       "go",
             "groovy":   "groovy",
             "h":        "c", # 2012/05/23.
+            "hh":       "cplusplus",
             "handlebars": "html", # McNab.
             "hbs":      "html", # McNab.
             "hs":       "haskell",

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2122,7 +2122,7 @@ class JEditColorizer(BaseColorizer):
         # Prepend "dots" to the kind, as a flag to setTag.
         dots = j > len(
             s) and begin in "'\"" and end in "'\"" and kind.startswith('literal')
-        dots = dots and self.language not in ('lisp', 'elisp', 'rust')
+        dots = dots and self.language not in ('lisp', 'elisp', 'rust', 'scheme')
         if dots:
             kind = 'dots' + kind
         # A match

--- a/leo/modes/scheme.py
+++ b/leo/modes/scheme.py
@@ -1,3 +1,5 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20231012163843.1: * @file ../modes/scheme.py
 # Leo colorizer control file for scheme mode.
 # This file is in the public domain.
 
@@ -353,3 +355,4 @@ rulesDictDict = {
 
 # Import dict for scheme mode.
 importDict = {}
+#@-leo

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -198,6 +198,7 @@ class Importer:
                         i = end
                     break
             assert i > progress, g.callers()
+        # g.printObj(results, tag=f"{g.my_name()} {i1} {i2}")
         return results
     #@+node:ekr.20230529075138.11: *4* i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:

--- a/leo/plugins/importers/elisp.py
+++ b/leo/plugins/importers/elisp.py
@@ -56,8 +56,8 @@ def do_import(c: Cmdr, parent: Position, s: str) -> None:
     Elisp_Importer(c).import_from_string(parent, s)
 
 importer_dict = {
-    'extensions': ['.el', '.clj', '.cljs', '.cljc',],
-    'func': do_import,  # Also clojure, clojurescript
+    'extensions': ['.el', '.clj', '.cljs', '.cljc'],
+    'func': do_import,  # Also clojure, clojurescript.
 }
 #@@language python
 #@@tabwidth -4

--- a/leo/plugins/importers/elisp.py
+++ b/leo/plugins/importers/elisp.py
@@ -18,10 +18,12 @@ class Elisp_Importer(Importer):
 
     language = 'lisp'
 
-    block_patterns = (
+    block_patterns: tuple = (
         # ( defun name
         ('defun', re.compile(r'\s*\(\s*\bdefun\s+([\w_-]+)')),
     )
+
+    string_list: list[str] = ['"']
 
     #@+others
     #@+node:ekr.20230516145728.1: *3* elisp_i.find_end_of_block

--- a/leo/plugins/importers/scheme.py
+++ b/leo/plugins/importers/scheme.py
@@ -1,0 +1,37 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20231012140553.1: * @file ../plugins/importers/scheme.py
+"""The @auto importer for the scheme language."""
+from __future__ import annotations
+import re
+from typing import TYPE_CHECKING
+from leo.plugins.importers.elisp import Elisp_Importer
+# from leo.core import leoGlobals as g
+
+if TYPE_CHECKING:
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoNodes import Position
+
+#@+others
+#@+node:ekr.20231012140553.2: ** class Scheme_Importer(Elisp_Importer)
+class Scheme_Importer(Elisp_Importer):
+    """The importer for the Scheme language."""
+
+    language = 'scheme'
+
+    block_patterns = (
+        # ( define name
+        ('define', re.compile(r'\s*\(\s*\bdefine\s+([\w_-]+)')),
+    )
+#@-others
+
+def do_import(c: Cmdr, parent: Position, s: str) -> None:
+    """The importer callback for scheme."""
+    Scheme_Importer(c).import_from_string(parent, s)
+
+importer_dict = {
+    'extensions': ['.scm',],
+    'func': do_import,
+}
+#@@language python
+#@@tabwidth -4
+#@-leo

--- a/leo/plugins/importers/scheme.py
+++ b/leo/plugins/importers/scheme.py
@@ -18,9 +18,12 @@ class Scheme_Importer(Elisp_Importer):
 
     language = 'scheme'
 
-    block_patterns = (
+    block_patterns: tuple = (
         # ( define name
-        ('define', re.compile(r'\s*\(\s*\bdefine\s+([\w_-]+)')),
+        ('define-library', re.compile(r'\s*\(\s*\bdefine-library\s*\(?\s*([\w_-]+)')),
+        ('define-module', re.compile(r'\s*\(\s*\bdefine-module\s*\(?\s*([\w_-]+)')),
+        ('define-public', re.compile(r'\s*\(\s*\bdefine-public\s*\(?\s*([\w_-]+)')),
+        ('define', re.compile(r'\s*\(\s*\bdefine\s*\(?([\w_-]+)')),
     )
 #@-others
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -901,8 +901,8 @@ class TestElisp(BaseTestImporter):
     ext = '.el'
 
     #@+others
-    #@+node:ekr.20210904065459.18: *3* TestElisp.test_1
-    def test_1(self):
+    #@+node:ekr.20210904065459.18: *3* TestElisp.test_elisp_1
+    def test_elisp_1(self):
 
         # Add weird assignments for coverage.
         s = """
@@ -3871,6 +3871,54 @@ class TestRust(BaseTestImporter):
                     'fn area(width: u32, height: u32) -> u32 {\n'
                     '    width * height\n'
                     '}\n'
+            ),
+        )
+        self.new_run_test(s, expected_results)
+    #@-others
+#@+node:ekr.20231012142113.1: ** class TestScheme (BaseTestImporter)
+class TestScheme(BaseTestImporter):
+
+    ext = '.scm'
+
+    #@+others
+    #@+node:ekr.20231012142113.2: *3* TestScheme.test_scheme_1
+    def test_scheme_1(self):
+
+        # Add weird assignments for coverage.
+        s = """
+            ;;; comment
+            ;;; continue
+            ;;;
+
+            (define abc (a b)
+               (assn a "abc")
+               (assn b \\x)
+               (+ 1 2 3))
+
+            ; comment re cde
+            (define cde (a b)
+               (+ 1 2 3))
+        """
+        expected_results = (
+            (0, '', # Ignore the first headline.
+                    '@others\n'
+                    '@language scheme\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, 'define abc',
+                    ';;; comment\n'
+                    ';;; continue\n'
+                    ';;;\n'
+                    '\n'
+                    '(define abc (a b)\n'
+                    '   (assn a "abc")\n'
+                    '   (assn b \\x)\n'
+                    '   (+ 1 2 3))\n'
+            ),
+            (1, 'define cde',
+                    '; comment re cde\n'
+                    '(define cde (a b)\n'
+                    '   (+ 1 2 3))\n'
             ),
         )
         self.new_run_test(s, expected_results)


### PR DESCRIPTION
See #3606.

- [x] Associate `.hh` and `.cc` file extensions with C++.
- [x] Add Scheme importer and associated unit test.
- [x] Add Scheme to a weird list of exceptions in `jedit.match_span` so that Scheme strings are colorized properly.
- [x] Fix bug in `Elisp_Importer`: Only double quotes start strings!