### PR TITLE
Remove 'Any' annotations in leoApp.py

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2896,11 +2896,11 @@ class LoadManager:
                 g.es_print = self.write
                 g.pr = self.write
 
-            def flush(self, *args: Any, **keys: Any) -> None:
+            def flush(self, *args: list, **keys: dict) -> None:
                 pass
             #@+others
             #@+node:ekr.20160718102306.1: *7* LeoStdOut.write
-            def write(self, *args: Any, **keys: Any) -> None:
+            def write(self, *args: list, **keys: dict) -> None:
                 """Put all non-keyword args to the log pane, as in g.es."""
                 #
                 # Tracing will lead to unbounded recursion unless

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -23,6 +23,7 @@ StringIO = io.StringIO
 #@+<< leoApp annotations >>
 #@+node:ekr.20220819191617.1: ** << leoApp annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from types import Module
     from leo.core.leoBackground import BackgroundProcessManager
     from leo.core.leoCache import GlobalCacher
     from leo.core.leoCommands import Commands as Cmdr
@@ -36,7 +37,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_events import LossageData
     from leo.plugins.qt_idle_time import IdleTime
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    Module = Any
     Widget = Any
 #@-<< leoApp annotations >>
 #@+others

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3337,8 +3337,8 @@ class RecentFilesManager:
     def __init__(self) -> None:
 
         self.edit_headline = 'Recent files. Do not change this headline!'
-        self.groupedMenus: list[str] = []  # Set in rf.createRecentFilesMenuItems.
-        self.recentFiles: list[Any] = []  # List of g.Bunches describing .leoRecentFiles.txt files.
+        self.groupedMenus: list[str] = []
+        self.recentFiles: list[str] = []
         self.recentFilesMenuName = 'Recent Files'  # May be changed later.
         self.recentFileMessageWritten = False  # To suppress all but the first message.
         self.write_recent_files_as_needed = False  # Will be set later.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_events import LossageData
     from leo.plugins.qt_idle_time import IdleTime
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    Module = Any
     Widget = Any
 #@-<< leoApp annotations >>
 #@+others
@@ -2437,7 +2438,7 @@ class LoadManager:
                         g.warning(f"can not import leo.plugins.importers.{module_name}")
                         g.printObj(filenames)
     #@+node:ekr.20140723140445.18076: *7* LM.parse_importer_dict
-    def parse_importer_dict(self, sfn: str, m: Any) -> None:
+    def parse_importer_dict(self, sfn: str, m: Module) -> None:
         """
         Set entries in g.app.classDispatchDict, g.app.atAutoDict and
         g.app.atAutoNames using entries in m.importer_dict.
@@ -2497,7 +2498,7 @@ class LoadManager:
             g.trace('LM.atAutoWritersDict')
             g.printDict(g.app.atAutoWritersDict)
     #@+node:ekr.20140728040812.17991: *7* LM.parse_writer_dict
-    def parse_writer_dict(self, sfn: str, m: Any) -> None:
+    def parse_writer_dict(self, sfn: str, m: Module) -> None:
         """
         Set entries in g.app.writersDispatchDict and g.app.atAutoWritersDict
         using entries in m.writers_dict.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3337,7 +3337,7 @@ class RecentFilesManager:
     def __init__(self) -> None:
 
         self.edit_headline = 'Recent files. Do not change this headline!'
-        self.groupedMenus: list[Any] = []  # Set in rf.createRecentFilesMenuItems.
+        self.groupedMenus: list[str] = []  # Set in rf.createRecentFilesMenuItems.
         self.recentFiles: list[Any] = []  # List of g.Bunches describing .leoRecentFiles.txt files.
         self.recentFilesMenuName = 'Recent Files'  # May be changed later.
         self.recentFileMessageWritten = False  # To suppress all but the first message.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3427,7 +3427,7 @@ class RecentFilesManager:
         rf_always = c.config.getBool("recent-files-group-always")
         groupedEntries = rf_group or rf_always
         if groupedEntries:  # if so, make dict of groups
