### PR TITLE
PR: Fix quirp in check_outline

### DIFF
--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -41,10 +41,10 @@ class BaseTestImporter(LeoUnitTest):
         """
         try:
             p0_level = p.level()
-            actual = [(z.level(), z.h, z.b) for z in p.self_and_subtree()]
-            for i, actual in enumerate(actual):
+            actual_list = [(z.level(), z.h, z.b) for z in p.self_and_subtree()]
+            for i, actual_tuple in enumerate(actual_list):
                 try:
-                    a_level, a_h, a_str = actual
+                    a_level, a_h, a_str = actual_tuple
                     e_level, e_h, e_str = expected[i]
                 except Exception:
                     assert False  # So we print the actual results.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -40,10 +40,10 @@ class BaseTestImporter(LeoUnitTest):
         """
         try:
             p0_level = p.level()
-            actual_list = [(z.level(), z.h, z.b) for z in p.self_and_subtree()]
-            for i, actual_tuple in enumerate(actual_list):
+            actuals = [(z.level(), z.h, z.b) for z in p.self_and_subtree()]
+            for i, actual in enumerate(actuals):
                 try:
-                    a_level, a_h, a_str = actual_tuple
+                    a_level, a_h, a_str = actual
                     e_level, e_h, e_str = expected[i]
                 except Exception:
                     assert False  # So we print the actual results.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -12,7 +12,6 @@ from leo.core.leoTest2 import LeoUnitTest
 from leo.plugins.importers.base_importer import Block
 from leo.plugins.importers.python import Python_Importer
 from leo.plugins.importers.c import C_Importer
-import leo.plugins.importers.coffeescript as cs
 import leo.plugins.importers.coffeescript as coffeescript
 import leo.plugins.importers.markdown as markdown
 import leo.plugins.importers.otl as otl
@@ -448,7 +447,6 @@ class TestC(BaseTestImporter):
     #@+node:ekr.20230510161130.1: *3* TestC.test_delete_comments_and_strings
     def test_delete_comments_and_strings(self):
 
-        from leo.plugins.importers.c import C_Importer
         importer = C_Importer(self.c)
 
         lines = [
@@ -476,8 +474,6 @@ class TestC(BaseTestImporter):
         self.assertEqual(result, expected_lines)
     #@+node:ekr.20230511044054.1: *3* TestC.test_find_blocks
     def test_find_blocks(self):
-
-        from leo.plugins.importers.c import C_Importer
 
         importer = C_Importer(self.c)
         lines = g.splitLines(textwrap.dedent("""\
@@ -718,7 +714,7 @@ class TestCoffeescript(BaseTestImporter):
     #@+node:ekr.20210904065459.126: *3* TestCoffeescript.test_scan_line
     def test_scan_line(self):
         c = self.c
-        x = cs.Coffeescript_Importer(c)
+        x = coffeescript.Coffeescript_Importer(c)
         self.assertEqual(x.single_comment, '#')
     #@-others
 #@+node:ekr.20211108062958.1: ** class TestCSharp (BaseTestImporter)


### PR DESCRIPTION
@boltex I'm happy to merge this PR into devel now, or after leoJS debuts. It's your call.

mypy was always good with the "overloaded" name `actual`. Surely there are other overloaded variable names scattered throughout Leo. I assume Typescript is more strict than mypy in this regard.

- [x] Split the `actual` var in `check_outline` into `actual_list` and `actual_tuple` vars.
- [x] Fix several valid pylint complaints by using the `coffeescript` name throughout `test_importers.py`.