### PR TITLE
PR for #3736: old-style unls do not work

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6794,8 +6794,8 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
             unl = unl[len(prefix) :]
             break
     else:
-        if not g.unitTesting:
-            print(f"Bad unl: {unl_s}")
+        # Unit tests suppress this output.
+        print(f"Bad unl: {unl_s}")
         return None
     file_part = g.getUNLFilePart(unl)
     c2 = g.openUNLFile(c, file_part)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6778,17 +6778,12 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
     """
     unl = unl_s
 
-    def oops() -> None:
-        if not g.unitTesting:
-            print(f"Bad unl: {unl_s}")
-
     if unl.startswith('unl:gnx:'):
         # Resolve a gnx-based unl.
         unl = unl[8:]
         file_part = g.getUNLFilePart(unl)
         c2 = g.openUNLFile(c, file_part)
         if file_part and not c2:
-            oops()
             return None
         c3 = c2 or c
         tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'
@@ -6799,12 +6794,12 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
             unl = unl[len(prefix) :]
             break
     else:
-        oops()
+        if not g.unitTesting:
+            print(f"Bad unl: {unl_s}")
         return None
     file_part = g.getUNLFilePart(unl)
     c2 = g.openUNLFile(c, file_part)
     if file_part and not c2:
-        oops()
         return None
     c3 = c2 or c
     tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7303,6 +7303,8 @@ def getUNLFilePart(s: str) -> str:
 def openUNLFile(c: Cmdr, s: str) -> Cmdr:
     """
     Open the commander for filename s, the file part of an unl.
+    
+    Use `@data unl-path-prefixes` to convert to relative to absolute paths.
 
     Return None if the file can not be found.
     """
@@ -7328,7 +7330,8 @@ def openUNLFile(c: Cmdr, s: str) -> Cmdr:
     if os.path.isabs(s):
         path = standard(s)
     else:
-        # Values of d should be directories.
+        # Use `@data unl-path-prefixes` to convert to relative to absolute paths.
+        # Keys are file names; values are directives.
         d = g.parsePathData(c)
         base_s = base(s)
         directory = d.get(base_s)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7183,8 +7183,8 @@ def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
                         if p.v.gnx == target:
                             c.selectPosition(p)
                             c.redraw()
-                            break
-                    return target
+                            return target
+                    return None
                 #@-<< look for gnx >>
     elif not isinstance(url, str):
         url = url.toString()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -7177,16 +7177,13 @@ def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
                         break
 
                 if target:
-                    found_gnx = False
                     if c.p.gnx == target:
                         return target
                     for p in c.all_unique_positions():
                         if p.v.gnx == target:
-                            found_gnx = True
+                            c.selectPosition(p)
+                            c.redraw()
                             break
-                    if found_gnx:
-                        c.selectPosition(p)
-                        c.redraw()
                     return target
                 #@-<< look for gnx >>
     elif not isinstance(url, str):

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6715,7 +6715,7 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #
 # 3. Leo's headline-based UNLs, as shown in the status pane:
 #
-#    Headline-based UNLs consist of `unl://` + `//{outline}#{headline_list}`
+#    Headline-based UNLs consist of `unl://` + `{outline}#{headline_list}`
 #    where headline_list is list of headlines separated by `-->`.
 #
 #    This link works: `unl://#Code-->About this file`.
@@ -6796,11 +6796,10 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
         return None
     file_part = g.getUNLFilePart(unl)
     c2 = g.openUNLFile(c, file_part)
-    if not c2:
-        return None
+    c3 = c2 or c
     tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'
     unlList = tail.split('-->')
-    return g.findUnl(unlList, c2)
+    return g.findUnl(unlList, c3)
 #@+node:ekr.20230624015529.1: *3* g.findGnx (new unls)
 find_gnx_pat = re.compile(r'^(.*)::([-\d]+)?$')
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6782,10 +6782,12 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
         unl = unl[8:]
         file_part = g.getUNLFilePart(unl)
         c2 = g.openUNLFile(c, file_part)
-        if not c2:
+        if file_part and not c2:
+            print(f"Bad unl: {unl_s}")
             return None
+        c3 = c2 or c
         tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'
-        return g.findGnx(tail, c2)
+        return g.findGnx(tail, c3)
     # Resolve a file-based unl.
     for prefix in ('unl:', 'file:'):
         if unl.startswith(prefix):
@@ -6796,6 +6798,9 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
         return None
     file_part = g.getUNLFilePart(unl)
     c2 = g.openUNLFile(c, file_part)
+    if file_part and not c2:
+        print(f"Bad unl: {unl_s}")
+        return None
     c3 = c2 or c
     tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'
     unlList = tail.split('-->')

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6777,13 +6777,18 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
     The UNL may be either a legacy (path-based) or new (gnx-based) unl.
     """
     unl = unl_s
