### PR TITLE
PR for #3781: skipTest statements

### DIFF
--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -19,7 +19,7 @@ the parse tree. For more details, see the "Overview" section below.
 See also leoTokens.py. It defines a Python beautifier that uses only
 Python's tokenize module.
 
-This file requires Python 3.9 or above.
+This commands in this file require Python 3.9 or above.
 
 
 **Stand-alone operation**
@@ -166,6 +166,7 @@ import glob
 import io
 import os
 import re
+import sys
 import subprocess
 import textwrap
 import time
@@ -181,6 +182,10 @@ except Exception:
 Node = ast.AST
 Settings = Optional[dict[str, Any]]
 #@-<< leoAst imports & annotations >>
+
+v1, v2, junk1, junk2, junk3 = sys.version_info
+if (v1, v2) < (3, 9):  # pragma: no cover
+    raise ImportError('The commands in leoAst.py require Python 3.9 or above')
 
 #@+others
 #@+node:ekr.20200702114522.1: **  leoAst.py: top-level commands

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2486,6 +2486,14 @@ def xxx_test_ternary(self):
     expected = contents
     results = self.beautify(contents, tokens)
     self.assertEqual(results, expected)
+#@+node:ekr.20210901140645.22: ** TestSyntax.test_syntax_of_setup_py
+def test_syntax_of_setup_py(self):
+    fn = g.finalize_join(g.app.loadDir, '..', '..', 'setup.py')
+    # Only run this test if setup.py exists: it may not in the actual distribution.
+    if not g.os_path_exists(fn):
+        self.skipTest('setup.py not found')  # pragma: no cover
+    s, e = g.readFileIntoString(fn)
+    assert self.check_syntax(fn, s)
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/unittests/commands/test_spellCommands.py
+++ b/leo/unittests/commands/test_spellCommands.py
@@ -28,7 +28,7 @@ class TestSpellCommands(LeoUnitTest):
             import enchant
             assert enchant
         except Exception:  # May throw WinError(!)
-            self.skipTest('enchant not found')
+            self.skipTest('Requires enchant')
 
         from leo.core.leoCommands import Commands as Cmdr
         from leo.commands.spellCommands import SpellTabHandler

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -411,9 +411,6 @@ class TestTOG(BaseTest):
     #@+node:ekr.20210914161519.1: *5* test_bug_2171
     def test_bug_2171(self):
 
-        if py_version < (3, 9):
-            self.skipTest('Requires Python 3.9')  # pragma: no cover
-
         contents = "'HEAD:%s' % g.os_path_join( *(relative_path + [filename]) )"
         contents, tokens, tree = self.make_data(contents)
     #@+node:ekr.20210318213133.1: *5* test_full_grammar
@@ -422,8 +419,7 @@ class TestTOG(BaseTest):
         dir_ = os.path.dirname(__file__)
         path = os.path.abspath(os.path.join(dir_, '..', 'py3_test_grammar.py'))
         assert os.path.exists(path), path
-        if py_version < (3, 9):
-            self.skipTest('Requires Python 3.9 or above')  # pragma: no cover
+
         # Verify that leoAst can parse the file.
         contents = g.readFileIntoUnicodeString(path)
         self.make_data(contents)
@@ -456,9 +452,6 @@ class TestTOG(BaseTest):
     #@+node:ekr.20210320065202.1: *5* test_line_483
     def test_line_483(self):
 
-        if py_version < (3, 8):
-            # Python 3.8: https://bugs.python.org/issue32117
-            self.skipTest(f"Python {v1}.{v2} does not support generalized iterable assignment")  # pragma: no cover
         contents = '''def g3(): return 1, *return_list'''
         contents, tokens, tree = self.make_data(contents)
     #@+node:ekr.20210320065344.1: *5* test_line_494
