### PR TITLE
PR for #3811: handle short unls

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6717,8 +6717,17 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #    For example, the link: `unl:gnx://#ekr.20031218072017.2406` refers to this
 #    outline's "Code" node. Try it. The link works in this outline.
 #
-#    *Note*: `{outline}` is optional. It can be an absolute path name or a relative
-#    path name resolved using `@data unl-path-prefixes`.
+#    *Note*: `{outline}` can be:
+#
+#    - An absolute path to a .leo file.
+#      The link fails unless the given file exits.
+#
+#    - A relative path to a .leo file.
+#      Leo searches for the gnx:
+#      a) among the paths in `@data unl-path-prefixes`,
+#      b) among all open commanders.
+#
+#    - Empty. Leo searches for the gnx in all open commanders.
 #
 # 3. Leo's headline-based UNLs, as shown in the status pane:
 #

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6800,16 +6800,16 @@ def findAnyUnl(unl_s: str, c: Cmdr) -> Optional[Position]:
         file_part = g.getUNLFilePart(unl)
         tail = unl[3 + len(file_part) :]  # 3: Skip the '//' and '#'
 
-        # If there is a file part, search *only* the given commander!
+        # First, search the open commander.
+        # #3811: Do *not* fail if this search fails.
         if file_part:
             c2 = g.openUNLFile(c, file_part)
-            if not c2:
-                return None
-            p = g.findGnx(tail, c2)
-            return p  # May be None.
+            if c2:
+                p = g.findGnx(tail, c2)
+                if p:
+                    return p
 
-        # New in Leo 6.7.7:
-        # There is no file part, so search all open commanders, starting with c.
+        # Search all open commanders, starting with c.
         p = g.findGnx(tail, c)
         if p:
             return p

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -1475,7 +1475,8 @@ unl:gnx://#ekr.20050831195449
 # lines have the form:
 # x.leo: &lt;absolute path to x.leo&gt;
 
-test.leo:    c:/Repos/leo-editor/leo/test
-LeoDocs.leo: c:/Repos/leo-editor/leo/doc</t>
+# test.leo:    c:/Repos/leo-editor/leo/test
+# LeoDocs.leo: c:/Repos/leo-editor/leo/doc
+</t>
 </tnodes>
 </leo_file>

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -1205,6 +1205,9 @@ class TestGlobals(LeoUnitTest):
         self.assertEqual(c3, c2)
         c4 = g.openUNLFile(c2, file_name1)
         self.assertEqual(c4, c1)
+        # Test of short file names.
+        c5 = g.openUNLFile(c1, c1.shortFileName())
+        self.assertEqual(c5, c1)
     #@+node:ekr.20230701103509.1: *4* TestGlobals.test_g_parsePathData
     def test_g_parsePathData(self) -> None:
 


### PR DESCRIPTION
See #3811.

- [x] Improve `test_g_openUNLFile` to show that `g.openUNLFile` handles short file names correctly.
- [x] Disable `@data unl-path-prefixes` in `test.leo` to simplify testing.
- [x] Fix `g.findAnyUnl` as described in [#3811](https://github.com/leo-editor/leo-editor/issues/3811).