### PR TITLE
PR fixes #3660: fix window title computations

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -256,6 +256,7 @@ def new(self: Self, event: Event = None, gui: LeoGui = None) -> Cmdr:
             shortcutsDict=lm.globalBindingsDict,
         ))
     t3 = time.process_time()
+    g.app.numberOfUntitledWindows += 1
     frame = c.frame
     g.app.unlockLog()
     if not old_c:

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -248,6 +248,7 @@ def new(self: Self, event: Event = None, gui: LeoGui = None) -> Cmdr:
     g.app.lockLog()
     # Retain all previous settings. Very important for theme code.
     t2 = time.process_time()
+    g.app.numberOfUntitledWindows += 1
     c = g.app.newCommander(
         fileName=None,
         gui=gui,
@@ -256,7 +257,6 @@ def new(self: Self, event: Event = None, gui: LeoGui = None) -> Cmdr:
             shortcutsDict=lm.globalBindingsDict,
         ))
     t3 = time.process_time()
-    g.app.numberOfUntitledWindows += 1
     frame = c.frame
     g.app.unlockLog()
     if not old_c:

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -46,7 +46,7 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
         c.mFileName = g.ensure_extension(fileName, g.defaultLeoFileExtension(c))
 
     # Set various ivars.
-    title = c.computeWindowTitle(c.mFileName)
+    title = c.computeWindowTitle()
     c.frame.title = title
     c.frame.setTitle(title)
     try:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3416,7 +3416,7 @@ class RecentFilesManager:
                     c.add_command(recentFilesMenu, label=baseName,
                         command=recentFilesCallback, underline=0)
             else:  # original behavior
-                label = f"{accel_ch[i]} {g.computeWindowTitle(name)}"
+                label = f"{accel_ch[i]} {c.computeWindowTitle(name)}"
                 c.add_command(recentFilesMenu, label=label,
                     command=recentFilesCallback, underline=0)
             i += 1

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2362,7 +2362,7 @@ class LoadManager:
             if not exists:
                 c.rootPosition().h = 'Workbook'
         # Create the outline with workbook's name.
-        c.frame.title = title = c.computeWindowTitle(fn)
+        c.frame.title = title = c.computeWindowTitle()
         c.frame.setTitle(title)
         if hasattr(c.frame, 'top'):
             c.frame.top.leo_master.setTabName(c, fn)
@@ -3198,7 +3198,7 @@ class LoadManager:
         # Fix smallish bug 1226816 Command line "leo xxx.leo" creates file xxx.leo.leo.
         c.mFileName = fn if fn.endswith('.leo') else f"{fn}.leo"
         c.wrappedFileName = fn
-        c.frame.title = c.computeWindowTitle(c.mFileName)
+        c.frame.title = c.computeWindowTitle()
         c.frame.setTitle(c.frame.title)
         if c.config.getBool('use-chapters') and c.chapterController:
             c.chapterController.finishCreate()
@@ -3416,7 +3416,7 @@ class RecentFilesManager:
                     c.add_command(recentFilesMenu, label=baseName,
                         command=recentFilesCallback, underline=0)
             else:  # original behavior
-                label = f"{accel_ch[i]} {c.computeWindowTitle(name)}"
+                label = f"{accel_ch[i]} {c.computeWindowTitle()}"
                 c.add_command(recentFilesMenu, label=label,
                     command=recentFilesCallback, underline=0)
             i += 1

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -160,35 +160,28 @@ class Commands:
                 f"    2: {t3-t2:5.2f}\n"  # 0.53 sec: c.finishCreate.
                 f"total: {t3-t1:5.2f}"
             )
-    #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle (trace)
-    ### def computeWindowTitle(self, fileName: str) -> str:
+    #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
     def computeWindowTitle(self) -> str:
         """
         Return the title for the top-level window with the given file name.
+        
+        A quirp: return 'untitled' for *all* untitled windows.
         """
         c = self
         branch = g.gitBranchName()
