### PR TITLE
PR: Fix rust-related bugs

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1489,7 +1489,6 @@ class LeoFind:
         """
         self.ftm.clear_focus()
         self.ftm.set_entry_focus()
-        self.total_links = 0  # Limit the total number of clickable links.
         self.start_state_machine(event, 'Search: ',
             handler=self.interactive_find_all1,
             escape_handler=self.find_all_escape_handler,
@@ -3022,6 +3021,7 @@ class LeoFind:
         k.getArgEscapes = ['\t'] if escape_handler else []
         self.handler = handler
         self.escape_handler = escape_handler
+        self.total_links = 0  # Limit the total number of clickable links.
         # Start the state matching!
         k.get1Arg(event, handler=self.state0, tabList=self.findTextList, completion=True)
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1486,11 +1486,10 @@ class LeoFind:
         search string.
 
         Typing tab converts this to the change-all command.
-
-
         """
         self.ftm.clear_focus()
         self.ftm.set_entry_focus()
+        self.total_links = 0  # Limit the total number of clickable links.
         self.start_state_machine(event, 'Search: ',
             handler=self.interactive_find_all1,
             escape_handler=self.find_all_escape_handler,
@@ -1698,10 +1697,15 @@ class LeoFind:
                         self.put_link(line, n, v)
         return ''.join(results)
     #@+node:ekr.20230124102225.1: *7* find.put_link
+    total_links = 0
+
     def put_link(self, line: str, line_number: int, v: VNode) -> None:  # pragma: no cover  # #2023
         """Put a link to the given line at the given line_number in v.h."""
         c = self.c
         log = c.frame.log
+        self.total_links += 1
+        if self.total_links > 100:
+            return
         # Find the first position with the given vnode.
         for p in c.all_unique_positions():
             if p.v == v:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1646,7 +1646,6 @@ class RecursiveImportController:
                     if not self.ignore_pattern.search(f):
                         self.import_one_file(f, parent=parent)
             if dirs:
-                assert self.recursive
                 for dir_ in sorted(dirs):
                     self.import_dir(dir_, parent)
     #@+node:ekr.20170404103953.1: *3* ric.import_one_file

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1621,7 +1621,7 @@ class RecursiveImportController:
             files = [dir_]
         else:
             if self.verbose:
-                g.es_print(f"importing directory: {os.path.normpath(dir_)}")
+                print(f"importing: {os.path.normpath(dir_)}")
             files = list(sorted(os.listdir(dir_)))
         dirs, files2 = [], []
         for path in files:
@@ -1861,7 +1861,7 @@ class RecursiveImportController:
                 if self.verbose:
                     # Only print this message if importing a *single* file.
                     print('')
-                    g.es_print(f"importing file: {os.path.normpath(dir_)}")
+                    print(f"importing file: {os.path.normpath(dir_)}")
                 self.import_one_file(dir_, parent)
             else:
                 self.import_dir(dir_, parent)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -619,7 +619,7 @@ class Importer:
                     count += 1
                 result.append(s)
         if count and not g.unitTesting:
-            g.es_print(f"{self.root.h}:\nchanged leading {kind2} to {kind} in {count} line{g.plural(count)}")
+            print(f"{self.root.h}:\nchanged leading {kind2} to {kind} in {count} line{g.plural(count)}")
         return result
     #@+node:ekr.20230529075138.7: *3* i: Utils
     # Subclasses are unlikely ever to need to override these methods.

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -344,14 +344,12 @@ class Rust_Importer(Importer):
                     # Don't generate small blocks.
                     if min_size == 0 or end - prev_i > min_size:
                         block = Block(kind, name, start=prev_i, start_body=i, end=end, lines=self.lines)
-                        ### g.printObj(self.lines[prev_i:end],tag=f"{g.my_name()} {name}")
                         results.append(block)
                         i = prev_i = end
                     else:
                         i = end
                     break  # The pattern fully matched.
             assert i > progress, g.callers()
-        ### g.printObj(results, tag=f"{g.my_name()} {i1} {i2}")
         return results
     #@+node:ekr.20231031131127.1: *3* rust_i.postprocess
     def postprocess(self, parent: Position, result_blocks: list[Block]) -> None:

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -106,9 +106,10 @@ class Rust_Importer(Importer):
             full_message = f"{self.root.h} line: {i}:\n{message}"
             g.es_print(full_message)
         #@+node:ekr.20231105043049.1: *4* rust_i function: skip_possible_character_constant
-        length10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]\}'")  # '\u{7FFF}'
+        length10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
         length6_pat = re.compile(r"'\\x[0-7][0-7a-fA-F]'")  # '\x7F'
         length4_pat = re.compile(r"'\\[\\\"'nrt0]'")  # '\n', '\r', '\t', '\\', '\0', '\'', '\"'
