### PR TITLE
PR fixes #3700: colorize f-strings for Python 3.12

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1848,6 +1848,117 @@ class JEditColorizer(BaseColorizer):
         # j = len(s)
         # self.colorRangeWithTag(s,i,j,kind,delegate=delegate)
         # return j
+    #@+node:ekr.20231209010844.1: *4* jedit.match_fstring
+    f_string_nesting_level = 0
+
+    def match_fstring(self, s: str, i: int) -> int:
+        """
+        Match a python 3.12 f-string.
+        
+        Called only for python 3.12+.
+        """
+        # Fail quickly if possible.
+        if i + 1 >= len(s):
+            return 0
+        j = 1 if s[i+1] in 'rfRF' else 0
+        delim_offset =  i + j + 1
+        if delim_offset >= len(s):
+            return 0
+        delim = s[delim_offset]
+        if delim not in ('"', '"'):
+            return 0
+            
+        # Init.
+        self.f_string_nesting_level = 0
+        if g.match(s, delim_offset, delim * 3):
+            delim = delim * 3
+
+        # Similar to code for docstrings (match_span).
+        start = delim_offset
+        end = self.match_fstring_helper(s, start + len(delim), delim)
+        if end == -1:
+            return 0  # A real failure.
+
+        # Color this line.
+        self.colorRangeWithTag(s, start, end, tag='literal1')
+        self.prev = (i, end, delim)
+        self.trace_match(delim, s, i, end)
+
+        # Continue the f-string if necessary.
+        if end >= len(s):
+            end = len(s) + 1
+
+            def fstring_restarter(s: str) -> int:
+                """Freeze the binding of delim"""
+                return self.restart_fstring(s, delim)
+
+            self.setRestart(fstring_restarter)
+            
+        return end - i  # Correct, whatever end is.
+    #@+node:ekr.20231209015334.1: *5* jedit.match_fstring_helper
+    def match_fstring_helper(self, s: str, i: int, delim: str) -> int:
+        """
+        Return n >= 0 if s[i:] contains with a non-escaped delim at fstring-level 0
+        """
+        escape, escapes = '\\', 0
+        level = self.f_string_nesting_level
+
+        # Scan, incrementing escape count and f-string level.
+        while i < len(s):
+            progress = i
+            if g.match(s, i, delim):
+                if (escapes % 2) == 0 and level == 0:
+                    return i + len(delim)
+                i += len(delim)
+                continue
+            ch = s[i]
+            i += 1
+            if ch == '#' and (escapes % 2) == 0:
+                break  # Don't scan comments.
+            if ch == escape:
+                escapes += 1
+            elif ch == '{':
+                level += 1
+            elif ch == '}':
+                level -= 1
+            else:
+                escapes = 0
+            assert progress < i, (i, s)
+
+        # Continue scanning.
+        self.f_string_nesting_level = level
+        return len(s) + 1
+    #@+node:ekr.20231209082830.1: *5* jedit.restart_fstring
+    def restart_fstring(self, s: str, delim: str) -> int:
+        """Remain in this state until 'delim' is seen."""
+        i = 0
+        j = self.match_fstring_helper(s, i, delim)
+        
+        if j == -1:
+            j2 = len(s) + 1
+        else:
+            j2 = j
+            
+        ###
+        # elif j > len(s):
+            # j2 = j
+        # else:
+            # j2 = j + len(delim)
+
+        self.colorRangeWithTag(s, i, j2, tag='literal1')
+        ### j = j2
+        self.trace_match(delim, s, i, j2)
+        if j > len(s):
+            
+            def fstring_restarter(s: str) -> int:
+                """Freeze the binding of delim."""
+                return self.restart_fstring(s, delim)
+
+            self.setRestart(fstring_restarter)
+
+        else:
+            self.clearState()
+        return j  # Return the new i, *not* the length of the match.
     #@+node:ekr.20110605121601.18614: *4* jedit.match_keywords
     # This is a time-critical method.
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1898,7 +1898,7 @@ class JEditColorizer(BaseColorizer):
     #@+node:ekr.20231209015334.1: *5* jedit.match_fstring_helper
     def match_fstring_helper(self, s: str, i: int, delim: str) -> int:
         """
-        Return n >= 0 if s[i:] contains with a non-escaped delim at fstring-level 0
+        Return n >= 0 if s[i:] contains with a non-escaped delim at fstring-level 0.
         """
         escape, escapes = '\\', 0
         level = self.f_string_nesting_level
