### PR TITLE
PR: Simplify unit tests with LeoUnitTest.prep

### DIFF
--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -14,6 +14,7 @@ tests in leo/unittest. Eventually these classes will move to scripts.leo.
 from __future__ import annotations
 import os
 import sys
+import textwrap
 import time
 import unittest
 import warnings
@@ -139,6 +140,74 @@ class LeoUnitTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.c = None
+    #@+node:ekr.20230703103458.1: *3* LeoUnitTest._set_setting
+    def _set_setting(self, c: Cmdr, kind: str, name: str, val: Any) -> None:
+        """
+        Call c.config.set with the given args, suppressing stdout.
+        """
+        try:
+            old_stdout = sys.stdout
+            sys.stdout = open(os.devnull, 'w')
+            c.config.set(p=None, kind=kind, name=name, val=val)
+        finally:
+            sys.stdout = old_stdout
+    #@+node:ekr.20240205005844.1: *3* LeoUnitTest.prep
+    def prep(self, s: str) -> str:
+        """
+        Return the "prepped" version of s.
+        
+        This should eliminate the need for backslashes in tests.
+        """
+        return textwrap.dedent(s).strip() + '\n'
+    #@+node:ekr.20230808113542.1: *3* LeoUnitTest: dumps
+    #@+node:ekr.20230724174102.1: *4* LeoUnitTest.dump_bodies
+    def dump_bodies(self, c: Cmdr) -> None:  # pragma: no cover
+        """Dump all headlines."""
+        print('')
+        g.trace(c.fileName())
+        print('')
+        for p in c.all_positions():
+            head_s = f"{' '*p.level()} {p.h}"
+            print(f"{p.gnx:<28} {head_s:<20} body: {p.b!r}")
+
+    #@+node:ekr.20230720210931.1: *4* LeoUnitTest.dump_clone_info
+    def dump_clone_info(self, c: Cmdr, tag: str = None) -> None:
+        """Dump all clone info."""
+        print('')
+        g.trace(f"{tag or ''} {c.fileName()}")
+        print('')
+        for p in c.all_positions():
+            head_s = f"{' '*p.level()}{p.h}"
+            print(
+                f"clone? {int(p.isCloned())} id(v): {id(p.v)} gnx: {p.gnx:30}: "
+                f"{head_s:<10} parents: {p.v.parents}"
+            )
+    #@+node:ekr.20220805071838.1: *4* LeoUnitTest.dump_headlines
+    def dump_headlines(self, c: Cmdr, tag: str = None) -> None:  # pragma: no cover
+        """Dump all headlines."""
+        print('')
+        g.trace(f"{tag or ''} {c.fileName()}")
+        print('')
+        for p in c.all_positions():
+            print(f"{p.gnx:25}: {' '*p.level()}{p.h}")
+    #@+node:ekr.20220806170537.1: *4* LeoUnitTest.dump_string
+    def dump_string(self, s: str, tag: str = None) -> None:
+        if tag:
+            print(tag)
+        g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
+    #@+node:ekr.20211129062220.1: *4* LeoUnitTest.dump_tree
+    def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
+        """
+        Dump root's tree, or the entire tree if root is None.
+        """
+        print('')
+        if tag:
+            print(tag)
+        _iter = root.self_and_subtree if root else self.c.all_positions
+        for p in _iter():
+            print('')
+            print('level:', p.level(), p.h)
+            g.printObj(g.splitLines(p.v.b))
     #@+node:ekr.20230808113454.1: *3* LeoUnitTest: setup utils
     #@+node:ekr.20230724140745.1: *4* LeoUnitTest.clean_tree
     def clean_tree(self) -> None:
@@ -276,66 +345,6 @@ class LeoUnitTest(unittest.TestCase):
             child.h = h
 
 
-    #@+node:ekr.20230703103458.1: *3* LeoUnitTest._set_setting
-    def _set_setting(self, c: Cmdr, kind: str, name: str, val: Any) -> None:
-        """
-        Call c.config.set with the given args, suppressing stdout.
-        """
-        try:
-            old_stdout = sys.stdout
-            sys.stdout = open(os.devnull, 'w')
-            c.config.set(p=None, kind=kind, name=name, val=val)
-        finally:
-            sys.stdout = old_stdout
-    #@+node:ekr.20230808113542.1: *3* LeoUnitTest: dumps
-    #@+node:ekr.20230724174102.1: *4* LeoUnitTest.dump_bodies
-    def dump_bodies(self, c: Cmdr) -> None:  # pragma: no cover
-        """Dump all headlines."""
-        print('')
-        g.trace(c.fileName())
-        print('')
-        for p in c.all_positions():
-            head_s = f"{' '*p.level()} {p.h}"
-            print(f"{p.gnx:<28} {head_s:<20} body: {p.b!r}")
-
-    #@+node:ekr.20230720210931.1: *4* LeoUnitTest.dump_clone_info
-    def dump_clone_info(self, c: Cmdr, tag: str = None) -> None:
-        """Dump all clone info."""
-        print('')
-        g.trace(f"{tag or ''} {c.fileName()}")
-        print('')
-        for p in c.all_positions():
-            head_s = f"{' '*p.level()}{p.h}"
-            print(
-                f"clone? {int(p.isCloned())} id(v): {id(p.v)} gnx: {p.gnx:30}: "
-                f"{head_s:<10} parents: {p.v.parents}"
-            )
-    #@+node:ekr.20220805071838.1: *4* LeoUnitTest.dump_headlines
-    def dump_headlines(self, c: Cmdr, tag: str = None) -> None:  # pragma: no cover
-        """Dump all headlines."""
-        print('')
-        g.trace(f"{tag or ''} {c.fileName()}")
-        print('')
-        for p in c.all_positions():
-            print(f"{p.gnx:25}: {' '*p.level()}{p.h}")
-    #@+node:ekr.20220806170537.1: *4* LeoUnitTest.dump_string
-    def dump_string(self, s: str, tag: str = None) -> None:
-        if tag:
-            print(tag)
-        g.printObj([f"{i:2} {z.rstrip()}" for i, z in enumerate(g.splitLines(s))])
-    #@+node:ekr.20211129062220.1: *4* LeoUnitTest.dump_tree
-    def dump_tree(self, root: Position = None, tag: str = None) -> None:  # pragma: no cover
-        """
-        Dump root's tree, or the entire tree if root is None.
-        """
-        print('')
-        if tag:
-            print(tag)
-        _iter = root.self_and_subtree if root else self.c.all_positions
-        for p in _iter():
-            print('')
-            print('level:', p.level(), p.h)
-            g.printObj(g.splitLines(p.v.b))
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -3,7 +3,6 @@
 """Tests of leo.commands.leoConvertCommands."""
 import os
 import re
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 from leo.commands.convertCommands import ConvertCommandsClass
@@ -62,7 +61,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220108091352.1: *3* test_ama.test_already_annotated
     def test_already_annotated(self):
         p = self.p
