### PR TITLE
PR fixes #3652: beautify only changed files

### DIFF
--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -385,18 +385,17 @@ if 1:  # pragma: no cover
 if 1:  # pragma: no cover
     #@+others
     #@+node:ekr.20231114133501.1: *3* function: get_modified_files
-    def get_modified_files(repo_path):
+    def get_modified_files(repo_path: str) -> list[str]:
         """Return the modified files in the given repo."""
         old_cwd = os.getcwd()
         os.chdir(repo_path)
         try:
-            # Run git status and get the output
+            # Run git status.
             result = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
             if result.returncode != 0:
                 print("Error running git command")
                 return []
-
-            # Parse the output to find modified files
+            # Parse the output.
             modified_files = []
             for line in result.stdout.split('\n'):
                 if line.startswith(' M') or line.startswith('M '):

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1759,9 +1759,10 @@ class Orange:
     def oops(self) -> None:  # pragma: no cover
         g.trace(f"Unknown kind: {self.kind}")
 
-    def beautify(self, contents: str, filename: str, tokens: list[Token], tree: Node,
-
-        max_join_line_length: Optional[int] = None, max_split_line_length: Optional[int] = None,
+    def beautify(self,
+        contents: str, filename: str, tokens: list[Token], tree: Node,
+        max_join_line_length: Optional[int] = None,
+        max_split_line_length: Optional[int] = None,
     ) -> str:
         """
         The main line. Create output tokens and return the result as a string.

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -4338,16 +4338,18 @@ class TokenOrderGenerator:
 def main() -> None:  # pragma: no cover
     """Run commands specified by sys.argv."""
     args, settings_dict, arg_files, recursive = scan_ast_args()
+    if recursive:
+        print('Ignoring deprecated --recursive command-line option')
     # Finalize arguments.
     cwd = os.getcwd()
     # Calculate requested files.
     requested_files = []
     for path in arg_files:
         if path.endswith('.py'):
-            requested_files = [os.path.join(cwd, path)]
+            requested_files.append([os.path.join(cwd, path)])
         else:
             root_dir = os.path.join(cwd, path)
-            requested_files = glob.glob(f'{root_dir}**{os.sep}*.py', recursive=recursive)
+            requested_files.extend(glob.glob(f'{root_dir}**{os.sep}*.py', recursive=True))
     if not requested_files:
         print(f"No files in {arg_files!r}")
         return
@@ -4371,7 +4373,7 @@ def main() -> None:  # pragma: no cover
         if kind:
             n = len(files)
             n_s = f" {n:>3} file" if n == 1 else f"{n:>3} files"
-            print(f"{kind}: {n_s} in {','.join(arg_files)}")
+            print(f"{kind}: {n_s} in {', '.join(arg_files)}")
     # Do the command.
     if args.f:
         fstringify_command(files)

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -4352,17 +4352,14 @@ def main() -> None:  # pragma: no cover
         print(f"No files in {arg_files!r}")
         return
     if args.force:
-        # Beautify all requested files.
+        # Handle all requested files.
         files = requested_files
     else:
-        # Beautify only requested files.
+        # Handle only modified files.
         modified_files = get_modified_files(cwd)
         files = [z for z in requested_files if os.path.abspath(z) in modified_files]
-        if not files:
-            if args.verbose:
-                print(f"No modified files in {arg_files!r}")
-            return
-    # Execute the command.
+    if not files:
+        return
     if args.verbose:
         kind = (
             'fstringify' if args.f else
@@ -4373,7 +4370,9 @@ def main() -> None:  # pragma: no cover
         )
         if kind:
             n = len(files)
-            print(f"{kind}: {n} file{g.plural(n)}.")
+            n_s = f" {n:>3} file in" if n == 1 else f"{n:>3} files in"
+            print(f"{kind}: {n_s} {','.join(arg_files)}")
+    # Do the command.
     if args.f:
         fstringify_command(files)
     if args.fd:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -392,15 +392,13 @@ if 1:  # pragma: no cover
         old_cwd = os.getcwd()
         os.chdir(repo_path)
         try:
-            # Run git status.
             result = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
             if result.returncode != 0:
                 print("Error running git command")
                 return []
-            # Parse the output.
             modified_files = []
             for line in result.stdout.split('\n'):
-                if line.startswith(' M') or line.startswith('M '):
+                if line.startswith((' M', 'M ', 'A ', ' A')):
                     modified_files.append(line[3:])
             return [os.path.abspath(z) for z in modified_files]
         finally:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -410,7 +410,7 @@ if 1:  # pragma: no cover
         finally:
             os.chdir(old_cwd)
     #@+node:ekr.20220404062739.1: *3* function: scan_ast_args
-    def scan_ast_args() -> tuple[Any, dict[str, Any], list[str], bool]:
+    def scan_ast_args() -> tuple[Any, dict[str, Any], list[str]]:
         description = textwrap.dedent("""\
             Execute fstringify or beautify commands contained in leoAst.py.
         """)
@@ -436,8 +436,6 @@ if 1:  # pragma: no cover
             help='max unsplit line length (default 0)')
         add2('--max-split', dest='max_split', metavar='N', type=int,
             help='max unjoined line length (default 0)')
-        add2('--recursive', dest='recursive', action='store_true',
-            help='include directories recursively')
         add2('--tab-width', dest='tab_width', metavar='N', type=int,
             help='tab-width (default -4)')
         # Newer arguments.
@@ -455,9 +453,8 @@ if 1:  # pragma: no cover
             tab_width=4,
             verbose=False
         )
-        args = parser.parse_args()
+        args: Any = parser.parse_args()
         files = args.PATHS
-        recursive = args.recursive
         # Create the settings dict, ensuring proper values.
         settings_dict: dict[str, Any] = {
             'allow_joined_strings': bool(args.allow_joined),
@@ -467,7 +464,7 @@ if 1:  # pragma: no cover
             'tab_width': abs(args.tab_width),  # Must be positive!
             'verbose': bool(args.verbose),
         }
-        return args, settings_dict, files, recursive
+        return args, settings_dict, files
     #@+node:ekr.20200107114409.1: *3* functions: reading & writing files
     #@+node:ekr.20200218071822.1: *4* function: regularize_nls
     def regularize_nls(s: str) -> str:
@@ -4337,22 +4334,21 @@ class TokenOrderGenerator:
 #@+node:ekr.20200702102239.1: ** function: main (leoAst.py)
 def main() -> None:  # pragma: no cover
     """Run commands specified by sys.argv."""
-    args, settings_dict, arg_files, recursive = scan_ast_args()
-    if recursive:
-        print('Ignoring deprecated --recursive command-line option')
+    args, settings_dict, arg_files = scan_ast_args()
     # Finalize arguments.
     cwd = os.getcwd()
     # Calculate requested files.
-    requested_files = []
+    requested_files: list[str] = []
     for path in arg_files:
         if path.endswith('.py'):
-            requested_files.append([os.path.join(cwd, path)])
+            requested_files.append(os.path.join(cwd, path))
         else:
             root_dir = os.path.join(cwd, path)
             requested_files.extend(glob.glob(f'{root_dir}**{os.sep}*.py', recursive=True))
     if not requested_files:
         print(f"No files in {arg_files!r}")
         return
+    files: list[str]
     if args.force:
         # Handle all requested files.
         files = requested_files

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -398,6 +398,8 @@ if 1:  # pragma: no cover
         old_cwd = os.getcwd()
         os.chdir(repo_path)
         try:
+            # We are not checking the return code here, so:
+            # pylint: disable=subprocess-run-check
             result = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
             if result.returncode != 0:
                 print("Error running git command")

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -4370,8 +4370,8 @@ def main() -> None:  # pragma: no cover
         )
         if kind:
             n = len(files)
-            n_s = f" {n:>3} file in" if n == 1 else f"{n:>3} files in"
-            print(f"{kind}: {n_s} {','.join(arg_files)}")
+            n_s = f" {n:>3} file" if n == 1 else f"{n:>3} files"
+            print(f"{kind}: {n_s} in {','.join(arg_files)}")
     # Do the command.
     if args.f:
         fstringify_command(files)

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -20,10 +20,10 @@ This file requires Python 3.9 or above.
 
 usage:
     python -m leo.core.leoAst.py --help
-    python -m leo.core.leoAst.py --fstringify ARGS PATHS
-    python -m leo.core.leoAst.py --fstringify-diff ARGS PATHS
-    python -m leo.core.leoAst.py --orange ARGS PATHS
-    python -m leo.core.leoAst.py --orange-diff ARGS PATHS
+    python -m leo.core.leoAst.py --fstringify [ARGS] PATHS
+    python -m leo.core.leoAst.py --fstringify-diff [ARGS] PATHS
+    python -m leo.core.leoAst.py --orange [ARGS] PATHS
+    python -m leo.core.leoAst.py --orange-diff [ARGS] PATHS
     python -m leo.core.leoAst.py --py-cov [ARGS]
     python -m leo.core.leoAst.py --pytest [ARGS]
     python -m leo.core.leoAst.py --unittest [ARGS]

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -19,29 +19,35 @@ This file requires Python 3.9 or above.
 **Stand-alone operation**
 
 usage:
-    leoAst.py --help
-    leoAst.py [--fstringify | --fstringify-diff | --orange | --orange-diff] PATHS
-    leoAst.py --py-cov [ARGS]
-    leoAst.py --pytest [ARGS]
-    leoAst.py --unittest [ARGS]
+    python -m leo.core.leoAst.py --help
+    python -m leo.core.leoAst.py --fstringify ARGS PATHS
+    python -m leo.core.leoAst.py --fstringify-diff ARGS PATHS
+    python -m leo.core.leoAst.py --orange ARGS PATHS
+    python -m leo.core.leoAst.py --orange-diff ARGS PATHS
+    python -m leo.core.leoAst.py --py-cov [ARGS]
+    python -m leo.core.leoAst.py --pytest [ARGS]
+    python -m leo.core.leoAst.py --unittest [ARGS]
 
 examples:
-    --py-cov "-f TestOrange"
-    --pytest "-f TestOrange"
-    --unittest TestOrange
+    python -m leo.core.leoAst.py --orange --force --verbose PATHS
+    python -m leo.core.leoAst.py --py-cov "-f TestOrange"
+    python -m leo.core.leoAst.py --pytest "-f TestOrange"
+    python -m leo.core.leoAst.py --unittest TestOrange
 
 positional arguments:
   PATHS              directory or list of files
 
 optional arguments:
   -h, --help         show this help message and exit
+  --force            operate on all files. Otherwise operate only on modified files
   --fstringify       leonine fstringify
   --fstringify-diff  show fstringify diff
-  --orange           leonine Black
+  --orange           leonine text formatter (Orange is the new Black)
   --orange-diff      show orange diff
   --py-cov           run pytest --cov on leoAst.py
   --pytest           run pytest on leoAst.py
   --unittest         run unittest on leoAst.py
+  --verbose          verbose output
 
 
 **Overview**

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -156,6 +156,7 @@ import io
 import os
 import pprint
 import re
+import subprocess
 import sys
 import textwrap
 import tokenize
@@ -383,6 +384,26 @@ if 1:  # pragma: no cover
 #@+node:ekr.20160521104628.1: **  leoAst.py: top-level utils
 if 1:  # pragma: no cover
     #@+others
+    #@+node:ekr.20231114133501.1: *3* function: get_modified_files
+    def get_modified_files(repo_path):
+        """Return the modified files in the given repo."""
+        old_cwd = os.getcwd()
+        os.chdir(repo_path)
+        try:
+            # Run git status and get the output
+            result = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True)
+            if result.returncode != 0:
+                print("Error running git command")
+                return []
+
+            # Parse the output to find modified files
+            modified_files = []
+            for line in result.stdout.split('\n'):
+                if line.startswith(' M') or line.startswith('M '):
+                    modified_files.append(line[3:])
+            return modified_files
+        finally:
+            os.chdir(old_cwd)
     #@+node:ekr.20220404062739.1: *3* function: scan_ast_args
     def scan_ast_args() -> tuple[Any, dict[str, Any], list[str], bool]:
         description = textwrap.dedent("""\

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -133,22 +133,22 @@ def rust_rule3(colorer, s, i):
 # A single quote does not always denote a character literal.
 
 # These patterns are the same as in the rust importer:
-    
+
 char10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
 char6_pat = re.compile(r"'\\x[0-7][0-7a-fA-F]'")  # '\x7F'
 char4_pat = re.compile(r"'\\[\\\"'nrt0]'")  # '\n', '\r', '\t', '\\', '\0', '\'', '\"'
 char3_pat = re.compile(r"'.'", re.UNICODE)  # 'x' where x is any unicode character.
 
-def rust_char10(colorer,s,i):
+def rust_char10(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin=char10_pat)
 
-def rust_char6(colorer,s,i):
+def rust_char6(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin=char6_pat)
 
-def rust_char4(colorer,s,i):
+def rust_char4(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin=char4_pat)
 
-def rust_char3(colorer,s,i):
+def rust_char3(colorer, s, i):
     return colorer.match_span_regexp(s, i, kind="literal2", begin=char3_pat)
 
 # #3631

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -53,7 +53,7 @@ from leo.core.leoGui import LeoKeyEvent
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoGui import LeoKeyEvent as Event # pylint: disable=reimported
+    from leo.core.leoGui import LeoKeyEvent as Event  # pylint: disable=reimported
     from leo.core.leoNodes import Position
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
 

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -335,7 +335,7 @@ class textLeoMenu(leoMenu.LeoMenu):
         self._top_menu = textLeoMenu(frame)
         self.createMenusFromTables()
     #@+node:ekr.20150107090324.48: *3* new_menu
-    def new_menu(self, parent: Widget, tearoff: int=0, labe: str=''):
+    def new_menu(self, parent: Widget, tearoff: int = 0, labe: str = ''):
         if tearoff:
             raise NotImplementedError(repr(tearoff))
         menu = textLeoMenu(parent or self.frame)
@@ -348,11 +348,11 @@ class textLeoMenu(leoMenu.LeoMenu):
         parent.entries.append(textMenuCascade(menu, label, underline,))
     #@+node:ekr.20150107090324.50: *3* add_command (cursesGui.py)
     def add_command(self, menu: Widget,
-        accelerator: str='',
-        command: Callable=None,
-        commandName: str=None,
-        label: str=None,
-        underline: int=0,
+        accelerator: str = '',
+        command: Callable = None,
+        commandName: str = None,
+        label: str = None,
+        underline: int = 0,
     ) -> None:
         # ?
         # underline - Offset into label. For those who memorised Alt, F, X rather than Alt+F4.
@@ -467,7 +467,7 @@ class textTree(leoFrame.LeoTree):
         w.setAllText(p.b)
         # and something to do with undo?
     #@+node:ekr.20150107090324.66: *3* editLabel & edit_widget
-    def editLabel(self, v, selectAll: bool=False, selection: tuple=None):
+    def editLabel(self, v, selectAll: bool = False, selection: tuple = None):
         pass  # N/A?
 
     def edit_widget(self, p):

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -376,7 +376,7 @@ class LeoTreeData(npyscreen.TreeData):
     #@+node:ekr.20170516085427.1: *4* LeoTreeData.overrides
     # Don't use weakrefs!
     #@+node:ekr.20170518103807.6: *5* LeoTreeData.find_depth
-    def find_depth(self, d: int=0) -> int:
+    def find_depth(self, d: int = 0) -> int:
         if native:
             p = self.content
             n = p.level()
@@ -469,10 +469,10 @@ class LeoTreeData(npyscreen.TreeData):
 
         def walk_tree(
             self,
-            only_expanded: bool=True,
-            ignore_root: bool=True,
-            sort: bool=None,  # not used here.
-            sort_function: Callable=None,
+            only_expanded: bool = True,
+            ignore_root: bool = True,
+            sort: bool = None,  # not used here.
+            sort_function: Callable = None,
         ) -> Generator:
             # Never change the stored position!
             # LeoTreeData(p) makes a copy of p.
@@ -547,7 +547,7 @@ class LeoTreeLine(npyscreen.TreeLine):
         s = self.value.content if self.value else None
         return g.toUnicode(s) if s else None
     #@+node:ekr.20170522032805.1: *4* LeoTreeLine._print
-    def _print(self, left_margin: int=0) -> None:
+    def _print(self, left_margin: int = 0) -> None:
         """LeoTreeLine._print. Adapted from TreeLine._print."""
         # pylint: disable=no-member
 
@@ -739,9 +739,9 @@ class QuitButton(npyscreen.MiniButtonPress):
 #@+node:ekr.20170603110639.1: *3* curses2: dump_handlers
 def dump_handlers(
     obj: Any,
-    dump_complex: bool=True,
-    dump_handlers: bool=True,
-    dump_keys: bool=True,
+    dump_complex: bool = True,
+    dump_handlers: bool = True,
+    dump_keys: bool = True,
 ) -> None:
     tag = obj.__class__.__name__
     if dump_keys:
@@ -988,7 +988,7 @@ class StringFindTabManager:
             if val:
                 w.toggle()
 
-            def check_box_callback(n: int, setting_name: str=setting_name, w: Wrapper=w) -> None:
+            def check_box_callback(n: int, setting_name: str = setting_name, w: Wrapper = w) -> None:
                 val = w.isChecked()
                 assert hasattr(find, setting_name), setting_name
                 setattr(find, setting_name, val)
@@ -1008,7 +1008,7 @@ class StringFindTabManager:
                 setattr(find, setting_name, val)
                 w.toggle()
 
-            def radio_button_callback(n: int, ivar: str=ivar, setting_name: str=setting_name, w: Wrapper=w) -> None:
+            def radio_button_callback(n: int, ivar: str = ivar, setting_name: str = setting_name, w: Wrapper = w) -> None:
                 val = w.isChecked()
                 if ivar:
                     assert hasattr(find, ivar), ivar
@@ -1081,10 +1081,10 @@ class KeyEvent:
         event: Event,
         shortcut: str,
         w: Wrapper,
-        x: int=None,
-        y: int=None,
-        x_root: Position=None,
-        y_root: Position=None,
+        x: int = None,
+        y: int = None,
+        x_root: Position = None,
+        y_root: Position = None,
     ) -> None:
         """Ctor for KeyEvent class."""
         assert not g.isStroke(shortcut), g.callers()
@@ -1544,7 +1544,7 @@ class LeoCursesGui(leoGui.LeoGui):
         """
         sys.exit(0)
     #@+node:ekr.20220618070256.1: *5* CGui.getFullVersion
-    def getFullVersion(self, c: Cmdr=None) -> str:
+    def getFullVersion(self, c: Cmdr = None) -> str:
         return 'Leo Console Gui (npyscreen)'
     #@+node:ekr.20170501032447.1: *5* CGui.init_logger
     def init_logger(self) -> None:
@@ -1658,8 +1658,8 @@ class LeoCursesGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str=None,
-        okButtonText: str=None,
+        cancelButtonText: str = None,
+        okButtonText: str = None,
     ) -> str:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
@@ -1676,10 +1676,10 @@ class LeoCursesGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str=None,
-        okButtonText: str=None,
-        default: str="",
-        wide: bool=False,
+        cancelButtonText: str = None,
+        okButtonText: str = None,
+        default: str = "",
+        wide: bool = False,
     ) -> str:
         """Create and run askOkCancelString dialog ."""
         if g.unitTesting:
@@ -1693,8 +1693,8 @@ class LeoCursesGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str=None,
-        text: str="Ok",
+        message: str = None,
+        text: str = "Ok",
     ) -> bool:
         """Create and run an askOK dialog ."""
         if g.unitTesting:
@@ -1711,12 +1711,12 @@ class LeoCursesGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str=None,
-        yesMessage: str="Yes",
-        noMessage: str="No",
-        yesToAllMessage: str=None,
-        defaultButton: str="Yes",
-        cancelMessage: str=None,
+        message: str = None,
+        yesMessage: str = "Yes",
+        noMessage: str = "No",
+        yesToAllMessage: str = None,
+        defaultButton: str = "Yes",
+        cancelMessage: str = None,
     ) -> str:
         """Create and run an askYesNoCancel dialog ."""
         if g.unitTesting:
@@ -1732,9 +1732,9 @@ class LeoCursesGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str=None,
-        yes_all: bool=False,
-        no_all: bool=False,
+        message: str = None,
+        yes_all: bool = False,
+        no_all: bool = False,
     ) -> str:
         """Create and run an askYesNo dialog."""
         if g.unitTesting:
@@ -1750,8 +1750,8 @@ class LeoCursesGui(leoGui.LeoGui):
         title: str,
         filetypes: list[str],
         defaultextension: str,
-        multiple: bool=False,
-        startpath: str=None,
+        multiple: bool = False,
+        startpath: str = None,
     ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.
         if not g.unitTesting:
             g.trace('not ready yet', title)
@@ -1760,10 +1760,10 @@ class LeoCursesGui(leoGui.LeoGui):
     #@+node:ekr.20171126182120.10: *5* CGui.runPropertiesDialog
     def runPropertiesDialog(
         self,
-        title: str='Properties',
-        data: Any=None,
-        callback: Callable=None,
-        buttons: list[str]=None,
+        title: str = 'Properties',
+        data: Any = None,
+        callback: Callable = None,
+        buttons: list[str] = None,
     ) -> None:
         """Dispay a modal TkPropertiesDialog"""
         if not g.unitTesting:
@@ -1832,7 +1832,7 @@ class LeoCursesGui(leoGui.LeoGui):
         """Put focus in minibuffer text widget."""
         self.set_focus(c, c.frame.miniBufferWidget)
     #@+node:ekr.20170502101347.1: *5* CGui.get_focus
-    def get_focus(self, c: Cmdr=None, raw: bool=False, at_idle: bool=False) -> Optional[Wrapper]:
+    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> Optional[Wrapper]:
         """
         Return the Leo wrapper for the npyscreen widget that is being edited.
         """
@@ -1913,7 +1913,7 @@ class LeoCursesGui(leoGui.LeoGui):
         if 0:
             # Inject 'leo-set-focus' into form.how_exited_handers
 
-            def switch_focus_callback(form: Wrapper=form, i: int=i, w: Wrapper=w) -> None:
+            def switch_focus_callback(form: Wrapper = form, i: int = i, w: Wrapper = w) -> None:
                 g.trace(i, w.__class__.__name__)
                 g.trace(g.callers(verbose=True))
                 w.display()
@@ -2245,7 +2245,7 @@ class CoreFrame(leoFrame.LeoFrame):
 
         return leoGui.StringCheckBox(name, label)
     #@+node:ekr.20171128053531.8: *6* CFrame.createLineEdit
-    def createLineEdit(self, name: str, disabled: bool=True) -> Wrapper:
+    def createLineEdit(self, name: str, disabled: bool = True) -> Wrapper:
 
         return leoGui.StringLineEdit(name, disabled)
     #@+node:ekr.20171128053531.9: *6* CFrame.createRadioButton
@@ -2256,7 +2256,7 @@ class CoreFrame(leoFrame.LeoFrame):
     def bringToFront(self) -> None:
         pass
 
-    def contractPane(self, event: Event=None) -> None:
+    def contractPane(self, event: Event = None) -> None:
         pass
 
     def deiconify(self) -> None:
@@ -2284,13 +2284,13 @@ class CoreFrame(leoFrame.LeoFrame):
     def getTitle(self) -> str:
         return self.title
 
-    def minimizeAll(self, event: Event=None) -> None:
+    def minimizeAll(self, event: Event = None) -> None:
         pass
 
     def resizePanesToRatio(self, ratio: float, secondary_ratio: float) -> None:
         """Resize splitter1 and splitter2 using the given ratios."""
 
-    def resizeToScreen(self, event: Event=None) -> None:
+    def resizeToScreen(self, event: Event = None) -> None:
         pass
 
     def setInitialWindowGeometry(self) -> None:
@@ -2313,7 +2313,7 @@ class CoreFrame(leoFrame.LeoFrame):
         return g.app.gui.get_focus()
     #@+node:ekr.20170522015906.1: *4* CFrame.pasteText (cursesGui2)
     @frame_cmd('paste-text')
-    def pasteText(self, event: Event=None, middleButton: bool=False) -> None:
+    def pasteText(self, event: Event = None, middleButton: bool = False) -> None:
         """
         Paste the clipboard into a widget.
         If middleButton is True, support x-windows middle-mouse-button easter-egg.
