### PR TITLE
PR for #3770: Revert colorizing for f-strings

### DIFF
--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -518,10 +518,12 @@ rulesDict1 = {
     "~": [python_rule19],
 }
 
-if (v1, v2) >= (3, 12):
-    # Update rules to for Python 3.12+ f-strings.
-    for key in 'frFR':
-        rulesDict1[key] = [python_rule_fstring, python_rule21]
+
+if False:  # #3770: Revert colorizing of PEP 701 f-strings.
+    if (v1, v2) >= (3, 12):
+        # Update rules to for Python 3.12+ f-strings.
+        for key in 'frFR':
+            rulesDict1[key] = [python_rule_fstring, python_rule21]
 
 # x.rulesDictDict for python mode.
 rulesDictDict = {


### PR DESCRIPTION
See #3770.

This PR leaves the new colorizing code intact, but `leo/modes/python.py` never calls the new code.