### PR TITLE
PR: Simplify version logic

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2953,8 +2953,7 @@ class LoadManager:
             "You may download Python from http://python.org/download/"
         )
         try:
-            ok = g.python_version_tuple >= g.minimum_python_version_tuple
-            if not ok:
+            if not g.isValidPython:
                 print(message)
                 try:
                     # g.app.gui does not exist yet.
@@ -2964,7 +2963,7 @@ class LoadManager:
                     d.run()
                 except Exception:
                     g.es_exception()
-            return ok
+            return g.isValidPython
         except Exception as e:
             print(f"LM.isValidPython: unexpected exception {e}")
             return False

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -12,7 +12,6 @@ import string
 import sys
 import textwrap
 import time
-import traceback
 from typing import Any, Optional, TYPE_CHECKING
 import zipfile
 import platform
@@ -2951,10 +2950,10 @@ class LoadManager:
             return True
         message = (
             f"Leo requires Python {g.minimum_python_version} or higher"
-            f"You may download Python from http://python.org/download/")
+            "You may download Python from http://python.org/download/"
+        )
         try:
-            version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
-            ok = g.CheckVersion(version, g.minimum_python_version)
+            ok = g.python_version_tuple >= g.minimum_python_version_tuple
             if not ok:
                 print(message)
                 try:
@@ -2966,9 +2965,8 @@ class LoadManager:
                 except Exception:
                     g.es_exception()
             return ok
-        except Exception:
-            print("isValidPython: unexpected exception: g.CheckVersion")
-            traceback.print_exc()
+        except Exception as e:
+            print(f"LM.isValidPython: unexpected exception {e}")
             return False
     #@+node:ekr.20120223062418.10393: *4* LM.openWithFileName & helpers
     def openWithFileName(self, fn: str, gui: LeoGui, old_c: Cmdr) -> Optional[Cmdr]:

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -233,35 +233,32 @@ class BridgeController:
     def isValidPython(self) -> bool:
         if sys.platform == 'cli':
             return True
-        message = """\
-    Leo requires Python 3.6 or higher.
-    You may download Python from http://python.org/download/
-    """
+        tag = 'leoBridge: isValidPython'
         try:
             # This will fail if True/False are not defined.
             from leo.core import leoGlobals as g
-            # print('leoBridge:isValidPython:g',g)
+
             # Set leoGlobals.g here, rather than in leoGlobals.py.
-            leoGlobals = g  # Don't set g.g, it would pollute the autocompleter.
+            leoGlobals = g
             leoGlobals.g = g
-        except ImportError:
-            print("isValidPython: can not import leoGlobals")
+        except Exception as e:
+            print(f"{tag}: can not import leoGlobals: {e}")
             return False
-        except Exception:
-            print("isValidPython: unexpected exception importing leoGlobals")
-            traceback.print_exc()
-            return False
+
+        message = (
+            f"Leo requires Python {g.minimum_python_version} or higher"
+            "You may download Python from http://python.org/download/"
+        )
+
         try:
-            version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
-            ok = g.CheckVersion(version, g.minimum_python_version)
+            ok = g.python_version_tuple >= g.minimum_python_version_tuple
             if not ok:
                 print(message)
                 g.app.gui.runAskOkDialog(
                     None, "Python version error", message=message, text="Exit")
             return ok
-        except Exception:
-            print("isValidPython: unexpected exception: g.CheckVersion")
-            traceback.print_exc()
+        except Exception as e:
+            print(f"{tag}: unexpected exception: {e}")
             return False
     #@+node:ekr.20070227093629.9: *4* bridge.reportDirectories
     def reportDirectories(self) -> None:

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -251,12 +251,11 @@ class BridgeController:
         )
 
         try:
-            ok = g.python_version_tuple >= g.minimum_python_version_tuple
-            if not ok:
+            if not g.isValidPython:
                 print(message)
                 g.app.gui.runAskOkDialog(
                     None, "Python version error", message=message, text="Exit")
-            return ok
+            return g.isValidPython
         except Exception as e:
             print(f"{tag}: unexpected exception: {e}")
             return False

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -63,7 +63,10 @@ if TYPE_CHECKING:  # pragma: no cover
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'
-isPython3 = sys.version_info >= (3, 0, 0)  # Not used in Leo's core.
+minimum_python_version_tuple = (3, 9, 0)
+v1, v2, v3, junk2, junk3 = sys.version_info
+python_version_tuple = (v1, v2, v3)
+isPython3 = python_version_tuple >= (3, 0, 0)
 isMac = sys.platform.startswith('darwin')
 isWindows = sys.platform.startswith('win')
 #@+<< define g.globalDirectiveList >>
@@ -5700,7 +5703,7 @@ def actualColor(color: str) -> str:
         return color2 or 'black'
     color2 = c.config.getColor(f"log_{color}_color")
     return color2 or color
-#@+node:ekr.20060921100435: *3* g.CheckVersion & helpers
+#@+node:ekr.20060921100435: *3* g.CheckVersion & helpers (deprecated)
 # Simplified version by EKR: stringCompare not used.
 
 def CheckVersion(
@@ -5711,7 +5714,10 @@ def CheckVersion(
     delimiter: str = '.',
     trace: bool = False,
 ) -> bool:
-    # CheckVersion is called early in the startup process.
+    """
+    Return True if the indicated relationship holds.
+    Deprecated: not used in Leo's core.
+    """
     vals1 = [g.CheckVersionToInt(s) for s in s1.split(delimiter)]
     n1 = len(vals1)
     vals2 = [g.CheckVersionToInt(s) for s in s2.split(delimiter)]

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -67,6 +67,7 @@ minimum_python_version_tuple = (3, 9, 0)
 v1, v2, v3, junk2, junk3 = sys.version_info
 python_version_tuple = (v1, v2, v3)
 isPython3 = python_version_tuple >= (3, 0, 0)
+isValidPython = python_version_tuple >= minimum_python_version_tuple
 isMac = sys.platform.startswith('darwin')
 isWindows = sys.platform.startswith('win')
 #@+<< define g.globalDirectiveList >>


### PR DESCRIPTION
- [x] Deprecate g.CheckVersion.
- [x] Define `g.python_version_tuple` and `g.minimum_python_version_tuple`.
- [x] Simplify `LM.isValidPython` and `leoBridge.isValidPython`.