+
+    def oops() -> None:
+        if not g.unitTesting:
+            print(f"Bad unl: {unl_s}")
+
     if unl.startswith('unl:gnx:'):
         # Resolve a gnx-based unl.
         unl = unl[8:]
         file_part = g.getUNLFilePart(unl)
         c2 = g.openUNLFile(c, file_part)
         if file_part and not c2:
-            print(f"Bad unl: {unl_s}")
+            oops()
             return None
         c3 = c2 or c
         tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'
@@ -6794,12 +6799,12 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
             unl = unl[len(prefix) :]
             break
     else:
-        print(f"Bad unl: {unl_s}")
+        oops()
         return None
     file_part = g.getUNLFilePart(unl)
     c2 = g.openUNLFile(c, file_part)
     if file_part and not c2:
-        print(f"Bad unl: {unl_s}")
+        oops()
         return None
     c3 = c2 or c
     tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -8,6 +8,7 @@
 <vnodes>
 <v t="ekr.20180311131353.1"><vh>test.leo: semi-official tests</vh></v>
 <v t="ekr.20230622114548.1"><vh>@settings</vh>
+<v t="ekr.20231231164138.1"><vh>@data unl-path-prefixes</vh></v>
 <v t="ekr.20230623064935.1"><vh>@data history-list</vh></v>
 <v t="ekr.20230622114556.1"><vh>@button copy-test</vh></v>
 <v t="ekr.20180311210803.1"><vh>Latex buttons</vh>
@@ -993,7 +994,8 @@ This is a comment</t>
 
 # Doesn't play, probably because of https.</t>
 <t tx="ekr.20230622112535.1"></t>
-<t tx="ekr.20230622112641.1"></t>
+<t tx="ekr.20230622112641.1"># Note: Modify @data unl-path-prefixes (in this file)
+# To match the paths on your machine.</t>
 <t tx="ekr.20230622112649.1"># These links will be active only if the @&lt;file&gt; node exists.
 
 # Absolute file names
@@ -1061,6 +1063,7 @@ unl:gnx://test.leo#ekr.20180311131424.1
 unl:gnx://test.leo#ekr.20230622112649.1
 
 # The following links depend on @data unl-path-prefixes.
+
 # These links should open LeoDocs.leo if it is not already open.
 
 # In LeoDocs.leo: Leo 6.7.3 release notes
@@ -1467,5 +1470,12 @@ unl:gnx://#ekr.20230409052507.1
 # In LeoDocs.leo: ** Read me first **
 unl:gnx://#ekr.20050831195449
 </t>
+<t tx="ekr.20231231164138.1"># These data work on EKR's machine.  Modify for your own!
+
+# lines have the form:
+# x.leo: &lt;absolute path to x.leo&gt;
+
+test.leo:    c:/Repos/leo-editor/leo/test
+LeoDocs.leo: c:/Repos/leo-editor/leo/doc</t>
 </tnodes>
 </leo_file>

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Created by Leo: https://leo-editor.github.io/leo-editor/leo_toc.html -->
-<leo_file xmlns:leo="http://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1" >
+<leo_file xmlns:leo="https://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1" >
 <leo_header file_format="2"/>
 <globals/>
 <preferences/>
@@ -55,16 +55,6 @@
 </v>
 <v t="ekr.20180311131424.1"><vh>Recent tests</vh>
 <v t="ekr.20180311131403.1"><vh>@jupyter</vh></v>