@@ -2371,13 +2371,13 @@ class CoreLog(leoFrame.LeoLog):
         self.tabWidget: Wrapper = None
     #@+node:ekr.20170419143731.7: *4* CLog.clearLog
     @log_cmd('clear-log')
-    def clearLog(self, event: Event=None) -> None:
+    def clearLog(self, event: Event = None) -> None:
         """Clear the log pane."""
     #@+node:ekr.20170420035717.1: *4* CLog.enable/disable
     def disable(self) -> None:
         self.enabled = False
 
-    def enable(self, enabled: bool=True) -> None:
+    def enable(self, enabled: bool = True) -> None:
         self.enabled = enabled
     #@+node:ekr.20170420041119.1: *4* CLog.finishCreate
     def finishCreate(self) -> None:
@@ -2387,14 +2387,14 @@ class CoreLog(leoFrame.LeoLog):
     def isLogWidget(self, w: Wrapper) -> bool:
         return w == self or w in list(self.contentsDict.values())
     #@+node:ekr.20170513184115.1: *4* CLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: Wrapper=None) -> list[str]:  # Unused: LeoLog
+    def orderedTabNames(self, LeoLog: Wrapper = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
         return []
         # w = self.tabWidget
         # return [w.tabText(i) for i in range(w.count())]
     #@+node:ekr.20170419143731.15: *4* CLog.put
     # Signature is different.
-    def put(self, s: str, color: str=None, tabName: str='Log', from_redirect: bool=False) -> None:  # type:ignore
+    def put(self, s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False) -> None:  # type:ignore
         """All output to the log stream eventually comes here."""
         c, w = self.c, self.widget
         if not c or not c.exists or not w:
@@ -2410,7 +2410,7 @@ class CoreLog(leoFrame.LeoLog):
         w.start_display_at += len(lines)
         w.update()
     #@+node:ekr.20170419143731.16: *4* CLog.putnl
-    def putnl(self, tabName: str='Log') -> None:
+    def putnl(self, tabName: str = 'Log') -> None:
         """Put a newline to the Qt log."""
         # This is not called normally.
         # print('CLog.put: %s' % g.callers())
@@ -2454,7 +2454,7 @@ class CoreTree(leoFrame.LeoTree):
         self.selecting = False
     #@+node:ekr.20170511094217.1: *4* CTree.Drawing
     #@+node:ekr.20170511094217.3: *5* CTree.redraw
-    def redraw(self, p: Position=None) -> None:
+    def redraw(self, p: Position = None) -> None:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -2473,16 +2473,16 @@ class CoreTree(leoFrame.LeoTree):
     redraw_now = redraw
     repaint = redraw
     #@+node:ekr.20170511100356.1: *5* CTree.redraw_after...
-    def redraw_after_contract(self, p: Position=None) -> None:
+    def redraw_after_contract(self, p: Position = None) -> None:
         self.redraw(p)
 
-    def redraw_after_expand(self, p: Position=None) -> None:
+    def redraw_after_expand(self, p: Position = None) -> None:
         self.redraw(p)
 
     def redraw_after_head_changed(self) -> None:
         self.redraw()
 
-    def redraw_after_select(self, p: Position=None) -> None:
+    def redraw_after_select(self, p: Position = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         # Prevent the selecting lockout from disabling the redraw.
         oldSelecting = self.selecting
@@ -2511,7 +2511,7 @@ class CoreTree(leoFrame.LeoTree):
     #@+node:ekr.20170511104533.12: *5* CTree.onHeadChanged (cursesGui2)
     # Tricky code: do not change without careful thought and testing.
 
-    def onHeadChanged(self, p: Position, s: str=None, undoType: str='Typing') -> None:  # type:ignore
+    def onHeadChanged(self, p: Position, s: str = None, undoType: str = 'Typing') -> None:  # type:ignore
         """
         Officially change a headline.
         This is c.frame.tree.onHeadChanged.
@@ -2595,7 +2595,7 @@ class CoreTree(leoFrame.LeoTree):
         """Returns the edit widget for position p."""
         return HeadWrapper(c=self.c, name='head', p=p)
     #@+node:ekr.20170511095353.1: *5* CTree.editLabel (cursesGui2) (not used)
-    def editLabel(self, p: Position, selectAll: bool=False, selection: tuple=None) -> tuple[None, None]:
+    def editLabel(self, p: Position, selectAll: bool = False, selection: tuple = None) -> tuple[None, None]:
         """Start editing p's headline."""
         return None, None
     #@+node:ekr.20170511105355.7: *5* CTree.endEditLabel (cursesGui2)
@@ -2769,7 +2769,7 @@ class LeoBody(npyscreen.MultiLineEditable):
         if continue_line and self.CONTINUE_EDITING_AFTER_EDITING_ONE_LINE:
             self._continue_editing()
     #@+node:ekr.20170604185028.1: *4* LeoBody.delete_line_value
-    def delete_line_value(self, ch_i: int=None) -> None:
+    def delete_line_value(self, ch_i: int = None) -> None:
 
         c = self.leo_c
         if self.values:
@@ -2903,7 +2903,7 @@ class LeoLog(npyscreen.MultiLineEditable):
 
     #@+others
     #@+node:ekr.20170604184928.2: *4* LeoLog.delete_line_value
-    def delete_line_value(self, ch_i: int=None) -> None:
+    def delete_line_value(self, ch_i: int = None) -> None:
         if self.values:
             del self.values[self.cursor_line]
             self.display()
@@ -3686,7 +3686,7 @@ class LeoMLTree(npyscreen.MLTree):
         self.set_handlers()
 
     #@+node:ekr.20170513032502.1: *4* LeoMLTree.update & helpers
-    def update(self, clear: bool=True, forceInit: bool=False) -> None:
+    def update(self, clear: bool = True, forceInit: bool = False) -> None:
         """Redraw the tree."""
         # This is a major refactoring of MultiLine.update.
         trace = False and not g.unitTesting
@@ -3968,7 +3968,7 @@ class TextMixin:
     """A minimal mixin class for QTextEditWrapper and QScintillaWrapper classes."""
     #@+others
     #@+node:ekr.20170511053143.2: *4* tm.ctor & helper
-    def __init__(self, c: Cmdr=None) -> None:
+    def __init__(self, c: Cmdr = None) -> None:
         """Ctor for TextMixin class"""
         self.c = c
         # self.changingText = False  # A lockout for onTextChanged.
@@ -4012,7 +4012,7 @@ class TextMixin:
     def clipboard_clear(self) -> None:
         g.app.gui.replaceClipboardWith('')
     #@+node:ekr.20170511053143.14: *5* tm.delete
-    def delete(self, i: int, j: int=None) -> None:
+    def delete(self, i: int, j: int = None) -> None:
         """TextMixin"""
         s = self.getAllText()
         if j is None:
@@ -4032,10 +4032,10 @@ class TextMixin:
     def disable(self) -> None:
         self.enabled = False
 
-    def enable(self, enabled: bool=True) -> None:
+    def enable(self, enabled: bool = True) -> None:
         self.enabled = enabled
     #@+node:ekr.20170511053143.16: *5* tm.get
-    def get(self, i: int, j: int=None) -> str:
+    def get(self, i: int, j: int = None) -> str:
         """TextMixin"""
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
@@ -4045,11 +4045,11 @@ class TextMixin:
             j = i + 1
         return all_s[i:j]
     #@+node:ekr.20170511053143.17: *5* tm.getLastIndex & getLength
-    def getLastIndex(self, s: str=None) -> int:
+    def getLastIndex(self, s: str = None) -> int:
         """TextMixin"""
         return len(self.getAllText()) if s is None else len(s)
 
-    def getLength(self, s: str=None) -> int:
+    def getLength(self, s: str = None) -> int:
         """TextMixin"""
         return len(self.getAllText()) if s is None else len(s)
     #@+node:ekr.20170511053143.18: *5* tm.getSelectedText
@@ -4085,7 +4085,7 @@ class TextMixin:
         # getInsertPoint defined in client classes.
         self.see(self.getInsertPoint())
     #@+node:ekr.20170511053143.21: *5* tm.selectAllText
-    def selectAllText(self, s: str=None) -> None:
+    def selectAllText(self, s: str = None) -> None:
         """TextMixin."""
         self.setSelectionRange(0, self.getLength(s))
     #@+node:ekr.20170511053143.11: *5* tm.setFocus
@@ -4127,7 +4127,7 @@ class BodyWrapper(leoFrame.StringTextWrapper):
         self.leo_name = '1'
         self.leo_label = None
     #@+node:ekr.20170504034655.6: *4* bw.onCursorPositionChanged
-    def onCursorPositionChanged(self, event: Event=None) -> None:
+    def onCursorPositionChanged(self, event: Event = None) -> None:
         if 0:
             g.trace('=====', event)
     #@-others

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -330,7 +330,7 @@ class Demo:
             aList.append(''.join(lines))
         return aList
     #@+node:ekr.20170128213103.43: *4* demo.wait & key_wait
-    def key_wait(self, speed: float=None, n1=None, n2=None):
+    def key_wait(self, speed: float = None, n1=None, n2=None):
         """Wait for an interval between n1 and n2, in seconds."""
         if n1 is None:
             n1 = self.n1
@@ -498,7 +498,7 @@ class Demo:
             p = g.findNodeAnywhere(c, headline)
         return p
     #@+node:ekr.20170211045602.1: *4* demo.insert_node
-    def insert_node(self, headline, end=True, keys=False, speed: float=None):
+    def insert_node(self, headline, end=True, keys=False, speed: float = None):
         """Helper for inserting a node."""
         c = self.c
         p = c.insertHeadline()

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -186,7 +186,7 @@ class FreeLayoutController:
             g.es("WARNING: @data free-layout-layout node is not under an active @settings node")
         c.redraw()
     #@+node:ekr.20160424035257.1: *3* flc.get_main_splitter
-    def get_main_splitter(self, w: Wrapper=None) -> Optional[Wrapper]:
+    def get_main_splitter(self, w: Wrapper = None) -> Optional[Wrapper]:
         """
         Return the splitter the main splitter, or None. The main splitter is a
         NestedSplitter that contains the body pane.
@@ -229,7 +229,7 @@ class FreeLayoutController:
             return child and child.top()
         return None
     #@+node:ekr.20120419095424.9927: *3* flc.loadLayouts (sets wrap=True)
-    def loadLayouts(self, tag: str, keys: Any, reloading: bool=False) -> None:
+    def loadLayouts(self, tag: str, keys: Any, reloading: bool = False) -> None:
         """loadLayouts - Load the outline's layout
 
         :Parameters:

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -349,87 +349,87 @@ if TYPE_CHECKING:  # pragma: no cover
 #@+node:tom.20210527153422.1: ** << declarations >>
 # pylint: disable=invalid-name
 # Dimensions and placing of editor windows
-W:int = 570
-H:int = 350
-X:int = 1200
-Y:int = 100
-DELTA_Y:int = 35
+W: int = 570
+H: int = 350
+X: int = 1200
+Y: int = 100
+DELTA_Y: int = 35
 
 clipboard = QApplication.clipboard()
 
-FG_COLOR_LIGHT:str = '#6B5B53'
-BG_COLOR_LIGHT:str = '#ededed'
-BG_COLOR_DARK:str = '#202020'
-FG_COLOR_DARK:str = '#cbdedc'
-FONT_FAMILY:str = 'Cousine, Consolas, Droid Sans Mono, DejaVu Sans Mono'
+FG_COLOR_LIGHT: str = '#6B5B53'
+BG_COLOR_LIGHT: str = '#ededed'
+BG_COLOR_DARK: str = '#202020'
+FG_COLOR_DARK: str = '#cbdedc'
+FONT_FAMILY: str = 'Cousine, Consolas, Droid Sans Mono, DejaVu Sans Mono'
 
-EDITOR_FONT_SIZE:str = '11pt'
-EDITOR_STYLESHEET_LIGHT_FILE:str = 'freewin_editor_light.css'
-EDITOR_STYLESHEET_DARK_FILE:str = 'freewin_editor_dark.css'
-ENCODING:str = 'utf-8'
-BROWSER:int = 1
-EDITOR:int = 0
-BROWSER_VIEW:str = 'browser_view'
-NAV_VIEW:str = 'nav-view'
+EDITOR_FONT_SIZE: str = '11pt'
+EDITOR_STYLESHEET_LIGHT_FILE: str = 'freewin_editor_light.css'
+EDITOR_STYLESHEET_DARK_FILE: str = 'freewin_editor_dark.css'
+ENCODING: str = 'utf-8'
+BROWSER: int = 1
+EDITOR: int = 0
+BROWSER_VIEW: str = 'browser_view'
+NAV_VIEW: str = 'nav-view'
 
-RST_NO_WARNINGS:int = 5
-RST_CUSTOM_STYLESHEET_LIGHT_FILE:str = 'freewin_rst_light.css'
-RST_CUSTOM_STYLESHEET_DARK_FILE:str = 'freewin_rst_dark.css'
+RST_NO_WARNINGS: int = 5
+RST_CUSTOM_STYLESHEET_LIGHT_FILE: str = 'freewin_rst_light.css'
+RST_CUSTOM_STYLESHEET_DARK_FILE: str = 'freewin_rst_dark.css'
 
-instances: dict[str, ZEditorWin ] = {}
+instances: dict[str, ZEditorWin] = {}
 
 #@+others
 #@+node:tom.20210709130401.1: *3* Fonts and Text
-ZOOM_FACTOR:float = 1.1
+ZOOM_FACTOR: float = 1.1
 
-F7_KEY:int = 0x01000036  # See https://doc.qt.io/qt-5/qt.html#Key-enum (enum Qt::Key)
-F9_KEY:int = 0x01000038
-KEY_S:int = 0x53
+F7_KEY: int = 0x01000036  # See https://doc.qt.io/qt-5/qt.html#Key-enum (enum Qt::Key)
+F9_KEY: int = 0x01000038
+KEY_S: int = 0x53
 
-GNXre:str = r'^(.+\.\d+\.\d+)'  # For gnx at start of line
-GNX1re:str = r'.*[([\s](\w+\.\d+\.\d+)'  # For gnx not at start of line
+GNXre: str = r'^(.+\.\d+\.\d+)'  # For gnx at start of line
+GNX1re: str = r'.*[([\s](\w+\.\d+\.\d+)'  # For gnx not at start of line
 
-GNX:re.Pattern = re.compile(GNXre)
-GNX1:re.Pattern = re.compile(GNX1re)
+GNX: re.Pattern = re.compile(GNXre)
+GNX1: re.Pattern = re.compile(GNX1re)
 
-fs:str = EDITOR_FONT_SIZE.split('pt', 1)[0]
-qf:QtGui.QFont = QFont(FONT_FAMILY[0], int(fs))
-qfont:QtGui.QFontInfo = QFontInfo(qf)  # Uses actual font if different
-FM:QtGui.QFontMetrics = QFontMetrics(qf)
+fs: str = EDITOR_FONT_SIZE.split('pt', 1)[0]
+qf: QtGui.QFont = QFont(FONT_FAMILY[0], int(fs))
+qfont: QtGui.QFontInfo = QFontInfo(qf)  # Uses actual font if different
+FM: QtGui.QFontMetrics = QFontMetrics(qf)
 
-TABWIDTH:int = 36  # Best guess but may not alays be right.
-TAB2SPACES:int = 4  # Tab replacement when writing back to host node
+TABWIDTH: int = 36  # Best guess but may not alays be right.
+TAB2SPACES: int = 4  # Tab replacement when writing back to host node
 #@-others
 
 #@-<< declarations >>
 #@+<< Stylesheets >>
 #@+node:tom.20210614172857.1: ** << Stylesheets >>
 
-EDITOR_STYLESHEET_LIGHT:str = f'''QTextEdit {{
+EDITOR_STYLESHEET_LIGHT: str = f'''QTextEdit {{
     color: {FG_COLOR_LIGHT};
     background: {BG_COLOR_LIGHT};
     font-family: {FONT_FAMILY};
     font-size: {EDITOR_FONT_SIZE};
     }}'''
 
-EDITOR_STYLESHEET_DARK:str = f'''QTextEdit {{
+EDITOR_STYLESHEET_DARK: str = f'''QTextEdit {{
     color: {FG_COLOR_DARK};
     background: {BG_COLOR_DARK};
     font-family: {FONT_FAMILY};
     font-size: {EDITOR_FONT_SIZE};
     }}'''
 
-RENDER_BTN_STYLESHEET_LIGHT:str = f'''color: {FG_COLOR_LIGHT};
+RENDER_BTN_STYLESHEET_LIGHT: str = f'''color: {FG_COLOR_LIGHT};
     background: {BG_COLOR_LIGHT};
     font-size: {EDITOR_FONT_SIZE};'''
 
-RENDER_BTN_STYLESHEET_DARK:str = f'''color: {FG_COLOR_DARK};
+RENDER_BTN_STYLESHEET_DARK: str = f'''color: {FG_COLOR_DARK};
     background: {BG_COLOR_DARK};
     font-size: {EDITOR_FONT_SIZE};'''
 
 #@+others
 #@+node:tom.20210625145324.1: *3* RsT Stylesheet Dark
-RST_STYLESHEET_DARK:str = '''body {
+RST_STYLESHEET_DARK: str = '''body {
   color: #cbdedc; /*#ededed;*/
   background: #202020;
   font-family: Verdana, Arial, "Bitstream Vera Sans", sans-serif;
@@ -480,7 +480,7 @@ RST_STYLESHEET_DARK:str = '''body {
 
 '''
 #@+node:tom.20210625155534.1: *3* RsT Stylesheet Light
-RST_STYLESHEET_LIGHT:str = '''body {
+RST_STYLESHEET_LIGHT: str = '''body {
   color: #6B5B53;
   background: #ededed;
   font-family: Verdana, Arial, "Bitstream Vera Sans", sans-serif;
@@ -601,7 +601,7 @@ def getLine(text_edit: QtWidgets.QTextEdit) -> str:
     line = before.split('\n')[-1] + after.split('\n')[0]
     return line
 #@+node:tom.20210625161018.1: ** gotoHostGnx
-def gotoHostGnx(c: Cmdr, target:str) -> bool:
+def gotoHostGnx(c: Cmdr, target: str) -> bool:
     """Change host node selection to target gnx.
 
     This will not change the node displayed by the
@@ -625,7 +625,7 @@ def gotoHostGnx(c: Cmdr, target:str) -> bool:
 def copy2clip(text: str) -> None:
     clipboard.setText(text)
 #@+node:tom.20220329145952.1: ** change_css_prop
-def change_css_prop(css: str, prop: str, newval:str) -> str:
+def change_css_prop(css: str, prop: str, newval: str) -> str:
     """Change the value of a named property in a css stylesheet fragment.
 
     If there is more than one instance of prop, only
@@ -647,13 +647,13 @@ def change_css_prop(css: str, prop: str, newval:str) -> str:
 # Get current colors from the body editor widget
 def get_body_colors(c: Cmdr) -> tuple[str, str]:
     wrapper = c.frame.body.wrapper
-    w:LeoQTextBrowser = wrapper.widget
+    w: LeoQTextBrowser = wrapper.widget
 
-    pallete:QtGui.QPalette = w.viewport().palette()
-    fg_hex:int = pallete.text().color().rgb()
-    bg_hex:int = pallete.window().color().rgb()
-    fg:str = f'#{fg_hex:x}'
-    bg:str = f'#{bg_hex:x}'
+    pallete: QtGui.QPalette = w.viewport().palette()
+    fg_hex: int = pallete.text().color().rgb()
+    bg_hex: int = pallete.window().color().rgb()
+    fg: str = f'#{fg_hex:x}'
+    bg: str = f'#{bg_hex:x}'
 
     return fg, bg
 #@+node:tom.20220329231604.1: ** is_body_dark
@@ -670,7 +670,7 @@ class ZEditorWin(QtWidgets.QMainWindow):
     """An editing window that echos the contents of an outline node."""
     #@+others
     #@+node:tom.20210527185804.1: *3* ctor
-    def __init__(self, c: Cmdr, title:str ='Z-editor') -> None:
+    def __init__(self, c: Cmdr, title: str = 'Z-editor') -> None:
         # pylint: disable=too-many-locals
         # pylint: disable = too-many-statements
         global TAB2SPACES
@@ -901,7 +901,7 @@ class ZEditorWin(QtWidgets.QMainWindow):
             self.doc.setModified(False)
 
     #@+node:tom.20210703173219.1: *3* teardown
-    def teardown(self, tag: str ='') -> None:
+    def teardown(self, tag: str = '') -> None:
         # Close window and delete it when host node is deleted.
         if self.closing:
             return

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -186,7 +186,7 @@ class API_Wrapper(leoFrame.StringTextWrapper):
         super().setInsertPoint(pos, s)
         self.finish_set_insert('setInsertPoint')
 
-    def setSelectionRange(self, i: int, j: int, insert: Optional[int]=None):
+    def setSelectionRange(self, i: int, j: int, insert: Optional[int] = None):
         super().setSelectionRange(i, j, insert)
         self.finish_set_insert('setSelectionRange')
     #@+node:ekr.20181127121642.1: *4* API_Wrapper.Text Setters
@@ -225,7 +225,7 @@ class API_Wrapper(leoFrame.StringTextWrapper):
         super().appendText(s)
         self.finish_setter('appendText')
 
-    def delete(self, i: int, j: Optional[int]=None):
+    def delete(self, i: int, j: Optional[int] = None):
         super().delete(i, j)
         self.finish_setter('delete')
 
@@ -1444,7 +1444,7 @@ class LeoBrowserMinibuffer(leoFrame.StringTextWrapper):
         w.minibuffer.set_selection(i, j)
         w.minibuffer.set_insert(self.ins)
 
-    def delete(self, i: int, j: Optional[int]=None):
+    def delete(self, i: int, j: Optional[int] = None):
         super().delete(i, j)
         self.update('delete')
 
@@ -1459,7 +1459,7 @@ class LeoBrowserMinibuffer(leoFrame.StringTextWrapper):
         super().setAllText(s)
         self.update('setAllText')
 
-    def setSelectionRange(self, i: int, j: int, insert: Optional[int]=None):
+    def setSelectionRange(self, i: int, j: int, insert: Optional[int] = None):
         super().setSelectionRange(i, j, insert)
         self.update('setSelectionRange')
 

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -884,7 +884,7 @@ class LeoActions:
         """Return the file like 'f' that leo_interface.send_head makes"""
         if self.request_handler.path.startswith('/_/add/bkmk/'):
             return self.add_bookmark()
-            
+
         # No longer used.
         # mod_scripting.py used to define the EvalController class, but that class was buggy.
 

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -161,7 +161,7 @@ if TYPE_CHECKING:  # pragma: no cover
 #@+others
 #@+node:ekr.20180328085010.1: ** Top level (mod_scripting)
 #@+node:tbrown.20140819100840.37719: *3* build_rclick_tree (mod_scripting.py)
-def build_rclick_tree(command_p: Position, rclicks: list[Any]=None, top_level: bool=False) -> list:
+def build_rclick_tree(command_p: Position, rclicks: list[Any] = None, top_level: bool = False) -> list:
     """
     Return a list of top level RClicks for the button at command_p, which can be
     used later to add the rclick menus.
@@ -270,7 +270,7 @@ class AtButtonCallback:
         self.source_c = c  # For GetArgs.command_source.
         self.__doc__ = docstring  # The docstring for this callback for g.getDocStringForFunction.
     #@+node:ekr.20141031053508.10: *3* __call__ (AtButtonCallback)
-    def __call__(self, event: Event=None) -> None:
+    def __call__(self, event: Event = None) -> None:
         """AtButtonCallbgack.__call__. The callback for @button nodes."""
         self.execute_script()
     #@+node:ekr.20141031053508.13: *3* __repr__ (AtButtonCallback)
@@ -325,7 +325,7 @@ class ScriptingController:
     """A class defining scripting commands."""
     #@+others
     #@+node:ekr.20060328125248.7: *3*  sc.ctor
-    def __init__(self, c: Cmdr, iconBar: Widget=None) -> None:
+    def __init__(self, c: Cmdr, iconBar: Widget = None) -> None:
         self.c = c
         self.gui = c.frame.gui
         getBool = c.config.getBool
@@ -368,7 +368,7 @@ class ScriptingController:
         self.seen: set[str] = set()  # Set of gnx's (not vnodes!) that created buttons or commands.
     #@+node:ekr.20150401113822.1: *3* sc.Callbacks
     #@+node:ekr.20060328125248.23: *4* sc.addScriptButtonCommand
-    def addScriptButtonCommand(self, event: Event=None) -> None:
+    def addScriptButtonCommand(self, event: Event = None) -> None:
         """Called when the user presses the 'script-button' button or executes the script-button command."""
         c = self.c
         p = c.p
@@ -381,7 +381,7 @@ class ScriptingController:
         self.createLocalAtButtonHelper(p, h, statusLine, kind='script-button', verbose=True)
         c.bodyWantsFocus()
     #@+node:ekr.20060522105937.1: *4* sc.runDebugScriptCommand
-    def runDebugScriptCommand(self, event: Event=None) -> None:
+    def runDebugScriptCommand(self, event: Event = None) -> None:
         """Called when user presses the 'debug-script' button or executes the debug-script command."""
         c = self.c
         p = c.p
@@ -440,7 +440,7 @@ class ScriptingController:
                 g.error('No debugger active')
         c.bodyWantsFocus()
     #@+node:ekr.20060328125248.21: *4* sc.runScriptCommand
-    def runScriptCommand(self, event: Event=None) -> None:
+    def runScriptCommand(self, event: Event = None) -> None:
         """Called when user presses the 'run-script' button or executes the run-script command."""
         c, p = self.c, self.c.p
         args = self.getArgs(p)
@@ -502,8 +502,8 @@ class ScriptingController:
         p: Position,
         h: Any,
         statusLine: Any,
-        kind: str='at-button',
-        verbose: bool=True,
+        kind: str = 'at-button',
+        verbose: bool = True,
     ) -> Wrapper:
         """Create a button for a local @button node."""
         c = self.c
@@ -558,8 +558,8 @@ class ScriptingController:
         text: str,
         command: Callable,
         statusLine: str,
-        bg: str=None,
-        kind: str=None,
+        bg: str = None,
+        kind: str = None,
     ) -> Wrapper:
         """
         Create one icon button.
@@ -596,7 +596,7 @@ class ScriptingController:
                 source_c=c,
                 tag='icon button')
 
-        def deleteButtonCallback(event: Event=None, self: Any=self, b: Widget=b) -> None:
+        def deleteButtonCallback(event: Event = None, self: Any = self, b: Widget = b) -> None:
             self.deleteButton(b, event=event)
 
         # Register the delete-x-button command.
@@ -616,7 +616,7 @@ class ScriptingController:
         buttonText: str,
         p: Position,
         script: str,
-        script_gnx: str=None,
+        script_gnx: str = None,
     ) -> None:
         """Execute an @button script in p.b or script."""
         c = self.c
@@ -680,7 +680,7 @@ class ScriptingController:
                 script = self.getScript(p)
                 self.createCommonButton(p, script, rclicks)
     #@+node:ekr.20070926084600: *4* sc.createCommonButton (common @button)
-    def createCommonButton(self, p: Position, script: str, rclicks: list[Any]=None) -> None:
+    def createCommonButton(self, p: Position, script: str, rclicks: list[Any] = None) -> None:
         """
         Create a button in the icon area for a common @button node in an @setting
         tree. Binds button presses to a callback that executes the script.
@@ -817,7 +817,7 @@ class ScriptingController:
             return
         args = self.getArgs(p)
 
-        def atCommandCallback(event: Event=None, args: Any=args, c: Cmdr=c, p: Position=p.copy()) -> None:
+        def atCommandCallback(event: Event = None, args: Any = args, c: Cmdr = c, p: Position = p.copy()) -> None:
             # pylint: disable=dangerous-default-value
             c.executeScript(args=args, p=p, silent=True)
 
@@ -856,7 +856,7 @@ class ScriptingController:
             return
         args = self.getArgs(p)
 
-        def atCommandCallback(event: Event=None, args: Any=args, c: Cmdr=c, p: Position=p.copy()) -> None:
+        def atCommandCallback(event: Event = None, args: Any = args, c: Cmdr = c, p: Position = p.copy()) -> None:
             # pylint: disable=dangerous-default-value
             c.executeScript(args=args, p=p, silent=True)
         if p.b.strip():
@@ -926,7 +926,7 @@ class ScriptingController:
             kind="script-button-button")
     #@+node:ekr.20061014075212: *3* sc.Utils
     #@+node:ekr.20060929135558: *4* sc.cleanButtonText
-    def cleanButtonText(self, s: str, minimal: bool=False) -> str:
+    def cleanButtonText(self, s: str, minimal: bool = False) -> str:
         """
         Clean the text following @button or @command so
         that it is a valid name of a minibuffer command.
@@ -1049,8 +1049,8 @@ class ScriptingController:
         func: Callable,
         h: str,
         pane: str,
-        source_c: Cmdr=None,
-        tag: str=None,
+        source_c: Cmdr = None,
+        tag: str = None,
     ) -> None:
         """Register @button <name> and @rclick <name> and <name>"""
         c, k = self.c, self.c.k
@@ -1075,7 +1075,7 @@ class ScriptingController:
                 commandName2 = commandName[len(prefix) :].strip()
                 # Create a *second* func, to avoid collision in c.commandsDict.
 
-                def registerAllCommandsCallback(event: Event=None, func: Callable=func) -> None:
+                def registerAllCommandsCallback(event: Event = None, func: Callable = func) -> None:
                     func()
 
                 # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252

--- a/leo/plugins/nodetags.py
+++ b/leo/plugins/nodetags.py
@@ -267,7 +267,7 @@ if QtWidgets:
     class LeoTagWidget(QtWidgets.QWidget):  # type:ignore
         #@+others
         #@+node:peckj.20140804114520.15200: *3* tag_w.__init__
-        def __init__(self, c: Cmdr, parent: Widget=None) -> None:
+        def __init__(self, c: Cmdr, parent: Widget = None) -> None:
             super().__init__(parent)
             self.c = c
             self.tc = self.c.theTagController
@@ -468,7 +468,7 @@ if QtWidgets:
             self.update_list()
             self.update_current_tags(self.c.p)
         #@+node:peckj.20140806145948.6579: *4* tag_w.add_tag
-        def add_tag(self, event: Event=None) -> None:
+        def add_tag(self, event: Event = None) -> None:
             p = self.c.p
             tag = str(self.comboBox.currentText()).strip()
             if not tag:

--- a/leo/plugins/pane_commands.py
+++ b/leo/plugins/pane_commands.py
@@ -29,8 +29,8 @@ def bottomOfPane(event=None):
     vp = w.viewport()
 
     # get the coordinates of the bottom of the visible area
-    vWidth = vp.width() -1
-    vHeight = vp.height() -1
+    vWidth = vp.width() - 1
+    vHeight = vp.height() - 1
     # g.es("width", vWidth, "height", vHeight)
 
     # create a QPoint from this

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -89,7 +89,7 @@ def addPluginMenuItem(plugin: PlugIn, c: Cmdr) -> None:
         # Check at runtime to see if the plugin has actually been loaded.
         # This prevents us from calling hasTopLevel() on unloaded plugins.
 
-        def callback(event: Event, c: Cmdr=c, plugin: "PlugIn"=plugin) -> None:
+        def callback(event: Event, c: Cmdr = c, plugin: "PlugIn" = plugin) -> None:
             path, name = g.os_path_split(plugin.filename)
             name, ext = g.os_path_splitext(name)
             pc = g.app.pluginsController
@@ -226,7 +226,7 @@ class PlugIn:
     """A class to hold information about one plugin"""
     #@+others
     #@+node:EKR.20040517080555.4: *3* PlugIn.__init__ & helper
-    def __init__(self, plgMod: Any, c: Cmdr=None) -> None:
+    def __init__(self, plgMod: Any, c: Cmdr = None) -> None:
         """
         @param plgMod: Module object for the plugin represented by this instance.
         @param c:  Leo-editor "commander" for the current .leo file
@@ -274,7 +274,7 @@ class PlugIn:
             if getattr(func, 'is_command', None):
                 self.othercmds[func.command_name] = func
     #@+node:EKR.20040517080555.8: *3* PlugIn.about
-    def about(self, event: Event=None) -> None:
+    def about(self, event: Event = None) -> None:
         """Put information about this plugin in a scrolledMessage dialog."""
         c = self.c
         msg = self.doc.strip() + '\n' if self.doc else ''
@@ -296,7 +296,7 @@ class PlugIn:
             name = name[4:]
         return name.capitalize()
     #@+node:EKR.20040517080555.9: *3* PlugIn.properties
-    def properties(self, event: Event=None) -> None:
+    def properties(self, event: Event = None) -> None:
         """Display a modal properties dialog for this plugin"""
         if self.hasapply:
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -74,7 +74,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
     """
     #@+others
     #@+node:ekr.20110605121601.18138: *3*  dw.ctor & reloadSettings
-    def __init__(self, c: Cmdr, parent: "LeoQtFrame"=None) -> None:
+    def __init__(self, c: Cmdr, parent: "LeoQtFrame" = None) -> None:
         """Ctor for the DynamicWindow class.  The main window is c.frame.top"""
             # Called from LeoQtFrame.finishCreate.
             # parent is a LeoTabbedTopLevel.
@@ -142,7 +142,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         else:
             event.ignore()
     #@+node:ekr.20110605121601.18139: *3* dw.construct & helpers
-    def construct(self, master: "LeoTabbedTopLevel"=None) -> None:
+    def construct(self, master: "LeoTabbedTopLevel" = None) -> None:
         """ Factor 'heavy duty' code out from the DynamicWindow ctor """
         c = self.leo_c
         self.leo_master = master
@@ -445,7 +445,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         # Official ivars.
         self.statusBar = w
     #@+node:ekr.20110605121601.18212: *5* dw.packLabel
-    def packLabel(self, w: Wrapper, n: int=None) -> None:
+    def packLabel(self, w: Wrapper, n: int = None) -> None:
         """
         Pack w into the body frame's QVGridLayout.
 
@@ -494,11 +494,11 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self,
         parent: LeoQtFrame,
         name: str,
-        hPolicy: Policy=None,
-        vPolicy: Policy=None,
-        lineWidth: int=1,
-        shadow: Shadow=None,
-        shape: Shape=None,
+        hPolicy: Policy = None,
+        vPolicy: Policy = None,
+        lineWidth: int = 1,
+        shadow: Shadow = None,
+        shape: Shape = None,
     ) -> LeoQtFrame:
         """Create a Qt Frame."""
         if shadow is None:
@@ -515,7 +515,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         return w
     #@+node:ekr.20110605121601.18156: *5* dw.createGrid
     def createGrid(self,
-        parent: LeoQtFrame, name: str, margin: int=0, spacing: int=0,
+        parent: LeoQtFrame, name: str, margin: int = 0, spacing: int = 0,
     ) -> LeoQtFrame:
         w = QtWidgets.QGridLayout(parent)
         w.setContentsMargins(QtCore.QMargins(margin, margin, margin, margin))
@@ -523,14 +523,14 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self.setName(w, name)
         return w
     #@+node:ekr.20110605121601.18157: *5* dw.createHLayout & createVLayout
-    def createHLayout(self, parent: LeoQtFrame, name: str, margin: int=0, spacing: int=0) -> Any:
+    def createHLayout(self, parent: LeoQtFrame, name: str, margin: int = 0, spacing: int = 0) -> Any:
         hLayout = QtWidgets.QHBoxLayout(parent)
         hLayout.setSpacing(spacing)
         hLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
         self.setName(hLayout, name)
         return hLayout
 
-    def createVLayout(self, parent: LeoQtFrame, name: str, margin: int=0, spacing: int=0) -> Any:
+    def createVLayout(self, parent: LeoQtFrame, name: str, margin: int = 0, spacing: int = 0) -> Any:
         vLayout = QtWidgets.QVBoxLayout(parent)
         vLayout.setSpacing(spacing)
         vLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
@@ -543,7 +543,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         w.setText(self.tr(label))
         return w
     #@+node:ekr.20110605121601.18159: *5* dw.createLineEdit
-    def createLineEdit(self, parent: LeoQtFrame, name: str, disabled: bool=True) -> LeoQtFrame:
+    def createLineEdit(self, parent: LeoQtFrame, name: str, disabled: bool = True) -> LeoQtFrame:
 
         w = QtWidgets.QLineEdit(parent)
         w.setObjectName(name)
@@ -562,9 +562,9 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self,
         parent: LeoQtFrame,
         name: str,
-        lineWidth: int=1,
-        hPolicy: Policy=None,
-        vPolicy: Policy=None,
+        lineWidth: int = 1,
+        hPolicy: Policy = None,
+        vPolicy: Policy = None,
     ) -> Widget:  # QtWidgets.QStackedWidget
         w = QtWidgets.QStackedWidget(parent)
         self.setSizePolicy(w, kind1=hPolicy, kind2=vPolicy)
@@ -574,7 +574,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         return w
     #@+node:ekr.20110605121601.18162: *5* dw.createTabWidget
     def createTabWidget(self,
-        parent: LeoQtFrame, name: str, hPolicy: Policy=None, vPolicy: Policy=None,
+        parent: LeoQtFrame, name: str, hPolicy: Policy = None, vPolicy: Policy = None,
     ) -> LeoQtFrame:
         w = QtWidgets.QTabWidget(parent)
         # tb = w.tabBar()
@@ -587,9 +587,9 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
         self,
         parent: LeoQtFrame,
         name: str,
-        lineWidth: int=0,
-        shadow: Shadow=None,
-        shape: Shape=None,
+        lineWidth: int = 0,
+        shadow: Shadow = None,
+        shape: Shape = None,
     ) -> LeoQtFrame:
         # Create a text widget.
         c = self.leo_c
@@ -975,7 +975,7 @@ class DynamicWindow(QtWidgets.QMainWindow):  # type:ignore
                 # name = 'leo_' + name
             widget.setObjectName(name)
     #@+node:ekr.20110605121601.18170: *5* dw.setSizePolicy
-    def setSizePolicy(self, widget: LeoQtFrame, kind1: Policy=None, kind2: Policy=None) -> None:
+    def setSizePolicy(self, widget: LeoQtFrame, kind1: Policy = None, kind2: Policy = None) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
         if kind2 is None:
@@ -1151,7 +1151,7 @@ class FindTabManager:
             if val:
                 w.toggle()
 
-            def check_box_callback(n: int, setting_name: str=setting_name, w: str=w) -> None:
+            def check_box_callback(n: int, setting_name: str = setting_name, w: str = w) -> None:
                 # The focus has already change when this gets called.
                 # focus_w = QtWidgets.QApplication.focusWidget()
                 val = w.isChecked()
@@ -1179,7 +1179,7 @@ class FindTabManager:
                 w.toggle()
 
             def radio_button_callback(
-                n: int, ivar: str=ivar, setting_name: str=setting_name, w: str=w
+                n: int, ivar: str = ivar, setting_name: str = setting_name, w: str = w
             ) -> None:
                 val = w.isChecked()
                 if ivar:
@@ -1548,7 +1548,7 @@ class LeoQtBody(leoFrame.LeoBody):
 
     @body_cmd('editor-add')
     @body_cmd('add-editor')
-    def add_editor_command(self, event: Event=None) -> None:
+    def add_editor_command(self, event: Event = None) -> None:
         """Add another editor to the body pane."""
         c, p = self.c, self.c.p
         d = self.editorWrappers
@@ -1603,7 +1603,7 @@ class LeoQtBody(leoFrame.LeoBody):
     #@+node:ekr.20110605121601.18199: *5* LeoQtBody.delete_editor_command
     @body_cmd('delete-editor')
     @body_cmd('editor-delete')
-    def delete_editor_command(self, event: Event=None) -> None:
+    def delete_editor_command(self, event: Event = None) -> None:
         """Delete the presently selected body text editor."""
         c, d = self.c, self.editorWrappers
         wrapper = c.frame.body.wrapper
@@ -1915,7 +1915,7 @@ class LeoQtBody(leoFrame.LeoBody):
                 pass
     #@+node:ekr.20110605121601.18217: *3* LeoQtBody.Renderer panes
     #@+node:ekr.20110605121601.18218: *4* LeoQtBody.hideCanvasRenderer
-    def hideCanvasRenderer(self, event: Event=None) -> None:
+    def hideCanvasRenderer(self, event: Event = None) -> None:
         """Hide canvas pane."""
         c, d = self.c, self.editorWrappers
         wrapper = c.frame.body.wrapper
@@ -1952,7 +1952,7 @@ class LeoQtBody(leoFrame.LeoBody):
                 w.leo_label = None  # 2011/11/12
         self.selectEditor(new_wrapper)
     #@+node:ekr.20110605121601.18219: *4* LeoQtBody.hideTextRenderer
-    def hideCanvas(self, event: Event=None) -> None:
+    def hideCanvas(self, event: Event = None) -> None:
         """Hide canvas pane."""
         c, d = self.c, self.editorWrappers
         wrapper = c.frame.body.wrapper
@@ -2006,7 +2006,7 @@ class LeoQtBody(leoFrame.LeoBody):
     #@+node:ekr.20110605121601.18221: *4* LeoQtBody.showCanvasRenderer
     # An override of leoFrame.addEditor.
 
-    def showCanvasRenderer(self, event: Event=None) -> None:
+    def showCanvasRenderer(self, event: Event = None) -> None:
         """Show the canvas area in the body pane, creating it if necessary."""
         c = self.c
         f = c.frame.top.leo_body_inner_frame
@@ -2021,7 +2021,7 @@ class LeoQtBody(leoFrame.LeoBody):
     #@+node:ekr.20110605121601.18222: *4* LeoQtBody.showTextRenderer
     # An override of leoFrame.addEditor.
 
-    def showTextRenderer(self, event: Event=None) -> None:
+    def showTextRenderer(self, event: Event = None) -> None:
         """Show the canvas area in the body pane, creating it if necessary."""
         c = self.c
         f = c.frame.top.leo_body_inner_frame
@@ -2066,7 +2066,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
     def setIvars(self) -> None:
         # "Official ivars created in createLeoFrame and its allies.
         self.bar1: LeoQtFrame = None
-        self.bar2: LeoQtFrame= None
+        self.bar2: LeoQtFrame = None
         self.body: "LeoQtBody" = None
         self.iconFrame: "QtIconBarClass" = None
         self.log: "LeoQtLog" = None
@@ -2277,10 +2277,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # It *is* called from Leo's core.
         pass
     #@+node:ekr.20110605121601.18280: *4* qtFrame.forceWrap & setWrap
-    def forceWrap(self, p: Position=None) -> None:
+    def forceWrap(self, p: Position = None) -> None:
         self.c.frame.body.forceWrap(p)
 
-    def setWrap(self, p: Position=None) -> None:
+    def setWrap(self, p: Position = None) -> None:
         self.c.frame.body.setWrap(p)
     #@+node:ekr.20110605121601.18281: *4* qtFrame.reconfigurePanes
     def reconfigurePanes(self) -> None:
@@ -2354,19 +2354,19 @@ class LeoQtFrame(leoFrame.LeoFrame):
         else:
             g.app.closeLeoWindow(self)
     #@+node:ekr.20110605121601.18287: *4* qtFrame.OnControlKeyUp/Down
-    def OnControlKeyDown(self, event: Event=None) -> None:
+    def OnControlKeyDown(self, event: Event = None) -> None:
         self.controlKeyIsDown = True
 
-    def OnControlKeyUp(self, event: Event=None) -> None:
+    def OnControlKeyUp(self, event: Event = None) -> None:
         self.controlKeyIsDown = False
     #@+node:ekr.20110605121601.18290: *4* qtFrame.OnActivateTree
-    def OnActivateTree(self, event: Event=None) -> None:
+    def OnActivateTree(self, event: Event = None) -> None:
         pass
     #@+node:ekr.20110605121601.18293: *3* qtFrame.Gui-dependent commands
     #@+node:ekr.20110605121601.18301: *4* qtFrame.Window Menu...
     #@+node:ekr.20110605121601.18302: *5* qtFrame.toggleActivePane
     @frame_cmd('toggle-active-pane')
-    def toggleActivePane(self, event: Event=None) -> None:
+    def toggleActivePane(self, event: Event = None) -> None:
         """Toggle the focus between the outline and body panes."""
         frame = self
         c = frame.c
@@ -2379,16 +2379,16 @@ class LeoQtFrame(leoFrame.LeoFrame):
             c.treeWantsFocus()
     #@+node:ekr.20110605121601.18304: *5* qtFrame.equalSizedPanes
     @frame_cmd('equal-sized-panes')
-    def equalSizedPanes(self, event: Event=None) -> None:
+    def equalSizedPanes(self, event: Event = None) -> None:
         """Make the outline and body panes have the same size."""
         self.resizePanesToRatio(0.5, self.secondary_ratio)
     #@+node:ekr.20110605121601.18305: *5* qtFrame.hideLogWindow
-    def hideLogWindow(self, event: Event=None) -> None:
+    def hideLogWindow(self, event: Event = None) -> None:
         """Hide the log pane."""
         self.divideLeoSplitter2(0.99)
     #@+node:ekr.20110605121601.18306: *5* qtFrame.minimizeAll
     @frame_cmd('minimize-all')
-    def minimizeAll(self, event: Event=None) -> None:
+    def minimizeAll(self, event: Event = None) -> None:
         """Minimize all Leo's windows."""
         for frame in g.app.windowList:
             self.minimize(frame)
@@ -2403,13 +2403,13 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 w.setWindowState(WindowState.WindowMinimized)
     #@+node:ekr.20110605121601.18307: *5* qtFrame.toggleSplitDirection
     @frame_cmd('toggle-split-direction')
-    def toggleSplitDirection(self, event: Event=None) -> None:
+    def toggleSplitDirection(self, event: Event = None) -> None:
         """Toggle the split direction in the present Leo window."""
         if hasattr(self.c, 'free_layout'):
             self.c.free_layout.get_top_splitter().rotate()
     #@+node:ekr.20110605121601.18308: *5* qtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
-    def resizeToScreen(self, event: Event=None) -> None:
+    def resizeToScreen(self, event: Event = None) -> None:
         """Resize the Leo window so it fill the entire screen."""
         frame = self
         # This unit test will fail when run externally.
@@ -2596,7 +2596,7 @@ class LeoQtLog(leoFrame.LeoLog):
         # Show the spell tab.
         c.spellCommands.openSpellTab()
         #
-        #794: Clicking Find Tab should do exactly what pushing Ctrl-F does
+        # 794: Clicking Find Tab should do exactly what pushing Ctrl-F does
 
         def tab_callback(index: str) -> None:
             name = w.tabText(index)
@@ -2612,7 +2612,7 @@ class LeoQtLog(leoFrame.LeoLog):
     #@+node:ekr.20150717102728.1: *3* LeoQtLog: clear-log & dump-log
     @log_cmd('clear-log')
     @log_cmd('log-clear')
-    def clearLog(self, event: Event=None) -> None:
+    def clearLog(self, event: Event = None) -> None:
         """Clear the log pane."""
         # self.logCtrl may be either a wrapper or a widget.
         w = self.logCtrl.widget
@@ -2621,7 +2621,7 @@ class LeoQtLog(leoFrame.LeoLog):
 
     @log_cmd('dump-log')
     @log_cmd('log-dump')
-    def dumpLog(self, event: Event=None) -> None:
+    def dumpLog(self, event: Event = None) -> None:
         """Clear the log pane."""
         # self.logCtrl may be either a wrapper or a widget.
         w = self.logCtrl.widget
@@ -2682,7 +2682,7 @@ class LeoQtLog(leoFrame.LeoLog):
             if val3:
                 g.es(key3, val3, tabName='Fonts')
     #@+node:ekr.20110605121601.18339: *4* LeoQtLog.hideFontTab
-    def hideFontTab(self, event: Event=None) -> None:
+    def hideFontTab(self, event: Event = None) -> None:
         c = self.c
         c.frame.log.selectTab('Log')
         c.bodyWantsFocus()
@@ -2721,10 +2721,10 @@ class LeoQtLog(leoFrame.LeoLog):
     #@+node:ekr.20110605121601.18322: *4* LeoQtLog.put & helper
     def put(self,
         s: str,
-        color: str=None,
-        tabName: str='Log',
-        from_redirect: bool=False,
-        nodeLink: str=None,
+        color: str = None,
+        tabName: str = 'Log',
+        from_redirect: bool = False,
+        nodeLink: str = None,
     ) -> None:
         """
         Put s to the Qt Log widget, converting to html.
@@ -2775,7 +2775,7 @@ class LeoQtLog(leoFrame.LeoLog):
         s = f'<font color="{color}">{s}</font>'
         return s
     #@+node:ekr.20110605121601.18323: *4* LeoQtLog.putnl
-    def putnl(self, tabName: str='Log') -> None:
+    def putnl(self, tabName: str = 'Log') -> None:
         """Put a newline to the Qt log."""
         #
         # This is not called normally.
@@ -2814,7 +2814,7 @@ class LeoQtLog(leoFrame.LeoLog):
                 color = 'black'
         return color
     #@+node:ekr.20150205181818.5: *4* LeoQtLog.scrollToEnd
-    def scrollToEnd(self, tabName: str='Log') -> None:
+    def scrollToEnd(self, tabName: str = 'Log') -> None:
         """Scroll the log to the end."""
         if g.app.quitting:
             return
@@ -2830,13 +2830,13 @@ class LeoQtLog(leoFrame.LeoLog):
         w.repaint()  # Slow, but essential.
     #@+node:ekr.20110605121601.18324: *3* LeoQtLog.Tab
     #@+node:ekr.20110605121601.18325: *4* LeoQtLog.clearTab
-    def clearTab(self, tabName: str, wrap: str='none') -> None:
+    def clearTab(self, tabName: str, wrap: str = 'none') -> None:
         w = self.logDict.get(tabName)
         if w:
             w.clear()  # w is a QTextBrowser.
     #@+node:ekr.20110605121601.18326: *4* LeoQtLog.createTab
     def createTab(self,
-        tabName: str, createText: bool=True, widget: LeoQtFrame=None, wrap: str='none',
+        tabName: str, createText: bool = True, widget: LeoQtFrame = None, wrap: str = 'none',
     ) -> Any:  # Widget or LeoQTextBrowser.
         """
         Create a new tab in tab widget
@@ -2899,7 +2899,7 @@ class LeoQtLog(leoFrame.LeoLog):
     def hideTab(self, tabName: str) -> None:
         self.selectTab('Log')
     #@+node:ekr.20111122080923.10185: *4* LeoQtLog.orderedTabNames
-    def orderedTabNames(self, LeoLog: str=None) -> list[str]:  # Unused: LeoLog
+    def orderedTabNames(self, LeoLog: str = None) -> list[str]:  # Unused: LeoLog
         """Return a list of tab names in the order in which they appear in the QTabbedWidget."""
         w = self.tabWidget
         return [w.tabText(i) for i in range(w.count())]
@@ -2922,7 +2922,7 @@ class LeoQtLog(leoFrame.LeoLog):
         # **Note**: the base-class version of this uses frameDict.
         return len([val for val in self.contentsDict.values() if val is not None])
     #@+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers
-    def selectTab(self, tabName: str, wrap: str='none') -> None:
+    def selectTab(self, tabName: str, wrap: str = 'none') -> None:
         """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)
         if i is None:
@@ -3030,11 +3030,11 @@ class LeoQtMenu(leoMenu.LeoMenu):
     #@+node:ekr.20110605121601.18345: *5* LeoQtMenu.add_command (Called by createMenuEntries)
     def add_command(self,
         menu: Widget,  # A QMenu.
-        accelerator: str='',
-        command: Callable=None,
-        commandName: str=None,
-        label: str=None,
-        underline: int=0,
+        accelerator: str = '',
+        command: Callable = None,
+        commandName: str = None,
+        label: str = None,
+        underline: int = 0,
     ) -> None:
         """Wrapper for the Tkinter add_command menu method."""
         if not label:
@@ -3048,7 +3048,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         action.leo_command_name = commandName or ''
         if command:
 
-            def qt_add_command_callback(checked: int, label: str=label, command: Callable=command) -> None:
+            def qt_add_command_callback(checked: int, label: str = label, command: Callable = command) -> None:
                 return command()
 
             action.triggered.connect(qt_add_command_callback)
@@ -3059,7 +3059,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             action = menu.addSeparator()
             action.leo_menu_label = '*seperator*'
     #@+node:ekr.20110605121601.18347: *5* LeoQtMenu.delete
-    def delete(self, menu: Wrapper, realItemName: str='<no name>') -> None:
+    def delete(self, menu: Wrapper, realItemName: str = '<no name>') -> None:
         """Wrapper for the Tkinter delete menu method."""
         # if menu:
             # return menu.delete(realItemName)
@@ -3081,7 +3081,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         return 0
     #@+node:ekr.20110605121601.18351: *5* LeoQtMenu.insert
     def insert(self,
-        menuName: str, position: int, label: str, command: Callable, underline: int=None,
+        menuName: str, position: int, label: str, command: Callable, underline: int = None,
     ) -> None:
 
         menu = self.getMenu(menuName)
@@ -3092,7 +3092,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             action = menu.addAction(label)
             if command:
 
-                def insert_callback(checked: str, label: str=label, command: Callable=command) -> None:
+                def insert_callback(checked: str, label: str = label, command: Callable = command) -> None:
                     command()
 
                 action.triggered.connect(insert_callback)
@@ -3119,7 +3119,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
             g.trace('no action for menu', label)
         return menu
     #@+node:ekr.20110605121601.18353: *5* LeoQtMenu.new_menu
-    def new_menu(self, parent: LeoQtFrame, tearoff: int=0, label: str='') -> Any:  # label is for debugging.
+    def new_menu(self, parent: LeoQtFrame, tearoff: int = 0, label: str = '') -> Any:  # label is for debugging.
         """Wrapper for the Tkinter new_menu menu method."""
         c, leoFrame = self.c, self.frame
         # Parent can be None, in which case it will be added to the menuBar.
@@ -3172,7 +3172,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         Return None if there is no such menu item."""
         # At present, it is valid to always return None.
     #@+node:ekr.20110605121601.18360: *5* LeoQtMenu.setMenuLabel
-    def setMenuLabel(self, menu: Widget, name: str, label: str, underline: int=-1) -> None:
+    def setMenuLabel(self, menu: Widget, name: str, label: str, underline: int = -1) -> None:
 
         def munge(s: str) -> str:
             return (s or '').replace('&', '')
@@ -3746,14 +3746,14 @@ class LeoQtSpellTab:
         """Handle a click in the Add button in the Check Spelling dialog."""
         self.handler.add()
     #@+node:ekr.20110605121601.18391: *4* onChangeButton & onChangeThenFindButton
-    def onChangeButton(self, event: Event=None) -> None:
+    def onChangeButton(self, event: Event = None) -> None:
         """Handle a click in the Change button in the Spell tab."""
         state = self.updateButtons()
         if state:
             self.handler.change()
         self.updateButtons()
 
-    def onChangeThenFindButton(self, event: Event=None) -> None:
+    def onChangeThenFindButton(self, event: Event = None) -> None:
         """Handle a click in the "Change, Find" button in the Spell tab."""
         state = self.updateButtons()
         if state:
@@ -3774,15 +3774,15 @@ class LeoQtSpellTab:
         """Handle a click in the Hide button in the Spell tab."""
         self.handler.hide()
     #@+node:ekr.20110605121601.18394: *4* onIgnoreButton
-    def onIgnoreButton(self, event: Event=None) -> None:
+    def onIgnoreButton(self, event: Event = None) -> None:
         """Handle a click in the Ignore button in the Check Spelling dialog."""
         self.handler.ignore()
     #@+node:ekr.20110605121601.18395: *4* onMap
-    def onMap(self, event: Event=None) -> None:
+    def onMap(self, event: Event = None) -> None:
         """Respond to a Tk <Map> event."""
         self.update(show=False, fill=False)
     #@+node:ekr.20110605121601.18396: *4* onSelectListBox
-    def onSelectListBox(self, event: Event=None) -> None:
+    def onSelectListBox(self, event: Event = None) -> None:
         """Respond to a click in the selection listBox."""
         c = self.c
         self.updateButtons()
@@ -3792,7 +3792,7 @@ class LeoQtSpellTab:
     def bringToFront(self) -> None:
         self.c.frame.log.selectTab('Spell')
     #@+node:ekr.20110605121601.18399: *4* fillbox (LeoQtSpellTab)
-    def fillbox(self, alts: list[str], word: str=None) -> None:
+    def fillbox(self, alts: list[str], word: str = None) -> None:
         """Update the suggestions listBox in the Check Spelling dialog."""
         self.suggestions = alts
         if not word:
@@ -3817,7 +3817,7 @@ class LeoQtSpellTab:
             w = self.c.frame.top.spellFrame
             c.widgetWantsFocus(w)
     #@+node:ekr.20110605121601.18401: *4* update (LeoQtSpellTab)
-    def update(self, show: bool=True, fill: bool=False) -> None:
+    def update(self, show: bool = True, fill: bool = False) -> None:
         """Update the Spell Check dialog."""
         c = self.c
         if fill:
@@ -3896,7 +3896,7 @@ class LeoQtTreeTab:
             ibw.addWidget(frame)
             ibw.addWidget(w)
 
-        def onIndexChanged(s: str, tt: LeoQtTreeTab=tt) -> None:
+        def onIndexChanged(s: str, tt: LeoQtTreeTab = tt) -> None:
             if isinstance(s, int):
                 s = '' if s == -1 else tt.w.currentText()
             else:  # s is the tab name.
@@ -3907,7 +3907,7 @@ class LeoQtTreeTab:
         # A change: the argument could now be an int instead of a string.
         w.currentIndexChanged.connect(onIndexChanged)
     #@+node:ekr.20110605121601.18443: *3* tt.createTab
-    def createTab(self, tabName: str, select: bool=True) -> None:
+    def createTab(self, tabName: str, select: bool = True) -> None:
         """LeoQtTreeTab."""
         tt = self
         # Avoid a glitch during initing.
@@ -3984,7 +3984,7 @@ class QtIconBarClass:
     #@+node:ekr.20110605121601.18264: *3*  QtIconBar.do-nothings
     # These *are* called from Leo's core.
 
-    def addRow(self, height: int=None) -> None:
+    def addRow(self, height: int = None) -> None:
         pass  # To do.
 
     def getNewFrame(self) -> None:
@@ -4036,7 +4036,7 @@ class QtIconBarClass:
         b.setObjectName(button_name)
         b.setContextMenuPolicy(ContextMenuPolicy.ActionsContextMenu)
 
-        def delete_callback(checked: str, action: str=action) -> None:
+        def delete_callback(checked: str, action: str = action) -> None:
             self.w.removeAction(action)
 
         b.leo_removeAction = rb = QAction('Remove Button', b)
@@ -4044,7 +4044,7 @@ class QtIconBarClass:
         rb.triggered.connect(delete_callback)
         if command:
 
-            def button_callback(event: Event, c: Cmdr=c, command: Callable=command) -> None:
+            def button_callback(event: Event, c: Cmdr = c, command: Callable = command) -> None:
                 val = command()
                 if c.exists:
                     # c.bodyWantsFocus()
@@ -4133,7 +4133,7 @@ class QtIconBarClass:
         def goto_callback(
             checked: str,
             controller: ScriptingController = controller,
-            gnx: str=gnx,
+            gnx: str = gnx,
         ) -> None:
             self.goto_command(controller, gnx)
 
@@ -4148,9 +4148,9 @@ class QtIconBarClass:
         action_container: Any,
         rclicks: list[Any],
         controller: ScriptingController,
-        top_level: bool=True,
-        button: Wrapper=None,
-        script: str=None,
+        top_level: bool = True,
+        button: Wrapper = None,
+        script: str = None,
     ) -> None:
         c = controller.c
         top_offset = -2  # insert before the remove button and goto script items
@@ -4164,7 +4164,7 @@ class QtIconBarClass:
                 act.setSeparator(True)
             elif rc.position.b.strip():
 
-                def cb(checked: str, p: Position=rc.position, button: Wrapper=button) -> None:
+                def cb(checked: str, p: Position = rc.position, button: Wrapper = button) -> None:
                     controller.executeScriptFromButton(
                         b=button,
                         buttonText=p.h[8:].strip(),
@@ -4290,16 +4290,16 @@ class QtStatusLineClass:
     def get(self) -> str:
         return self.textWidget2.text()
 
-    def put(self, s: str, bg: str=None, fg: str=None) -> None:
+    def put(self, s: str, bg: str = None, fg: str = None) -> None:
         self.put_helper(s, self.textWidget2, bg, fg)
 
-    def put1(self, s: str, bg: str=None, fg: str=None) -> None:
+    def put1(self, s: str, bg: str = None, fg: str = None) -> None:
         self.put_helper(s, self.textWidget1, bg, fg)
 
     # Keys are widgets, values are stylesheets.
     styleSheetCache: dict[Any, str] = {}
 
-    def put_helper(self, s: str, w: LeoQtFrame, bg: str=None, fg: str=None) -> None:
+    def put_helper(self, s: str, w: LeoQtFrame, bg: str = None, fg: str = None) -> None:
         """Put string s in the indicated widget, with proper colors."""
         c = self.c
         bg = bg or c.config.getColor('status-bg') or 'white'
@@ -4429,10 +4429,10 @@ class QtStatusLineClass:
             self.put1(
                 f"fline: {fline:2} line: {row:2d} col: {col:2} fcol: {fcol:2}")
     #@+node:ekr.20220911120019.1: *3* QtStatusLineClass: do-nothings
-    def disable(self, background: str=None) -> None:
+    def disable(self, background: str = None) -> None:
         pass
 
-    def enable(self, background: str="white") -> None:
+    def enable(self, background: str = "white") -> None:
         pass
 
     def isEnabled(self) -> bool:
@@ -4445,7 +4445,7 @@ class QtStatusLineClass:
 class QtTabBarWrapper(QtWidgets.QTabBar):  # type:ignore
     #@+others
     #@+node:peckj.20140516114832.10108: *3* __init__
-    def __init__(self, parent: LeoQtFrame=None) -> None:
+    def __init__(self, parent: LeoQtFrame = None) -> None:
         super().__init__(parent)
         self.setMovable(True)
     #@+node:peckj.20140516114832.10109: *3* mouseReleaseEvent (QtTabBarWrapper)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -327,9 +327,9 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str='Select Date/Time',
-        init: datetime.datetime=None,
-        step_min: dict=None,
+        message: str = 'Select Date/Time',
+        init: datetime.datetime = None,
+        step_min: dict = None,
     ) -> None:
         """Create and run a qt date/time selection dialog.
 
@@ -356,7 +356,7 @@ class LeoQtGui(leoGui.LeoGui):
             for a minimum 5 minute increment on the minute field.
             """
 
-            def __init__(self, parent: Widget=None, init: bool=None, step_min: dict=None) -> None:
+            def __init__(self, parent: Widget = None, init: bool = None, step_min: dict = None) -> None:
                 if step_min is None:
                     step_min = {}
                 self.step_min = step_min
@@ -376,10 +376,10 @@ class LeoQtGui(leoGui.LeoGui):
 
             def __init__(
                 self,
-                parent: Widget=None,
-                message: str='Select Date/Time',
-                init: Any=None,  # Hard to annotate.
-                step_min: dict=None,
+                parent: Widget = None,
+                message: str = 'Select Date/Time',
+                init: Any = None,  # Hard to annotate.
+                step_min: dict = None,
             ) -> None:
                 if step_min is None:
                     step_min = {}
@@ -443,7 +443,7 @@ class LeoQtGui(leoGui.LeoGui):
         return s
     #@+node:ekr.20110605121601.18491: *4* qt_gui.runAskOkCancelNumberDialog (not used)
     def runAskOkCancelNumberDialog(self,
-        c: Cmdr, title: str, message: str, cancelButtonText: str=None, okButtonText: str=None,
+        c: Cmdr, title: str, message: str, cancelButtonText: str = None, okButtonText: str = None,
     ) -> Optional[int]:
         """Create and run askOkCancelNumber dialog ."""
         if g.unitTesting:
@@ -476,10 +476,10 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         message: str,
-        cancelButtonText: str=None,
-        okButtonText: str=None,
-        default: str="",
-        wide: bool=False,
+        cancelButtonText: str = None,
+        okButtonText: str = None,
+        default: str = "",
+        wide: bool = False,
     ) -> Optional[str]:
         """Create and run askOkCancelString dialog.
 
@@ -507,7 +507,7 @@ class LeoQtGui(leoGui.LeoGui):
         ok = dialog.exec_()
         return str(dialog.textValue()) if ok else None
     #@+node:ekr.20110605121601.18495: *4* qt_gui.runAskOkDialog (changed)
-    def runAskOkDialog(self, c: Cmdr, title: str, message: str=None, text: str="Ok") -> None:
+    def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:
         """Create and run a qt askOK dialog ."""
         if g.unitTesting:
             return
@@ -535,12 +535,12 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        message: str=None,
-        yesMessage: str="&Yes",
-        noMessage: str="&No",
-        yesToAllMessage: str=None,
-        defaultButton: str="Yes",
-        cancelMessage: str=None,
+        message: str = None,
+        yesMessage: str = "&Yes",
+        noMessage: str = "&No",
+        yesToAllMessage: str = None,
+        defaultButton: str = "Yes",
+        cancelMessage: str = None,
     ) -> str:
         """
         Create and run an askYesNo dialog.
@@ -587,7 +587,7 @@ class LeoQtGui(leoGui.LeoGui):
         }.get(val, 'cancel')
     #@+node:ekr.20110605121601.18498: *4* qt_gui.runAskYesNoDialog (changed)
     def runAskYesNoDialog(self,
-        c: Cmdr, title: str, message: str=None, yes_all: bool=False, no_all: bool=False,
+        c: Cmdr, title: str, message: str = None, yes_all: bool = False, no_all: bool = False,
     ) -> str:
         """
         Create and run an askYesNo dialog.
@@ -639,12 +639,12 @@ class LeoQtGui(leoGui.LeoGui):
         # Tested with both Qt6 and Qt5.
         return_d = {0: 'yes', 1: 'no'}
         if yes_all and no_all:
-            return_d [2] = 'yes-all'
-            return_d [3] = 'no-all'
+            return_d[2] = 'yes-all'
+            return_d[3] = 'no-all'
         elif yes_all:
-            return_d [2] = 'yes-all'
+            return_d[2] = 'yes-all'
         elif no_all:
-            return_d [2] = 'no-all'
+            return_d[2] = 'no-all'
         return return_d.get(val, 'cancel')
     #@+node:ekr.20110605121601.18499: *4* qt_gui.runOpenDirectoryDialog
     def runOpenDirectoryDialog(self, title: str, startdir: str) -> Optional[str]:
@@ -660,9 +660,9 @@ class LeoQtGui(leoGui.LeoGui):
         c: Cmdr,
         title: str,
         filetypes: list[str],
-        defaultextension: str='',
-        multiple: bool=False,
-        startpath: str=None,
+        defaultextension: str = '',
+        multiple: bool = False,
+        startpath: str = None,
     ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.
         """
         Create and run an Qt open file dialog.
