### PR TITLE
PR for #3800: goto prev/back

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -689,27 +689,13 @@ def findNextClone(self: Cmdr, event: Event = None) -> None:
 def goNextVisitedNode(self: Cmdr, event: Event = None) -> None:
     """Select the next visited node."""
     c = self
-    p = c.nodeHistory.goNext()
-    if p:
-        c.nodeHistory.skipBeadUpdate = True
-        try:
-            c.selectPosition(p)
-        finally:
-            c.nodeHistory.skipBeadUpdate = False
-            c.redraw_after_select(p)
+    c.nodeHistory.goNext()
 #@+node:ekr.20031218072017.1627: *3* c_oc.goPrevVisitedNode
 @g.commander_command('go-back')
 def goPrevVisitedNode(self: Cmdr, event: Event = None) -> None:
     """Select the previously visited node."""
     c = self
-    p = c.nodeHistory.goPrev()
-    if p:
-        c.nodeHistory.skipBeadUpdate = True
-        try:
-            c.selectPosition(p)
-        finally:
-            c.nodeHistory.skipBeadUpdate = False
-            c.redraw_after_select(p)
+    c.nodeHistory.goPrev()
 #@+node:ekr.20031218072017.2914: *3* c_oc.goToFirstNode
 @g.commander_command('goto-first-node')
 def goToFirstNode(self: Cmdr, event: Event = None) -> None:


### PR DESCRIPTION
See #3800. 

This PR removes the *extremely evil* effects of kwargs and switch-like ivars.

- [x] Eliminate the evil `skipBeadUpdate` ivar.
- [x] Rewrite `NodeHistory.goPrev/goNext`.
   These methods delete entries in the node list if the position no longer exits.
- [x] Rewrite `NodeHistory.update`, eliminating the evil `changed` kwarg.
  Fix the **central bug** of the old code:
  The code must insert new beads in the *middle* of the bead list, *not* the end!
- [x] Rewrite `NodeHistory.select` w/o the evil `skipBeadUpdate` ivar.
- [x] Simplify the `go-back` and `go-forward` commands in `commanderOutlineCommands.py`.
