### PR TITLE
PR: Bugs relating to c_file.openRecentFile

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -952,16 +952,6 @@ def editRecentFiles(self: Self, event: Event = None) -> None:
     """Opens recent files list in a new node for editing."""
     c = self
     g.app.recentFilesManager.editRecentFiles(c)
-#@+node:ekr.20031218072017.2081: *3* c_file.openRecentFile
-@g.commander_command('open-recent-file')
-def openRecentFile(self: Self, event: Event = None, fn: str = None) -> None:
-    c = self
-    if g.doHook("recentfiles1", c=c, p=c.p, v=c.p, fileName=fn):
-        return
-    c2 = g.openWithFileName(fn, old_c=c)
-    if c2:
-        g.app.makeAllBindings()
-        g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
 #@+node:tbrown.20080509212202.8: *3* c_file.sortRecentFiles
 @g.commander_command('sort-recent-files')
 def sortRecentFiles(self: Self, event: Event = None) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3315,6 +3315,21 @@ class Commands:
             else:
                 g.internalError(f"no gnx for vnode: {v}")
         c.fileCommands.gnxDict = d
+    #@+node:ekr.20031218072017.2081: *4* c.openRecentFile
+    def openRecentFile(self, event: Event = None, fn: str = None) -> None:
+        """
+        c.openRecentFile: This is not a command!
+        
+        This method is a helper called only from the recentFilesCallback in
+        rf.createRecentFilesMenuItems.
+        """
+        c = self
+        if g.doHook("recentfiles1", c=c, p=c.p, v=c.p, fileName=fn):
+            return
+        c2 = g.openWithFileName(fn, old_c=c)
+        if c2:
+            g.app.makeAllBindings()
+            g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
     #@+node:ekr.20180508111544.1: *3* c.Git
     #@+node:ekr.20180510104805.1: *4* c.diff_file
     def diff_file(self, fn: str, rev1: str = 'HEAD', rev2: str = '') -> None:
@@ -3972,9 +3987,7 @@ class Commands:
     ) -> None:
         c = self
         if command:
-            # Command is always either:
-            # one of two callbacks defined in createMenuEntries or
-            # recentFilesCallback, defined in createRecentFilesMenuItems.
+            # Command is one of two callbacks defined in createMenuEntries.
 
             def add_commandCallback(c: Commands = c, command: Callable = command) -> Any:
                 val = command()


### PR DESCRIPTION
**Background**

This PR started as a documentation quirp: `c_file.openRecentFile` lacked a docstring. Apparently this method never had one.

But this PR fixes several more serious issues. The changes may affect leoJS.

The legacy code defined the `open-recent-file` as a command, presumably to inject `openRecentFile` into the namespace of the `Commands` class! But the `open-recent-file` does not work as a stand-alone command!

- [x] Move the `openRecentFile` method from `leo.commands.commanderFileCommands` to `leo.core.commands`,
    removing the decorator `@g.commander_command('open-recent-file')`.
- [x] Add a docstring for `c.openRecentFile`.
- [x] Simplify the comment in `c.add_command` about the `command` arg.
- [x] Check all mentions of `open-recent-file`:
   - It can remain in the "bad list" in `server._bad_commands`.
   - It does not appear in `LeoDocs.leo`.