### PR TITLE
PR fixes #3712: use walrus operator

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -468,8 +468,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         ))
         changed = False
         # Perform at most one scripting substitution.
-        m = pattern.match(p.h)
-        if m:
+        if m := pattern.match(p.h):
             content = m.group(2)
             c.abbrev_subst_env['x'] = ''
             try:

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -531,15 +531,13 @@ def extractDef(c: Cmdr, s: str) -> str:
     for pat in c.config.getData('extract-patterns') or []:
         try:
             pat = re.compile(pat)
-            m = pat.search(s)
-            if m:
+            if m := pat.search(s):
                 return m.group(1)
         except Exception:
             g.es_print('bad regex in @data extract-patterns', color='blue')
             g.es_print(pat)
     for pat in extractDef_patterns:
-        m = pat.search(s)
-        if m:
+        if m := pat.search(s):
             return m.group(1)
     return ''
 #@+node:ekr.20171123135625.26: *3* function: extractDef_find

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -651,8 +651,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                     break
                 # Handle comments following arguments.
                 if multiline and result:
-                    m = self.comment_pat.match(rest)
-                    if m:
+                    if m := self.comment_pat.match(rest):
                         comment = m.group(0)
                         i += len(comment)
                         last = result.pop()

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1621,8 +1621,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             while i < len(lines):
                 progress = i
                 for (kind, pattern, handler) in self.patterns:
-                    m = pattern.match(lines[i])
-                    if m:
+                    if m := pattern.match(lines[i]):
                         j = handler(self, i, lines, m, p)  # May change lines.
                         break
                 else:
@@ -2095,8 +2094,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 'class', 'def', 'elif', 'for', 'if', 'print', 'public', 'return', 'with', 'while',
             )
             for i, s in enumerate(lines):
-                m = self.assignment_pat.match(s)
-                if m:
+                if m := self.assignment_pat.match(s):
                     lws, lhs, rhs = m.group(1), m.group(2), m.group(3).rstrip()
                     if not any(z in lhs for z in table):
                         lines[i] = f"{lws}let {lhs} = {rhs}\n"
@@ -2322,8 +2320,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 progress = i
                 line = lines[i]
                 for (pattern, handler) in self.patterns:
-                    m = pattern.match(line)
-                    if m:
+                    if m := pattern.match(line):
                         i = handler(i, lines, m, p)  # May change lines.
                         break
                 else:
@@ -2844,8 +2841,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 'class', 'def', 'elif', 'for', 'if', 'print', 'public', 'return', 'with', 'while',
             )
             for i, s in enumerate(lines):
-                m = self.assignment_pat.match(s)
-                if m:
+                if m := self.assignment_pat.match(s):
                     lws, lhs, rhs = m.group(1), m.group(2), m.group(3).rstrip()
                     if not any(z in lhs for z in table):
                         lines[i] = f"{lws}const {lhs} = {rhs}\n"

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1260,8 +1260,7 @@ class EditCommandsClass(BaseEditCommandsClass):
     def hn_delete(self, p: Position) -> None:
         """Helper: delete the headline number in p.h."""
         c = self.c
-        m = re.match(self.hn_pattern, p.h)
-        if m:
+        if m := re.match(self.hn_pattern, p.h):
             # Do not strip the headline!
             n = len(m.group(0))
             c.setHeadString(p, p.v.h[n:])

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -34,13 +34,11 @@ def find_next_trace(ins: int, p: Position) -> tuple[int, int, Position]:
     while p:
         ins = max(0, ins - 1)  # Back up over newline.
         s = p.b[ins:]
-        m = re.search(skip_pat, s)
-        if m:
+        if m := re.search(skip_pat, s):
             # Skip this node.
             g.es_print('Skipping', p.h)
         else:
-            m = re.search(if_pat, s)
-            if m:
+            if m := re.search(if_pat, s):
                 i = m.start() + 1
                 j = m.end()
                 k = find_trace_block(i, j, s)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -116,8 +116,7 @@ class ConvertAtRoot:
     def make_clones(self, p: Position) -> None:
         """Make clones for all undefined sections in p.b."""
         for s in g.splitLines(p.b):
