### PR TITLE
PR: Fix db quirp by adding a new arg

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1136,7 +1136,7 @@ class FileCommands:
         c.setCurrentPosition(p)
         return rootChildren[0]
     #@+node:vitalije.20170815162307.1: *6* fc.initNewDb
-    def initNewDb(self, conn: Any, path: str) -> VNode:
+    def initNewDb(self, conn: Any, path: str = None) -> VNode:
         """ Initializes tables and returns None"""
         c, fc = self.c, self
         v = leoNodes.VNode(context=c)
@@ -1144,7 +1144,7 @@ class FileCommands:
         (w, h, x, y, r1, r2, encp) = fc.getWindowGeometryFromDb(conn)
         c.frame.setTopGeometry(w, h, x, y)
         c.frame.resizePanesToRatio(r1, r2)
-        fc.exportToSqlite(path)
+        fc.exportToSqlite(path or c.mFileName)
         return v
     #@+node:vitalije.20170630200802.1: *6* fc.getWindowGeometryFromDb
     def getWindowGeometryFromDb(self, conn: Any) -> tuple:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -930,7 +930,7 @@ class FileCommands:
         try:
             c.loading = True  # disable c.changed
             conn = sqlite3.connect(path)
-            v = fc.retrieveVnodesFromDb(conn) or fc.initNewDb(conn)
+            v = fc.retrieveVnodesFromDb(conn) or fc.initNewDb(conn, path)
             if not v:
                 return None
 
@@ -1136,7 +1136,7 @@ class FileCommands:
         c.setCurrentPosition(p)
         return rootChildren[0]
     #@+node:vitalije.20170815162307.1: *6* fc.initNewDb
-    def initNewDb(self, conn: Any) -> VNode:
+    def initNewDb(self, conn: Any, path: str) -> VNode:
         """ Initializes tables and returns None"""
         c, fc = self.c, self
         v = leoNodes.VNode(context=c)
@@ -1144,7 +1144,7 @@ class FileCommands:
         (w, h, x, y, r1, r2, encp) = fc.getWindowGeometryFromDb(conn)
         c.frame.setTopGeometry(w, h, x, y)
         c.frame.resizePanesToRatio(r1, r2)
-        fc.exportToSqlite(c.mFileName)
+        fc.exportToSqlite(path)
         return v
     #@+node:vitalije.20170630200802.1: *6* fc.getWindowGeometryFromDb
     def getWindowGeometryFromDb(self, conn: Any) -> tuple:


### PR DESCRIPTION
- [x] Add an optional `path` kwarg to `fc.initNewDb`.
   This change clarifies the logic while retaining strict compatibility with existing scripts and plugins.
   *Note*: it would be wrong for the `path` arg to default to `c.fileName()` instead of `c.mFileName`.

**Analysis**

The calling sequence for all calls to `fc.initNewDb` is as follows:

- Leo's code contains four calls to `fc.getAnyLeoFileByName(path)`. See below.
- `fc.getAnyLeoFileByName` calls `fc._getLeoDBFileByName(path)`.
- `fc._getLeoDBFileByName(path)` now contains:
    `v = fc.retrieveVnodesFromDb(conn) or fc.initNewDb(conn, path)`

This last call makes explicit that `fc.initNewDb` should use the given path rather than `c.mFileName`.

As mentioned above, four methods call ` `fc.getAnyLeoFileByName`:

- `gdc.make_leo_outline`
- `lm.openExistingLeoFile`
- `lm.openSettingsFile`
- `lm.revertCommander`

For each of these calls, `path` *might* always be equivalent to `c.mFileName`, but it's tricky to say for sure.

**Summary**: This PR most likely clarifies the code's intention.