-<v t="ekr.20230622112641.1"><vh>--- tests of UNL</vh>
-<v t="ekr.20140723122936.18139"><vh>@file ../plugins/importers/__init__.py</vh></v>
-<v t="ekr.20230622112535.1"><vh>@clean ../plugins/leo_babel/__init__.py</vh></v>
-<v t="ekr.20230622112649.1"><vh>Error messages (copy to log)</vh></v>
-<v t="ekr.20230625084119.1"><vh>Legacy UNLs: in this file</vh></v>
-<v t="ekr.20230628090119.1"><vh>Legacy UNLs: other files</vh></v>
-<v t="ekr.20230623141357.1"><vh>URLs and UNLs: </vh></v>
-<v t="ekr.20230627150454.1"><vh>New UNLs with short file parts</vh></v>
-<v t="ekr.20230707065449.1"><vh>New UNLS with long(absolute) file parts</vh></v>
-</v>
 <v t="ekr.20180311212134.1"><vh>Coloring tests</vh>
 <v t="ekr.20180311131449.1"><vh>Syntax coloring template</vh></v>
 <v t="ekr.20180311212134.2"><vh>g.es test</vh></v>
@@ -98,6 +88,16 @@
 </v>
 <v t="ekr.20230906100141.24"><vh>script: asttokens</vh></v>
 <v t="ekr.20230906100141.25"><vh>QToolBar test</vh></v>
+</v>
+<v t="ekr.20230622112641.1"><vh>--- tests of UNL (do not delete!)</vh>
+<v t="ekr.20140723122936.18139"><vh>@file ../plugins/importers/__init__.py</vh></v>
+<v t="ekr.20230622112535.1"><vh>@clean ../plugins/leo_babel/__init__.py</vh></v>
+<v t="ekr.20230622112649.1"><vh>Error messages (copy to log)</vh></v>
+<v t="ekr.20230625084119.1"><vh>Legacy UNLs: in this file</vh></v>
+<v t="ekr.20230628090119.1"><vh>Legacy UNLs: other files</vh></v>
+<v t="ekr.20230623141357.1"><vh>URLs and UNLs: </vh></v>
+<v t="ekr.20230627150454.1"><vh>New UNLs with short file parts</vh></v>
+<v t="ekr.20230707065449.1"><vh>New UNLS with long(absolute) file parts</vh></v>
 </v>
 </vnodes>
 <tnodes>
@@ -1022,7 +1022,7 @@ convert-unls
 copy-test</t>
 <t tx="ekr.20230623141357.1">https://github.com/leo-editor/leo-editor/pull/3215/files
 
-# Exists: Recent
+# Exists: Recent tests.
 unl:gnx://#ekr.20180311131424.1
 
 # Error mssages (copy to log)
@@ -1050,7 +1050,7 @@ unl://#Viewrendered examples
 unl://C:/Repos/leo-editor/leo/test/test.leo#Viewrendered examples--&gt;Python code
 unl://#Viewrendered examples--&gt;Python code
 </t>
-<t tx="ekr.20230627150454.1"># Exists: Recent
+<t tx="ekr.20230627150454.1"># Exists: Recent tests
 unl:gnx://test.leo#ekr.20180311131424.1
 unl:gnx://#ekr.20180311131424.1
 
@@ -1079,7 +1079,7 @@ unl://LeoDocs.leo#Web pages
 <t tx="ekr.20230707065449.1"># These unls will work only on EKR's machine.
 # They are a test of absolute matches in g.openUNLFile.
 
-# Exists: Recent
+# Exists: Recent tests
 unl:gnx://c:\Repos\leo-editor\leo\test\test.leo#ekr.20180311131424.1
 
 # Error mssages (copy to log)

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -96,6 +96,7 @@
 <v t="ekr.20230625084119.1"><vh>Legacy UNLs: in this file</vh></v>
 <v t="ekr.20230628090119.1"><vh>Legacy UNLs: other files</vh></v>
 <v t="ekr.20230623141357.1"><vh>URLs and UNLs: </vh></v>
+<v t="ekr.20231231043342.1"><vh>New UNLs with empty file parts</vh></v>
 <v t="ekr.20230627150454.1"><vh>New UNLs with short file parts</vh></v>
 <v t="ekr.20230707065449.1"><vh>New UNLS with long(absolute) file parts</vh></v>
 </v>
@@ -1031,6 +1032,9 @@ unl:gnx://#ekr.20230622112649.1
 # Bad gnx
 unl:gnx://xyzzy.leo#.20230622112649.1
 