-            m = self.section_pat.match(s)
-            if m:
+            if m := self.section_pat.match(s):
                 section_name = g.angleBrackets(m.group(1).strip())
                 section_p = self.make_clone(p, section_name)
                 if not section_p:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2790,14 +2790,12 @@ class LoadManager:
             """Handle --trace-binding, --trace-setting and --trace"""
 
             # --trace-binding
-            m = utils.find_complex_option(r'--trace-binding=([\w\-\+]+)')
-            if m:
+            if m := utils.find_complex_option(r'--trace-binding=([\w\-\+]+)'):
                 g.app.trace_binding = m.group(1)
                 print(f"Enabling --trace-binding={m.group(1)}")
 
             # --trace-setting=setting
-            m = utils.find_complex_option(r'--trace-setting=([\w]+)')
-            if m:
+            if m := utils.find_complex_option(r'--trace-setting=([\w]+)'):
                 # g.app.config does not exist yet.
                 g.app.trace_setting = m.group(1)
                 print(f"Enabling --trace-setting={m.group(1)}")

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1896,8 +1896,7 @@ class Orange:
             val = self.line.rstrip()
             # #3056: Insure one space after '#' in non-sentinel comments.
             #        Do not change bang lines or '##' comments.
-            m = self.comment_pat.match(val)
-            if m:
+            if m := self.comment_pat.match(val):
                 i = len(m.group(1))
                 val = val[:i] + '# ' + val[i + 1 :]
         else:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3239,8 +3239,7 @@ class FastAtRead:
             # These three sections might clear in_doc.
             #@+<< handle @others >>
             #@+node:ekr.20180602103135.14: *4* << handle @others >>
-            m = self.others_pat.match(line)
-            if m:
+            if m := self.others_pat.match(line):
                 in_doc = False
                 if m.group(2) == '+':  # opening sentinel
                     body.append(f"{m.group(1)}@others{m.group(3) or ''}\n")
@@ -3259,8 +3258,7 @@ class FastAtRead:
             #@+node:ekr.20180602103135.18: *4* << handle section refs >>
             # Note: scan_header sets *comment* delims, not *section* delims.
             # This section coordinates with the section that handles @section-delims.
-            m = self.ref_pat.match(line)
-            if m:
+            if m := self.ref_pat.match(line):
                 in_doc = False
                 if m.group(2) == '+':
                     # Any later @section-delims directive is a serious error.
@@ -3277,8 +3275,7 @@ class FastAtRead:
             #@-<< handle section refs >>
             #@+<< handle node_start >>
             #@+node:ekr.20180602103135.19: *4* << handle node_start >>
-            m = self.node_start_pat.match(line)
-            if m:
+            if m := self.node_start_pat.match(line):
                 in_doc = False
                 gnx, head = m.group(2), m.group(5)
                 # m.group(3) is the level number, m.group(4) is the number of stars.
@@ -3362,8 +3359,7 @@ class FastAtRead:
                     continue
                 #
                 # Check for @c or @code.
-                m = self.code_pat.match(line)
-                if m:
+                if m := self.code_pat.match(line):
                     in_doc = False
                     body.append('@code\n' if m.group(1) else '@c\n')
                     continue
@@ -3373,8 +3369,7 @@ class FastAtRead:
                 #@+node:ekr.20211031033754.1: *4* << handle @ or @doc >>
                 assert not in_doc, repr(line)
 
-                m = self.doc_pat.match(line)
-                if m:
+                if m := self.doc_pat.match(line):
                     #@verbatim
                     # @+at or @+doc?
                     doc = '@doc' if m.group(1) == 'doc' else '@'
@@ -3394,8 +3389,7 @@ class FastAtRead:
             # Order doesn't matter.
             #@+<< handle @all >>
             #@+node:ekr.20180602103135.13: *4* << handle @all >>