-        p.b = contents = textwrap.dedent(
+        p.b = contents = self.prep(
         '''
             def f1(i: int, s: str) -> str:
                 return s
@@ -77,7 +76,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
         # https://github.com/leo-editor/leo-editor/issues/2606
         p = self.p
         # Make sure any adjustment to the args logic doesn't affect following functions.
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         '''
             def f1(root=p and p.copy()):
                 pass
@@ -88,7 +87,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
             def f3(a, self=self):
                 pass
         ''')
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             def f1(root: Any=p and p.copy()) -> None:
                 pass
@@ -104,12 +103,12 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220108093044.1: *3* test_ama.test_initializers
     def test_initializers(self):
         p = self.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         '''
             def f3(i = 2, f = 1.1, b = True, s = 'abc', x = None):
                 pass
         ''')
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             def f3(i: int=2, f: float=1.1, b: bool=True, s: str='abc', x: Any=None) -> None:
                 pass
@@ -119,7 +118,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220108093621.1: *3* test_ama.test_multiline_def
     def test_multiline_def(self):
         p = self.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         '''
             def f (
                 self,
@@ -131,7 +130,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
             ):
                 pass
         ''')
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             def f(
                 self,
@@ -148,7 +147,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220108153333.1: *3* test_ama.test_multiline_def_with_comments
     def test_multiline_def_with_comments(self):
         p = self.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         '''
             def f (
                 self,# comment 1
@@ -160,7 +159,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
                 pass
         ''')
         # Note: The command insert exactly two spaces before comments.
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             def f(
                 self,  # comment 1
@@ -177,12 +176,12 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220108083112.4: *3* test_ama.test_plain_args
     def test_plain_args(self):
         p = self.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         '''
             def f1(event, i, s):
                 pass
         ''')
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             def f1(event: Event, i: int, s: str) -> None:
                 pass
@@ -192,7 +191,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
     #@+node:ekr.20220416082758.1: *3* test_ama.test_special_methods
     def test_special_methods(self):
         p = self.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         '''
             def __init__(self):
                 pass
@@ -203,7 +202,7 @@ class TestAddMypyAnnotations(LeoUnitTest):
             def __str__(self):
                 pass
         ''')
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             def __init__(self) -> None:
                 pass

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -824,7 +824,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.30: *5* clean-lines
     def test_clean_lines(self):
         """Test case for clean-lines"""
-        before_b = textwrap.dedent(
+        before_b = self.prep(
         """
             # Should remove all trailing whitespace.
 
@@ -1979,20 +1979,22 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20210926144000.1: *5* insert-newline-bug-2230
     def test_insert_newline_bug_2230(self):
         """Test case for insert-newline"""
-        before_b = textwrap.dedent("""
-    #@@language python
-    def spam():
-        if 1:  # test
-    # after line
-    """).strip() + '\n'
-        # There are 8 spaces in the line after "if 1:..."
-        after_b = textwrap.dedent("""
-    #@@language python
-    def spam():
-        if 1:  # test
+        before_b = self.prep("""
+            @language python
+            def spam():
+                if 1:  # test
+            # after line
+        """)
 
-    # after line
-    """).strip() + '\n'
+        # There are 8 spaces in the line after "if 1:..."
+        after_b = self.prep(
+        """
+            @language python
+            def spam():
+                if 1:  # test
+
+            # after line
+        """)
         self.run_test(
             before_b=before_b,
             after_b=after_b,

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -2320,24 +2320,21 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20220517064432.1: *5* merge-node-with-next-node
     def test_merge_node_with_next_node(self):
         c, u = self.c, self.c.undoer
-        prev_b = textwrap.dedent(
+        prev_b = self.prep(
         """
             def spam():
                 pass
-        """).strip() + '\n'
+        """)
 
-        next_b = textwrap.dedent(
-        """
-            spam2 = spam
-        """).strip() + '\n'
+        next_b = self.prep("""spam2 = spam""")
 
-        result_b = textwrap.dedent(
+        result_b = self.prep(
         """
             def spam():
                 pass
 
             spam2 = spam
-        """).strip() + '\n'
+        """)
         self.before_p.b = prev_b
         self.after_p.b = next_b
         c.selectPosition(self.before_p)
@@ -2359,24 +2356,24 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20220517064507.1: *5* merge-node-with-prev-node
     def test_merge_node_with_prev_node(self):
         c, u = self.c, self.c.undoer
-        prev_b = textwrap.dedent(
+        prev_b = self.prep(
         """
             def spam():
                 pass
-        """).strip() + '\n'
+        """)
 
-        next_b = textwrap.dedent(
+        next_b = self.prep(
         """
             spam2 = spam
-        """).strip() + '\n'
+        """)
 
-        result_b = textwrap.dedent(
+        result_b = self.prep(
         """
             def spam():
                 pass
 
             spam2 = spam
-        """).strip() + '\n'
+        """)
         self.before_p.b = prev_b
         self.after_p.b = next_b
         c.selectPosition(self.after_p)
@@ -2534,7 +2531,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.91: *5* newline-and-indent
     def test_newline_and_indent(self):
         """Test case for newline-and-indent"""
-        before_b = textwrap.dedent(
+        before_b = self.prep(
         """
             first line
             line 1
@@ -2542,7 +2539,7 @@ class TestEditCommands(LeoUnitTest):
                     line b
             line c
             last line
-        """).strip() + '\n'
+        """)
 
         # docstrings strip blank lines, so we can't use a docstring here!
         after_b = ''.join([
@@ -2735,7 +2732,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.99: *5* test_rectangle-string
     def test_rectangle_string(self):
         """Test case for rectangle-string"""
-        before_b = textwrap.dedent(
+        before_b = self.prep(
         """
             before
             aaaxxxbbb
@@ -2744,7 +2741,7 @@ class TestEditCommands(LeoUnitTest):
             aaaxxxbbb
             after
         """).strip() + '\n'
-        after_b = textwrap.dedent(
+        after_b = self.prep(
         """
             before
             aaas...sbbb
@@ -2765,7 +2762,7 @@ class TestEditCommands(LeoUnitTest):
     #@+node:ekr.20201130090918.100: *5* test_rectangle-yank
     def test_rectangle_yank(self):
         """Test case for rectangle-yank"""
-        before_b = textwrap.dedent(
+        before_b = self.prep(
         """
             before
             aaaxxxbbb
@@ -2773,9 +2770,9 @@ class TestEditCommands(LeoUnitTest):
             aaaxxxbbb
             aaaxxxbbb
             after
-        """).strip() + '\n'
+        """)
 
-        after_b = textwrap.dedent(
+        after_b = self.prep(
         """
             before
             aaaY1Ybbb
@@ -2783,7 +2780,7 @@ class TestEditCommands(LeoUnitTest):
             aaaY3Ybbb
             aaaY4Ybbb
             after
-        """).strip() + '\n'
+        """)
 
         self.run_test(
             before_b=before_b,

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4409,7 +4409,7 @@ class TestEditCommands(LeoUnitTest):
         )
         #@-<< define table >>
         w = c.frame.body.wrapper
-        s = textwrap.dedent(
+        s = self.prep(
         """
             Paragraph 1.
                 line 2.

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -2740,7 +2740,7 @@ class TestEditCommands(LeoUnitTest):
             aaaxxxbbb
             aaaxxxbbb
             after
-        """).strip() + '\n'
+        """)
         after_b = self.prep(
         """
             before
@@ -2749,7 +2749,7 @@ class TestEditCommands(LeoUnitTest):
             aaas...sbbb
             aaas...sbbb
             after
-        """).strip() + '\n'
+        """)
 
         # A hack. The command tests for g.unitTesting!
         self.run_test(

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -245,6 +245,14 @@ class BaseTest(unittest.TestCase):
         contents = g.readFileIntoUnicodeString(filename)
         contents, tokens, tree = self.make_data(contents, description=filename)
         return contents, tokens, tree
+    #@+node:ekr.20240205023615.1: *4* BaseTest.prep
+    def prep(self, s: str) -> str:
+        """
+        Return the "prepped" version of s.
+        
+        This should eliminate the need for backslashes in tests.
+        """
+        return textwrap.dedent(s).strip() + '\n'
     #@+node:ekr.20191228101601.1: *4* BaseTest: passes...
     #@+node:ekr.20191228095945.11: *5* 0.1: BaseTest.make_tokens
     def make_tokens(self, contents):
@@ -1402,7 +1410,7 @@ class TestFstringify(BaseTest):
             f = TestClass('abc', 0, 10)
         """
         contents, tokens, tree = self.make_data(contents)
-        expected = textwrap.dedent(contents).rstrip() + '\n'
+        expected = self.prep(contents)
         results = self.fstringify(contents, tokens, tree)
         self.assertEqual(results, expected)
     #@+node:ekr.20200111043311.2: *5* TestFstringify.test_crash_1
@@ -1525,7 +1533,7 @@ class TestFstringify(BaseTest):
 
         expected = """print(f'{"done"} in {2.9:5.2f} sec') # trailing comment\n"""
         contents, tokens, tree = self.make_data(contents)
-        expected = textwrap.dedent(expected).rstrip() + '\n'
+        expected = self.prep(expected)
         results = self.fstringify(contents, tokens, tree)
         self.assertEqual(results, expected)
     #@+node:ekr.20200206173126.1: *4* TestFstringify.test_change_quotes
@@ -1954,7 +1962,7 @@ class TestOrange(BaseTest):
         )
         for i, contents in enumerate(table):
             contents, tokens, tree = self.make_data(contents)
-            expected = textwrap.dedent(contents.strip() + '\n')
+            expected = self.prep(contents)
             results = self.beautify(contents, tokens, tree)
             if results != expected:
                 g.trace('Fail:', i)  # pragma: no cover
@@ -2007,7 +2015,7 @@ class TestOrange(BaseTest):
         )
         for i, contents in enumerate(table):
             contents, tokens, tree = self.make_data(contents)
-            expected = self.blacken(textwrap.dedent(contents.strip() + '\n'))
+            expected = self.blacken(self.prep(contents))
             results = self.beautify(contents, tokens, tree)
             self.assertEqual(results, expected)
     #@+node:ekr.20200116104031.1: *4* TestOrange.test_join_and_strip_condition
@@ -2025,7 +2033,7 @@ class TestOrange(BaseTest):
                 pass
         """.strip() + '\n'
         contents, tokens, tree = self.make_data(contents)
-        expected = textwrap.dedent(expected)
+        expected = self.prep(expected)
         # Black also removes parens, which is beyond our scope at present.
             # expected = self.blacken(contents, line_length=40)
         results = self.beautify(contents, tokens, tree)
@@ -2114,7 +2122,7 @@ class TestOrange(BaseTest):
                 print(a)
         """.strip() + '\n'
         contents, tokens, tree = self.make_data(contents)
-        expected = textwrap.dedent(expected)
+        expected = self.prep(expected)
         results = self.beautify(contents, tokens, tree)
         self.assertEqual(results, expected)
     #@+node:ekr.20200207093606.1: *4* TestOrange.test_join_too_long_lines
@@ -2344,7 +2352,7 @@ class TestOrange(BaseTest):
     def test_relative_imports(self):
 
         # #2533.
-        contents = textwrap.dedent(
+        contents = self.prep(
         """
             from .module1 import w
             from . module2 import x
@@ -2354,9 +2362,9 @@ class TestOrange(BaseTest):
             from.import b
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
-        """).strip() + '\n'
+        """)
 
-        expected = textwrap.dedent(
+        expected = self.prep(
         """
             from .module1 import w
             from .module2 import x
@@ -2366,7 +2374,7 @@ class TestOrange(BaseTest):
             from . import b
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
-        """).strip() + '\n'
+        """)
 
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree)
@@ -2432,11 +2440,12 @@ class TestOrange(BaseTest):
         return False
     """
 
-        expected = textwrap.dedent("""
-    if not any(
-        [z.kind == 'lt' for z in line_tokens]):
-        return False
-    """).strip() + '\n'
+        expected = self.prep(
+        """
+            if not any(
+                [z.kind == 'lt' for z in line_tokens]):
+                return False
+        """)
 
         fails = 0
         contents, tokens, tree = self.make_data(contents)
@@ -2461,15 +2470,15 @@ class TestOrange(BaseTest):
         contents = """print('eee', ('fffffff, ggggggg', 'hhhhhhhh', 'iiiiiii'), 'jjjjjjj', 'kkkkkk')"""
 
         # This is a bit different from black, but it's good enough for now.
-        expected = textwrap.dedent(
-            """
-                print(
-                    'eee',
-                    ('fffffff, ggggggg', 'hhhhhhhh', 'iiiiiii'),
-                    'jjjjjjj',
-                    'kkkkkk',
-                )
-            """).strip() + '\n'
+        expected = self.prep(
+        """
+            print(
+                'eee',
+                ('fffffff, ggggggg', 'hhhhhhhh', 'iiiiiii'),
+                'jjjjjjj',
+                'kkkkkk',
+            )
+        """)
         fails = 0
         contents, tokens, tree = self.make_data(contents)
         results = self.beautify(contents, tokens, tree,
@@ -2518,7 +2527,7 @@ class TestOrange(BaseTest):
 
         line_length = 40  # For testing.
 
-        contents = textwrap.dedent("""
+        contents = self.prep("""
     #@@nobeautify
 
     def addOptionsToParser(self, parser, trace_m):
@@ -2542,7 +2551,7 @@ class TestOrange(BaseTest):
     docDirective    =  3 # @doc.
 
     #@@beautify
-    """).lstrip()
+    """)
         contents, tokens, tree = self.make_data(contents)
         expected = contents
         results = self.beautify(contents, tokens, tree,

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2021,17 +2021,19 @@ class TestOrange(BaseTest):
     #@+node:ekr.20200116104031.1: *4* TestOrange.test_join_and_strip_condition
     def test_join_and_strip_condition(self):
 
-        contents = """
+        contents = self.prep(
+        """
             if (
                 a == b or
                 c == d
             ):
                 pass
-        """.strip() + '\n'
-        expected = """
+        """)
+        expected = self.prep(
+        """
             if (a == b or c == d):
                 pass
-        """.strip() + '\n'
+        """)
         contents, tokens, tree = self.make_data(contents)
         expected = self.prep(expected)
         # Black also removes parens, which is beyond our scope at present.
@@ -2109,18 +2111,18 @@ class TestOrange(BaseTest):
     #@+node:ekr.20200210051900.1: *4* TestOrange.test_join_suppression
     def test_join_suppression(self):
 
-        contents = """
+        contents = self.prep("""
             class T:
                 a = 1
                 print(
                    a
                 )
-        """.strip() + '\n'
-        expected = """
+        """)
+        expected = self.prep("""
             class T:
                 a = 1
                 print(a)
-        """.strip() + '\n'
+        """)
         contents, tokens, tree = self.make_data(contents)
         expected = self.prep(expected)
         results = self.beautify(contents, tokens, tree)

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -3,7 +3,6 @@
 """Tests of leoAtFile.py"""
 import os
 import tempfile
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core import leoAtFile
 from leo.core import leoBridge
@@ -107,14 +106,14 @@ class TestAtFile(LeoUnitTest):
         at, p = self.at, self.c.p
 
         # dedent is required.
-        s = textwrap.dedent('''
+        s = self.prep('''
             # no error
             def spam():
                 pass
         ''')
         assert at.checkPythonSyntax(p, s), 'fail 1'
 
-        s2 = textwrap.dedent('''
+        s2 = self.prep('''
             # syntax error
             def spam:  # missing parens.
                 pass
@@ -220,14 +219,14 @@ class TestAtFile(LeoUnitTest):
         at, c = self.at, self.c
         root = c.rootPosition()
         root.h = '@file test.html'
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             @doc
             First @doc part
             @doc
             Second @doc part
         ''')
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             <!--@+doc-->
             <!--
@@ -251,17 +250,17 @@ class TestAtFile(LeoUnitTest):
         root.h = '@file test.py'
         child = root.insertAsLastChild()
         child.h = 'child'
-        child.b = textwrap.dedent(
+        child.b = self.prep(
         '''
             def spam():
                 pass
 
             @ A single-line doc part.
-        ''').lstrip()
+        ''')
 
         child.v.fileIndex = '<GNX>'
         contents = '''ATall'''.replace('AT', '@')
-        expected_contents = textwrap.dedent('''
+        expected_contents = self.prep('''
             #AT+all
             #AT+node:<GNX>: ** child
             def spam():
@@ -269,7 +268,7 @@ class TestAtFile(LeoUnitTest):
 
             @ A single-line doc part.
             #AT-all
-        ''').lstrip().replace('AT', '@')
+        ''').replace('AT', '@')
 
         for blacken in (True, False):
 
@@ -294,22 +293,22 @@ class TestAtFile(LeoUnitTest):
         at, c = self.at, self.c
         root = c.rootPosition()
         root.h = '@file test.py'
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             ATdoc
             doc line 1
             ATall
-        ''').lstrip().replace('AT', '@')
+        ''').replace('AT', '@')
 
         # Only @c or @code end an @doc part.
         # Therefore, the @all line is part of the @doc part.
 
-        expected_contents = textwrap.dedent(
+        expected_contents = self.prep(
         '''
             #AT+doc
             # doc line 1
             # ATall
-        ''').lstrip().replace('AT', '@')
+        ''').replace('AT', '@')
 
         for blacken in (True, False):
 
@@ -339,14 +338,14 @@ class TestAtFile(LeoUnitTest):
         child.b = '@others\n'
         child.v.fileIndex = '<GNX>'
         contents = '''ATothers'''.replace('AT', '@')
-        expected_contents = textwrap.dedent(
+        expected_contents = self.prep(
         '''
             #AT+others
             #AT+node:<GNX>: ** child
             #AT+others
             #AT-others
             #AT-others
-        ''').lstrip().replace('AT', '@')
+        ''').replace('AT', '@')
 
         for blacken in (True, False):
 
@@ -379,19 +378,19 @@ class TestAtFile(LeoUnitTest):
         root = c.rootPosition()
         root.h = '@file test.html'
 
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             @doc
             Unterminated @doc parts (not an error)
-        ''').lstrip()
+        ''')
 
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             <!--@+doc-->
             <!--
             Unterminated @doc parts (not an error)
             -->
-        ''').lstrip()
+        ''')
         root.b = contents
         at.initWriteIvars(root)
         at.putBody(root)
