### PR TITLE
PR for #3718: Remove CommanderCacher class and related code

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -105,8 +105,10 @@ def restartLeo(self: Self, event: Event = None) -> None:
         frame = c.frame
         # This is similar to g.app.closeLeoWindow.
         g.doHook("close-frame", c=c)
+
+        ### g.app.commander_cacher.commit()  # store cache, but don't close it.
+
         # Save the window state
-        g.app.commander_cacher.commit()  # store cache, but don't close it.
         # This may remove frame from the window list.
         if frame in g.app.windowList:
             g.app.destroyWindow(frame)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -105,9 +105,6 @@ def restartLeo(self: Self, event: Event = None) -> None:
         frame = c.frame
         # This is similar to g.app.closeLeoWindow.
         g.doHook("close-frame", c=c)
-
-        ### g.app.commander_cacher.commit()  # store cache, but don't close it.
-
         # Save the window state
         # This may remove frame from the window list.
         if frame in g.app.windowList:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -427,13 +427,11 @@ class EditCommandsClass(BaseEditCommandsClass):
     def clearAllCaches(self, event: Event = None) -> None:  # pragma: no cover
         """Clear all of Leo's file caches."""
         g.app.global_cacher.clear()
-        ### g.app.commander_cacher.clear()
 
     @cmd('dump-caches')
     def dumpCaches(self, event: Event = None) -> None:  # pragma: no cover
         """Dump, all of Leo's file caches."""
         g.app.global_cacher.dump()
-        ### g.app.commander_cacher.dump()
     #@+node:ekr.20150514063305.118: *3* ec.doNothing
     @cmd('do-nothing')
     def doNothing(self, event: Event) -> None:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -427,13 +427,13 @@ class EditCommandsClass(BaseEditCommandsClass):
     def clearAllCaches(self, event: Event = None) -> None:  # pragma: no cover
         """Clear all of Leo's file caches."""
         g.app.global_cacher.clear()
-        g.app.commander_cacher.clear()
+        ### g.app.commander_cacher.clear()
 
     @cmd('dump-caches')
     def dumpCaches(self, event: Event = None) -> None:  # pragma: no cover
         """Dump, all of Leo's file caches."""
         g.app.global_cacher.dump()
-        g.app.commander_cacher.dump()
+        ### g.app.commander_cacher.dump()
     #@+node:ekr.20150514063305.118: *3* ec.doNothing
     @cmd('do-nothing')
     def doNothing(self, event: Event) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -24,7 +24,7 @@ StringIO = io.StringIO
 #@+node:ekr.20220819191617.1: ** << leoApp annotations >>
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoBackground import BackgroundProcessManager
-    from leo.core.leoCache import CommanderCacher, GlobalCacher
+    from leo.core.leoCache import GlobalCacher  ### CommanderCacher,
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoConfig import GlobalConfigManager
     from leo.core.leoExternalFiles import ExternalFilesController
@@ -182,8 +182,8 @@ class LeoApp:
         #@+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
         # Singleton applications objects...
         self.backgroundProcessManager: BackgroundProcessManager = None  # A BackgroundProcessManager.
-        self.commander_cacher: CommanderCacher = None
-        self.commander_db: GlobalCacher = None  # Managed by g.app.commander_cacher.
+        ### self.commander_cacher: CommanderCacher = None
+        ### self.commander_db: GlobalCacher = None  # Managed by g.app.commander_cacher.
         self.config: GlobalConfigManager = None  # g.app.config.
         self.db: GlobalCacher = None  # A global db, managed by g.app.global_cacher.
         self.externalFilesController: ExternalFilesController = None
@@ -1034,8 +1034,8 @@ class LeoApp:
         from leo.core import leoCache
         g.app.global_cacher = leoCache.GlobalCacher()
         g.app.db = g.app.global_cacher.db
-        g.app.commander_cacher = leoCache.CommanderCacher()
-        g.app.commander_db = g.app.commander_cacher.db
+        ### g.app.commander_cacher = leoCache.CommanderCacher()
+        ### g.app.commander_db = g.app.commander_cacher.db
     #@+node:ekr.20031218072017.1978: *4* app.setLeoID & helpers
     def setLeoID(self, useDialog: bool = True, verbose: bool = True) -> str:
         """Get g.app.leoID from various sources."""
@@ -1257,9 +1257,10 @@ class LeoApp:
                 return False
         g.app.setLog(None)  # no log until we reactive a window.
         g.doHook("close-frame", c=c)