-            dirCount: dict[str, Any] = {}
+            dirCount: dict[str, dict[str, Optional[list[str]]]] = {}
             for fileName in rf.getRecentFiles()[:n]:
                 dirName, baseName = g.os_path_split(fileName)
                 if baseName not in dirCount:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3256,7 +3256,7 @@ class LoadManager:
         c.frame.setTitle(title)
         c.clearChanged()
     #@+node:ekr.20120223062418.10410: *5* LM.openZipFile
-    def openZipFile(self, fn: str) -> Any:
+    def openZipFile(self, fn: str) -> Optional[StringIO]:
         """
         Open a zipped file for reading.
         Return a StringIO file if successful.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -28,13 +28,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoConfig import GlobalConfigManager
     from leo.core.leoExternalFiles import ExternalFilesController
-    from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoGui import LeoGui
+    from leo.core.leoGui import LeoKeyEvent, LeoGui
     from leo.core.leoIPython import InternalIPKernel
     from leo.core.leoNodes import NodeIndices, Position
     from leo.core.leoPlugins import LeoPluginsController
     from leo.core.leoSessions import SessionManager
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_idle_time import IdleTime
     Widget = Any
 #@-<< leoApp annotations >>
 #@+others
@@ -139,7 +139,7 @@ class LeoApp:
         self.debug_dict: dict[str, Any] = {}  # For general use.
         self.disable_redraw = False  # True: disable all redraws.
         self.disableSave = False  # May be set by plugins.
-        self.idle_timers: list[Any] = []  # A list of IdleTime instances, so they persist.
+        self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
         self.log_listener: Any = None  # The external process created by the 'listen-for-log' command.
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -3757,7 +3757,7 @@ def openUrl(event: LeoKeyEvent = None) -> None:
         g.openUrl(c.p)
 #@+node:ekr.20150514125218.6: *3* open-url-under-cursor
 @g.command('open-url-under-cursor')
-def openUrlUnderCursor(event: LeoKeyEvent = None) -> Any:
+def openUrlUnderCursor(event: LeoKeyEvent = None) -> Optional[str]:
     """Open the url under the cursor."""
     return g.openUrlOnClick(event)
 #@-others

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -37,7 +37,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_events import LossageData
     from leo.plugins.qt_idle_time import IdleTime
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    Widget = Any
 #@-<< leoApp annotations >>
 #@+others
 #@+node:ekr.20150509193629.1: ** cmd (decorator)
@@ -237,7 +236,7 @@ class LeoApp:
         #@-<< LeoApp: global status vars >>
         #@+<< LeoApp: the global log >>
         #@+node:ekr.20161028040141.1: *5* << LeoApp: the global log >>
-        self.log: Widget = None  # The LeoFrame containing the present log.
+        self.log: LeoFrame = None  # The LeoFrame containing the present log.
         self.logInited = False  # False: all log message go to logWaiting list.
         self.logIsLocked = False  # True: no changes to log are allowed.
         self.logWaiting: list[tuple] = []  # List of tuples (s, color, newline) waiting to go to a log.
@@ -1237,7 +1236,7 @@ class LeoApp:
         return self.log and self.log.c
     #@+node:ekr.20171127111053.1: *3* app.Closing
     #@+node:ekr.20031218072017.2609: *4* app.closeLeoWindow
-    def closeLeoWindow(self, frame: Widget, new_c: Cmdr = None, finish_quit: bool = True) -> bool:
+    def closeLeoWindow(self, frame: LeoFrame, new_c: Cmdr = None, finish_quit: bool = True) -> bool:
         """
         Attempt to close a Leo window.
 
@@ -1288,7 +1287,7 @@ class LeoApp:
             g.app.externalFilesController.shut_down()
             g.app.externalFilesController = None
     #@+node:ekr.20031218072017.2615: *4* app.destroyWindow