-            m = self.all_pat.match(line)
-            if m:
+            if m := self.all_pat.match(line):
                 #@verbatim
                 # @all tells Leo's *write* code not to check for undefined sections.
                 # Here, in the read code, we merely need to add it to the body.
@@ -3411,15 +3405,13 @@ class FastAtRead:
             #@-<< handle @all >>
             #@+<< handle afterref >>
             #@+node:ekr.20180603063102.1: *4* << handle afterref >>
-            m = self.after_pat.match(line)
-            if m:
+            if m := self.after_pat.match(line):
                 afterref = True
                 continue
             #@-<< handle afterref >>
             #@+<< handle @first and @last >>
             #@+node:ekr.20180606053919.1: *4* << handle @first and @last >>
-            m = self.first_pat.match(line)
-            if m:
+            if m := self.first_pat.match(line):
                 # pylint: disable=no-else-continue
                 if 0 <= first_i < len(first_lines):
                     body.append('@first ' + first_lines[first_i])
@@ -3431,8 +3423,7 @@ class FastAtRead:
                     g.printObj(first_lines, tag='first_lines')
                     g.printObj(lines[start : i + 2], tag='lines[start:i+2]')
                     continue
-            m = self.last_pat.match(line)
-            if m:
+            if m := self.last_pat.match(line):
                 # Just increment the count of the expected last lines.
                 # We'll fill in the @last line directives after we see the @-leo directive.
                 n_last_lines += 1
@@ -3441,8 +3432,7 @@ class FastAtRead:
             #@+<< handle @comment >>
             #@+node:ekr.20180621050901.1: *4* << handle @comment >>
             # https://leo-editor.github.io/leo-editor/directives.html#part-4-dangerous-directives
-            m = self.comment_pat.match(line)
-            if m:
+            if m := self.comment_pat.match(line):
                 # <1, 2 or 3 comment delims>
                 delims = m.group(1).strip()
 
@@ -3473,8 +3463,7 @@ class FastAtRead:
             #@-<< handle @comment >>
             #@+<< handle @delims >>
             #@+node:ekr.20180608104836.1: *4* << handle @delims >>
-            m = self.delims_pat.match(line)
-            if m:
+            if m := self.delims_pat.match(line):
                 # Get 1 or 2 comment delims
                 # Whatever happens, retain the original @delims line.
                 delims = m.group(1).strip()
@@ -3507,8 +3496,7 @@ class FastAtRead:
             #@-<< handle @delims >>
             #@+<< handle @section-delims >>
             #@+node:ekr.20211030033211.1: *4* << handle @section-delims >>
-            m = self.section_delims_pat.match(line)
-            if m:
+            if m := self.section_delims_pat.match(line):
                 if section_reference_seen:  # pragma: no cover
                     # This is a serious error.
                     # This kind of error should have been caught by Leo's atFile write logic.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3119,8 +3119,7 @@ class FastAtRead:
         first_lines: list[str] = []
         i = 0  # To keep some versions of pylint happy.
         for i, line in enumerate(lines):
-            m = self.header_pattern.match(line)
-            if m:
+            if m := self.header_pattern.match(line):
                 delims = m.group(1), m.group(8) or ''
                 return delims, first_lines, i + 1
             first_lines.append(line)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2328,8 +2328,7 @@ class AtFile:
         # Use regex to properly distinguish between Leo directives
         # and python decorators.
         s2 = s[i:]
-        m = self.at_directive_kind_pattern.match(s2)
-        if m:
+        if m := self.at_directive_kind_pattern.match(s2):
             word = m.group(1)
             if word not in g.globalDirectiveList:
                 return at.noDirective
@@ -2690,8 +2689,7 @@ class AtFile:
         # Scan root.b.
         lines = []
         for s in g.splitLines(root.b):
