### PR TITLE
PR: full coverage for leoTokens.py

### DIFF
--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1133,7 +1133,7 @@ class TokenBasedOrange:  # Orange is the new Black.
 
         if val == '~':
             return True
-        if val not in '+-':
+        if val not in '+-':  # pragma: no cover
             return False
         # Get the previous significant token.
         prev_i = self.prev(i)
@@ -1504,22 +1504,23 @@ class TokenBasedOrange:  # Orange is the new Black.
         Return True if token is a unary op in the context of prev, the previous
         significant token.
         """
-        if token.value == '~':
+        if token.value == '~':  # pragma: no cover
             return True
         if prev is None:
             return True  # pragma: no cover
         assert token.value in '**-+', repr(token.value)
-        kind, value = prev.kind, prev.value
-        if kind in ('number', 'string'):
+        if prev.kind in ('number', 'string'):
             return_val = False
-        elif kind == 'op' and value in ')]':
-            return_val = False
-        elif kind == 'op' and value in '{([:,':
+        elif prev.kind == 'op' and prev.value in ')]':
+             # An unnecessary test?
+            return_val = False  # pragma: no cover
+        elif prev.kind == 'op' and prev.value in '{([:,':
             return_val = True
-        elif kind != 'name':
-            return_val = True
+        elif prev.kind != 'name':
+            # An unnecessary test?
+            return_val = True  # pragma: no cover
         else:
-            # A 'name' token.
+            # prev is a'name' token.
             return self.is_python_keyword(token)
         return return_val
     #@+node:ekr.20240129035336.1: *5* tbo.is_python_keyword
@@ -1555,7 +1556,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         while i < len(self.tokens):
             token = self.tokens[i]
             if self.is_significant_token(token):
-                if trace:
+                if trace:  # pragma: no cover
                     print(
                         f"next: {g.callers(1):25} "
                         f"token: {token.brief_dump()} "
@@ -1563,7 +1564,7 @@ class TokenBasedOrange:  # Orange is the new Black.
                     )
                 return i
             i += 1
-        return None
+        return None  # pragma: no cover
     #@+node:ekr.20240115233050.1: *5* tbo.prev
     def prev(self, i: int) -> Optional[int]:
         """

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -595,54 +595,6 @@ class TokenBasedOrange:  # Orange is the new Black.
             print(tag)
         for token in self.tokens[i1 : i2 + 1]:
             print(token.dump())
-    #@+node:ekr.20240106090914.1: *5* tbo.expect
-    def expect(self, i: int, kind: str, value: str = None) -> None:
-        """Raise an exception if self.tokens[i] is not as expected."""
-        try:
-            token = self.tokens[i]
-        except Exception as e:  # pragma: no cover
-            self.oops(f"At index {i!r}: Expected{kind!r}:{value!r}, got {e}")
-
-        if token.kind != kind or (value and token.value != value):
-            self.oops(f"Expected {kind!r}:{value!r}, got {token!r}")  # pragma: no cover
-    #@+node:ekr.20240116042811.1: *5* tbo.expect_name
-    def expect_name(self, i: int) -> None:
-        """Raise an exception if self.tokens[i] is not as expected."""
-        try:
-            token = self.tokens[i]
-        except Exception as e:  # pragma: no cover
-            self.oops(f"At index {i!r}: Expected 'name', got {e}")
-
-        if token.kind != 'name':
-            self.oops(f"Expected 'name', got {token!r}")  # pragma: no cover
-    #@+node:ekr.20240114015808.1: *5* tbo.expect_op
-    def expect_op(self, i: int, value: str) -> None:
-        """Raise an exception if self.tokens[i] is not as expected."""
-        try:
-            token = self.tokens[i]
-        except Exception as e:  # pragma: no cover
-            self.oops(f"At index {i!r}: Expected 'op':{value!r}, got {e!r}")
-
-        if (token.kind, token.value) != ('op', value):
-            self.oops(f"Expected 'op':{value!r}, got {token!r}")  # pragma: no cover
-    #@+node:ekr.20240114013952.1: *5* tbo.expect_ops
-    def expect_ops(self, i: int, values: list) -> None:
-        """Raise an exception if self.tokens[i] is not as expected."""
-        try:
-            token = self.tokens[i]
-        except Exception as e:  # pragma: no cover
-            self.oops(f"At index {i!r}: Expected 'op' in {values!r}, got {e!r}")
-
-        if token.kind != 'op' or token.value not in values:
-            self.oops(f"Expected 'op' in {values!r}, got {token!r}")  # pragma: no cover
-    #@+node:ekr.20240127051941.1: *5* tbo.get_token
-    def get_token(self, i: int) -> InputToken:
-        """Return the token at i, with full error checking."""
-        try:
-            token = self.tokens[i]
-        except Exception as e:  # pragma: no cover
-            self.oops(f"Invalid index: {i!r}: {e}")
-        return token
     #@+node:ekr.20240117053310.1: *5* tbo.oops & helper
     def oops(self, message: str) -> None:  # pragma: no cover
         """Raise InternalBeautifierError."""
@@ -671,33 +623,6 @@ class TokenBasedOrange:  # Orange is the new Black.
             f"{context_s}"
             "Please report this message to Leo's developers"
         )
