### PR TITLE
PR for #3624: crash in rust importer

### DIFF
--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -212,8 +212,7 @@ class Importer:
         This method assumes that that '{' and '}' delimit blocks.
         Subclasses may override this method as necessary.
         """
-        level = 1  # All blocks start with '{'
-        assert '{' in self.guide_lines[i - 1]
+        level = 1 if '{' in self.guide_lines[i - 1] else 0
         while i < i2:
             line = self.guide_lines[i]
             i += 1


### PR DESCRIPTION
See #3624.

- [x] Replace assert by more general assignment.

This change allows function/method definitions to continue across multiple lines.

All unit tests pass unchanged.