-        file_name = c.fileName()
-        ### g.trace(repr(g.shortFileName(file_name)), g.callers(1))  ###
         branch_s = f"{branch}: " if branch else ''
-        if file_name:
-            return f"{branch_s}{file_name}"
-        # Return 'untitled' or 'untitled{n}
-        n = g.app.numberOfUntitledWindows
-        n_s = '' if n == 0 else str(n)
-        title = f"{branch_s}untitled{n_s}"
-        return title
-    #@+node:ekr.20231123014221.1: *5* c.computeTabTitle (new)
+        name_s = c.fileName() or 'untitled'
+        return f"{branch_s}{name_s}"
+    #@+node:ekr.20231123014221.1: *5* c.computeTabTitle
     def computeTabTitle(self, fileName: str) -> str:
         """
         Return the tab title for the window with the given file name.
         """
-        ### g.trace(repr(g.shortFileName(fileName)), g.callers(1))  ###
         if fileName:
             return fileName
         # Return 'untitled' or 'untitled{n}
         n = g.app.numberOfUntitledWindows
-        n_s = '' if n == 0 else str(n)
+        n_s = '' if n == 1 else str(n)
         title = f"untitled{n_s}"
         return title
     #@+node:ekr.20120217070122.10473: *5* c.initCommandIvars

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -171,12 +171,13 @@ class Commands:
         name_s = fileName or c.fileName() or 'untitled'
         return f"{branch_s}{name_s}"
     #@+node:ekr.20231123014221.1: *5* c.computeTabTitle
-    def computeTabTitle(self, fileName: str) -> str:
+    def computeTabTitle(self) -> str:
         """
-        Return the tab title for the window with the given file name.
+        Return the tab title for this commander.
         """
-        if fileName:
-            return fileName
+        c = self
+        if c.fileName():
+            return c.fileName()
         # Return 'untitled' or 'untitled{n}
         n = g.app.numberOfUntitledWindows
         n_s = '' if n == 1 else str(n)
@@ -268,7 +269,7 @@ class Commands:
         self.hiddenRootNode = leoNodes.VNode(context=c, gnx='hidden-root-vnode-gnx')
         self.hiddenRootNode.h = '<hidden root vnode>'
         # Create the gui frame.
-        title = c.computeTabTitle(c.mFileName)
+        title = c.computeTabTitle()
         if not g.app.initing:
             g.doHook("before-create-leo-frame", c=c)
         self.frame = gui.createLeoFrame(c, title)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -161,16 +161,14 @@ class Commands:
                 f"total: {t3-t1:5.2f}"
             )
     #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
-    def computeWindowTitle(self) -> str:
+    def computeWindowTitle(self, fileName: str = None) -> str:
         """
-        Return the title for the top-level window with the given file name.
-        
-        A quirp: return 'untitled' for *all* untitled windows.
+        Return the title for the top-level window.
         """
         c = self
         branch = g.gitBranchName()
         branch_s = f"{branch}: " if branch else ''
-        name_s = c.fileName() or 'untitled'
+        name_s = fileName or c.fileName() or 'untitled'
         return f"{branch_s}{name_s}"
     #@+node:ekr.20231123014221.1: *5* c.computeTabTitle
     def computeTabTitle(self, fileName: str) -> str:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -166,8 +166,9 @@ class Commands:
         Return the tab title for this commander.
         """
         c = self
-        if c.fileName():
-            return c.fileName()
+        file_name = c.fileName()
+        if file_name:
+            return file_name
         # Return 'untitled' or 'untitled{n}
         n = g.app.numberOfUntitledWindows
         n_s = '' if n == 1 else str(n)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -163,16 +163,18 @@ class Commands:
     #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
     def computeWindowTitle(self, fileName: str) -> str:
         """Set the window title and fileName."""
-        if fileName:
-            title = g.computeWindowTitle(fileName)
-        else:
-            s = "untitled"
-            n = g.app.numberOfUntitledWindows
-            if n > 0:
-                s += str(n)
-            title = g.computeWindowTitle(s)
-            g.app.numberOfUntitledWindows = n + 1
-        return title
+        return g.shortFileName(fileName) if fileName.strip() else 'untitled'
+        ###
+            # if fileName:
+                # title = g.computeWindowTitle(fileName)
+            # else:
+                # s = "untitled"
+                # n = g.app.numberOfUntitledWindows
+                # if n > 0:
+                    # s += str(n)
+                # title = g.computeWindowTitle(s)
+                # g.app.numberOfUntitledWindows = n + 1
+            # return title
     #@+node:ekr.20120217070122.10473: *5* c.initCommandIvars
     def initCommandIvars(self) -> None:
         """Init ivars used while executing a command."""

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -180,9 +180,17 @@ class Commands:
         Return the title for the top-level window.
         """
         c = self