-        #
+
+        ###g.app.commander_cacher.commit()  # store cache, but don't close it.
+
         # Save the window state for *all* open files.
-        g.app.commander_cacher.commit()  # store cache, but don't close it.
         # This may remove frame from the window list.
         if frame in g.app.windowList:
             g.app.destroyWindow(frame)
@@ -1304,9 +1305,11 @@ class LeoApp:
             g.doHook("end1")
             if g.app.global_cacher:  # #1766.
                 g.app.global_cacher.commit_and_close()
-            if g.app.commander_cacher:  # #1766.
-                g.app.commander_cacher.commit()
-                g.app.commander_cacher.close()
+            ###
+            # if g.app.commander_cacher:  # #1766.
+                # g.app.commander_cacher.commit()
+                # g.app.commander_cacher.close()
+
         if g.app.ipk:
             g.app.ipk.cleanup_consoles()
         g.app.destroyAllOpenWithFiles()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -24,7 +24,7 @@ StringIO = io.StringIO
 #@+node:ekr.20220819191617.1: ** << leoApp annotations >>
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoBackground import BackgroundProcessManager
-    from leo.core.leoCache import GlobalCacher  ### CommanderCacher,
+    from leo.core.leoCache import GlobalCacher
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoConfig import GlobalConfigManager
     from leo.core.leoExternalFiles import ExternalFilesController
@@ -182,8 +182,6 @@ class LeoApp:
         #@+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
         # Singleton applications objects...
         self.backgroundProcessManager: BackgroundProcessManager = None  # A BackgroundProcessManager.
-        ### self.commander_cacher: CommanderCacher = None
-        ### self.commander_db: GlobalCacher = None  # Managed by g.app.commander_cacher.
         self.config: GlobalConfigManager = None  # g.app.config.
         self.db: GlobalCacher = None  # A global db, managed by g.app.global_cacher.
         self.externalFilesController: ExternalFilesController = None