+        length3_pat = re.compile(r"'.'", re.UNICODE)  # 'x' where x is any unicode character.
 
         def skip_possible_character_constant() -> None:
             """
@@ -122,6 +123,7 @@ class Rust_Importer(Importer):
                 (10, length10_pat),
                 (6, length6_pat),
                 (4, length4_pat),
+                (3, length3_pat),
             ):
                 if pattern.match(s, i):
                     skip_n(n)

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -16,11 +16,8 @@ if TYPE_CHECKING:
 class Rust_Importer(Importer):
 
     language = 'rust'
-
-    minimum_block_size = 0
-
     string_list: list[str] = []  # Not used.
-
+    minimum_block_size = 0
     #@+<< define rust block patterns >>
     #@+node:ekr.20231111065650.1: *3* << define rust block patterns >>
 
@@ -46,7 +43,8 @@ class Rust_Importer(Importer):
         ('struct', re.compile(r'\s*pub\s+struct\b(.*?)$')),
         ('trait', re.compile(r'\s*trait\b(.*?)$')),
         ('trait', re.compile(r'\s*pub\s+trait\b(.*?)$')),
-        ('use', re.compile(r'\s*use\s*\{')),  # No m.group(1).
+        
+        ('use', re.compile(r'\s*use.*?\{')),  # No m.group(1).
     )
     #@-<< define rust block patterns >>
 
@@ -98,6 +96,7 @@ class Rust_Importer(Importer):
         i = 0
         s = ''.join(lines)
         result = []
+        line_number, line_start = 1, 0  # For traces.
 
         #@+others  # Define helper functions.
         #@+node:ekr.20231105045331.1: *4* rust_i function: is_raw_string_literal
@@ -129,8 +128,8 @@ class Rust_Importer(Importer):
             return count if 0 < count < 256 else 0
         #@+node:ekr.20231105043204.1: *4* rust_i function: oops
         def oops(message: str) -> None:
-            full_message = f"{self.root.h} line: {i}:\n{message}"
-            g.es_print(full_message)
+            full_message = f"{self.root.h} line: {line_number}:\n{message}"
+            print(full_message)
         #@+node:ekr.20231105043049.1: *4* rust_i function: skip_possible_character_constant
         length10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
         length6_pat = re.compile(r"'\\x[0-7][0-7a-fA-F]'")  # '\x7F'
@@ -245,7 +244,6 @@ class Rust_Importer(Importer):
                 skip()
         #@-others
 
-        line_number, line_start = 1, 0  # For traces.
         while i < len(s):
             ch = s[i]
             if ch == '\n':
@@ -350,6 +348,7 @@ class Rust_Importer(Importer):
                         i = end
                     break  # The pattern fully matched.
             assert i > progress, g.callers()
+        # g.printObj(results, tag=f"{g.my_name()} {i1}:{i2}")
         return results
     #@+node:ekr.20231031131127.1: *3* rust_i.postprocess
     def postprocess(self, parent: Position, result_blocks: list[Block]) -> None:

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -43,7 +43,7 @@ class Rust_Importer(Importer):
         ('struct', re.compile(r'\s*pub\s+struct\b(.*?)$')),
         ('trait', re.compile(r'\s*trait\b(.*?)$')),
         ('trait', re.compile(r'\s*pub\s+trait\b(.*?)$')),
-        
+
         ('use', re.compile(r'\s*use.*?\{')),  # No m.group(1).
     )
     #@-<< define rust block patterns >>

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -50,6 +50,16 @@ class Rust_Importer(Importer):
     #@-<< define rust block patterns >>
 
     #@+others
+    #@+node:ekr.20231111073652.1: *3* rust_i.check_blanks_and_tabs
+    def check_blanks_and_tabs(self, lines: list[str]) -> bool:  # pragma: no cover (missing test)
+        """
+        Rust_Importer.check_blanks_and_tabs.
+
+        Check for intermixed blank & tabs.
+
+        Ruff uses intermixed blanks and tabs.
+        """
+        return True
     #@+node:ekr.20231031033255.1: *3* rust_i.compute_headline
     def compute_headline(self, block: Block) -> str:
         """

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -21,8 +21,15 @@ class Rust_Importer(Importer):
     #@+<< define rust block patterns >>
     #@+node:ekr.20231111065650.1: *3* << define rust block patterns >>
 