-        branch = g.gitBranchName()
+        file_name = fileName or c.fileName()
+        branch = g.gitBranchName(file_name)
         branch_s = f"{branch}: " if branch else ''
-        name_s = fileName or c.fileName() or 'untitled'
+        if not file_name:
+            return f"{branch_s}untitled"
+        # Pretty-print file_name.
+        path, fn = g.os_path_split(file_name)
+        name_s = f"{fn} in {path}" if path else fn
+        # Regularize slashes.
+        if os.sep in '/\\':
+            name_s = name_s.replace('/', os.sep).replace('\\', os.sep)
         return f"{branch_s}{name_s}"
     #@+node:ekr.20120217070122.10473: *5* c.initCommandIvars
     def initCommandIvars(self) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -183,6 +183,8 @@ class Commands:
         file_name = fileName or c.fileName()
         if not file_name:
             return 'untitled'
+        if re.match(r'^untitled\d+$', file_name):
+            return file_name
         branch = g.gitBranchName(file_name)
         branch_s = f"{branch}: " if branch else ''
         # Pretty-print file_name.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -160,16 +160,6 @@ class Commands:
                 f"    2: {t3-t2:5.2f}\n"  # 0.53 sec: c.finishCreate.
                 f"total: {t3-t1:5.2f}"
             )