@@ -565,22 +564,22 @@ class TestAtFile(LeoUnitTest):
         at, p = self.at, self.c.p
 
         # Test 1.
-        s = textwrap.dedent(
+        s = self.prep(
         """
             # no error
             def spam():
                 pass
-        """).lstrip()
+        """)
         at.tabNannyNode(p, body=s)
 
         # Test 2.
-        s2 = textwrap.dedent(
+        s2 = self.prep(
         """
             # syntax error
             def spam:
                 pass
               a = 2
-        """).lstrip()
+        """)
         try:
             at.tabNannyNode(p, body=s2)
         except IndentationError:

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -611,10 +611,10 @@ class TestFastAtRead(LeoUnitTest):
         root = c.rootPosition()
         root.h = h  # To match contents.
         #@+<< define contents >>
-        #@+node:ekr.20211106112233.1: *4* << define contents >>
+        #@+node:ekr.20211106112233.1: *4* << define contents >> (test_afterref)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
             '''
                 #AT+leo-ver=5-thin
                 #AT+node:{root.gnx}: * {h}
@@ -630,16 +630,14 @@ class TestFastAtRead(LeoUnitTest):
                  ):
                     a = 2
                 #AT-leo
-            ''').lstrip()
-
-        contents = contents.replace('AT', '@').replace('LB', '<<')
+            ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
         #@+<< define expected_body >>
         #@+node:ekr.20211106115654.1: *4* << define expected_body >>
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        expected_body = textwrap.dedent(
+        expected_body = self.prep(
         '''
             ATlanguage python
 
@@ -647,13 +645,13 @@ class TestFastAtRead(LeoUnitTest):
             if (
             LB test >> ):
                 a = 2
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         #@-<< define expected_body >>
         #@+<< define expected_contents >>
         #@+node:ekr.20211107053133.1: *4* << define expected_contents >>
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        expected_contents = textwrap.dedent(
+        expected_contents = self.prep(
         '''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -664,7 +662,7 @@ class TestFastAtRead(LeoUnitTest):
             LB test >> ):
                 a = 2
             #AT-leo
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         expected_contents = expected_contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define expected_contents >>
 
@@ -696,7 +694,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211103093424.1: *4* << define contents >> (test_at_all)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -717,8 +715,7 @@ class TestFastAtRead(LeoUnitTest):
             #AT-all
             #AT@nosearch
             #AT-leo
-        ''').lstrip()
-        contents = contents.replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
 
@@ -748,7 +745,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101090447.1: *4* << define contents >> (test_at_comment)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             !!! -*- coding: utf-8 -*-
             !!!AT+leo-ver=5-thin
@@ -776,8 +773,7 @@ class TestFastAtRead(LeoUnitTest):
 
             !!!AT@language plain
             !!!AT-leo
-        ''').lstrip()
-        contents = contents.replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
 
@@ -817,7 +813,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101111652.1: *4* << define contents >> (test_at_delims)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             # -*- coding: utf-8 -*-
             #AT+leo-ver=5-thin
@@ -843,8 +839,7 @@ class TestFastAtRead(LeoUnitTest):
 
             !!AT@language python
             !!AT-leo
-        ''').lstrip()
-        contents = contents.replace('AT', '@').replace('LB', '<<').replace('SPACE', ' ')
+        ''').replace('AT', '@').replace('LB', '<<').replace('SPACE', ' ')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
 
         #@-<< define contents >>
@@ -886,7 +881,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211103095959.1: *4* << define contents >> (test_at_last)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -900,8 +895,7 @@ class TestFastAtRead(LeoUnitTest):
             #AT@last
             #AT-leo
             # last line
-        ''').lstrip()
-        contents = contents.replace('AT', '@')
+        ''').replace('AT', '@')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
 
 
@@ -910,13 +904,13 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211104052937.1: *4* << define expected_body >> (test_at_last)
         # Use neither a raw string nor an f-string here.
         # Be careful: no line should look like a Leo sentinel!
-        expected_body = textwrap.dedent(
+        expected_body = self.prep(
         '''
             # Test of @last
             ATothers
             ATlanguage python
             ATlast # last line
-        ''').lstrip().replace('AT', '@')
+        ''').replace('AT', '@')
         #@-<< define expected_body >>
 
         for blacken in (True, False):
@@ -947,7 +941,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20211103092228.2: *4* << define contents >> (test_at_others)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(
+        contents = self.prep(
         f'''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -960,7 +954,7 @@ class TestFastAtRead(LeoUnitTest):
                     pass
                 #AT-others
             #AT-leo
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         #@-<< define contents >>
 
         for blacken in (True, False):
@@ -992,7 +986,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101050923.1: *4* << define contents >> (test_at_section_delim)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             AT+leo-ver=5-thin
             AT+node:{root.gnx}: * {h}
@@ -1018,8 +1012,7 @@ class TestFastAtRead(LeoUnitTest):
 
             AT@language python
             AT-leo
-        ''').lstrip().replace('AT', '#@')
-        contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
+        ''').replace('AT', '#@').replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
 
         for blacken in (True, False):