+# In LeoDocs.leo: will work only if LeoDocs.leo is open!
+unl:gnx://#ekr.20100805171546.4412
+
 </t>
 <t tx="ekr.20230625084119.1"># Shorter UNL:
 unl://#Coloring tests--&gt;Syntax coloring template
@@ -1052,13 +1056,12 @@ unl://#Viewrendered examples--&gt;Python code
 </t>
 <t tx="ekr.20230627150454.1"># Exists: Recent tests
 unl:gnx://test.leo#ekr.20180311131424.1
-unl:gnx://#ekr.20180311131424.1
 
 # Error mssages (copy to log)
 unl:gnx://test.leo#ekr.20230622112649.1
-unl:gnx://#ekr.20230622112649.1
 
-# These links depend on @data unl-path-prefixes.
+# The following links depend on @data unl-path-prefixes.
+# These links should open LeoDocs.leo if it is not already open.
 
 # In LeoDocs.leo: Leo 6.7.3 release notes
 unl:gnx://LeoDocs.leo#ekr.20230409052507.1
@@ -1068,13 +1071,15 @@ unl:gnx://LeoDocs.leo#ekr.20050831195449
 
 # Bad gnx: xyzzy.leo does not exist.
 unl:gnx://xyzzy.leo#.20230622112649.1</t>
-<t tx="ekr.20230628090119.1"># These links will work only if *your* @data unl-path-prefixes setting
-# contains the proper paths to the viles on your machine.
+<t tx="ekr.20230628090119.1"># The following links depend on @data unl-path-prefixes.
 
 unl://LeoDocs.leo#Release Notes--&gt;Leo 6.7.3 release notes
 
 # In LeoDocs.leo
 unl://LeoDocs.leo#Web pages
+
+# In LeoDocs.leo. Will work only if LeoDocs.leo is open!
+unl://#Web pages
 </t>
 <t tx="ekr.20230707065449.1"># These unls will work only on EKR's machine.
 # They are a test of absolute matches in g.openUNLFile.
@@ -1087,6 +1092,8 @@ unl:gnx://c:\Repos\leo-editor\leo\test\test.leo#ekr.20230622112649.1
 
 # Should fail
 unl:gnx://c:\Repos\leo-editor\leo\doc\test.leo#ekr.20230622112649.1
+
+# The following links should open LeoDocs.leo if it is not already open.
 
 # In LeoDocs.leo: Leo 6.7.3 release notes
 unl:gnx://c:\Repos\leo-editor\leo\doc\LeoDocs.leo#ekr.20230409052507.1
@@ -1445,6 +1452,20 @@ g.registerHandler('select3', ud['alt_body_font_proc'])
 
 
 
+</t>
+<t tx="ekr.20231231043342.1"># Exists: Recent tests
+unl:gnx://#ekr.20180311131424.1
+
+# Error mssages (copy to log)
+unl:gnx://#ekr.20230622112649.1
+
+# The following will work only if LeoDocs.leo is open!
+
+# In LeoDocs.leo: Leo 6.7.3 release notes
+unl:gnx://#ekr.20230409052507.1
+
+# In LeoDocs.leo: ** Read me first **
+unl:gnx://#ekr.20050831195449
 </t>
 </tnodes>
 </leo_file>

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -94,7 +94,7 @@ class TestGlobals(LeoUnitTest):
     #@-<< define missing_unls >>
     #@+<< define valid_unl_templates >>
     #@+node:ekr.20230701090956.2: *4* << define valid_unl_templates >>
-    # These links are functional only if on @data unl-path-prefixes contains the proper file part.
+    # These links are functional only if an @data unl-path-prefixes contains the proper file part.
     valid_unls = (
 
         'unl:gnx://#ekr.20180311131424.1',
@@ -128,7 +128,6 @@ class TestGlobals(LeoUnitTest):
 
         # Absolute file: valid, but can't be resolved in a unit test.
         'unl://C:/Repos/leo-editor/leo/test/test.leo#@file ../plugins/importers/__init__.py',
-
     )
     #@-<< define valid_unl_templates >>
     #@-<< TestGlboals: define unchanging data >>
@@ -997,7 +996,8 @@ class TestGlobals(LeoUnitTest):
             fn, n = g.getLastTracebackFileAndLineNumber()
         self.assertEqual(fn.lower(), __file__.lower())
 
