### PR TITLE
PR: Improve error messages in the spell checker

### DIFF
--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -333,13 +333,16 @@ class EnchantWrapper(BaseSpellWrapper):
         language = g.checkUnicode(c.config.getString('enchant-language'))
         if language:
             try:
-                ok = enchant.dict_exists(language)
+                enchant.dict_exists(language)
+            except AttributeError:
+                pass  # ? dict_exists does not exist in later version of enchant.
             except Exception:
-                ok = False
-            if not ok:
-                g.warning('Invalid language code for Enchant', repr(language))
-                g.es_print('Using "en_US" instead')
-                g.es_print('Use @string enchant_language to specify your language')
+                if language == 'en_US':
+                    g.es_exception() # Valid language.
+                else:
+                    g.warning('Invalid language code for Enchant', repr(language))
+                    g.es_print('Using "en_US" instead')
+                    g.es_print('Use @string enchant_language to specify your language')
                 language = 'en_US'
         self.language = language
     #@+node:ekr.20180207102856.1: *3* enchant.open_dict_file

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -335,7 +335,9 @@ class EnchantWrapper(BaseSpellWrapper):
             try:
                 enchant.dict_exists(language)
             except AttributeError:
-                pass  # ? dict_exists does not exist in later version of enchant.
+                # Likely an install error.
+                # open_dict_file gives the error.
+                pass
             except Exception:
                 if language == 'en_US':
                     g.es_exception()  # Valid language.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -338,7 +338,7 @@ class EnchantWrapper(BaseSpellWrapper):
                 pass  # ? dict_exists does not exist in later version of enchant.
             except Exception:
                 if language == 'en_US':
-                    g.es_exception() # Valid language.
+                    g.es_exception()  # Valid language.
                 else:
                     g.warning('Invalid language code for Enchant', repr(language))
                     g.es_print('Using "en_US" instead')
@@ -373,7 +373,9 @@ class EnchantWrapper(BaseSpellWrapper):
                 d = enchant.Dict(language)
             except Exception:
                 d = {}
-        # Common exit, for traces.
+        if not d:
+            g.es_print('Error opening dictionary')
+            g.es_print('pip install pyenchant, NOT enchant')
         return d
 
     #@+node:ekr.20150514063305.517: *3* enchant.process_word


### PR DESCRIPTION
The problem: I used `pip install enchant` rather than `pip install pyenchant'.

- [x] Improve error messages in `init_language` and `open_dict_file`.
- [x] Test changes with Python 3.11 and 3.12.