@@ -1058,7 +1051,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20211101155930.2: *4* << define contents >> (test_clones)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(
+        contents = self.prep(
         f'''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -1077,7 +1070,7 @@ class TestFastAtRead(LeoUnitTest):
             a = 3
             #AT-others
             #AT-leo
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         #@-<< define contents >>
 
         for blacken in (True, False):
@@ -1126,7 +1119,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211103080718.2: *4* << define contents >> (test_cweb)
         # Lines must not look like Leo sentinels!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             ATq@@+leo-ver=5-thin@>
             ATq@@+node:{root.gnx}: * @{h}@>
@@ -1158,8 +1151,7 @@ class TestFastAtRead(LeoUnitTest):
             BSLaTeX and BSc should not be colored.
             if else, while, do // C keywords.
             ATq@@-leo@>
-        ''').lstrip()
-        contents = contents.replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
 
@@ -1190,7 +1182,7 @@ class TestFastAtRead(LeoUnitTest):
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
         # The doc part should contain at least one blank line.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -1209,7 +1201,7 @@ class TestFastAtRead(LeoUnitTest):
             #AT@c
 
             #AT-leo
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
         for blacken in (True, False):
@@ -1240,7 +1232,7 @@ class TestFastAtRead(LeoUnitTest):
         # Use neither a raw string nor an f-string here.
 
         # The doc part should contain at least one blank line.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
@@ -1263,7 +1255,7 @@ class TestFastAtRead(LeoUnitTest):
             <!--AT@c-->
 
             <!--AT-leo
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
         #@+<< define expected_contents >>
@@ -1271,7 +1263,7 @@ class TestFastAtRead(LeoUnitTest):
         # For languages with a trailing delim,
         #@verbatim
         # @doc parts contain extra lines for the start/end delims.
-        expected_contents = textwrap.dedent(
+        expected_contents = self.prep(
         '''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
@@ -1294,7 +1286,7 @@ class TestFastAtRead(LeoUnitTest):
             <!--AT@c-->
 
             <!--AT-leo-->
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         expected_contents = expected_contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define expected_contents >>
 
@@ -1327,7 +1319,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20211101154651.1: *4* << define contents >> (test_html_doc_part)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        contents = textwrap.dedent(
+        contents = self.prep(
         '''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
@@ -1338,14 +1330,14 @@ class TestFastAtRead(LeoUnitTest):
             Line 2.
             <!--AT@c-->
             <!--AT-leo-->
-        ''').lstrip().replace('AT', '@').replace('LB', '<<')
+        ''').replace('AT', '@').replace('LB', '<<')
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
         #@+<< define expected >>
         #@+node:ekr.20231204050205.1: *4* << define expected >> (test_html_doc_part)
         # Be careful: no line should look like a Leo sentinel!
         # Use neither a raw string nor an f-string here.
-        expected = textwrap.dedent(
+        expected = self.prep(
         '''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
@@ -1358,8 +1350,7 @@ class TestFastAtRead(LeoUnitTest):
             -->
             <!--AT@c-->
             <!--AT-leo-->
-        ''').lstrip().replace('AT', '@')
-        expected = expected.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
+        ''').replace('AT', '@').replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define expected >>
 
         for blacken in (True, False):
@@ -1396,7 +1387,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+node:ekr.20231203092436.2: *4* << define contents >> (test_cweb)
         # Be careful: no line should look like a Leo sentinel!
         # Use a raw string so pyflakes won't complain about \document.
-        contents = textwrap.dedent(
+        contents = self.prep(
         r'''
             ATq@@+leo-ver=5-thin@>
             ATq@@+node:{root.gnx}: * @{h}@>
@@ -1414,8 +1405,7 @@ class TestFastAtRead(LeoUnitTest):
             AT
             \end{document}
             ATq@@-leo@>
-        ''').lstrip()
-        contents = contents.replace('AT', '@').replace('{root.gnx}', root.gnx).replace('{h}', root.h)
+        ''').replace('AT', '@').replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         #@-<< define contents >>
 
         for blacken in (True, False):
@@ -1443,7 +1433,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20211101180404.1: *4* << define contents >> (test_verbatim)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(
+        contents = self.prep(
         f'''
             #AT+leo-ver=5-thin
             #AT+node:{root.gnx}: * {h}
@@ -1453,17 +1443,17 @@ class TestFastAtRead(LeoUnitTest):
             #ATverbatim
             #AT+node (verbatim)
             #AT-leo
-        ''').lstrip().replace('AT', '@')  # .replace('LB', '<<')
+        ''').replace('AT', '@')  # .replace('LB', '<<')
         #@-<< define contents >>
         #@+<< define expected_body >>
         #@+node:ekr.20211106070035.1: *4* << define expected_body >> (test_verbatim)
-        expected_body = textwrap.dedent(
+        expected_body = self.prep(
         '''
-        ATlanguage python
-        # Test of @verbatim
-        print('hi')
-        #AT+node (verbatim)
-        ''').lstrip().replace('AT', '@')
+            ATlanguage python
+            # Test of @verbatim
+            print('hi')
+            #AT+node (verbatim)
+        ''').replace('AT', '@')
         #@-<< define expected_body >>
         for blacken in (True, False):
             g.app.write_black_sentinels = blacken
@@ -1502,7 +1492,7 @@ class TestFastAtRead(LeoUnitTest):
         #@+<< define contents >>
         #@+node:ekr.20231207080536.2: *4* << define contents >> (test_verbatim_html)
         # Be careful: no line should look like a Leo sentinel!
-        contents = textwrap.dedent(
+        contents = self.prep(
         f'''
             <!--AT+leo-ver=5-thin-->
             <!--AT+node:{root.gnx}: * {h}-->
@@ -1514,18 +1504,18 @@ class TestFastAtRead(LeoUnitTest):
                 <!--ATverbatim-->
                 <!--AT+node (verbatim)-->
             <!--AT-leo-->
-        ''').lstrip().replace('AT', '@')  # .replace('LB', '<<')
+        ''').replace('AT', '@')  # .replace('LB', '<<')
         #@-<< define contents >>
         #@+<< define expected_body >>
         #@+node:ekr.20231207080536.3: *4* << define expected_body >> (test_verbatim_html)
-        expected_body = textwrap.dedent(
+        expected_body = self.prep(
         '''
             ATlanguage html
             <!-- Test of @verbatim-->
             print('hi')
             <!--AT+node (verbatim)-->
                 <!--AT+node (verbatim)-->
-        ''').lstrip().replace('AT', '@')
+        ''').replace('AT', '@')
         #@-<< define expected_body >>
 
         for blacken in (True, False):

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -21,7 +21,7 @@ class TestColorizer(LeoUnitTest):
         c.recolor_now()
     #@+node:ekr.20210905170507.2: *3* TestColorizer.test__comment_after_language_plain
     def test__comment_after_language_plain(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             @comment # /* */
 
@@ -35,7 +35,7 @@ class TestColorizer(LeoUnitTest):
             continues */
 
             More plain text.
-        """).lstrip()
+        """)
         self.color('plain', text)
     #@+node:ekr.20210905170507.3: *3* TestColorizer.test_bc_scanLanguageDirectives
     def test_bc_scanLanguageDirectives(self):

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -2,7 +2,6 @@
 #@+node:ekr.20210905151702.1: * @file ../unittests/core/test_leoColorizer.py
 """Tests of leoColorizer.py"""
 
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 from leo.core.leoQt import Qt
@@ -102,7 +101,7 @@ class TestColorizer(LeoUnitTest):
             self.assertEqual(got, expected, msg=f"i: {i} {language}")
     #@+node:ekr.20210905170507.5: *3* TestColorizer.test_colorizer_Actionscript
     def test_colorizer_Actionscript(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             break
             call, continue
@@ -159,11 +158,11 @@ class TestColorizer(LeoUnitTest):
             _x, _xmouse, _xscale
             _y, _ymouse, _yscale
             and, add, eq, ge, gt, le, lt, ne, not, or, Array, Boolean, Color, Date, Key, Math, MovieClip, Mouse, Number, Object, Selection, Sound, String, XML, XMLSocket
-    """).lstrip()
+    """)
         self.color('actionscript', text)
     #@+node:ekr.20210905170507.6: *3* TestColorizer.test_colorizer_C
     def test_colorizer_C(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             @comment /* */
 
@@ -181,11 +180,11 @@ class TestColorizer(LeoUnitTest):
             #include "eeprom.h"
             #include <hpc_ram.h>
             #include <rlydef.h>
-        """).lstrip()
+        """)
         self.color('c', text)
     #@+node:ekr.20210905170507.7: *3* TestColorizer.test_colorizer_C_
     def test_colorizer_C_(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             @ comment
             @c
@@ -217,11 +216,11 @@ class TestColorizer(LeoUnitTest):
             value virtual void volatile
             where while
             yield
-    """).lstrip()
+    """)
         self.color('csharp', text)
     #@+node:ekr.20210905170507.8: *3* TestColorizer.test_colorizer_css
     def test_colorizer_css(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             /* New in 4.2. */
 
@@ -290,11 +289,12 @@ class TestColorizer(LeoUnitTest):
             /*aural values*/
             stress, azimuth, elevation, pitch, richness, volume,
             page-break, page-after, page-inside
-        """).lstrip()
+        """)
         self.color('css', text)
     #@+node:ekr.20210905170507.9: *3* TestColorizer.test_colorizer_CWEB
     def test_colorizer_CWEB(self):
-        text = textwrap.dedent(r"""\\\
+        text = self.prep(
+            r"""\\\
             % This is limbo in cweb mode... It should be in \LaTeX mode, not \c mode.
             % The following should not be colorized: class,if,else.
 
@@ -320,7 +320,7 @@ class TestColorizer(LeoUnitTest):
         self.color('cweb', text)
     #@+node:ekr.20210905170507.10: *3* TestColorizer.test_colorizer_cython
     def test_colorizer_cython(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             by cdef cimport cpdef ctypedef enum except?
             extern gil include nogil property public
@@ -333,11 +333,11 @@ class TestColorizer(LeoUnitTest):
                 pass
             except Exception:
                 pass
-        """).lstrip()
+        """)
         self.color('cython', text)
     #@+node:ekr.20210905170507.11: *3* TestColorizer.test_colorizer_elisp
     def test_colorizer_elisp(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             ; Maybe...
             error princ
@@ -358,20 +358,20 @@ class TestColorizer(LeoUnitTest):
             t type-of
             unless
             when while
-        """).lstrip()
+        """)
         self.color('elisp', text)
     #@+node:ekr.20210905170507.12: *3* TestColorizer.test_colorizer_erlang
     def test_colorizer_erlang(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             halt()
 
             -module()
-        """).lstrip()
+        """)
         self.color('erlang', text)
     #@+node:ekr.20210905170507.13: *3* TestColorizer.test_colorizer_forth
     def test_colorizer_forth(self):
-        text = textwrap.dedent(
+        text = self.prep(
         r"""\\\
             \ tiny demo of Leo forth syntax colouring
 
@@ -407,7 +407,7 @@ class TestColorizer(LeoUnitTest):
         self.color('forth', text)
     #@+node:ekr.20210905170507.15: *3* TestColorizer.test_colorizer_HTML1
     def test_colorizer_HTML1(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             <HTML>
             <!-- Author: Edward K. Ream, edream@tds.net -->
@@ -500,21 +500,21 @@ class TestColorizer(LeoUnitTest):
 
             </BODY>
             </HTML>
-        """).lstrip()
+        """)
         self.color('html', text)
     #@+node:ekr.20210905170507.16: *3* TestColorizer.test_colorizer_HTML2
     def test_colorizer_HTML2(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             <? xml version="1.0">
             <!-- test -->
             <project name="Converter" default="dist">
             </project>
-        """).lstrip()
+        """)
         self.color('html', text)
     #@+node:ekr.20230421104052.1: *3* TestColorizer.test_colorizer_HTML_script_tag
     def test_colorizer_HTML_script_tag(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             <html>
             <head>
@@ -531,19 +531,19 @@ class TestColorizer(LeoUnitTest):
             This is a test.
             </body>
             </html>
-        """).lstrip()
+        """)
         self.color('html', text)
     #@+node:ekr.20210905170507.14: *3* TestColorizer.test_colorizer_HTML_string_bug
     def test_colorizer_HTML_string_bug(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             b = "cd"
             d
-        """).lstrip()
+        """)
         self.color('html', text)
     #@+node:ekr.20210905170507.17: *3* TestColorizer.test_colorizer_Java
     def test_colorizer_Java(self):
-        text = textwrap.dedent(
+        text = self.prep(
         '''
             @ doc part
             @c
@@ -561,7 +561,8 @@ class TestColorizer(LeoUnitTest):
         self.color('java', text)
     #@+node:ekr.20210905170507.18: *3* TestColorizer.test_colorizer_LaTex
     def test_colorizer_LaTex(self):
-        text = textwrap.dedent(r"""\\\
+        text = self.prep(
+        r"""\\\
             % This is a \LaTeX mode comment.
 
             This is a test of \LaTeX mode.
@@ -583,11 +584,11 @@ class TestColorizer(LeoUnitTest):
 
             \(\)\{\}\@
             \(abc\)abc\{abc\}abc\@abc
-    """)
+        """)
         self.color('latex', text)
     #@+node:ekr.20210905170507.19: *3* TestColorizer.test_colorizer_lisp
     def test_colorizer_lisp(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             ; Maybe...
             error princ
@@ -608,11 +609,11 @@ class TestColorizer(LeoUnitTest):
             t type-of
             unless
             when while
-        """).lstrip()
+        """)
         self.color('lisp', text)
     #@+node:ekr.20210905170507.20: *3* TestColorizer.test_colorizer_objective_c
     def test_colorizer_objective_c(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             @interface Application
                 -(void) init;
@@ -644,11 +645,11 @@ class TestColorizer(LeoUnitTest):
             @var test
             @todo
             */
-        """).lstrip()
+        """)
         self.color('objective_c', text)
     #@+node:ekr.20210905170507.21: *3* TestColorizer.test_colorizer_perl
     def test_colorizer_perl(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             # From a perl tutorial.
 
@@ -703,11 +704,11 @@ class TestColorizer(LeoUnitTest):
                 ($a =~ /$b/ || $b =~ /$a/);     # Is $b inside $a
                                 #   or $a inside $b?
             }
-        """).lstrip()
+        """)
         self.color('perl', text)
     #@+node:ekr.20210905170507.22: *3* TestColorizer.test_colorizer_PHP
     def test_colorizer_PHP(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             @ doc
             This is a doc part.
@@ -722,11 +723,11 @@ class TestColorizer(LeoUnitTest):
             __CLASS__
             <?php and or array() ?>
             <?PHP and or array() ?>
-        """).lstrip()
+        """)
         self.color('php', text)
     #@+node:ekr.20210905170507.23: *3* TestColorizer.test_colorizer_plsql
     def test_colorizer_plsql(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             "a string"
             -- reserved keywords
@@ -1105,21 +1106,21 @@ class TestColorizer(LeoUnitTest):
             work,
             write,
             xor
-        """).lstrip()
+        """)
         self.color('plsql', text)
     #@+node:ekr.20210905170507.25: *3* TestColorizer.test_colorizer_Python1
     def test_colorizer_Python1(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             int
             float
             dict
-        """).lstrip()
+        """)
         self.color('python', text)
     #@+node:ekr.20210905170507.26: *3* TestColorizer.test_colorizer_Python2
     def test_colorizer_Python2(self):
 
-        text = textwrap.dedent(
+        text = self.prep(
         '''
             """This creates a free-floating copy of v's tree for undo.
             The copied trees must use different vnodes than the original."""
@@ -1137,28 +1138,29 @@ class TestColorizer(LeoUnitTest):
                     v = leoNodes.VNode(c)
                     v = v.threadNext()
                 return result
-    ''')
+        ''')
         self.color('python', text)
 
     #@+node:ekr.20231209161622.1: *3* TestColorizer.test_colorizer_Python_fstrings
     def test_colorizer_Python_fstrings(self):
 
-        text = textwrap.dedent(r'''
-    my_dict = {'key': 'value', 'key2': 'value2'}
+        text = self.prep(
+        r'''
+            my_dict = {'key': 'value', 'key2': 'value2'}
 
-    print(repr(f"{'':*^{1:{1}}}"))
+            print(repr(f"{'':*^{1:{1}}}"))
 
-    for key in ('key', 'key2'):
-        print(f"{my_dict[key]=}")
-    print(f"{my_dict['key']=}")
-    print(f"{my_dict['key2']=}")
-
-    ''').lstrip()
+            for key in ('key', 'key2'):
+                print(f"{my_dict[key]=}")
+            print(f"{my_dict['key']=}")
+            print(f"{my_dict['key2']=}")
+        ''')
         self.color('python', text)
 
     #@+node:ekr.20210905170507.24: *3* TestColorizer.test_colorizer_python_xml_jEdit_
     def test_colorizer_python_xml_jEdit_(self):
-        text = textwrap.dedent(r"""\\\
+        text = self.prep(
+        r"""\\\
             <?xml version="1.0"?>
 
             <!DOCTYPE MODE SYSTEM "xmode.dtd">
@@ -1177,11 +1179,11 @@ class TestColorizer(LeoUnitTest):
                     < < keywords > >
                 </RULES>
             </MODE>
-    """)
+        """)
         self.color('html', text)
     #@+node:ekr.20210905170507.27: *3* TestColorizer.test_colorizer_r
     def test_colorizer_r(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             x <- rnorm(10)
 
@@ -1189,11 +1191,11 @@ class TestColorizer(LeoUnitTest):
 
             def python_funct(uu):
             return uu
-        """).lstrip()
+        """)
         self.color('r', text)
     #@+node:ekr.20210905170507.28: *3* TestColorizer.test_colorizer_rapidq
     def test_colorizer_rapidq(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             ' New in 4.2.
             ' a comment.
@@ -1224,11 +1226,11 @@ class TestColorizer(LeoUnitTest):
             SUB,SUBI,SWAP,TALLY,TAN,THEN,TIME$,TIMER,TO,TYPE,UBOUND,
             UCASE$,UNLOADLIBRARY,UNTIL,VAL,VARIANT,VARPTR,VARPTR$,VARTYPE,
             WEND,WHILE,WITH,WORD,XOR
-        """).lstrip()
+        """)
         self.color('rapidq', text)
     #@+node:ekr.20210905170507.29: *3* TestColorizer.test_colorizer_Rebol
     def test_colorizer_Rebol(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
         ; a comment
         about abs absolute add alert alias all alter and and~ any append arccosine arcsine arctangent array ask at
@@ -1294,11 +1296,12 @@ class TestColorizer(LeoUnitTest):
         value? view?
         within? word?
         zero?
-        """).lstrip()
+        """)
         self.color('rebol', text)
     #@+node:ekr.20210905170507.30: *3* TestColorizer.test_colorizer_rest
     def test_colorizer_rest(self):
-        text = textwrap.dedent(r"""\\\
+        text = self.prep(
+        r"""\\\
             @ @rst-options
             code_mode=False
             generate_rst=True
@@ -1365,7 +1368,7 @@ class TestColorizer(LeoUnitTest):
         self.color('rest', text)
     #@+node:ekr.20210905170507.31: *3* TestColorizer.test_colorizer_scala
     def test_colorizer_scala(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             /* A comment */
 
@@ -1374,11 +1377,11 @@ class TestColorizer(LeoUnitTest):
                   println("Hello, world!")
                 }
               }
-        """).lstrip()
+        """)
         self.color('scala', text)
     #@+node:ekr.20210905170507.32: *3* TestColorizer.test_colorizer_shell
     def test_colorizer_shell(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             # New in 4.2.
 
@@ -1399,11 +1402,11 @@ class TestColorizer(LeoUnitTest):
             exit,kill,newgrp,pwd,read,readonly,
             shift,test,trap,ulimit,
             umask,wait
-        """).lstrip()
+        """)
         self.color('shell', text)
     #@+node:ekr.20210905170507.33: *3* TestColorizer.test_colorizer_shellscript
     def test_colorizer_shellscript(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             # comment
             $# not a comment
@@ -1422,11 +1425,11 @@ class TestColorizer(LeoUnitTest):
             exit,kill,newgrp,pwd,read,readonly,
             shift,test,trap,ulimit,
             umask,wait
-        """).lstrip()
+        """)
         self.color('shellscript', text)
     #@+node:ekr.20210905170507.34: *3* TestColorizer.test_colorizer_tex_xml_jEdit_
     def test_colorizer_tex_xml_jEdit_(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             <!-- ekr uses the MARK_FOLLOWING to mark _anything_ after \\ -->
 
@@ -1447,12 +1450,12 @@ class TestColorizer(LeoUnitTest):
                     < < math rules > >
                 </RULES>
             </MODE>
-        """).lstrip()
+        """)
         self.color('html', text)
     #@+node:ekr.20210905170507.36: *3* TestColorizer.test_colorizer_wikiTest
     def test_colorizer_wikiTest(self):
         # both color_markup & add_directives plugins must be enabled.
-        text = textwrap.dedent(
+        text = self.prep(
         '''
             @markup wiki
 
@@ -1462,7 +1465,7 @@ class TestColorizer(LeoUnitTest):
 
             if 1 and 2:
                 pass
-    ''')
+        ''')
         self.color('html', text)
     #@+node:ekr.20231229142541.1: *3* TestColorizer.test_match_fstring_helper
     def test_match_fstring_helper(self):
@@ -1499,11 +1502,11 @@ class TestColorizer(LeoUnitTest):
         self.assertEqual(language, 'python')
     #@+node:ekr.20210905170507.40: *3* TestColorizer.test_vbscript
     def test_vbscript(self):
-        text = textwrap.dedent(
+        text = self.prep(
         """
             if
             IF