-    # None of these patterns need end with '{' on the same line.
     block_patterns = (
+
+        # Patterns that *do* require '{' on the same line...
+
+        ('enum', re.compile(r'\s*enum\s+(\w+)\s*\{')),
+        ('macro', re.compile(r'\s*(\w+)\!\s*\{')),
+        ('use', re.compile(r'\s*use.*?\{')),  # No m.group(1).
+
+         # Patterns that do *not* require '{' on the same line...
 
         ('fn', re.compile(r'\s*fn\s+(\w+)\s*\(')),
         ('fn', re.compile(r'\s*pub\s+fn\s+(\w+)\s*\(')),
@@ -38,13 +45,13 @@ class Rust_Importer(Importer):
         ('fn', re.compile(r'\s*pub\s*\(\s*in\s*super::.*?\)\s*fn\s+(\w+)\s*\(')),
 
         ('impl', re.compile(r'\s*impl\b(.*?)$')),  # Use the rest of the line.
+
         ('mod', re.compile(r'\s*mod\s+(\w+)')),
+
         ('struct', re.compile(r'\s*struct\b(.*?)$')),
         ('struct', re.compile(r'\s*pub\s+struct\b(.*?)$')),
         ('trait', re.compile(r'\s*trait\b(.*?)$')),
         ('trait', re.compile(r'\s*pub\s+trait\b(.*?)$')),
-
-        ('use', re.compile(r'\s*use.*?\{')),  # No m.group(1).
     )
     #@-<< define rust block patterns >>
 

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -129,7 +129,10 @@ class Rust_Importer(Importer):
         #@+node:ekr.20231105043204.1: *4* rust_i function: oops
         def oops(message: str) -> None:
             full_message = f"{self.root.h} line: {line_number}:\n{message}"
-            print(full_message)
+            if g.unitTesting:
+                assert False, full_message
+            else:
+                print(full_message)
         #@+node:ekr.20231105043049.1: *4* rust_i function: skip_possible_character_constant
         length10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
         length6_pat = re.compile(r"'\\x[0-7][0-7a-fA-F]'")  # '\x7F'
@@ -189,8 +192,10 @@ class Rust_Importer(Importer):
         #@+node:ekr.20231105045459.1: *4* rust_i function: skip_raw_string_literal
         def skip_raw_string_literal(n: int) -> None:
             nonlocal i
-            assert s[i - n - 1] == 'r'
-            assert s[i - n] == '#'
+            assert s[i - n - 1] == 'r', repr(s[i - n - 1])
+            assert s[i - n] == '#', repr(s[i - n])
+            assert s[i] == '"', repr(s[i])
+            i += 1
             j = i
             target = '"' + '#' * n
             while i + len(target) < len(s):
@@ -200,6 +205,7 @@ class Rust_Importer(Importer):
                 else:
                     skip()
             else:
+                g.printObj(g.splitLines(s[j:]), tag=f"{g.my_name()}: run-on raw string literal at")
                 oops(f"Unterminated raw string literal: {s[j:]!r}")
         #@+node:ekr.20231105043337.1: *4* rust_i function: skip_string_constant
         def skip_string_constant() -> None:
@@ -214,7 +220,8 @@ class Rust_Importer(Importer):
                 elif ch == '"':
                     break
             else:
-                oops(f"Run-on string: {s[j:j+10]!r}")
+                g.printObj(g.splitLines(s[j:]), tag=f"{g.my_name()}: run-on string at")
+                oops(f"Run-on string! offset: {j} line number: {line_number}")
         #@+node:ekr.20231105042315.1: *4* rust_i functions: scanning
         def add() -> None:
             nonlocal i

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -21,11 +21,25 @@ class Rust_Importer(Importer):
 
     string_list: list[str] = []  # Not used.
 
+    #@+<< define rust block patterns >>
+    #@+node:ekr.20231111065650.1: *3* << define rust block patterns >>
+
     # None of these patterns need end with '{' on the same line.
     block_patterns = (
+
         ('fn', re.compile(r'\s*fn\s+(\w+)\s*\(')),
         ('fn', re.compile(r'\s*pub\s+fn\s+(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s*\(crate\)\s*fn\s+(\w+)\s*\(')),
+
+        # https://doc.rust-lang.org/stable/reference/visibility-and-privacy.html
+        # 2018 edition+, paths for pub(in path) must start with crate, self, or super.
+        ('fn', re.compile(r'\s*pub\s*\(\s*crate\s*\)\s*fn\s+(\w+)\s*\(')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*self\s*\)\s*fn\s+(\w+)\s*\(')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*super\s*\)\s*fn\s+(\w+)\s*\(')),
+
+        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*crate::.*?\)\s*fn\s+(\w+)\s*\(')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*self::.*?\)\s*fn\s+(\w+)\s*\(')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*super::.*?\)\s*fn\s+(\w+)\s*\(')),
+
         ('impl', re.compile(r'\s*impl\b(.*?)$')),  # Use the rest of the line.
         ('mod', re.compile(r'\s*mod\s+(\w+)')),
         ('struct', re.compile(r'\s*struct\b(.*?)$')),
@@ -33,6 +47,7 @@ class Rust_Importer(Importer):
         ('trait', re.compile(r'\s*trait\b(.*?)$')),
         ('trait', re.compile(r'\s*pub\s+trait\b(.*?)$')),
     )
