### PR TITLE
PR for #3814: Better defaults for UNLs with short file names

### DIFF
--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2678,6 +2678,26 @@ def xxx_test_ternary(self):
     expected = contents
     results = self.beautify(contents, tokens)
     self.assertEqual(results, expected)
+#@+node:ekr.20240225091259.1: ** unused from _patch_at_data_unl_path_prefixes
+
+    def make_line(c):
+        file_name = c.fileName()
+        key = os.path.basename(file_name)
+        # Values must be directories.
+        value = os.path.normpath(os.path.dirname(file_name))
+        # print(f"{key:17} {value}")
+        return f"{key}: {value}"
+
+    # Init the @data unl-path-prefixes.
+    lines = [make_line(z) for z in (c, c2)]
+    self._set_setting(c, kind='data', name='unl-path-prefixes', val=lines)
+    lines2 = c.config.getData('unl-path-prefixes')
+    self.assertEqual(list(sorted(lines)), list(sorted(lines2)))
+    d = g.parsePathData(c)
+    if 0:
+        print('')
+        g.printObj(d)
+    return c2
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -90,6 +90,7 @@
 <v t="ekr.20230906100141.24"><vh>script: asttokens</vh></v>
 <v t="ekr.20230906100141.25"><vh>QToolBar test</vh></v>
 </v>
+<v t="ekr.20231231164138.1"></v>
 <v t="ekr.20230622112641.1"><vh>--- tests of UNL (do not delete!)</vh>
 <v t="ekr.20140723122936.18139"><vh>@file ../plugins/importers/__init__.py</vh></v>
 <v t="ekr.20230622112535.1"><vh>@clean ../plugins/leo_babel/__init__.py</vh></v>
@@ -1475,8 +1476,8 @@ unl:gnx://#ekr.20050831195449
 # lines have the form:
 # x.leo: &lt;absolute path to x.leo&gt;
 
-# test.leo:    c:/Repos/leo-editor/leo/test
-# LeoDocs.leo: c:/Repos/leo-editor/leo/doc
+test.leo:    c:/Repos/leo-editor/leo/test
+LeoDocs.leo: c:/Repos/leo-editor/leo/doc
 </t>
 </tnodes>
 </leo_file>

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -247,7 +247,7 @@ class TestGlobals(LeoUnitTest):
         Patch @data unl-path-prefixes so that g.findAnyUnl will find nodes in
         the new commander.
 
-        Return the commander for the new outline.
+        Return the commander for the *second* new outline.
         """
         from leo.core.leoCommands import Commands
         c = c1 = self.c
@@ -266,24 +266,6 @@ class TestGlobals(LeoUnitTest):
         c2.mFileName = os.path.normpath(os.path.join(directory, c2_name))
         self.assertEqual(c1_name, os.path.basename(c.fileName()))
         self.assertEqual(c2_name, os.path.basename(c2.fileName()))
-
-        def make_line(c):
-            file_name = c.fileName()
-            key = os.path.basename(file_name)
-            # Values must be directories.
-            value = os.path.normpath(os.path.dirname(file_name))
-            # print(f"{key:17} {value}")
-            return f"{key}: {value}"
-
-        # Init the @data unl-path-prefixes.
-        lines = [make_line(z) for z in (c, c2)]
-        self._set_setting(c, kind='data', name='unl-path-prefixes', val=lines)
-        lines2 = c.config.getData('unl-path-prefixes')
-        self.assertEqual(list(sorted(lines)), list(sorted(lines2)))
-        d = g.parsePathData(c)
-        if 0:
-            print('')
-            g.printObj(d)
         return c2
     #@+node:ekr.20230701084035.1: *4* TestGlobals.test_per_commander_data
     def test_per_commander_data(self):
@@ -1197,7 +1179,7 @@ class TestGlobals(LeoUnitTest):
         # Create a new commander
         c1 = self.c
         c2 = self._patch_at_data_unl_path_prefixes()
-        # Change both filenames.
+        # Use short file names.
         file_name1 = os.path.basename(c1.fileName())
         file_name2 = os.path.basename(c2.fileName())
         # Cross-file tests.


### PR DESCRIPTION
See #3814.

- [x] Rewrite `g.openUNLFile`.
    Require exact matches for absolute file paths or paths found in `@data unl-path-prefixes`.
    Otherwise, resolve paths using the `c's` directory, but see the code for the details.
- [x] Revise unit tests accordingly, moving no-long-used code to the attic.
- [x] In `test.leo`, activate entries `@data unl-path-prefixes`.