### PR TITLE
Boltex/issue3826

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -546,7 +546,6 @@ class FastRead:
 
                     v._headString = v_dict.get('vh', '')
                     v._bodyString = gnx2body.get(gnx, '')
-                    v.statusBits = v_dict.get('status', 0)  # Needed ?
                     if v.isExpanded():
                         fc.descendentExpandedList.append(gnx)
                     if v.isMarked():
@@ -1728,14 +1727,6 @@ class FileCommands:
         if forceWrite or self.usingClipboard:
             v.setWriteBit()  # 4.2: Indicate we wrote the body text.
 
-        status = 0
-        if v.isMarked():
-            status |= v.markedBit
-        if p.isExpanded():
-            status |= v.expandedBit
-        if p == c.p:
-            status |= v.selectedBit
-
         children: list[dict[str, Any]] = []  # Start empty
 
         if p.hasChildren() and (forceWrite or self.usingClipboard):
@@ -1759,10 +1750,6 @@ class FileCommands:
             gnxSet.add(v.fileIndex)
             if children:
                 result['children'] = children
-
-        # Else, just add status if needed
-        if status:
-            result['status'] = status
 
         return result
     #@+node:ekr.20100119145629.6111: *5* fc.write_xml_file

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -2519,6 +2519,16 @@ class LeoServer:
                 for p in c.all_unique_positions(copy=False)
         }
         return self._make_minimal_response({"position-data-dict": result})
+    #@+node:felix.20240302203609.1: *5* server.get_recent_files
+    def get_recent_files(self, param: Param) -> Response:
+        """
+        Return the recent files list
+        """
+        try:
+            recentFiles = g.app.recentFilesManager.recentFiles
+        except Exception:  # pragma: no cover
+            recentFiles = []
+        return self._make_minimal_response({"files": recentFiles})
     #@+node:felix.20210621233316.46: *5* server.get_ua
     def get_ua(self, param: Param) -> Response:
         """Return p.v.u, making sure it can be serialized."""


### PR DESCRIPTION
Make sure .leojs file format has no state bits in file, and instead all saved in db.  Making the .leojs JSON file format a pure equivalent of the .leo xml file format.

Fixes #3826

I also added a 'getrecentfileslist' method to the server.

I've tested manually and ran unit test to make sure they all pass.