### PR TITLE
PR for #3739: yet another syntax coloring bug

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1903,6 +1903,8 @@ class JEditColorizer(BaseColorizer):
     #@+node:ekr.20231209015334.1: *5* jedit.match_fstring_helper
     def match_fstring_helper(self, s: str, i: int, delim: str) -> int:
         """
+        s is an fstring (or its continuation) *without* the leadin characters and the opening delim.
+
         Return n >= 0 if s[i:] contains with a non-escaped delim at fstring-level 0.
         
         Return len(s) + 1 if the fstring should continue.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1845,7 +1845,7 @@ class JEditColorizer(BaseColorizer):
         # j = len(s)
         # self.colorRangeWithTag(s,i,j,kind,delegate=delegate)
         # return j
-    #@+node:ekr.20231209010844.1: *4* jedit.match_fstring
+    #@+node:ekr.20231209010844.1: *4* jedit.match_fstring & helper
     f_string_nesting_level = 0
 
     def match_fstring(self, s: str, i: int) -> int:
@@ -1910,7 +1910,7 @@ class JEditColorizer(BaseColorizer):
         escape, escapes = '\\', 0
         level = self.f_string_nesting_level
         alt_delim = '"' if delim == "'" else "'"  # Works for triple delims.
-        in_alt_delim = False
+        in_alt_delim, in_comment = False, False
 
         # Scan, incrementing escape count and f-string level.
         while i < len(s):
@@ -1924,11 +1924,14 @@ class JEditColorizer(BaseColorizer):
                 in_alt_delim = not in_alt_delim
                 i += 1
                 continue
+            if in_comment:
+                i += 1
+                continue
             ch = s[i]
             i += 1
             if ch == '#' and (escapes % 2) == 0 and not in_alt_delim:
-                break  # Don't scan comments.
-            if ch == escape:
+                in_comment = True
+            elif ch == escape:
                 escapes += 1
             elif ch == '{':
                 level += 1

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -1443,8 +1443,8 @@ class TestColorizer(LeoUnitTest):
         colorizer = JEditColorizer(c, None)
         
         table = (
-            # Strings must not be f-strings! We don't want to evaluate them!
-            # Strings starting *after* the opening delim *without* a closing delim.
+            # These are *plain* strings that start *after* the opening delim.
+            # These strings do *not* end with the closing delim.
             "{'':*^{1:{1}}}",
             "{my_dict[key]=}",
             "{my_dict['key']=}",

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -396,13 +396,6 @@ class TestColorizer(LeoUnitTest):
             ;
     """)
         self.color('forth', text)
-    #@+node:ekr.20210905170507.14: *3* TestColorizer.test_colorizer_HTML_string_bug
-    def test_colorizer_HTML_string_bug(self):
-        text = textwrap.dedent("""\
-            b = "cd"
-            d
-    """)
-        self.color('html', text)
     #@+node:ekr.20210905170507.15: *3* TestColorizer.test_colorizer_HTML1
     def test_colorizer_HTML1(self):
         text = textwrap.dedent("""\
@@ -526,6 +519,13 @@ class TestColorizer(LeoUnitTest):
             This is a test.
             </body>
             </html>
+    """)
+        self.color('html', text)
+    #@+node:ekr.20210905170507.14: *3* TestColorizer.test_colorizer_HTML_string_bug
+    def test_colorizer_HTML_string_bug(self):
+        text = textwrap.dedent("""\
+            b = "cd"
+            d
     """)
         self.color('html', text)
     #@+node:ekr.20210905170507.17: *3* TestColorizer.test_colorizer_Java