@@ -703,10 +703,10 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20110605121601.18501: *4* qt_gui.runPropertiesDialog
     def runPropertiesDialog(
         self,
-        title: str='Properties',
-        data: Any=None,
-        callback: Callable=None,
-        buttons: list[str]=None,
+        title: str = 'Properties',
+        data: Any = None,
+        callback: Callable = None,
+        buttons: list[str] = None,
     ) -> tuple[str, dict]:
         """Display a modal TkPropertiesDialog"""
         if not g.unitTesting:
@@ -714,7 +714,7 @@ class LeoQtGui(leoGui.LeoGui):
         return 'Cancel', {}
     #@+node:ekr.20110605121601.18502: *4* qt_gui.runSaveFileDialog (changed)
     def runSaveFileDialog(self,
-        c: Cmdr, title: str='Save', filetypes: list[str]=None, defaultextension: str='',
+        c: Cmdr, title: str = 'Save', filetypes: list[str] = None, defaultextension: str = '',
     ) -> str:
         """Create and run an Qt save file dialog ."""
         if g.unitTesting:
@@ -754,11 +754,11 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20110605121601.18503: *4* qt_gui.runScrolledMessageDialog
     def runScrolledMessageDialog(
         self,
-        short_title: str='',
-        title: str='Message',
-        label: str='',
-        msg: str='',
-        c: Cmdr=None,
+        short_title: str = '',
+        title: str = 'Message',
+        label: str = '',
+        msg: str = '',
+        c: Cmdr = None,
         **keys: Any,
     ) -> None:
         if g.unitTesting:
