### PR TITLE
PR for #3766: Clean unit test files

### DIFF
--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -773,6 +773,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         self.filename = filename
         contents, encoding = g.readFileIntoString(filename)
         if not contents:
+            self.tokens = []
             return None, None, None
         self.tokens = tokens = Tokenizer().make_input_tokens(contents)
         return contents, encoding, tokens

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -592,6 +592,9 @@ class TokenBasedOrange:  # Orange is the new Black.
         self.tab_width = 4
         self.verbose = False
 
+        # Make sure tokens is defined, even for empty files.
+        self.tokens: list[InputToken] = []
+
         # Override defaults from settings dict.
         valid_keys = ('diff', 'force', 'orange', 'safe', 'silent', 'tab_width', 'verbose')
         for key in settings:  # pragma: no cover

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -51,5 +51,4 @@ class TestChecker(LeoUnitTest):
     #@-others
 #@-others
 
-
 #@-leo

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -1,7 +1,6 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20210904022712.2: * @file ../unittests/commands/test_checkerCommands.py
 """Tests of leo.commands.leoCheckerCommands."""
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 #@+others
@@ -33,12 +32,12 @@ class TestChecker(LeoUnitTest):
         x.c = c
         x.ok_head_patterns = []
         table = (
-            textwrap.dedent("""\
+            """
                 def spam():
                     pass
                 def eggs():
                     pass
-            """),  # Too many defs.
+            """,  # Too many defs.
             "   ",  # Empty body.
             "\ntest\n",  # Leading blank line.
             "\n\nclass MyClass\n",  # Trailing class line.

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -21,15 +21,15 @@ class Test_To_Python(BaseTestImporter):
         c = self.c
         x1 = ConvertCommandsClass(c)
         x = x1.C_To_Python(c)
-        s = textwrap.dedent("""\
-        void hello_world()
-        {
-            print('hi')
-            if a == 2 {
-                print('2')
+        s = """
+            void hello_world()
+            {
+                print('hi')
+                if a == 2 {
+                    print('2')
+                }
             }
-        }
-        """)
+        """
         lines = g.splitLines(s)
         x.convertCodeList(lines)
     #@-others
@@ -62,13 +62,14 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220108091352.1: *3* test_ama.test_already_annotated
     def test_already_annotated(self):
         p = self.p
-        p.b = contents = textwrap.dedent('''\
+        p.b = contents = textwrap.dedent(
+        '''
             def f1(i: int, s: str) -> str:
                 return s
 
             def f2(self, c: Cmdr, g: Any, ivars: list[str]) -> Any:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, contents)
     #@+node:ekr.20220416053117.1: *3* test_ama.test_bug_2606
@@ -76,7 +77,8 @@ class TestAddMypyAnnotations(LeoUnitTest):
         # https://github.com/leo-editor/leo-editor/issues/2606
         p = self.p
         # Make sure any adjustment to the args logic doesn't affect following functions.
-        p.b = textwrap.dedent('''\
+        p.b = textwrap.dedent(
+        '''
             def f1(root=p and p.copy()):
                 pass
 
@@ -85,8 +87,9 @@ class TestAddMypyAnnotations(LeoUnitTest):
 
             def f3(a, self=self):
                 pass
-    ''')
-        expected = textwrap.dedent('''\
+        ''')
+        expected = textwrap.dedent(
+        '''
             def f1(root: Any=p and p.copy()) -> None:
                 pass
 
@@ -95,26 +98,29 @@ class TestAddMypyAnnotations(LeoUnitTest):
 
             def f3(a: Any, self=self) -> None:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220108093044.1: *3* test_ama.test_initializers
     def test_initializers(self):
         p = self.p
-        p.b = textwrap.dedent('''\
+        p.b = textwrap.dedent(
+        '''
             def f3(i = 2, f = 1.1, b = True, s = 'abc', x = None):
                 pass
-    ''')
-        expected = textwrap.dedent('''\
+        ''')
+        expected = textwrap.dedent(
+        '''
             def f3(i: int=2, f: float=1.1, b: bool=True, s: str='abc', x: Any=None) -> None:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220108093621.1: *3* test_ama.test_multiline_def
     def test_multiline_def(self):
         p = self.p
-        p.b = textwrap.dedent('''\
+        p.b = textwrap.dedent(
+        '''
             def f (
                 self,
                 a,
@@ -124,8 +130,9 @@ class TestAddMypyAnnotations(LeoUnitTest):
                 **kwargs,
             ):
                 pass
-    ''')
-        expected = textwrap.dedent('''\
+        ''')
+        expected = textwrap.dedent(
+        '''
             def f(
                 self,
                 a: Any,
@@ -135,13 +142,14 @@ class TestAddMypyAnnotations(LeoUnitTest):
                 **kwargs: Any,
             ) -> None:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220108153333.1: *3* test_ama.test_multiline_def_with_comments
     def test_multiline_def_with_comments(self):
         p = self.p
-        p.b = textwrap.dedent('''\
+        p.b = textwrap.dedent(
+        '''
             def f (
                 self,# comment 1
                 a,   # comment, 2
@@ -150,9 +158,10 @@ class TestAddMypyAnnotations(LeoUnitTest):
                 e=3,
             ):
                 pass
-    ''')
+        ''')
         # Note: The command insert exactly two spaces before comments.
-        expected = textwrap.dedent('''\
+        expected = textwrap.dedent(
+        '''
             def f(
                 self,  # comment 1
                 a: Any,  # comment, 2
@@ -161,27 +170,30 @@ class TestAddMypyAnnotations(LeoUnitTest):
                 e: int=3,
             ) -> None:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         # g.printObj(p.b)
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220108083112.4: *3* test_ama.test_plain_args
     def test_plain_args(self):
         p = self.p
-        p.b = textwrap.dedent('''\
+        p.b = textwrap.dedent(
+        '''
             def f1(event, i, s):
                 pass
-    ''')
-        expected = textwrap.dedent('''\
+        ''')
+        expected = textwrap.dedent(
+        '''
             def f1(event: Event, i: int, s: str) -> None:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
     #@+node:ekr.20220416082758.1: *3* test_ama.test_special_methods
     def test_special_methods(self):
         p = self.p
-        p.b = textwrap.dedent('''\
+        p.b = textwrap.dedent(
+        '''
             def __init__(self):
                 pass
 
@@ -190,8 +202,9 @@ class TestAddMypyAnnotations(LeoUnitTest):
 
             def __str__(self):
                 pass
-    ''')
-        expected = textwrap.dedent('''\
+        ''')
+        expected = textwrap.dedent(
+        '''
             def __init__(self) -> None:
                 pass
 
@@ -200,7 +213,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
 
             def __str__(self) -> str:
                 pass
-    ''')
+        ''')
         self.x.convert_body(p)
         self.assertEqual(p.b, expected)
     #@-others

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -824,7 +824,8 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.30: *5* clean-lines
     def test_clean_lines(self):
         """Test case for clean-lines"""
-        before_b = textwrap.dedent("""\
+        before_b = textwrap.dedent(
+        """
             # Should remove all trailing whitespace.
 
             a = 2
@@ -1978,6 +1979,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20210926144000.1: *5* insert-newline-bug-2230
     def test_insert_newline_bug_2230(self):
         """Test case for insert-newline"""
+        # The backslash is required.
         before_b = textwrap.dedent("""\
     #@@language python
     def spam():
@@ -2317,6 +2319,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20220517064432.1: *5* merge-node-with-next-node
     def test_merge_node_with_next_node(self):
         c, u = self.c, self.c.undoer
+        # The backslash is required.
         prev_b = textwrap.dedent("""\
     def spam():
         pass
@@ -2351,6 +2354,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20220517064507.1: *5* merge-node-with-prev-node
     def test_merge_node_with_prev_node(self):
         c, u = self.c, self.c.undoer
+        # The backslash is required.
         prev_b = textwrap.dedent("""\
     def spam():
         pass
@@ -2521,14 +2525,15 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.91: *5* newline-and-indent
     def test_newline_and_indent(self):
         """Test case for newline-and-indent"""
-        before_b = textwrap.dedent("""\
-    first line
-    line 1
-        line a
-            line b
-    line c
-    last line
-    """)
+        before_b = textwrap.dedent(
+        """
+            first line
+            line 1
+                line a
+                    line b
+            line c
+            last line
+        """).strip() + '\n'
         # docstrings strip blank lines, so we can't use a docstring here!
         after_b = ''.join([
             'first line\n'
@@ -4391,7 +4396,8 @@ class TestEditCommands(LeoUnitTest):
         )
         #@-<< define table >>
         w = c.frame.body.wrapper
-        s = textwrap.dedent("""\
+        s = textwrap.dedent(
+        """
             Paragraph 1.
                 line 2.
 

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -1979,21 +1979,20 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20210926144000.1: *5* insert-newline-bug-2230
     def test_insert_newline_bug_2230(self):
         """Test case for insert-newline"""
-        # The backslash is required.
-        before_b = textwrap.dedent("""\
+        before_b = textwrap.dedent("""
     #@@language python
     def spam():
         if 1:  # test
     # after line
-    """)
+    """).strip() + '\n'
         # There are 8 spaces in the line after "if 1:..."
-        after_b = textwrap.dedent("""\
+        after_b = textwrap.dedent("""
     #@@language python
     def spam():
         if 1:  # test
 
     # after line
-    """)
+    """).strip() + '\n'
         self.run_test(
             before_b=before_b,
             after_b=after_b,
@@ -2319,20 +2318,24 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20220517064432.1: *5* merge-node-with-next-node
     def test_merge_node_with_next_node(self):
         c, u = self.c, self.c.undoer
-        # The backslash is required.
-        prev_b = textwrap.dedent("""\
-    def spam():
-        pass
-    """)
-        next_b = textwrap.dedent("""\
-    spam2 = spam
-    """)
-        result_b = textwrap.dedent("""\
-    def spam():
-        pass
+        prev_b = textwrap.dedent(
+        """
+            def spam():
+                pass
+        """).strip() + '\n'
 
-    spam2 = spam
-    """)
+        next_b = textwrap.dedent(
+        """
+            spam2 = spam
+        """).strip() + '\n'
+
+        result_b = textwrap.dedent(
+        """
+            def spam():
+                pass
+
+            spam2 = spam
+        """).strip() + '\n'
         self.before_p.b = prev_b
         self.after_p.b = next_b
         c.selectPosition(self.before_p)
@@ -2354,20 +2357,24 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20220517064507.1: *5* merge-node-with-prev-node
     def test_merge_node_with_prev_node(self):
         c, u = self.c, self.c.undoer
-        # The backslash is required.
-        prev_b = textwrap.dedent("""\
-    def spam():
-        pass
-    """)
-        next_b = textwrap.dedent("""\
-    spam2 = spam
-    """)
-        result_b = textwrap.dedent("""\
-    def spam():
-        pass
+        prev_b = textwrap.dedent(
+        """
+            def spam():
+                pass
+        """).strip() + '\n'
 
-    spam2 = spam
-    """)
+        next_b = textwrap.dedent(
+        """
+            spam2 = spam
+        """).strip() + '\n'
+
+        result_b = textwrap.dedent(
+        """
+            def spam():
+                pass
+
+            spam2 = spam
+        """).strip() + '\n'
         self.before_p.b = prev_b
         self.after_p.b = next_b
         c.selectPosition(self.after_p)
@@ -2726,23 +2733,25 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.99: *5* test_rectangle-string
     def test_rectangle_string(self):
         """Test case for rectangle-string"""
-        # The backslash is required.
-        before_b = textwrap.dedent("""\
+        before_b = textwrap.dedent(
+        """
             before
             aaaxxxbbb
             aaaxxxbbb
             aaaxxxbbb
             aaaxxxbbb
             after
-    """)
-        after_b = textwrap.dedent("""\
+        """).strip() + '\n'
+        after_b = textwrap.dedent(
+        """
             before
             aaas...sbbb
             aaas...sbbb
             aaas...sbbb
             aaas...sbbb
             after
-    """)
+        """).strip() + '\n'
+
         # A hack. The command tests for g.unitTesting!
         self.run_test(
             before_b=before_b,
@@ -2754,24 +2763,26 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.100: *5* test_rectangle-yank
     def test_rectangle_yank(self):
         """Test case for rectangle-yank"""
-        # The backslash is required.
-        before_b = textwrap.dedent("""\
+        before_b = textwrap.dedent(
+        """
             before
             aaaxxxbbb
             aaaxxxbbb
             aaaxxxbbb
             aaaxxxbbb
             after
-        """)
-        after_b = textwrap.dedent("""\
+        """).strip() + '\n'
+
+        after_b = textwrap.dedent(
+        """
             before
             aaaY1Ybbb
             aaaY2Ybbb
             aaaY3Ybbb
             aaaY4Ybbb
             after
-        """)
-        # A hack. The command tests for g.unitTesting!
+        """).strip() + '\n'
+
         self.run_test(
             before_b=before_b,
             after_b=after_b,

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -835,7 +835,7 @@ class TestEditCommands(LeoUnitTest):
             d = 5
             e = 6
             x
-            """)
+        """)
         after_b = before_b
         # Add some trailing ws to before_b
         i = 1 + before_b.find('3')
@@ -2534,6 +2534,7 @@ class TestEditCommands(LeoUnitTest):
             line c
             last line
         """).strip() + '\n'
+
         # docstrings strip blank lines, so we can't use a docstring here!
         after_b = ''.join([
             'first line\n'
@@ -2725,6 +2726,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.99: *5* test_rectangle-string
     def test_rectangle_string(self):
         """Test case for rectangle-string"""
+        # The backslash is required.
         before_b = textwrap.dedent("""\
             before
             aaaxxxbbb
@@ -2752,6 +2754,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.100: *5* test_rectangle-yank
     def test_rectangle_yank(self):
         """Test case for rectangle-yank"""
+        # The backslash is required.
         before_b = textwrap.dedent("""\
             before
             aaaxxxbbb
@@ -4403,7 +4406,7 @@ class TestEditCommands(LeoUnitTest):
 
             Paragraph 2.
             line 2, paragraph 2
-    """)
+        """)
         w.setAllText(s)
         child = c.rootPosition().insertAfter()
         c.selectPosition(child)

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2519,8 +2519,7 @@ class TestOrange(BaseTest):
 
         line_length = 40  # For testing.
 
-        # The backslash is required.
-        contents = textwrap.dedent("""\
+        contents = textwrap.dedent("""
     #@@nobeautify
 
     def addOptionsToParser(self, parser, trace_m):
@@ -2544,7 +2543,7 @@ class TestOrange(BaseTest):
     docDirective    =  3 # @doc.
 
     #@@beautify
-    """)
+    """).lstrip()
         contents, tokens, tree = self.make_data(contents)
         expected = contents
         results = self.beautify(contents, tokens, tree,

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1390,17 +1390,17 @@ class TestFstringify(BaseTest):
     #@+node:ekr.20210318054321.1: *5* TestFstringify.test_bug_1851
     def test_bug_1851(self):
         # leoCheck.py.
-        contents = """\
-    from dataclasses import dataclass
+        contents = """
+            from dataclasses import dataclass
 
-    @dataclass(frozen=True)
-    class TestClass:
-        value: str
-        start: int
-        end: int
+            @dataclass(frozen=True)
+            class TestClass:
+                value: str
+                start: int
+                end: int
 
-    f = TestClass('abc', 0, 10)
-    """
+            f = TestClass('abc', 0, 10)
+        """
         contents, tokens, tree = self.make_data(contents)
         expected = textwrap.dedent(contents).rstrip() + '\n'
         results = self.fstringify(contents, tokens, tree)
@@ -1516,15 +1516,16 @@ class TestFstringify(BaseTest):
     #@+node:ekr.20200122035055.1: *4* TestFstringify.test_call_with_comments
     def test_call_with_comments(self):
 
-        contents = """\
-    print('%s in %5.2f sec' % (
-        "done", # message
-        2.9, # time
-    )) # trailing comment"""
+        contents = """
+            print('%s in %5.2f sec' % (
+                "done", # message
+                2.9, # time
+            )) # trailing comment
+        """
 
         expected = """\
-    print(f'{"done"} in {2.9:5.2f} sec') # trailing comment
-    """
+            print(f'{"done"} in {2.9:5.2f} sec') # trailing comment
+        """
         contents, tokens, tree = self.make_data(contents)
         expected = textwrap.dedent(expected).rstrip() + '\n'
         results = self.fstringify(contents, tokens, tree)
@@ -2014,17 +2015,17 @@ class TestOrange(BaseTest):
     #@+node:ekr.20200116104031.1: *4* TestOrange.test_join_and_strip_condition
     def test_join_and_strip_condition(self):
 
-        contents = """\
-    if (
-        a == b or
-        c == d
-    ):
-        pass
-    """
-        expected = """\
-    if (a == b or c == d):
-        pass
-    """
+        contents = """
+            if (
+                a == b or
+                c == d
+            ):
+                pass
+        """.strip() + '\n'
+        expected = """
+            if (a == b or c == d):
+                pass
+        """.strip() + '\n'
         contents, tokens, tree = self.make_data(contents)
         expected = textwrap.dedent(expected)
         # Black also removes parens, which is beyond our scope at present.
@@ -2102,18 +2103,18 @@ class TestOrange(BaseTest):
     #@+node:ekr.20200210051900.1: *4* TestOrange.test_join_suppression
     def test_join_suppression(self):
 
-        contents = """\
-    class T:
-        a = 1
-        print(
-           a
-        )
-    """
-        expected = """\
-    class T:
-        a = 1
-        print(a)
-    """
+        contents = """
+            class T:
+                a = 1
+                print(
+                   a
+                )
+        """.strip() + '\n'
+        expected = """
+            class T:
+                a = 1
+                print(a)
+        """.strip() + '\n'
         contents, tokens, tree = self.make_data(contents)
         expected = textwrap.dedent(expected)
         results = self.beautify(contents, tokens, tree)
@@ -2154,18 +2155,19 @@ class TestOrange(BaseTest):
     def test_leading_stars(self):
 
         # #2533.
-        contents = """\
+        contents = """
             def f(
                 arg1,
                 *args,
                 **kwargs
             ):
                 pass
-    """
-        expected = textwrap.dedent("""\
+        """.strip() + '\n'
+
+        expected = """
             def f(arg1, *args, **kwargs):
                 pass
-    """)
+        """.strip() + '\n'
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
         self.assertEqual(expected, results)
@@ -2344,6 +2346,7 @@ class TestOrange(BaseTest):
     def test_relative_imports(self):
 
         # #2533.
+        # backslash is required.
         contents = """\
             from .module1 import w
             from . module2 import x
@@ -2353,7 +2356,7 @@ class TestOrange(BaseTest):
             from.import b
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
-    """
+        """
         expected = textwrap.dedent("""\
             from .module1 import w
             from .module2 import x
@@ -2363,7 +2366,7 @@ class TestOrange(BaseTest):
             from . import b
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
-    """)
+        """)
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
         self.assertEqual(expected, results)

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2346,8 +2346,8 @@ class TestOrange(BaseTest):
     def test_relative_imports(self):
 
         # #2533.
-        # backslash is required.
-        contents = """\
+        contents = textwrap.dedent(
+        """
             from .module1 import w
             from . module2 import x
             from ..module1 import y
@@ -2356,8 +2356,10 @@ class TestOrange(BaseTest):
             from.import b
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
+        """).strip() + '\n'
+
+        expected = textwrap.dedent(
         """
-        expected = textwrap.dedent("""\
             from .module1 import w
             from .module2 import x
             from ..module1 import y
@@ -2366,7 +2368,8 @@ class TestOrange(BaseTest):
             from . import b
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
-        """)
+        """).strip() + '\n'
+
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
         self.assertEqual(expected, results)
@@ -2515,6 +2518,7 @@ class TestOrange(BaseTest):
     def test_verbatim(self):
 
         line_length = 40  # For testing.
+
         # The backslash is required.
         contents = textwrap.dedent("""\
     #@@nobeautify

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2515,6 +2515,7 @@ class TestOrange(BaseTest):
     def test_verbatim(self):
 
         line_length = 40  # For testing.
+        # The backslash is required.
         contents = textwrap.dedent("""\
     #@@nobeautify
 

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -105,17 +105,19 @@ class TestAtFile(LeoUnitTest):
     def test_checkPythonSyntax(self):
 
         at, p = self.at, self.c.p
-        s = textwrap.dedent('''\
-    # no error
-    def spam():
-        pass
+        
+        # dedent is required.
+        s = textwrap.dedent('''
+            # no error
+            def spam():
+                pass
         ''')
         assert at.checkPythonSyntax(p, s), 'fail 1'
 
-        s2 = textwrap.dedent('''\
-    # syntax error
-    def spam:  # missing parens.
-        pass
+        s2 = textwrap.dedent('''
+            # syntax error
+            def spam:  # missing parens.
+                pass
         ''')
 
         assert not at.checkPythonSyntax(p, s2), 'fail2'
@@ -218,13 +220,15 @@ class TestAtFile(LeoUnitTest):
         at, c = self.at, self.c
         root = c.rootPosition()
         root.h = '@file test.html'
-        contents = textwrap.dedent('''\
+        contents = textwrap.dedent(
+        '''
             @doc
             First @doc part
             @doc
             Second @doc part
         ''')
-        expected = textwrap.dedent('''\
+        expected = textwrap.dedent(
+        '''
             <!--@+doc-->
             <!--
             First @doc part
@@ -247,16 +251,17 @@ class TestAtFile(LeoUnitTest):
         root.h = '@file test.py'
         child = root.insertAsLastChild()
         child.h = 'child'
-        child.b = textwrap.dedent('''\
+        child.b = textwrap.dedent(
+        '''
             def spam():
                 pass
 
-            @ A single-line doc part.''')
+            @ A single-line doc part.
+        ''').lstrip()
+
         child.v.fileIndex = '<GNX>'
-        contents = textwrap.dedent('''\
-            ATall
-        ''').replace('AT', '@')
-        expected_contents = textwrap.dedent('''\
+        contents = '''ATall'''.replace('AT', '@')
+        expected_contents = textwrap.dedent('''
             #AT+all
             #AT+node:<GNX>: ** child
             def spam():
@@ -264,7 +269,7 @@ class TestAtFile(LeoUnitTest):
 
             @ A single-line doc part.
             #AT-all
-        ''').replace('AT', '@')
+        ''').lstrip().replace('AT', '@')
 
         for blacken in (True, False):
 
@@ -289,20 +294,22 @@ class TestAtFile(LeoUnitTest):
         at, c = self.at, self.c
         root = c.rootPosition()
         root.h = '@file test.py'
-        contents = textwrap.dedent('''\
+        contents = textwrap.dedent(
+        '''
             ATdoc
             doc line 1
             ATall
-        ''').replace('AT', '@')
+        ''').lstrip().replace('AT', '@')
 
         # Only @c or @code end an @doc part.
         # Therefore, the @all line is part of the @doc part.
 
-        expected_contents = textwrap.dedent('''\
+        expected_contents = textwrap.dedent(
+        '''
             #AT+doc
             # doc line 1
             # ATall
-        ''').replace('AT', '@')
+        ''').lstrip().replace('AT', '@')
 
         for blacken in (True, False):
 
@@ -331,16 +338,15 @@ class TestAtFile(LeoUnitTest):
         child.h = 'child'
         child.b = '@others\n'
         child.v.fileIndex = '<GNX>'
-        contents = textwrap.dedent('''\
-            ATothers
-        ''').replace('AT', '@')
-        expected_contents = textwrap.dedent('''\
+        contents = '''ATothers'''.replace('AT', '@')
+        expected_contents = textwrap.dedent(
+        '''
             #AT+others
             #AT+node:<GNX>: ** child
             #AT+others
             #AT-others
             #AT-others
-        ''').replace('AT', '@')
+        ''').lstrip().replace('AT', '@')
 
         for blacken in (True, False):
 
@@ -372,16 +378,20 @@ class TestAtFile(LeoUnitTest):
         at, c = self.at, self.c
         root = c.rootPosition()
         root.h = '@file test.html'
-        contents = textwrap.dedent('''\
+        
+        contents = textwrap.dedent(
+        '''
             @doc
             Unterminated @doc parts (not an error)
-        ''')
-        expected = textwrap.dedent('''\
+        ''').lstrip()
+
+        expected = textwrap.dedent(
+        '''
             <!--@+doc-->
             <!--
             Unterminated @doc parts (not an error)
             -->
-        ''')
+        ''').lstrip()
         root.b = contents
         at.initWriteIvars(root)
         at.putBody(root)
@@ -553,20 +563,24 @@ class TestAtFile(LeoUnitTest):
     def test_tabNannyNode(self):
 
         at, p = self.at, self.c.p
+
         # Test 1.
-        s = textwrap.dedent("""\
+        s = textwrap.dedent(
+        """
             # no error
             def spam():
                 pass
-        """)
+        """).lstrip()
         at.tabNannyNode(p, body=s)
+
         # Test 2.
-        s2 = textwrap.dedent("""\
+        s2 = textwrap.dedent(
+        """
             # syntax error
             def spam:
                 pass
               a = 2
-        """)
+        """).lstrip()
         try:
             at.tabNannyNode(p, body=s2)
         except IndentationError:
@@ -600,22 +614,24 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211106112233.1: *4* << define contents >>
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-            #AT+leo-ver=5-thin
-            #AT+node:{root.gnx}: * {h}
-            #AT@language python
+        contents = textwrap.dedent(
+            '''
+                #AT+leo-ver=5-thin
+                #AT+node:{root.gnx}: * {h}
+                #AT@language python
 
-            a = 1
-            if (
-            #AT+LB test >>
-            #AT+node:ekr.20211107051401.1: ** LB test >>
-            a == 2
-            #AT-LB test >>
-            #ATafterref
-             ):
-                a = 2
-            #AT-leo
-        ''').lstrip()
+                a = 1
+                if (
+                #AT+LB test >>
+                #AT+node:ekr.20211107051401.1: ** LB test >>
+                a == 2
+                #AT-LB test >>
+                #ATafterref
+                 ):
+                    a = 2
+                #AT-leo
+            ''').lstrip()
+
         contents = contents.replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
@@ -623,7 +639,8 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211106115654.1: *4* << define expected_body >>
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        expected_body = textwrap.dedent('''
+        expected_body = textwrap.dedent(
+        '''
             ATlanguage python
 
             a = 1
@@ -636,7 +653,8 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211107053133.1: *4* << define expected_contents >>
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        expected_contents = textwrap.dedent('''
+        expected_contents = textwrap.dedent(
+        '''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
             #AT@language python
@@ -678,26 +696,27 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211103093424.1: *4* << define contents >> (test_at_all)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        # This is Leo's final resting place for dead code.
-        # Much easier to access than a git repo.
+        contents = textwrap.dedent(
+        '''
+            #AT+leo-ver=5-thin
+            #AT+node:{root.gnx}: * {h}
+            # This is Leo's final resting place for dead code.
+            # Much easier to access than a git repo.
 
-        #AT@language python
-        #AT@killbeautify
-        #AT+all
-        #AT+node:ekr.20211103093559.1: ** node 1
-        Section references can be undefined.
+            #AT@language python
+            #AT@killbeautify
+            #AT+all
+            #AT+node:ekr.20211103093559.1: ** node 1
+            Section references can be undefined.
 
-        LB missing reference >>
-        #AT+node:ekr.20211103093633.1: ** node 2
-        #ATverbatim
-        #ATothers doesn't generate anything.
-        ATothers
-        #AT-all
-        #AT@nosearch
-        #AT-leo
+            LB missing reference >>
+            #AT+node:ekr.20211103093633.1: ** node 2
+            #ATverbatim
+            #ATothers doesn't generate anything.
+            ATothers
+            #AT-all
+            #AT@nosearch
+            #AT-leo
         ''').lstrip()
         contents = contents.replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
@@ -729,33 +748,34 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101090447.1: *4* << define contents >> (test_at_comment)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        !!! -*- coding: utf-8 -*-
-        !!!AT+leo-ver=5-thin
-        !!!AT+node:{root.gnx}: * {h}
-        !!!AT@first
+        contents = textwrap.dedent(
+        '''
+            !!! -*- coding: utf-8 -*-
+            !!!AT+leo-ver=5-thin
+            !!!AT+node:{root.gnx}: * {h}
+            !!!AT@first
 
-        """Classes to read and write @file nodes."""
+            """Classes to read and write @file nodes."""
 
-        !!!AT@comment !!!
+            !!!AT@comment !!!
 
-        !!!AT+LB test >>
-        !!!AT+node:ekr.20211101090015.2: ** LB test >>
-        print('in test section')
-        print('done')
-        !!!AT-LB test >>
+            !!!AT+LB test >>
+            !!!AT+node:ekr.20211101090015.2: ** LB test >>
+            print('in test section')
+            print('done')
+            !!!AT-LB test >>
 
-        !!!AT+others
-        !!!AT+node:ekr.20211101090015.3: ** spam
-        def spam():
-            pass
-        !!!AT+node:ekr.20211101090015.4: ** eggs
-        def eggs():
-            pass
-        !!!AT-others
+            !!!AT+others
+            !!!AT+node:ekr.20211101090015.3: ** spam
+            def spam():
+                pass
+            !!!AT+node:ekr.20211101090015.4: ** eggs
+            def eggs():
+                pass
+            !!!AT-others
 
-        !!!AT@language plain
-        !!!AT-leo
+            !!!AT@language plain
+            !!!AT-leo
         ''').lstrip()
         contents = contents.replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
@@ -797,31 +817,32 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101111652.1: *4* << define contents >> (test_at_delims)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        # -*- coding: utf-8 -*-
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        #AT@first
+        contents = textwrap.dedent(
+        '''
+            # -*- coding: utf-8 -*-
+            #AT+leo-ver=5-thin
+            #AT+node:{root.gnx}: * {h}
+            #AT@first
 
-        #ATdelims !!SPACE
+            #ATdelims !!SPACE
 
-        !!AT+LB test >>
-        !!AT+node:ekr.20211101111409.2: ** LB test >>
-        print('in test section')
-        print('done')
-        !!AT-LB test >>
+            !!AT+LB test >>
+            !!AT+node:ekr.20211101111409.2: ** LB test >>
+            print('in test section')
+            print('done')
+            !!AT-LB test >>
 
-        !!AT+others
-        !!AT+node:ekr.20211101111409.3: ** spam
-        def spam():
-            pass
-        !!AT+node:ekr.20211101111409.4: ** eggs
-        def eggs():
-            pass
-        !!AT-others
+            !!AT+others
+            !!AT+node:ekr.20211101111409.3: ** spam
+            def spam():
+                pass
+            !!AT+node:ekr.20211101111409.4: ** eggs
+            def eggs():
+                pass
+            !!AT-others
 
-        !!AT@language python
-        !!AT-leo
+            !!AT@language python
+            !!AT-leo
         ''').lstrip()
         contents = contents.replace('AT', '@').replace('LB', '<<').replace('SPACE', ' ')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
@@ -865,19 +886,20 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211103095959.1: *4* << define contents >> (test_at_last)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        # Test of ATlast
-        #AT+others
-        #AT+node:ekr.20211103095810.1: ** spam
-        def spam():
-            pass
-        #AT-others
-        #AT@language python
-        #AT@last
-        #AT-leo
-        # last line
+        contents = textwrap.dedent(
+        '''
+            #AT+leo-ver=5-thin
+            #AT+node:{root.gnx}: * {h}
+            # Test of ATlast
+            #AT+others
+            #AT+node:ekr.20211103095810.1: ** spam
+            def spam():
+                pass
+            #AT-others
+            #AT@language python
+            #AT@last
+            #AT-leo
+            # last line
         ''').lstrip()
         contents = contents.replace('AT', '@')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
@@ -888,11 +910,12 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211104052937.1: *4* << define expected_body >> (test_at_last)
         # Use neither a raw string nor an f-string here.
         # Be careful: no line should look like a Leo sentinel!
-        expected_body = textwrap.dedent('''
-        # Test of @last
-        ATothers
-        ATlanguage python
-        ATlast # last line
+        expected_body = textwrap.dedent(
+        '''
+            # Test of @last
+            ATothers
+            ATlanguage python
+            ATlast # last line
         ''').lstrip().replace('AT', '@')
         #@-<< define expected_body >>
 
@@ -924,19 +947,20 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20211103092228.2: *4* << define contents >> (test_at_others)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(f'''\
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        #AT@language python
+        contents = textwrap.dedent(
+        f'''
+            #AT+leo-ver=5-thin
+            #AT+node:{root.gnx}: * {h}
+            #AT@language python
 
-        class AtOthersTestClass:
-            #AT+others
-            #AT+node:ekr.20211103092443.1: ** method1
-            def method1(self):
-                pass
-            #AT-others
-        #AT-leo
-        ''').replace('AT', '@').replace('LB', '<<')
+            class AtOthersTestClass:
+                #AT+others
+                #AT+node:ekr.20211103092443.1: ** method1
+                def method1(self):
+                    pass
+                #AT-others
+            #AT-leo
+        ''').lstrip().replace('AT', '@').replace('LB', '<<')
         #@-<< define contents >>
 
         for blacken in (True, False):
@@ -968,31 +992,32 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101050923.1: *4* << define contents >> (test_at_section_delim)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        AT+leo-ver=5-thin
-        AT+node:{root.gnx}: * {h}
+        contents = textwrap.dedent(
+        '''
+            AT+leo-ver=5-thin
+            AT+node:{root.gnx}: * {h}
 
-        """Classes to read and write @file nodes."""
+            """Classes to read and write @file nodes."""
 
-        AT@section-delims <!< >!>
+            AT@section-delims <!< >!>
 
-        AT+<!< test >!>
-        AT+node:ekr.20211029054238.1: ** <!< test >!>
-        print('in test section')
-        print('done')
-        AT-<!< test >!>
+            AT+<!< test >!>
+            AT+node:ekr.20211029054238.1: ** <!< test >!>
+            print('in test section')
+            print('done')
+            AT-<!< test >!>
 
-        AT+others
-        AT+node:ekr.20211030052810.1: ** spam
-        def spam():
-        pass
-        AT+node:ekr.20211030053502.1: ** eggs
-        def eggs():
-        pass
-        AT-others
+            AT+others
+            AT+node:ekr.20211030052810.1: ** spam
+            def spam():
+            pass
+            AT+node:ekr.20211030053502.1: ** eggs
+            def eggs():
+            pass
+            AT-others
 
-        AT@language python
-        AT-leo
+            AT@language python
+            AT-leo
         ''').lstrip().replace('AT', '#@')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
@@ -1033,25 +1058,26 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20211101155930.2: *4* << define contents >> (test_clones)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(f'''\
-        #AT+leo-ver=5-thin
-        #AT+node:{root.gnx}: * {h}
-        #AT@language python
+        contents = textwrap.dedent(
+        f'''
+            #AT+leo-ver=5-thin
+            #AT+node:{root.gnx}: * {h}
+            #AT@language python
 
-        a = 1
+            a = 1
 
-        #AT+others
-        #AT+node:ekr.20211101152631.1: ** cloned node
-        a = 2
-        #AT+node:ekr.20211101153300.1: *3* child
-        a = 3
-        #AT+node:ekr.20211101152631.1: ** cloned node
-        a = 2
-        #AT+node:ekr.20211101153300.1: *3* child
-        a = 3
-        #AT-others
-        #AT-leo
-        ''').replace('AT', '@').replace('LB', '<<')
+            #AT+others
+            #AT+node:ekr.20211101152631.1: ** cloned node
+            a = 2
+            #AT+node:ekr.20211101153300.1: *3* child
+            a = 3
+            #AT+node:ekr.20211101152631.1: ** cloned node
+            a = 2
+            #AT+node:ekr.20211101153300.1: *3* child
+            a = 3
+            #AT-others
+            #AT-leo
+        ''').lstrip().replace('AT', '@').replace('LB', '<<')
         #@-<< define contents >>
 
         for blacken in (True, False):
@@ -1100,37 +1126,38 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211103080718.2: *4* << define contents >> (test_cweb)
         # Lines must not look like Leo sentinels!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        ATq@@+leo-ver=5-thin@>
-        ATq@@+node:{root.gnx}: * @{h}@>
-        ATq@@@@language cweb@>
+        contents = textwrap.dedent(
+        '''
+            ATq@@+leo-ver=5-thin@>
+            ATq@@+node:{root.gnx}: * @{h}@>
+            ATq@@@@language cweb@>
 
-        % This is limbo in cweb mode... It should be in BSLaTeX mode, not BSc mode.
-        % The following should not be colorized: class,if,else.
+            % This is limbo in cweb mode... It should be in BSLaTeX mode, not BSc mode.
+            % The following should not be colorized: class,if,else.
 
-        @* this is a _cweb_ comment.  Code is written in BSc.
-        "strings" should not be colorized.
-        It should be colored in BSLaTeX mode.
-        The following are not keywords in latex mode: if, else, etc.
-        Section references are _valid_ in cweb comments!
-        ATq@@+LB section ref 1 >>@>
-        ATq@@+node:ekr.20211103082104.1: ** LB section ref 1 >>@>
-        This is section 1.
-        ATq@@-LB section ref 1 >>@>
-        ATc
+            @* this is a _cweb_ comment.  Code is written in BSc.
+            "strings" should not be colorized.
+            It should be colored in BSLaTeX mode.
+            The following are not keywords in latex mode: if, else, etc.
+            Section references are _valid_ in cweb comments!
+            ATq@@+LB section ref 1 >>@>
+            ATq@@+node:ekr.20211103082104.1: ** LB section ref 1 >>@>
+            This is section 1.
+            ATq@@-LB section ref 1 >>@>
+            ATc
 
-        and this is C code. // It is colored in BSLaTeX mode by default.
-        /* This is a C block comment.  It may also be colored in restricted BSLaTeX mode. */
+            and this is C code. // It is colored in BSLaTeX mode by default.
+            /* This is a C block comment.  It may also be colored in restricted BSLaTeX mode. */
 
-        // Section refs are valid in code too, of course.
-        ATq@@+LB section ref 2 >>@>
-        ATq@@+node:ekr.20211103083538.1: ** LB section ref 2 >>@>
-        This is section 2.
-        ATq@@-LB section ref 2 >>@>
+            // Section refs are valid in code too, of course.
+            ATq@@+LB section ref 2 >>@>
+            ATq@@+node:ekr.20211103083538.1: ** LB section ref 2 >>@>
+            This is section 2.
+            ATq@@-LB section ref 2 >>@>
 
-        BSLaTeX and BSc should not be colored.
-        if else, while, do // C keywords.
-        ATq@@-leo@>
+            BSLaTeX and BSc should not be colored.
+            if else, while, do // C keywords.
+            ATq@@-leo@>
         ''').lstrip()
         contents = contents.replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
@@ -1163,7 +1190,8 @@ class TestFastAtRead(LeoUnitTest):
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
         # The doc part should contain at least one blank line.
-        contents = textwrap.dedent('''
+        contents = textwrap.dedent(
+        '''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
             #AT@language python
@@ -1212,7 +1240,8 @@ class TestFastAtRead(LeoUnitTest):
         # Use neither a raw string nor an f-string here.
 
         # The doc part should contain at least one blank line.
-        contents = textwrap.dedent('''
+        contents = textwrap.dedent(
+        '''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
             <!--AT@language html-->
@@ -1242,7 +1271,8 @@ class TestFastAtRead(LeoUnitTest):
         # For languages with a trailing delim,
         #@verbatim
         # @doc parts contain extra lines for the start/end delims.
-        expected_contents = textwrap.dedent('''
+        expected_contents = textwrap.dedent(
+        '''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
             <!--AT@language html-->
@@ -1297,16 +1327,17 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101154651.1: *4* << define contents >> (test_html_doc_part)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent('''
-        <!--AT+leo-ver=5-thin-->
-        <!--AT+node:{root.gnx}: * {h}-->
-        <!--AT@language html-->
-        <!--AT+at-->
-        Line 1.
+        contents = textwrap.dedent(
+        '''
+            <!--AT+leo-ver=5-thin-->
+            <!--AT+node:{root.gnx}: * {h}-->
+            <!--AT@language html-->
+            <!--AT+at-->
+            Line 1.
 
-        Line 2.
-        <!--AT@c-->
-        <!--AT-leo-->
+            Line 2.
+            <!--AT@c-->
+            <!--AT-leo-->
         ''').lstrip().replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
@@ -1314,18 +1345,19 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20231204050205.1: *4* << define expected >> (test_html_doc_part)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        expected = textwrap.dedent('''
-        <!--AT+leo-ver=5-thin-->
-        <!--AT+node:{root.gnx}: * {h}-->
-        <!--AT@language html-->
-        <!--AT+at-->
-        <!--
-        Line 1.
+        expected = textwrap.dedent(
+        '''
+            <!--AT+leo-ver=5-thin-->
+            <!--AT+node:{root.gnx}: * {h}-->
+            <!--AT@language html-->
+            <!--AT+at-->
+            <!--
+            Line 1.
 
-        Line 2.
-        -->
-        <!--AT@c-->
-        <!--AT-leo-->
+            Line 2.
+            -->
+            <!--AT@c-->
+            <!--AT-leo-->
         ''').lstrip().replace('AT', '@')
         expected = expected.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define expected >>
@@ -1364,23 +1396,24 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20231203092436.2: *4* << define contents >> (test_cweb)
         # Be careful: no line should look like a Leo sentinel!
         # Use a raw string so pyflakes won't complain about \document.
-        contents = textwrap.dedent(r'''
-        ATq@@+leo-ver=5-thin@>
-        ATq@@+node:{root.gnx}: * @{h}@>
-        ATq@@@@language cweb@>
-        % $Id: minimal.w,v 1.4 1995/08/25 19:12:41 schrod Exp $
-        %----------------------------------------------------------------------
+        contents = textwrap.dedent(
+        r'''
+            ATq@@+leo-ver=5-thin@>
+            ATq@@+node:{root.gnx}: * @{h}@>
+            ATq@@@@language cweb@>
+            % $Id: minimal.w,v 1.4 1995/08/25 19:12:41 schrod Exp $
+            %----------------------------------------------------------------------
 
-        % tests minimal CWEB w/ LaTeX input file
+            % tests minimal CWEB w/ LaTeX input file
 
-        \documentclass{cweb}
-        \begin{document}
+            \documentclass{cweb}
+            \begin{document}
 
-        Test.
+            Test.
 
-        AT
-        \end{document}
-        ATq@@-leo@>
+            AT
+            \end{document}
+            ATq@@-leo@>
         ''').lstrip()
         contents = contents.replace('AT', '@').replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
@@ -1410,7 +1443,8 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20211101180404.1: *4* << define contents >> (test_verbatim)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(f'''\
+        contents = textwrap.dedent(
+        f'''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
             #AT@language python
@@ -1419,16 +1453,17 @@ class TestFastAtRead(LeoUnitTest):
             #ATverbatim
             #AT+node (verbatim)
             #AT-leo
-        ''').replace('AT', '@') # .replace('LB', '<<')
+        ''').lstrip().replace('AT', '@') # .replace('LB', '<<')
         #@-<< define contents >>
         #@+<< define expected_body >>
         #@+node:ekr.20211106070035.1: *4* << define expected_body >> (test_verbatim)
-        expected_body = textwrap.dedent('''\
+        expected_body = textwrap.dedent(
+        '''
         ATlanguage python
         # Test of @verbatim
         print('hi')
         #AT+node (verbatim)
-        ''').replace('AT', '@')
+        ''').lstrip().replace('AT', '@')
         #@-<< define expected_body >>
         for blacken in (True, False):
             g.app.write_black_sentinels = blacken
@@ -1467,7 +1502,8 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20231207080536.2: *4* << define contents >> (test_verbatim_html)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(f'''\
+        contents = textwrap.dedent(
+        f'''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
             <!--AT@language html-->
@@ -1478,17 +1514,18 @@ class TestFastAtRead(LeoUnitTest):
                 <!--ATverbatim-->
                 <!--AT+node (verbatim)-->
             <!--AT-leo-->
-        ''').replace('AT', '@') # .replace('LB', '<<')
+        ''').lstrip().replace('AT', '@') # .replace('LB', '<<')
         #@-<< define contents >>
         #@+<< define expected_body >>
         #@+node:ekr.20231207080536.3: *4* << define expected_body >> (test_verbatim_html)
-        expected_body = textwrap.dedent('''\
-        ATlanguage html
-        <!-- Test of @verbatim-->
-        print('hi')
-        <!--AT+node (verbatim)-->
+        expected_body = textwrap.dedent(
+        '''
+            ATlanguage html
+            <!-- Test of @verbatim-->
+            print('hi')
             <!--AT+node (verbatim)-->
-        ''').replace('AT', '@')
+                <!--AT+node (verbatim)-->
+        ''').lstrip().replace('AT', '@')
         #@-<< define expected_body >>
 
         for blacken in (True, False):

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -530,7 +530,8 @@ class TestColorizer(LeoUnitTest):
         self.color('html', text)
     #@+node:ekr.20210905170507.17: *3* TestColorizer.test_colorizer_Java
     def test_colorizer_Java(self):
-        text = textwrap.dedent('''\
+        text = textwrap.dedent(
+        '''
             @ doc part
             @c
 
@@ -1099,7 +1100,8 @@ class TestColorizer(LeoUnitTest):
     #@+node:ekr.20210905170507.26: *3* TestColorizer.test_colorizer_Python2
     def test_colorizer_Python2(self):
 
-        text = textwrap.dedent('''\
+        text = textwrap.dedent(
+        '''
             """This creates a free-floating copy of v's tree for undo.
             The copied trees must use different vnodes than the original."""
 
@@ -1424,7 +1426,8 @@ class TestColorizer(LeoUnitTest):
     #@+node:ekr.20210905170507.36: *3* TestColorizer.test_colorizer_wikiTest
     def test_colorizer_wikiTest(self):
         # both color_markup & add_directives plugins must be enabled.
-        text = textwrap.dedent('''\
+        text = textwrap.dedent(
+        '''
             @markup wiki
 
             """ text~~red:some text~~more text"""

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -21,7 +21,8 @@ class TestColorizer(LeoUnitTest):
         c.recolor_now()
     #@+node:ekr.20210905170507.2: *3* TestColorizer.test__comment_after_language_plain
     def test__comment_after_language_plain(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             @comment # /* */
 
             This is plain text.
@@ -34,7 +35,7 @@ class TestColorizer(LeoUnitTest):
             continues */
 
             More plain text.
-        """)
+        """).lstrip()
         self.color('plain', text)
     #@+node:ekr.20210905170507.3: *3* TestColorizer.test_bc_scanLanguageDirectives
     def test_bc_scanLanguageDirectives(self):
@@ -101,7 +102,8 @@ class TestColorizer(LeoUnitTest):
             self.assertEqual(got, expected, msg=f"i: {i} {language}")
     #@+node:ekr.20210905170507.5: *3* TestColorizer.test_colorizer_Actionscript
     def test_colorizer_Actionscript(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             break
             call, continue
             delete, do
@@ -157,11 +159,12 @@ class TestColorizer(LeoUnitTest):
             _x, _xmouse, _xscale
             _y, _ymouse, _yscale
             and, add, eq, ge, gt, le, lt, ne, not, or, Array, Boolean, Color, Date, Key, Math, MovieClip, Mouse, Number, Object, Selection, Sound, String, XML, XMLSocket
-    """)
+    """).lstrip()
         self.color('actionscript', text)
     #@+node:ekr.20210905170507.6: *3* TestColorizer.test_colorizer_C
     def test_colorizer_C(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             @comment /* */
 
             @
@@ -178,11 +181,12 @@ class TestColorizer(LeoUnitTest):
             #include "eeprom.h"
             #include <hpc_ram.h>
             #include <rlydef.h>
-    """)
+        """).lstrip()
         self.color('c', text)
     #@+node:ekr.20210905170507.7: *3* TestColorizer.test_colorizer_C_
     def test_colorizer_C_(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             @ comment
             @c
 
@@ -213,11 +217,12 @@ class TestColorizer(LeoUnitTest):
             value virtual void volatile
             where while
             yield
-    """)
+    """).lstrip()
         self.color('csharp', text)
     #@+node:ekr.20210905170507.8: *3* TestColorizer.test_colorizer_css
     def test_colorizer_css(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             /* New in 4.2. */
 
             /*html tags*/
@@ -285,7 +290,7 @@ class TestColorizer(LeoUnitTest):
             /*aural values*/
             stress, azimuth, elevation, pitch, richness, volume,
             page-break, page-after, page-inside
-    """)
+        """).lstrip()
         self.color('css', text)
     #@+node:ekr.20210905170507.9: *3* TestColorizer.test_colorizer_CWEB
     def test_colorizer_CWEB(self):
@@ -315,7 +320,8 @@ class TestColorizer(LeoUnitTest):
         self.color('cweb', text)
     #@+node:ekr.20210905170507.10: *3* TestColorizer.test_colorizer_cython
     def test_colorizer_cython(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             by cdef cimport cpdef ctypedef enum except?
             extern gil include nogil property public
             readonly struct union DEF IF ELIF ELSE
@@ -327,11 +333,12 @@ class TestColorizer(LeoUnitTest):
                 pass
             except Exception:
                 pass
-    """)
+        """).lstrip()
         self.color('cython', text)
     #@+node:ekr.20210905170507.11: *3* TestColorizer.test_colorizer_elisp
     def test_colorizer_elisp(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             ; Maybe...
             error princ
 
@@ -351,19 +358,21 @@ class TestColorizer(LeoUnitTest):
             t type-of
             unless
             when while
-    """)
+        """).lstrip()
         self.color('elisp', text)
     #@+node:ekr.20210905170507.12: *3* TestColorizer.test_colorizer_erlang
     def test_colorizer_erlang(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             halt()
 
             -module()
-    """)
+        """).lstrip()
         self.color('erlang', text)
     #@+node:ekr.20210905170507.13: *3* TestColorizer.test_colorizer_forth
     def test_colorizer_forth(self):
-        text = textwrap.dedent(r"""\\\
+        text = textwrap.dedent(
+        r"""\\\
             \ tiny demo of Leo forth syntax colouring
 
             : some-forth-word ( x1 x2 -- x3 ) \ blue :, black/bold some-forth-word
@@ -394,11 +403,12 @@ class TestColorizer(LeoUnitTest):
                [ a b c
                x y z]
             ;
-    """)
+        """)
         self.color('forth', text)
     #@+node:ekr.20210905170507.15: *3* TestColorizer.test_colorizer_HTML1
     def test_colorizer_HTML1(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             <HTML>
             <!-- Author: Edward K. Ream, edream@tds.net -->
             <HEAD>
@@ -490,20 +500,22 @@ class TestColorizer(LeoUnitTest):
 
             </BODY>
             </HTML>
-    """)
+        """).lstrip()
         self.color('html', text)
     #@+node:ekr.20210905170507.16: *3* TestColorizer.test_colorizer_HTML2
     def test_colorizer_HTML2(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             <? xml version="1.0">
             <!-- test -->
             <project name="Converter" default="dist">
             </project>
-    """)
+        """).lstrip()
         self.color('html', text)
     #@+node:ekr.20230421104052.1: *3* TestColorizer.test_colorizer_HTML_script_tag
     def test_colorizer_HTML_script_tag(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             <html>
             <head>
             <script>
@@ -519,14 +531,15 @@ class TestColorizer(LeoUnitTest):
             This is a test.
             </body>
             </html>
-    """)
+        """).lstrip()
         self.color('html', text)
     #@+node:ekr.20210905170507.14: *3* TestColorizer.test_colorizer_HTML_string_bug
     def test_colorizer_HTML_string_bug(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             b = "cd"
             d
-    """)
+        """).lstrip()
         self.color('html', text)
     #@+node:ekr.20210905170507.17: *3* TestColorizer.test_colorizer_Java
     def test_colorizer_Java(self):
@@ -574,7 +587,8 @@ class TestColorizer(LeoUnitTest):
         self.color('latex', text)
     #@+node:ekr.20210905170507.19: *3* TestColorizer.test_colorizer_lisp
     def test_colorizer_lisp(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             ; Maybe...
             error princ
 
@@ -594,11 +608,12 @@ class TestColorizer(LeoUnitTest):
             t type-of
             unless
             when while
-    """)
+        """).lstrip()
         self.color('lisp', text)
     #@+node:ekr.20210905170507.20: *3* TestColorizer.test_colorizer_objective_c
     def test_colorizer_objective_c(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             @interface Application
                 -(void) init;
                 -(void) showMessage;
@@ -629,11 +644,12 @@ class TestColorizer(LeoUnitTest):
             @var test
             @todo
             */
-    """)
+        """).lstrip()
         self.color('objective_c', text)
     #@+node:ekr.20210905170507.21: *3* TestColorizer.test_colorizer_perl
     def test_colorizer_perl(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             # From a perl tutorial.
 
             print 'Hello world.';               # Print a message
@@ -687,11 +703,12 @@ class TestColorizer(LeoUnitTest):
                 ($a =~ /$b/ || $b =~ /$a/);     # Is $b inside $a
                                 #   or $a inside $b?
             }
-    """)
+        """).lstrip()
         self.color('perl', text)
     #@+node:ekr.20210905170507.22: *3* TestColorizer.test_colorizer_PHP
     def test_colorizer_PHP(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             @ doc
             This is a doc part.
             @c
@@ -705,11 +722,12 @@ class TestColorizer(LeoUnitTest):
             __CLASS__
             <?php and or array() ?>
             <?PHP and or array() ?>
-    """)
+        """).lstrip()
         self.color('php', text)
     #@+node:ekr.20210905170507.23: *3* TestColorizer.test_colorizer_plsql
     def test_colorizer_plsql(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             "a string"
             -- reserved keywords
             ABORT,
@@ -1087,15 +1105,16 @@ class TestColorizer(LeoUnitTest):
             work,
             write,
             xor
-    """)
+        """).lstrip()
         self.color('plsql', text)
     #@+node:ekr.20210905170507.25: *3* TestColorizer.test_colorizer_Python1
     def test_colorizer_Python1(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             int
             float
             dict
-    """)
+        """).lstrip()
         self.color('python', text)
     #@+node:ekr.20210905170507.26: *3* TestColorizer.test_colorizer_Python2
     def test_colorizer_Python2(self):
@@ -1162,18 +1181,20 @@ class TestColorizer(LeoUnitTest):
         self.color('html', text)
     #@+node:ekr.20210905170507.27: *3* TestColorizer.test_colorizer_r
     def test_colorizer_r(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             x <- rnorm(10)
 
             vv <- function(z) return(z)
 
             def python_funct(uu):
             return uu
-    """)
+        """).lstrip()
         self.color('r', text)
     #@+node:ekr.20210905170507.28: *3* TestColorizer.test_colorizer_rapidq
     def test_colorizer_rapidq(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             ' New in 4.2.
             ' a comment.
 
@@ -1203,11 +1224,12 @@ class TestColorizer(LeoUnitTest):
             SUB,SUBI,SWAP,TALLY,TAN,THEN,TIME$,TIMER,TO,TYPE,UBOUND,
             UCASE$,UNLOADLIBRARY,UNTIL,VAL,VARIANT,VARPTR,VARPTR$,VARTYPE,
             WEND,WHILE,WITH,WORD,XOR
-    """)
+        """).lstrip()
         self.color('rapidq', text)
     #@+node:ekr.20210905170507.29: *3* TestColorizer.test_colorizer_Rebol
     def test_colorizer_Rebol(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
         ; a comment
         about abs absolute add alert alias all alter and and~ any append arccosine arcsine arctangent array ask at
         back bind boot-prefs break browse build-port build-tag
@@ -1272,7 +1294,7 @@ class TestColorizer(LeoUnitTest):
         value? view?
         within? word?
         zero?
-    """)
+        """).lstrip()
         self.color('rebol', text)
     #@+node:ekr.20210905170507.30: *3* TestColorizer.test_colorizer_rest
     def test_colorizer_rest(self):
@@ -1343,7 +1365,8 @@ class TestColorizer(LeoUnitTest):
         self.color('rest', text)
     #@+node:ekr.20210905170507.31: *3* TestColorizer.test_colorizer_scala
     def test_colorizer_scala(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             /* A comment */
 
             object HelloWorld {
@@ -1351,11 +1374,12 @@ class TestColorizer(LeoUnitTest):
                   println("Hello, world!")
                 }
               }
-    """)
+        """).lstrip()
         self.color('scala', text)
     #@+node:ekr.20210905170507.32: *3* TestColorizer.test_colorizer_shell
     def test_colorizer_shell(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             # New in 4.2.
 
             # comment
@@ -1375,11 +1399,12 @@ class TestColorizer(LeoUnitTest):
             exit,kill,newgrp,pwd,read,readonly,
             shift,test,trap,ulimit,
             umask,wait
-    """)
+        """).lstrip()
         self.color('shell', text)
     #@+node:ekr.20210905170507.33: *3* TestColorizer.test_colorizer_shellscript
     def test_colorizer_shellscript(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             # comment
             $# not a comment
             break
@@ -1397,11 +1422,12 @@ class TestColorizer(LeoUnitTest):
             exit,kill,newgrp,pwd,read,readonly,
             shift,test,trap,ulimit,
             umask,wait
-    """)
+        """).lstrip()
         self.color('shellscript', text)
     #@+node:ekr.20210905170507.34: *3* TestColorizer.test_colorizer_tex_xml_jEdit_
     def test_colorizer_tex_xml_jEdit_(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             <!-- ekr uses the MARK_FOLLOWING to mark _anything_ after \\ -->
 
             <?xml version="1.0"?>
@@ -1421,7 +1447,7 @@ class TestColorizer(LeoUnitTest):
                     < < math rules > >
                 </RULES>
             </MODE>
-    """)
+        """).lstrip()
         self.color('html', text)
     #@+node:ekr.20210905170507.36: *3* TestColorizer.test_colorizer_wikiTest
     def test_colorizer_wikiTest(self):
@@ -1473,10 +1499,11 @@ class TestColorizer(LeoUnitTest):
         self.assertEqual(language, 'python')
     #@+node:ekr.20210905170507.40: *3* TestColorizer.test_vbscript
     def test_vbscript(self):
-        text = textwrap.dedent("""\
+        text = textwrap.dedent(
+        """
             if
             IF
-    """)
+        """).lstrip()
         self.color('vbscript', text)
     #@-others
 #@-others

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -14,22 +14,24 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.28: *3* TestCommands.test_add_comments_with_multiple_language_directives
     def test_add_comments_with_multiple_language_directives(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language rest
             rest text.
             @language python
             def spam():
                 pass
             # after
-    """)
-        expected = textwrap.dedent("""\
+    """).lstrip()
+        expected = textwrap.dedent(
+        """
             @language rest
             rest text.
             @language python
             def spam():
                 # pass
             # after
-    """)
+    """).lstrip()
         i = p.b.find('pass')
         assert i > -1, 'fail1: %s' % (repr(p.b))
         w.setSelectionRange(i, i + 4)
@@ -38,18 +40,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.30: *3* TestCommands.test_add_html_comments
     def test_add_html_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language html
             <html>
                 text
             </html>
-    """)
-        expected = textwrap.dedent("""\
+        """).lstrip()
+        expected = textwrap.dedent(
+        """
             @language html
             <html>
                 <!-- text -->
             </html>
-    """)
+        """).lstrip()
         i = p.b.find('text')
         w.setSelectionRange(i, i + 4)
         c.addComments()
@@ -57,18 +61,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.32: *3* TestCommands.test_add_python_comments
     def test_add_python_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language python
             def spam():
                 pass
             # after
-    """)
-        expected = textwrap.dedent("""\
+        """).lstrip()
+        expected = textwrap.dedent(
+        """
             @language python
             def spam():
                 # pass
             # after
-    """)
+        """).lstrip()
         i = p.b.find('pass')
         w.setSelectionRange(i, i + 4)
         c.addComments()
@@ -93,12 +99,13 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210901140645.16: *3* TestCommands.test_c_checkPythonNode
     def test_c_checkPythonNode(self):
         c, p = self.c, self.c.p
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language python
 
             def abc:  # missing parens.
                 pass
-        """)
+        """).lstrip()
         result = c.checkPythonCode(event=None, checkOnSave=False, ignoreAtIgnore=True)
         self.assertEqual(result, 'error')
     #@+node:ekr.20210906075242.4: *3* TestCommands.test_c_contractAllHeadlines
@@ -324,19 +331,21 @@ class TestCommands(LeoUnitTest):
     def test_c_tabNannyNode(self):
         c, p = self.c, self.c.p
         # Test 1.
-        s = textwrap.dedent("""\
+        s = textwrap.dedent(
+        """
             # no error
             def spam():
                 pass
-        """)
+        """).lstrip()
         c.tabNannyNode(p, headline=p.h, body=s)
         # Test 2.
-        s2 = textwrap.dedent("""\
+        s2 = textwrap.dedent(
+        """
             # syntax error
             def spam:
                 pass
               a = 2
-        """)
+        """).lstrip()
         try:
             c.tabNannyNode(p, headline=p.h, body=s2)
         except IndentationError:
@@ -359,22 +368,24 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.29: *3* TestCommands.test_delete_comments_with_multiple_at_language_directives
     def test_delete_comments_with_multiple_at_language_directives(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language rest
             rest text.
             @language python
             def spam():
                 pass
             # after
-    """)
-        expected = textwrap.dedent("""\
+        """).lstrip()
+        expected = textwrap.dedent(
+        """
             @language rest
             rest text.
             @language python
             def spam():
                 pass
             # after
-    """)
+        """).lstrip()
         i = p.b.find('pass')
         w.setSelectionRange(i, i + 4)
         c.deleteComments()
@@ -383,18 +394,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.31: *3* TestCommands.test_delete_html_comments
     def test_delete_html_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language html
             <html>
                 <!-- text -->
             </html>
-    """)
-        expected = textwrap.dedent("""\
+        """).lstrip()
+        expected = textwrap.dedent(
+        """
             @language html
             <html>
                 text
             </html>
-    """)
+        """).lstrip()
         i = p.b.find('text')
         w.setSelectionRange(i, i + 4)
         c.deleteComments()
@@ -402,18 +415,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.33: *3* TestCommands.test_delete_python_comments
     def test_delete_python_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             @language python
             def spam():
                 # pass
             # after
-    """)
-        expected = textwrap.dedent("""\
+        """).lstrip()
+        expected = textwrap.dedent(
+        """
             @language python
             def spam():
                 pass
             # after
-    """)
+        """).lstrip()
         i = p.b.find('pass')
         w.setSelectionRange(i, i + 4)
         c.deleteComments()

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -460,13 +460,14 @@ class TestGlobals(LeoUnitTest):
         c = self.c
         p = c.p
         # Note: @comment must follow @language.
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
             ATlanguage python
             ATcomment a b c
             ATtabwidth -8
             ATpagewidth 72
             ATencoding utf-8
-    """).replace('AT', '@')
+        """).lstrip().replace('AT', '@')
         d = g.get_directives_dict(p)
         self.assertEqual(d.get('language'), 'python')
         self.assertEqual(d.get('tabwidth'), '-8')
@@ -479,14 +480,14 @@ class TestGlobals(LeoUnitTest):
         s1 = 'no docstring'
         s2 = textwrap.dedent(
         '''
-    # comment
-    """docstring2."""
-    ''')
+            # comment
+            """docstring2."""
+        ''')
         s3 = textwrap.dedent(
         '''
-    """docstring3."""
-    \'\'\'docstring2.\'\'\'
-    ''')
+            """docstring3."""
+            \'\'\'docstring2.\'\'\'
+        ''')
         table = (
             (s1, ''),
             (s2, 'docstring2.'),
@@ -1209,7 +1210,8 @@ class TestGlobals(LeoUnitTest):
 
         # Set @data unl-path-prefixes
 
-        s = textwrap.dedent("""
+        s = textwrap.dedent(
+        """
             # lines have the form:
             # x.leo: <absolute path to x.leo>
 

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -477,11 +477,13 @@ class TestGlobals(LeoUnitTest):
     #@+node:ekr.20210905203541.17: *4* TestGlobals.test_g_getDocString
     def test_g_getDocString(self):
         s1 = 'no docstring'
-        s2 = textwrap.dedent('''\
+        s2 = textwrap.dedent(
+        '''
     # comment
     """docstring2."""
     ''')
-        s3 = textwrap.dedent('''\
+        s3 = textwrap.dedent(
+        '''
     """docstring3."""
     \'\'\'docstring2.\'\'\'
     ''')

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -23,11 +23,12 @@ class TestLeoImport(BaseTestImporter):
         target.h = 'target'
         from leo.core.leoImport import MindMapImporter
         x = MindMapImporter(c)
-        s = textwrap.dedent("""\
+        s = textwrap.dedent(
+        """
             header1, header2, header3
             a1, b1, c1
             a2, b2, c2
-        """)
+        """).lstrip()
         f = StringIO(s)
         x.scan(f, target)
 

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -890,7 +890,8 @@ class TestNodes(LeoUnitTest):
     def test_p_nosentinels(self):
 
         p = self.c.p
-        p.b = textwrap.dedent("""\
+        p.b = textwrap.dedent(
+        """
 
             def not_a_sentinel(x):
                 pass
@@ -898,8 +899,7 @@ class TestNodes(LeoUnitTest):
             @not_a_sentinel
             def spam():
                 pass
-
-    """)
+        """).lstrip()
         self.assertEqual(p.b, p.nosentinels)
     #@+node:ekr.20210830095545.22: *4* TestNodes.test_p_relinkAsCloneOf
     def test_p_relinkAsCloneOf(self):

--- a/leo/unittests/core/test_leoRst.py
+++ b/leo/unittests/core/test_leoRst.py
@@ -32,19 +32,21 @@ class TestRst(LeoUnitTest):
         child = root.insertAsLastChild()
         child.h = '@rst-no-head section'
         # Insert the body texts.  Overindent to eliminate @verbatim sentinels.
-        root.b = textwrap.dedent("""\
+        root.b = textwrap.dedent(
+        """
             #####
             Title
             #####
 
             This is test.html
 
-            """)
-        child.b = textwrap.dedent("""\
-            This is the body of the section.
-            """)
+        """).lstrip()
+
+        child.b = """This is the body of the section.\n"""
+        
         # Define the expected output.
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+        f"""
             .. rst3: filename: {fn}
 
             .. _http-node-marker-1:
@@ -57,7 +59,7 @@ class TestRst(LeoUnitTest):
 
             This is the body of the section.
 
-    """)
+        """).lstrip()
         # Get and check the rst result.
         rc.nodeNumber = 0
         rc.http_server_support = True  # Override setting for testing.
@@ -93,13 +95,16 @@ class TestRst(LeoUnitTest):
         root = c.rootPosition().insertAfter()
         root.h = fn = '@rst unicode_test.html'
         # Insert the body text.  Overindent to eliminate @verbatim sentinels.
-        root.b = textwrap.dedent("""\
+        root.b = textwrap.dedent(
+        """
             Test of unicode characters: ÀǋϢﻙ
 
             End of test.
-        """)
+        """).lstrip()
+
         # Define the expected output.
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+        f"""
             .. rst3: filename: {fn}
 
             .. _http-node-marker-1:
@@ -108,7 +113,7 @@ class TestRst(LeoUnitTest):
 
             End of test.
 
-    """)
+        """).lstrip()
         # Get and check the rst result.
         rc.nodeNumber = 0
         rc.http_server_support = True  # Override setting for testing.
@@ -128,7 +133,8 @@ class TestRst(LeoUnitTest):
         child = root.insertAsLastChild()
         child.h = 'section'
         # Insert the body texts.  Overindent to eliminate @verbatim sentinels.
-        root.b = textwrap.dedent("""\
+        root.b = textwrap.dedent(
+        """
             @language rest
 
             #####
@@ -136,15 +142,17 @@ class TestRst(LeoUnitTest):
             #####
 
             This is test.html
-        """)
-        child.b = textwrap.dedent("""\
+        """).lstrip()
+        child.b = textwrap.dedent(
+        """
             @ This is a doc part
             it has two lines.
             @c
             This is the body of the section.
-        """)
+        """).lstrip()
         # Define the expected output.
-        expected = textwrap.dedent(f"""\
+        expected = textwrap.dedent(
+        f"""
             .. rst3: filename: {fn}
 
             .. _http-node-marker-1:
@@ -167,7 +175,7 @@ class TestRst(LeoUnitTest):
             @c
             This is the body of the section.
 
-    """)
+        """).lstrip()
         # Get and check the rst result.
         rc.nodeNumber = 0
         rc.http_server_support = True  # Override setting for testing.

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -102,7 +102,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             ATothers
             node 1 line 1
             node 1 line 2
@@ -112,7 +113,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             ATothers
             node 1 line 1
             node 1 line 1 changed
@@ -128,7 +130,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -136,7 +139,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1 changed
             line 2
             line 3
@@ -150,7 +154,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -158,7 +163,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3 changed
@@ -172,7 +178,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -180,7 +187,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             line 2 changed
             line 3
@@ -194,7 +202,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -204,7 +213,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -220,7 +230,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -230,7 +241,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -245,7 +257,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -254,7 +267,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 2
@@ -268,7 +282,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -276,7 +291,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 2
             line 3
         """)
@@ -289,7 +305,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -297,7 +314,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             line 2
         """)
@@ -310,7 +328,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -318,7 +337,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             line 3
         """)
@@ -331,7 +351,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -339,7 +360,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -354,7 +376,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -362,7 +385,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             inserted line
             line 1
             line 2
@@ -377,7 +401,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -385,7 +410,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             inserted line
             line 2
@@ -400,7 +426,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
@@ -408,7 +435,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line 1
             line 2
             inserted line
@@ -423,7 +451,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -431,7 +460,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             inserted node at end of node 1
@@ -446,7 +476,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             inserted node 1 at end of node 1
@@ -456,7 +487,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -470,7 +502,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -481,7 +514,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2 changed
@@ -498,7 +532,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -508,7 +543,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -524,7 +560,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -535,7 +572,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -550,7 +588,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -560,7 +599,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 3
@@ -574,7 +614,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -584,7 +625,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2 changed
@@ -600,13 +642,15 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             line
         """)
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             line
         """)
         # Run the test.
@@ -620,7 +664,8 @@ class TestAtShadow(LeoUnitTest):
         old.b = '@others\n'
         old_node1 = old.insertAsLastChild()
         old_node1.h = 'node1'
-        old_node1.b = textwrap.dedent("""\
+        old_node1.b = textwrap.dedent(
+        """
             node 1 line 1
             node 1 old line 1
             node 1 old line 2
@@ -631,7 +676,8 @@ class TestAtShadow(LeoUnitTest):
         new.b = '@others\n'
         new_node1 = new.insertAsLastChild()
         new_node1.h = 'node1'
-        new_node1.b = textwrap.dedent("""\
+        new_node1.b = textwrap.dedent(
+        """
             node 1 line 1
             node 1 new line 1
             node 1 new line 2
@@ -649,7 +695,8 @@ class TestAtShadow(LeoUnitTest):
         old.b = '@others\n'
         old_node1 = old.insertAsLastChild()
         old_node1.h = 'node1'
-        old_node1.b = textwrap.dedent("""\
+        old_node1.b = textwrap.dedent(
+        """
             node 1 line 1
             node 1 old line 1
             node 1 old line 2
@@ -663,7 +710,8 @@ class TestAtShadow(LeoUnitTest):
         new.b = '@others\n'
         new_node1 = new.insertAsLastChild()
         new_node1.h = 'node1'
-        new_node1.b = textwrap.dedent("""\
+        new_node1.b = textwrap.dedent(
+        """
             node 1 line 1
             node 1 new line 1
             node 1 new line 2
@@ -678,7 +726,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 1 line 2
@@ -688,7 +737,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             at-verbatim
@@ -706,7 +756,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             at-verbatim
@@ -719,7 +770,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             line 1 line 3
@@ -736,7 +788,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             at-verbatim
@@ -747,7 +800,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 1
@@ -762,7 +816,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             at-verbatim
@@ -772,7 +827,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             node 2 line 2
@@ -786,7 +842,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent("""\
+        old.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             at-verbatim
@@ -799,7 +856,8 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent("""\
+        new.b = textwrap.dedent(
+        """
             at-others
             node 1 line 1
             at-verbatim

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -613,7 +613,8 @@ class TestTokenBasedOrange(BaseTest):
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
         """
-        expected = textwrap.dedent("""
+        expected = textwrap.dedent(
+        """
             from .module1 import w
             from .module2 import x
             from ..module1 import y

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -204,7 +204,7 @@ class TestUndo(LeoUnitTest):
 
                 pass
         """).lstrip()
-        after = textwrap.dedent("""\
+        after = textwrap.dedent("""
             @language python
 
             def deleteCommentTest():

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -44,7 +44,8 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.2: *3* TestUndo.test_addComments
     def test_addComments(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @language python
 
             def addCommentTest():
@@ -54,8 +55,9 @@ class TestUndo(LeoUnitTest):
                     b = 3
 
                 pass
-    """)
-        after = textwrap.dedent("""\
+        """).lstrip()
+        after = textwrap.dedent(
+        """
             @language python
 
             def addCommentTest():
@@ -65,7 +67,7 @@ class TestUndo(LeoUnitTest):
                     # b = 3
 
                 pass
-    """)
+        """).lstrip()
         i = before.find('if 1')
         j = before.find('b = 3')
         func = c.addComments
@@ -73,106 +75,116 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.3: *3* TestUndo.test_convertAllBlanks
     def test_convertAllBlanks(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
                 line 2
                   line 3
             line4
-    """)
-        after = textwrap.dedent("""\
+        """).lstrip()
+        after = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
             TABline 2
             TAB  line 3
             line4
-    """).replace('TAB', '\t')
+        """).lstrip().replace('TAB', '\t')
         i, j = 13, len(before)
         func = c.convertAllBlanks
         self.runTest(before, after, i, j, func)
     #@+node:ekr.20210906172626.4: *3* TestUndo.test_convertAllTabs
     def test_convertAllTabs(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
             TABline 2
             TAB  line 3
             line4
-    """).replace('TAB', '\t')
-        after = textwrap.dedent("""\
+        """).replace('TAB', '\t')
+        after = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
                 line 2
                   line 3
             line4
-    """).replace('TAB', '\t')
+        """).replace('TAB', '\t')
         i, j = 13, 45
         func = c.convertAllTabs
         self.runTest(before, after, i, j, func)
     #@+node:ekr.20210906172626.5: *3* TestUndo.test_convertBlanks
     def test_convertBlanks(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
                 line 2
                   line 3
             line4
-    """)
-        after = textwrap.dedent("""\
+        """)
+        after = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
             TABline 2
             TAB  line 3
             line4
-    """).replace('TAB', '\t')
+        """).replace('TAB', '\t')
         i, j = 13, 51
         func = c.convertBlanks
         self.runTest(before, after, i, j, func)
     #@+node:ekr.20210906172626.6: *3* TestUndo.test_convertTabs
     def test_convertTabs(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
             TABline 2
             TAB  line 3
             line4
-    """).replace('TAB', '\t')
-        after = textwrap.dedent("""\
+        """).replace('TAB', '\t')
+        after = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
                 line 2
                   line 3
             line4
-    """).replace('TAB', '\t')
+        """).replace('TAB', '\t')
         i, j = 13, 45
         func = c.convertTabs
         self.runTest(before, after, i, j, func)
     #@+node:ekr.20210906172626.7: *3* TestUndo.test_dedentBody
     def test_dedentBody(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             line 1
                 line 2
                 line 3
             line 4
-    """)
-        after = textwrap.dedent("""\
+        """)
+        after = textwrap.dedent(
+        """
             line 1
             line 2
             line 3
             line 4
-    """)
+        """)
         i = before.find('line 2')
         j = before.find('3')
         func = c.dedentBody
@@ -180,7 +192,8 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.8: *3* TestUndo.test_deleteComments
     def test_deleteComments(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @language python
 
             def deleteCommentTest():
@@ -190,7 +203,7 @@ class TestUndo(LeoUnitTest):
             #         b = 3
 
                 pass
-    """)
+        """).lstrip()
         after = textwrap.dedent("""\
             @language python
 
@@ -201,7 +214,7 @@ class TestUndo(LeoUnitTest):
                     b = 3
 
                 pass
-    """)
+        """).lstrip()
         i = before.find('if 1')
         j = before.find('b = 3')
         func = c.deleteComments
@@ -209,7 +222,8 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.9: *3* TestUndo.test_deleteComments 2
     def test_deleteComments_2(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             @language python
 
             def deleteCommentTest():
@@ -223,8 +237,9 @@ class TestUndo(LeoUnitTest):
                     # b = 3
 
                 pass
-    """)
-        after = textwrap.dedent("""\
+        """).lstrip()
+        after = textwrap.dedent(
+        """
             @language python
 
             def deleteCommentTest():
@@ -238,7 +253,7 @@ class TestUndo(LeoUnitTest):
                     b = 3
 
                 pass
-    """)
+        """).lstrip()
         i = before.find('if 1')
         j = before.find('# b = 3')
         func = c.deleteComments
@@ -273,19 +288,21 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.10: *3* TestUndo.test_extract_test
     def test_extract_test(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             before
                 < < section > >
                 sec line 1
                     sec line 2 indented
             sec line 3
             after
-    """)
-        after = textwrap.dedent("""\
+        """).lstrip()
+        after = textwrap.dedent(
+        """
             before
                 < < section > >
             after
-    """)
+        """).lstrip()
         i = before.find('< <')
         j = before.find('line 3')
         func = c.extract
@@ -293,15 +310,17 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.14: *3* TestUndo.test_line_to_headline
     def test_line_to_headline(self):
         c = self.c
-        before = textwrap.dedent("""\
+        before = textwrap.dedent(
+        """
             before
             headline
             after
-    """)
-        after = textwrap.dedent("""\
+        """).lstrip()
+        after = textwrap.dedent(
+        """
             before
             after
-    """)
+        """).lstrip()
         i, j = 10, 10
         func = c.line_to_headline
         self.runTest(before, after, i, j, func)
@@ -333,14 +352,15 @@ class TestUndo(LeoUnitTest):
         # The buggy redoGroup code worked if the undo group was the first item on the undo stack.
         c, p = self.c, self.c.p
         original = p.insertAfter()
-        original_s = original.b = textwrap.dedent("""\
+        original_s = original.b = textwrap.dedent(
+        """
             @tabwidth -4
 
             line 1
                 line 2
                   line 3
             line4
-    """)
+        """).lstrip()
         c.undoer.clearUndoState()
         c.selectPosition(original)
         c.copyOutline()  # Add state to the undo stack!

--- a/leo/unittests/test_design.py
+++ b/leo/unittests/test_design.py
@@ -105,7 +105,7 @@ class AnnotationsTraverser(NodeVisitor):
             # Problem annotating Cmdr in leoCommands.py...
             'add_commandCallback', 'bringToFront', 'universalCallback',
             #
-            'find_language', # p_or_v is a false match.
+            'find_language',  # p_or_v is a false match.
             # These methods should always be annotated Any.
             '__eq__', '__ne__',
             'resolveArchivedPosition',
@@ -154,7 +154,7 @@ class AnnotationsTraverser(NodeVisitor):
             if annotation:
                 id_s = arg.arg
                 self.test_annotation(node, id_s, annotation)
-        self.generic_visit(node) # Visit all children.
+        self.generic_visit(node)  # Visit all children.
     #@-others
 #@+node:ekr.20230506111927.1: *3* class ChainsTraverser(NodeVisitor)
 class ChainsTraverser(NodeVisitor):
@@ -179,7 +179,7 @@ class TestAnnotations(unittest.TestCase):
         traverser = AnnotationsTraverser(tester=self)
         for path in files_dict:
             self.path = path
-            contents, tree = files_dict [path]
+            contents, tree = files_dict[path]
             traverser.visit(tree)
         if 0:
             for s in sorted(list(traverser.annotations_set)):
@@ -210,7 +210,7 @@ class TestChains(unittest.TestCase):
         traverser = ChainsTraverser()
         traverser.chains_set = set()
         for path in files_dict:
-            contents, tree = files_dict [path]
+            contents, tree = files_dict[path]
             traverser.visit(tree)
         chains_list = [filter_chain(z) for z in sorted(list(traverser.chains_set))]
         long_chains_list = [z for z in chains_list if z.count('.') > 2]

--- a/leo/unittests/test_design.py
+++ b/leo/unittests/test_design.py
@@ -8,7 +8,6 @@ from ast import NodeVisitor
 import glob
 import os
 import re
-import textwrap
 import unittest
 from leo.core import leoGlobals as g
 #@-<< test_design imports >>
@@ -241,9 +240,7 @@ class TestChains(unittest.TestCase):
         self.assertEqual(chain, 'leoImport.MORE_Importer().import_file')
     #@+node:ekr.20230507122925.1: *3* TestChains.test_one_chain
     def test_one_chain(self):
-        contents = textwrap.dedent('''\
-            w = c.frame.body.wrapper.widget
-    ''')
+        contents = """w = c.frame.body.wrapper.widget"""
         tree = ast.parse(contents, filename='test_one_chain')
         traverser = ChainsTraverser()
         traverser.chains_set = set()

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -523,7 +523,7 @@ class TestC(BaseTestImporter):
         # The result lines must tile (cover) the original lines.
         result_lines = []
         for block in blocks:
-            result_lines.extend(lines[block.start : block.end])
+            result_lines.extend(lines[block.start:block.end])
         self.assertEqual(lines, result_lines)
     #@+node:ekr.20230511073719.1: *3* TestC.test_codon_file
     def test_codon_file(self):
@@ -539,7 +539,7 @@ class TestC(BaseTestImporter):
         if 1:  # Test gen_lines.
             importer.root = c.p
             importer.gen_lines(lines, c.p)
-        else: # Test find_blocks.
+        else:  # Test find_blocks.
             importer.guide_lines = importer.make_guide_lines(lines)
             result = importer.find_blocks(0, len(importer.guide_lines))
 
@@ -547,7 +547,7 @@ class TestC(BaseTestImporter):
             result_lines = []
             for z in result:
                 kind, name, start, start_body, end = z
-                result_lines.extend(lines[start : end])
+                result_lines.extend(lines[start:end])
             self.assertEqual(lines, result_lines)
     #@+node:ekr.20230607164309.1: *3* TestC.test_struct
     def test_struct(self):
@@ -913,7 +913,7 @@ class TestElisp(BaseTestImporter):
                (+ 1 2 3))
         """
         expected_results = (
-            (0, '', # Ignore the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language lisp\n'
                     '@tabwidth -4\n'
@@ -1518,7 +1518,7 @@ class TestJava(BaseTestImporter):
 
         """
         expected_results = (
-            (0, '', # Ignore the first headline.
+            (0, '',  # Ignore the first headline.
                 '@others\n'
                 '@language java\n'
                 '@tabwidth -4\n'
@@ -1763,7 +1763,7 @@ class TestJavascript(BaseTestImporter):
         assert not line1.strip(), repr(line1)
     #@-others
 #@+node:ekr.20220816082603.1: ** class TestLua (BaseTestImporter)
-class TestLua (BaseTestImporter):
+class TestLua(BaseTestImporter):
 
     ext = '.lua'
 
@@ -1792,7 +1792,7 @@ class TestLua (BaseTestImporter):
              print("main", coroutine.resume(co, "x", "y"))
         """
         expected_results = (
-            (0, '', # Ignore the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     'print("main", coroutine.resume(co, 1, 10))\n'
                     'print("main", coroutine.resume(co, "r"))\n'
@@ -4100,7 +4100,7 @@ class TestScheme(BaseTestImporter):
                (+ 1 2 3))
         """
         expected_results = (
-            (0, '', # Ignore the first headline.
+            (0, '',  # Ignore the first headline.
                     '@others\n'
                     '@language scheme\n'
                     '@tabwidth -4\n'
@@ -4124,7 +4124,7 @@ class TestScheme(BaseTestImporter):
         self.new_run_test(s, expected_results)
     #@-others
 #@+node:ekr.20220813174450.1: ** class TestTcl (BaseTestImporter)
-class TestTcl (BaseTestImporter):
+class TestTcl(BaseTestImporter):
 
     ext = '.tcl'
 
@@ -4187,7 +4187,7 @@ class TestTcl (BaseTestImporter):
         self.new_run_test(s, expected_results)
     #@-others
 #@+node:ekr.20220809161015.1: ** class TestTreepad (BaseTestImporter)
-class TestTreepad (BaseTestImporter):
+class TestTreepad(BaseTestImporter):
 
     ext = '.hjt'
 

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -2504,7 +2504,7 @@ class TestPascal(BaseTestImporter):
         # From GSTATOBJ.PAS
         #@+<< define s >>
         #@+node:ekr.20220830112013.1: *4* << define s >>
-        s = textwrap.dedent(
+        s = textwrap.dedent(  # Dedent is required.
         """
         unit gstatobj;
 
@@ -3928,7 +3928,7 @@ class TestRust(BaseTestImporter):
     def test_rust_import_fails(self):
 
         # From ruff/crates/ruff_formatter/shared_traits.rs
-        s = textwrap.dedent(
+        s = textwrap.dedent(  # dedent is required.
     """
         /// Used to get an object that knows how to format this object.
         pub trait AsFormat<Context> {
@@ -3991,27 +3991,26 @@ class TestRust(BaseTestImporter):
     def test_rust_postpass(self):
 
         # Modified from ruff/crates/ruff_formatter/src/arguments.rs
-        s = textwrap.dedent(
-    """
-    use super::{Buffer, Format, Formatter};
-    use crate::FormatResult;
+        s = """
+            use super::{Buffer, Format, Formatter};
+            use crate::FormatResult;
 
-    /// Mono-morphed type to format an object.
-    /// Used by the [`crate::format`!].
-    ///
-    /// This struct is similar to a dynamic dispatch (using `dyn Format`)
-    /// because it stores a pointer to the value.
-    pub struct Argument<'fmt, Context> {
-        /// The value to format stored as a raw pointer where `lifetime` stores the value's lifetime.
-        value: *const c_void,
+            /// Mono-morphed type to format an object.
+            /// Used by the [`crate::format`!].
+            ///
+            /// This struct is similar to a dynamic dispatch (using `dyn Format`)
+            /// because it stores a pointer to the value.
+            pub struct Argument<'fmt, Context> {
+                /// The value to format stored as a raw pointer where `lifetime` stores the value's lifetime.
+                value: *const c_void,
 
-        /// Stores the lifetime of the value.
-        lifetime: PhantomData<&'fmt ()>,
+                /// Stores the lifetime of the value.
+                lifetime: PhantomData<&'fmt ()>,
 
-        /// The function pointer to `value`'s `Format::format` method
-        formatter: fn(*const c_void, &mut Formatter<'_, Context>) -> FormatResult<()>,
-    }
-    """)
+                /// The function pointer to `value`'s `Format::format` method
+                formatter: fn(*const c_void, &mut Formatter<'_, Context>) -> FormatResult<()>,
+            }
+        """
         expected_results = (
             (0, '',  # Ignore the first headline.
                     'use super::{Buffer, Format, Formatter};\n'
@@ -4051,15 +4050,14 @@ class TestRust(BaseTestImporter):
     def test_invalid_runon_string(self):
 
         # From ruff_linter/src/rules/eradicate/detection.rs
-        s = textwrap.dedent(
+        s = """
+            #[test]
+            fn comment_contains_code_basic() {
+                assert!(comment_contains_code("#import eradicate", &[]));
+                assert!(comment_contains_code(r#"#"key": value,"#, &[]));
+                assert!(comment_contains_code(r#"#"key": "value","#, &[]));
+            }
     """
-        #[test]
-        fn comment_contains_code_basic() {
-            assert!(comment_contains_code("#import eradicate", &[]));
-            assert!(comment_contains_code(r#"#"key": value,"#, &[]));
-            assert!(comment_contains_code(r#"#"key": "value","#, &[]));
-        }
-    """)
         expected_results = (
             (0, '',  # Ignore the first headline.
                     '@others\n'

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -162,13 +162,14 @@ class TestImporterClass(LeoUnitTest):
 
         c = self.c
         importer = Python_Importer(c)
-        lines = g.splitLines(textwrap.dedent(
+        lines = g.splitLines(
             """
-            import sys\n
+            import sys
             def spam_and_eggs():
-               pass'
+               pass
             """
-        ))
+        )
+
         # Test that Importer.trace_block doesn't crash.
         # Comment out the assignment to sys.stdout to see the actual results.
         try:
@@ -181,13 +182,13 @@ class TestImporterClass(LeoUnitTest):
     #@+node:ekr.20231011021056.1: *3* TestImporterClass.test_long_repr
     def test_long_repr(self):
 
-        lines = g.splitLines(textwrap.dedent(
+        lines = g.splitLines(
             """
-            import sys\n
+            import sys
             def spam_and_eggs():
-               pass'
+               pass
             """
-        ))
+        )
         block = Block('def', 'spam_and_eggs', start=3, start_body=4, end=5, lines=lines)
 
         # Test that long_repr doesn't crash.
@@ -484,35 +485,36 @@ class TestC(BaseTestImporter):
     def test_find_blocks(self):
 
         importer = C_Importer(self.c)
-        lines = g.splitLines(textwrap.dedent("""\
+        lines = g.splitLines(textwrap.dedent(  # dedent is required.
+        """
 
-        # enable-trace
+            # enable-trace
 
-        namespace {
-            n1;
-        }
+            namespace {
+                n1;
+            }
 
-        namespace outer {
-            n2;
-        }
+            namespace outer {
+                n2;
+            }
 
-        int foo () {
-            foo1;
-            foo2;
-        }
+            int foo () {
+                foo1;
+                foo2;
+            }
 
-        class class1 {
-            class1;
-        }
+            class class1 {
+                class1;
+            }
 
-        class class2 {
-            x = 2;
-            int bar (a, b) {
-                if (0) {
-                    a = 1;
+            class class2 {
+                x = 2;
+                int bar (a, b) {
+                    if (0) {
+                        a = 1;
+                    }
                 }
             }
-        }
         """))
         importer.lines = lines
         importer.guide_lines = importer.make_guide_lines(lines)

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -1605,7 +1605,7 @@ class TestJava(BaseTestImporter):
         #@+node:ekr.20231225065840.1: *4* << define contents: test_round_trip >>
         # #3727: The blank lines below cause the round-trip to fail.
         #        For now, this unit test will hack the expected lines.
-        contents =  textwrap.dedent("""
+        contents = """
             public class Main {
                 public static void main(String[] args) {
                     myMethod();
@@ -1616,8 +1616,7 @@ class TestJava(BaseTestImporter):
                 }
 
             }
-
-        """).strip() + '\n'
+        """.strip() + '\n'
         #@-<< define contents: test_round_trip >>
 
         # Import contents into root's tree.
@@ -1690,7 +1689,7 @@ class TestJavascript(BaseTestImporter):
     #@+node:ekr.20210904065459.36: *3* TestJavascript.test_var_equal_function
     def test_var_equal_function(self):
 
-        s = textwrap.dedent("""\
+        s = """
             var c3 = (function () {
                 "use strict";
 
@@ -1703,7 +1702,7 @@ class TestJavascript(BaseTestImporter):
 
                 return c3;
             }());
-        """)
+        """
 
         expected_results = (
             (0, '',  # Ignore the first headline.
@@ -1728,7 +1727,6 @@ class TestJavascript(BaseTestImporter):
                     '};\n'
             ),
         )
-        # g.printObj(g.splitLines(s), tag='source')
         self.new_run_test(s, expected_results)
     #@+node:ekr.20220814014851.1: *3* TestJavascript.test_comments
     def test_comments(self):
@@ -2412,7 +2410,7 @@ class TestPascal(BaseTestImporter):
 
         #@+<< define s >>
         #@+node:ekr.20230518071612.1: *4* << define s >>
-        s = textwrap.dedent(
+        s = textwrap.dedent(  # dedent is required.
         """
             unit Unit1;
 
@@ -4348,20 +4346,17 @@ class TestXML(BaseTestImporter):
     def test_standard_opening_elements(self):
 
         s = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE note SYSTEM "Note.dtd">
-        <html>
-        <head>
-            <title>Bodystring</title>
-        </head>
-        <body class='bodystring'>
-        <div id='bodydisplay'></div>
-        </body>
-        </html>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE note SYSTEM "Note.dtd">
+            <html>
+            <head>
+                <title>Bodystring</title>
+            </head>
+            <body class='bodystring'>
+            <div id='bodydisplay'></div>
+            </body>
+            </html>
         """
-
-        # A good trace while single-stepping.
-        # g.printObj(g.splitLines(textwrap.dedent(s)), tag='Input File')
 
         expected_results = (
             (0, '',  # Ignore level 0 headlines.

--- a/leo/unittests/test_importers.py
+++ b/leo/unittests/test_importers.py
@@ -3929,29 +3929,29 @@ class TestRust(BaseTestImporter):
 
         # From ruff/crates/ruff_formatter/shared_traits.rs
         s = textwrap.dedent(  # dedent is required.
-    """
-        /// Used to get an object that knows how to format this object.
-        pub trait AsFormat<Context> {
-            type Format<'a>: ruff_formatter::Format<Context>
-            where
-                Self: 'a;
+            """
+                /// Used to get an object that knows how to format this object.
+                pub trait AsFormat<Context> {
+                    type Format<'a>: ruff_formatter::Format<Context>
+                    where
+                        Self: 'a;
 
-            /// Returns an object that is able to format this object.
-            fn format(&self) -> Self::Format<'_>;
-        }
+                    /// Returns an object that is able to format this object.
+                    fn format(&self) -> Self::Format<'_>;
+                }
 
-        /// Implement [`AsFormat`] for references to types that implement [`AsFormat`].
-        impl<T, C> AsFormat<C> for &T
-        where
-            T: AsFormat<C>,
-        {
-            type Format<'a> = T::Format<'a> where Self: 'a;
+                /// Implement [`AsFormat`] for references to types that implement [`AsFormat`].
+                impl<T, C> AsFormat<C> for &T
+                where
+                    T: AsFormat<C>,
+                {
+                    type Format<'a> = T::Format<'a> where Self: 'a;
 
-            fn format(&self) -> Self::Format<'_> {
-                AsFormat::format(&**self)
-            }
-        }
-    """)
+                    fn format(&self) -> Self::Format<'_> {
+                        AsFormat::format(&**self)
+                    }
+                }
+            """)
         expected_results = (
             (0, '',  # Ignore the first headline.
                     '@others\n'

--- a/leo/unittests/test_plugins.py
+++ b/leo/unittests/test_plugins.py
@@ -169,40 +169,40 @@ class TestIndentedTypeScript(LeoUnitTest):
         # Contains "over-indented" parenthesized lines, a good test for check_indentation.
 
         contents = textwrap.dedent(  # dedent is required.
-        """\
-        import { NodeIndices, VNode, Position } from './leoNodes';
+            """
+            import { NodeIndices, VNode, Position } from './leoNodes';
 
-        export class Config implements ConfigMembers {
+            export class Config implements ConfigMembers {
 
-        constructor(
-            private _context: vscode.ExtensionContext,
-            private _leoUI: LeoUI
-        ) { }
+            constructor(
+                private _context: vscode.ExtensionContext,
+                private _leoUI: LeoUI
+            ) { }
 
-        const w_config: FontSettings = {
-            zoomLevel: Number(w_zoomLevel),
-            fontSize: Number(w_fontSize)
-        };
+            const w_config: FontSettings = {
+                zoomLevel: Number(w_zoomLevel),
+                fontSize: Number(w_fontSize)
+            };
 
-        public getFontConfig(): FontSettings {
-            let w_zoomLevel = vscode.workspace.getConfiguration(
-                "window"
-            ).get("zoomLevel");
+            public getFontConfig(): FontSettings {
+                let w_zoomLevel = vscode.workspace.getConfiguration(
+                    "window"
+                ).get("zoomLevel");
 
-            return w_config;
-        }
-
-        public getEncodingFromHeader(fileName: string, s: string): BufferEncoding {
-            if (at.errors) {
-                if (g.unitTesting) {
-                    console.assert(false, g.callers());
-                }
-            } else {
-                at.initReadLine(s);
+                return w_config;
             }
-        }
-        }
-        """)
+
+            public getEncodingFromHeader(fileName: string, s: string): BufferEncoding {
+                if (at.errors) {
+                    if (g.unitTesting) {
+                        console.assert(false, g.callers());
+                    }
+                } else {
+                    at.initReadLine(s);
+                }
+            }
+            }
+            """)
         #@-<< define contents: test_typescript >>
 
         # Set p.h and p.b.

--- a/leo/unittests/test_plugins.py
+++ b/leo/unittests/test_plugins.py
@@ -164,11 +164,11 @@ class TestIndentedTypeScript(LeoUnitTest):
 
         #@+<< define contents: test_typescript >>
         #@+node:ekr.20231022133716.1: *4* << define contents: test_typescript >>
-
         # Snippets from indented_typescript_test.ts.
 
         # Contains "over-indented" parenthesized lines, a good test for check_indentation.
-        contents = textwrap.dedent(
+
+        contents = textwrap.dedent(  # dedent is required.
         """\
         import { NodeIndices, VNode, Position } from './leoNodes';
 
@@ -235,23 +235,22 @@ class TestIndentedLisp(LeoUnitTest):
     def test_lisp_reduce_fraction(self):
 
         c, p = self.c, self.c.p
-        contents = textwrap.dedent(
-    """\
-    (defun test (a)
-        (+ 1 (* 2 a))
-        (= 0 (% (cadr result) divisor))
-    )
+        contents = """
+            (defun test (a)
+                (+ 1 (* 2 a))
+                (= 0 (% (cadr result) divisor))
+            )
 
-    (defun reduce-fraction (f divisor)
-        "Eliminates divisor from fraction if present"
-        (while (and (= 0 (% (car result) divisor))
-             (= 0 (% (cadr result) divisor))
-             (< 1 (cadr result))
-             (< 0 (car result)))
-        (setq result (list (/ (car result) divisor) (/ (cadr result) divisor))))
-        result
-    )
-    """)
+            (defun reduce-fraction (f divisor)
+                "Eliminates divisor from fraction if present"
+                (while (and (= 0 (% (car result) divisor))
+                     (= 0 (% (cadr result) divisor))
+                     (< 1 (cadr result))
+                     (< 0 (car result)))
+                (setq result (list (/ (car result) divisor) (/ (cadr result) divisor))))
+                result
+            )
+        """
 
         # Setup.
         p.h = '@@file reduce_fraction.el'

--- a/leo/unittests/test_writers.py
+++ b/leo/unittests/test_writers.py
@@ -63,7 +63,7 @@ class TestMDWriter(BaseTestWriter):
         c, root = self.c, self.c.p
         #@+<< define contents: test_markdown_sections >>
         #@+node:ekr.20231221072635.1: *4* << define contents: test_markdown_sections >>
-        contents = textwrap.dedent("""
+        contents = """
             # 1st level title X
 
             some text in body X
@@ -77,7 +77,7 @@ class TestMDWriter(BaseTestWriter):
             ## 2nd level title B
 
             some body content of the 2nd node
-        """).strip() + '\n'  # End the last node with '\n'.
+        """.strip() + '\n'  # End the last node with '\n'.
         #@-<< define contents: test_markdown_sections >>
 
         # Import contents into root's tree.
@@ -104,13 +104,13 @@ class TestMDWriter(BaseTestWriter):
         c, root = self.c, self.c.p
         #@+<< define contents: test_markdown_image >>
         #@+node:ekr.20231225025012.2: *4* << define contents: test_markdown_image >>
-        contents = textwrap.dedent("""
+        contents = """
             declaration text
 
             # ![label](https://raw.githubusercontent.com/boltext/leojs/master/resources/leoapp.png)
 
             Body text
-        """).strip() + '\n'  # End the last node with '\n'.
+        """.strip() + '\n'  # End the last node with '\n'.
         #@-<< define contents: test_markdown_image >>
 
         # Import contents into root's tree.
@@ -138,7 +138,7 @@ class TestMDWriter(BaseTestWriter):
         #@+<< define contents: test_markdown_placeholders >>
         #@+node:ekr.20231227225358.1: *4* << define contents: test_markdown_placeholders >>
         # There must be two newlines after each node.
-        contents = textwrap.dedent("""
+        contents = """
             # Level 1
 
             Level 1 text.
@@ -146,7 +146,7 @@ class TestMDWriter(BaseTestWriter):
             ### Level 3
 
             Level 3 text.
-        """).strip() + '\n'  # End the last node with '\n'.
+        """.strip() + '\n'  # End the last node with '\n'.
         #@-<< define contents: test_markdown_placeholders >>
 
         # Import contents into root's tree.
@@ -179,7 +179,8 @@ class TestRstWriter(BaseTestWriter):
         child = root.insertAsLastChild()
         child.h = 'h'
         # For full coverage, we don't want a leading newline.
-        child.b = textwrap.dedent("""\
+        child.b = textwrap.dedent(  # dedent is required.
+        """
             .. toc
 
             ====


### PR DESCRIPTION
See #3766.

- [x] Remove unnecessary calls to `textwrap.dedent`. Some remain.
- [x] Remove almost all backslash-newline combinations in the testing infrastructure.
   The general pattern is to use `lstrip()` or `strip() + '\n'` instead.
- [x] Fix a crash `leoTokens.py` when called as follows:
  `python312 -m leo.core.leoTokens leo\unittests --force`
- [x] Beautify all files in `leo/unittests` *except* `py3_test_grammar.py`.
