### PR TITLE
Fixed set_name_and_title to reset the db 'key' used for its entries when 'save-as' changes the filename.

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -39,7 +39,6 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
 
     Return the finalized name.
     """
-    oldFilename = c.mFileName
     # Finalize fileName.
     if fileName.endswith(('.leo', '.db', '.leojs')):
         c.mFileName = fileName
@@ -50,11 +49,6 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
     title = c.computeWindowTitle()
     c.frame.title = title
     c.frame.setTitle(title)
-
-    # #3822 if name changed 'save-as' needs to change the keys of settings saved in db.
-    if oldFilename != c.mFileName:
-        c.db = CommanderWrapper(c)
-
     try:
         # Does not exist during unit testing. May not exist in all guis.
         c.frame.top.leo_master.setTabName(c, c.mFileName)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -10,6 +10,7 @@ import time
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoImport
+from leo.core.leoCache import CommanderWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -38,7 +39,7 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
 
     Return the finalized name.
     """
-
+    oldFilename = c.mFileName
     # Finalize fileName.
     if fileName.endswith(('.leo', '.db', '.leojs')):
         c.mFileName = fileName
@@ -49,6 +50,11 @@ def set_name_and_title(c: Cmdr, fileName: str) -> str:
     title = c.computeWindowTitle()
     c.frame.title = title
     c.frame.setTitle(title)
+
+    # #3822 if name changed 'save-as' needs to change the keys of settings saved in db.
+    if oldFilename != c.mFileName:
+        c.db = CommanderWrapper(c)
+
     try:
         # Does not exist during unit testing. May not exist in all guis.
         c.frame.top.leo_master.setTabName(c, c.mFileName)

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -39,32 +39,31 @@ class CommanderWrapper:
     """
 
     def __init__(self, c: Cmdr) -> None:
-        self.c = c
+        self.c = c  # Key is c.mFilemane to fix #3822
         self.db = g.app.db
-        self.key = c.mFileName
         self.user_keys: set[str] = set()
 
     def get(self, key: str, default: Any = None) -> Any:
-        value = self.db.get(f"{self.key}:::{key}")
+        value = self.db.get(f"{self.c.mFileName}:::{key}")
         return default if value is None else value
 
     def keys(self) -> list[str]:
         return sorted(list(self.user_keys))
 
     def __contains__(self, key: Any) -> bool:
-        return f"{self.key}:::{key}" in self.db
+        return f"{self.c.mFileName}:::{key}" in self.db
 
     def __delitem__(self, key: Any) -> None:
         if key in self.user_keys:
             self.user_keys.remove(key)
-        del self.db[f"{self.key}:::{key}"]
+        del self.db[f"{self.c.mFileName}:::{key}"]
 
     def __getitem__(self, key: str) -> Any:
-        return self.db[f"{self.key}:::{key}"]  # May (properly) raise KeyError
+        return self.db[f"{self.c.mFileName}:::{key}"]  # May (properly) raise KeyError
 
     def __setitem__(self, key: str, value: Any) -> None:
         self.user_keys.add(key)
-        self.db[f"{self.key}:::{key}"] = value
+        self.db[f"{self.c.mFileName}:::{key}"] = value
 #@+node:ekr.20180627041556.1: ** class GlobalCacher (g.app.db)
 class GlobalCacher:
     """


### PR DESCRIPTION
Fixes #3822

I've tested it manually, and ran unit tests: all pass.