@@ -934,7 +934,7 @@ class LeoQtGui(leoGui.LeoGui):
                 factory.setTabForCommander(c)
                 c.bodyWantsFocusNow()
     #@+node:ekr.20190601054958.1: *4* qt_gui.get_focus (no longer used)
-    def get_focus(self, c: Cmdr=None, raw: bool=False, at_idle: bool=False) -> Widget:
+    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> Widget:
         """Returns the widget that has focus."""
         trace = 'focus' in g.app.debug
         trace_idle = False
@@ -972,7 +972,7 @@ class LeoQtGui(leoGui.LeoGui):
     font_ids: list[int] = []  # id's of traced fonts.
 
     def getFontFromParams(self,
-        family: str, size: str, slant: str, weight: str, defaultSize: int = 12, tag = '',
+        family: str, size: str, slant: str, weight: str, defaultSize: int = 12, tag='',
     ) -> Any:
         """Required to handle syntax coloring."""
         if isinstance(size, str):
@@ -1018,7 +1018,7 @@ class LeoQtGui(leoGui.LeoGui):
             # g.es_exception() # Confusing for most users.
             return None
     #@+node:ekr.20110605121601.18511: *3* qt_gui.getFullVersion
-    def getFullVersion(self, c: Cmdr=None) -> str:
+    def getFullVersion(self, c: Cmdr = None) -> str:
         """Return the PyQt version (for signon)"""
         try:
             qtLevel = f"version {QtCore.qVersion()}"