-    #@+node:ekr.20240125182219.1: *5* tbo.trace & helper
-    def trace(self, i: int, i2: Optional[int] = None, *, tag: str = None) -> None:  # pragma: no cover
-        """
-        Print i, token, and get_token_line(i).
-
-        A surprisingly useful debugging utility.
-        """
-
-        token = self.tokens[i]
-        indices_s = f"{i}" if i2 is None else f"i: {i} i2: {i2}"
-
-        # Adjust widths below as necessary.
-        print(
-            f"{g.callers(1)}: {tag or ''}\n"
-            f"  callers: {g.callers()}\n"
-            f"  indices: {indices_s} token: {token.kind:}:{token.show_val(30)}\n"
-            f"     line: {self.get_token_line(i)!r}\n"
-        )
-    #@+node:ekr.20240124094344.1: *6* tbo.get_token_line
-    def get_token_line(self, i: int) -> str:  # pragma: no cover
-        """return self.tokens[i].line"""
-        try:
-            token = self.tokens[i]
-        except Exception as e:
-            self.oops(f"Bad token index {i!r}: {e}")
-
-        return token.line.rstrip()
     #@+node:ekr.20240105145241.4: *4* tbo: Entries & helpers
     #@+node:ekr.20240105145241.5: *5* tbo.beautify (main token loop)
     def no_visitor(self) -> None:  # pragma: no cover
@@ -746,10 +671,10 @@ class TokenBasedOrange:  # Orange is the new Black.
         try:
             # Pre-scan the token list, setting context.s
             self.pre_scan()
-        except InternalBeautifierError as e:
+        except InternalBeautifierError as e:  # pragma: no cover
             # oops calls self.error_message to creates e.
             print(e)
-        except AssertionError as e:
+        except AssertionError as e:  # pragma: no cover
             g.es_exception()
             print(self.error_message(repr(e)))
 
@@ -768,10 +693,10 @@ class TokenBasedOrange:  # Orange is the new Black.
                 else:
                     func = getattr(self, f"do_{self.token.kind}", self.no_visitor)
                     func()
-            except InternalBeautifierError as e:
+            except InternalBeautifierError as e:  # pragma: no cover
                 # oops calls self.error_message to creates e.
                 print(e)
-            except AssertionError as e:
+            except AssertionError as e:  # pragma: no cover
                 g.es_exception()
                 print(self.error_message(repr(e)))
 
@@ -856,7 +781,7 @@ class TokenBasedOrange:  # Orange is the new Black.
             s2 = g.toEncodedString(s, encoding=encoding, reportErrors=True)
             with open(filename, 'wb') as f:
                 f.write(s2)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover
             g.trace(f"Error writing {filename}\n{e}")
     #@+node:ekr.20200107040729.1: *5* tbo.show_diffs
     def show_diffs(self, s1: str, s2: str) -> None:  # pragma: no cover
@@ -1106,8 +1031,6 @@ class TokenBasedOrange:  # Orange is the new Black.
             self.gen_blank()
         elif context == 'simple-slice':
             self.gen_token('op-no-blanks', val)
-        elif context == 'end-statement':
-            self.gen_token('op-no-blank', val)
         elif context == 'dict':
             self.gen_token('op', val)
             self.gen_blank()
@@ -1375,7 +1298,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         prev_token: InputToken = None
         for i, token in enumerate(self.tokens):
             kind, value = token.kind, token.value
-            if trace:
+            if trace:  # pragma: no cover
                 val = repr(value) if not value or '\n' in value else value
                 g.trace(f"{self.index:3} {kind:>8}: {val}")
             if kind in 'newline':
@@ -1401,7 +1324,7 @@ class TokenBasedOrange:  # Orange is the new Black.
 
                 top_state = scan_stack[-1] if scan_stack else None
 
-                if trace:
+                if trace:  # pragma: no cover
                     g.trace(f"{value:3} prev: {prev_token} state: {top_state}")
                     g.printObj(scan_stack, tag='scan_stack')
 
@@ -1436,7 +1359,7 @@ class TokenBasedOrange:  # Orange is the new Black.
 
                 # Handle interior tokens in 'arg' and 'slice' states.
                 if top_state:
-                    if top_state.kind == 'slice' and value == ':':
+                    if top_state.kind in ('dict', 'slice') and value == ':':
                         top_state.value.append(i)
                     if top_state.kind == 'arg' and value in '**=:,':
                         top_state.value.append(i)
@@ -1458,7 +1381,7 @@ class TokenBasedOrange:  # Orange is the new Black.
             if kind not in self.insignificant_kinds:
                 prev_token = token
         # Sanity check.
-        if scan_stack:
+        if scan_stack:  # pragma: no cover
             g.printObj(scan_stack, tag='pre_scan: non-empty scan_stack')
     #@+node:ekr.20240129041304.1: *6* tbo.finish_arg
     def finish_arg(self, end: int, state: ScanState) -> None:
@@ -1474,7 +1397,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         if not values:
             return
 
-        if 0:  ###
+        if 0:  # pragma: no cover
             tokens_s = ''.join([z.value for z in self.tokens[i1 : end + 1]])
             g.trace(f"{i1:3} {end:3} {values!r} {tokens_s}")
 
@@ -1533,7 +1456,7 @@ class TokenBasedOrange:  # Orange is the new Black.
                 if kind == 'op':
                     if value == '.':
                         # Ignore '.' tokens and any preceding 'name' token.
