### PR TITLE
PR for #3754: non-ascii chars in scripts

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -354,6 +354,7 @@ class LeoApp:
             "iss":      "inno_setup",
             "java":     "java",
             "jhtml":    "jhtml",
+            "jl":       "julia",
             "jmk":      "jmk",
             "js":       "javascript", # For javascript import test.
             "jsp":      "javaserverpage",
@@ -374,6 +375,7 @@ class LeoApp:
             "mpl":      "maple",
             "mqsc":     "mqsc",
             "nqc":      "nqc",
+            "nim":      "nim",
             "nsi":      "nsi", # EKR: 2010/10/27
             # "nsi":      "nsis2",
             "nw":       "noweb",
@@ -556,6 +558,7 @@ class LeoApp:
             "jmk"                : "#",
             "json"               : "#", # EKR: 2020/07/27: Json has no delims. This is a dummy entry.
             "jsp"                : "<%-- --%>",
+            "julia"              : "#",
             "jupyter"            : "<%-- --%>", # Default to markdown?
             "kivy"               : "#", # PeckJ 2014/05/05
             "kshell"             : "#", # Leo 4.5.1.
@@ -576,6 +579,7 @@ class LeoApp:
             "moin"               : "##",
             "mqsc"               : "*",
             "netrexx"            : "-- /* */",
+            "nim"                : "#",
             "noweb"              : "%", # EKR: 2009-01-30. Use Latex for doc chunks.
             "nqc"                : "// /* */",
             "nsi"                : ";", # EKR: 2010/10/27
@@ -739,6 +743,7 @@ class LeoApp:
             "jmk"           : "jmk",
             "json"          : "json",
             "jsp"           : "jsp",
+            "julia"         : "jl",
             # "jupyter"       : "ipynb",
             "kivy"          : "kv", # PeckJ 2014/05/05
             "kshell"        : "ksh", # Leo 4.5.1.
@@ -754,6 +759,7 @@ class LeoApp:
             "modula3"       : "mod",
             "moin"          : "wiki",
             "mqsc"          : "mqsc",
+            "nim"           : "nim",
             "noweb"         : "nw",
             "nqc"           : "nqc",
             "nsi"           : "nsi", # EKR: 2010/10/27

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -640,7 +640,6 @@ class Commands:
         Set the cwd before calling the command.
         """
         c, p, tag = self, self.p, 'execute-general-script'
-
         def get_setting_for_language(setting: str) -> Optional[str]:
             """
             Return the setting from the given @data setting.
@@ -2889,7 +2888,7 @@ class Commands:
         use_temp = not root.isAnyAtFileNode()
         if use_temp:
             fd, root_path = tempfile.mkstemp(suffix=ext, prefix="")
-            with os.fdopen(fd, 'w') as f:
+            with os.fdopen(fd, 'w', encoding = 'utf-8') as f:
                 f.write(script)
         else:
             root_path = c.fullPath(root)


### PR DESCRIPTION
See #3754.

Add Nim and Julia to dictionaries of languages and extensions used by execute-general-script command.