### PR TITLE
PR: workaround for #3744: autocomplete/calltips fails

### DIFF
--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -844,9 +844,11 @@ class AutoCompleterClass:
                 put("varargs: *" + argspec.varargs)
             if argspec.keywords:
                 put("keywords: **" + argspec.keywords)
-            put('\n')  # separate docstring
-        except TypeError:
-            put('\n')  # not a callable
+            put('\n')
+        except Exception:
+            # In Python 3.12, inspect does not handle bound methods!
+            # See https://github.com/python/cpython/issues/115630.
+            pass
         doc = inspect.getdoc(obj)
         put(doc if doc else "No docstring for " + repr(prefix))
     #@+node:ekr.20110510071925.14586: *4* ac.init_qcompleter


### PR DESCRIPTION
See #3743.

This PR is a workaround for an apparent Python bug.  See [Python bug #115630](https://github.com/python/cpython/issues/115630).

- [x] Catch all exceptions in ac.info.