-                        if prev and prev.kind == 'name':
+                        if prev and prev.kind == 'name':  # pragma: no cover
                             inter_colon_tokens -= 1
                     elif value == ':':
                         inter_colon_tokens = 0
@@ -1593,29 +1516,21 @@ class TokenBasedOrange:  # Orange is the new Black.
         if token.value == '~':
             return True
         if prev is None:
-            return True  ### New.
+            return True  # pragma: no cover
         assert token.value in '**-+', repr(token.value)
         kind, value = prev.kind, prev.value
         if kind in ('number', 'string'):
             return_val = False
         elif kind == 'op' and value in ')]':
             return_val = False
-        elif kind == 'op' and value in '{([:,':  ### Add ,
+        elif kind == 'op' and value in '{([:,':
             return_val = True
         elif kind != 'name':
             return_val = True
         else:
             # A 'name' token.
-            ### return_val = keyword.iskeyword(value) or keyword.issoftkeyword(value)
             return self.is_python_keyword(token)
         return return_val
-    #@+node:ekr.20240125082325.1: *5* tbo.is_name
-    def is_name(self, i: int) -> bool:
-
-        if i is None:  # pragma: no cover
-            return False
-        token = self.tokens[i]
-        return token.kind == 'name'
     #@+node:ekr.20240129035336.1: *5* tbo.is_python_keyword
     def is_python_keyword(self, token: InputToken) -> bool:
         """Return True if token is a 'name' token referring to a Python keyword."""