-        """).lstrip()
+        """)
         self.color('vbscript', text)
     #@-others
 #@-others

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -14,7 +14,7 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.28: *3* TestCommands.test_add_comments_with_multiple_language_directives
     def test_add_comments_with_multiple_language_directives(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language rest
             rest text.
@@ -22,7 +22,7 @@ class TestCommands(LeoUnitTest):
             def spam():
                 pass
             # after
-    """).lstrip()
+        """)
         expected = textwrap.dedent(
         """
             @language rest

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -2,7 +2,7 @@
 #@+node:ekr.20210903162431.1: * @file ../unittests/core/test_leoCommands.py
 """Tests of leoCommands.py"""
 # pylint: disable=no-member
-import textwrap
+
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 
@@ -23,7 +23,7 @@ class TestCommands(LeoUnitTest):
                 pass
             # after
         """)
-        expected = textwrap.dedent(
+        expected = self.prep(
         """
             @language rest
             rest text.
@@ -31,7 +31,7 @@ class TestCommands(LeoUnitTest):
             def spam():
                 # pass
             # after
-    """).lstrip()
+        """)
         i = p.b.find('pass')
         assert i > -1, 'fail1: %s' % (repr(p.b))
         w.setSelectionRange(i, i + 4)
@@ -40,20 +40,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.30: *3* TestCommands.test_add_html_comments
     def test_add_html_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language html
             <html>
                 text
             </html>
-        """).lstrip()
-        expected = textwrap.dedent(
+        """)
+        expected = self.prep(
         """
             @language html
             <html>
                 <!-- text -->
             </html>
-        """).lstrip()
+        """)
         i = p.b.find('text')
         w.setSelectionRange(i, i + 4)
         c.addComments()
