### PR TITLE
PR fixes #3690: cursesGui2.py does not work with Python 3.12

### DIFF
--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1568,7 +1568,19 @@ class LeoCursesGui(leoGui.LeoGui):
         #
         # Do NOT change g.app!
         self.curses_app = LeoApp()
-        stdscr = curses.initscr()
+
+        if 1:  # Call our own version of curses.initscr().
+            import _curses
+            # This crashes on Python 3.12.
+                # setupterm(term=_os.environ.get("TERM", "unknown"),
+                    # fd=_sys.__stdout__.fileno())
+            stdscr = _curses.initscr()
+            for key, value in _curses.__dict__.items():
+                if key[0:4] == 'ACS_' or key in ('LINES', 'COLS'):
+                    setattr(curses, key, value)
+            # return stdscr
+        else:
+            stdscr = curses.initscr()
         if 1:  # Must follow initscr.
             self.dump_keys()
         try:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -506,7 +506,7 @@ class LeoQtGui(leoGui.LeoGui):
         dialog.raise_()
         ok = dialog.exec_()
         return str(dialog.textValue()) if ok else None
-    #@+node:ekr.20110605121601.18495: *4* qt_gui.runAskOkDialog (changed)
+    #@+node:ekr.20110605121601.18495: *4* qt_gui.runAskOkDialog
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> None:
         """Create and run a qt askOK dialog ."""
         if g.unitTesting:


### PR DESCRIPTION
See #3690.

This PR works around an evident crasher in the `curses` module.

- [x] Work around a crash in `Lib/curses/__init__.py`: Don't call `setupterm`!
- [x] Test with Python 3.12 and 3.9.
- [x] Add comment in windows-curses [issue #50](https://github.com/zephyrproject-rtos/windows-curses/issues/50)

The following code crashes on Python 3.12:
```python
setupterm(term=_os.environ.get("TERM", "unknown"), fd=_sys.__stdout__.fileno())
```