### PR TITLE
PR for #3616: Remove mention of eval* commands in leoTips.py

### DIFF
--- a/leo/core/leoTips.py
+++ b/leo/core/leoTips.py
@@ -171,7 +171,6 @@ Become familiar with Leo's most important plugins:
 - bookmarks.py manages bookmarks.
 - contextmenu.py shows a menu when when right-clicking.
 - mod_scripting.py supports @button and @command nodes.
-  The eval* command support persistent evaluation.
 - quicksearch.py adds a Nav tab for searching.
 - todo.py handles to-do lists and is a project manager.
 - viewrendered.py renders content in the rendering pane.


### PR DESCRIPTION
See #3616.