-    #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
-    def computeWindowTitle(self, fileName: str = None) -> str:
-        """
-        Return the title for the top-level window.
-        """
-        c = self
-        branch = g.gitBranchName()
-        branch_s = f"{branch}: " if branch else ''
-        name_s = fileName or c.fileName() or 'untitled'
-        return f"{branch_s}{name_s}"
     #@+node:ekr.20231123014221.1: *5* c.computeTabTitle
     def computeTabTitle(self) -> str:
         """
@@ -183,6 +173,16 @@ class Commands:
         n_s = '' if n == 1 else str(n)
         title = f"untitled{n_s}"
         return title
+    #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
+    def computeWindowTitle(self, fileName: str = None) -> str:
+        """
+        Return the title for the top-level window.
+        """
+        c = self
+        branch = g.gitBranchName()
+        branch_s = f"{branch}: " if branch else ''
+        name_s = fileName or c.fileName() or 'untitled'
+        return f"{branch_s}{name_s}"
     #@+node:ekr.20120217070122.10473: *5* c.initCommandIvars
     def initCommandIvars(self) -> None:
         """Init ivars used while executing a command."""
@@ -240,26 +240,6 @@ class Commands:
         self.orphan_at_file_nodes: list[Position] = []  # List of orphaned nodes for c.raise_error_dialogs.
         self.wrappedFileName: Optional[str] = None  # The name of the wrapped file, for wrapper commanders.
 
-    #@+node:ekr.20120217070122.10469: *5* c.initOptionsIvars
-    def initOptionsIvars(self) -> None:
-        """Init Commander ivars corresponding to user options."""
-        self.fixed = False
-        self.fixedWindowPosition: list[tuple[int, int, int, int]] = []
-        self.forceExecuteEntireBody = False
-        self.focus_border_color = 'white'
-        self.focus_border_width = 1  # pixels
-        self.outlineHasInitialFocus = False
-        self.page_width = 132
-        self.sparse_find = True
-        self.sparse_move = True
-        self.sparse_spell = True
-        self.sparse_goto_visible = False
-        self.stayInTreeAfterSelect = False
-        self.tab_width = -4
-        self.tangle_batch_flag = False
-        self.target_language = "python"
-        self.untangle_batch_flag = False
-        self.vim_mode = False
     #@+node:ekr.20120217070122.10470: *5* c.initObjects
     #@@nobeautify
 
@@ -401,6 +381,26 @@ class Commands:
             self.subCommanders.append(self.styleSheetManager)
         else:
             self.styleSheetManager = None
+    #@+node:ekr.20120217070122.10469: *5* c.initOptionsIvars
+    def initOptionsIvars(self) -> None:
+        """Init Commander ivars corresponding to user options."""
+        self.fixed = False
+        self.fixedWindowPosition: list[tuple[int, int, int, int]] = []
+        self.forceExecuteEntireBody = False
+        self.focus_border_color = 'white'
+        self.focus_border_width = 1  # pixels
+        self.outlineHasInitialFocus = False
+        self.page_width = 132
+        self.sparse_find = True
+        self.sparse_move = True
+        self.sparse_spell = True
+        self.sparse_goto_visible = False
+        self.stayInTreeAfterSelect = False
+        self.tab_width = -4
+        self.tangle_batch_flag = False
+        self.target_language = "python"
+        self.untangle_batch_flag = False
+        self.vim_mode = False
     #@+node:ekr.20140815160132.18837: *5* c.initSettings
     def initSettings(self, previousSettings: "PreviousSettings") -> None:
         """Instantiate c.config from previous settings."""

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -161,15 +161,18 @@ class Commands:
                 f"total: {t3-t1:5.2f}"
             )
     #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle (trace)
-    def computeWindowTitle(self, fileName: str) -> str:
+    ### def computeWindowTitle(self, fileName: str) -> str:
+    def computeWindowTitle(self) -> str:
         """
         Return the title for the top-level window with the given file name.
         """
+        c = self
         branch = g.gitBranchName()
-        g.trace(repr(g.shortFileName(fileName)), g.callers(1))  ###
+        file_name = c.fileName()
+        ### g.trace(repr(g.shortFileName(file_name)), g.callers(1))  ###
         branch_s = f"{branch}: " if branch else ''
-        if fileName:
-            return f"{branch_s}{fileName}"
+        if file_name:
+            return f"{branch_s}{file_name}"
         # Return 'untitled' or 'untitled{n}
         n = g.app.numberOfUntitledWindows
         n_s = '' if n == 0 else str(n)
@@ -180,6 +183,7 @@ class Commands:
         """
         Return the tab title for the window with the given file name.
         """
+        ### g.trace(repr(g.shortFileName(fileName)), g.callers(1))  ###
         if fileName:
             return fileName
         # Return 'untitled' or 'untitled{n}
@@ -273,7 +277,7 @@ class Commands:
         self.hiddenRootNode = leoNodes.VNode(context=c, gnx='hidden-root-vnode-gnx')
         self.hiddenRootNode.h = '<hidden root vnode>'
         # Create the gui frame.
-        title = c.computeWindowTitle(c.mFileName)
+        title = c.computeTabTitle(c.mFileName)
         if not g.app.initing:
             g.doHook("before-create-leo-frame", c=c)
         self.frame = gui.createLeoFrame(c, title)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -171,7 +171,7 @@ class Commands:
             return file_name
         # Return 'untitled' or 'untitled{n}
         n = g.app.numberOfUntitledWindows
-        n_s = '' if n == 1 else str(n)
+        n_s = '' if n < 2 else str(n)
         title = f"untitled{n_s}"
         return title
     #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
@@ -181,10 +181,10 @@ class Commands:
         """
         c = self
         file_name = fileName or c.fileName()
