### PR TITLE
PR: Tweaks to Nim coloring

### DIFF
--- a/leo/modes/nim.py
+++ b/leo/modes/nim.py
@@ -160,7 +160,7 @@ nim_main_keywords_dict = {
     #@-<< Nim constants >>
     # https://nim-lang.org/docs/system.html
     #@+<< Nim upper-case constants >>
-    #@+node:ekr.20240203194744.1: ** << Nim upper-case constants >>
+    #@+node:ekr.20240203194744.1: ** << Nim upper-case constants >> (keyword3)
     # Upper-case names are constants.
 
     "ATOMIC_ACQUIRE": "keyword3",
@@ -316,7 +316,7 @@ nim_main_keywords_dict = {
     "WriteIOEffect": "keyword3",
     #@-<< Nim upper-case constants >>
     #@+<< Nim lower-case functions >>
-    #@+node:ekr.20240203080936.1: ** << Nim lower-case functions >>
+    #@+node:ekr.20240203080936.1: ** << Nim lower-case functions >> (keyword4)
     # From the unitcode module.
     "runes": "keyword4",
 
@@ -706,7 +706,7 @@ def nim_unusual_single_quote(colorer, s, i):
     word = m.group(0)
     colorer.colorRangeWithTag(s, i + 1, i + 1 + len(word), tag='literal1')
     return 1 + len(word)
-#@+node:ekr.20240202211600.26: *3* nim_keyword
+#@+node:ekr.20240202211600.26: *3* nim_keyword (keyword1)
 def nim_keyword(colorer, s, i):
     return colorer.match_keywords(s, i)
 #@+node:ekr.20240206040507.1: *3* nim_multi_line_comment (comment2)
@@ -714,13 +714,14 @@ def nim_multi_line_comment(colorer, s, i):
 
     return colorer.match_span(s, i,
         kind="comment2", begin="#[", end="]#", nested=True)
-#@+node:ekr.20240206033640.1: *3* nim_number (literal2)
+#@+node:ekr.20240206033640.1: *3* nim_number (do-nothing)
 # Only an approximation.
 # Underscores are allowed in numbers.
 number_regex = re.compile(r'([0-9_]+)(b|B|d|D|f|F|i|I|u|U|x|X|32|64)*')
 
 def nim_number(colorer, s, i):
-    return colorer.match_compiled_regexp(s, i, 'literal2', regexp=number_regex)
+    # return colorer.match_compiled_regexp(s, i, 'literal2', regexp=number_regex)
+    return 0
 #@+node:ekr.20240206051847.1: *3* nim_op (do-nothing)
 def nim_op(colorer, s: str, i: int) -> int:
     # Don't color ordinary ops.
@@ -731,11 +732,12 @@ def nim_string(colorer, s, i):
 #@+node:ekr.20240202211600.6: *3* nim_triple_quote (literal2)
 def nim_triple_quote(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"")
-#@+node:ekr.20240206062831.1: *3* nim_unary
+#@+node:ekr.20240206062831.1: *3* nim_unary (do-nothing
 unary_pattern = re.compile(r'(\+|\-)')
 
 def nim_unary(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=unary_pattern)
+    # return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=unary_pattern)
+    return 0
 #@-others
 #@-<< Nim rules >>
 #@+<< nim_rules_dict >>


### PR DESCRIPTION
Tweak `modes/nim.py`: color neither plain numbers nor operators.