@@ -1030,12 +1028,9 @@ class LeoApp:
             g.app.db['hello'] = [1,2,5]
 
         """
-        # Fixes bug 670108.
         from leo.core import leoCache
         g.app.global_cacher = leoCache.GlobalCacher()
         g.app.db = g.app.global_cacher.db
-        ### g.app.commander_cacher = leoCache.CommanderCacher()
-        ### g.app.commander_db = g.app.commander_cacher.db
     #@+node:ekr.20031218072017.1978: *4* app.setLeoID & helpers
     def setLeoID(self, useDialog: bool = True, verbose: bool = True) -> str:
         """Get g.app.leoID from various sources."""
@@ -1257,9 +1252,6 @@ class LeoApp:
                 return False
         g.app.setLog(None)  # no log until we reactive a window.
         g.doHook("close-frame", c=c)
-
-        ###g.app.commander_cacher.commit()  # store cache, but don't close it.
-
         # Save the window state for *all* open files.
         # This may remove frame from the window list.
         if frame in g.app.windowList:
@@ -1305,17 +1297,14 @@ class LeoApp:
             g.doHook("end1")
             if g.app.global_cacher:  # #1766.
                 g.app.global_cacher.commit_and_close()
-            ###
-            # if g.app.commander_cacher:  # #1766.
-                # g.app.commander_cacher.commit()
-                # g.app.commander_cacher.close()
-
         if g.app.ipk:
             g.app.ipk.cleanup_consoles()
         g.app.destroyAllOpenWithFiles()
-        if hasattr(g.app, 'pyzo_close_handler'):
-            # pylint: disable=no-member
-            g.app.pyzo_close_handler()
+        ###
+            # if hasattr(g.app, 'pyzo_close_handler'):
+                # # pylint: disable=no-member
+                # g.app.pyzo_close_handler()
+
         # Disable all further hooks and events.
         # Alas, "idle" events can still be called
         # even after the following code.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1300,10 +1300,6 @@ class LeoApp:
         if g.app.ipk:
             g.app.ipk.cleanup_consoles()
         g.app.destroyAllOpenWithFiles()
-        ###
-            # if hasattr(g.app, 'pyzo_close_handler'):
-                # # pylint: disable=no-member
-                # g.app.pyzo_close_handler()
 
         # Disable all further hooks and events.
         # Alas, "idle" events can still be called

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -174,7 +174,7 @@ class BridgeController:
             g.app.setGlobalDb()  # #556.
         else:
             g.app.db = g.NullObject()
-            g.app.commander_cacher = g.NullObject()
+            ### g.app.commander_cacher = g.NullObject()
             g.app.global_cacher = g.NullObject()
         if self.readSettings:
             # reads only standard settings files, using a null gui.
@@ -321,8 +321,8 @@ class BridgeController:
         except Exception:
             g.app.global_cacher = leoCache.GlobalCacher()
             g.app.db = g.app.global_cacher.db
-            g.app.commander_cacher = leoCache.CommanderCacher()
-            g.app.commander_db = g.app.commander_cacher.db
+            ### g.app.commander_cacher = leoCache.CommanderCacher()
+            ### g.app.commander_db = g.app.commander_cacher.db
     #@-others
 #@-others
 #@-leo

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -174,7 +174,6 @@ class BridgeController:
             g.app.setGlobalDb()  # #556.
         else:
             g.app.db = g.NullObject()
-            ### g.app.commander_cacher = g.NullObject()
             g.app.global_cacher = g.NullObject()
         if self.readSettings:
             # reads only standard settings files, using a null gui.
@@ -321,8 +320,6 @@ class BridgeController:
         except Exception:
             g.app.global_cacher = leoCache.GlobalCacher()
             g.app.db = g.app.global_cacher.db
-            ### g.app.commander_cacher = leoCache.CommanderCacher()
-            ### g.app.commander_db = g.app.commander_cacher.db
     #@-others
 #@-others
 #@-leo

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -100,13 +100,13 @@ class GlobalCacher:
         if 'cache' in g.app.debug:
             g.trace('clear g.app.db')
         try:
-            self.db.clear()
+            self.db.clear()  # SqlitePickleShare.clear.
         except TypeError:
-            self.db = {}
+            self.db = {}  # self.db was a dict.
         except Exception:
             g.trace('unexpected exception')
             g.es_exception()
-            self.db = {}  # type:ignore
+            self.db = {}
     #@+node:ekr.20180627042948.1: *3* g_cacher.commit_and_close()
     def commit_and_close(self) -> None:
         # Careful: self.db may be a dict.
@@ -273,9 +273,12 @@ class SqlitePickleShare:
         return fnmatch.fnmatch(basename(s), pattern)
     #@+node:vitalije.20170716201700.15: *3* clear (SqlitePickleShare)
     def clear(self) -> None:
-        # Deletes all files in the fcache subdirectory.
-        # It would be more thorough to delete everything
-        # below the root directory, but it's not necessary.
+        """
+        Deletes all files in the fcache subdirectory.
+        
+        It would be more thorough to delete everything
+        below the root directory, but it's not necessary.
+        """
         self.conn.execute('delete from cachevalues;')
     #@+node:vitalije.20170716201700.16: *3* get  (SqlitePickleShare)
     def get(self, key: str, default: Any = None) -> Any:

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -68,7 +68,7 @@ class CommanderWrapper:
 #@+node:ekr.20180627041556.1: ** class GlobalCacher (g.app.db)
 class GlobalCacher:
     """
-    A calss creating a singleton global database, g.app.db.
+    A class creating a singleton global database, g.app.db.
     
     This DB resides in ~/.leo/db.
     

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -29,97 +29,17 @@ join = g.os_path_join
 normcase = g.os_path_normcase
 split = g.os_path_split
 #@+others
