### PR TITLE
PR for #3829: Retire runAskLeoIDDialog

### DIFF
--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -101,10 +101,6 @@ class LeoGui:
         """Create and run Leo's About Leo dialog."""
         raise NotImplementedError
 
-    def runAskLeoIDDialog(self) -> Any:
-        """Create and run a dialog to get g.app.LeoID."""
-        raise NotImplementedError
-
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> Any:
         """Create and run an askOK dialog ."""
         raise NotImplementedError
@@ -366,9 +362,6 @@ class NullGui(LeoGui):
     #@+node:ekr.20031218072017.3744: *3* NullGui.dialogs
     def runAboutLeoDialog(self, c: Cmdr, version: str, theCopyright: str, url: str, email: str) -> str:
         return self.simulateDialog("aboutLeoDialog", None)
-
-    def runAskLeoIDDialog(self) -> str:
-        return self.simulateDialog("leoIDDialog", None)
 
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> str:
         return self.simulateDialog("okDialog", "Ok")

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -1220,6 +1220,46 @@ def readOutlineOnly(self, theFile: Any, fileName: str) -> VNode:
     junk, junk, secondary_ratio = self.frame.initialRatios()
     c.frame.resizePanesToRatio(ratio, secondary_ratio)
     return v
+#@+node:ekr.20240304050056.1: ** retire runAskLeoIDDialog
+@nosearch
+
+# Word, Ignore Case, Body
+
+# found 6 nodes
+#@+node:ekr.20171126182120.3: *3* CGui.runAskLeoIDDialog (not used)
+def runAskLeoIDDialog(self) -> None:
+    """Create and run a dialog to get g.app.LeoID."""
+    if not g.unitTesting:
+        message = (
+            "leoID.txt not found\n\n" +
+            "The curses gui can not set this file." +
+            "Exiting..."
+        )
+        g.trace(message)
+        # "Please enter an id that identifies you uniquely.\n" +
+        # "Your cvs/bzr login name is a good choice.\n\n" +
+        # "Leo uses this id to uniquely identify nodes.\n\n" +
+        # "Your id must contain only letters and numbers\n" +
+        # "and must be at least 3 characters in length."
+        sys.exit(0)
+
+#@+node:ekr.20110605121601.18494: *3* qt_gui.runAskLeoIDDialog (not used)
+def runAskLeoIDDialog(self) -> Optional[str]:
+    """Create and run a dialog to get g.app.LeoID."""
+    if g.unitTesting:
+        return None
+    message = (
+        "leoID.txt not found\n\n" +
+        "Please enter an id that identifies you uniquely.\n" +
+        "Your cvs/bzr login name is a good choice.\n\n" +
+        "Leo uses this id to uniquely identify nodes.\n\n" +
+        "Your id must contain only letters and numbers\n" +
+        "and must be at least 3 characters in length.")
+    parent = None
+    title = 'Enter Leo id'
+    s, ok = QtWidgets.QInputDialog.getText(parent, title, message)
+
+    return s
 #@+node:ekr.20240206030539.1: ** retire setup.py
 #@+node:maphew.20180224170853.1: *3* leo-editor/setup.py
 """

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1647,23 +1647,6 @@ class LeoCursesGui(leoGui.LeoGui):
             # form_color='STANDOUT', wrap=True, wide=False, editw=0)
             utilNotify.notify_confirm(message, title="About Leo")
 
-    #@+node:ekr.20171126182120.3: *5* CGui.runAskLeoIDDialog
-    def runAskLeoIDDialog(self) -> None:
-        """Create and run a dialog to get g.app.LeoID."""
-        if not g.unitTesting:
-            message = (
-                "leoID.txt not found\n\n" +
-                "The curses gui can not set this file." +
-                "Exiting..."
-            )
-            g.trace(message)
-            # "Please enter an id that identifies you uniquely.\n" +
-            # "Your cvs/bzr login name is a good choice.\n\n" +
-            # "Leo uses this id to uniquely identify nodes.\n\n" +
-            # "Your id must contain only letters and numbers\n" +
-            # "and must be at least 3 characters in length."
-            sys.exit(0)
-
     #@+node:ekr.20171126182120.5: *5* CGui.runAskOkCancelNumberDialog
     def runAskOkCancelNumberDialog(self,
         c: Cmdr,

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -424,23 +424,6 @@ class LeoQtGui(leoGui.LeoGui):
         if val == DialogCode.Accepted:
             return dialog.dt.dateTime().toPyDateTime()
         return None
-    #@+node:ekr.20110605121601.18494: *4* qt_gui.runAskLeoIDDialog (not used)
-    def runAskLeoIDDialog(self) -> Optional[str]:
-        """Create and run a dialog to get g.app.LeoID."""
-        if g.unitTesting:
-            return None
-        message = (
-            "leoID.txt not found\n\n" +
-            "Please enter an id that identifies you uniquely.\n" +
-            "Your cvs/bzr login name is a good choice.\n\n" +
-            "Leo uses this id to uniquely identify nodes.\n\n" +
-            "Your id must contain only letters and numbers\n" +
-            "and must be at least 3 characters in length.")
-        parent = None
-        title = 'Enter Leo id'
-        s, ok = QtWidgets.QInputDialog.getText(parent, title, message)
-
-        return s
     #@+node:ekr.20110605121601.18491: *4* qt_gui.runAskOkCancelNumberDialog (not used)
     def runAskOkCancelNumberDialog(self,
         c: Cmdr, title: str, message: str, cancelButtonText: str = None, okButtonText: str = None,

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -32,7 +32,6 @@ class TestNullGui(LeoUnitTest):
         # Make sure the ctors don't crash.
         gui = g.app.gui
         gui.runAboutLeoDialog(c, 'version', 'copyright', 'url', 'email')
-        gui.runAskLeoIDDialog()
         gui.runAskOkDialog(c, 'title', 'message')
         gui.runAskOkCancelNumberDialog(c, 'title', 'message')
         gui.runAskOkCancelStringDialog(c, 'title', 'message')
@@ -94,7 +93,6 @@ class TestQtGui(LeoUnitTest):
         gui = g.app.gui
         self.assertEqual(gui.__class__.__name__, 'LeoQtGui')
         gui.runAboutLeoDialog(c, 'version', 'copyright', 'url', 'email')
-        gui.runAskLeoIDDialog()
         gui.runAskOkDialog(c, 'title', 'message')
         gui.runAskOkCancelNumberDialog(c, 'title', 'message')
         gui.runAskOkCancelStringDialog(c, 'title', 'message')


### PR DESCRIPTION
See #3829.

- [x] Move non-trivial `runAskLeoIDDialog` methods to the attic.
- [x] Delete other `runAskLeoIDDialog` methods.
- [x] Remove references to these methods from unit tests.