@@ -1152,16 +1152,16 @@ class LeoQtGui(leoGui.LeoGui):
     def makeScriptButton(
         self,
         c: Cmdr,
-        args: Any=None,
-        p: Position=None,  # A node containing the script.
-        script: str=None,  # The script itself.
-        buttonText: str=None,
-        balloonText: str='Script Button',
-        shortcut: str=None,
-        bg: str='LightSteelBlue1',
-        define_g: bool=True,
-        define_name: str='__main__',
-        silent: bool=False,  # Passed on to c.executeScript.
+        args: Any = None,
+        p: Position = None,  # A node containing the script.
+        script: str = None,  # The script itself.
+        buttonText: str = None,
+        balloonText: str = 'Script Button',
+        shortcut: str = None,
+        bg: str = 'LightSteelBlue1',
+        define_g: bool = True,
+        define_name: str = '__main__',
+        silent: bool = False,  # Passed on to c.executeScript.
     ) -> None:
         """
         Create a script button for the script in node p.
@@ -1179,18 +1179,18 @@ class LeoQtGui(leoGui.LeoGui):
         #@-<< create the button b >>
         #@+<< define the callbacks for b >>
         #@+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
-        def deleteButtonCallback(event: Event=None, b: Widget=b, c: Cmdr=c) -> None:
+        def deleteButtonCallback(event: Event = None, b: Widget = b, c: Cmdr = c) -> None:
             if b:
                 b.pack_forget()
             c.bodyWantsFocus()
 
         def executeScriptCallback(
-            event: Event=None,
-            b: Widget=b,
-            c: Cmdr=c,
-            buttonText: str=buttonText,
-            p: Position=p and p.copy(),
-            script: str=script
+            event: Event = None,
+            b: Widget = b,
+            c: Cmdr = c,
+            buttonText: str = buttonText,
+            p: Position = p and p.copy(),
+            script: str = script
         ) -> None:
             if c.disableCommandsMessage:
                 g.blue('', c.disableCommandsMessage)
@@ -1251,7 +1251,7 @@ class LeoQtGui(leoGui.LeoGui):
         menu.popup(menuPos)
         self._contextmenu = menu
     #@+node:ekr.20170612065255.1: *3* qt_gui.put_help
-    def put_help(self, c: Cmdr, s: str, short_title: str='') -> Any:
+    def put_help(self, c: Cmdr, s: str, short_title: str = '') -> Any:
         """Put the help command."""
         s = textwrap.dedent(s.rstrip())
         if s.startswith('<') and not s.startswith('<<'):
@@ -1330,7 +1330,7 @@ class LeoQtGui(leoGui.LeoGui):
             sys.exit(1)
     #@+node:ekr.20180117053546.1: *3* qt_gui.show_tips & helpers
     @g.command('show-tips')
-    def show_next_tip(self, event: Event=None) -> None:
+    def show_next_tip(self, event: Event = None) -> None:
         c = g.app.log and g.app.log.c
         if c:
             g.app.gui.show_tips(c)
@@ -1572,11 +1572,11 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         parent: Widget,
         name: str,
-        hPolicy: Policy=None,
-        vPolicy: Policy=None,
-        lineWidth: int=1,
-        shadow: Shadow=None,
-        shape: Shape=None,
+        hPolicy: Policy = None,
+        vPolicy: Policy = None,
+        lineWidth: int = 1,
+        shadow: Shadow = None,
+        shape: Shape = None,
     ) -> Widget:
         """Create a Qt Frame."""
         if shadow is None:
@@ -1592,21 +1592,21 @@ class LeoQtGui(leoGui.LeoGui):
         w.setObjectName(name)
         return w
     #@+node:ekr.20190819091851.1: *4* qt_gui.createGrid
-    def createGrid(self, parent: Widget, name: str, margin: int=0, spacing: int=0) -> Widget:
+    def createGrid(self, parent: Widget, name: str, margin: int = 0, spacing: int = 0) -> Widget:
         w = QtWidgets.QGridLayout(parent)
         w.setContentsMargins(QtCore.QMargins(margin, margin, margin, margin))
         w.setSpacing(spacing)
         w.setObjectName(name)
         return w
     #@+node:ekr.20190819093830.1: *4* qt_gui.createHLayout & createVLayout
-    def createHLayout(self, parent: Widget, name: str, margin: int=0, spacing: int=0) -> Any:
+    def createHLayout(self, parent: Widget, name: str, margin: int = 0, spacing: int = 0) -> Any:
         hLayout = QtWidgets.QHBoxLayout(parent)
         hLayout.setObjectName(name)
         hLayout.setSpacing(spacing)
         hLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
         return hLayout
 
-    def createVLayout(self, parent: Widget, name: str, margin: int=0, spacing: int=0) -> Any:
+    def createVLayout(self, parent: Widget, name: str, margin: int = 0, spacing: int = 0) -> Any:
         vLayout = QtWidgets.QVBoxLayout(parent)
         vLayout.setObjectName(name)
         vLayout.setSpacing(spacing)
@@ -1619,13 +1619,13 @@ class LeoQtGui(leoGui.LeoGui):
         w.setText(label)
         return w
     #@+node:ekr.20190819092523.1: *4* qt_gui.createTabWidget
-    def createTabWidget(self, parent: Widget, name: str, hPolicy: Policy=None, vPolicy: Policy=None) -> Widget:
+    def createTabWidget(self, parent: Widget, name: str, hPolicy: Policy = None, vPolicy: Policy = None) -> Widget:
         w = QtWidgets.QTabWidget(parent)
         self.setSizePolicy(w, kind1=hPolicy, kind2=vPolicy)
         w.setObjectName(name)
         return w
     #@+node:ekr.20190819091214.1: *4* qt_gui.setSizePolicy
-    def setSizePolicy(self, widget: Widget, kind1: Policy=None, kind2: Policy=None) -> None:
+    def setSizePolicy(self, widget: Widget, kind1: Policy = None, kind2: Policy = None) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
         if kind2 is None:
@@ -1715,7 +1715,7 @@ class StyleSheetManager:
     #@+others
     #@+node:ekr.20180316091829.1: *3*  ssm.Birth
     #@+node:ekr.20140912110338.19371: *4* ssm.__init__
-    def __init__(self, c: Cmdr, safe: bool=False) -> None:
+    def __init__(self, c: Cmdr, safe: bool = False) -> None:
         """Ctor the ReloadStyle class."""
         self.c = c
         self.color_db = leoColor.leo_color_database
@@ -1727,7 +1727,7 @@ class StyleSheetManager:
                 # g.es("No '@settings' node found in outline.  See:")
                 # g.es("https://leo-editor.github.io/leo-editor/tutorial-basics.html#configuring-leo")
     #@+node:ekr.20170222051716.1: *4* ssm.reload_settings
-    def reload_settings(self, sheet: str=None) -> None:
+    def reload_settings(self, sheet: str = None) -> None:
         """
         Recompute and apply the stylesheet.
         Called automatically by the reload-settings commands.
@@ -1840,7 +1840,7 @@ class StyleSheetManager:
         sheet = w.styleSheet()
         print(f"style sheet for: {w}...\n\n{sheet}")
     #@+node:ekr.20110605121601.18175: *4* ssm.set_style_sheets
-    def set_style_sheets(self, all: bool=True, top: Widget=None, w: Widget=None) -> None:
+    def set_style_sheets(self, all: bool = True, top: Widget = None, w: Widget = None) -> None:
         """Set the master style sheet for all widgets using config settings."""
         c = self.c
         if top is None:
@@ -1876,7 +1876,7 @@ class StyleSheetManager:
     #@+node:ekr.20140915062551.19510: *4* ssm.expand_css_constants & helpers
     css_warning_given = False  # For do_pass.
 
-    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict=None) -> str:
+    def expand_css_constants(self, sheet: str, settingsDict: g.SettingsDict = None) -> str:
         """Expand @ settings into their corresponding constants."""
         c = self.c
         trace = 'zoom' in g.app.debug
@@ -2122,7 +2122,7 @@ class StyleSheetManager:
         """
         RE = r'([=:])[ ]*([.1234567890]+)(p[tx])'
 
-        def scale(matchobj: Any, scale: float=factor) -> str:
+        def scale(matchobj: Any, scale: float = factor) -> str:
             prefix = matchobj.group(1)
             sz = matchobj.group(2)
             units = matchobj.group(3)
@@ -2137,7 +2137,7 @@ class StyleSheetManager:
         return newsheet
     #@+node:ekr.20180316092116.1: *3* ssm.Widgets
     #@+node:ekr.20140913054442.19390: *4* ssm.get_master_widget
-    def get_master_widget(self, top: Widget=None) -> Widget:
+    def get_master_widget(self, top: Widget = None) -> Widget:
         """
         Carefully return the master widget.
         c.frame.top is a DynamicWindow.

--- a/leo/plugins/qt_quicksearch_sub.py
+++ b/leo/plugins/qt_quicksearch_sub.py
@@ -2,7 +2,7 @@
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
-#from PyQt4 import QtCore, QtGui
+# from PyQt4 import QtCore, QtGui
 from leo.core.leoQt import QtCore, QtWidgets
 from leo.core.leoQt import Policy
 QtGui = QtWidgets

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -28,7 +28,7 @@ QFontMetrics = QtGui.QFontMetrics
 #@+node:ekr.20191001084541.1: **  zoom commands
 #@+node:tbrown.20130411145310.18857: *3* @g.command("zoom-in")
 @g.command("zoom-in")
-def zoom_in(event: Event=None, delta: int=1) -> None:
+def zoom_in(event: Event = None, delta: int = 1) -> None:
     """increase body font size by one
 
     @font-size-body must be present in the stylesheet
@@ -36,7 +36,7 @@ def zoom_in(event: Event=None, delta: int=1) -> None:
     zoom_helper(event, delta=1)
 #@+node:ekr.20191001084646.1: *3* @g.command("zoom-out")
 @g.command("zoom-out")
-def zoom_out(event: Event=None) -> None:
+def zoom_out(event: Event = None) -> None:
     """decrease body font size by one
 
     @font-size-body must be present in the stylesheet