@@ -1088,29 +1088,6 @@ class TestColorizer(LeoUnitTest):
             xor
     """)
         self.color('plsql', text)
-    #@+node:ekr.20210905170507.24: *3* TestColorizer.test_colorizer_python_xml_jEdit_
-    def test_colorizer_python_xml_jEdit_(self):
-        text = textwrap.dedent(r"""\\\
-            <?xml version="1.0"?>
-
-            <!DOCTYPE MODE SYSTEM "xmode.dtd">
-            < < remarks > >
-
-            <MODE>
-                <PROPS>
-                    <PROPERTY NAME="indentPrevLine" VALUE="\s*.{3,}:\s*(#.*)?" />
-                    <PROPERTY NAME="lineComment" VALUE="#" />
-                </PROPS>
-                <RULES ESCAPE="\" IGNORE_CASE="FALSE" HIGHLIGHT_DIGITS="TRUE">
-                    < < comments > >
-                    < < literals > >
-                    < < operators > >
-                    <MARK_PREVIOUS TYPE="FUNCTION" EXCLUDE_MATCH="TRUE">(</MARK_PREVIOUS>
-                    < < keywords > >
-                </RULES>
-            </MODE>
-    """)
-        self.color('html', text)
     #@+node:ekr.20210905170507.25: *3* TestColorizer.test_colorizer_Python1
     def test_colorizer_Python1(self):
         text = textwrap.dedent("""\
@@ -1158,6 +1135,29 @@ class TestColorizer(LeoUnitTest):
     ''').lstrip()
         self.color('python', text)
 
+    #@+node:ekr.20210905170507.24: *3* TestColorizer.test_colorizer_python_xml_jEdit_
+    def test_colorizer_python_xml_jEdit_(self):
+        text = textwrap.dedent(r"""\\\
+            <?xml version="1.0"?>
+
+            <!DOCTYPE MODE SYSTEM "xmode.dtd">
+            < < remarks > >
+
+            <MODE>
+                <PROPS>
+                    <PROPERTY NAME="indentPrevLine" VALUE="\s*.{3,}:\s*(#.*)?" />
+                    <PROPERTY NAME="lineComment" VALUE="#" />
+                </PROPS>
+                <RULES ESCAPE="\" IGNORE_CASE="FALSE" HIGHLIGHT_DIGITS="TRUE">
+                    < < comments > >
+                    < < literals > >
+                    < < operators > >
+                    <MARK_PREVIOUS TYPE="FUNCTION" EXCLUDE_MATCH="TRUE">(</MARK_PREVIOUS>
+                    < < keywords > >
+                </RULES>
+            </MODE>
+    """)
+        self.color('html', text)
     #@+node:ekr.20210905170507.27: *3* TestColorizer.test_colorizer_r
     def test_colorizer_r(self):
         text = textwrap.dedent("""\
@@ -1435,6 +1435,34 @@ class TestColorizer(LeoUnitTest):
                 pass
     ''')
         self.color('html', text)
+    #@+node:ekr.20231229142541.1: *3* TestColorizer.test_match_fstring_helper
+    def test_match_fstring_helper(self):
+
+        c = self.c
+        from leo.core.leoColorizer import JEditColorizer
+        colorizer = JEditColorizer(c, None)
+        
+        table = (
+            # Strings must not be f-strings! We don't want to evaluate them!
+            # Strings starting *after* the opening delim *without* a closing delim.
+            "{'':*^{1:{1}}}",
+            "{my_dict[key]=}",
+            "{my_dict['key']=}",
+            "{'#' * level} {p.h.lstrip()}",  # #3739.
+        )
+        
+        # These examples assume that the lead-in is f".
+        delim = '"'
+        for terminated in (True, False):
+            for s in table:
+                # Add a closing delim if we are testing a terminated string.
+                if terminated:
+                    s = s + delim
+                n = colorizer.match_fstring_helper(s, 0, delim)
+                if terminated:
+                    assert n == len(s), (n, len(s), s)
+                else:
+                    assert n == len(s) + 1, (n, len(s), s)
     #@+node:ekr.20210905170507.39: *3* TestColorizer.test_scanColorDirectives
     def test_scanColorDirectives(self):
         c = self.c


### PR DESCRIPTION
See #3739.

- [x] Fix `jedit.match_fstring_helper` and improve its docstring.
- [x] Create a (tricky!) new unit test.
    This is a much stronger unit test than the typical tests for colorizers.