-#@+node:ekr.20100208062523.5885: ** class CommanderCacher
-class CommanderCacher:
-    """A class to manage per-commander caches."""
-
-    def __init__(self) -> None:
-        self.db: Any
-        try:
-            path = join(g.app.homeLeoDir, 'db', 'global_data')
-            self.db = SqlitePickleShare(path)
-        except Exception:
-            self.db = {}  # type:ignore
-    #@+others
-    #@+node:ekr.20100209160132.5759: *3* cacher.clear
-    def clear(self) -> None:
-        """Clear the cache for all commanders."""
-        # Careful: self.db may be a Python dict.
-        try:
-            self.db.clear()
-        except Exception:
-            g.trace('unexpected exception')
-            g.es_exception()
-            self.db = {}  # type:ignore
-    #@+node:ekr.20180627062431.1: *3* cacher.close
-    def close(self) -> None:
-        # Careful: self.db may be a dict.
-        if hasattr(self.db, 'conn'):
-            # pylint: disable=no-member
-            self.db.conn.commit()
-            self.db.conn.close()
-    #@+node:ekr.20180627042809.1: *3* cacher.commit
-    def commit(self) -> None:
-        # Careful: self.db may be a dict.
-        if hasattr(self.db, 'conn'):
-            # pylint: disable=no-member
-            self.db.conn.commit()
-    #@+node:ekr.20180611054447.1: *3* cacher.dump
-    def dump(self) -> None:
-        """Dump the indicated cache if --trace-cache is in effect."""
-        dump_cache(g.app.commander_db, tag='Commander Cache')
-    #@+node:ekr.20180627053508.1: *3* cacher.get_wrapper
-    def get_wrapper(self, c: Cmdr, fn: str = None) -> "CommanderWrapper":
-        """Return a new wrapper for c."""
-        return CommanderWrapper(c, fn=fn)
-    #@+node:ekr.20100208065621.5890: *3* cacher.test
-    def test(self) -> bool:
-
-        # pylint: disable=no-member
-        if g.app.gui.guiName() == 'nullGui':
-            # Null gui's don't normally set the g.app.gui.db.
-            g.app.setGlobalDb()
-        # Fixes bug 670108.
-        assert g.app.db is not None
-        # Make sure g.guessExternalEditor works.
-        g.app.db.get("LEO_EDITOR")
-        # self.initFileDB('~/testpickleshare')
-        db = self.db
-        db.clear()
-        assert not list(db.items())
-        db['hello'] = 15
-        db['aku ankka'] = [1, 2, 313]
-        db['paths/nest/ok/keyname'] = [1, (5, 46)]
-        db.uncache()  # frees memory, causes re-reads later
-        # print(db.keys())
-        db.clear()
-        return True
-    #@+node:ekr.20100210163813.5747: *3* cacher.save
-    def save(self, c: Cmdr, fn: str) -> None:
-        """
-        Save the per-commander cache.
-
-        Change the cache prefix if changeName is True.
-
-        save and save-as set changeName to True, save-to does not.
-        """
-        self.commit()
-        if fn:
-            # 1484: Change only the key!
-            if isinstance(c.db, CommanderWrapper):
-                c.db.key = fn
-                self.commit()
-            else:
-                g.trace('can not happen', c.db.__class__.__name__)
-    #@-others
 #@+node:ekr.20180627052459.1: ** class CommanderWrapper
 class CommanderWrapper:
     """A class to distinguish keys from separate commanders."""
 
-    def __init__(self, c: Cmdr, fn: str = None) -> None:
+    ### def __init__(self, c: Cmdr, fn: str = None) -> None:
+    def __init__(self, c: Cmdr) -> None:
+        ###g.trace('(CommanderWrapper)', repr(fn))
         self.c = c
         self.db = g.app.db
-        self.key = fn or c.mFileName
+        ### self.key = fn or c.mFileName
+        self.key = c.mFileName
         self.user_keys: set[str] = set()
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -31,7 +31,12 @@ split = g.os_path_split
 #@+others
 #@+node:ekr.20180627052459.1: ** class CommanderWrapper (c.db)
 class CommanderWrapper:
-    """A class to distinguish keys from separate commanders."""
+    """
+    A class that creates distinct keys for all commanders, allowing
+    commanders to share g.app.db without collisions.
+    
+    Instances of this class are c.db.
+    """
 
     def __init__(self, c: Cmdr) -> None:
         self.c = c
@@ -62,7 +67,14 @@ class CommanderWrapper:
         self.db[f"{self.key}:::{key}"] = value
 #@+node:ekr.20180627041556.1: ** class GlobalCacher (g.app.db)
 class GlobalCacher:
-    """A singleton global cacher, g.app.db"""
+    """
+    A calss creating a singleton global database, g.app.db.
+    
+    This DB resides in ~/.leo/db.
+    
+    New in Leo 6.7.7: All instances of c.db may use g.app.db because the
+    CommanderWrapper class creates distinct keys for each commander.
+    """
 
     def __init__(self) -> None:
         """Ctor for the GlobalCacher class."""
@@ -116,7 +128,12 @@ _sentinel = object()
 
 
 class SqlitePickleShare:
-    """ The main 'connection' object for SqlitePickleShare database """
+    """
+    The main 'connection' object for SqlitePickleShare database.
+    
+    Opening this DB may fail. If so the GlobalCacher class uses a plain
+    Python dict instead.
+    """
     #@+others
     #@+node:vitalije.20170716201700.2: *3*  Birth & special methods
     def init_dbtables(self, conn: Any) -> None:

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -33,12 +33,9 @@ split = g.os_path_split
 class CommanderWrapper:
     """A class to distinguish keys from separate commanders."""
 