@@ -94,7 +94,7 @@ Valid values are standard css color names like `lightgrey`, and css rgb values l
 '''
 
 @g.command('help-for-highlight-current-line')
-def helpForLineHighlight(self: Any, event: Event=None) -> None:
+def helpForLineHighlight(self: Any, event: Event = None) -> None:
     """Displays Settings used by current line highlighter."""
     self.c.putHelpFor(hilite_doc)
 
@@ -127,7 +127,7 @@ class QTextMixin:
     """A minimal mixin class for QTextEditWrapper and QScintillaWrapper classes."""
     #@+others
     #@+node:ekr.20140901062324.18732: *3* qtm.ctor & helper
-    def __init__(self, c: Cmdr=None) -> None:
+    def __init__(self, c: Cmdr = None) -> None:
         """Ctor for QTextMixin class"""
         self.c = c
         self.changingText = False  # A lockout for onTextChanged.
@@ -160,7 +160,7 @@ class QTextMixin:
     #@+node:ekr.20140901122110.18733: *3* qtm.Event handlers
     # These are independent of the kind of Qt widget.
     #@+node:ekr.20140901062324.18716: *4* qtm.onCursorPositionChanged
-    def onCursorPositionChanged(self, event: Event=None) -> None:
+    def onCursorPositionChanged(self, event: Event = None) -> None:
 
         c = self.c
         name = c.widget_name(self)
@@ -208,7 +208,7 @@ class QTextMixin:
     def disable(self) -> None:
         self.enabled = False
 
-    def enable(self, enabled: bool=True) -> None:
+    def enable(self, enabled: bool = True) -> None:
         self.enabled = enabled
     #@+node:ekr.20140902181058.18644: *4* qtm.Clipboard
     def clipboard_append(self, s: str) -> None:
@@ -238,7 +238,7 @@ class QTextMixin:
         self.setAllText(s2 + s)
         self.setInsertPoint(len(s2))
     #@+node:ekr.20140901141402.18706: *5* qtm.delete
-    def delete(self, i: int, j: int=None) -> None:
+    def delete(self, i: int, j: int = None) -> None:
         """QTextMixin"""
         if j is None:
             j = i + 1
@@ -255,7 +255,7 @@ class QTextMixin:
         i, j = self.getSelectionRange()
         self.delete(i, j)
     #@+node:ekr.20110605121601.18102: *5* qtm.get
-    def get(self, i: int, j: int=None) -> str:
+    def get(self, i: int, j: int = None) -> str:
         """QTextMixin"""
         # 2012/04/12: fix the following two bugs by using the vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
@@ -263,11 +263,11 @@ class QTextMixin:
         s = self.getAllText()
         return s[i:j]
     #@+node:ekr.20140901062324.18704: *5* qtm.getLastIndex & getLength
-    def getLastIndex(self, s: str=None) -> int:
+    def getLastIndex(self, s: str = None) -> int:
         """QTextMixin"""
         return len(self.getAllText()) if s is None else len(s)
 
-    def getLength(self, s: str=None) -> int:
+    def getLength(self, s: str = None) -> int:
         """QTextMixin"""
         return len(self.getAllText()) if s is None else len(s)
     #@+node:ekr.20140901062324.18705: *5* qtm.getSelectedText
@@ -291,7 +291,7 @@ class QTextMixin:
         # getInsertPoint defined in client classes.
         self.see(self.getInsertPoint())
     #@+node:ekr.20140902135648.18668: *5* qtm.selectAllText
-    def selectAllText(self, s: str=None) -> None:
+    def selectAllText(self, s: str = None) -> None:
         """QTextMixin."""
         self.setSelectionRange(0, self.getLength(s))
     #@+node:ekr.20140901141402.18704: *5* qtm.toPythonIndexRowCol
@@ -324,7 +324,7 @@ class QLineEditWrapper(QTextMixin):
     """
     #@+others
     #@+node:ekr.20110605121601.18060: *3* qlew.Birth
-    def __init__(self, widget: Widget, name: str, c: Cmdr=None) -> None:
+    def __init__(self, widget: Widget, name: str, c: Cmdr = None) -> None:
         """Ctor for QLineEditWrapper class."""
         super().__init__(c)
         self.widget = widget
@@ -343,7 +343,7 @@ class QLineEditWrapper(QTextMixin):
         return True
     #@+node:ekr.20110605121601.18118: *3* qlew.Widget-specific overrides
     #@+node:ekr.20220911105050.1: *4* qlew: do-nothings
-    def flashCharacter(self, i: int, bg: str='white', fg: str='red', flashes: int=3, delay: int=75) -> None:
+    def flashCharacter(self, i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75) -> None:
         pass
 
     def getXScrollPosition(self) -> int:
@@ -371,7 +371,7 @@ class QLineEditWrapper(QTextMixin):
             return self.widget.cursorPosition()
         return 0
     #@+node:ekr.20110605121601.18122: *4* qlew.getSelectionRange
-    def getSelectionRange(self, sort: bool=True) -> tuple[int, int]:
+    def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
         """QHeadlineWrapper."""
         w = self.widget
         if self.check():
@@ -407,7 +407,7 @@ class QLineEditWrapper(QTextMixin):
         if self.check():
             g.app.gui.set_focus(self.c, self.widget)
     #@+node:ekr.20110605121601.18129: *4* qlew.setInsertPoint
-    def setInsertPoint(self, i: int, s: str=None) -> None:
+    def setInsertPoint(self, i: int, s: str = None) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -417,7 +417,7 @@ class QLineEditWrapper(QTextMixin):
         i = max(0, min(i, len(s)))
         w.setCursorPosition(i)
     #@+node:ekr.20110605121601.18130: *4* qlew.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: Optional[int]=None, s: str=None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: Optional[int] = None, s: str = None) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -723,7 +723,7 @@ if QtWidgets:
         #@+node:tom.20210827225119.3: *4* lqtb.parse_css
         #@@language python
         @staticmethod
-        def parse_css(css_string: str, clas: str='') -> tuple[str, str]:
+        def parse_css(css_string: str, clas: str = '') -> tuple[str, str]:
             """Extract colors from a css stylesheet string.
 
             This is an extremely simple-minded function. It assumes
@@ -1260,7 +1260,7 @@ class QMinibufferWrapper(QLineEditWrapper):
         # Monkey-patch the event handlers
         #@+<< define mouseReleaseEvent >>
         #@+node:ekr.20110605121601.18132: *3* << define mouseReleaseEvent >> (QMinibufferWrapper)
-        def mouseReleaseEvent(event: Event, self: Any=self) -> None:
+        def mouseReleaseEvent(event: Event, self: Any = self) -> None:
             """Override QLineEdit.mouseReleaseEvent.
 
             Simulate alt-x if we are not in an input state.
@@ -1289,7 +1289,7 @@ class QMinibufferWrapper(QLineEditWrapper):
         # level sheet will get pushed down quite frequently.
         self.widget.setStyleSheet(self.c.frame.top.styleSheet())
 
-    def setSelectionRange(self, i: int, j: int, insert: int=None, s: str=None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
         QLineEditWrapper.setSelectionRange(self, i, j, insert, s)
         insert = j if insert is None else insert
         if self.widget:
@@ -1306,7 +1306,7 @@ class QScintillaWrapper(QTextMixin):
     """
     #@+others
     #@+node:ekr.20110605121601.18105: *3* qsciw.ctor
-    def __init__(self, widget: Widget, c: Cmdr, name: str=None) -> None:
+    def __init__(self, widget: Widget, c: Cmdr, name: str = None) -> None:
         """Ctor for the QScintillaWrapper class."""
         super().__init__(c)
         self.baseClassName = 'QScintillaWrapper'
@@ -1338,7 +1338,7 @@ class QScintillaWrapper(QTextMixin):
         w.setAutoIndent(True)
     #@+node:ekr.20110605121601.18107: *3* qsciw.WidgetAPI
     #@+node:ekr.20140901062324.18593: *4* qsciw.delete
-    def delete(self, i: int, j: int=None) -> None:
+    def delete(self, i: int, j: int = None) -> None:
         """Delete s[i:j]"""
         w = self.widget
         if j is None:
@@ -1351,7 +1351,7 @@ class QScintillaWrapper(QTextMixin):
             self.changingText = False
     #@+node:ekr.20140901062324.18594: *4* qsciw.flashCharacter (disabled)
     def flashCharacter(self,
-        i: int, bg: str='white', fg: str='red', flashes: int=2, delay: int=50,
+        i: int, bg: str = 'white', fg: str = 'red', flashes: int = 2, delay: int = 50,
     ) -> None:
         """Flash the character at position i."""
         if 0:  # This causes a lot of problems: Better to use Scintilla matching.
@@ -1361,7 +1361,7 @@ class QScintillaWrapper(QTextMixin):
                 return
             #@+others
             #@+node:ekr.20140902084950.18635: *5* after
-            def after(func: Callable, delay: int=delay) -> None:
+            def after(func: Callable, delay: int = delay) -> None:
                 """Run func after the given delay."""
                 QtCore.QTimer.singleShot(delay, func)
             #@+node:ekr.20140902084950.18636: *5* addFlashCallback
@@ -1400,7 +1400,7 @@ class QScintillaWrapper(QTextMixin):
             self.flashFg = None if fg.lower() == 'same' else fg
             addFlashCallback()
     #@+node:ekr.20140901062324.18595: *4* qsciw.get
-    def get(self, i: int, j: int=None) -> str:
+    def get(self, i: int, j: int = None) -> str:
         # Fix the following two bugs by using vanilla code:
         # https://bugs.launchpad.net/leo-editor/+bug/979142
         # https://bugs.launchpad.net/leo-editor/+bug/971166
@@ -1418,7 +1418,7 @@ class QScintillaWrapper(QTextMixin):
         i = int(w.SendScintilla(w.SCI_GETCURRENTPOS))
         return i
     #@+node:ekr.20110605121601.18110: *4* qsciw.getSelectionRange
-    def getSelectionRange(self, sort: bool=True) -> tuple[int, int]:
+    def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
         """Get the selection range from a QsciScintilla widget."""
         w = self.widget
         i = int(w.SendScintilla(w.SCI_GETCURRENTPOS))
@@ -1502,14 +1502,14 @@ class QScintillaWrapper(QTextMixin):
         w.setText(s)
         # w.update()
     #@+node:ekr.20110605121601.18114: *4* qsciw.setInsertPoint
-    def setInsertPoint(self, i: int, s: str=None) -> None:
+    def setInsertPoint(self, i: int, s: str = None) -> None:
         """Set the insertion point in a QsciScintilla widget."""
         w = self.widget
         # w.SendScintilla(w.SCI_SETCURRENTPOS,i)
         # w.SendScintilla(w.SCI_SETANCHOR,i)
         w.SendScintilla(w.SCI_SETSEL, i, i)
     #@+node:ekr.20110605121601.18115: *4* qsciw.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: int=None, s: str=None) -> None:
+    def setSelectionRange(self, i: int, j: int, insert: int = None, s: str = None) -> None:
         """Set the selection range in a QsciScintilla widget."""
         w = self.widget
         if insert is None:
@@ -1530,7 +1530,7 @@ class QTextEditWrapper(QTextMixin):
     """A wrapper for a QTextEdit/QTextBrowser supporting the high-level interface."""
     #@+others
     #@+node:ekr.20110605121601.18073: *3* QTextEditWrapper.ctor & helpers
-    def __init__(self, widget: Widget, name: str='TestWrapper', c: Cmdr=None) -> None:
+    def __init__(self, widget: Widget, name: str = 'TestWrapper', c: Cmdr = None) -> None:
         """Ctor for QTextEditWrapper class. widget is a QTextEdit/QTextBrowser."""
         super().__init__(c)
         # Make sure all ivars are set.
@@ -1570,7 +1570,7 @@ class QTextEditWrapper(QTextMixin):
             # Monkey patch the event handler.
             #@+others
             #@+node:ekr.20140901062324.18565: *5* QTextEditWrapper.mouseReleaseEvent (monkey-patch)
-            def mouseReleaseEvent(event: Event, self: Any=self) -> None:
+            def mouseReleaseEvent(event: Event, self: Any = self) -> None:
                 """
                 Monkey patch for self.widget (QTextEditWrapper) mouseReleaseEvent.
                 """
@@ -1600,7 +1600,7 @@ class QTextEditWrapper(QTextMixin):
     #@+node:ekr.20110605121601.18078: *3* QTextEditWrapper.High-level interface
     # These are all widget-dependent
     #@+node:ekr.20110605121601.18079: *4* qtew.delete (avoid call to setAllText)
-    def delete(self, i: int, j: int=None) -> None:
+    def delete(self, i: int, j: int = None) -> None:
         """QTextEditWrapper."""
         w = self.widget
         if j is None:
@@ -1629,7 +1629,7 @@ class QTextEditWrapper(QTextMixin):
         sb.setSliderPosition(pos)
     #@+node:ekr.20110605121601.18080: *4* qtew.flashCharacter
     def flashCharacter(self,
-        i: int, bg: str='white', fg: str='red', flashes: int=3, delay: int=75,
+        i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75,
     ) -> None:
         """QTextEditWrapper."""
         # numbered color names don't work in Ubuntu 8.10, so...
@@ -1648,7 +1648,7 @@ class QTextEditWrapper(QTextMixin):
         def after(func: Callable) -> None:
             QtCore.QTimer.singleShot(delay, func)
 
-        def addFlashCallback(self: Any=self, w: str=w) -> None:
+        def addFlashCallback(self: Any = self, w: str = w) -> None:
             i = self.flashIndex
             cursor = w.textCursor()  # Must be the widget's cursor.
             cursor.setPosition(i)
@@ -1665,7 +1665,7 @@ class QTextEditWrapper(QTextMixin):
             self.flashCount -= 1
             after(removeFlashCallback)
 
-        def removeFlashCallback(self: Any=self, w: Widget=w) -> None:
+        def removeFlashCallback(self: Any = self, w: Widget = w) -> None:
             w.setExtraSelections(last_selections)
             if self.flashCount > 0:
                 after(addFlashCallback)
@@ -1688,7 +1688,7 @@ class QTextEditWrapper(QTextMixin):
         """QTextEditWrapper."""
         return self.widget.textCursor().position()
     #@+node:ekr.20110605121601.18083: *4* qtew.getSelectionRange
-    def getSelectionRange(self, sort: bool=True) -> tuple[int, int]:
+    def getSelectionRange(self, sort: bool = True) -> tuple[int, int]:
         """QTextEditWrapper."""
         w = self.widget
         tc = w.textCursor()
@@ -1729,7 +1729,7 @@ class QTextEditWrapper(QTextMixin):
         finally:
             self.changingText = False
     #@+node:ekr.20110605121601.18077: *4* qtew.leoMoveCursorHelper & helper
-    def leoMoveCursorHelper(self, kind: str, extend: bool=False, linesPerPage: int=15) -> None:
+    def leoMoveCursorHelper(self, kind: str, extend: bool = False, linesPerPage: int = 15) -> None:
         """QTextEditWrapper."""
         w = self.widget
         d = {
@@ -1887,7 +1887,7 @@ class QTextEditWrapper(QTextMixin):
         finally:
             self.changingText = False
     #@+node:ekr.20110605121601.18095: *4* qtew.setInsertPoint
-    def setInsertPoint(self, i: int, s: str=None) -> None:
+    def setInsertPoint(self, i: int, s: str = None) -> None:
         # Fix bug 981849: incorrect body content shown.
         # Use the more careful code in setSelectionRange.
         self.setSelectionRange(i=i, j=i, insert=i, s=s)
@@ -1895,8 +1895,8 @@ class QTextEditWrapper(QTextMixin):
     def setSelectionRange(self,
         i: Optional[int],
         j: Optional[int],
-        insert: Optional[int]=None,
-        s: Optional[str]=None,
+        insert: Optional[int] = None,
+        s: Optional[str] = None,
     ) -> None:
         """Set the selection range and the insert point."""
         #

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -127,7 +127,7 @@ class LeoQtTree(leoFrame.LeoTree):
         self.use_chapters = c.config.getBool('use-chapters')
         self.use_declutter = c.config.getBool('tree-declutter', default=False)
         self.use_mouse_expand_gestures = c.config.getBool('use-mouse-expand-gestures',
-                                                           default = False)
+                                                           default=False)
     #@+node:ekr.20110605121601.17940: *4* qtree.wrapQLineEdit
     def wrapQLineEdit(self, w: Wrapper) -> Wrapper:
         """A wretched kludge for MacOs k.masterMenuHandler."""
@@ -154,7 +154,7 @@ class LeoQtTree(leoFrame.LeoTree):
         w = self.treeWidget
         w.clear()
     #@+node:ekr.20110605121601.17873: *4* qtree.full_redraw & helpers
-    def full_redraw(self, p: Position=None) -> Position:
+    def full_redraw(self, p: Position = None) -> Position:
         """
         Redraw all visible nodes of the tree.
         Preserve the vertical scrolling unless scroll is True.
@@ -244,7 +244,7 @@ class LeoQtTree(leoFrame.LeoTree):
             elif cmd == 'REPLACE-TAIL':
                 s = text[m.end() :].lstrip()
             elif cmd == 'REPLACE-REST':
-                s = (text[:m.start()] + text[m.end() :]).strip()
+                s = (text[: m.start()] + text[m.end() :]).strip()
 
             # 's' is string when 'cmd' is recognized
             # and is None otherwise
@@ -385,7 +385,7 @@ class LeoQtTree(leoFrame.LeoTree):
                     patterns.append((re.compile(arg), []))
                 except re.error:
                     g.log('Invalid declutter pattern: %r' % (arg,), color='error')
-                    patterns.append((re.compile('a^'), [])) # create a rule that matches nothing
+                    patterns.append((re.compile('a^'), []))  # create a rule that matches nothing
             else:
                 if patterns:
                     patterns[-1][1].append((cmd, arg))
@@ -474,7 +474,7 @@ class LeoQtTree(leoFrame.LeoTree):
             t2 = time.process_time()
             g.trace(f"{t2 - t1:5.2f} sec.", g.callers(5))
     #@+node:ekr.20110605121601.17877: *5* qtree.drawTree
-    def drawTree(self, p: Position, parent_item: Item=None) -> None:
+    def drawTree(self, p: Position, parent_item: Item = None) -> None:
         if g.app.gui.isNullGui:
             return
         # Draw the (visible) parent node.
@@ -518,7 +518,7 @@ class LeoQtTree(leoFrame.LeoTree):
                         icon = self.declutter_node(c, p, item)
                         item.setIcon(0, icon)  # 0 is the column number.
     #@+node:ekr.20110605121601.17884: *4* qtree.redraw_after_select
-    def redraw_after_select(self, p: Position=None) -> None:
+    def redraw_after_select(self, p: Position = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         if self.busy:
             return
@@ -557,7 +557,7 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.17885: *3* qtree.Event handlers
     #@+node:ekr.20110605121601.17887: *4*  qtree.Click Box
     #@+node:ekr.20110605121601.17888: *5* qtree.onClickBoxClick
-    def onClickBoxClick(self, event: Event, p: Position=None) -> None:
+    def onClickBoxClick(self, event: Event, p: Position = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -565,7 +565,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("boxclick2", c=c, p=p, event=event)
         c.outerUpdate()
     #@+node:ekr.20110605121601.17889: *5* qtree.onClickBoxRightClick
-    def onClickBoxRightClick(self, event: Event, p: Position=None) -> None:
+    def onClickBoxRightClick(self, event: Event, p: Position = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -573,7 +573,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("boxrclick2", c=c, p=p, event=event)
         c.outerUpdate()
     #@+node:ekr.20110605121601.17890: *5* qtree.onPlusBoxRightClick
-    def onPlusBoxRightClick(self, event: Event, p: Position=None) -> None:
+    def onPlusBoxRightClick(self, event: Event, p: Position = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -582,7 +582,7 @@ class LeoQtTree(leoFrame.LeoTree):
     #@+node:ekr.20110605121601.17891: *4*  qtree.Icon Box
     # For Qt, there seems to be no way to trigger these events.
     #@+node:ekr.20110605121601.17892: *5* qtree.onIconBoxClick
-    def onIconBoxClick(self, event: Event, p: Position=None) -> None:
+    def onIconBoxClick(self, event: Event, p: Position = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -590,7 +590,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("iconclick2", c=c, p=p, event=event)
         c.outerUpdate()
     #@+node:ekr.20110605121601.17893: *5* qtree.onIconBoxRightClick
-    def onIconBoxRightClick(self, event: Event, p: Position=None) -> None:
+    def onIconBoxRightClick(self, event: Event, p: Position = None) -> None:
         """Handle a right click in any outline widget."""
         if self.busy:
             return
@@ -599,7 +599,7 @@ class LeoQtTree(leoFrame.LeoTree):
         g.doHook("iconrclick2", c=c, p=p, event=event)
         c.outerUpdate()
     #@+node:ekr.20110605121601.17894: *5* qtree.onIconBoxDoubleClick
-    def onIconBoxDoubleClick(self, event: Event, p: Position=None) -> None:
+    def onIconBoxDoubleClick(self, event: Event, p: Position = None) -> None:
         if self.busy:
             return
         c = self.c
@@ -1111,7 +1111,7 @@ class LeoQtTree(leoFrame.LeoTree):
         return None
     #@+node:ekr.20110605121601.17909: *4* qtree.editLabel and helper
     def editLabel(self,
-        p: Position, selectAll: bool=False, selection: tuple=None,
+        p: Position, selectAll: bool = False, selection: tuple = None,
     ) -> tuple[Editor, Any]:
         """Start editing p's headline."""
         if self.busy:
@@ -1135,7 +1135,7 @@ class LeoQtTree(leoFrame.LeoTree):
         return e, wrapper
     #@+node:ekr.20110605121601.18422: *5* qtree.editLabelHelper
     def editLabelHelper(self,
-        item: Any, selectAll: bool=False, selection: tuple=None,
+        item: Any, selectAll: bool = False, selection: tuple = None,
     ) -> tuple[Item, Any]:
         """Helper for qtree.editLabel."""
         c, vc = self.c, self.c.vimCommands

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -389,7 +389,7 @@ class quickMove:
             b = sc.createIconButton(
                 args=None,
                 text=text,
-                command = mb.moveCurrentNodeToTarget,
+                command=mb.moveCurrentNodeToTarget,
                 statusLine='%s current node to %s child of %s' % (
                     type_.title(), which, v.h),
                 kind="quick-move"

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -186,7 +186,7 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
     c.frame.nav = wdg
 
     # make activating this tab activate the input box
-    def activate_input(idx: int, c: Cmdr=c) -> None:
+    def activate_input(idx: int, c: Cmdr = c) -> None:
         wdg = c.frame.nav
         tab_widget = wdg.parent().parent()
         if (tab_widget and
@@ -288,7 +288,7 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
 
     #@+others
     #@+node:ekr.20111015194452.15695: *3* quick_w.ctor
-    def __init__(self, c: Cmdr, mode: str="nav", parent: Position=None) -> None:
+    def __init__(self, c: Cmdr, mode: str = "nav", parent: Position = None) -> None:
 
         super().__init__(parent)
         self.ui = qt_quicksearch.Ui_LeoQuickSearchWidget()
@@ -366,7 +366,7 @@ class QuickSearchController:
         self.frozen = False
         self._search_patterns: list[str] = []
 
-        def searcher(inp:str) -> tuple[Match_List, Match_List]:
+        def searcher(inp: str) -> tuple[Match_List, Match_List]:
             if self.frozen:
                 return None
             exp = inp.replace(" ", "*")
@@ -401,7 +401,7 @@ class QuickSearchController:
         w.itemPressed.connect(self.onSelectItem)
         w.currentItemChanged.connect(self.onSelectItem)
     #@+node:ville.20121120225024.3636: *3* freeze
-    def freeze(self, val: bool=True) -> None:
+    def freeze(self, val: bool = True) -> None:
         self.frozen = val
 
     #@+node:vitalije.20170705203722.1: *3* addItem
@@ -427,7 +427,7 @@ class QuickSearchController:
                     return lineMatchHits
         return lineMatchHits
     #@+node:jlunz.20151027092130.1: *3* addParentMatches
-    def addParentMatches(self, parent_list: dict[str,  Match_List]) -> int:
+    def addParentMatches(self, parent_list: dict[str, Match_List]) -> int:
         lineMatchHits = 0
         for parent_key, parent_value in parent_list.items():
             if isinstance(parent_key, str):
@@ -618,7 +618,7 @@ class QuickSearchController:
                 self.lw.insertItem(0, "External file directive not found " +
                                       "during search")
     #@+node:ville.20121118193144.3620: *3* bgSearch
-    def bgSearch(self, pat:str) -> tuple[Match_List, Match_List]:
+    def bgSearch(self, pat: str) -> tuple[Match_List, Match_List]:
 
         if self.frozen:
             return None
@@ -646,7 +646,7 @@ class QuickSearchController:
     def find_h(self,
         regex: str,
         positions: Iterable[Position],
-        flags: RegexFlag=re.IGNORECASE,
+        flags: RegexFlag = re.IGNORECASE,
     ) -> Match_List:
         """
         Return the list of all tuple (Position, matchiter/None) whose headline matches the given pattern.
@@ -660,7 +660,7 @@ class QuickSearchController:
     def find_b(self,
         regex: str,
         positions: Iterable[Position],
-        flags: RegexFlag=re.IGNORECASE | re.MULTILINE,
+        flags: RegexFlag = re.IGNORECASE | re.MULTILINE,
     ) -> Match_List:
         """
         Return list of all tuple (Position, matchiter/None) whose body matches regex one or more times.
@@ -688,11 +688,11 @@ class QuickSearchController:
         self.clear()
         c = self.c
         self.addHeadlineMatches([
-            (p.copy(), None) for p in c.all_positions()if p.isMarked()
+            (p.copy(), None) for p in c.all_positions() if p.isMarked()
         ])
     #@+node:ekr.20111015194452.15700: *3* Event handlers
     #@+node:ekr.20111015194452.15686: *4* onSelectItem (quicksearch.py)
-    def onSelectItem(self, it: Iterable, it_prev: Iterable=None) -> None:
+    def onSelectItem(self, it: Iterable, it_prev: Iterable = None) -> None:
 
         c = self.c
         if not it:

--- a/leo/plugins/rpcalc.py
+++ b/leo/plugins/rpcalc.py
@@ -33,7 +33,7 @@ from leo.plugins.mod_scripting import scriptingController
 Qt = QtCore.Qt
 
 QApplication = QtWidgets.QApplication
-QButtonGroup  = QtWidgets.QButtonGroup
+QButtonGroup = QtWidgets.QButtonGroup
 QCheckBox = QtWidgets.QCheckBox
 QClipboard = QtGui.QClipboard
 QColor = QtGui.QColor
@@ -200,7 +200,7 @@ def toggle_tab(event) -> None:
     c = event.c
     log = c.frame.log
 
-    toggle_app_tab(log, TABNAME, widget = CalcDlg)
+    toggle_app_tab(log, TABNAME, widget=CalcDlg)
 #@+node:tom.20230501083631.1: ** copyToClip
 def copyToClip(text):
     """Copy text to the clipboard.
@@ -217,23 +217,23 @@ def onCreate(tag: str, keys: Any) -> None:
     if c:
         sc = scriptingController(c)
         sc.createIconButton(
-            args = None,
-            text = 'RPCalc',
-            command = lambda: c.doCommandByName('rpcalc-toggle'),
+            args=None,
+            text='RPCalc',
+            command=lambda: c.doCommandByName('rpcalc-toggle'),
             statusLine=None)
 #@+node:tom.20230424130102.2: **  altbasedialog
 #@+others
 #@+node:tom.20230424130102.3: *3* class AltBaseDialog
-class AltBaseDialog(QWidget): # type: ignore
+class AltBaseDialog(QWidget):  # type: ignore
     """Displays edit boxes for other number bases.
     """
-    baseCode = {'X':16, 'O':8, 'B':2, 'D':10}
+    baseCode = {'X': 16, 'O': 8, 'B': 2, 'D': 10}
     #@+others
     #@+node:tom.20230424130102.4: *4* __init__
     def __init__(self, dlgRef, parent=None):
         QWidget.__init__(self, parent)
         self.dlgRef = dlgRef
-        self.prevBase = None   # revert to prevBase after temp base change
+        self.prevBase = None  # revert to prevBase after temp base change
         self.setAttribute(Qt.WidgetAttribute.WA_QuitOnClose, False)
         self.setWindowTitle('rpCalc Alternate Bases')
         topLay = QVBoxLayout(self)
@@ -365,7 +365,7 @@ class AltBaseDialog(QWidget): # type: ignore
 
     #@-others
 #@+node:tom.20230424130102.13: *3* class AltBaseBox
-class AltBaseBox(QLabel): # type: ignore
+class AltBaseBox(QLabel):  # type: ignore
     """Displays an edit box at a particular base.
     """
     #@+others
@@ -401,7 +401,7 @@ class AltBaseBox(QLabel): # type: ignore
 #@+node:tom.20230424130102.18: **  calcbutton
 #@+others
 #@+node:tom.20230424130102.19: *3* class CalcButton
-class CalcButton(QPushButton): # type: ignore
+class CalcButton(QPushButton):  # type: ignore
     """Calculator button class - size change & emits clicked text signal.
     """
     activated = pyqtSignal(str)
@@ -455,12 +455,12 @@ class Mode:
     """Enum for calculator modes.
     """
     entryMode = 100  # in num entry - adds to num string
-    saveMode = 101   # after result - previous result becomes Y
-    replMode = 102   # after enter key - replaces X
-    expMode = 103    # in exponent entry - adds to exp string
-    memStoMode = 104 # in memory register entry - needs 0-9 for num to store
-    memRclMode = 105 # in memory register entry - needs 0-9 for num to recall
-    decPlcMode = 106 # in decimal places entry - needs 0-9 for value
+    saveMode = 101  # after result - previous result becomes Y
+    replMode = 102  # after enter key - replaces X
+    expMode = 103  # in exponent entry - adds to exp string
+    memStoMode = 104  # in memory register entry - needs 0-9 for num to store
+    memRclMode = 105  # in memory register entry - needs 0-9 for num to recall
+    decPlcMode = 106  # in decimal places entry - needs 0-9 for value
     errorMode = 107  # error notification - any cmd to resume
 
 
@@ -549,7 +549,7 @@ class CalcCore:
             exp = int(math.floor(math.log10(absNum)))
             if useEng:
                 exp = 3 * (exp // 3)
-            num /= 10**exp
+            num /= 10 ** exp
             num = round(num, plcs)  # check if rounding bumps exponent
             if useEng and abs(num) >= 1000.0:
                 num /= 1000.0
@@ -610,7 +610,7 @@ class CalcCore:
             else:
                 newStr = self.numberStr(self.stack[0], self.base) + entStr
         else:
-            newStr = ' ' + entStr    # space for minus sign
+            newStr = ' ' + entStr  # space for minus sign
             if newStr == ' .':
                 newStr = ' 0.'
         try:
@@ -618,7 +618,7 @@ class CalcCore:
         except ValueError:
             return False
         if self.base != 10:
-            newStr = self.formatNum(num)    # decimal num in main display
+            newStr = self.formatNum(num)  # decimal num in main display
         self.stack[0] = num
         if self.option.boolData('ThousandsSeparator'):
             newStr = self.addThousandsSep(newStr)
@@ -638,16 +638,16 @@ class CalcCore:
         if number == 0:
             return '0'
         if self.useTwosComplement:
-            if number >= 2**(self.numBits - 1) or \
-                    number < -2**(self.numBits - 1):
+            if number >= 2 ** (self.numBits - 1) or \
+                    number < -2 ** (self.numBits - 1):
                 return 'overflow'
             if number < 0:
-                number = 2**self.numBits + number
+                number = 2 ** self.numBits + number
         else:
             if number < 0:
                 number = abs(number)
                 sign = '-'
-            if number >= 2**self.numBits:
+            if number >= 2 ** self.numBits:
                 return 'overflow'
         while number:
             number, remainder = divmod(number, base)
@@ -662,13 +662,13 @@ class CalcCore:
         if self.base == 10:
             return float(numStr)
         num = float(int(numStr, self.base))
-        if num >= 2**self.numBits:
+        if num >= 2 ** self.numBits:
             self.xStr = 'error 9'
             self.flag = Mode.errorMode
             self.stack[0] = num
             raise ValueError
-        if self.useTwosComplement and num >= 2**(self.numBits - 1):
-            num = num - 2**self.numBits
+        if self.useTwosComplement and num >= 2 ** (self.numBits - 1):
+            num = num - 2 ** self.numBits
         return num
 
     #@+node:tom.20230424130102.41: *4* expCmd
@@ -682,7 +682,7 @@ class CalcCore:
         else:
             if self.flag == Mode.saveMode:
                 self.stack.enterX()
-            self.stack[0]= 1.0
+            self.stack[0] = 1.0
             self.xStr = '1e+0'
         self.flag = Mode.expMode
         return True
@@ -745,10 +745,10 @@ class CalcCore:
             elif self.flag == Mode.memRclMode:
                 self.stack.enterX()
                 self.stack[0] = self.mem[num]
-            else:        # decimal place mode
+            else:  # decimal place mode
                 self.option.changeData('NumDecimalPlaces', numStr, 1)
                 self.option.writeChanges()
-        elif numStr == '<-':         # backspace
+        elif numStr == '<-':  # backspace
             pass
         else:
             return False
@@ -765,7 +765,7 @@ class CalcCore:
             return 1.0
         if type == 'grad':
             return math.pi / 200
-        return math.pi / 180   # degree
+        return math.pi / 180  # degree
 
     #@+node:tom.20230424130102.46: *4* cmd
     def cmd(self, cmdStr):
@@ -773,7 +773,7 @@ class CalcCore:
         """
         if self.flag in (Mode.memStoMode, Mode.memRclMode, Mode.decPlcMode):
             return self.memStoRcl(cmdStr)
-        if self.flag == Mode.errorMode:    # reset display, ignore next command
+        if self.flag == Mode.errorMode:  # reset display, ignore next command
             self.updateXStr()
             self.flag = Mode.saveMode
             return True
@@ -798,95 +798,95 @@ class CalcCore:
                         self.stack.replaceXY(self.stack[1] / self.stack[0])
                 else:
                     return False
-            elif cmdStr == 'ENT':          # enter
+            elif cmdStr == 'ENT':  # enter
                 self.stack.enterX()
                 self.flag = Mode.replMode
                 self.updateXStr()
                 return True
             elif cmdStr == 'EXP':
                 return self.expCmd()
-            elif cmdStr == 'X<>Y':         # exchange
+            elif cmdStr == 'X<>Y':  # exchange
                 self.stack[0], self.stack[1] = self.stack[1], self.stack[0]
-            elif cmdStr == 'CHS':          # change sign
+            elif cmdStr == 'CHS':  # change sign
                 return self.chsCmd()
-            elif cmdStr == 'CLR':          # clear
+            elif cmdStr == 'CLR':  # clear
                 self.stack.replaceAll([0.0, 0.0, 0.0, 0.0])
-            elif cmdStr == '<-':           # backspace
+            elif cmdStr == '<-':  # backspace
                 return self.bspCmd()
-            elif cmdStr == 'STO':          # store to memory
+            elif cmdStr == 'STO':  # store to memory
                 self.flag = Mode.memStoMode
                 self.xStr = '0-9:'
                 return True
-            elif cmdStr == 'RCL':          # recall from memory
+            elif cmdStr == 'RCL':  # recall from memory
                 self.flag = Mode.memRclMode
                 self.xStr = '0-9:'
                 return True
-            elif cmdStr == 'PLCS':         # change dec plc setting
+            elif cmdStr == 'PLCS':  # change dec plc setting
                 self.flag = Mode.decPlcMode
                 self.xStr = '0-9:'
                 return True
-            elif cmdStr == 'SCI':          # toggle fix/sci setting
+            elif cmdStr == 'SCI':  # toggle fix/sci setting
                 orig = self.option.boolData('ForceSciNotation')
                 new = orig and 'no' or 'yes'
                 self.option.changeData('ForceSciNotation', new, 1)
                 self.option.writeChanges
-            elif cmdStr == 'DEG':           # change deg/rad setting
+            elif cmdStr == 'DEG':  # change deg/rad setting
                 orig = self.option.strData('AngleUnit')
                 new = orig == 'deg' and 'rad' or 'deg'
                 self.option.changeData('AngleUnit', new, 1)
                 self.option.writeChanges()
-            elif cmdStr == 'R>':           # roll stack back
+            elif cmdStr == 'R>':  # roll stack back
                 self.stack.rollBack()
-            elif cmdStr == 'R^':           # roll stack forward
+            elif cmdStr == 'R^':  # roll stack forward
                 self.stack.rollUp()
-            elif cmdStr == 'PI':           # pi constant
+            elif cmdStr == 'PI':  # pi constant
                 self.stack.enterX()
                 self.stack[0] = math.pi
-            elif cmdStr == 'X^2':          # square
+            elif cmdStr == 'X^2':  # square
                 eqn = '{0}^2'.format(self.formatNum(self.stack[0]))
                 self.stack[0] = self.stack[0] * self.stack[0]
-            elif cmdStr == 'Y^X':          # x power of y
+            elif cmdStr == 'Y^X':  # x power of y
                 eqn = '({0})^{1}'.format(self.formatNum(self.stack[1]),
                                          self.formatNum(self.stack[0]))
                 self.stack.replaceXY(self.stack[1] ** self.stack[0])
-            elif cmdStr == 'XRTY':          # x root of y
+            elif cmdStr == 'XRTY':  # x root of y
                 eqn = '({0})^(1/{1})'.format(self.formatNum(self.stack[1]),
                                              self.formatNum(self.stack[0]))
-                self.stack.replaceXY(self.stack[1] ** (1/self.stack[0]))
-            elif cmdStr == 'RCIP':         # 1/x
+                self.stack.replaceXY(self.stack[1] ** (1 / self.stack[0]))
+            elif cmdStr == 'RCIP':  # 1/x
                 eqn = '1 / ({0})'.format(self.formatNum(self.stack[0]))
                 self.stack[0] = 1 / self.stack[0]
-            elif cmdStr == 'E^X':          # inverse natural log
+            elif cmdStr == 'E^X':  # inverse natural log
                 eqn = 'e^({0})'.format(self.formatNum(self.stack[0]))
                 self.stack[0] = math.exp(self.stack[0])
-            elif cmdStr == 'TN^X':         # inverse base 10 log
+            elif cmdStr == 'TN^X':  # inverse base 10 log
                 eqn = '10^({0})'.format(self.formatNum(self.stack[0]))
                 self.stack[0] = 10.0 ** self.stack[0]
             else:
                 eqn = '{0}({1})'.format(cmdStr, self.formatNum(self.stack[0]))
-                if cmdStr == 'SQRT':         # square root
+                if cmdStr == 'SQRT':  # square root
                     self.stack[0] = math.sqrt(self.stack[0])
-                elif cmdStr == 'SIN':          # sine
+                elif cmdStr == 'SIN':  # sine
                     self.stack[0] = math.sin(self.stack[0] *
                                              self.angleConv())
-                elif cmdStr == 'COS':          # cosine
+                elif cmdStr == 'COS':  # cosine
                     self.stack[0] = math.cos(self.stack[0] *
                                              self.angleConv())
-                elif cmdStr == 'TAN':          # tangent
+                elif cmdStr == 'TAN':  # tangent
                     self.stack[0] = math.tan(self.stack[0] *
                                              self.angleConv())
-                elif cmdStr == 'LN':           # natural log
+                elif cmdStr == 'LN':  # natural log
                     self.stack[0] = math.log(self.stack[0])
-                elif cmdStr == 'ASIN':         # arcsine
+                elif cmdStr == 'ASIN':  # arcsine
                     self.stack[0] = math.asin(self.stack[0]) \
                                     / self.angleConv()
-                elif cmdStr == 'ACOS':         # arccosine
+                elif cmdStr == 'ACOS':  # arccosine
                     self.stack[0] = math.acos(self.stack[0]) \
                                     / self.angleConv()
-                elif cmdStr == 'ATAN':         # arctangent
+                elif cmdStr == 'ATAN':  # arctangent
                     self.stack[0] = math.atan(self.stack[0]) \
                                     / self.angleConv()
-                elif cmdStr == 'LOG':          # base 10 log
+                elif cmdStr == 'LOG':  # base 10 log
                     self.stack[0] = math.log10(self.stack[0])
                 else:
                     return False
@@ -901,7 +901,7 @@ class CalcCore:
                 while len(self.history) > maxLen:
                     del self.history[0]
             return True
-        except (ValueError, ZeroDivisionError):
+        except(ValueError, ZeroDivisionError):
             self.xStr = 'error 0'
             self.flag = Mode.errorMode
             return True
@@ -923,7 +923,7 @@ class CalcCore:
 #@@language python
 #@@tabwidth -4
 #@+node:tom.20230424130102.50: ** class CalcDlg
-class CalcDlg(QWidget): # type: ignore
+class CalcDlg(QWidget):  # type: ignore
     """Main dialog for calculator program.
     """
     #@+others
@@ -1209,7 +1209,7 @@ class CalcDlg(QWidget): # type: ignore
         """Show extra data view.
         """
         if self.optDlg:
-            self.optDlg.reject()   # unfortunately necessary?
+            self.optDlg.reject()  # unfortunately necessary?
         if not self.extraView:
             self.extraView = ExtraDisplay(self)
         self.extraView.tabUpdate(defaultTab)
@@ -1264,7 +1264,7 @@ class CalcDlg(QWidget): # type: ignore
         """Show alternate base view.
         """
         if self.optDlg:
-            self.optDlg.reject()   # unfortunately necessary?
+            self.optDlg.reject()  # unfortunately necessary?
 
         if not self.altBaseView:
             self.altBaseView = AltBaseDialog(self)
@@ -1276,7 +1276,7 @@ class CalcDlg(QWidget): # type: ignore
         """View the ReadMe file.
         """
         if self.optDlg:
-            self.optDlg.reject()   # unfortunately necessary?
+            self.optDlg.reject()  # unfortunately necessary?
 
         self.helpView = HelpView('', 'rpCalc README File', self.icons, self)
         self.helpView.show()
@@ -1309,7 +1309,7 @@ class CalcDlg(QWidget): # type: ignore
         """
         button = CalcButton(text)
         self.mainDict[key] = button
-        self.mainLay.addWidget(button, row, col, 1+extraRow, 1+extraCol)
+        self.mainLay.addWidget(button, row, col, 1 + extraRow, 1 + extraCol)
         button.activated.connect(self.issueCmd)
 
     #@+node:tom.20230424130102.68: *3* updateLcd
@@ -1358,11 +1358,11 @@ class CalcDlg(QWidget): # type: ignore
         """
         if not ch:
             return False
-        if ord(ch) == 8:   # backspace key
+        if ord(ch) == 8:  # backspace key
             self.entryStr = self.entryStr[:-1]
         elif ord(ch) == 27:  # escape key
             self.entryStr = ''
-        elif ch == '\t':     # tab key
+        elif ch == '\t':  # tab key
             cmds = [key for key in self.cmdDict.keys() if
                     key.startswith(self.entryStr.upper())]
             if len(cmds) == 1:
@@ -1373,10 +1373,10 @@ class CalcDlg(QWidget): # type: ignore
             else:
                 QApplication.beep()
         elif ch == ':' and not self.entryStr:
-            self.entryStr = ':'   # optional command prefix
+            self.entryStr = ':'  # optional command prefix
         else:
             newStr = (self.entryStr + ch).upper()
-            if newStr == ':Q':    # vim-like shortcut
+            if newStr == ':Q':  # vim-like shortcut
                 newStr = '>CLIP'
             button = self.cmdDict.get(newStr.lstrip(':'))
             if button:
@@ -1478,7 +1478,7 @@ class CalcDlg(QWidget): # type: ignore
 
 #@+others
 #@+node:tom.20230424130102.76: *3* class Lcd
-class Lcd(QLCDNumber): # type: ignore
+class Lcd(QLCDNumber):  # type: ignore
     """Main LCD Display.
     """
     #@+others
@@ -1496,7 +1496,7 @@ class Lcd(QLCDNumber): # type: ignore
         """
         text = text.replace('e', ' E', 1)  # add space before exp
         if len(text) > numDigits:  # mark if digits hidden
-            text = 'c{0}'.format(text[1-numDigits:])
+            text = 'c{0}'.format(text[1 - numDigits :])
         self.setNumDigits(numDigits)
         self.display(text)
 
@@ -1512,7 +1512,7 @@ class Lcd(QLCDNumber): # type: ignore
 
     #@-others
 #@+node:tom.20230424130102.80: *3* class LcdBox
-class LcdBox(QFrame): # type: ignore
+class LcdBox(QFrame):  # type: ignore
     """Frame for LCD display.
     """
     #@+others
@@ -1588,7 +1588,7 @@ class CalcStack(list):
 
 #@+others
 #@+node:tom.20230424130102.94: *3* class ExtraViewWidget
-class ExtraViewWidget(QTreeWidget): # type: ignore
+class ExtraViewWidget(QTreeWidget):  # type: ignore
     """Base class of list views for ExtraDisplay.
     """
     #@+others
@@ -1663,7 +1663,7 @@ class HistViewWidget(ExtraViewWidget):
         maxLen = self.calcRef.option.intData('MaxHistLength',
                                              self.calcRef.minMaxHist,
                                              self.calcRef.maxMaxHist)
-        for eqn, value in self.calcRef.history[-self.calcRef.histChg:]:
+        for eqn, value in self.calcRef.history[-self.calcRef.histChg :]:
             item = QTreeWidgetItem(self,
                                          [eqn, self.calcRef.formatNum(value)])
             if self.topLevelItemCount() > maxLen:
@@ -1722,7 +1722,7 @@ class MemViewWidget(ExtraViewWidget):
 
     #@-others
 #@+node:tom.20230424130102.109: *3* class ExtraDisplay
-class ExtraDisplay(QWidget): # type: ignore
+class ExtraDisplay(QWidget):  # type: ignore
     """Displays registers, history or memory values, allows copies.
     """
     #@+others
@@ -1849,7 +1849,7 @@ class ExtraDisplay(QWidget): # type: ignore
 #@+node:tom.20230424130102.121: **  helpview
 #@+others
 #@+node:tom.20230424130102.122: *3* class HelpView
-class HelpView(QMainWindow): # type: ignore
+class HelpView(QMainWindow):  # type: ignore
     """Main window for viewing an html help file.
     """
     #@+others
@@ -1993,7 +1993,7 @@ class IconDict(dict):
         self.pathList = [iconPath]
 
     #@+node:tom.20230424130102.136: *3* addIconPath
-    def addIconPath(self, potentialPaths = []):
+    def addIconPath(self, potentialPaths=[]):
         pass
     #@+node:tom.20230424130102.137: *3* __getitem__
     def __getitem__(self, name):
@@ -2075,8 +2075,8 @@ class Option:
                             print('Error - could not write to config dir')
                             self.path = ''
         self.keySpaces = keySpaces
-        self.dfltDict = {} # type: ignore
-        self.userDict = {} # type: ignore
+        self.dfltDict = {}  # type: ignore
+        self.userDict = {}  # type: ignore
         self.dictList = (self.userDict, self.dfltDict)
         self.chgList = []
 
@@ -2108,7 +2108,7 @@ class Option:
         for line in list:
             line = line.split('#', 1)[0].strip()
             if line:
-                item = line.split(None, 1) + ['']   # add value if blank
+                item = line.split(None, 1) + ['']  # add value if blank
                 data[item[0]] = item[1].strip()
 
     #@+node:tom.20230424130102.146: *3* addData
@@ -2228,7 +2228,7 @@ class Option:
 #@+node:tom.20230424130102.156: **  optiondlg
 #@+others
 #@+node:tom.20230424130102.157: *3* class OptionDlg
-class OptionDlg(QDialog): # type: ignore
+class OptionDlg(QDialog):  # type: ignore
     """Works with Option class to provide a dialog for pref/options.
     """
     #@+others
@@ -3041,7 +3041,7 @@ Issues:
 #@-<< help text >>
 """
 #@+node:tom.20230424140347.3: ** toggle_app_tab
-def toggle_app_tab(log, tabname, widget = CalcDlg):
+def toggle_app_tab(log, tabname, widget=CalcDlg):
     """Create or remove our app's tab.
 
     ARGUMENTS
@@ -3060,8 +3060,8 @@ def toggle_app_tab(log, tabname, widget = CalcDlg):
         # Show our tab, reusing our widget if already loaded
         if log.contentsDict.get(LOADED, False):
             log.createTab(tabname,
-                          widget = log.contentsDict[WIDGET_NAME],
-                          createText = False)
+                          widget=log.contentsDict[WIDGET_NAME],
+                          createText=False)
             log.contentsDict[VISIBLE] = True
             log.selectTab(tabname)
             w = log.contentsDict[WIDGET_NAME]
@@ -3069,7 +3069,7 @@ def toggle_app_tab(log, tabname, widget = CalcDlg):
             # Create our widget for the first time
             # w = CalcDlg()
             w = widget()
-            log.createTab(tabname, widget = w, createText = False)
+            log.createTab(tabname, widget=w, createText=False)
             log.selectTab(tabname)
             log.contentsDict[LOADED] = True
             log.contentsDict[VISIBLE] = True

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent as Event
     from leo.core.leoNodes import Position, VNode
-    Icon = Any # QtGui.QIcon
+    Icon = Any  # QtGui.QIcon
     Menu = Any
     Priority = Union[int, str]
 
@@ -121,7 +121,7 @@ if g.app.gui.guiName() == "qt":
     class todoQtUI(QtWidgets.QWidget):  # type:ignore
         #@+others
         #@+node:ekr.20111118104929.10204: *3* ctor (todo.py)
-        def __init__(self, owner: Any, logTab: bool=True) -> None:
+        def __init__(self, owner: Any, logTab: bool = True) -> None:
 
             self.owner = owner
             super().__init__()
@@ -201,7 +201,7 @@ if g.app.gui.guiName() == "qt":
                     except(TypeError, ValueError):
                         pri = -1
 
-                def setter(pri: int=pri) -> None:
+                def setter(pri: int = pri) -> None:
                     o.setPri(pri)
 
                 w.clicked.connect(lambda checked, setter=setter: setter())
@@ -265,11 +265,11 @@ if g.app.gui.guiName() == "qt":
 
             def func(
                 value: Any,
-                edit: Any=edit,
-                toggle: Any=toggle,
-                method: Any=method,
-                default: Any=default,
-                self: Any=self,
+                edit: Any = edit,
+                toggle: Any = toggle,
+                method: Any = method,
+                default: Any = default,
+                self: Any = self,
             ) -> None:
 
                 edit.blockSignals(True)
@@ -476,7 +476,7 @@ class todoController:
             a = m.addAction(icon, self.priorities[i]["long"])
             a.setIconVisibleInMenu(True)
 
-            def icon_cb(checked: Any, pri: int=i) -> None:
+            def icon_cb(checked: Any, pri: int = i) -> None:
                 self.setPri(pri)
 
             a.triggered.connect(icon_cb)
@@ -486,7 +486,7 @@ class todoController:
             a = submenu.addAction(icon, "%d%%" % (i * 10))
             a.setIconVisibleInMenu(True)
 
-            def progress_cb(checked: bool, prog: int=i) -> None:
+            def progress_cb(checked: bool, prog: int = i) -> None:
                 self.set_progress(val=10 * prog)
 
             a.triggered.connect(progress_cb)
@@ -509,7 +509,7 @@ class todoController:
             a.enabled = False
         todoQtUI.populateMenu(taskmenu, self)
     #@+node:tbrown.20090630144958.5320: *3* menuicon
-    def menuicon(self, pri: int, progress: bool=False) -> Icon:
+    def menuicon(self, pri: int, progress: bool = False) -> Icon:
         """return icon from cache, placing it there if needed"""
         key: Priority = f"prog-{pri}" if progress else pri
         # mypy doesn't know (and can't be told) that priorities[key]["icon"] is a string.
@@ -552,13 +552,13 @@ class todoController:
         return project_changer_callback
     #@+node:tbrown.20090119215428.15: *3* loadAllIcons
     @redrawer
-    def loadAllIcons(self, tag: str=None, k: int=None, clear: bool=None) -> None:
+    def loadAllIcons(self, tag: str = None, k: int = None, clear: bool = None) -> None:
         """Load icons to represent cleo state"""
         for p in self.c.all_positions():
             self.loadIcons(p, clear=clear)
     #@+node:tbrown.20090119215428.16: *3* loadIcons (todo.py)
     @redrawer
-    def loadIcons(self, p: Position, clear: bool=False) -> None:
+    def loadIcons(self, p: Position, clear: bool = False) -> None:
 
         c = self.c
         com = c.editCommands
@@ -627,14 +627,14 @@ class todoController:
     # annotate was the previous name of this plugin, which is why the default values
     # for several keyword args is 'annotate'.
     #@+node:tbrown.20090119215428.20: *4* delUD
-    def delUD(self, node: VNode, udict: str="annotate") -> None:
+    def delUD(self, node: VNode, udict: str = "annotate") -> None:
         """ Remove our dict from the node"""
         if (hasattr(node, "unknownAttributes") and
             udict in node.unknownAttributes
         ):
             del node.unknownAttributes[udict]
     #@+node:tbrown.20090119215428.21: *4* hasUD
-    def hasUD(self, node: VNode, udict: str="annotate") -> bool:
+    def hasUD(self, node: VNode, udict: str = "annotate") -> bool:
         """ Return True if the node has an UD."""
         return (
             hasattr(node, "unknownAttributes")
@@ -726,7 +726,7 @@ class todoController:
         if isDefault:  # check if all default, if so drop dict.
             self.dropEmpty(node, dictOk=True)
     #@+node:tbrown.20090119215428.25: *4* dropEmpty
-    def dropEmpty(self, node: VNode, dictOk: bool=False) -> bool:
+    def dropEmpty(self, node: VNode, dictOk: bool = False) -> bool:
 
         if (dictOk or
             hasattr(node, 'unknownAttributes') and
@@ -751,7 +751,7 @@ class todoController:
     #@+node:tbrown.20090119215428.27: *3* drawing...
     #@+node:tbrown.20090119215428.29: *4* clear_all
     @redrawer
-    def clear_all(self, recurse: bool=False, all: bool=False) -> None:
+    def clear_all(self, recurse: bool = False, all: bool = False) -> None:
 
         what: Iterable
         if all:
@@ -770,13 +770,13 @@ class todoController:
     #@+node:tbrown.20090119215428.31: *4* progress_clear
     @redrawer
     @projectChanger
-    def progress_clear(self, v: VNode=None) -> None:
+    def progress_clear(self, v: VNode = None) -> None:
 
         self.setat(self.c.currentPosition().v, 'progress', '')
     #@+node:tbrown.20090119215428.32: *4* set_progress
     @redrawer
     @projectChanger
-    def set_progress(self, p: Position=None, val: Any=None) -> None:  # Hard to annotate.
+    def set_progress(self, p: Position = None, val: Any = None) -> None:  # Hard to annotate.
         if p is None:
             p = self.c.currentPosition()
         v = p.v
@@ -788,7 +788,7 @@ class todoController:
     #@+node:tbrown.20090119215428.33: *4* set_time_req
     @redrawer
     @projectChanger
-    def set_time_req(self, p: Position=None, val: Any=None) -> None:  # Hard to annotate.
+    def set_time_req(self, p: Position = None, val: Any = None) -> None:  # Hard to annotate.
         if p is None:
             p = self.c.currentPosition()
         v = p.v
@@ -799,7 +799,7 @@ class todoController:
             self.setat(v, 'progress', 0)
     #@+node:tbrown.20090119215428.34: *4* show_times
     @redrawer
-    def show_times(self, p: Position=None, show: bool=False) -> None:
+    def show_times(self, p: Position = None, show: bool = False) -> None:
 
         def rnd(x: float) -> str:
             return re.sub('.0$', '', '%.1f' % x)
@@ -836,7 +836,7 @@ class todoController:
                     nd.h = nd.h + ans
                 self.loadIcons(nd)  # update progress icon
     #@+node:tbrown.20090119215428.35: *4* recalc_time
-    def recalc_time(self, p: Position=None, clear: bool=False) -> tuple[str, str]:
+    def recalc_time(self, p: Position = None, clear: bool = False) -> tuple[str, str]:
 
         if p is None:
             p = self.c.currentPosition()
@@ -890,7 +890,7 @@ class todoController:
     #@+node:tbrown.20090119215428.36: *4* clear_time_req
     @redrawer
     @projectChanger
-    def clear_time_req(self, p: Position=None) -> None:
+    def clear_time_req(self, p: Position = None) -> None:
 
         if p is None:
             p = self.c.currentPosition()
@@ -898,7 +898,7 @@ class todoController:
         self.setat(v, 'time_req', '')
     #@+node:tbrown.20090119215428.37: *4* update_project
     @redrawer
-    def update_project(self, p: Position=None) -> None:
+    def update_project(self, p: Position = None) -> None:
         """Find highest parent with '@project' in headline and run recalc_time
         and maybe show_times (if headline has '@project time')"""
 
@@ -920,18 +920,18 @@ class todoController:
             self.show_times(p, show=False)
     #@+node:tbrown.20090119215428.38: *4* local_recalc
     @redrawer
-    def local_recalc(self, p: Position=None) -> None:
+    def local_recalc(self, p: Position = None) -> None:
         self.recalc_time(p)
     #@+node:tbrown.20090119215428.39: *4* local_clear
     @redrawer
-    def local_clear(self, p: Position=None) -> None:
+    def local_clear(self, p: Position = None) -> None:
         self.recalc_time(p, clear=True)
     #@+node:tbrown.20110213091328.16233: *4* set_due_date
     def set_due_date(self,
-        p: Position=None,
-        val: Any=None,  # Hard to annotate.
-        mode: str='adjust',
-        field: str='duedate',
+        p: Position = None,
+        val: Any = None,  # Hard to annotate.
+        mode: str = 'adjust',
+        field: str = 'duedate',
     ) -> None:
         "mode: `adjust` for change in time, `check` for checkbox toggle"
         if p is None:
@@ -956,10 +956,10 @@ class todoController:
         self.loadIcons(p)
     #@+node:tbrown.20110213091328.16235: *4* set_due_time
     def set_due_time(self,
-        p: Position=None,
-        val: Any=None,  # Hard to annotate.
-        mode: str='adjust',
-        field: str='duetime',
+        p: Position = None,
+        val: Any = None,  # Hard to annotate.
+        mode: str = 'adjust',
+        field: str = 'duetime',
     ) -> None:
         "mode: `adjust` for change in time, `check` for checkbox toggle"
         if p is None:
@@ -982,7 +982,7 @@ class todoController:
         self.loadIcons(p)
 
     #@+node:tbrown.20121204084515.60965: *4* set_date_offset
-    def set_date_offset(self, field: str='nextworkdate') -> None:
+    def set_date_offset(self, field: str = 'nextworkdate') -> None:
         """set_nxtwk_date_offset - update date by selected offset
 
         offset sytax::
@@ -1015,7 +1015,7 @@ class todoController:
     #@+node:tbrown.20090119215428.40: *3* ToDo icon related...
     #@+node:tbrown.20090119215428.41: *4* childrenTodo
     @redrawer
-    def childrenTodo(self, p: Position=None) -> None:
+    def childrenTodo(self, p: Position = None) -> None:
         if p is None:
             p = self.c.currentPosition()
         for p in p.children():
@@ -1025,7 +1025,7 @@ class todoController:
             self.loadIcons(p)
     #@+node:tbrown.20130207095125.20463: *4* dueClear
     @redrawer
-    def dueClear(self, p: Position=None) -> None:
+    def dueClear(self, p: Position = None) -> None:
         """clear due date on descendants, useful for creating a master todo
         item with sub items which previously had their own dates"""
         if p is None:
@@ -1033,7 +1033,7 @@ class todoController:
         for p in p.subtree():
             self.setat(p.v, 'duedate', '')
     #@+node:tbrown.20130207103126.28498: *4* needs_doing
-    def needs_doing(self, v: VNode=None, pri: Any=None, due: Any=None) -> bool:  # Hard to annotate.
+    def needs_doing(self, v: VNode = None, pri: Any = None, due: Any = None) -> bool:  # Hard to annotate.
         """needs_doing - Return true if the node is a todo node that needs doing
 
         :Parameters:
@@ -1047,7 +1047,7 @@ class todoController:
         return (pri in self.todo_priorities) or (due and pri == 9999)
     #@+node:tbrown.20090119215428.42: *4* find_todo
     @redrawer
-    def find_todo(self, p: Position=None, stage: int=0) -> bool:
+    def find_todo(self, p: Position = None, stage: int = 0) -> bool:
         """Recursively find the next todo"""
 
         # search is like XPath 'following' axis, all nodes after p in document order.
@@ -1095,7 +1095,7 @@ class todoController:
 
         return pa if pa != 24 else 0
     #@+node:tbrown.20110213153425.16373: *4* duekey
-    def duekey(self, v: VNode, field: str='due') -> tuple[bool, datetime.date, datetime.time, int]:
+    def duekey(self, v: VNode, field: str = 'due') -> tuple[bool, datetime.date, datetime.time, int]:
         """key function for sorting by due date/time"""
         # pylint: disable=boolean-datetime
         priority = self.getat(v, 'priority')
@@ -1105,14 +1105,14 @@ class todoController:
         return done, date_, time_, priority
     #@+node:tbrown.20110213153425.16377: *4* dueSort
     @redrawer
-    def dueSort(self, p: Position=None, field: str='due') -> None:
+    def dueSort(self, p: Position = None, field: str = 'due') -> None:
         if p is None:
             p = self.c.currentPosition()
         self.c.selectPosition(p)
         self.c.sortSiblings(key=lambda x: self.duekey(x, field=field))
     #@+node:tbrown.20090119215428.44: *4* priority_clear
     @redrawer
-    def priority_clear(self, v: VNode=None) -> None:
+    def priority_clear(self, v: VNode = None) -> None:
 
         if v is None:
             v = self.c.currentPosition().v
@@ -1120,14 +1120,14 @@ class todoController:
         self.loadIcons(self.c.currentPosition())
     #@+node:tbrown.20090119215428.45: *4* priSort
     @redrawer
-    def priSort(self, p: Position=None) -> None:
+    def priSort(self, p: Position = None) -> None:
         if p is None:
             p = self.c.currentPosition()
         self.c.selectPosition(p)
         self.c.sortSiblings(key=self.prikey)
     #@+node:tbrown.20090119215428.46: *4* reclassify
     @redrawer
-    def reclassify(self, p: Position=None) -> None:
+    def reclassify(self, p: Position = None) -> None:
         """change priority codes"""
 
         if p is None:
@@ -1196,7 +1196,7 @@ class todoController:
         self.setat(p.v, 'prisetdate', str(datetime.date.today()))
         self.loadIcons(p)
     #@+node:tbrown.20090119215428.48: *4* showDist
-    def showDist(self, p: Position=None) -> None:
+    def showDist(self, p: Position = None) -> None:
         """show distribution of priority levels in subtree"""
         if p is None:
             p = self.c.currentPosition()
@@ -1213,7 +1213,7 @@ class todoController:
                 g.es('%s\t%d\t%s\t(%s)' % (self.priorities[item[0]]['short'], item[1],
                     self.priorities[item[0]]['long'], item[0]))
     #@+node:tbrown.20150605111428.1: *3* updateStyle
-    def updateStyle(self, tag: str=None, k: int=None) -> None:
+    def updateStyle(self, tag: str = None, k: int = None) -> None:
         """
         updateStyle - calling widget.setStyleSheet("/* */") is a trick to get Qt to
         update appearance on a widget styled depending on changes in attributes.
@@ -1240,7 +1240,7 @@ class todoController:
                 w.setStyleSheet("/* */")
                 self._widget_to_style = None
     #@+node:tbrown.20090119215428.49: *3* updateUI
-    def updateUI(self, tag: str=None, k: dict=None) -> None:
+    def updateUI(self, tag: str = None, k: dict = None) -> None:
 
         if k and k['c'] != self.c:
             return  # wrong number
@@ -1354,7 +1354,7 @@ def todo_fix_datetime(event: Event) -> None:
 
 #@+node:tbrown.20100701093750.13800: ** command inc/dec priority
 @g.command('todo-dec-pri')
-def todo_dec_pri(event: Event, direction: int=1) -> None:
+def todo_dec_pri(event: Event, direction: int = 1) -> None:
 
     c = event['c']
     if not hasattr(c, 'cleo'):  # 2856.
@@ -1381,7 +1381,7 @@ for cmd, method in [
     ("todo-find-todo", "find_todo"),
 ]:
 
-    def f(event: Event, method: str=method) -> None:
+    def f(event: Event, method: str = method) -> None:
         getattr(event.c.cleo, method)()
         event.c.redraw()
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -480,7 +480,7 @@ def hide_rendering_pane(event: Event) -> None:
     vr.deactivate()
     vr.deleteLater()
 
-    def at_idle(c: Cmdr=c, _vr: ViewRenderedController=vr) -> None:
+    def at_idle(c: Cmdr = c, _vr: ViewRenderedController = vr) -> None:
         _vr.adjust_layout('closed')
         c.bodyWantsFocusNow()
 
@@ -672,7 +672,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     """A class to control rendering in a rendering pane."""
     #@+others
     #@+node:ekr.20110317080650.14380: *3*  vr.ctor & helpers
-    def __init__(self, c: Cmdr, parent: Position=None) -> None:
+    def __init__(self, c: Cmdr, parent: Position = None) -> None:
         """Ctor for ViewRenderedController class."""
         self.c = c
         # Create the widget.
@@ -933,7 +933,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 pass
         return w
     #@+node:ekr.20110320120020.14486: *4* vr.embed_widget & helper
-    def embed_widget(self, w: Wrapper, delete_callback: Callable=None) -> None:
+    def embed_widget(self, w: Wrapper, delete_callback: Callable = None) -> None:
         """Embed widget w in the free_layout splitter."""
         pc = self
         c = pc.c
@@ -1643,7 +1643,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             w.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
             w.customContextMenuRequested.connect(contextMenuCallback)
 
-            def handleClick(url: str, w: Widget=w) -> None:
+            def handleClick(url: str, w: Widget = w) -> None:
                 wrapper = qt_text.QTextEditWrapper(w, name='vr-body', c=c)
                 event = g.Bunch(c=c, w=wrapper)
                 g.openUrlOnClick(event, url=url)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -942,7 +942,7 @@ from urllib.request import urlopen
 import leo.core.leoGlobals as g
 from leo.core.leoApp import LoadManager as LM
 
-#1946
+# 1946
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 
 #@+<< Qt Imports >>
@@ -1107,7 +1107,7 @@ RST_ERROR_MSG_STYLE = ('color:red;'
                        'border:thin solid gray;'
                        'border-radius:.4em;')
 #@-<< RsT Error styles>>
-#RST_HEADING_CHARS = '''=-:.`'"-~^_*+#'''# Symbol hierarchy - maybe some day
+# RST_HEADING_CHARS = '''=-:.`'"-~^_*+#'''# Symbol hierarchy - maybe some day
 RST_HEADING_CHARS = '''=============='''  # For now, same symbol for all levels
 RST_NO_WARNINGS = 5
 