@@ -1933,21 +1933,11 @@ class JEditColorizer(BaseColorizer):
         """Remain in this state until 'delim' is seen."""
         i = 0
         j = self.match_fstring_helper(s, i, delim)
-        
-        if j == -1:
-            j2 = len(s) + 1
-        else:
-            j2 = j
-            
-        ###
-        # elif j > len(s):
-            # j2 = j
-        # else:
-            # j2 = j + len(delim)
-
+        j2 = len(s) + 1 if j == -1 else j
         self.colorRangeWithTag(s, i, j2, tag='literal1')
-        ### j = j2
         self.trace_match(delim, s, i, j2)
+        
+        # Restart of necessary.
         if j > len(s):
             
             def fstring_restarter(s: str) -> int:

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -4,6 +4,10 @@
 # Leo colorizer control file for python mode.
 # This file is in the public domain.
 
+import sys
+
+v1, v2, junk1, junk2, junk3 = sys.version_info
+
 # Properties for python mode.
 properties = {
     "indentNextLines": "\\s*[^#]{3,}:\\s*(#.*)?",
@@ -308,16 +312,16 @@ keywordsDictDict = {
 #@+node:ekr.20230419163819.1: *3* python_rule0
 def python_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
-#@+node:ekr.20230419163819.2: *3* python_rule1
+#@+node:ekr.20230419163819.2: *3* python_rule1 """
 def python_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"")
-#@+node:ekr.20230419163819.3: *3* python_rule2
+#@+node:ekr.20230419163819.3: *3* python_rule2 '''
 def python_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''")
-#@+node:ekr.20230419163819.4: *3* python_rule3
+#@+node:ekr.20230419163819.4: *3* python_rule3 "
 def python_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
-#@+node:ekr.20230419163819.5: *3* python_rule4
+#@+node:ekr.20230419163819.5: *3* python_rule4 '
 def python_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 #@+node:ekr.20230419163819.6: *3* python_rule5
@@ -399,9 +403,12 @@ def python_rule19(colorer, s, i):
 if 0:  # #1821.
     def python_rule20(colorer, s, i):
         return colorer.match_mark_previous(s, i, kind="function", pattern="(")
-#@+node:ekr.20230419163819.22: *3* python_rule21
+#@+node:ekr.20230419163819.22: *3* python_rule21 (keyword)
 def python_rule21(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@+node:ekr.20231209010502.1: *3* python_rule_fstring
+def python_rule_fstring(colorer, s, i):
+    return colorer.match_fstring(s, i)
 #@+node:ekr.20230419163931.1: *3* python_rule_h_url/rule_f_url (not used)
 if 0:
     url = False
@@ -510,6 +517,11 @@ rulesDict1 = {
     "|": [python_rule17],
     "~": [python_rule19],
 }
+
+if (v1, v2) >= (3, 12):
+    # Update rules to for Python 3.12+ f-strings.
+    for key in 'frFR':
+        rulesDict1 [key] = [python_rule_fstring, python_rule21]
 
 # x.rulesDictDict for python mode.
 rulesDictDict = {

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -1142,6 +1142,22 @@ class TestColorizer(LeoUnitTest):
     ''')
         self.color('python', text)
 
+    #@+node:ekr.20231209161622.1: *3* TestColorizer.test_colorizer_Python_fstrings
+    def test_colorizer_Python_fstrings(self):
+
+        text = textwrap.dedent(r'''
+    my_dict = {'key': 'value', 'key2': 'value2'}
+
+    print(repr(f"{'':*^{1:{1}}}"))
+
+    for key in ('key', 'key2'):
+        print(f"{my_dict[key]=}")
+    print(f"{my_dict['key']=}")
+    print(f"{my_dict['key2']=}")
+
+    ''').lstrip()
+        self.color('python', text)
+
     #@+node:ekr.20210905170507.27: *3* TestColorizer.test_colorizer_r
     def test_colorizer_r(self):
         text = textwrap.dedent("""\


### PR DESCRIPTION
See #3700.

- [x] Add f-string rules to `leo/modes/python.py`, but only for Python 3.12+.
   These rules call `jedit.match_fstring`.
- [x] Add `jedit.match_fstring` and helpers.
- [x] Add typical (minimal) unit test.
- [x] Test with Python 3.11 and 3.12.