### PR TITLE
PR for #3839: Add g.bytesToStr and g.strToBytes

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4855,6 +4855,25 @@ def unCamel(s: str) -> list[str]:
         result.append(''.join(word))
     return result
 #@+node:ekr.20031218072017.1498: *3* g.Unicode
+#@+node:ekr.20240325175438.1: *4* g.bytesToStr
+def bytesToStr(b: bytes, reportErrors: bool = False) -> str:
+    """Convert bytes to unicode."""
+    assert isinstance(b, bytes), g.callers()
+    tag = 'g.bytesToStr'
+    encoding = 'utf-8'
+    try:
+        s = b.decode(encoding, 'strict')
+    except(UnicodeDecodeError, UnicodeError):  # noqa
+        # https://wiki.python.org/moin/UnicodeDecodeError
+        s = b.decode(encoding, 'replace')
+        if reportErrors:
+            g.error(f"{tag}: unicode error. encoding: {encoding!r}, s:\n{s!r}")
+            g.trace(g.callers())
+    except Exception:
+        g.es_exception()
+        g.error(f"{tag}: unexpected error! encoding: {encoding!r}, s:\n{s!r}")
+        g.trace(g.callers())
+    return s
 #@+node:ekr.20190505052756.1: *4* g.checkUnicode
 checkUnicode_dict: dict[str, bool] = {}
 
@@ -4974,6 +4993,19 @@ def stripBOM(s_bytes: bytes) -> tuple[str, bytes]:
             if bom == s_bytes[: len(bom)]:
                 return e, s_bytes[len(bom) :]
     return None, s_bytes
+#@+node:ekr.20240325175449.1: *4* g.strToBytes
+def strToBytes(s: str, reportErrors: bool = False) -> bytes:
+    """Convert unicode string to an encoded string."""
+    assert isinstance(s, str), g.callers()
+    encoding = 'utf-8'
+    try:
+        b = s.encode(encoding, "strict")
+    except UnicodeError:
+        b = s.encode(encoding, "replace")
+        if reportErrors:
+            g.error(f"Error converting {s} from unicode to {encoding}")
+    # Tracing these calls directly yields thousands of calls.
+    return b
 #@+node:ekr.20050208093800: *4* g.toEncodedString
 def toEncodedString(s: str, encoding: str = 'utf-8', reportErrors: bool = False) -> bytes:
     """Convert unicode string to an encoded string."""

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -203,16 +203,16 @@ python_main_keywords_dict = {
     "apply": "keyword2",
     "as": "keyword1",
     "assert": "keyword1",
-    "async": "keyword1",  # Python 3.7
-    "await": "keyword1",  # Python 3.7.
-    "basestring": "keyword2",  # Only in Python 2.
+    "async": "keyword1",
+    "await": "keyword1",
     "bool": "keyword2",
     "break": "keyword1",
     "buffer": "keyword2",
+    "bytes": "keyword2",
     "callable": "keyword2",
     "chr": "keyword2",
     "class": "keyword1",
-    "@classmethod": "keyword2",  # Bug fix: 5/14/2016
+    "@classmethod": "keyword2",
     "cmp": "keyword2",
     "coerce": "keyword2",
     "compile": "keyword2",
@@ -286,7 +286,7 @@ python_main_keywords_dict = {
     "setattr": "keyword2",
     "slice": "keyword2",
     "sorted": "keyword2",
-    "@staticmethod": "keyword2",  # Bug fix: 5/14/2016
+    "@staticmethod": "keyword2",
     "str": "keyword2",
     "sum": "keyword2",
     "super": "keyword2",
@@ -297,7 +297,7 @@ python_main_keywords_dict = {
     "unicode": "keyword2",
     "vars": "keyword2",
     "while": "keyword1",
-    "with": "keyword1",  # Fix bug 1174532: Python mode file missing 'with' keyword
+    "with": "keyword1",
     "xrange": "keyword2",
     "yield": "keyword1",
     "zip": "keyword2",


### PR DESCRIPTION
See #3839.

- [x] Add `g.bytesToStr` and `g.strToBytes`.
- [x] Colorize `bytes` properly!
- [ ] Replace `g.toEncodedString` with`g.strToBytes` where possible.
- [ ] Replace `g.toUnicode` with`g.bytesToStr` where possible.