@@ -1277,11 +1277,11 @@ def find_dir(name, path):
             return os.path.join(root, name)
     return None
 #@+node:tom.20221231143118.1: ** get_gems()
-def check_gems(gem:str, encoding:str = 'utf-8') -> bool:
+def check_gems(gem: str, encoding: str = 'utf-8') -> bool:
     """Check if a particular ruby gem is installed."""
     cmd = f'gem list {gem}'
     # pylint: disable = subprocess-run-check
-    proc = subprocess.run(cmd, shell = True, capture_output = True)
+    proc = subprocess.run(cmd, shell=True, capture_output=True)
     installed = gem in proc.stdout.decode(encoding)
     return installed
 
@@ -1509,7 +1509,7 @@ def split_last_sizes(sizes):
 def open_in_tab(c, vr3):
     """Open a vr3 instance in a tab in the log pane."""
     log = c.frame.log
-    log.createTab(TABNAME, widget = vr3, createText = False)
+    log.createTab(TABNAME, widget=vr3, createText=False)
     log.selectTab(TABNAME)
     positions[c.hash()] = OPENED_IN_TAB
 #@+node:tom.20230403143106.1: *3* vr3.close_tab
@@ -3815,14 +3815,14 @@ class ViewRenderedController3(QtWidgets.QWidget):
         i_path = g.finalize_join(home, 'vr3_input.pandoc')
         o_path = g.finalize_join(home, 'vr3_output.html')
         # Write the input file.