-    def destroyWindow(self, frame: Widget) -> None:
+    def destroyWindow(self, frame: LeoFrame) -> None:
         """Destroy all ivars in a Leo frame."""
         if 'shutdown' in g.app.debug:
             g.pr(f"destroyWindow:  {frame.c.shortFileName()}")

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -23,6 +23,7 @@ StringIO = io.StringIO
 #@+<< leoApp annotations >>
 #@+node:ekr.20220819191617.1: ** << leoApp annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from subprocess import Popen
     from types import Module
     from leo.core.leoBackground import BackgroundProcessManager
     from leo.core.leoCache import GlobalCacher
@@ -141,7 +142,7 @@ class LeoApp:
         self.disable_redraw = False  # True: disable all redraws.
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
-        self.log_listener: Any = None  # The external process created by the 'listen-for-log' command.
+        self.log_listener: Optional[Popen] = None  # The external process created by the 'listen-for-log' command.
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.
         self.statsDict: dict[str, Any] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoConfig import GlobalConfigManager
     from leo.core.leoExternalFiles import ExternalFilesController
-    from leo.core.leoGui import LeoKeyEvent, LeoGui
+    from leo.core.leoGui import LeoKeyEvent, LeoFrame, LeoGui
     from leo.core.leoIPython import InternalIPKernel
     from leo.core.leoNodes import NodeIndices, Position
     from leo.core.leoPlugins import LeoPluginsController
@@ -176,7 +176,7 @@ class LeoApp:
         self.paste_c: Cmdr = None  # The commander that pasted the last outline.
         self.spellDict: dict = None  # The singleton PyEnchant spell dict.
         self.numberOfUntitledWindows = 0  # Number of opened untitled windows.
-        self.windowList: list[Any] = []  # Global list of all frames.
+        self.windowList: list[LeoFrame] = []  # Global list of all frames.
         self.realMenuNameDict: dict[str, str] = {}  # Translations of menu names.
         #@-<< LeoApp: global data >>
         #@+<< LeoApp: global controller/manager objects >>
@@ -1178,7 +1178,7 @@ class LeoApp:
                     pass
                 g.error('can not create', tag, 'in', theDir)
     #@+node:ekr.20031218072017.1847: *4* app.setLog, lockLog, unlocklog
-    def setLog(self, log: Any) -> None:
+    def setLog(self, log: LeoFrame) -> None:
         """set the frame to which log messages will go"""
         if not self.logIsLocked:
             self.log = log

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -33,8 +33,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import NodeIndices, Position
     from leo.core.leoPlugins import LeoPluginsController
     from leo.core.leoSessions import SessionManager
-    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+    from leo.plugins.qt_events import LossageData
     from leo.plugins.qt_idle_time import IdleTime
+    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     Widget = Any
 #@-<< leoApp annotations >>
 #@+others
@@ -171,7 +172,7 @@ class LeoApp:
         self.globalKillBuffer: list[str] = []  # The global kill buffer.
         self.globalRegisters: dict[str, str] = {}  # The global register list.
         self.leoID: str = None  # The id part of gnx's.
-        self.lossage: list[Any] = []  # List of last 100 keystrokes.
+        self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
         self.paste_c: Cmdr = None  # The commander that pasted the last outline.
         self.spellDict: dict = None  # The singleton PyEnchant spell dict.
         self.numberOfUntitledWindows = 0  # Number of opened untitled windows.

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -195,7 +195,7 @@ class TextFrame(leoFrame.LeoFrame):
     #@+node:ekr.20150107090324.25: *3* destroySelf
     def destroySelf(self):
         pass
-    #@+node:ekr.20150107090324.26: *3* finishCreate
+    #@+node:ekr.20150107090324.26: *3* finishCreate (cursesGui.py)
     def finishCreate(self):
         c, f = self.c, self
         f.tree = textTree(self)


### PR DESCRIPTION
The only remaining `Any` annotations are for general-purpose user dictionaries.

I am thrilled that `LeoFrame` annotations pass mypy.

- [x] Improve annotations of `LeoApp` ivars: `idle_timers`, `lossage`, `windowList`.
- [x] Improve annotations of `LeoApp` methods, especially the `Module` and `LeoFrame` annotations.
- [x] Improve annotations in `RecentFilesManager` class.