### PR TITLE
PR: mod_http end-of-life changes

### DIFF
--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -258,7 +258,10 @@ def init():
         if not message_given:
             message_given = True
             print('')
-            print('mod_http plugin does not work on Python 3.12 and above.')
+            g.es_print(
+                'mod_http plugin does not work on Python 3.12 and above.',
+                color='red',
+            )
             print('')
         return False
     getGlobalConfiguration()


### PR DESCRIPTION
#3682 has been marked `Won'tDo`. Unless someone steps up this PR will be the end.

This PR warns that `mod_http.py` does not work with Python 3.12 and above.

- [x] Issue warning only once.
- [x] Define classes only if `asyncore` and `asynchat` modules exist.
- [x] Test on Python 3.11: `mod_http` works.
- [x] Test on Python 3.12: `mod_http` issues error message, as expected.