-    ### def __init__(self, c: Cmdr, fn: str = None) -> None:
     def __init__(self, c: Cmdr) -> None:
-        ###g.trace('(CommanderWrapper)', repr(fn))
         self.c = c
         self.db = g.app.db
-        ### self.key = fn or c.mFileName
         self.key = c.mFileName
         self.user_keys: set[str] = set()
 

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -29,7 +29,7 @@ join = g.os_path_join
 normcase = g.os_path_normcase
 split = g.os_path_split
 #@+others
-#@+node:ekr.20180627052459.1: ** class CommanderWrapper
+#@+node:ekr.20180627052459.1: ** class CommanderWrapper (c.db)
 class CommanderWrapper:
     """A class to distinguish keys from separate commanders."""
 
@@ -60,7 +60,7 @@ class CommanderWrapper:
     def __setitem__(self, key: str, value: Any) -> None:
         self.user_keys.add(key)
         self.db[f"{self.key}:::{key}"] = value
-#@+node:ekr.20180627041556.1: ** class GlobalCacher
+#@+node:ekr.20180627041556.1: ** class GlobalCacher (g.app.db)
 class GlobalCacher:
     """A singleton global cacher, g.app.db"""
 
@@ -90,7 +90,7 @@ class GlobalCacher:
         try:
             self.db.clear()
         except TypeError:
-            self.db.clear()
+            self.db = {}
         except Exception:
             g.trace('unexpected exception')
             g.es_exception()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -275,6 +275,7 @@ class Commands:
         from leo.core import leoAtFile
         from leo.core import leoBeautify  # So decorators are executed.
         assert leoBeautify  # for pyflakes.
+        from leo.core.leoCache import CommanderWrapper  ###
         from leo.core import leoChapters
         # User commands...
         from leo.commands import abbrevCommands
@@ -376,7 +377,11 @@ class Commands:
         # Other objects
         # A list of other classes that have a reloadSettings method
         c.configurables = c.subCommanders[:]
-        c.db = g.app.commander_cacher.get_wrapper(c)
+        
+        ###
+        ### c.db = g.app.commander_cacher.get_wrapper(c)
+        c.db = CommanderWrapper(c) ### , fn=fn)
+        
         # #2485: Load the free_layout plugin in the proper context.
         #        g.app.pluginsController.loadOnePlugin won't work here.
         try:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -275,7 +275,7 @@ class Commands:
         from leo.core import leoAtFile
         from leo.core import leoBeautify  # So decorators are executed.
         assert leoBeautify  # for pyflakes.
-        from leo.core.leoCache import CommanderWrapper  ###
+        from leo.core.leoCache import CommanderWrapper
         from leo.core import leoChapters
         # User commands...
         from leo.commands import abbrevCommands
@@ -374,13 +374,11 @@ class Commands:
             self.vimCommands,
             self.undoer,
         ]
+
         # Other objects
         # A list of other classes that have a reloadSettings method
         c.configurables = c.subCommanders[:]
-        
-        ###
-        ### c.db = g.app.commander_cacher.get_wrapper(c)
-        c.db = CommanderWrapper(c) ### , fn=fn)
+        c.db = CommanderWrapper(c)
         
         # #2485: Load the free_layout plugin in the proper context.
         #        g.app.pluginsController.loadOnePlugin won't work here.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1335,7 +1335,7 @@ class FileCommands:
         ok = g.doHook("save1", c=c, p=p, fileName=fileName)
         if ok is None:
             c.endEditing()  # Set the current headline text.
-            g.app.commander_cacher.save(c, fileName)
+            ### g.app.commander_cacher.save(c, fileName)
             ok = c.checkFileTimeStamp(fileName)
             if ok:
                 ok = self.write_Leo_file(fileName)
@@ -1355,7 +1355,9 @@ class FileCommands:
         p = c.p
         if not g.doHook("save1", c=c, p=p, fileName=fileName):
             c.endEditing()  # Set the current headline text.
-            g.app.commander_cacher.save(c, fileName)
+
+            ### g.app.commander_cacher.save(c, fileName)
+
             # Disable path-changed messages in writeAllHelper.
             try:
                 c.ignoreChangedPaths = True
@@ -1372,7 +1374,8 @@ class FileCommands:
         p = c.p
         if not g.doHook("save1", c=c, p=p, fileName=fileName):
             c.endEditing()  # Set the current headline text.