+        if not file_name:
+            return 'untitled'
         branch = g.gitBranchName(file_name)
         branch_s = f"{branch}: " if branch else ''
-        if not file_name:
-            return f"{branch_s}untitled"
         # Pretty-print file_name.
         path, fn = g.os_path_split(file_name)
         name_s = f"{fn} in {path}" if path else fn

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -160,10 +160,33 @@ class Commands:
                 f"    2: {t3-t2:5.2f}\n"  # 0.53 sec: c.finishCreate.
                 f"total: {t3-t1:5.2f}"
             )
-    #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle
+    #@+node:ekr.20120217070122.10475: *5* c.computeWindowTitle (trace)
     def computeWindowTitle(self, fileName: str) -> str:
-        """Set the window title and fileName."""
-        return g.shortFileName(fileName) if fileName.strip() else 'untitled'
+        """
+        Return the title for the top-level window with the given file name.
+        """
+        branch = g.gitBranchName()
+        g.trace(repr(g.shortFileName(fileName)), g.callers(1))  ###
+        branch_s = f"{branch}: " if branch else ''
+        if fileName:
+            return f"{branch_s}{fileName}"
+        # Return 'untitled' or 'untitled{n}
+        n = g.app.numberOfUntitledWindows
+        n_s = '' if n == 0 else str(n)
+        title = f"{branch_s}untitled{n_s}"
+        return title
+    #@+node:ekr.20231123014221.1: *5* c.computeTabTitle (new)
+    def computeTabTitle(self, fileName: str) -> str:
+        """
+        Return the tab title for the window with the given file name.
+        """
+        if fileName:
+            return fileName
+        # Return 'untitled' or 'untitled{n}
+        n = g.app.numberOfUntitledWindows
+        n_s = '' if n == 0 else str(n)
+        title = f"untitled{n_s}"
+        return title
     #@+node:ekr.20120217070122.10473: *5* c.initCommandIvars
     def initCommandIvars(self) -> None:
         """Init ivars used while executing a command."""

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -164,17 +164,6 @@ class Commands:
     def computeWindowTitle(self, fileName: str) -> str:
         """Set the window title and fileName."""
         return g.shortFileName(fileName) if fileName.strip() else 'untitled'
-        ###
-            # if fileName:
-                # title = g.computeWindowTitle(fileName)
-            # else:
-                # s = "untitled"
-                # n = g.app.numberOfUntitledWindows
-                # if n > 0:
-                    # s += str(n)
-                # title = g.computeWindowTitle(s)
-                # g.app.numberOfUntitledWindows = n + 1
-            # return title
     #@+node:ekr.20120217070122.10473: *5* c.initCommandIvars
     def initCommandIvars(self) -> None:
         """Init ivars used while executing a command."""

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3027,23 +3027,6 @@ def computeMachineName() -> str:
 
 def computeStandardDirectories() -> str:
     return g.app.loadManager.computeStandardDirectories()