@@ -1667,7 +1582,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         """
         i -= 1
         while i >= 0:
-            ### self.n_scanned_tokens += 1
             token = self.tokens[i]
             if self.is_significant_token(token):
                 return i

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2152,6 +2152,327 @@ def get_token_line(self, i: int) -> str:  # pragma: no cover
         self.oops(f"Bad token index {i!r}: {e}")
 
     return token.line.rstrip()
+#@+node:ekr.20240201023006.1: *3* deleted unit tests
+#@+node:ekr.20240105153425.52: *4* TestTBO.xxx_test_bug_1851
+def xxx_test_bug_1851(self):
+
+    contents = r'''\
+def foo(a1):
+    pass
+'''
+    contents, tokens = self.make_data(contents)
+    expected = contents.rstrip() + '\n'
+    results = self.beautify(contents, tokens)
+    self.assertEqual(results, expected)
+#@+node:ekr.20240116155903.1: *4* TestTBO.xxx_test_colorizer_fail
+def xxx_test_colorizer_fail(self):
+
+    contents = '''
+
+        # leoColorizer.py: line 2268
+        if j > len(s) and not dots:
+            j = len(s) + 1
+
+            def span(s: str) -> int:
+                # Note: bindings are frozen by this def.
+                return self.restart_match_span(s, kind,
+                    delegate=delegate,
+                )
+    '''
+
+    contents, tokens = self.make_data(contents)
+    # dump_tokens(tokens)
+    expected = contents
+    results = self.beautify(contents, tokens)
+    if False and results != expected:
+        g.printObj(expected, tag='Expected (same as Contents)')
+        g.printObj(results, tag='Results')
+    self.maxDiff = None
+    self.assertEqual(results, expected)
+#@+node:ekr.20240112134732.1: *4* TestTBO.xxx_test_def_colons
+def xxx_test_def_colons(self):
+
+    contents = '''
+        self.configDict: dict[str, Any] = {}
+        self.configUnderlineDict: dict[str, bool] = {}
+    '''
+    contents, tokens = self.make_data(contents)
+    # dump_tokens(tokens)
+    expected = contents
+    results = self.beautify(contents, tokens)
+    if results != expected:  # pragma: no cover
+        # g.printObj(contents, tag='Contents')
+        g.printObj(expected, tag='Expected (same as Contents)')
+        g.printObj(results, tag='Results')
+
+    self.maxDiff = None
+    self.assertEqual(results, expected)
+
+#@+node:ekr.20240114100847.1: *4* TestTBO.xxx_test_def_square_brackets
+def xxx_test_def_square_brackets(self):
+
+    contents = (
+        """def checkForDuplicateShortcuts(self, c: Cmdr, d: dict[str, str]) -> None:\n"""
+    )
+    contents, tokens = self.make_data(contents)
+    # dump_tokens(tokens)
+    expected = contents
+    results = self.beautify(contents, tokens)
+    if False and results != expected:
+        # g.printObj(contents, tag='Contents')
+        g.printObj(expected, tag='Expected (same as Contents)')
+        g.printObj(results, tag='Results')
+
+    self.maxDiff = None
+    self.assertEqual(results, expected)
+#@+node:ekr.20240116072845.1: *4* TestTBO.xxx_test_expressions
+def xxx_test_expressions(self):
+
+    contents = """skip_count = max(0, (len(target) - 1))\n"""
+
+    contents, tokens = self.make_data(contents)
+    expected = self.blacken(contents)
+    results = self.beautify(contents, tokens)
+    if expected != results:  # pragma: no cover
+        g.printObj(expected, tag='Explected (blackened)')
+        g.printObj(results, tag='Results')
+    self.assertEqual(results, expected)
+#@+node:ekr.20240124092041.1: *4* TestTBO.xxx_test_fstrings
+def xxx_test_fstrings(self):
+
+    # leoApp.py, line 885.
+    contents = """signon = [f"Leo {leoVer}"]\n"""
+    contents, tokens = self.make_data(contents)
+    expected = self.blacken(contents)
+    results = self.beautify(contents, tokens)
+    self.assertEqual(results, expected)
+#@+node:ekr.20240126062946.1: *4* TestTBO.xxx_test_function_call_with_parens
+def xxx_test_function_calls_with_parens(self):
+
+    # LeoFrame.py, line 1650.
+
+    # Test 1: The 'if' statement on a single line.
+    contents1 = """
+        if (g.doHook("select1", c = c, new_p=p)):
+            return
+        """
+
+    # Black would remove the outer parens.
+    expected1 = textwrap.dedent(
+        """
+        if (g.doHook("select1", c=c, new_p=p)):
+            return
+        """).strip() + '\n'
+
+    # Test 2: The 'if' statement spans several lines.
+    contents2 = """
+        if (
+            whatever and g.doHook(
+                "select1", c = c, new_p=p)
+        ):
+            return
+        """
+
+    # Black would remove the outer parens.
+    expected2 = textwrap.dedent(
+        """
+        if (
+            whatever and g.doHook(
+                "select1", c=c, new_p=p)
+        ):
+            return
+        """).strip() + '\n'
+
+    table = (
+        (contents1, expected1),
+        (contents2, expected2),
+    )
+    for contents, expected in table:
+        contents, tokens = self.make_data(contents)
+        results = self.beautify(contents, tokens)
+        if results != expected:
+            if 1:
+                g.printObj(contents, tag='Contents')
+                g.printObj(expected, tag='Expected (blackened)')
+                g.printObj(results, tag='Results')
+            self.assertEqual(expected, results)
+#@+node:ekr.20240107080413.1: *4* TestTBO.xxx_test_function_calls
+def xxx_test_function_calls(self):
+
+    # Put recent failures first.
+    table = (
+        # leoserver.py, line 584.
+        """timeline.sort(key=lambda x: x[0].gnx, reverse=True)""",
+
+        # leoserver.py, line 42 and other lines.
+        """jsonPackage = json.dumps(package, separators=(',', ':'), cls=SetEncoder)""",
+
+        # #1429: https://github.com/leo-editor/leo-editor/issues/1429
+        """
+        version = str(version2.Version.coerce(tag, partial=True))
+        """,
+
+        # LeoApp.py, line 1872.
+        """
+        if path.startswith(tag):
+            return self.computeBindingLetter(c, path=path[len(tag) :])
+        """,
+
+        # LeoApp.py, line 3416.
+        """
+        if groupedEntries:
+            dirCount: dict[str, Any] = {}
+            for fileName in rf.getRecentFiles()[:n]:
+                dirName, baseName = g.os_path_split(fileName)
+        """,
+
+        # leoPersistence, line 526.
+        """
+        return '-->'.join(reversed(
+            [self.expected_headline(p2) for p2 in p.self_and_parents(copy=False)]))
+        """,
+
+        # leoNodes, line 881.
+        """
+        path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
+        """,
+
+        # leoserver.py, line 2302.
+        """
+        result = [
+            self._get_position_d(p, c) for p in c.all_positions(copy=False)
+        ]
+        """,
+
+        # leoApp, line 1657
+        """
+        if True:
+            home = os.getenv(home[1:-1], default=None)
+        """,
+    )
+    for i, contents in enumerate(table):
+        contents, tokens = self.make_data(contents)
+        expected = contents  # Black would join lines.
+        results = self.beautify(contents, tokens)
+        if results != expected:
+            # dump_tokens(tokens)
+            if 1:
+                print('')
+                # g.printObj(contents, tag='Contents')
+                g.printObj(expected, tag='Expected (same as contents)')
+                g.printObj(results, tag='Results')
+            self.assertEqual(expected, results)
+#@+node:ekr.20240105153425.57: *4* TestTBO.xxx_test_function_defs
+def xxx_test_function_defs(self):
+
+    long_table = (
+        # Case 1.
+        """
+            def f1(a=2 + 5):
+                pass
+        """,
+        # Case 2
+        """
+            def f2(a):
+                pass
+        """,
+        # Case 3.
+        """
+        def f3(a: int = 2):
+            pass
+        """,
+        # Case 4.
+        '''
+        def should_kill_beautify(p):
+            """Return True if p.b contains @killbeautify"""
+            return 'killbeautify' in g.get_directives_dict(p)
+        ''',
+        # Case 5 (new)
+        '''
+            def reloadSettings():
+                pass
+        ''',
+        # Case 6 (new)
+        '''
+            def tuple_init(stack: Sequence[str] = ('root',)) -> Generator:
+                pass
+        ''',
+        # Case 7 (new)
+    )
+    short_table = (
+        '''
+            def tuple_init(stack: Sequence[str] = ('root',)) -> Generator:
+                pass
+        ''',
+    )
+    assert long_table and short_table
+    table = long_table
+    for i, contents in enumerate(table):
+        contents, tokens = self.make_data(contents)
+        expected = self.blacken(contents).rstrip() + '\n'
+        results = self.beautify(contents, tokens)
+        if expected != results:  # pragma: no cover
+            g.printObj(expected, tag='Explected (blackened)')
+            g.printObj(results, tag='Results')
+        self.assertEqual(results, expected)
+#@+node:ekr.20240105153425.64: *4* TestTBO.xxx_test_leading_stars_one_line
+def xxx_test_leading_stars_one_line(self):
+
+    # #2533.
+    contents = """
+        def f(arg1, *args, **kwargs):
+            pass
+    """
+    contents, tokens = self.make_data(contents)
+    results = self.beautify(contents, tokens)
+    self.assertEqual(contents, results)
+#@+node:ekr.20240105153425.63: *4* TestTBO.xxx_test_leading_stars
+def xxx_test_leading_stars(self):
+
+    # #2533.
+    contents = """
+        def f(
+            arg1,
+            *args,
+            **kwargs
+        ):
+            pass
+    """
+    contents, tokens = self.make_data(contents)
+    if 1:  # w/o join:
+        expected = contents
+    else:  # with join.
+        expected = """
+            def f(arg1, *args, **kwargs):
+                pass
+        """
+    results = self.beautify(contents, tokens)
+    self.assertEqual(expected, results)
+#@+node:ekr.20240105153425.71: *4* TestTBO.xxx_test_return
+def xxx_test_return(self):
+
+    contents = """return []"""
+    expected = self.blacken(contents)
+    contents, tokens = self.make_data(contents)
+    results = self.beautify(contents, tokens)
+    self.assertEqual(results, expected)
+#@+node:ekr.20240105153425.72: *4* TestTBO.xxx_test_single_quoted_string
+def xxx_test_single_quoted_string(self):
+
+    contents = """print('hi')"""
+    # blacken suppresses string normalization.
+    expected = self.blacken(contents)
+    contents, tokens = self.make_data(contents)
+    results = self.beautify(contents, tokens)
+    self.assertEqual(results, expected)
+#@+node:ekr.20240105153425.78: *4* TestTBO.xxx_test_ternary
+def xxx_test_ternary(self):
+
+    contents = """print(2 if name == 'class' else 1)"""
+    contents, tokens = self.make_data(contents)
+    expected = contents
+    results = self.beautify(contents, tokens)
+    self.assertEqual(results, expected)
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -1920,7 +1920,7 @@ elif 0:  # Print all ratios.
         f"scanned: {scanned:<5} total: {tokens:<5} ratio: {token_ratio:4.2f} "
         f"{g.shortFileName(filename)}"
     )
-#@+node:ekr.20240129094959.1: *3* tbo.scanning methods
+#@+node:ekr.20240129094959.1: *3* from tbo: Scanning
 if 0:
     @others
 #@+node:ekr.20240114022135.1: *4* tbo.find_close_paren
@@ -2026,6 +2026,13 @@ def get_tokens_after(self, i: int) -> str:
         self.oops(f"Invalid index: {i!r}: {e}")
     end = self.find_end_of_line(i)
     return repr(''.join([z.value for z in tokens[i:end]]))
+#@+node:ekr.20240125082325.1: *4* tbo.is_name
+def is_name(self, i: int) -> bool:
+
+    if i is None:  # pragma: no cover
+        return False
+    token = self.tokens[i]
+    return token.kind == 'name'
 #@+node:ekr.20240106172054.1: *4* tbo.is_op & is_ops
 def is_op(self, i: int, value: str) -> bool:
 
@@ -2069,6 +2076,82 @@ def skip_past_matching_delim(self, i: int, delim1: str, delim2: str) -> int:
             self.oops('no progress!')
     self.oops(f"no matching {delim2!r}")  # pragma: no cover
     return None  # pragma: no cover
+#@+node:ekr.20240131065522.1: *3* from tbo: Checking & dumping
+#@+node:ekr.20240106090914.1: *4* tbo.expect
+def expect(self, i: int, kind: str, value: str = None) -> None:
+    """Raise an exception if self.tokens[i] is not as expected."""
+    try:
+        token = self.tokens[i]
+    except Exception as e:  # pragma: no cover
+        self.oops(f"At index {i!r}: Expected{kind!r}:{value!r}, got {e}")
+
+    if token.kind != kind or (value and token.value != value):
+        self.oops(f"Expected {kind!r}:{value!r}, got {token!r}")  # pragma: no cover
+#@+node:ekr.20240116042811.1: *4* tbo.expect_name
+def expect_name(self, i: int) -> None:
+    """Raise an exception if self.tokens[i] is not as expected."""
+    try:
+        token = self.tokens[i]
+    except Exception as e:  # pragma: no cover
+        self.oops(f"At index {i!r}: Expected 'name', got {e}")
+
+    if token.kind != 'name':
+        self.oops(f"Expected 'name', got {token!r}")  # pragma: no cover
+#@+node:ekr.20240114015808.1: *4* tbo.expect_op
+def expect_op(self, i: int, value: str) -> None:
+    """Raise an exception if self.tokens[i] is not as expected."""
+    try:
+        token = self.tokens[i]
+    except Exception as e:  # pragma: no cover
+        self.oops(f"At index {i!r}: Expected 'op':{value!r}, got {e!r}")
+
+    if (token.kind, token.value) != ('op', value):
+        self.oops(f"Expected 'op':{value!r}, got {token!r}")  # pragma: no cover
+#@+node:ekr.20240114013952.1: *4* tbo.expect_ops
+def expect_ops(self, i: int, values: list) -> None:
+    """Raise an exception if self.tokens[i] is not as expected."""
+    try:
+        token = self.tokens[i]
+    except Exception as e:  # pragma: no cover
+        self.oops(f"At index {i!r}: Expected 'op' in {values!r}, got {e!r}")
+
+    if token.kind != 'op' or token.value not in values:
+        self.oops(f"Expected 'op' in {values!r}, got {token!r}")  # pragma: no cover
+#@+node:ekr.20240127051941.1: *4* tbo.get_token
+def get_token(self, i: int) -> InputToken:
+    """Return the token at i, with full error checking."""
+    try:
+        token = self.tokens[i]
+    except Exception as e:  # pragma: no cover
+        self.oops(f"Invalid index: {i!r}: {e}")
+    return token
+#@+node:ekr.20240125182219.1: *4* tbo.trace & helper
+def trace(self, i: int, i2: Optional[int] = None, *, tag: str = None) -> None:  # pragma: no cover
+    """
+    Print i, token, and get_token_line(i).
+
+    A surprisingly useful debugging utility.
+    """
+
+    token = self.tokens[i]
+    indices_s = f"{i}" if i2 is None else f"i: {i} i2: {i2}"
+
+    # Adjust widths below as necessary.
+    print(
+        f"{g.callers(1)}: {tag or ''}\n"
+        f"  callers: {g.callers()}\n"
+        f"  indices: {indices_s} token: {token.kind:}:{token.show_val(30)}\n"
+        f"     line: {self.get_token_line(i)!r}\n"
+    )
+#@+node:ekr.20240124094344.1: *5* tbo.get_token_line
+def get_token_line(self, i: int) -> str:  # pragma: no cover
+    """return self.tokens[i].line"""
+    try:
+        token = self.tokens[i]
+    except Exception as e:
+        self.oops(f"Bad token index {i!r}: {e}")
+
+    return token.line.rstrip()
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -657,9 +657,6 @@ class TestTokenBasedOrange(BaseTest):
                     g.printObj(expected, tag='Expected (same as contents)')
                     g.printObj(results, tag='Results')
                 self.assertEqual(expected, results)
-            if 0: ###
-                g.trace('First case passes')
-                break
     #@+node:ekr.20240105153425.57: *3* TestTBO.test_function_defs
     def test_function_defs(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -338,42 +338,6 @@ class TestTokenBasedOrange(BaseTest):
         expected = contents
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected)
-    #@+node:ekr.20240105153425.52: *3* TestTBO.test_bug_1851
-    def test_bug_1851(self):
-
-        contents = r'''\
-    def foo(a1):
-        pass
-    '''
-        contents, tokens = self.make_data(contents)
-        expected = contents.rstrip() + '\n'
-        results = self.beautify(contents, tokens)
-        self.assertEqual(results, expected)
-    #@+node:ekr.20240116155903.1: *3* TestTBO.test_colorizer_fail
-    def test_colorizer_fail(self):
-
-        contents = '''
-
-            # leoColorizer.py: line 2268
-            if j > len(s) and not dots:
-                j = len(s) + 1
-
-                def span(s: str) -> int:
-                    # Note: bindings are frozen by this def.
-                    return self.restart_match_span(s, kind,
-                        delegate=delegate,
-                    )
-        '''
-
-        contents, tokens = self.make_data(contents)
-        # dump_tokens(tokens)
-        expected = contents
-        results = self.beautify(contents, tokens)
-        if False and results != expected:
-            g.printObj(expected, tag='Expected (same as Contents)')
-            g.printObj(results, tag='Results')
-        self.maxDiff = None
-        self.assertEqual(results, expected)
     #@+node:ekr.20240105153425.53: *3* TestTBO.test_comment_indented
     def test_comment_indented(self):
 
@@ -468,42 +432,6 @@ class TestTokenBasedOrange(BaseTest):
             if results != expected:
                 g.trace('Fail:', i)  # pragma: no cover
             self.assertEqual(results, expected)
-    #@+node:ekr.20240112134732.1: *3* TestTBO.test_def_colons
-    def test_def_colons(self):
-
-        contents = '''
-            self.configDict: dict[str, Any] = {}
-            self.configUnderlineDict: dict[str, bool] = {}
-        '''
-        contents, tokens = self.make_data(contents)
-        # dump_tokens(tokens)
-        expected = contents
-        results = self.beautify(contents, tokens)
-        if results != expected:  # pragma: no cover
-            # g.printObj(contents, tag='Contents')
-            g.printObj(expected, tag='Expected (same as Contents)')
-            g.printObj(results, tag='Results')
-
-        self.maxDiff = None
-        self.assertEqual(results, expected)
-
-    #@+node:ekr.20240114100847.1: *3* TestTBO.test_def_square_brackets
-    def test_def_square_brackets(self):
-
-        contents = (
-            """def checkForDuplicateShortcuts(self, c: Cmdr, d: dict[str, str]) -> None:\n"""
-        )
-        contents, tokens = self.make_data(contents)
-        # dump_tokens(tokens)
-        expected = contents
-        results = self.beautify(contents, tokens)
-        if False and results != expected:
-            # g.printObj(contents, tag='Contents')
-            g.printObj(expected, tag='Expected (same as Contents)')
-            g.printObj(results, tag='Results')
-
-        self.maxDiff = None
-        self.assertEqual(results, expected)
     #@+node:ekr.20240105153425.56: *3* TestTBO.test_dont_delete_blank_lines
     def test_dont_delete_blank_lines(self):
 
@@ -520,229 +448,6 @@ class TestTokenBasedOrange(BaseTest):
         expected = contents.rstrip() + '\n'
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected)
-    #@+node:ekr.20240116072845.1: *3* TestTBO.test_expressions
-    def test_expressions(self):
-
-        contents = """skip_count = max(0, (len(target) - 1))\n"""
-
-        contents, tokens = self.make_data(contents)
-        expected = self.blacken(contents)
-        results = self.beautify(contents, tokens)
-        if expected != results:  # pragma: no cover
-            g.printObj(expected, tag='Explected (blackened)')
-            g.printObj(results, tag='Results')
-        self.assertEqual(results, expected)
-    #@+node:ekr.20240124092041.1: *3* TestTBO.test_fstrings
-    def test_fstrings(self):
-
-        # leoApp.py, line 885.
-        contents = """signon = [f"Leo {leoVer}"]\n"""
-        contents, tokens = self.make_data(contents)
-        expected = self.blacken(contents)
-        results = self.beautify(contents, tokens)
-        self.assertEqual(results, expected)
-    #@+node:ekr.20240126062946.1: *3* TestTBO.test_function_call_with_parens
-    def test_function_calls_with_parens(self):
-
-        # LeoFrame.py, line 1650.
-
-        # Test 1: The 'if' statement on a single line.
-        contents1 = """
-            if (g.doHook("select1", c = c, new_p=p)):
-                return
-            """
-
-        # Black would remove the outer parens.
-        expected1 = textwrap.dedent(
-            """
-            if (g.doHook("select1", c=c, new_p=p)):
-                return
-            """).strip() + '\n'
-
-        # Test 2: The 'if' statement spans several lines.
-        contents2 = """
-            if (
-                whatever and g.doHook(
-                    "select1", c = c, new_p=p)
-            ):
-                return
-            """
-
-        # Black would remove the outer parens.
-        expected2 = textwrap.dedent(
-            """
-            if (
-                whatever and g.doHook(
-                    "select1", c=c, new_p=p)
-            ):
-                return
-            """).strip() + '\n'
-
-        table = (
-            (contents1, expected1),
-            (contents2, expected2),
-        )
-        for contents, expected in table:
-            contents, tokens = self.make_data(contents)
-            results = self.beautify(contents, tokens)
-            if results != expected:
-                if 1:
-                    g.printObj(contents, tag='Contents')
-                    g.printObj(expected, tag='Expected (blackened)')
-                    g.printObj(results, tag='Results')
-                self.assertEqual(expected, results)
-    #@+node:ekr.20240107080413.1: *3* TestTBO.test_function_calls
-    def test_function_calls(self):
-
-        # Put recent failures first.
-        table = (
-            # leoserver.py, line 584.
-            """timeline.sort(key=lambda x: x[0].gnx, reverse=True)""",
-
-            # leoserver.py, line 42 and other lines.
-            """jsonPackage = json.dumps(package, separators=(',', ':'), cls=SetEncoder)""",
-
-            # #1429: https://github.com/leo-editor/leo-editor/issues/1429
-            """
-            version = str(version2.Version.coerce(tag, partial=True))
-            """,
-
-            # LeoApp.py, line 1872.
-            """
-            if path.startswith(tag):
-                return self.computeBindingLetter(c, path=path[len(tag) :])
-            """,
-
-            # LeoApp.py, line 3416.
-            """
-            if groupedEntries:
-                dirCount: dict[str, Any] = {}
-                for fileName in rf.getRecentFiles()[:n]:
-                    dirName, baseName = g.os_path_split(fileName)
-            """,
-
-            # leoPersistence, line 526.
-            """
-            return '-->'.join(reversed(
-                [self.expected_headline(p2) for p2 in p.self_and_parents(copy=False)]))
-            """,
-
-            # leoNodes, line 881.
-            """
-            path_part = '-->'.join(list(reversed([z.h for z in self.self_and_parents(copy=False)])))
-            """,
-
-            # leoserver.py, line 2302.
-            """
-            result = [
-                self._get_position_d(p, c) for p in c.all_positions(copy=False)
-            ]
-            """,
-
-            # leoApp, line 1657
-            """
-            if True:
-                home = os.getenv(home[1:-1], default=None)
-            """,
-        )
-        for i, contents in enumerate(table):
-            contents, tokens = self.make_data(contents)
-            expected = contents  # Black would join lines.
-            results = self.beautify(contents, tokens)
-            if results != expected:
-                # dump_tokens(tokens)
-                if 1:
-                    print('')
-                    # g.printObj(contents, tag='Contents')
-                    g.printObj(expected, tag='Expected (same as contents)')
-                    g.printObj(results, tag='Results')
-                self.assertEqual(expected, results)
-    #@+node:ekr.20240105153425.57: *3* TestTBO.test_function_defs
-    def test_function_defs(self):
-
-        long_table = (
-            # Case 1.
-            """
-                def f1(a=2 + 5):
-                    pass
-            """,
-            # Case 2
-            """
-                def f2(a):
-                    pass
-            """,
-            # Case 3.
-            """
-            def f3(a: int = 2):
-                pass
-            """,
-            # Case 4.
-            '''
-            def should_kill_beautify(p):
-                """Return True if p.b contains @killbeautify"""
-                return 'killbeautify' in g.get_directives_dict(p)
-            ''',
-            # Case 5 (new)
-            '''
-                def reloadSettings():
-                    pass
-            ''',
-            # Case 6 (new)
-            '''
-                def tuple_init(stack: Sequence[str] = ('root',)) -> Generator:
-                    pass
-            ''',
-            # Case 7 (new)
-        )
-        short_table = (
-            '''
-                def tuple_init(stack: Sequence[str] = ('root',)) -> Generator:
-                    pass
-            ''',
-        )
-        assert long_table and short_table
-        table = long_table
-        for i, contents in enumerate(table):
-            contents, tokens = self.make_data(contents)
-            expected = self.blacken(contents).rstrip() + '\n'
-            results = self.beautify(contents, tokens)
-            if expected != results:  # pragma: no cover
-                g.printObj(expected, tag='Explected (blackened)')
-                g.printObj(results, tag='Results')
-            self.assertEqual(results, expected)
-    #@+node:ekr.20240105153425.63: *3* TestTBO.test_leading_stars
-    def test_leading_stars(self):
-
-        # #2533.
-        contents = """
-            def f(
-                arg1,
-                *args,
-                **kwargs
-            ):
-                pass
-        """
-        contents, tokens = self.make_data(contents)
-        if 1:  # w/o join:
-            expected = contents
-        else:  # with join.
-            expected = """
-                def f(arg1, *args, **kwargs):
-                    pass
-            """
-        results = self.beautify(contents, tokens)
-        self.assertEqual(expected, results)
-    #@+node:ekr.20240105153425.64: *3* TestTBO.test_leading_stars_one_line
-    def test_leading_stars_one_line(self):
-
-        # #2533.
-        contents = """
-            def f(arg1, *args, **kwargs):
-                pass
-        """
-        contents, tokens = self.make_data(contents)
-        results = self.beautify(contents, tokens)
-        self.assertEqual(contents, results)
     #@+node:ekr.20240105153425.65: *3* TestTBO.test_leo_sentinels
     def test_leo_sentinels_1(self):
 
@@ -844,8 +549,8 @@ class TestTokenBasedOrange(BaseTest):
         # See https://peps.python.org/pep-0008/#other-recommendations
 
         tag = 'test_one_line_pet_peeves'
-        # Except where noted, all entries are expected values....
 
+        # Except where noted, all entries are expected values...
         table = (
             # Assignments...
             """a = b * c""",
@@ -940,23 +645,6 @@ class TestTokenBasedOrange(BaseTest):
             g.printObj(results, tag='Results')
             g.printObj(expected, tag='Expected')
         self.assertEqual(expected, results)
-    #@+node:ekr.20240105153425.71: *3* TestTBO.test_return
-    def test_return(self):
-
-        contents = """return []"""
-        expected = self.blacken(contents)
-        contents, tokens = self.make_data(contents)
-        results = self.beautify(contents, tokens)
-        self.assertEqual(results, expected)
-    #@+node:ekr.20240105153425.72: *3* TestTBO.test_single_quoted_string
-    def test_single_quoted_string(self):
-
-        contents = """print('hi')"""
-        # blacken suppresses string normalization.
-        expected = self.blacken(contents)
-        contents, tokens = self.make_data(contents)
-        results = self.beautify(contents, tokens)
-        self.assertEqual(results, expected)
     #@+node:ekr.20240109090653.1: *3* TestTBO.test_slice
     def test_slice(self):
 
@@ -1036,24 +724,15 @@ class TestTokenBasedOrange(BaseTest):
             self.assertEqual(expected, results)
     #@+node:ekr.20240105153425.76: *3* TestTBO.test_star_star_operator
     def test_star_star_operator(self):
-        # Was tested in pet peeves, but this is more permissive.
+
+        # Don't rely on black for this test.
         contents = """a = b ** c"""
         contents, tokens = self.make_data(contents)
-        # Don't rely on black for this test.
-        # expected = self.blacken(contents)
         expected = contents
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected)
-    #@+node:ekr.20240105153425.78: *3* TestTBO.test_ternary
-    def test_ternary(self):
-
-        contents = """print(2 if name == 'class' else 1)"""
-        contents, tokens = self.make_data(contents)
-        expected = contents
-        results = self.beautify(contents, tokens)
-        self.assertEqual(results, expected)
-    #@+node:ekr.20240109070553.1: *3* TestTBO.test_unary_op
-    def test_unary_op(self):
+    #@+node:ekr.20240109070553.1: *3* TestTBO.test_unary_ops
+    def test_unary_ops(self):
 
         # One-line pet peeves involving unary ops but *not* slices.
 
@@ -1070,8 +749,14 @@ class TestTokenBasedOrange(BaseTest):
             # Dicts...
             """d = {key: -3}""",
             """d['key'] = a[-i]""",
-            # Unary ops...
+            # Unary minus...
             """v = -1 if a < b else -2""",
+            # ~
+            """a = ~b""",
+            """c = a[:~e:]""",
+            # """d = a[f() - 1 :]""",
+            # """e = a[2 - 1 :]""",
+            # """e = a[b[2] - 1 :]""",
         )
         for i, contents in enumerate(table):
             description = f"{tag} part {i}"


### PR DESCRIPTION
- [x] Fix bug: `finish_dict` was never called!
- [x] Add comment: `finis_dict` could be a do-nothing:
   the `dict` context does not change the output of `tbo.gen_colon`.
- [x] Move unused methods to the attic.
- [x] Remove '###' comments and traces.
- [x] Document valid contexts in `pre_scan`.
- [x] Add unit test to cover unary `~'.
- [x] Remove recent (feeble!) unit tests that tested the parser instead of results.