-            m = g.g_section_delims_pat.match(s)
-            if m:
+            if m := g.g_section_delims_pat.match(s):
                 lines.append(s)
                 at.section_delim1 = m.group(1)
                 at.section_delim2 = m.group(2)

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -263,8 +263,7 @@ class ChapterController:
                 #@verbatim
                 # @chapter (all up to @) (@key=(binding))?
                 # name=group(1), binding=group(3)
-        m = self.re_chapter.search(p.h)
-        if m:
+        if m := self.re_chapter.search(p.h):
             chapterName, binding = m.group(1), m.group(3)
             if chapterName:
                 chapterName = self.sanitize(chapterName)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -932,8 +932,7 @@ class JEditColorizer(BaseColorizer):
 
         def find_delims(v: VNode) -> Optional[re.Match]:
             for s in g.splitLines(v.b):
-                m = g.g_section_delims_pat.match(s)
-                if m:
+                if m := g.g_section_delims_pat.match(s):
                     return m
             return None
 
@@ -1626,8 +1625,7 @@ class JEditColorizer(BaseColorizer):
 
     def match_image(self, s: str, i: int) -> int:
         """Matcher for <img...>"""
-        m = self.image_url.match(s, i)
-        if m:
+        if m := self.image_url.match(s, i):
             self.image_src = src = m.group(1)
             j = len(src)
             doc = self.highlighter.document()
@@ -2464,8 +2462,7 @@ class JEditColorizer(BaseColorizer):
         2. Exactly one character, of any kind.
         """
         assert s[i] == '\\'
-        m = self.ascii_letters.match(s, i + 1)
-        if m:
+        if m := self.ascii_letters.match(s, i + 1):
             n = len(m.group(0))
             j = i + n + 1
         else:
@@ -2478,8 +2475,7 @@ class JEditColorizer(BaseColorizer):
     #@+node:ekr.20170205074106.1: *4* jedit.match_wiki_pattern
     def match_wiki_pattern(self, s: str, i: int, pattern: Any) -> int:
         """Show or hide a regex pattern managed by the wikiview plugin."""
-        m = pattern.match(s, i)
-        if m:
+        if m := pattern.match(s, i):
             n = len(m.group(0))
             self.colorRangeWithTag(s, i, i + n, 'url')
             return n

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3380,8 +3380,7 @@ if pygments:
             return
         while 1:
             for rexmatch, action, new_state in statetokens:
-                m = rexmatch(text, pos)
-                if m:
+                if m := rexmatch(text, pos):
                     if action is not None:
                         # pylint: disable=unidiomatic-typecheck
                         # EKR: Why not use isinstance?

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -171,8 +171,7 @@ class BaseColorizer:
             for setting in sorted(c.config.settingsDict):
                 gs = c.config.settingsDict.get(setting)
                 if gs and gs.source:  # An @font setting.
-                    m = setting_pat.match(gs.source)
-                    if m:
+                    if m := setting_pat.match(gs.source):
                         language, tag = m.group(1), m.group(2)
                         if language in valid_languages and tag in valid_tags:
                             self.resolve_font(setting, language, tag, gs.val)

--- a/leo/core/leoDebugger.py
+++ b/leo/core/leoDebugger.py
@@ -356,8 +356,7 @@ def get_gnx_from_file(file_s, p, path):
     """Set p's gnx from the @file node in the derived file."""
     pat = re.compile(r'^#@\+node:(.*): \*+ @file (.+)$')
     for line in g.splitLines(file_s):
-        m = pat.match(line)
-        if m:
+        if m := pat.match(line):
             gnx, path2 = m.group(1), m.group(2)
             path2 = path2.replace('\\', '/')
             p.v.fileIndex = gnx

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1298,8 +1298,7 @@ class LeoLog:
             if not line.strip():
                 return None, None, None
             for filename_i, line_number_i, pattern in self.link_table:
-                m = pattern.match(line)
-                if m:
+                if m := pattern.match(line):
                     return m, filename_i, line_number_i
             return None, None, None
         #@+node:ekr.20220412084258.1: *5* function: find_at_file_node

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1502,8 +1502,7 @@ class OptionsUtils:
         option_pattern = re.compile(r'\s*(-\w)?,?\s*(--[\w-]+=?)')
         valid = ['-?']
         for line in g.splitLines(self.usage):