-            g.app.commander_cacher.commit()  # Commit, but don't save file name.
+
+            ### g.app.commander_cacher.commit()  # Commit, but don't save file name.
 
             # Disable path-changed messages in writeAllHelper.
             try:
@@ -1615,7 +1618,9 @@ class FileCommands:
             # Write bytes.
             f.write(bytes(json_s, self.leo_file_encoding, 'replace'))
             f.close()
-            g.app.commander_cacher.save(c, fileName)
+
+            ### g.app.commander_cacher.save(c, fileName)
+
             c.setFileTimeStamp(fileName)
             # Delete backup file.
             if backupName and g.os_path_exists(backupName):

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1335,7 +1335,6 @@ class FileCommands:
         ok = g.doHook("save1", c=c, p=p, fileName=fileName)
         if ok is None:
             c.endEditing()  # Set the current headline text.
-            ### g.app.commander_cacher.save(c, fileName)
             ok = c.checkFileTimeStamp(fileName)
             if ok:
                 ok = self.write_Leo_file(fileName)
@@ -1355,9 +1354,6 @@ class FileCommands:
         p = c.p
         if not g.doHook("save1", c=c, p=p, fileName=fileName):
             c.endEditing()  # Set the current headline text.
-
-            ### g.app.commander_cacher.save(c, fileName)
-
             # Disable path-changed messages in writeAllHelper.
             try:
                 c.ignoreChangedPaths = True
@@ -1374,9 +1370,6 @@ class FileCommands:
         p = c.p
         if not g.doHook("save1", c=c, p=p, fileName=fileName):
             c.endEditing()  # Set the current headline text.
-
-            ### g.app.commander_cacher.commit()  # Commit, but don't save file name.
-
             # Disable path-changed messages in writeAllHelper.
             try:
                 c.ignoreChangedPaths = True
@@ -1618,9 +1611,6 @@ class FileCommands:
             # Write bytes.
             f.write(bytes(json_s, self.leo_file_encoding, 'replace'))
             f.close()
-
-            ### g.app.commander_cacher.save(c, fileName)
-
             c.setFileTimeStamp(fileName)
             # Delete backup file.
             if backupName and g.os_path_exists(backupName):

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -64,7 +64,7 @@ def create_app(gui_name: str = 'null') -> Cmdr:
     # Disable dangerous code.
     g.app.db = g.NullObject('g.app.db')  # type:ignore
     g.app.pluginsController = g.NullObject('g.app.pluginsController')  # type:ignore
-    g.app.commander_cacher = g.NullObject('g.app.commander_cacher')  # type:ignore
+    ### g.app.commander_cacher = g.NullObject('g.app.commander_cacher')  # type:ignore
     if gui_name == 'null':
         g.app.gui = NullGui()
     elif gui_name == 'qt':

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -64,7 +64,6 @@ def create_app(gui_name: str = 'null') -> Cmdr:
     # Disable dangerous code.
     g.app.db = g.NullObject('g.app.db')  # type:ignore
     g.app.pluginsController = g.NullObject('g.app.pluginsController')  # type:ignore
-    ### g.app.commander_cacher = g.NullObject('g.app.commander_cacher')  # type:ignore
     if gui_name == 'null':
         g.app.gui = NullGui()
     elif gui_name == 'qt':


### PR DESCRIPTION
See #3718.

**Overview**

The following relationships *remain unchanged*:

- `g.app.db` is a singleton instance of the `GlobalCacher` class.
-  For each commander, `c.db` is an instance of the `CommanderWrapper` class.
   However, Leo creates `c.db` without using the (deleted) `CommanderCacher` class.

The `.leo/db` folder now contains only a `g_app_db` folder.
Leo no longer writes per-commander sub-folders in the  `.leo/db` folder!

**Details**

- [x] Delete the `CommanderCacher` class.
- [x] Instantiate per-commander `CommanderWrapper` instances in `c.initObjects`.
- [x] Remove all references to the `g.app.commander_cacher` and `g.app.commander_db` ivars.
- [x] Fix error recover code in `GlobalCacher.clear`.
- [x] Remove mypy suppression in `GlobalCacher.clear`.

**Extras**

- [x] Remove the never-used `fn` kwarg to `CommanderWrapper.__init__`.
- [x] `app.finishQuit` no longer calls `pyzo_close_handler`.


Later (in a separate PR) or never: `clear-all-caches` deletes entire contents of `./leo/db'.