### PR TITLE
Replace lost "@" character when command line option "--load-type" is processed

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3188,6 +3188,9 @@ class LoadManager:
             if p:
                 # The 'load_type' key may not exist when run from the bridge.
                 load_type = self.options.get('load_type', '@edit')  # #2489.
+                if not load_type.startswith('@'):  # #3546
+                    # The "@" may get lost so restore it
+                    load_type = '@' + load_type
                 p.setHeadString(f"{load_type} {fn}")
                 c.refreshFromDisk()
                 c.selectPosition(p)


### PR DESCRIPTION
This PR fixes issue #3546. But the option `@file` fails with an error message:

`read_into_root Invalid external file:`

This is an unrelated bug.  The `@edit`  option acts as expected.