### PR TITLE
PR Fix valid mypy complaints re leoServer.py

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -5446,7 +5446,9 @@ def main() -> None:  # pragma: no cover (tested in client)
                         print(f"{tag}: got: {d}", flush=True)
                     answer = controller._do_message(d)
                 except TerminateServer as e:
-                    raise websockets.exceptions.ConnectionClosed()
+                    if trace and verbose:
+                        print(f"{tag}: TerminateServer {e}", flush=True)
+                    raise websockets.exceptions.ConnectionClosed(None, None)
                 except ServerError as e:
                     data = f"{d}" if d else f"json syntax error: {json_message!r}"
                     error = f"{tag}:  ServerError: {e}...\n{tag}:  {data}"


### PR DESCRIPTION
Tested with leoInteg with either Python 3.11 and 3.12.

All tests pass with Python 3.11. Unrelated tests fail on Python 3.12.

- [x] Use the `e` value per other logging code.
- [x] Raise `ConnectionClosed(None, None)` to supply two required args.