-            m = option_pattern.match(line)
-            if m:
+            if m := option_pattern.match(line):
                 if m.group(1):
                     valid.append(m.group(1))
                 if m.group(2):
@@ -1520,8 +1519,7 @@ class OptionsUtils:
         prefix = regex.split('=')[0]
         for arg in sys.argv:
             if arg.split('=')[0] == prefix:
-                m = re.match(regex, arg)
-                if m:
+                if m := re.match(regex, arg):
                     return m
                 self.option_error(arg, 'Missing or erroneous value')
         return None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2735,8 +2735,7 @@ def inAtNosearch(p: Position) -> bool:
 #@+node:ekr.20131230090121.16528: *3* g.isDirective
 def isDirective(s: str) -> bool:
     """Return True if s starts with a directive."""
-    m = g_is_directive_pattern.match(s)
-    if m:
+    if m := g_is_directive_pattern.match(s):
         s2 = s[m.end(1) :]
         if s2 and s2[0] in ".(":
             return False
@@ -3888,8 +3887,7 @@ def is_special(s: str, directive: str) -> tuple[bool, int]:
     lws = directive in ("@others", "@all")
     pattern_s = r'^\s*(%s\b)' if lws else r'^(%s\b)'
     pattern = re.compile(pattern_s % directive, re.MULTILINE)
-    m = re.search(pattern, s)
-    if m:
+    if m := re.search(pattern, s):
         return True, m.start(1)
     return False, -1
 #@+node:ekr.20031218072017.3177: *4* g.is_c_id
@@ -6542,8 +6540,7 @@ def extractExecutableString(c: Cmdr, p: Position, s: str) -> str:
     # Scan the lines, extracting only the valid lines.
     extracting, result = False, []
     for line in g.splitLines(s):
-        m = re.match(pattern, line)
-        if m:
+        if m := re.match(pattern, line):
             extracting = m.group(1) == language
         elif extracting:
             result.append(line)
