### PR TITLE
PR fixes #3596: Fix two quirps in revert command

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -553,7 +553,7 @@ def revert(self: Self, event: Event = None) -> None:
         g.es('Can not revert unnamed file.')
         return
     if not g.os_path_exists(fn):
-        g.es(f"Can not revert unsaved file: {fn}")
+        g.es(f"Can not revert non-existent file: {fn}")
         return
     reply = g.app.gui.runAskYesNoDialog(
         c, 'Revert', f"Revert to previous version of {fn}?")

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3255,7 +3255,13 @@ class LoadManager:
 
         # Re-read the file.
         c.fileCommands.initIvars()
-        v = fc.getAnyLeoFileByName(fn, readAtFileNodesFlag=True)
+        try:
+            g.app.reverting = True
+            v = fc.getAnyLeoFileByName(fn, readAtFileNodesFlag=True)
+        finally:
+            g.app.reverting = False
+
+        # Report failure.
         if not v:
             g.error(f"Revert failed: {fn!r}")
     #@-others

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3252,18 +3252,23 @@ class LoadManager:
             return
         if not lm.isLeoFile(fn):
             return
-
         # Re-read the file.
         c.fileCommands.initIvars()
         try:
             g.app.reverting = True
             v = fc.getAnyLeoFileByName(fn, readAtFileNodesFlag=True)
+            # Report failure.
+            if not v:
+                g.error(f"Revert failed: {fn!r}")
+                return
+            # #3596: Redo all buttons.
+            sc = getattr(c, 'theScriptingController', None)
+            if sc:
+                sc.createAllButtons()
+            if not g.unitTesting:
+                g.es_print(f"Reverted {c.fileName()}")
         finally:
             g.app.reverting = False
-
-        # Report failure.
-        if not v:
-            g.error(f"Revert failed: {fn!r}")
     #@-others
 #@+node:ekr.20120223062418.10420: ** class PreviousSettings
 class PreviousSettings:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3099,7 +3099,10 @@ class KeyHandlerClass:
         c, k = self.c, self
         # Setup...
         if trace:
-            g.trace(repr(k.state.kind), repr(event.char), repr(event.stroke))
+            handler_s = f"{k.state.handler.__name__}" if k.state.handler else 'No handler'
+            g.trace(
+                f"char: {event.char!r} stroke: {event.stroke!r} "
+                f"state.kind: {k.state.kind!r}, state.handler: {handler_s}")
         k.checkKeyEvent(event)
         k.setEventWidget(event)
         k.traceVars(event)
@@ -3285,6 +3288,8 @@ class KeyHandlerClass:
                     g.trace(state, 'k.generalModeHandler', stroke)
                 return True
             # Unbound keys end mode.
+            if trace:
+                g.trace(state, stroke, 'no binding')
             k.endMode()
             return False
         # Fourth, call the state handler.
@@ -3503,6 +3508,8 @@ class KeyHandlerClass:
         #
         # #327: Ignore killed bindings.
         if bi and bi.commandName in k.killedBindings:
+            if trace:
+                g.trace(f"{event.stroke!s} {bi.commandName}: in killed bindings")
             return False
         #
         # Execute the command if the binding exists.
@@ -3514,6 +3521,8 @@ class KeyHandlerClass:
             return True
         #
         # No binding exists.
+        if trace:
+            g.trace(f"{event.stroke!s} {bi.commandName}: no binding")
         return False
     #@+node:ekr.20091230094319.6240: *6* k.getPaneBinding & helper
     def getPaneBinding(self, event: Event) -> Any:

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -453,7 +453,9 @@ class ScriptingController:
     def createAllButtons(self) -> None:
         """Scan for @button, @rclick, @command, @plugin and @script nodes."""
         c = self.c
-        if self.scanned:
+        if g.app.reverting:
+            self.deleteAllButtons()
+        elif self.scanned:
             return  # Defensive.
         self.scanned = True
         #
@@ -610,6 +612,13 @@ class ScriptingController:
         )
         # Reporting this command is way too annoying.
         return b
+    #@+node:ekr.20231117041244.1: *3* sc.deleteAllButtons
+    def deleteAllButtons(self) -> None:
+        """Delete all buttons during revert."""
+        for w in self.buttonsDict:
+            self.iconBar.deleteButton(w)
+        self.buttonsDict = {}
+        self.seen = set()
     #@+node:ekr.20060328125248.28: *3* sc.executeScriptFromButton
     def executeScriptFromButton(self,
         b: Wrapper,


### PR DESCRIPTION
See #3596.

- `LM.revertCommander` safely calls `c.theScriptingController.createAllButtons`.
- `sc.createAllButtons` calls `sc.deleteAllButtons` when `g.app.reverting` is True.

These changes fix the UI problem.

**Another quirp**

During a `revert`, `sc.createAllButtons` re-registers the *commands* created by `@button` nodes.

There is no reasonable way to *unregister* the commands that the *old* (potentially zombie) buttons created!

However, executing the zombie *commands* is safe because because the `AtButtonCallback` (ABC) class is safe:

- `<Alt-X>zombie<Return>` eventually(!) calls `ABC.execute_script`.
- `ABC.execute_script` calls `ABC.find_script`, which returns None because the node with the zombie gnx no longer exists!
- `ABC.execute_script` returns *without calling* `ScriptingController.executeScriptFromButton`.

In short, the *zombie script does nothing*, safely.

**Extras**

- [x] Improve the warning about non-existent file.
- [x] Suppress the warning about an already-open file.
- [x] Report successful `revert` operations to the console and the log.
- [x] Improve traces for `--trace=keys`.