### PR TITLE
Fix quirps re @asis and @nosent

### DIFF
--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -641,7 +641,7 @@ class ExternalFilesController:
             c=c,
             message=(
                 f"{path_name} has changed outside Leo.\n\n"
-                f"An {kind} file created this file.\n\n"
+                f"An {kind} node created this file.\n\n"
                 'Warning: Leo can not update this file!\n'
                 'Neither refresh-from-disk nor restarting Leo will work.\n'
             ),

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -642,7 +642,7 @@ class ExternalFilesController:
             message=(
                 f"{path_name} has changed outside Leo.\n\n"
                 f"An {kind} node created this file.\n\n"
-                'Warning: Leo can not update this file!\n'
+                'Warning: Leo can not update this node!\n'
                 'Neither refresh-from-disk nor restarting Leo will work.\n'
             ),
             title='External file changed',

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -589,7 +589,7 @@ class ExternalFilesController:
         old_sum = self.checksum_d.get(path)
         new_sum = self.checksum(path)
         if new_sum == old_sum:
-            # The modtime changed, but it's contents didn't.
+            # The modtime changed, but its contents didn't.
             # Update the time, so we don't keep checking the checksums.
             # Return False so we don't prompt the user for an update.
             self.set_time(path, new_time)
@@ -634,16 +634,17 @@ class ExternalFilesController:
         if g.unitTesting or c not in g.app.commanders():
             return
         if not p:
-            g.trace('NO P')
             return
+        path_name = g.splitLongFileName(path)
+        kind = '@asis' if p.h.startswith('@asis') else '@nosent'
         g.app.gui.runAskOkDialog(
             c=c,
-            message='\n'.join([
-                f"{g.splitLongFileName(path)} has changed outside Leo.\n",
-                'Leo can not update this file automatically.\n',
-                f"This file was created from {p.h}.\n",
-                'Warning: refresh-from-disk will destroy all children.'
-            ]),
+            message=(
+                f"{path_name} has changed outside Leo.\n\n"
+                f"An {kind} file created this file.\n\n"
+                'Warning: Leo can not update this file!\n'
+                'Neither refresh-from-disk nor restarting Leo will work.\n'
+            ),
             title='External file changed',
         )
     #@-others

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -8421,7 +8421,7 @@ By default, the file's extension determines the importer::
 
 The ``@asis`` directive creates an external file without sentinels and without any expansions.
 
-Use this directive only when you must have complete control over every character of the external file. When writing ``@asis`` nodes, writes the body text of all nodes in outline order. Leo writes the body text *as is*, without recognizing section definitions, without expanding section references, and without treating directives specially in any way. In particular, Leo copies all directives, including ``@`` or ``@c`` directives, to the external file as text. **Warning**: Because the external file contains no sentinels, ``@nosent`` trees can not be updated from changes made outside of Leo. If you want this capability, use ``@clean`` instead.
+Use this directive only when you must have complete control over every character of the external file. When writing ``@asis`` nodes, writes the body text of all nodes in outline order. Leo writes the body text *as is*, without recognizing section definitions, without expanding section references, and without treating directives specially in any way. In particular, Leo copies all directives, including ``@`` or ``@c`` directives, to the external file as text. **Warning**: Because the external file contains no sentinels, ``@asis`` trees can not be updated from changes made outside of Leo. If you want this capability, use ``@clean`` instead.
 
 .. index::
     pair: @@ convention in @asis trees; Reference


### PR DESCRIPTION
- [x] Fix a typo in the documentation for `@asis`.
- [x] Simplify the dialog raised when Leo detects changes to `@asis` and `@nosent` nodes.

**Félix**: Original report from private email (slightly edited):

QQQ
When external file changes are detected for `@nosent` and `@asis`, a dialog message appears. The message says those nodes can't be read, and that *using the refresh from disk will clear the node*.

When I manually tried `refresh-from-disk` on those nodes, Leo just prints a message in the log warning the user, *without* changing the node.

The dialog message should be amended to say `@nosent` / `@asis` do not read from file.
QQQ

The original report mentioned `@edit` rather than `@asis`.

**First, do no harm**

In fact, the user *can* recover the external changes as follows:

- Change `@asis` or `@nosent` to `@edit` *without* saving the file.
- Execute refresh-from-disk or restart Leo *without* saving the outline.

However, this procedure will overwrite changes made externally if the user *does* save the outline.

Imo, it's best not to mention this recovery method in the dialog! Long error dialogs can cause panic, and panic might lead to data loss.