@@ -61,20 +61,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.32: *3* TestCommands.test_add_python_comments
     def test_add_python_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language python
             def spam():
                 pass
             # after
-        """).lstrip()
-        expected = textwrap.dedent(
+        """)
+        expected = self.prep(
         """
             @language python
             def spam():
                 # pass
             # after
-        """).lstrip()
+        """)
         i = p.b.find('pass')
         w.setSelectionRange(i, i + 4)
         c.addComments()
@@ -99,13 +99,13 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210901140645.16: *3* TestCommands.test_c_checkPythonNode
     def test_c_checkPythonNode(self):
         c, p = self.c, self.c.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language python
 
             def abc:  # missing parens.
                 pass
-        """).lstrip()
+        """)
         result = c.checkPythonCode(event=None, checkOnSave=False, ignoreAtIgnore=True)
         self.assertEqual(result, 'error')
     #@+node:ekr.20210906075242.4: *3* TestCommands.test_c_contractAllHeadlines
@@ -331,21 +331,21 @@ class TestCommands(LeoUnitTest):
     def test_c_tabNannyNode(self):
         c, p = self.c, self.c.p
         # Test 1.
-        s = textwrap.dedent(
+        s = self.prep(
         """
             # no error
             def spam():
                 pass
-        """).lstrip()
+        """)
         c.tabNannyNode(p, headline=p.h, body=s)
         # Test 2.
-        s2 = textwrap.dedent(
+        s2 = self.prep(
         """
             # syntax error
             def spam:
                 pass
               a = 2
-        """).lstrip()
+        """)
         try:
             c.tabNannyNode(p, headline=p.h, body=s2)
         except IndentationError:
@@ -368,7 +368,7 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.29: *3* TestCommands.test_delete_comments_with_multiple_at_language_directives
     def test_delete_comments_with_multiple_at_language_directives(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language rest
             rest text.
@@ -376,8 +376,8 @@ class TestCommands(LeoUnitTest):
             def spam():
                 pass
             # after
-        """).lstrip()
-        expected = textwrap.dedent(
+        """)
+        expected = self.prep(
         """
             @language rest
             rest text.
@@ -385,7 +385,7 @@ class TestCommands(LeoUnitTest):
             def spam():
                 pass
             # after
-        """).lstrip()
+        """)
         i = p.b.find('pass')
         w.setSelectionRange(i, i + 4)
         c.deleteComments()
@@ -394,20 +394,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.31: *3* TestCommands.test_delete_html_comments
     def test_delete_html_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language html
             <html>
                 <!-- text -->
             </html>
-        """).lstrip()
-        expected = textwrap.dedent(
+        """)
+        expected = self.prep(
         """
             @language html
             <html>
                 text
             </html>
-        """).lstrip()
+        """)
         i = p.b.find('text')
         w.setSelectionRange(i, i + 4)
         c.deleteComments()
@@ -415,20 +415,20 @@ class TestCommands(LeoUnitTest):
     #@+node:ekr.20210906075242.33: *3* TestCommands.test_delete_python_comments
     def test_delete_python_comments(self):
         c, p, w = self.c, self.c.p, self.c.frame.body.wrapper
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             @language python
             def spam():
                 # pass
             # after
-        """).lstrip()
-        expected = textwrap.dedent(
+        """)
+        expected = self.prep(
         """
             @language python
             def spam():
                 pass
             # after
-        """).lstrip()
+        """)
         i = p.b.find('pass')
         w.setSelectionRange(i, i + 4)
         c.deleteComments()

--- a/leo/unittests/core/test_leoCompare.py
+++ b/leo/unittests/core/test_leoCompare.py
@@ -3,7 +3,6 @@
 """Tests of leoCompare.py"""
 import os
 import tempfile
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 assert g
@@ -81,8 +80,8 @@ class TestCompare(LeoUnitTest):
         self.assertEqual(c.lastTopLevel(), root)
 
         # The contents of a small .leo file.
-        contents1 = textwrap.dedent(
-            """
+        contents1 = self.prep(
+        """
             <?xml version="1.0" encoding="utf-8"?>
             <!-- Created by Leo: https://leo-editor.github.io/leo-editor/leo_toc.html -->
             <leo_file xmlns:leo="http://leo-editor.github.io/leo-editor/namespaces/leo-python-editor/1.1" >
@@ -97,7 +96,7 @@ class TestCompare(LeoUnitTest):
             <t tx="ekr.20230714162224.2"></t>
             </tnodes>
             </leo_file>
-            """).lstrip()  # Leo doesn't tolerate a leading blank line!
+        """)
         contents2 = contents1.replace('test_file1.leo', 'test_file2.leo')
 
         # Create the absolute paths.

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -7,7 +7,6 @@ import os
 import re
 import stat
 import sys
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 
@@ -460,14 +459,14 @@ class TestGlobals(LeoUnitTest):
         c = self.c
         p = c.p
         # Note: @comment must follow @language.
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
             ATlanguage python
             ATcomment a b c
             ATtabwidth -8
             ATpagewidth 72
             ATencoding utf-8
-        """).lstrip().replace('AT', '@')
+        """).replace('AT', '@')
         d = g.get_directives_dict(p)
         self.assertEqual(d.get('language'), 'python')
         self.assertEqual(d.get('tabwidth'), '-8')
@@ -478,12 +477,12 @@ class TestGlobals(LeoUnitTest):
     #@+node:ekr.20210905203541.17: *4* TestGlobals.test_g_getDocString
     def test_g_getDocString(self):
         s1 = 'no docstring'