-    #@+node:ekr.20230325055810.1: *3* TestGlobals.test_g_findGnx
+    #@+node:ekr.20231228234020.1: *3* --- gnx tests
+    #@+node:ekr.20230325055810.1: *4* TestGlobals.test_g_findGnx
     def test_g_findGnx(self):
         c = self.c
 
@@ -1020,7 +1020,7 @@ class TestGlobals(LeoUnitTest):
         for p in c.all_positions():
             for gnx in (f"{p.gnx}", f"{p.gnx}::0"):
                 self.assertEqual(p, g.findGnx(gnx, c), msg=gnx)
-    #@+node:ekr.20230703175743.1: *3* TestGlobals.test_g_findUnl (legacy)
+    #@+node:ekr.20230703175743.1: *4* TestGlobals.test_g_findUnl (legacy)
     def test_g_findUnl(self):
 
         c = self.c
@@ -1039,14 +1039,14 @@ class TestGlobals(LeoUnitTest):
             if 0:  # I don't understand the old-style format!
                 aList2 = [f"{z}:0" for z in headlines]
                 self.assertEqual(p, g.findUnl(aList2, c), msg=','.join(aList2))
-    #@+node:ekr.20230701085746.1: *3* TestGlobals.test_g_isValidUnl
+    #@+node:ekr.20230701085746.1: *4* TestGlobals.test_g_isValidUnl
     def test_g_isValidUnl(self):
 
         for unl in self.valid_unls + self.missing_unls:
             self.assertTrue(g.isValidUnl(unl), msg=unl)
         for unl in self.invalid_unls:
             self.assertFalse(g.isValidUnl(unl), msg=unl)
-    #@+node:ekr.20230701171707.1: *3* TestGlobals.test_g_getUNLFilePart
+    #@+node:ekr.20230701171707.1: *4* TestGlobals.test_g_getUNLFilePart
     def test_g_getUNLFilePart(self):
 
         table = (
@@ -1057,7 +1057,7 @@ class TestGlobals(LeoUnitTest):
         )
         for unl, expected in table:
             self.assertEqual(expected, g.getUNLFilePart(unl), msg=unl)
-    #@+node:ekr.20230701101300.1: *3* TestGlobals.test_g_isValidUrl
+    #@+node:ekr.20230701101300.1: *4* TestGlobals.test_g_isValidUrl
     def test_g_isValidUrl(self):
 
         bad_table = ('@whatever',)
@@ -1069,20 +1069,41 @@ class TestGlobals(LeoUnitTest):
             self.assertTrue(g.isValidUrl(unl), msg=unl)
         for unl in self.invalid_unls + bad_table:
             self.assertFalse(g.isValidUrl(unl), msg=unl)
-    #@+node:ekr.20230701095636.1: *3* TestGlobals.test_g_findAnyUnl
+    #@+node:ekr.20230701095636.1: *4* TestGlobals.test_g_findAnyUnl
     def test_g_findAnyUnl(self):
 
-        # g.findAnyUnl returns a Position or None.
-
-        ### To do: resolve all valid unls to a real position.
-
         c = self.c
+        # Create a sibling after the root position.
         self._make_tree(c, root_h='root')
-
-        if 0:  ### Not yet.
-            for unl in self.valid_unls + self.missing_unls:
-                p = c.rootPosition()
-                self.assertEqual(p, g.findAnyUnl(unl, c), msg=unl)
+        sib = c.rootPosition().next()
+        child2 = sib.firstChild()
+        child2_gnx = child2.gnx
+        if 0:
+            for p in sib.self_and_subtree():
+                print(f"{p.gnx:30} {p.h}")
+        
+        # Create a table of various kinds of unls.
+        bad_gnx = 'TestLeoId.20231229001812.666'
+        file_name = c.fileName()
+        gnx_head = 'unl:gnx://#'
+        gnx_file_head = 'unl:gnx://' + file_name + '#'
+        unl_head = 'unl://#'
+        unl_file_head = 'unl://' + file_name + '#'
+        table = (
+            # Good gnxs...
+            (child2, f"{gnx_head}{child2_gnx}"),
+            (child2, f"{gnx_file_head}{child2_gnx}"),
+            (child2, f"{unl_head}Node 1-->child 2"),
+            (child2, f"{unl_file_head}Node 1-->child 2"),
+            # Bad gnxs...
+            (None, f"{gnx_head}{bad_gnx}"),
+            (None, f"{gnx_file_head}{bad_gnx}"),
+            (None, f"{unl_head}Node 1-->child 666"),
+            (None, f"{unl_file_head}Node 666-->child 1"),
+        )
+        for expected_p, unl in table:
+            result_p = g.findAnyUnl(unl, c)
+            self.assertEqual(expected_p, result_p, msg=unl)
 
         # Suppress warnings.
         old_stdout = sys.stdout