-#@+node:ekr.20031218072017.3103: *3* g.computeWindowTitle
-def computeWindowTitle(fileName: str) -> str:
-
-    branch, commit = g.gitInfoForFile(fileName)  # #1616
-    if not fileName:
-        return branch + ": untitled" if branch else 'untitled'
-    path, fn = g.os_path_split(fileName)
-    if path:
-        title = fn + " in " + path
-    else:
-        title = fn
-    # Yet another fix for bug 1194209: regularize slashes.
-    if os.sep in '/\\':
-        title = title.replace('/', os.sep).replace('\\', os.sep)
-    if branch:
-        title = branch + ": " + title
-    return title
 #@+node:ekr.20031218072017.3117: *3* g.create_temp_file
 def create_temp_file(textMode: bool = False) -> tuple[Any, str]:
     """

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -333,7 +333,7 @@ class LeoBrowserApp(flx.PyComponent):
             w.body.set_focus()
         # Set the inited flag *last*.
         self.inited = True
-    #@+node:ekr.20181216042806.1: *5* app.init
+    #@+node:ekr.20181216042806.1: *5* app.init (leoflexx.py)
     def init(self):
         # Set the ivars.
         global g  # Always use the imported g.

--- a/leo/plugins/leoflexx.py
+++ b/leo/plugins/leoflexx.py
@@ -365,7 +365,7 @@ class LeoBrowserApp(flx.PyComponent):
         for frame in g.app.windowList:
             assert isinstance(frame, DummyFrame), repr(frame)
         # Instantiate all wrappers here, not in app.finish_create.
-        title = c.computeWindowTitle(c.mFileName)
+        title = c.computeWindowTitle()
         c.frame = gui.lastFrame = LeoBrowserFrame(c, title, gui)
         # The main window will be created (much) later.
         main_window = LeoFlexxMainWindow()

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4636,7 +4636,9 @@ class TabbedFrameFactory:
         f = self.leoFrames.get(w)
         if not f:
             return
-        tabw.setWindowTitle(f.title)
+        c = f.c
+        title = c.computeWindowTitle()
+        tabw.setWindowTitle(title)
         # Don't do this: it would break --minimize.
             # g.app.selectLeoWindow(f.c)
         # Fix bug 690260: correct the log.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4637,7 +4637,7 @@ class TabbedFrameFactory:
         if not f:
             return
         c = f.c
-        title = c.computeWindowTitle()
+        title = c.computeWindowTitle(f.title)
         tabw.setWindowTitle(title)
         # Don't do this: it would break --minimize.
             # g.app.selectLeoWindow(f.c)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4616,7 +4616,7 @@ class TabbedFrameFactory:
                         tabw.setCurrentIndex(i)
                         break
                 break
-    #@+node:ekr.20110605121601.18470: *3* frameFactory.signal handlers (trace)
+    #@+node:ekr.20110605121601.18470: *3* frameFactory.signal handlers
     def slotCloseRequest(self, idx: int) -> None:
 
         tabw = self.masterFrame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2053,7 +2053,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.initComplete = False  # Set by initCompleteHint().
         self.minibufferVisible = True
         self.statusLineClass: Any = QtStatusLineClass  # A Union. 'Any' can't easily be removed.
-        self.title = 'Branch! ' + title
+        self.title = title
         self.setIvars()
         self.reloadSettings()
 
@@ -4616,7 +4616,7 @@ class TabbedFrameFactory:
                         tabw.setCurrentIndex(i)
                         break
                 break
-    #@+node:ekr.20110605121601.18470: *3* frameFactory.signal handlers
+    #@+node:ekr.20110605121601.18470: *3* frameFactory.signal handlers (trace)
     def slotCloseRequest(self, idx: int) -> None:
 
         tabw = self.masterFrame

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2053,7 +2053,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         self.initComplete = False  # Set by initCompleteHint().
         self.minibufferVisible = True
         self.statusLineClass: Any = QtStatusLineClass  # A Union. 'Any' can't easily be removed.
-        self.title = title
+        self.title = 'Branch! ' + title
         self.setIvars()
         self.reloadSettings()
 


### PR DESCRIPTION
See #3660.  This PR may affect LeoJS.

- [x] Retire `g.computeWindowTitle`. Use `c.computeWindowTitle` everywhere.
- [x] Simplify `c.computeWindowTitle`.
- [x] Update `g.app.numberOfUntitledWindows` *only* in `c_file.new`.
- [x] Add `c.computeTabTitle`. It never adds a branch name.
- [x] Only `c.init_objects` calls  `c.computeTabTitle`.
- [x] Only `slotCurrentChanged` calls `c.computeWindowTitle`.
- [x] Revise `c.computeWindowTitle` as Félix suggests.  See rev e52296d.