-        s2 = textwrap.dedent(
+        s2 = self.prep(
         '''
             # comment
             """docstring2."""
         ''')
-        s3 = textwrap.dedent(
+        s3 = self.prep(
         '''
             """docstring3."""
             \'\'\'docstring2.\'\'\'
@@ -1213,7 +1212,7 @@ class TestGlobals(LeoUnitTest):
 
         # Set @data unl-path-prefixes
 
-        s = textwrap.dedent(
+        s = self.prep(
         """
             # lines have the form:
             # x.leo: <absolute path to x.leo>

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -4,7 +4,6 @@
 
 import io
 import os
-import textwrap
 from leo.unittests.plugins.test_importers import BaseTestImporter
 from leo.core import leoImport
 from leo.core import leoGlobals as g
@@ -23,12 +22,12 @@ class TestLeoImport(BaseTestImporter):
         target.h = 'target'
         from leo.core.leoImport import MindMapImporter
         x = MindMapImporter(c)
-        s = textwrap.dedent(
+        s = self.prep(
         """
             header1, header2, header3
             a1, b1, c1
             a2, b2, c2
-        """).lstrip()
+        """)
         f = StringIO(s)
         x.scan(f, target)
 
@@ -51,7 +50,7 @@ class TestLeoImport(BaseTestImporter):
         target = c.p.insertAfter()
         target.h = 'target'
 
-        body_1 = textwrap.dedent(
+        body_1 = self.prep(
         """
             import os
 
@@ -59,7 +58,7 @@ class TestLeoImport(BaseTestImporter):
                 def new_func(*args, **kwds):
                     raise RuntimeError('blah blah blah')
             return new_func
-        """).strip() + '\n'
+        """)
         target.b = body_1
         x.parse_body(target)
 

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -4,7 +4,6 @@
 
 # pylint has troubles finding Commands methods.
 # pylint: disable=no-member
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 
@@ -890,7 +889,7 @@ class TestNodes(LeoUnitTest):
     def test_p_nosentinels(self):
 
         p = self.c.p
-        p.b = textwrap.dedent(
+        p.b = self.prep(
         """
 
             def not_a_sentinel(x):
@@ -899,7 +898,7 @@ class TestNodes(LeoUnitTest):
             @not_a_sentinel
             def spam():
                 pass
-        """).lstrip()
+        """)
         self.assertEqual(p.b, p.nosentinels)
     #@+node:ekr.20210830095545.22: *4* TestNodes.test_p_relinkAsCloneOf
     def test_p_relinkAsCloneOf(self):

--- a/leo/unittests/core/test_leoRst.py
+++ b/leo/unittests/core/test_leoRst.py
@@ -2,7 +2,6 @@
 #@+node:ekr.20210902055206.1: * @file ../unittests/core/test_leoRst.py
 """Tests of leoRst.py"""
 
-import textwrap
 try:
     import docutils
 except Exception:  # pragma: no cover
@@ -32,20 +31,19 @@ class TestRst(LeoUnitTest):
         child = root.insertAsLastChild()
         child.h = '@rst-no-head section'
         # Insert the body texts.  Overindent to eliminate @verbatim sentinels.
-        root.b = textwrap.dedent(
+        root.b = self.prep(
         """
             #####
             Title
             #####
 
             This is test.html
-
-        """).lstrip()
+        """)
 
         child.b = """This is the body of the section.\n"""
 
         # Define the expected output.
-        expected = textwrap.dedent(
+        expected = self.prep(
         f"""
             .. rst3: filename: {fn}
 
@@ -58,8 +56,7 @@ class TestRst(LeoUnitTest):
             This is test.html
 
             This is the body of the section.
-
-        """).lstrip()
+        """) + '\n'  # Required.
         # Get and check the rst result.
         rc.nodeNumber = 0
         rc.http_server_support = True  # Override setting for testing.
@@ -95,15 +92,15 @@ class TestRst(LeoUnitTest):
         root = c.rootPosition().insertAfter()
         root.h = fn = '@rst unicode_test.html'
         # Insert the body text.  Overindent to eliminate @verbatim sentinels.
-        root.b = textwrap.dedent(
+        root.b = self.prep(
         """
             Test of unicode characters: ÀǋϢﻙ
 
             End of test.
-        """).lstrip()
+        """)
 
         # Define the expected output.
-        expected = textwrap.dedent(
+        expected = self.prep(
         f"""
             .. rst3: filename: {fn}
 
@@ -112,8 +109,8 @@ class TestRst(LeoUnitTest):
             Test of unicode characters: ÀǋϢﻙ
 
             End of test.
+        """) + '\n'  # Required.
 
-        """).lstrip()
         # Get and check the rst result.
         rc.nodeNumber = 0
         rc.http_server_support = True  # Override setting for testing.
@@ -133,7 +130,7 @@ class TestRst(LeoUnitTest):
         child = root.insertAsLastChild()
         child.h = 'section'
         # Insert the body texts.  Overindent to eliminate @verbatim sentinels.
-        root.b = textwrap.dedent(
+        root.b = self.prep(
         """
             @language rest
 
@@ -142,16 +139,16 @@ class TestRst(LeoUnitTest):
             #####
 
             This is test.html
-        """).lstrip()
-        child.b = textwrap.dedent(
+        """)
+        child.b = self.prep(
         """
             @ This is a doc part
             it has two lines.
             @c
             This is the body of the section.
-        """).lstrip()
+        """)
         # Define the expected output.
-        expected = textwrap.dedent(
+        expected = self.prep(
         f"""
             .. rst3: filename: {fn}
 
@@ -174,8 +171,8 @@ class TestRst(LeoUnitTest):
             it has two lines.
             @c
             This is the body of the section.
+        """) + '\n'  # Required.
 
-        """).lstrip()
         # Get and check the rst result.
         rc.nodeNumber = 0
         rc.http_server_support = True  # Override setting for testing.

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -4,7 +4,6 @@
 
 import glob
 import os
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoShadow import ShadowController
 from leo.core.leoTest2 import LeoUnitTest
@@ -102,7 +101,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             ATothers
             node 1 line 1
@@ -113,7 +112,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             ATothers
             node 1 line 1
@@ -130,7 +129,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -139,7 +138,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1 changed
             line 2
@@ -154,7 +153,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -163,7 +162,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             line 2
@@ -178,7 +177,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -187,7 +186,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             line 2 changed
@@ -202,7 +201,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -213,7 +212,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -230,7 +229,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -241,7 +240,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -257,7 +256,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -267,7 +266,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -282,7 +281,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -291,7 +290,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 2
             line 3
@@ -305,7 +304,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -314,7 +313,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             line 2
@@ -328,7 +327,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -337,7 +336,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             line 3
@@ -351,7 +350,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -360,7 +359,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             line 2
@@ -376,7 +375,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -385,7 +384,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             inserted line
             line 1
@@ -401,7 +400,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -410,7 +409,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             inserted line
@@ -426,7 +425,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line 1
             line 2
@@ -435,7 +434,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line 1
             line 2
@@ -451,7 +450,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -460,7 +459,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -476,7 +475,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -487,7 +486,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -502,7 +501,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -514,7 +513,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -532,7 +531,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -543,7 +542,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -560,7 +559,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -572,7 +571,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -588,7 +587,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -599,7 +598,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -614,7 +613,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -625,7 +624,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -642,14 +641,14 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             line
         """)
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             line
         """)
@@ -664,26 +663,26 @@ class TestAtShadow(LeoUnitTest):
         old.b = '@others\n'
         old_node1 = old.insertAsLastChild()
         old_node1.h = 'node1'
-        old_node1.b = textwrap.dedent(
+        old_node1.b = self.prep(
         """
             node 1 line 1
             node 1 old line 1
             node 1 old line 2
             node 1 line 2
-    """)
+        """)
         new = p.insertAsLastChild()
         new.h = 'new'
         new.b = '@others\n'
         new_node1 = new.insertAsLastChild()
         new_node1.h = 'node1'
-        new_node1.b = textwrap.dedent(
+        new_node1.b = self.prep(
         """
             node 1 line 1
             node 1 new line 1
             node 1 new line 2
             node 1 new line 3
             node 1 line 2
-    """)
+        """)
         results, expected = self.make_lines(old, new)
         self.assertEqual(results, expected)
     #@+node:ekr.20210908134131.2: *4* TestShadow.test_replace_in_node_new_lt_old
@@ -695,7 +694,7 @@ class TestAtShadow(LeoUnitTest):
         old.b = '@others\n'
         old_node1 = old.insertAsLastChild()
         old_node1.h = 'node1'
-        old_node1.b = textwrap.dedent(
+        old_node1.b = self.prep(
         """
             node 1 line 1
             node 1 old line 1
@@ -710,7 +709,7 @@ class TestAtShadow(LeoUnitTest):
         new.b = '@others\n'
         new_node1 = new.insertAsLastChild()
         new_node1.h = 'node1'
-        new_node1.b = textwrap.dedent(
+        new_node1.b = self.prep(
         """
             node 1 line 1
             node 1 new line 1
@@ -726,7 +725,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -737,7 +736,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -756,7 +755,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -770,7 +769,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -788,7 +787,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -800,7 +799,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -816,7 +815,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -827,7 +826,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -842,7 +841,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'old' node.
         old = p.insertAsLastChild()
         old.h = 'old'
-        old.b = textwrap.dedent(
+        old.b = self.prep(
         """
             at-others
             node 1 line 1
@@ -856,7 +855,7 @@ class TestAtShadow(LeoUnitTest):
         # Create the 'new' node.
         new = p.insertAsLastChild()
         new.h = 'new'
-        new.b = textwrap.dedent(
+        new.b = self.prep(
         """
             at-others
             node 1 line 1

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -123,6 +123,14 @@ class BaseTest(unittest.TestCase):
         contents = g.readFileIntoUnicodeString(filename)
         contents, tokens = self.make_data(contents, description=filename)
         return contents, tokens
+    #@+node:ekr.20240205025458.1: *3* BaseTest.prep
+    def prep(self, s: str) -> str:
+        """
+        Return the "prepped" version of s.
+        
+        This should eliminate the need for backslashes in tests.
+        """
+        return textwrap.dedent(s).strip() + '\n'
     #@-others
 #@+node:ekr.20240105153425.2: ** class Optional_TestFiles (BaseTest)
 class Optional_TestFiles(BaseTest):
@@ -512,7 +520,7 @@ class TestTokenBasedOrange(BaseTest):
                 pass
         """
         # At present Orange doesn't split lines...
-        expected = textwrap.dedent(
+        expected = self.prep(
             """
                 if x == 4: pass
                 if x == 4: pass
@@ -524,7 +532,7 @@ class TestTokenBasedOrange(BaseTest):
                     pass
                 while (3):
                     pass
-            """).strip() + '\n'
+            """)
         contents, tokens = self.make_data(contents)
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected)
@@ -614,7 +622,7 @@ class TestTokenBasedOrange(BaseTest):
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
         """
-        expected = textwrap.dedent(
+        expected = self.prep(
         """
             from .module1 import w
             from .module2 import x
@@ -626,7 +634,7 @@ class TestTokenBasedOrange(BaseTest):
             from .. import d
             from leo.core import leoExternalFiles
             import leo.core.leoGlobals as g
-        """).strip() + '\n'
+        """)
         contents, tokens = self.make_data(contents)
         # dump_tokens(tokens)
         results = self.beautify(contents, tokens)

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -2,7 +2,6 @@
 #@+node:ekr.20210906141410.1: * @file ../unittests/core/test_leoUndo.py
 """Tests of leoUndo.py"""
 
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 assert g
@@ -44,7 +43,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.2: *3* TestUndo.test_addComments
     def test_addComments(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             @language python
 
@@ -55,8 +54,8 @@ class TestUndo(LeoUnitTest):
                     b = 3
 
                 pass
-        """).lstrip()
-        after = textwrap.dedent(
+        """)
+        after = self.prep(
         """
             @language python
 
@@ -67,7 +66,7 @@ class TestUndo(LeoUnitTest):
                     # b = 3
 
                 pass
-        """).lstrip()
+        """)
         i = before.find('if 1')
         j = before.find('b = 3')
         func = c.addComments
@@ -75,7 +74,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.3: *3* TestUndo.test_convertAllBlanks
     def test_convertAllBlanks(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             @tabwidth -4
 
@@ -83,23 +82,8 @@ class TestUndo(LeoUnitTest):
                 line 2
                   line 3
             line4
-        """).lstrip()
-        after = textwrap.dedent(
-        """
-            @tabwidth -4
-
-            line 1
-            TABline 2
-            TAB  line 3
-            line4
-        """).lstrip().replace('TAB', '\t')
-        i, j = 13, len(before)
-        func = c.convertAllBlanks
-        self.runTest(before, after, i, j, func)
-    #@+node:ekr.20210906172626.4: *3* TestUndo.test_convertAllTabs
-    def test_convertAllTabs(self):
-        c = self.c
-        before = textwrap.dedent(
+        """)
+        after = self.prep(
         """
             @tabwidth -4
 
@@ -108,7 +92,22 @@ class TestUndo(LeoUnitTest):
             TAB  line 3
             line4
         """).replace('TAB', '\t')
-        after = textwrap.dedent(
+        i, j = 13, len(before)
+        func = c.convertAllBlanks
+        self.runTest(before, after, i, j, func)
+    #@+node:ekr.20210906172626.4: *3* TestUndo.test_convertAllTabs
+    def test_convertAllTabs(self):
+        c = self.c
+        before = self.prep(
+        """
+            @tabwidth -4
+
+            line 1
+            TABline 2
+            TAB  line 3
+            line4
+        """).replace('TAB', '\t')
+        after = self.prep(
         """
             @tabwidth -4
 
@@ -123,7 +122,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.5: *3* TestUndo.test_convertBlanks
     def test_convertBlanks(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             @tabwidth -4
 
@@ -132,7 +131,7 @@ class TestUndo(LeoUnitTest):
                   line 3
             line4
         """)
-        after = textwrap.dedent(
+        after = self.prep(
         """
             @tabwidth -4
 
@@ -147,7 +146,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.6: *3* TestUndo.test_convertTabs
     def test_convertTabs(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             @tabwidth -4
 
@@ -156,7 +155,7 @@ class TestUndo(LeoUnitTest):
             TAB  line 3
             line4
         """).replace('TAB', '\t')
-        after = textwrap.dedent(
+        after = self.prep(
         """
             @tabwidth -4
 
@@ -171,14 +170,14 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.7: *3* TestUndo.test_dedentBody
     def test_dedentBody(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             line 1
                 line 2
                 line 3
             line 4
         """)
-        after = textwrap.dedent(
+        after = self.prep(
         """
             line 1
             line 2
@@ -192,7 +191,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.8: *3* TestUndo.test_deleteComments
     def test_deleteComments(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             @language python
 
@@ -203,8 +202,8 @@ class TestUndo(LeoUnitTest):
             #         b = 3
 
                 pass
-        """).lstrip()
-        after = textwrap.dedent("""
+        """)
+        after = self.prep("""
             @language python
 
             def deleteCommentTest():
@@ -214,7 +213,7 @@ class TestUndo(LeoUnitTest):
                     b = 3
 
                 pass
-        """).lstrip()
+        """)
         i = before.find('if 1')
         j = before.find('b = 3')
         func = c.deleteComments
@@ -222,7 +221,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.9: *3* TestUndo.test_deleteComments 2
     def test_deleteComments_2(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             @language python
 
@@ -237,8 +236,8 @@ class TestUndo(LeoUnitTest):
                     # b = 3
 
                 pass
-        """).lstrip()
-        after = textwrap.dedent(
+        """)
+        after = self.prep(
         """
             @language python
 
@@ -253,7 +252,7 @@ class TestUndo(LeoUnitTest):
                     b = 3
 
                 pass
-        """).lstrip()
+        """)
         i = before.find('if 1')
         j = before.find('# b = 3')
         func = c.deleteComments
@@ -288,7 +287,7 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.10: *3* TestUndo.test_extract_test
     def test_extract_test(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             before
                 < < section > >
@@ -296,13 +295,13 @@ class TestUndo(LeoUnitTest):
                     sec line 2 indented
             sec line 3
             after
-        """).lstrip()
-        after = textwrap.dedent(
+        """)
+        after = self.prep(
         """
             before
                 < < section > >
             after
-        """).lstrip()
+        """)
         i = before.find('< <')
         j = before.find('line 3')
         func = c.extract
@@ -310,17 +309,17 @@ class TestUndo(LeoUnitTest):
     #@+node:ekr.20210906172626.14: *3* TestUndo.test_line_to_headline
     def test_line_to_headline(self):
         c = self.c
-        before = textwrap.dedent(
+        before = self.prep(
         """
             before
             headline
             after
-        """).lstrip()
-        after = textwrap.dedent(
+        """)
+        after = self.prep(
         """
             before
             after
-        """).lstrip()
+        """)
         i, j = 10, 10
         func = c.line_to_headline
         self.runTest(before, after, i, j, func)
@@ -352,7 +351,7 @@ class TestUndo(LeoUnitTest):
         # The buggy redoGroup code worked if the undo group was the first item on the undo stack.
         c, p = self.c, self.c.p
         original = p.insertAfter()
-        original_s = original.b = textwrap.dedent(
+        original_s = original.b = self.prep(
         """
             @tabwidth -4
 
@@ -360,7 +359,7 @@ class TestUndo(LeoUnitTest):
                 line 2
                   line 3
             line4
-        """).lstrip()
+        """)
         c.undoer.clearUndoState()
         c.selectPosition(original)
         c.copyOutline()  # Add state to the undo stack!

--- a/leo/unittests/core/test_leoVim.py
+++ b/leo/unittests/core/test_leoVim.py
@@ -2,7 +2,6 @@
 #@+node:ekr.20210910072917.1: * @file ../unittests/core/test_leoVim.py
 """Tests of leoVim.py"""
 
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 assert g
@@ -15,7 +14,7 @@ class TestVim(LeoUnitTest):
     def test_vc_on_same_line(self):
         c = self.c
         vc = c.vimCommands
-        s = textwrap.dedent("""
+        s = self.prep("""
             abc
             xyz
             pdq
@@ -34,7 +33,7 @@ class TestVim(LeoUnitTest):
     def test_vc_to_bol(self):
         c = self.c
         vc = c.vimCommands
-        s = textwrap.dedent("""
+        s = self.prep("""
             abc
             xyz
         """)
@@ -51,7 +50,7 @@ class TestVim(LeoUnitTest):
     def test_vc_to_eol(self):
         c = self.c
         vc = c.vimCommands
-        s = textwrap.dedent("""
+        s = self.prep("""
             abc
             xyz
         """)

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -2410,7 +2410,7 @@ class TestPascal(BaseTestImporter):
 
         #@+<< define s >>
         #@+node:ekr.20230518071612.1: *4* << define s >>
-        s = textwrap.dedent(  # dedent is required.
+        s = self.prep(
         """
             unit Unit1;
 
@@ -2447,7 +2447,7 @@ class TestPascal(BaseTestImporter):
             end;
 
             end. // interface
-        """).strip() + '\n'
+        """)
         #@-<< define s >>
 
         expected_results = (
@@ -2504,7 +2504,7 @@ class TestPascal(BaseTestImporter):
         # From GSTATOBJ.PAS
         #@+<< define s >>
         #@+node:ekr.20220830112013.1: *4* << define s >>
-        s = textwrap.dedent(  # Dedent is required.
+        s = self.prep(
         """
         unit gstatobj;
 
@@ -2573,7 +2573,7 @@ class TestPascal(BaseTestImporter):
         for i := 1 to max do
             data^[i].y := data^[i].y + pstatObj(source)^.data^[i].y;
         end;
-        """).strip() + '\n'
+        """)
         #@-<< define s >>
         expected_results = (
             (0, '',  # Ignore the first headline.

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -485,7 +485,7 @@ class TestC(BaseTestImporter):
     def test_find_blocks(self):
 
         importer = C_Importer(self.c)
-        lines = g.splitLines(textwrap.dedent(  # dedent is required.
+        lines = g.splitLines(self.prep(
         """
 
             # enable-trace

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3928,7 +3928,7 @@ class TestRust(BaseTestImporter):
     def test_rust_import_fails(self):
 
         # From ruff/crates/ruff_formatter/shared_traits.rs
-        s = textwrap.dedent(  # dedent is required.
+        s = self.prep(
             """
                 /// Used to get an object that knows how to format this object.
                 pub trait AsFormat<Context> {

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -5,7 +5,6 @@
 import glob
 import os
 import re
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 from leo.core.leoPlugins import LeoPluginsController
@@ -168,7 +167,7 @@ class TestIndentedTypeScript(LeoUnitTest):
 
         # Contains "over-indented" parenthesized lines, a good test for check_indentation.
 
-        contents = textwrap.dedent(  # dedent is required.
+        contents = self.prep(
             """
             import { NodeIndices, VNode, Position } from './leoNodes';
 

--- a/leo/unittests/plugins/test_writers.py
+++ b/leo/unittests/plugins/test_writers.py
@@ -1,7 +1,6 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20220812224747.1: * @file ../unittests/plugins/test_writers.py
 """Tests of leo/plugins/writers"""
-import textwrap
 from leo.core import leoGlobals as g
 from leo.core.leoTest2 import LeoUnitTest
 from leo.plugins.importers.markdown import Markdown_Importer
@@ -179,7 +178,7 @@ class TestRstWriter(BaseTestWriter):
         child = root.insertAsLastChild()
         child.h = 'h'
         # For full coverage, we don't want a leading newline.
-        child.b = textwrap.dedent(  # dedent is required.
+        child.b = self.prep(  # dedent is required.
         """
             .. toc
 

--- a/leo/unittests/plugins/test_writers.py
+++ b/leo/unittests/plugins/test_writers.py
@@ -178,7 +178,7 @@ class TestRstWriter(BaseTestWriter):
         child = root.insertAsLastChild()
         child.h = 'h'
         # For full coverage, we don't want a leading newline.
-        child.b = self.prep(  # dedent is required.
+        child.b = self.prep(
         """
             .. toc
 


### PR DESCRIPTION
This PR:

- Shows that "fancy" syntax is not needed in Python or any other language.
  No backslashes remain in the testing infrastructure.
  Some unit tests contain backslashes as part of their data.
- Makes Leo's unit tests more immune from being blackened.
- Will make it easier to transliterate `leoTokens.py` and its unit tests to Nim.

**Changes**

- [x] Add `prep` method to three test classes.
- [x] Replace `textwrap.dedent` with `self.prep` in all unit tests.
- [x] Remove `.lstrip()` and `.strip()` in all tests.
- [x] Add `+ '\n'` in several rst-related tests that require a trailing newline.

**Extras**

Testing revealed that `TestPlugins.test_cursesGui2` can cause later unit tests to fail.
The usual way of running Leo's unit tests works because it runs the plugins tests last.
This test is minor, and could be omitted without any problem.