@@ -1092,7 +1113,7 @@ class TestGlobals(LeoUnitTest):
                 self.assertEqual(None, g.findAnyUnl(unl, c), msg=unl)
         finally:
             sys.stdout = old_stdout
-    #@+node:ekr.20230701113123.1: *3* TestGlobals.test_p_get_star_UNL
+    #@+node:ekr.20230701113123.1: *4* TestGlobals.test_p_get_star_UNL
     def test_p_get_star_UNL(self):
 
         # Test 11 p.get_*_UNL methods.
@@ -1165,7 +1186,21 @@ class TestGlobals(LeoUnitTest):
                 ):
                     msg = f"{f.__name__}: kind: {kind} full: {full}"
                     self.assertEqual(expected, f(), msg=msg)
-    #@+node:ekr.20230701103509.1: *3* TestGlobals.test_g_parsePathData
+    #@+node:ekr.20230703175447.1: *4* TestGlobals.test_g_openUNLFile
+    def test_g_openUNLFile(self):
+
+        # Create a new commander
+        c1 = self.c
+        c2 = self._patch_at_data_unl_path_prefixes()
+        # Change both filenames.
+        file_name1 = os.path.basename(c1.fileName())
+        file_name2 = os.path.basename(c2.fileName())
+        # Cross-file tests.
+        c3 = g.openUNLFile(c1, file_name2)
+        self.assertEqual(c3, c2)
+        c4 = g.openUNLFile(c2, file_name1)
+        self.assertEqual(c4, c1)
+    #@+node:ekr.20230701103509.1: *4* TestGlobals.test_g_parsePathData
     def test_g_parsePathData(self) -> None:
 
         c = self.c
@@ -1191,20 +1226,6 @@ class TestGlobals(LeoUnitTest):
         paths = ['c:/Repos/leo-editor/leo/test', 'c:/Repos/leo-editor/leo/doc']
         expected_paths = [os.path.normpath(z) for z in paths]
         self.assertEqual(list(sorted(d.values())), list(sorted(expected_paths)))
-    #@+node:ekr.20230703175447.1: *3* TestGlobals.test_g_openUNLFile
-    def test_g_openUNLFile(self):
-
-        # Create a new commander
-        c1 = self.c
-        c2 = self._patch_at_data_unl_path_prefixes()
-        # Change both filenames.
-        file_name1 = os.path.basename(c1.fileName())
-        file_name2 = os.path.basename(c2.fileName())
-        # Cross-file tests.
-        c3 = g.openUNLFile(c1, file_name2)
-        self.assertEqual(c3, c2)
-        c4 = g.openUNLFile(c2, file_name1)
-        self.assertEqual(c4, c1)
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
See #3736.

- [x] Fix `g.findAnyUnl`: see the diffs.
- [x] Fix a quirp in `<< About clickable links >>`: Remove redundant `//`.
- [x] Remove the unnecessary `found` var in `<< look for gnx >>` in `g.openUrlHelper`.
- [x] `test.leo`: move the node that tests unls to the top level and update some comments.
- [x] Make the unit test functional: `TestGlobals.test_g_findAnyUnl`.

<details><summary>Won't do</summary>
<br>

**Note**: The present code breaks on the *first* match of `gnx_regex.finditer`, regardless of `target`.

"Simplifying" the code as follows would be a real (and subtle) change. I see no need to do it.

```python
for match in gnx_regex.finditer(line):
    # Don't open if we click after the gnx.
    if match.start() <= col < match.end():
        target = match.group(0)[4:]  # Strip the leading 'gnx:'
        if target:
            if c.p.gnx == target:
                return target
            for p in c.all_unique_positions():
                if p.v.gnx == target:
                    c.selectPosition(p)
                    c.redraw()
                    break
            return target
```

</details>