@@ -6818,8 +6815,7 @@ def findGnx(gnx: str, c: Cmdr) -> Optional[Position]:
     """
     # Get the actual gnx and line number.
     n: int = 0  # The line number.
-    m = find_gnx_pat.match(gnx)
-    if m:
+    if m := find_gnx_pat.match(gnx):
         # Get the actual gnx and line number.
         gnx = m.group(1)
         try:
@@ -6915,8 +6911,7 @@ def findUnl(unlList1: list[str], c: Cmdr) -> Optional[Position]:
                 assert p == p1, (p, p1)
                 n = 0  # The default line number.
                 # Parse the last target.
-                m = new_pat.match(unlList[-1])
-                if m:
+                if m := new_pat.match(unlList[-1]):
                     line = m.group(3)
                     try:
                         n = int(line)
@@ -7331,8 +7326,7 @@ def parsePathData(c: Cmdr) -> dict[str, str]:
     lines = c.config.getData('unl-path-prefixes')
     d: dict[str, str] = {}
     for line in lines:
-        m = path_data_pattern.match(line)
-        if m:
+        if m := path_data_pattern.match(line):
             key, path = m.group(1), m.group(2)
             if key in d:
                 g.trace(f"Ignoring duplicate key: {line!r}")  # pragma: no cover

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1728,8 +1728,7 @@ class RecursiveImportController:
         outline_dir = norm(self.outline_directory.replace('\\', '/'))
         len_outline_dir = len(outline_dir)
 
-        m = self.file_pattern.match(p.h)
-        if m:
+        if m := self.file_pattern.match(p.h):
             # p is an @file node of some kind.
             kind = m.group(0)
             path = p.h[len(kind) :].strip()

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -782,8 +782,7 @@ class AutoCompleterClass:
         aList = prefix.split('.')
         if len(aList) > 1:
             name = aList[0]
-            m = sys.modules.get(name)
-            if m:
+            if m := sys.modules.get(name):
                 d[name] = m
         return d
     #@+node:ekr.20110512170111.14472: *4* ac.get_object

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -588,8 +588,7 @@ class AutoCompleterClass:
     def get_codewise_completions(self, prefix: str) -> list[str]:
         """Use codewise to generate a list of hits."""
         c = self.c
-        m = re.match(r"(\S+(\.\w+)*)\.(\w*)$", prefix)
-        if m:
+        if m := re.match(r"(\S+(\.\w+)*)\.(\w*)$", prefix):
             varname = m.group(1)
             ivar = m.group(3)
             kind, aList = self.guess_class(c, varname)
@@ -648,8 +647,7 @@ class AutoCompleterClass:
             # Return the nearest enclosing class.
             for p in c.p.parents():
                 h = p.h
-                m = re.search(r'class\s+(\w+)', h)
-                if m:
+                if m := re.search(r'class\s+(\w+)', h):
                     return 'class', [m.group(1)]
         # This is not needed now that we add the completions for 'self'.
             # aList = ContextSniffer().get_classes(c.p.b, varname)

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -305,8 +305,7 @@ class MarkupCommands:
         kind = self.kind
         h = p.h.rstrip()
         if kind == 'adoc':
-            m = self.adoc_pattern.match(h)
-            if m:
+            if m := self.adoc_pattern.match(h):
                 prefix = m.group(1)
                 return h[1 + len(prefix) :].strip()
             return None

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -382,9 +382,10 @@ class RstCommands:
         i = s.find('<title></title>')
         if i == -1:
             return s
-        m = re.search(r'<h1>([^<]*)</h1>', s)
-        if not m:
-            m = re.search(r'<h1><[^>]+>([^<]*)</a></h1>', s)
+        m = (
+            re.search(r'<h1>([^<]*)</h1>', s) or
+            re.search(r'<h1><[^>]+>([^<]*)</a></h1>', s)
+        )
         if m:
             s = s.replace('<title></title>',
                 f"<title>{m.group(1)}</title>")

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -164,8 +164,7 @@ def session_snapshot_load_command(event: Event) -> None:
 @g.command('session-snapshot-save')
 def session_snapshot_save_command(event: Event) -> None:
     """Save a snapshot of the present session to the leo.session file."""
-    m = g.app.sessionManager
-    if m:
+    if m := g.app.sessionManager:
         m.save_snapshot()
 #@-others
 #@@language python

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -117,8 +117,7 @@ def import_from_string(self, parent: Position, s: str) -> None:
     lines_dict: dict[VNode, list[str]] = {root.v: []}
     parents: list[Position] = [root]
     for line in g.splitLines(s):
-        m = header_pat.match(line)
-        if m:
+        if m := header_pat.match(line):
             level = len(m.group(1)) - 2
             assert level >= 1, m.group(1)
             parents = parents[:level]

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -867,8 +867,7 @@ def trace(*args: Any, **keys: Any) -> None:
 def method_name(f: Callable) -> str:
     """Print a method name is a simplified format."""
     pattern = r'<bound method ([\w\.]*\.)?(\w+) of <([\w\.]*\.)?(\w+) object at (.+)>>'
-    m = re.match(pattern, repr(f))
-    if m:
+    if m := re.match(pattern, repr(f)):
         # Shows actual method: very useful
         return '%20s%s' % (m.group(1), m.group(2))
     return repr(f)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -246,8 +246,7 @@ class Importer:
             i += 1
             # Assume that no pattern matches a compound statement.
             for kind, pattern in self.block_patterns:
-                m = pattern.match(s)
-                if m:
+                if m := pattern.match(s):
                     # cython may include trailing whitespace.
                     name = m.group(1).strip()
                     end = self.find_end_of_block(i, i2)

--- a/leo/plugins/importers/lua.py
+++ b/leo/plugins/importers/lua.py
@@ -43,13 +43,11 @@ class Lua_Importer(Importer):
             line = self.guide_lines[i]
             i += 1
             for (kind, pat) in self.block_patterns:
-                m1 = pat.match(line)
-                if m1:
+                if pat.match(line):
                     level += 1
                     break
             else:
-                m2 = self.end_pat.match(line)
-                if m2:
+                if self.end_pat.match(line):
                     level -= 1
                     if level == 0:
                         return i

--- a/leo/plugins/importers/markdown.py
+++ b/leo/plugins/importers/markdown.py
@@ -68,8 +68,7 @@ class Markdown_Importer(Importer):
         Return level, name if line is a hash section line.
         else return None, None.
         """