@@ -471,9 +464,6 @@ class TestTOG(BaseTest):
         requires enclosing parentheses. This brings the yield and return syntax
         into better agreement with normal assignment syntax.
         """
-        if py_version < (3, 8):
-            # Python 3.8: https://bugs.python.org/issue32117
-            self.skipTest(f"Python {v1}.{v2} does not support generalized iterable assignment")  # pragma: no cover
         contents = '''def g2(): yield 1, *yield_list'''
         contents, tokens, tree = self.make_data(contents)
     #@+node:ekr.20210319130349.1: *5* test_line_875
@@ -489,8 +479,6 @@ class TestTOG(BaseTest):
     #@+node:ekr.20210320085705.1: *5* test_walrus_operator
     def test_walrus_operator(self):
 
-        if py_version < (3, 8):
-            self.skipTest(f"Python {v1}.{v2} does not support assignment expressions")  # pragma: no cover
         contents = '''if (n := len(a)) > 10: pass'''
         contents, tokens, tree = self.make_data(contents)
     #@+node:ekr.20191227052446.10: *4* TestTOG.Contexts...
@@ -542,10 +530,7 @@ class TestTOG(BaseTest):
     #@+node:ekr.20210802162650.1: *5* test_FunctionDef_with_posonly_args
     def test_FunctionDef_with_posonly_args(self):
 
-        if py_version < (3, 9):
-            self.skipTest('Requires Python 3.9')  # pragma: no cover
-
-        # From PEP 570
+        # From PEP 570. (Python 3.9+).
         contents = r"""
     def pos_only_arg(arg, /):
         pass
@@ -1121,7 +1106,7 @@ class TestTOG(BaseTest):
     def test_Match(self):
 
         if py_version < (3, 10):  # pragma: no cover
-            self.skipTest('Require python 3.10')
+            self.skipTest('Requires python 3.10+')
         #@+<< test_Match: define contents >>
         #@+node:ekr.20231215010832.1: *6* << test_Match: define contents >>
         contents = """
@@ -1177,7 +1162,7 @@ class TestTOG(BaseTest):
     def test_TryStar(self):
 
         if py_version < (3, 11):
-            self.skipTest('Python 3.11+ only')
+            self.skipTest('Requires Python 3.11+')
 
         contents = r"""
     try:
@@ -1297,7 +1282,7 @@ class Optional_TestFiles(BaseTest):
     def compare_tog_vs_asttokens(self):  # pragma: no cover
         """Compare asttokens token lists with TOG token lists."""
         if not asttokens:
-            self.skipTest('requires asttokens')
+            self.skipTest('Requires asttokens')
         # Define TestToken class and helper functions.
         stack: list[ast.AST] = []
         #@+others
@@ -1705,7 +1690,7 @@ class TestOrange(BaseTest):
     def blacken(self, contents, line_length=None):
         """Return the results of running black on contents"""
         if not black:
-            self.skipTest('Can not import black')  # pragma: no cover
+            self.skipTest('Requires Black')  # pragma: no cover
         # Suppress string normalization!
         try:
             mode = black.FileMode()
@@ -1713,7 +1698,7 @@ class TestOrange(BaseTest):
             if line_length is not None:
                 mode.line_length = line_length
         except TypeError:  # pragma: no cover
-            self.skipTest('old version of black')
+            self.skipTest('Requires later version of Black')
         return black.format_str(contents, mode=mode)
     #@+node:ekr.20230115150916.1: *4* TestOrange.test_annotations
     def test_annotations(self):

--- a/leo/unittests/core/test_leoQt6.py
+++ b/leo/unittests/core/test_leoQt6.py
@@ -18,7 +18,7 @@ class TestQt6(BaseTestImporter):
         try:
             import leo.core.leoQt6 as Qt6
         except Exception:
-            self.skipTest('No Qt6')
+            self.skipTest('Requires Qt6')
 
         attrs = [z for z in dir(Qt6) if not z.startswith('__')]
 

--- a/leo/unittests/core/test_leoRst.py
+++ b/leo/unittests/core/test_leoRst.py
@@ -18,7 +18,7 @@ class TestRst(LeoUnitTest):
     def setUp(self):
         super().setUp()
         if not docutils:
-            self.skipTest('no docutils')  # pragma: no cover
+            self.skipTest('Requires docutils')  # pragma: no cover
 
     #@+others
     #@+node:ekr.20210902211919.12: *3* TestRst.test_at_no_head

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -184,14 +184,14 @@ class TestTokenBasedOrange(BaseTest):
     def blacken(self, contents):
         """Return the results of running black on contents"""
         if not black:
-            self.skipTest('Can not import black')  # pragma: no cover
+            self.skipTest('Requires Black')  # pragma: no cover
         # Suppress string normalization!
         try:
             mode = black.FileMode()
             mode.string_normalization = False
             # mode.line_length = line_length
         except TypeError:  # pragma: no cover
-            self.skipTest('old version of black')
+            self.skipTest('Requires newer version of Black')
         return black.format_str(contents, mode=mode)
     #@+node:ekr.20240116104552.1: *3* TestTBO.slow_test_leoColorizer
     def slow_test_leoApp(self) -> None:  # pragma: no cover

--- a/leo/unittests/misc_tests/test_syntax.py
+++ b/leo/unittests/misc_tests/test_syntax.py
@@ -45,14 +45,6 @@ class TestSyntax(LeoUnitTest):
                     fn = g.shortFileName(z)
                     s, e = g.readFileIntoString(z)
                     self.assertTrue(self.check_syntax(fn, s), msg=fn)
-    #@+node:ekr.20210901140645.22: *4* TestSyntax.test_syntax_of_setup_py
-    def test_syntax_of_setup_py(self):
-        fn = g.finalize_join(g.app.loadDir, '..', '..', 'setup.py')
-        # Only run this test if setup.py exists: it may not in the actual distribution.
-        if not g.os_path_exists(fn):
-            self.skipTest('setup.py not found')  # pragma: no cover
-        s, e = g.readFileIntoString(fn)
-        assert self.check_syntax(fn, s)
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -57,7 +57,7 @@ class TestQtGui(LeoUnitTest):
             from leo.core.leoQt import Qt
             assert Qt
         except Exception:
-            self.skipTest('Qt not installed')
+            self.skipTest('Requires Qt')
     #@+node:ekr.20210913120449.1: *3* TestQtGui.test_bug_2164
     def test_bug_2164(self):
         # show-invisibles crashes with PyQt6.
@@ -106,7 +106,7 @@ class TestQtGui(LeoUnitTest):
         # https://github.com/leo-editor/leo-editor/issues/1973 list of enums
 
         if not QtCore and QtCore.Qt:
-            self.skipTest('no qt')  # pragma: no cover
+            self.skipTest('Requires Qt')  # pragma: no cover
         table = (
             'DropAction', 'ItemFlag', 'KeyboardModifier',
             'MouseButton', 'Orientation',

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3496,7 +3496,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         s = """
             .. toc
@@ -3596,7 +3596,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         s = """
             .. toc
@@ -3633,7 +3633,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         s = """
             .. toc
@@ -3732,7 +3732,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         s = """
             .. toc
@@ -3764,7 +3764,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         s = """
             .. toc
@@ -3797,7 +3797,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         s = """
             .. toc
@@ -3834,7 +3834,7 @@ class TestRst(BaseTestImporter):
             import docutils
             assert docutils
         except Exception:  # pragma: no cover
-            self.skipTest('no docutils')
+            self.skipTest('Requires docutils')
 
         # All heading must be followed by an empty line.
         s = """\

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -112,7 +112,7 @@ class TestPlugins(LeoUnitTest):
         try:
             import leo.plugins.cursesGui2 as cursesGui2
         except Exception:
-            self.skipTest('Missing cursesGui2 requirements')
+            self.skipTest('Requires cursesGui2 requirements')
 
         # Instantiating this class caused the crash.
         cursesGui2.LeoTreeData()


### PR DESCRIPTION
See #3781.

- [x] Edit all skipTest statements.
- [x] Move test of `setup.py` to the attic.
- [x] Raise `ImportError` at the top level of `leoAst.py` if Python < 3.9.