+    #@-<< define rust block patterns >>
 
     #@+others
     #@+node:ekr.20231031033255.1: *3* rust_i.compute_headline

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -46,6 +46,7 @@ class Rust_Importer(Importer):
         ('struct', re.compile(r'\s*pub\s+struct\b(.*?)$')),
         ('trait', re.compile(r'\s*trait\b(.*?)$')),
         ('trait', re.compile(r'\s*pub\s+trait\b(.*?)$')),
+        ('use', re.compile(r'\s*use\s*\{')),  # No m.group(1).
     )
     #@-<< define rust block patterns >>
 
@@ -337,7 +338,7 @@ class Rust_Importer(Importer):
                         continue
                     i += 1
                     # cython may include trailing whitespace.
-                    name = m.group(1).strip()
+                    name = m.group(1).strip() if m.groups() else ''
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
                     # Don't generate small blocks.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3995,6 +3995,35 @@ class TestRust(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
+    #@+node:ekr.20231113092341.1: *3* TestRust.test_invalid_runon_string
+    def test_invalid_runon_string(self):
+
+        # From ruff_linter/src/rules/eradicate/detection.rs
+        s = textwrap.dedent(
+    """
+        #[test]
+        fn comment_contains_code_basic() {
+            assert!(comment_contains_code("#import eradicate", &[]));
+            assert!(comment_contains_code(r#"#"key": value,"#, &[]));
+            assert!(comment_contains_code(r#"#"key": "value","#, &[]));
+        }
+    """)
+        expected_results = (
+            (0, '',  # Ignore the first headline.
+                    '@others\n'
+                    '@language rust\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, 'fn comment_contains_code_basic',
+                    '#[test]\n'
+                    'fn comment_contains_code_basic() {\n'
+                    '    assert!(comment_contains_code("#import eradicate", &[]));\n'
+                    '    assert!(comment_contains_code(r#"#"key": value,"#, &[]));\n'
+                    '    assert!(comment_contains_code(r#"#"key": "value","#, &[]));\n'
+                    '}\n'
+            ),
+        )
+        self.new_run_test(s, expected_results)
     #@-others
 #@+node:ekr.20231012142113.1: ** class TestScheme (BaseTestImporter)
 class TestScheme(BaseTestImporter):


### PR DESCRIPTION
- [x] Fix several bugs in the rust importer and generate separate nodes for more rust constructs.
- [x] Don't check tabs and spaces in the rust importer. Such checks interfere with unit tests.
- [x] Handle character constants properly in `modes/rust.py`.
- [x] Generalize `jedit.match_span_regexp` and `jedit.match_regexp_helper`.

**Status**

The Rust importer has passed a milestone. It imports all of Ruff's sources without surprises.

**Extras**

This PR contains all my recent work. Rather than create other PR's I have added the following extras:

- [x] Limit the amount of clickable links that `find-all` will create. Leo may hang without this limit.
- [x] Don't write verbose messages to the log pane.
- [x] Don't crash during recursive imports if the 'recursive' flag is set incorrectly.

<details><summary>Colorizing Rust</summary>
<br>

**Character Patterns**

Leo's colorizer (`modes/rust.py`) and Rust importer use the same patterns to detect rust character constants:
```python
re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
re.compile(r"'\\x[0-7][0-7a-fA-F]'")         # '\x7F'
re.compile(r"'\\[\\\"'nrt0]'")               # '\n', '\r', '\t', '\\', '\0', '\'', '\"'
re.compile(r"'.'", re.UNICODE)               # 'x' where x is any unicode character.
```

**Colorizer test**

This PR colorizes the following correctly. So too does GitHub, if you look very closely.
```rust
// Characters, length 3.
a = 'x'
b = 'é'

// Characters, length 4.
nl = '\n'
null = '\0'
tab = '\t'
ret = '\r'
bs = '\\'

// Characters, length 10 and 8.
char10 = '\u{7fff}'
uNull = '\u{0000}'
char8 = '\x7f'
charNull = '\x00'

// Non characters.
'xx 
'\y'
'yy'

// Lifetimes.
pub fn <'a>:
```

</details>