-        m = self.md_hash_pattern.match(line)
-        if m:
+        if m := self.md_hash_pattern.match(line):
             level = len(m.group(1))
             name = m.group(2).strip()
             if name:

--- a/leo/plugins/importers/org.py
+++ b/leo/plugins/importers/org.py
@@ -39,8 +39,7 @@ class Org_Importer(Importer):
         while i < len(lines):
             line = lines[i]
             i += 1
-            m = self.section_pat.match(line)
-            if m:
+            if m := self.section_pat.match(line):
                 level = len(m.group(1))
                 headline = m.group(2)  # Don't strip.
                 # Cut back the stack.

--- a/leo/plugins/importers/otl.py
+++ b/leo/plugins/importers/otl.py
@@ -54,13 +54,11 @@ class Otl_Importer(Importer):
         for line in lines:
             if not line.strip():
                 continue  # New.
-            m = self.otl_body_pattern.match(line)
-            if m:
+            if m := self.otl_body_pattern.match(line):
                 top = parents[-1]
                 lines_dict[top.v].append(m.group(1) + '\n')
                 continue
-            m = self.otl_node_pattern.match(line)
-            if m:
+            if m := self.otl_node_pattern.match(line):
                 # Cut back the stack, then allocate a new node.
                 level = 1 + len(m.group(1))
                 parents = parents[:level]

--- a/leo/plugins/importers/perl.py
+++ b/leo/plugins/importers/perl.py
@@ -38,8 +38,7 @@ class Perl_Importer(Importer):
         """Remove regexes."""
         result = []
         for line in lines:
-            m = self.regex_pat.match(line)
-            if m:
+            if m := self.regex_pat.match(line):
                 result.append(line[: len(m.group(0))])
             else:
                 result.append(line)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -222,8 +222,7 @@ class Python_Importer(Importer):
                     for ancestor in child.parents():
                         if ancestor == parent:
                             break
-                        m = self.class_pat.match(ancestor.h)
-                        if m:
+                        if m := self.class_pat.match(ancestor.h):
                             found = True
                             # Replace 'def ' by the class name + '.'
                             child.h = f"{m.group(1)}.{child.h[4:].strip()}"

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -120,8 +120,7 @@ class Python_Importer(Importer):
             s = self.guide_lines[i]
             i += 1
             for kind, pattern in self.block_patterns:
-                m = pattern.match(s)
-                if m:
+                if m := pattern.match(s):
                     # cython may include trailing whitespace.
                     name = m.group(1).strip()
                     end = self.find_end_of_block(i, i2)

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -342,8 +342,7 @@ class Rust_Importer(Importer):
             # Assume that no pattern matches a compound statement.
             for kind, pattern in self.block_patterns:
                 assert i == progress + 1, (i, progress)
-                m = pattern.match(line)
-                if m:
+                if m := pattern.match(line):
                     i = find_curly_bracket_line(i - 1)  # Rescan the line.
                     if i is None:
                         i = progress + 1

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -69,8 +69,7 @@ class Xml_Importer(Importer):
         tag1: str = None
         line = self.guide_lines[i1 - 1]
         for pattern in self.start_patterns:
-            m = pattern.match(line)
-            if m:
+            if m := pattern.match(line):
                 tag1 = m.group(1).lower()
                 tag_stack.append(tag1)
                 break
