### PR TITLE
PR for #3816: improved UNLs

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6740,8 +6740,11 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #
 #    This link works: `unl://#Code-->About this file`.
 #
-#    *Note*: `{outline}` is optional. It can be an absolute path name or a relative
-#    path name resolved using `@data unl-path-prefixes`.
+#    As in point 2 above, `{outline}` or `{gnx}` may be empty, but at least
+#    one must exist.
+#
+#    `{outline}` may be an absolute path name or a *short* name resolved
+#    using `@data unl-path-prefixes`.
 #
 # 4. Web URLs: file, ftp, gopher, http, https, mailto, news, nntp, prospero, telnet, wais.
 #

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6708,26 +6708,30 @@ def run_unit_tests(tests: str = None, verbose: bool = False) -> None:
 #    provided the outline contains an `@<file>` node for file mentioned in
 #    the error message.
 #
-# 2. New in Leo 6.7.4: UNLs based on gnx's (global node indices):
+# 2. UNLs based on gnx's (global node indices):
 #
 #    Links of the form `unl:gnx:` + `//{outline}#{gnx}` open the given
-#    outline and select the first outline node with the given gnx. These UNLs
-#    will work as long as the node exists anywhere in the outline.
+#    outline and select the first outline node with the given gnx.
 #
 #    For example, the link: `unl:gnx://#ekr.20031218072017.2406` refers to this
 #    outline's "Code" node. Try it. The link works in this outline.
 #
-#    *Note*: `{outline}` can be:
+#    Either `{outline}` or `{gnx}` may be empty, but at least one must exist.
 #
-#    - An absolute path to a .leo file.
-#      The link fails unless the given file exits.
+#    `{outline}` can be:
 #
-#    - A relative path to a .leo file.
-#      Leo searches for the gnx:
+#    - An *absolute path* to a .leo file.
+#    - A *relative path*, resolved using the outline's directory.
+#
+#      Leo will select the outline if it is already open.
+#      Otherwise, Leo will open the outline if it exists.
+#
+#    - A *short* name, say x.leo.
+#      Leo searches for x.leo file:
 #      a) among the paths in `@data unl-path-prefixes`,
 #      b) among all open commanders.
 #
-#    - Empty. Leo searches for the gnx in all open commanders.
+#    - *Empty*. Leo searches for the gnx in all open outlines.
 #
 # 3. Leo's headline-based UNLs, as shown in the status pane:
 #

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -100,6 +100,7 @@
 <v t="ekr.20230623141357.1"><vh>URLs and UNLs: </vh></v>
 <v t="ekr.20231231043342.1"><vh>New UNLs with empty file parts</vh></v>
 <v t="ekr.20230627150454.1"><vh>New UNLs with short file parts</vh></v>
+<v t="ekr.20240226115140.1"><vh>New UNLs with relative file parts</vh></v>
 <v t="ekr.20230707065449.1"><vh>New UNLS with long(absolute) file parts</vh></v>
 </v>
 </vnodes>
@@ -1479,5 +1480,13 @@ unl:gnx://#ekr.20050831195449
 test.leo:    c:/Repos/leo-editor/leo/test
 LeoDocs.leo: c:/Repos/leo-editor/leo/doc
 </t>
+<t tx="ekr.20240226115140.1"># In LeoDocs.leo: Leo 6.7.3 release notes
+unl:gnx://../doc/LeoDocs.leo#ekr.20230409052507.1
+
+# In LeoDocs.leo: ** Leo's Documentation **
+unl:gnx://../doc/LeoDocs.leo#ekr.20040414161647
+
+# Just open LeoDocs.leo.
+unl:gnx://../doc/LeoDocs.leo#</t>
 </tnodes>
 </leo_file>


### PR DESCRIPTION
See #3816. This PR was easier to do than I imagined. It makes minor, easily understood, changes in the expected places, namely `g.findAnyUnl`,  `g.openUNLFile` and the regex in `g.getUNLFilePart`.

- [x] Add easy special case to `g.findAnyUnl`.
- [x] Make the gnx part optional in the `file_part_pattern` used by `g.getUNLFilePart`.
- [x] Add easy special case to `g.openUNLFile` for file parts containing `os.sep`.
   In addition, improve the `standard` function.
- [x] Add new test cases to `test.leo`. Everything appears to work as expected.
   All unit tests pass.
- [x] Update the documentation in the section `<< About clickable links >>`.

The new code uses `@data unl-path-prefixes` only for *short* (not relative) paths.
Imo, this behavior is both reasonable and compatible with all existing UNLs.