-        with open(i_path, 'w', encoding = ENCODING) as f:
+        with open(i_path, 'w', encoding=ENCODING) as f:
             f.write(s)
         # Call pandoc to write the output file.
         # --quiet does no harm.
         command = f"pandoc {i_path} -t html5 -o {o_path}"
         g.execute_shell_commands(command)
         # Read the output file and return it.
-        with open(o_path, 'r', encoding = ENCODING) as f:
+        with open(o_path, 'r', encoding=ENCODING) as f:
             return f.read()
     #@+node:TomP.20191215195433.72: *4* vr3.update_pyplot
     def update_pyplot(self, s, keywords):
@@ -4636,7 +4636,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             if body.startswith('@language'):
                 i = body.find('\n')
                 if i > -1:
-                    body = body[i + 1:]
+                    body = body[i + 1 :]
             lines.append(body)
         s = '\n'.join(lines)
         self.last_markup = s
@@ -5078,10 +5078,10 @@ class StateMachine:
             # and encounter another @language block.
             if tag == CODE:
                 next = State.AT_LANG_CODE
-                #_lang = language
+                # _lang = language
             else:
                 next = State.BASE
-                #_lang = self.base_lang
+                # _lang = self.base_lang
 
         action(self, line, tag, language)
         self.state = next
@@ -5217,7 +5217,7 @@ class StateMachine:
     State_table = {  # (state, marker): (action, next_state)
 
         (State.BASE, Marker.AT_LANGUAGE_MARKER): (Action.new_chunk, State.AT_LANG_CODE),
-        #(State.AT_LANG_CODE, Marker.MARKER_NONE): (Action.add_line, State.AT_LANG_CODE),
+        # (State.AT_LANG_CODE, Marker.MARKER_NONE): (Action.add_line, State.AT_LANG_CODE),
         (State.AT_LANG_CODE, Marker.MARKER_NONE): (Action.add_line, State.BASE),
         (State.BASE, Marker.MARKER_NONE): (Action.add_line, State.BASE),
 

--- a/leo/scripts/beautify-leo-force.cmd
+++ b/leo/scripts/beautify-leo-force.cmd
@@ -1,0 +1,10 @@
+@echo off
+cd %~dp0..\..
+
+echo beautify-leo
+call py -m leo.core.leoAst --orange --force --recursive leo\core
+call py -m leo.core.leoAst --orange --force --recursive leo\commands
+call py -m leo.core.leoAst --orange --force --recursive leo\plugins\importers
+call py -m leo.core.leoAst --orange --force --recursive leo\plugins\writers
+call py -m leo.core.leoAst --orange --force leo\plugins\indented_languages.py
+rem call py -m leo.core.leoAst --orange --force --recursive leo\modes

--- a/leo/scripts/beautify-leo-force.cmd
+++ b/leo/scripts/beautify-leo-force.cmd
@@ -1,12 +1,15 @@
 @echo off
 cd %~dp0..\..
---verbose 
+
 echo beautify-leo
+
 call py -m leo.core.leoAst --orange --force --verbose leo\core
 call py -m leo.core.leoAst --orange --force --verbose leo\commands
-call py -m leo.core.leoAst --orange --force --verbose leo\plugins\importers
-call py -m leo.core.leoAst --orange --force --verbose leo\plugins\writers
 
-rem Never force the following:
+rem It's ok to beautify everything:
+
 call py -m leo.core.leoAst --orange --verbose leo\plugins
 call py -m leo.core.leoAst --orange --verbose leo\modes
+
+rem call py -m leo.core.leoAst --orange --force --verbose leo\plugins\importers
+rem call py -m leo.core.leoAst --orange --force --verbose leo\plugins\writers

--- a/leo/scripts/beautify-leo-force.cmd
+++ b/leo/scripts/beautify-leo-force.cmd
@@ -1,10 +1,12 @@
 @echo off
 cd %~dp0..\..
-
+--verbose 
 echo beautify-leo
-call py -m leo.core.leoAst --orange --force --recursive leo\core
-call py -m leo.core.leoAst --orange --force --recursive leo\commands
-call py -m leo.core.leoAst --orange --force --recursive leo\plugins\importers
-call py -m leo.core.leoAst --orange --force --recursive leo\plugins\writers
-call py -m leo.core.leoAst --orange --force leo\plugins\indented_languages.py
-rem call py -m leo.core.leoAst --orange --force --recursive leo\modes
+call py -m leo.core.leoAst --orange --force --verbose leo\core
+call py -m leo.core.leoAst --orange --force --verbose leo\commands
+call py -m leo.core.leoAst --orange --force --verbose leo\plugins\importers
+call py -m leo.core.leoAst --orange --force --verbose leo\plugins\writers
+
+rem Never force the following:
+call py -m leo.core.leoAst --orange --verbose leo\plugins
+call py -m leo.core.leoAst --orange --verbose leo\modes

--- a/leo/scripts/beautify-leo.cmd
+++ b/leo/scripts/beautify-leo.cmd
@@ -2,9 +2,9 @@
 cd %~dp0..\..
 
 echo beautify-leo
-call py -m leo.core.leoAst --orange --recursive leo\core
-call py -m leo.core.leoAst --orange --recursive leo\commands
-call py -m leo.core.leoAst --orange --recursive leo\plugins\importers
-call py -m leo.core.leoAst --orange --recursive leo\plugins\writers
-call py -m leo.core.leoAst --orange leo\plugins\indented_languages.py
-rem call py -m leo.core.leoAst --orange --recursive leo\modes
+call py -m leo.core.leoAst --orange --verbose leo\core
+call py -m leo.core.leoAst --orange --verbose leo\commands
+
+rem Never force these!
+call py -m leo.core.leoAst --orange --verbose leo\plugins
+call py -m leo.core.leoAst --orange --verbose leo\modes

--- a/leo/scripts/beautify-leo.cmd
+++ b/leo/scripts/beautify-leo.cmd
@@ -2,9 +2,8 @@
 cd %~dp0..\..
 
 echo beautify-leo
+
 call py -m leo.core.leoAst --orange --verbose leo\core
 call py -m leo.core.leoAst --orange --verbose leo\commands
-
-rem Never force these!
 call py -m leo.core.leoAst --orange --verbose leo\plugins
 call py -m leo.core.leoAst --orange --verbose leo\modes

--- a/leo/scripts/blacken-leo.cmd
+++ b/leo/scripts/blacken-leo.cmd
@@ -1,5 +1,6 @@
 @echo off
 cd %~dp0..\..
 
+rem not recommended!
 echo black leo.core
 call py -m black --skip-string-normalization leo\core

--- a/leo/scripts/full-test-leo.cmd
+++ b/leo/scripts/full-test-leo.cmd
@@ -3,8 +3,8 @@ cls
 cd %~dp0..\..
 
 echo full-test-leo
-rem call reindent-leo.cmd
-rem call beautify-leo.cmd
+rem beautify also removes trailing whitespace.
+call beautify-leo.cmd
 call test-leo.cmd
 rem echo.
 call ruff-leo.cmd

--- a/leo/scripts/ruff-leo.cmd
+++ b/leo/scripts/ruff-leo.cmd
@@ -1,16 +1,12 @@
 @echo off
 cd %~dp0..\..
 
-echo ruff leo/core
-call py -m ruff leo/core
-
-echo ruff leo/commands
-call py -m ruff leo/commands
-
 rem qt_main.py is auto generated.
 rem call py -m ruff leo/plugins/qt*.py
 
-echo ruff leo/plugins/qt...
+echo ruff leo/core, leo/commands, leo/plugins/qt...
+call py -m ruff leo/core
+call py -m ruff leo/commands
 call py -m ruff leo/plugins/qt_gui.py
 call py -m ruff leo/plugins/qt_text.py
 call py -m ruff leo/plugins/qt_tree.py


### PR DESCRIPTION
See #3652.  A *significant* performance enhancement.

- [x] Add `--force` command-line arg.  It forces beautification of all given files.
- [x] Add `--verbose` command-line arg.
- [x] Add `get_modified_files` helper function.
- [x] Remove `--recursive` option.
- [x] Don't call `reindent` in test scripts: the Orange beautifier removes trailing whitespace.
   This is another large performance boost.
- [x] Beautify all files in `leo/modes`: one file changed.
- [x] Beautify all files in `leo/plugins`. This should have been done long ago.
- [x] Update example scripts.

**Status**

All files were beautified *without* splitting or joining lines.

- `--max-join=60` produces only one bad join.
- `--max-split=88` produces many bad splits.  Orange is worse than Black here.