@@ -82,14 +81,12 @@ class Xml_Importer(Importer):
             i += 1
             # Push start patterns.
             for pattern in self.start_patterns:
-                m = pattern.match(line)
-                if m:
+                if m := pattern.match(line):
                     tag = m.group(1).lower()
                     tag_stack.append(tag)
                     break
             for pattern in self.end_patterns:
-                m = pattern.match(line)
-                if m:
+                if m := pattern.match(line):
                     end_tag = m.group(1).lower()
                     while tag_stack:
                         tag = tag_stack.pop()

--- a/leo/plugins/leocursor.py
+++ b/leo/plugins/leocursor.py
@@ -76,8 +76,7 @@ class AM_Colon(AttribManager):
             m = self.pattern.match(i)
 
             if m and m.group(1) == what:
-                m = m.group(3)
-                if m:
+                if m := m.group(3):
                     m = m.strip()
                 else:
                     # don't return None
@@ -89,8 +88,7 @@ class AM_Colon(AttribManager):
     def keys(self, v):
         ans = []
         for i in v.b.split('\n'):
-            m = self.pattern.match(i)
-            if m:
+            if m := self.pattern.match(i):
                 ans.append(m.group(1))
         return ans
 

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -232,8 +232,7 @@ def universal_line_numbers(root, target_p, delim_st, delim_en):
                 flines_data[pkey(p1)] = tuple(flines), n
             return 1, n - st
         #@+node:vitalije.20170726193920.1: *4* section reference
-        m = section_pat.match(line)
-        if m:
+        if m := section_pat.match(line):
             p1 = g.findReference(m.group(2), p)
             if not p1:
                 g.warning('unresolved section reference %s' % m.group(2))

--- a/leo/plugins/line_numbering.py
+++ b/leo/plugins/line_numbering.py
@@ -205,8 +205,7 @@ def universal_line_numbers(root, target_p, delim_st, delim_en):
         if is_verbatim(line):
             return 1, 2
         #@+node:vitalije.20170726193927.1: *4* others
-        m = others_pat.match(line)
-        if m:
+        if m := others_pat.match(line):
             n = inc(st)
             for p1 in others_iterator(p):
                 n = numerate_node(p1, n)

--- a/leo/plugins/md_docer.py
+++ b/leo/plugins/md_docer.py
@@ -59,8 +59,7 @@ def md_write_files(event):
             yield hl(v, lev)
             yield ''
         for line in v.b.splitlines(False):
-            m = pat.match(line)
-            if m:
+            if m := pat.match(line):
                 v1 = c.fileCommands.gnxDict.get(m.group(2))
                 if not v1:
                     g.es('gnx not found:[%s]' % m.group(2))

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -493,8 +493,7 @@ class ScriptingController:
                 p.moveToThreadNext()
             else:
                 self.seen.add(gnx)
-                m = pattern.match(p.h)
-                if m:
+                if m := pattern.match(p.h):
                     func = d.get(m.group(1))
                     func(p)
                 p.moveToThreadNext()

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -345,8 +345,7 @@ class LeoQtTree(leoFrame.LeoTree):
             new_icons = []
             modifiers_and_args = []
             for pattern, cmds in self.get_declutter_patterns():
-                m = pattern.match(text) or pattern.search(text)
-                if m:
+                if m := pattern.match(text) or pattern.search(text):
                     modifiers_and_args.extend(apply_declutter_rules(cmds))
             # Save the lists of the icons and the adjusting operations.
             dd[(v.h, iconVal)] = new_icons, modifiers_and_args

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2691,8 +2691,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             """
             sections = {}
             for i, line in enumerate(pagelines):
-                m = SECTION_RE.match(line)
-                if m:
+                if m := SECTION_RE.match(line):
                     sections[m[1]] = i
             return sections
         #@+node:tom.20211104105903.8: *6* set custom_style()


### PR DESCRIPTION
See #3712. The regex cff `m = (.*?)\n *if m:` finds 90 nodes.

Replacing each match with `if m := \1:` converts the code to `:=` operator: