### PR TITLE
Improve annotations in leoGlobals.py

### DIFF
--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -435,7 +435,7 @@ class MypyCommand:
         if not mypy:
             print('install mypy with `pip install mypy`')
             return
-        command = f"{sys.executable} -m mypy {fn}".split()
+        command = f"{sys.executable} -m mypy {fn}"
         bpm = g.app.backgroundProcessManager
         bpm.start_process(c, command, fn=fn, kind='mypy')
     #@+node:ekr.20210302111935.7: *3* mypy.run (entry)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -151,11 +151,11 @@ def importAnyFile(self: Self, event: LeoKeyEvent = None) -> None:
         ("Python files", "*.py"),
         ("Text files", "*.txt"),
     ]
-    names = g.app.gui.runOpenFileDialog(c,
+    names = g.app.gui.runOpenFilesDialog(c,
         title="Import File",
         filetypes=filetypes,
         defaultextension=".py",
-        multiple=True)
+    )
     c.bringToFront()
     if names:
         g.chdir(names[0])
@@ -742,11 +742,11 @@ def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
         ("Pascal files", "*.pas"),
         ("Python files", "*.py"),
     ]
-    names = g.app.gui.runOpenFileDialog(c,
+    names = g.app.gui.runOpenFilesDialog(c,
         title="Remove Sentinels",
         filetypes=filetypes,
         defaultextension=".py",
-        multiple=True)
+    )
     c.bringToFront()
     if names:
         g.chdir(names[0])

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -134,7 +134,7 @@ def importAnyFile(self: Self, event: LeoKeyEvent = None) -> None:
     """Import one or more files."""
     c = self
     ic = c.importCommands
-    types = [
+    filetypes = [
         ("All files", "*"),
         ("C/C++ files", "*.c"),
         ("C/C++ files", "*.cpp"),
@@ -153,7 +153,7 @@ def importAnyFile(self: Self, event: LeoKeyEvent = None) -> None:
     ]
     names = g.app.gui.runOpenFileDialog(c,
         title="Import File",
-        filetypes=types,
+        filetypes=filetypes,
         defaultextension=".py",
         multiple=True)
     c.bringToFront()
@@ -299,18 +299,18 @@ def new(self: Self, event: LeoKeyEvent = None, gui: LeoGui = None) -> Cmdr:
 def open_outline(self: Self, event: LeoKeyEvent = None) -> None:
     """Open a Leo window containing the contents of a .leo file."""
     c = self
-    table = [
+    filetypes = [
         ("Leo files", "*.leo *.leojs *.db"),
         ("Python files", "*.py"),
         ("All files", "*"),
     ]
     fileName = g.app.gui.runOpenFileDialog(c,
         defaultextension=g.defaultLeoFileExtension(c),
-        filetypes=table,
+        filetypes=filetypes,
         title="Open",
     )
     if fileName:
-        g.openWithFileName(fileName, old_c=c)
+        g.openWithFileName(fileName, old_c=c)  # type:ignore
 #@+node:ekr.20140717074441.17772: *3* c_file.refreshFromDisk
 @g.commander_command('refresh-from-disk')
 def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
@@ -731,7 +731,7 @@ def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
     while removing any sentinels they contain.
     """
     c = self
-    types = [
+    filetypes = [
         ("All files", "*"),
         ("C/C++ files", "*.c"),
         ("C/C++ files", "*.cpp"),
@@ -740,10 +740,11 @@ def removeSentinels(self: Self, event: LeoKeyEvent = None) -> None:
         ("Java files", "*.java"),
         ("Lua files", "*.lua"),
         ("Pascal files", "*.pas"),
-        ("Python files", "*.py")]
+        ("Python files", "*.py"),
+    ]
     names = g.app.gui.runOpenFileDialog(c,
         title="Remove Sentinels",
-        filetypes=types,
+        filetypes=filetypes,
         defaultextension=".py",
         multiple=True)
     c.bringToFront()
@@ -820,13 +821,19 @@ def readFileIntoNode(self: Self, event: LeoKeyEvent = None) -> None:
     u = c.undoer
     undoType = 'Read File Into Node'
     c.endEditing()
-    filetypes = [("All files", "*"), ("Python files", "*.py"), ("Leo files", "*.leo *.leojs"),]
+    filetypes = [
+        ("All files", "*"),
+        ("Python files", "*.py"),
+        ("Leo files", "*.leo *.leojs"),
+    ]
     fileName = g.app.gui.runOpenFileDialog(c,
         title="Read File Into Node",
         filetypes=filetypes,
         defaultextension=None)
     if not fileName:
         return
+    if isinstance(fileName, list):
+        fileName = fileName[0]
     s, e = g.readFileIntoString(fileName)
     if s is None:
         return
@@ -859,7 +866,11 @@ def writeFileFromNode(self: Self, event: LeoKeyEvent = None) -> None:
     if not fileName:
         fileName = g.app.gui.runSaveFileDialog(c,
             title='Write File From Node',
-            filetypes=[("All files", "*"), ("Python files", "*.py"), ("Leo files", "*.leo *.leojs")],
+            filetypes=[
+                ("All files", "*"),
+                ("Python files", "*.py"),
+                ("Leo files", "*.leo *.leojs"),
+            ],
             defaultextension=None)
     if fileName:
         try:
@@ -894,7 +905,11 @@ def writeFileFromSubtree(self: Self, event: LeoKeyEvent = None) -> None:
     if not fileName:
         fileName = g.app.gui.runSaveFileDialog(c,
             title='Write File From Node',
-            filetypes=[("All files", "*"), ("Python files", "*.py"), ("Leo files", "*.leo *.leojs")],
+            filetypes=[
+                ("All files", "*"),
+                ("Python files", "*.py"),
+                ("Leo files", "*.leo *.leojs"),
+            ],
             defaultextension=None)
     if fileName:
         try:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -435,7 +435,10 @@ class EditCommandsClass(BaseEditCommandsClass):
     @cmd('dump-caches')
     def dumpCaches(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """Dump, all of Leo's file caches."""
-        g.app.global_cacher.dump()
+        if hasattr(g.app.global_cacher, 'dump'):
+            g.app.global_cacher.dump()
+        else:
+            g.printObj(g.app.global_cacher)
     #@+node:ekr.20150514063305.118: *3* ec.doNothing
     @cmd('do-nothing')
     def doNothing(self, event: LeoKeyEvent) -> None:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1400,7 +1400,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         c, p = self.c, self.c.p
         iconDir = g.finalize_join(g.app.loadDir, "..", "Icons")
         os.chdir(iconDir)
-        paths = g.app.gui.runOpenFileDialog(c,
+        paths = g.app.gui.runOpenFilesDialog(c,
             title='Get Icons',
             filetypes=[
                 ('All files', '*'),
@@ -1408,7 +1408,8 @@ class EditCommandsClass(BaseEditCommandsClass):
                 ('Bitmap', '*.bmp'),
                 ('Icon', '*.ico'),
             ],
-            defaultextension=None, multiple=True)
+            defaultextension=None,
+        )
         if not paths:
             return
         aList: list[Any] = []

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -269,7 +269,10 @@ class EditFileCommandsClass(BaseEditCommandsClass):
                 return
         else:
             # Prompt for the file to be compared with the present outline.
-            filetypes = [("Leo files", "*.leo *.leojs *.db"), ("All files", "*"),]
+            filetypes = [
+                ("Leo files", "*.leo *.leojs *.db"),
+                ("All files", "*"),
+            ]
             fileName = g.app.gui.runOpenFileDialog(c,
                 title="Compare Leo Files", filetypes=filetypes, defaultextension='.leo')
             if not fileName:

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -181,12 +181,10 @@ class DefaultWrapper(BaseSpellWrapper):
         # pylint: disable=super-init-not-called
         self.c = c
         if not g.app.spellDict:
-            g.app.spellDict = DefaultDict()
-        self.d = g.app.spellDict
+            g.app.spellDict = DefaultDict().d  # 2024/04/09: bug fix.
+        self.d: dict = g.app.spellDict
         self.user_fn = self.find_user_dict()
         if not g.os_path_exists(self.user_fn):
-            # Fix bug 1175013: leo/plugins/spellpyx.txt is
-            # both source controlled and customized.
             self.create(self.user_fn)
         self.main_fn = self.find_main_dict()
         table = (

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -12,7 +12,7 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING, Union
 import zipfile
 import platform
 from leo.core import leoGlobals as g
@@ -25,6 +25,7 @@ StringIO = io.StringIO
 if TYPE_CHECKING:  # pragma: no cover
     from subprocess import Popen
     from types import Module
+    from leo.commands.spellCommands import SqlitePickleShare
     from leo.core.leoBackground import BackgroundProcessManager
     from leo.core.leoCache import GlobalCacher
     from leo.core.leoCommands import Commands as Cmdr
@@ -129,8 +130,8 @@ class LeoApp:
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.
         self.start_minimized = False  # For qt_frame plugin.
-        self.trace_binding: bool = None  # The name of a binding to trace, or None.
-        self.trace_setting: bool = None  # The name of a setting to trace, or None.
+        self.trace_binding: Optional[str] = None  # The name of a binding to trace, or None.
+        self.trace_setting: Optional[str] = None  # The name of a setting to trace, or None.
         self.translateToUpperCase = False  # Never set to True.
         self.useIpython = False  # True: add support for IPython.
         self.use_splash_screen = True  # True: put up a splash screen.
@@ -185,9 +186,9 @@ class LeoApp:
         # Singleton applications objects...
         self.backgroundProcessManager: BackgroundProcessManager = None  # A BackgroundProcessManager.
         self.config: GlobalConfigManager = None  # g.app.config.
-        self.db: dict = None  # A global db, managed by g.app.global_cacher.
+        self.db: Union[dict, SqlitePickleShare] = None  # A global db, managed by g.app.global_cacher.
         self.externalFilesController: ExternalFilesController = None
-        self.global_cacher: GlobalCacher = None
+        self.global_cacher: Union[dict, GlobalCacher] = None
         self.idleTimeManager: IdleTimeManager = None
         self.ipk: InternalIPKernel = None  # A python kernel.
         self.loadManager: LoadManager = None
@@ -1309,7 +1310,8 @@ class LeoApp:
         if not g.app.killed:
             g.doHook("end1")
             if g.app.global_cacher:  # #1766.
-                g.app.global_cacher.commit_and_close()
+                if isinstance(g.app.global_cacher, GlobalCacher):
+                    g.app.global_cacher.commit_and_close()
         if g.app.ipk:
             g.app.ipk.cleanup_consoles()
         g.app.destroyAllOpenWithFiles()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -122,7 +122,7 @@ class LeoApp:
         self.failFast = False  # True: Use the failfast option in unit tests.
         self.gui: LeoGui = None  # The gui class.
         self.guiArgName: str = None  # The gui name given in --gui option.
-        self.ipython_inited = False  # True if leoIpython.py imports succeeded.
+        self.ipython_inited: bool = False  # True if leoIpython.py imports succeeded.
         self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
         self.loaded_session = False  # Set by startup logic to True if no files specified on the command line.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -58,7 +58,7 @@ class IdleTimeManager:
     def __init__(self) -> None:
         """Ctor for IdleTimeManager class."""
         self.callback_list: list[Callable] = []
-        self.timer = None
+        self.timer: IdleTime = None
     #@+others
     #@+node:ekr.20161026125611.1: *3* itm.add_callback
     def add_callback(self, callback: Callable) -> None:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -17,6 +17,7 @@ import zipfile
 import platform
 from leo.core import leoGlobals as g
 from leo.core import leoExternalFiles
+from leo.core.leoCache import GlobalCacher
 from leo.core.leoQt import QCloseEvent
 StringIO = io.StringIO
 #@-<< leoApp imports >>
@@ -27,7 +28,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from types import Module
     from leo.commands.spellCommands import SqlitePickleShare
     from leo.core.leoBackground import BackgroundProcessManager
-    from leo.core.leoCache import GlobalCacher
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoConfig import GlobalConfigManager
     from leo.core.leoExternalFiles import ExternalFilesController

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -185,7 +185,7 @@ class LeoApp:
         # Singleton applications objects...
         self.backgroundProcessManager: BackgroundProcessManager = None  # A BackgroundProcessManager.
         self.config: GlobalConfigManager = None  # g.app.config.
-        self.db: GlobalCacher = None  # A global db, managed by g.app.global_cacher.
+        self.db: dict = None  # A global db, managed by g.app.global_cacher.
         self.externalFilesController: ExternalFilesController = None
         self.global_cacher: GlobalCacher = None
         self.idleTimeManager: IdleTimeManager = None

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -175,7 +175,7 @@ class LeoApp:
         self.leoID: str = None  # The id part of gnx's.
         self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
         self.paste_c: Cmdr = None  # The commander that pasted the last outline.
-        self.spellDict: dict = None  # The singleton PyEnchant spell dict.
+        self.spellDict: Optional[dict] = None  # 2024/04/09: A plain dict.
         self.numberOfUntitledWindows = 0  # Number of opened untitled windows.
         self.windowList: list[LeoFrame] = []  # Global list of all frames.
         self.realMenuNameDict: dict[str, str] = {}  # Translations of menu names.

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -173,8 +173,8 @@ class BridgeController:
         if self.useCaches:
             g.app.setGlobalDb()  # #556.
         else:
-            g.app.db = g.NullObject()
-            g.app.global_cacher = g.NullObject()
+            g.app.db = g.NullObject()  # type:ignore
+            g.app.global_cacher = g.NullObject()  # type:ignore
         if self.readSettings:
             # reads only standard settings files, using a null gui.
             # uses lm.files[0] to compute the local directory

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -8,7 +8,7 @@ import fnmatch
 import os
 import pickle
 import sqlite3
-from typing import Any, Generator, Optional, Sequence, TYPE_CHECKING
+from typing import Any, Generator, Optional, Sequence, TYPE_CHECKING, Union
 import zlib
 from leo.core import leoGlobals as g
 
@@ -78,7 +78,7 @@ class GlobalCacher:
     def __init__(self) -> None:
         """Ctor for the GlobalCacher class."""
         trace = 'cache' in g.app.debug
-        self.db: Any
+        self.db: Union[dict, SqlitePickleShare]
         try:
             path = join(g.app.homeLeoDir, 'db', 'g_app_db')
             if trace:

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -701,13 +701,13 @@ def diff_leo_files_helper(event: LeoKeyEvent, title: str, visible: bool) -> None
     c = event and event.get('c')
     if not c:
         return
-    types = [
+    filetypes = [
         ("Leo files", "*.leo *.leojs *.db"),
         ("All files", "*"),
     ]
     paths = g.app.gui.runOpenFileDialog(c,
         title=title,
-        filetypes=types,
+        filetypes=filetypes,
         defaultextension=".leo",
         multiple=True,
     )
@@ -717,7 +717,7 @@ def diff_leo_files_helper(event: LeoKeyEvent, title: str, visible: bool) -> None
         # Prompt for another file.
         paths2 = g.app.gui.runOpenFileDialog(c,
             title=title,
-            filetypes=types,
+            filetypes=filetypes,
             defaultextension=".leo",
             multiple=True,
         )

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -705,21 +705,19 @@ def diff_leo_files_helper(event: LeoKeyEvent, title: str, visible: bool) -> None
         ("Leo files", "*.leo *.leojs *.db"),
         ("All files", "*"),
     ]
-    paths = g.app.gui.runOpenFileDialog(c,
+    paths = g.app.gui.runOpenFilesDialog(c,
         title=title,
         filetypes=filetypes,
         defaultextension=".leo",
-        multiple=True,
     )
     if not paths:
         return
     if len(paths) == 1:
         # Prompt for another file.
-        paths2 = g.app.gui.runOpenFileDialog(c,
+        paths2 = g.app.gui.runOpensFileDialog(c,
             title=title,
             filetypes=filetypes,
             defaultextension=".leo",
-            multiple=True,
         )
         if not paths2:
             return

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -55,6 +55,7 @@ StringIO = io.StringIO
 #@+<< leoGlobals annotations >>
 #@+node:ekr.20220824084642.1: ** << leoGlobals annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from leo.core.leoApp import LeoApp
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoGui, LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
@@ -347,8 +348,8 @@ url_kinds = '(file|ftp|gopher|http|https|mailto|news|nntp|prospero|telnet|wais)'
 url_regex = re.compile(fr"""\b{url_kinds}://[^\s'"]+""")
 #@-<< define regexes >>
 tree_popup_handlers: list[Callable] = []  # Set later.
-user_dict: dict[Any, Any] = {}  # Non-persistent dictionary for scripts and plugins.
-app: Any = None  # The singleton app object. Set by runLeo.py.
+user_dict: dict[str, Any] = {}  # Non-persistent dictionary for scripts and plugins.
+app: LeoApp = None  # The singleton app object. Set by runLeo.py.
 # Global status vars.
 inScript = False  # A synonym for app.inScript
 unitTesting = False  # A synonym for app.unitTesting.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -61,11 +61,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoGui, LeoKeyEvent, LeoFrame
     from leo.core.leoNodes import Position, VNode
-    from leo.core.leoQt import QMouseEvent, QWidget
+    from leo.core.leoQt import QMouseEvent, QWidget, QEvent
     from leo.plugins.qt_idle_time import IdleTime as QtIdleTime
-    Args = Any
-    KWargs = Any
-    Event = Any
+    # Mypy could do better with *args and **kwargs.
+    Args = Any  # Good enough.
+    KWargs = Any  # Good enough.
 #@-<< leoGlobals annotations >>
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
@@ -588,7 +588,7 @@ class EmergencyDialog:
         self.top.destroy()
         self.top = None
     #@+node:ekr.20120219154958.10497: *4* emergencyDialog.onKey
-    def onKey(self, event: Event) -> None:
+    def onKey(self, event: QEvent) -> None:
         """Handle Key events in askOk dialogs."""
         self.okButton()
     #@+node:ekr.20120219154958.10498: *4* emergencyDialog.run
@@ -1715,7 +1715,7 @@ class TkIDDialog(EmergencyDialog):
 
     #@+others
     #@+node:ekr.20191013145710.1: *4* leo_id_dialog.onKey
-    def onKey(self, event: Event) -> None:
+    def onKey(self, event: QEvent) -> None:
         """Handle Key events in askOk dialogs."""
         if event.char in '\n\r':
             self.okButton()
@@ -1807,7 +1807,7 @@ class Tracer:
         sys.settrace(None)
         self.report()
     #@+node:ekr.20080531075119.6: *4* tracer
-    def tracer(self, frame: LeoFrame, event: Event, arg: Any) -> Optional[Callable]:
+    def tracer(self, frame: LeoFrame, event: QEvent, arg: Any) -> Optional[Callable]:
         """A function to be passed to sys.settrace."""
         n = len(self.stack)
         if event == 'return':
@@ -4475,7 +4475,7 @@ def gitInfo(path: str = None) -> tuple[str, str]:
     return branch, commit
 #@+node:ekr.20031218072017.3139: ** g.Hooks & Plugins
 #@+node:ekr.20101028131948.5860: *3* g.act_on_node
-def dummy_act_on_node(c: Cmdr, p: Position, event: Event) -> None:
+def dummy_act_on_node(c: Cmdr, p: Position, event: QEvent) -> None:
     pass
 
 # This dummy definition keeps pylint happy.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -4558,7 +4558,7 @@ def getLoadedPlugins() -> list:
     pc = g.app.pluginsController
     return pc.getLoadedPlugins()
 
-def getPluginModule(moduleName: str) -> Any:
+def getPluginModule(moduleName: str) -> Optional[Module]:
     pc = g.app.pluginsController
     return pc.getPluginModule(moduleName)
 
@@ -6362,7 +6362,7 @@ def exec_file(path: str, d: dict[str, Any], script: str = None) -> None:
             script = f.read()
     exec(compile(script, path, 'exec'), d)
 #@+node:ekr.20131016032805.16721: *3* g.execute_shell_commands
-def execute_shell_commands(commands: Any, trace: bool = False) -> None:
+def execute_shell_commands(commands: Union[str, list[str]], trace: bool = False) -> None:
     """
     Execute each shell command in a separate process.
     Wait for each command to complete, except those starting with '&'
@@ -7127,7 +7127,7 @@ def handleUnl(unl_s: str, c: Cmdr) -> Optional[Cmdr]:
     c2.redraw(p)
     return c2
 #@+node:tbrown.20090219095555.63: *3* g.handleUrl & helpers
-def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> Any:
+def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> Optional[str]:
     """Open a url or a unl."""
     if c and not p:
         p = c.p

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -409,7 +409,7 @@ class BindingInfo:
         func: Callable = None,
         nextMode: str = None,
         pane: str = None,
-        stroke: "KeyStroke" = None,
+        stroke: KeyStroke = None,
     ) -> None:
         if not g.isStrokeOrNone(stroke):
             g.trace('***** (BindingInfo) oops', repr(stroke))

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -404,7 +404,7 @@ class BindingInfo:
     # Important: The startup code uses this class,
     # so it is convenient to define it in leoGlobals.py.
     #@+others
-    #@+node:ekr.20120129040823.10254: *4* bi.__init__
+    #@+node:ekr.20120129040823.10254: *4* BindingInfo.__init__
     def __init__(
         self,
         kind: str,
@@ -422,10 +422,10 @@ class BindingInfo:
         self.nextMode = nextMode
         self.pane = pane
         self.stroke = stroke  # The *caller* must canonicalize the shortcut.
-    #@+node:ekr.20120203153754.10031: *4* bi.__hash__
+    #@+node:ekr.20120203153754.10031: *4* BindingInfo.__hash__
     def __hash__(self) -> Any:
         return self.stroke.__hash__() if self.stroke else 0
-    #@+node:ekr.20120125045244.10188: *4* bi.__repr__ & ___str_& dump
+    #@+node:ekr.20120125045244.10188: *4* BindingInfo.__repr__ & ___str_& dump
     def __repr__(self) -> str:
         return self.dump()
 
@@ -445,7 +445,7 @@ class BindingInfo:
                     result.append(s)
         # Clearer w/o f-string.
         return "<%s>" % ' '.join(result).strip()
-    #@+node:ekr.20120129040823.10226: *4* bi.isModeBinding
+    #@+node:ekr.20120129040823.10226: *4* BindingInfo.isModeBinding
     def isModeBinding(self) -> bool:
         return self.kind.startswith('*mode')
     #@-others
@@ -1954,7 +1954,7 @@ def null_object_print(id_: int, kind: Any, *args: Any) -> None:
 class UiTypeException(Exception):
     pass
 
-def assertUi(uitype: Any) -> None:
+def assertUi(uitype: str) -> None:
     if not g.app.gui.guiName() == uitype:
         raise UiTypeException
 #@+node:ekr.20200219071828.1: *3* class TestLeoGlobals (leoGlobals.py)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoGui, LeoKeyEvent, LeoFrame
     from leo.core.leoNodes import Position, VNode
     from leo.core.leoQt import QMouseEvent, QWidget
+    from leo.plugins.qt_idle_time import IdleTime as QtIdleTime
     Args = Any
     KWargs = Any
     Event = Any
@@ -4577,7 +4578,7 @@ def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
     """Enable idle-time processing."""
     g.app.idle_time_hooks_enabled = True
 #@+node:ekr.20140825042850.18410: *3* g.IdleTime
-def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> Any:
+def IdleTime(handler: Callable, delay: int = 500, tag: str = None) -> QtIdleTime:
     """
     A thin wrapper for the LeoQtGui.IdleTime class.
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1747,7 +1747,7 @@ class Tracer:
     def __init__(self, limit: int = 0, trace: bool = False, verbose: bool = False) -> None:
         # Keys are function names.
         # Values are the number of times the function was called by the caller.
-        self.callDict: dict[str, Any] = {}
+        self.callDict: dict[str, dict] = {}
         # Keys are function names.
         # Values are the total number of times the function was called.
         self.calledDict: dict[str, int] = {}

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1994,7 +1994,7 @@ class TestLeoGlobals(unittest.TestCase):
 def isTextWidget(w: LeoFrame) -> bool:
     return g.app.gui.isTextWidget(w)
 
-def isTextWrapper(w: Any) -> bool:
+def isTextWrapper(w: LeoFrame) -> bool:
     return g.app.gui.isTextWrapper(w)
 #@+node:ekr.20140711071454.17649: ** g.Debugging, GC, Stats & Timing
 #@+node:ekr.20031218072017.3104: *3* g.Debugging

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5399,17 +5399,17 @@ def es_dump(s: str, n: int = 30, title: str = None) -> None:
         g.es_print('', aList)
         i += n
 #@+node:ekr.20031218072017.3110: *3* g.es_error & es_print_error
-def es_error(*args: Args, **keys: Any) -> None:
-    color = keys.get('color')
+def es_error(*args: Args, **kwargs: KWargs) -> None:
+    color = kwargs.get('color')
     if color is None and g.app.config:
-        keys['color'] = g.app.config.getColor("log-error-color") or 'red'
-    g.es(*args, **keys)
+        kwargs['color'] = g.app.config.getColor("log-error-color") or 'red'
+    g.es(*args, **kwargs)
 
-def es_print_error(*args: Args, **keys: Any) -> None:
-    color = keys.get('color')
+def es_print_error(*args: Args, **kwargs: KWargs) -> None:
+    color = kwargs.get('color')
     if color is None and g.app and g.app.config:
-        keys['color'] = g.app.config.getColor("log-error-color") or 'red'
-    g.es_print(*args, **keys)
+        kwargs['color'] = g.app.config.getColor("log-error-color") or 'red'
+    g.es_print(*args, **kwargs)
 #@+node:ekr.20031218072017.3111: *3* g.es_event_exception
 def es_event_exception(eventName: str, full: bool = False) -> None:
     g.es("exception handling ", eventName, "event")
@@ -5437,25 +5437,25 @@ def es_exception_type(c: Cmdr = None, color: str = "red") -> None:
 #@+node:ekr.20050707064040: *3* g.es_print
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def es_print(*args: Args, **keys: Any) -> None:
+def es_print(*args: Args, **kwargs: KWargs) -> None:
     """
     Print all non-keyword args, and put them to the log pane.
 
     The first, third, fifth, etc. arg translated by g.translateString.
     Supports color, comma, newline, spaces and tabName keyword arguments.
     """
-    g.pr(*args, **keys)
+    g.pr(*args, **kwargs)
     if g.app and not g.unitTesting:
-        g.es(*args, **keys)
+        g.es(*args, **kwargs)
 #@+node:ekr.20050707065530: *3* g.es_trace
-def es_trace(*args: Args, **keys: Any) -> None:
+def es_trace(*args: Args, **kwargs: KWargs) -> None:
     if args:
         try:
             s = args[0]
             g.trace(g.toEncodedString(s, 'ascii'))
         except Exception:
             pass
-    g.es(*args, **keys)
+    g.es(*args, **kwargs)
 #@+node:ekr.20220820050145.1: *3* g.function_name
 def function_name() -> str:
     """Return the name of function or method that called this function."""
@@ -5563,7 +5563,7 @@ def log_to_file(s: str, fn: str = None) -> None:
 #@+node:ekr.20080710101653.1: *3* g.pr
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def pr(*args: Args, **keys: Any) -> None:
+def pr(*args: Args, **kwargs: KWargs) -> None:
     """
     Print all non-keyword args. This is a wrapper for the print statement.
 
@@ -5572,7 +5572,7 @@ def pr(*args: Args, **keys: Any) -> None:
     """
     # Compute the effective args.
     d = {'commas': False, 'newline': True, 'spaces': True}
-    d = doKeywordArgs(keys, d)
+    d = doKeywordArgs(kwargs, d)
     newline = d.get('newline')
     # Unit tests require sys.stdout.
     stdout = sys.stdout if sys.stdout and g.unitTesting else sys.__stdout__
@@ -5677,7 +5677,7 @@ def printLeoModules(message: str = None) -> None:
 def printStack() -> None:
     traceback.print_stack()
 #@+node:ekr.20031218072017.2317: *3* g.trace
-def trace(*args: Args, **keys: Any) -> None:
+def trace(*args: Args, **kwargs: KWargs) -> None:
     """Print the name of the calling function followed by all the args."""
     name = g._callerName(2)
     if name.endswith(".pyc"):
@@ -5940,9 +5940,9 @@ def issueSecurityWarning(setting: str) -> None:
 #@+node:ekr.20031218072017.3144: *3* g.makeDict (Python Cookbook)
 # From the Python cookbook.
 
-def makeDict(**keys: Any) -> dict:
+def makeDict(**kwargs: KWargs) -> dict:
     """Returns a Python dictionary from using the optional keyword arguments."""
-    return keys
+    return kwargs
 #@+node:ekr.20140528065727.17963: *3* g.pep8_class_name
 def pep8_class_name(s: str) -> str:
     """Return the proper class name for s."""
@@ -6110,7 +6110,7 @@ def os_path_isfile(path: str) -> bool:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
 #@+node:ekr.20031218072017.2154: *3* g.os_path_join
-def os_path_join(*args: Args, **keys: Any) -> str:
+def os_path_join(*args: Args, **kwargs: KWargs) -> str:
     """
     Wrap os.path.join, *without* finalizing the result.
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3328,7 +3328,7 @@ def readFileIntoUnicodeString(
 # same.
 #@@c
 
-def readlineForceUnixNewline(f: Any, fileName: Optional[str] = None) -> str:
+def readlineForceUnixNewline(f: IO, fileName: Optional[str] = None) -> str:
     try:
         s = f.readline()
     except UnicodeDecodeError:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1131,7 +1131,7 @@ class MatchBrackets:
         right: int,
         max_right: int,
         expand: bool = False,
-    ) -> tuple[Any, Any, Any, Any]:
+    ) -> tuple[Optional[int], Optional[int], Optional[str], Optional[int]]:
         """
         Find the bracket nearest the cursor searching outwards left and right.
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1173,7 +1173,7 @@ class MatchBrackets:
             return left, right, s[right], right
         return None, None, None, None
     #@+node:ekr.20061113221414: *4* mb.find_matching_bracket
-    def find_matching_bracket(self, ch1: str, s: str, i: int) -> Any:
+    def find_matching_bracket(self, ch1: str, s: str, i: int) -> Optional[int]:
         """Find the bracket matching s[i] for self.language."""
         self.forward = ch1 in self.open_brackets
         # Find the character matching the initial bracket.
@@ -6173,7 +6173,7 @@ def os_path_splitext(path: str) -> tuple[str, str]:
 def os_startfile(fname: str) -> None:
     #@+others
     #@+node:bob.20170516112250.1: *4* stderr2log()
-    def stderr2log(g: Any, ree: Any, fname: str) -> None:
+    def stderr2log(g: LeoGlobals, ree: Any, fname: str) -> None:
         """ Display stderr output in the Leo-Editor log pane
 
         Arguments:
@@ -6192,7 +6192,7 @@ def os_startfile(fname: str) -> None:
             else:
                 break
     #@+node:bob.20170516112304.1: *4* itPoll()
-    def itPoll(fname: str, ree: Any, subPopen: Any, g: Any, ito: Any) -> None:
+    def itPoll(fname: str, ree: Any, subPopen: Any, g: LeoGlobals, ito: Any) -> None:
         """ Poll for subprocess done
 
         Arguments:
@@ -7189,7 +7189,7 @@ def handleUrlHelper(url: str, c: Cmdr, p: Position) -> None:  # pragma: no cover
             webbrowser.open(url)
         except Exception:
             pass
-#@+node:ekr.20170226060816.1: *4* g.traceUrl
+#@+node:ekr.20170226060816.1: *4* g.traceUrl (not used)
 def traceUrl(c: Cmdr, path: str, parsed: Any, url: str) -> None:  # pragma: no cover
 
     print()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -35,7 +35,7 @@ import textwrap
 import time
 import traceback
 import types
-from typing import Any, Generator, Iterable, Optional, Sequence, Union, TYPE_CHECKING
+from typing import Any, Generator, IO, Iterable, Optional, Sequence, Union, TYPE_CHECKING
 import unittest
 import urllib
 import urllib.parse as urlparse
@@ -2166,7 +2166,7 @@ def plugin_date(plugin_mod: Module, format: str = None) -> str:
     root, ext = g.os_path_splitext(theFile)
     return g.file_date(root + ".py", format=str)
 
-def file_date(theFile: Any, format: str = None) -> str:
+def file_date(theFile: IO, format: str = None) -> str:
     if theFile and g.os_path_exists(theFile):
         try:
             n = g.os_path_getmtime(theFile)
@@ -2525,7 +2525,7 @@ def findLanguageDirectives(c: Cmdr, p: Position) -> Optional[str]:
 
     v0 = p.v
 
-    def find_language(p_or_v: Any) -> Optional[str]:
+    def find_language(p_or_v: Union[Position, VNode]) -> Optional[str]:
         for s in p_or_v.h, p_or_v.b:
             for m in g_language_pat.finditer(s):
                 language = m.group(1)
@@ -3031,7 +3031,7 @@ def computeMachineName() -> str:
 def computeStandardDirectories() -> str:
     return g.app.loadManager.computeStandardDirectories()
 #@+node:ekr.20031218072017.3117: *3* g.create_temp_file
-def create_temp_file(textMode: bool = False) -> tuple[Any, str]:
+def create_temp_file(textMode: bool = False) -> tuple[IO, str]:
     """
     Return a tuple (theFile,theFileName)
 

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5979,7 +5979,7 @@ def truncate(s: str, n: int) -> str:
     return s2
 #@+node:ekr.20031218072017.3150: *3* g.windows
 def windows() -> Optional[list]:
-    return app and app.windowList
+    return app.windowList if app else None
 #@+node:ekr.20031218072017.2145: ** g.os_path_ Wrappers
 #@+at Note: all these methods return Unicode strings. It is up to the user to
 # convert to an encoded string as needed, say when opening a file.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -62,6 +62,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoGui, LeoKeyEvent, LeoFrame
     from leo.core.leoNodes import Position, VNode
     from leo.core.leoQt import QMouseEvent
+    Args = Any
+    KWargs = Any
     Event = Any
 #@-<< leoGlobals annotations >>
 in_bridge = False  # True: leoApp object loads a null Gui.
@@ -198,7 +200,7 @@ class Command:
     g can *not* be used anywhere in this class!
     """
 
-    def __init__(self, name: str, **kwargs: Any) -> None:
+    def __init__(self, name: str, **kwargs: KWargs) -> None:
         """Ctor for command decorator class."""
         self.name = name
 
@@ -239,7 +241,7 @@ class CommanderCommand:
     g can *not* be used anywhere in this class!
     """
 
-    def __init__(self, name: str, **kwargs: Any) -> None:
+    def __init__(self, name: str, **kwargs: KWargs) -> None:
         """Ctor for command decorator class."""
         self.name = name
 
@@ -469,7 +471,7 @@ class Bunch:
                 point.isok = True
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: KWargs) -> None:
         self.__dict__.update(kwargs)
 
     def __repr__(self) -> str:
@@ -1563,7 +1565,7 @@ class RedirectClass:
     #@+node:ekr.20041012082437.2: *5* flush
     # For LeoN: just for compatibility.
 
-    def flush(self, *args: Any) -> None:
+    def flush(self, *args: Args) -> None:
         return
     #@+node:ekr.20041012091252: *5* rawPrint
     def rawPrint(self, s: str) -> None:
@@ -1865,9 +1867,9 @@ def startTracer(limit: int = 0, trace: bool = False, verbose: bool = False) -> C
 tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
 class NullObject:
     """An object that does nothing, and does it very well."""
-    def __init__(self, ivars: list[str]=None, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, ivars: list[str]=None, *args: Args, **kwargs: KWargs) -> None:
         pass
-    def __call__(self, *args: Any, **kwargs: Any) -> "NullObject":
+    def __call__(self, *args: Args, **kwargs: KWargs) -> "NullObject":
         return self
     def __repr__(self) -> str:
         return "NullObject"
@@ -1900,9 +1902,9 @@ class NullObject:
 
 class TracingNullObject:
     """Tracing NullObject."""
-    def __init__(self, tag: str, ivars: list[str]=None, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, tag: str, ivars: list[str]=None, *args: Args, **kwargs: KWargs) -> None:
         tracing_tags [id(self)] = tag
-    def __call__(self, *args: Any, **kwargs: Any) -> "TracingNullObject":
+    def __call__(self, *args: Args, **kwargs: KWargs) -> "TracingNullObject":
         return self
     def __repr__(self) -> str:
         return f'TracingNullObject: {tracing_tags.get(id(self), "<NO TAG>")}'
@@ -1941,7 +1943,7 @@ class TracingNullObject:
         g.null_object_print(id(self), '__setitem__')
         # pylint doesn't like trailing return None.
 #@+node:ekr.20190330072832.1: *4* g.null_object_print
-def null_object_print(id_: int, kind: Any, *args: Any) -> None:
+def null_object_print(id_: int, kind: Any, *args: Args) -> None:
     tag = tracing_tags.get(id_, "<NO TAG>")
     callers = g.callers(3).split(',')
     callers_s = ','.join(callers[:-1])
@@ -4483,7 +4485,7 @@ act_on_node = dummy_act_on_node
 childrenModifiedSet: set[VNode] = set()
 contentModifiedSet: set[VNode] = set()
 #@+node:ekr.20031218072017.1596: *3* g.doHook
-def doHook(tag: str, *args: Any, **kwargs: Any) -> Any:
+def doHook(tag: str, *args: Args, **kwargs: KWargs) -> Any:
     """
     This global function calls a hook routine. Hooks are identified by the
     tag param.
@@ -4571,7 +4573,7 @@ def disableIdleTimeHook() -> None:
     """Disable the global idle-time hook."""
     g.app.idle_time_hooks_enabled = False
 #@+node:EKR.20040602125018: *3* g.enableIdleTimeHook
-def enableIdleTimeHook(*args: Any, **kwargs: Any) -> None:
+def enableIdleTimeHook(*args: Args, **kwargs: KWargs) -> None:
     """Enable idle-time processing."""
     g.app.idle_time_hooks_enabled = True
 #@+node:ekr.20140825042850.18410: *3* g.IdleTime
@@ -5322,22 +5324,22 @@ def enl(tabName: str = 'Log') -> None:
         log.newlines += 1
         log.putnl(tabName)
 #@+node:ekr.20100914094836.5892: *3* g.error, g.note, g.warning, g.red, g.blue
-def blue(*args: Any, **kwargs: Any) -> None:
+def blue(*args: Args, **kwargs: KWargs) -> None:
     g.es_print(color='blue', *args, **kwargs)
 
-def error(*args: Any, **kwargs: Any) -> None:
+def error(*args: Args, **kwargs: KWargs) -> None:
     g.es_print(color='error', *args, **kwargs)
 
-def note(*args: Any, **kwargs: Any) -> None:
+def note(*args: Args, **kwargs: KWargs) -> None:
     g.es_print(color='note', *args, **kwargs)
 
-def red(*args: Any, **kwargs: Any) -> None:
+def red(*args: Args, **kwargs: KWargs) -> None:
     g.es_print(color='red', *args, **kwargs)
 
-def warning(*args: Any, **kwargs: Any) -> None:
+def warning(*args: Args, **kwargs: KWargs) -> None:
     g.es_print(color='warning', *args, **kwargs)
 #@+node:ekr.20070626132332: *3* g.es
-def es(*args: Any, **kwargs: Any) -> None:
+def es(*args: Args, **kwargs: KWargs) -> None:
     """Put all non-keyword args to the log pane.
     The first, third, fifth, etc. arg translated by g.translateString.
     Supports color, comma, newline, spaces and tabName keyword arguments.
@@ -5397,13 +5399,13 @@ def es_dump(s: str, n: int = 30, title: str = None) -> None:
         g.es_print('', aList)
         i += n
 #@+node:ekr.20031218072017.3110: *3* g.es_error & es_print_error
-def es_error(*args: Any, **keys: Any) -> None:
+def es_error(*args: Args, **keys: Any) -> None:
     color = keys.get('color')
     if color is None and g.app.config:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
     g.es(*args, **keys)
 
-def es_print_error(*args: Any, **keys: Any) -> None:
+def es_print_error(*args: Args, **keys: Any) -> None:
     color = keys.get('color')
     if color is None and g.app and g.app.config:
         keys['color'] = g.app.config.getColor("log-error-color") or 'red'
@@ -5435,7 +5437,7 @@ def es_exception_type(c: Cmdr = None, color: str = "red") -> None:
 #@+node:ekr.20050707064040: *3* g.es_print
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def es_print(*args: Any, **keys: Any) -> None:
+def es_print(*args: Args, **keys: Any) -> None:
     """
     Print all non-keyword args, and put them to the log pane.
 
@@ -5446,7 +5448,7 @@ def es_print(*args: Any, **keys: Any) -> None:
     if g.app and not g.unitTesting:
         g.es(*args, **keys)
 #@+node:ekr.20050707065530: *3* g.es_trace
-def es_trace(*args: Any, **keys: Any) -> None:
+def es_trace(*args: Args, **keys: Any) -> None:
     if args:
         try:
             s = args[0]
@@ -5514,7 +5516,7 @@ def goto_last_exception(c: Cmdr) -> None:
     else:
         g.trace('No previous exception')
 #@+node:ekr.20100126062623.6240: *3* g.internalError
-def internalError(*args: Any) -> None:
+def internalError(*args: Args) -> None:
     """Report a serious internal error in Leo."""
     callers = g.callers(20).split(',')
     caller = callers[-1]
@@ -5561,7 +5563,7 @@ def log_to_file(s: str, fn: str = None) -> None:
 #@+node:ekr.20080710101653.1: *3* g.pr
 # see: http://www.diveintopython.org/xml_processing/unicode.html
 
-def pr(*args: Any, **keys: Any) -> None:
+def pr(*args: Args, **keys: Any) -> None:
     """
     Print all non-keyword args. This is a wrapper for the print statement.
 
@@ -5675,7 +5677,7 @@ def printLeoModules(message: str = None) -> None:
 def printStack() -> None:
     traceback.print_stack()
 #@+node:ekr.20031218072017.2317: *3* g.trace
-def trace(*args: Any, **keys: Any) -> None:
+def trace(*args: Args, **keys: Any) -> None:
     """Print the name of the calling function followed by all the args."""
     name = g._callerName(2)
     if name.endswith(".pyc"):
@@ -6009,7 +6011,7 @@ def finalize(path: str) -> str:
 
 os_path_finalize = finalize  # Compatibility.
 #@+node:ekr.20230410133838.1: *3* g.finalize_join
-def finalize_join(*args: Any) -> str:
+def finalize_join(*args: Args) -> str:
     """
     Join and finalize. Do not call os.path.realpath.
 
@@ -6108,7 +6110,7 @@ def os_path_isfile(path: str) -> bool:
     """Return True if path is a file."""
     return os.path.isfile(path) if path else False
 #@+node:ekr.20031218072017.2154: *3* g.os_path_join
-def os_path_join(*args: Any, **keys: Any) -> str:
+def os_path_join(*args: Args, **keys: Any) -> str:
     """
     Wrap os.path.join, *without* finalizing the result.
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoGui, LeoKeyEvent, LeoFrame
     from leo.core.leoNodes import Position, VNode
-    from leo.core.leoQt import QMouseEvent
+    from leo.core.leoQt import QMouseEvent, QWidget
     Args = Any
     KWargs = Any
     Event = Any
@@ -5636,7 +5636,7 @@ def print_exception(
     except Exception:
         return "<no file>", 0
 #@+node:ekr.20031218072017.3113: *3* g.printBindings
-def print_bindings(name: str, window: Any) -> None:
+def print_bindings(name: str, window: QWidget) -> None:
     bindings = window.bind()
     g.pr("\nBindings for", name)
     for b in bindings:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -61,6 +61,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoGui, LeoKeyEvent, LeoFrame
     from leo.core.leoNodes import Position, VNode
+    from leo.core.leoQt import QMouseEvent
     Event = Any
 #@-<< leoGlobals annotations >>
 in_bridge = False  # True: leoApp object loads a null Gui.
@@ -3250,7 +3251,7 @@ def readFileIntoString(
     encoding: str = 'utf-8',  # BOM may override this.
     kind: str = None,  # @file, @edit, ...
     verbose: bool = True,
-) -> tuple[Any, Any]:
+) -> tuple[Any, Any]:  # bytes or string.
     """
     Return the contents of the file whose full path is fileName.
 
@@ -7242,7 +7243,7 @@ def openUrl(p: Position) -> None:  # pragma: no cover
                 g.handleUrl(url, c=c, p=p)
             g.doHook("@url2", c=c, p=p, url=url)
 #@+node:ekr.20110605121601.18135: *3* g.openUrlOnClick (open-url-under-cursor)
-def openUrlOnClick(event: Any, url: str = None) -> Optional[str]:  # pragma: no cover
+def openUrlOnClick(event: QMouseEvent, url: str = None) -> Optional[str]:  # pragma: no cover
     """Open the URL under the cursor.  Return it for unit testing."""
     # QTextEditWrapper.mouseReleaseEvent calls this outside Leo's command logic.
     # Make sure to catch all exceptions!
@@ -7252,7 +7253,7 @@ def openUrlOnClick(event: Any, url: str = None) -> Optional[str]:  # pragma: no 
         g.es_exception()
         return None
 #@+node:ekr.20170216091704.1: *4* g.openUrlHelper
-def openUrlHelper(event: Any, url: str = None) -> Optional[str]:
+def openUrlHelper(event: LeoKeyEvent, url: str = None) -> Optional[str]:
     """Open the unl, url or gnx under the cursor.  Return it for unit testing."""
     c = getattr(event, 'c', None)
     if not c:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -163,7 +163,8 @@ class LeoGui:
     def runOpenFileDialog(self,
         c: Cmdr,
         title: str,
-        filetypes: list[str],
+        *,
+        filetypes: list[tuple[str, str]],
         defaultextension: str,
         multiple: bool = False,
         startpath: str = None,
@@ -171,7 +172,14 @@ class LeoGui:
         """Create and run an open file dialog ."""
         raise NotImplementedError
 
-    def runSaveFileDialog(self, c: Cmdr, title: str, filetypes: list[str], defaultextension: str) -> str:
+    def runSaveFileDialog(
+        self,
+        c: Cmdr,
+        title: str,
+        *,
+        filetypes: list[tuple[str, str]],
+        defaultextension: str,
+    ) -> str:
         """Create and run a save file dialog ."""
         raise NotImplementedError
     #@+node:ekr.20031218072017.3732: *4* LeoGui.panels
@@ -394,14 +402,21 @@ class NullGui(LeoGui):
         self,
         c: Cmdr,
         title: str,
-        filetypes: list[str],
-        defaultextension: str,
+        *,
+        filetypes: list[tuple[str, str]] = None,
+        defaultextension: str = '',
         multiple: bool = False,
         startpath: str = None,
     ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.
         return self.simulateDialog("openFileDialog", None)
 
-    def runSaveFileDialog(self, c: Cmdr, title: str, filetypes: list[str], defaultextension: str) -> str:
+    def runSaveFileDialog(self,
+        c: Cmdr,
+        title: str,
+        *,
+        filetypes: list[tuple[str, str]] = None,
+        defaultextension: str = '',
+    ) -> str:
         return self.simulateDialog("saveFileDialog", None)
 
     def runAskYesNoDialog(

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -12,7 +12,7 @@ Plugins may define their own gui classes by setting g.app.gui.
 #@+node:ekr.20220414080546.1: ** << leoGui imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
 
@@ -166,10 +166,20 @@ class LeoGui:
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',
-        multiple: bool = False,
         startpath: str = None,
-    ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.
+    ) -> str:
         """Create and run an open file dialog ."""
+        raise NotImplementedError
+
+    def runOpenFilesDialog(self,
+        c: Cmdr,
+        title: str,
+        *,
+        filetypes: list[tuple[str, str]],
+        defaultextension: str = '',
+        startpath: str = None,
+    ) -> list[str]:
+        """Create and run an open files dialog ."""
         raise NotImplementedError
 
     def runSaveFileDialog(
@@ -368,10 +378,10 @@ class NullGui(LeoGui):
         self.script = None
     #@+node:ekr.20031218072017.3744: *3* NullGui.dialogs
     def runAboutLeoDialog(self, c: Cmdr, version: str, theCopyright: str, url: str, email: str) -> str:
-        return self.simulateDialog("aboutLeoDialog", None)
+        return None
 
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> str:
-        return self.simulateDialog("okDialog", "Ok")
+        return 'Ok'
 
     def runAskOkCancelNumberDialog(
         self,
@@ -381,7 +391,7 @@ class NullGui(LeoGui):
         cancelButtonText: str = None,
         okButtonText: str = None,
     ) -> str:
-        return self.simulateDialog("numberDialog", 'no')
+        return 'no'
 
     def runAskOkCancelStringDialog(
         self,
@@ -393,22 +403,28 @@ class NullGui(LeoGui):
         default: str = "",
         wide: bool = False,
     ) -> str:
-        return self.simulateDialog("stringDialog", '')
+        return ''
 
     def runCompareDialog(self, c: Cmdr) -> str:
-        return self.simulateDialog("compareDialog", '')
+        return ''
 
-    def runOpenFileDialog(
+    def runOpenFileDialog(self, c: Cmdr, title: str, *,
+        filetypes: list[tuple[str, str]] = None,
+        defaultextension: str = '',
+        startpath: str = None,
+    ) -> str:
+        return ''
+
+    def runOpenFilesDialog(
         self,
         c: Cmdr,
         title: str,
         *,
         filetypes: list[tuple[str, str]] = None,
         defaultextension: str = '',
-        multiple: bool = False,
         startpath: str = None,
-    ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.
-        return self.simulateDialog("openFileDialog", None)
+    ) -> list[str]:
+        return []
 
     def runSaveFileDialog(self,
         c: Cmdr,
@@ -416,8 +432,8 @@ class NullGui(LeoGui):
         *,
         filetypes: list[tuple[str, str]] = None,
         defaultextension: str = '',
-    ) -> str:
-        return self.simulateDialog("saveFileDialog", None)
+    ) -> list[str]:
+        return ''
 
     def runAskYesNoDialog(
         self,
@@ -427,7 +443,7 @@ class NullGui(LeoGui):
         yes_all: bool = False,
         no_all: bool = False,
     ) -> str:
-        return self.simulateDialog("yesNoDialog", "no")
+        return 'no'
 
     def runAskYesNoCancelDialog(
         self,
@@ -440,10 +456,7 @@ class NullGui(LeoGui):
         defaultButton: str = "Yes",
         cancelMessage: str = None,
     ) -> str:
-        return self.simulateDialog("yesNoCancelDialog", "cancel")
-
-    def simulateDialog(self, key: str, defaultVal: str) -> str:
-        return defaultVal
+        return 'cancel'
     #@+node:ekr.20170613101737.1: *3* NullGui.clipboard & focus
     def get_focus(self, *args: str, **kwargs: str) -> Widget:
         return self.focusWidget

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -153,7 +153,7 @@ class LeoGui:
 
     def runPropertiesDialog(self,
         title: str = 'Properties',
-        data: str = None,
+        data: Any = None,
         callback: Callable = None,
         buttons: list[str] = None,
     ) -> Any:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -165,7 +165,7 @@ class LeoGui:
         title: str,
         *,
         filetypes: list[tuple[str, str]],
-        defaultextension: str,
+        defaultextension: str = '',
         multiple: bool = False,
         startpath: str = None,
     ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -415,6 +415,15 @@ class NullGui(LeoGui):
     ) -> str:
         return ''
 
+    def runSaveFileDialog(self,
+        c: Cmdr,
+        title: str,
+        *,
+        filetypes: list[tuple[str, str]] = None,
+        defaultextension: str = '',
+    ) -> str:
+        return ''
+
     def runOpenFilesDialog(
         self,
         c: Cmdr,
@@ -426,14 +435,6 @@ class NullGui(LeoGui):
     ) -> list[str]:
         return []
 
-    def runSaveFileDialog(self,
-        c: Cmdr,
-        title: str,
-        *,
-        filetypes: list[tuple[str, str]] = None,
-        defaultextension: str = '',
-    ) -> list[str]:
-        return ''
 
     def runAskYesNoDialog(
         self,

--- a/leo/core/leoIPython.py
+++ b/leo/core/leoIPython.py
@@ -42,7 +42,7 @@ except ImportError:
     IPKernelApp = None  # type:ignore
     import_fail('IPKernelApp')
 
-g.app.ipython_inited = IPKernelApp is not None
+g.app.ipython_inited = bool(IPKernelApp is not None)
 #@-<< leoIPython imports >>
 #@+<< leoIPython annotations >>
 #@+node:ekr.20220901090431.1: ** << leoIPython annotations >>

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -120,13 +120,13 @@ class FreeMindImporter:
             g.trace("FreeMind importer requires lxml")
             return
         c = self.c
-        types = [
+        filetypes = [
             ("FreeMind files", "*.mm.html"),
             ("All files", "*"),
         ]
         names = g.app.gui.runOpenFileDialog(c,
             title="Import FreeMind File",
-            filetypes=types,
+            filetypes=filetypes,
             defaultextension=".html",
             multiple=True)
         c.bringToFront()
@@ -1308,13 +1308,13 @@ class MindMapImporter:
     def prompt_for_files(self) -> None:
         """Prompt for a list of MindJet (.csv) files and import them."""
         c = self.c
-        types = [
+        filetypes = [
             ("MindJet files", "*.csv"),
             ("All files", "*"),
         ]
         names = g.app.gui.runOpenFileDialog(c,
             title="Import MindJet File",
-            filetypes=types,
+            filetypes=filetypes,
             defaultextension=".csv",
             multiple=True)
         c.bringToFront()
@@ -1387,12 +1387,12 @@ class MORE_Importer:
     def prompt_for_files(self) -> None:
         """Prompt for a list of MORE files and import them."""
         c = self.c
-        types = [
+        filetypes = [
             ("All files", "*"),
         ]
         names = g.app.gui.runOpenFileDialog(c,
             title="Import MORE Files",
-            filetypes=types,
+            filetypes=filetypes,
             # defaultextension=".txt",
             multiple=True)
         c.bringToFront()
@@ -2515,13 +2515,13 @@ class LegacyExternalFileImporter:
     def prompt_for_files(self) -> None:
         """Prompt for a list of legacy external .py files and import them."""
         c = self.c
-        types = [
+        filetypes = [
             ("Legacy external files", "*.py"),
             ("All files", "*"),
         ]
         paths = g.app.gui.runOpenFileDialog(c,
             title="Import Legacy External Files",
-            filetypes=types,
+            filetypes=filetypes,
             defaultextension=".py",
             multiple=True)
         c.bringToFront()

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -124,11 +124,11 @@ class FreeMindImporter:
             ("FreeMind files", "*.mm.html"),
             ("All files", "*"),
         ]
-        names = g.app.gui.runOpenFileDialog(c,
+        names = g.app.gui.runOpenFilesDialog(c,
             title="Import FreeMind File",
             filetypes=filetypes,
             defaultextension=".html",
-            multiple=True)
+        )
         c.bringToFront()
         if names:
             g.chdir(names[0])
@@ -1312,11 +1312,11 @@ class MindMapImporter:
             ("MindJet files", "*.csv"),
             ("All files", "*"),
         ]
-        names = g.app.gui.runOpenFileDialog(c,
+        names = g.app.gui.runOpenFilesDialog(c,
             title="Import MindJet File",
             filetypes=filetypes,
             defaultextension=".csv",
-            multiple=True)
+        )
         c.bringToFront()
         if names:
             g.chdir(names[0])
@@ -1390,11 +1390,11 @@ class MORE_Importer:
         filetypes = [
             ("All files", "*"),
         ]
-        names = g.app.gui.runOpenFileDialog(c,
+        names = g.app.gui.runOpenFilesDialog(c,
             title="Import MORE Files",
             filetypes=filetypes,
             # defaultextension=".txt",
-            multiple=True)
+        )
         c.bringToFront()
         if names:
             g.chdir(names[0])
@@ -1956,11 +1956,11 @@ class TabImporter:
         types = [
             ("All files", "*"),
         ]
-        names = g.app.gui.runOpenFileDialog(c,
+        names = g.app.gui.runOpenFilesDialog(c,
             title="Import Tabbed File",
             filetypes=types,
             defaultextension=".html",
-            multiple=True)
+        )
         c.bringToFront()
         if names:
             g.chdir(names[0])
@@ -2149,11 +2149,10 @@ class ToDoImporter:
             ("Text files", "*.txt"),
             ("All files", "*"),
         ]
-        names = g.app.gui.runOpenFileDialog(c,
+        names = g.app.gui.runOpenFilesDialog(c,
             title="Import todo.txt File",
             filetypes=types,
             defaultextension=".txt",
-            multiple=True,
         )
         c.bringToFront()
         if not names:
@@ -2519,11 +2518,11 @@ class LegacyExternalFileImporter:
             ("Legacy external files", "*.py"),
             ("All files", "*"),
         ]
-        paths = g.app.gui.runOpenFileDialog(c,
+        paths = g.app.gui.runOpenFilesDialog(c,
             title="Import Legacy External Files",
             filetypes=filetypes,
             defaultextension=".py",
-            multiple=True)
+        )
         c.bringToFront()
         if paths:
             g.chdir(paths[0])

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2579,8 +2579,8 @@ class KeyHandlerClass:
                 c = p.v.context
                 tag = 'M' if c.shortFileName().endswith('myLeoSettings.leo') else 'G'
                 data.append((p.h, tag),)
-        for aList in [g.app.config.atLocalButtonsList, g.app.config.atLocalCommandsList]:
-            for p in aList:
+        for aList2 in [g.app.config.atLocalButtonsList, g.app.config.atLocalCommandsList]:
+            for p in aList2:
                 data.append((p.h, 'L'),)
         result = [f"{z[1]} {z[0]}" for z in sorted(data)]
         result.extend([

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -600,7 +600,7 @@ class LeoMenu:
         cmn = self.canonicalizeTranslatedMenuName(menuName)
         return g.app.realMenuNameDict.get(cmn, menuName)
 
-    def setRealMenuName(self, untrans: str, trans: list) -> None:
+    def setRealMenuName(self, untrans: str, trans: str) -> None:
         cmn = self.canonicalizeTranslatedMenuName(untrans)
         g.app.realMenuNameDict[cmn] = trans
 

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -9,7 +9,7 @@ import copy
 import os
 import time
 import uuid
-from typing import Any, Generator, Optional, TYPE_CHECKING
+from typing import Any, Generator, Iterable, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import signal_manager
 
@@ -2089,7 +2089,7 @@ class VNode:
         return {}
     #@+node:ekr.20031218072017.3346: *3* v.Comparisons
     #@+node:ekr.20040705201018: *4* v.findAtFileName
-    def findAtFileName(self, names: tuple, h: Optional[str] = None) -> str:
+    def findAtFileName(self, names: Iterable, h: Optional[str] = None) -> str:
         """Return the name following one of the names in nameList or """
         # Allow h argument for unit testing.
         if not h:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -487,6 +487,8 @@ class LeoPluginsController:
         Using a module name allows plugins to be loaded from outside the leo/plugins directory.
         """
         global optional_modules
+        
+        moduleName: str
 
         trace = verbose or 'plugins' in g.app.debug
 

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -487,7 +487,7 @@ class LeoPluginsController:
         Using a module name allows plugins to be loaded from outside the leo/plugins directory.
         """
         global optional_modules
-        
+
         moduleName: str
 
         trace = verbose or 'plugins' in g.app.debug

--- a/leo/plugins/bigdash.py
+++ b/leo/plugins/bigdash.py
@@ -37,6 +37,7 @@ Requires the whoosh library ('easy_install whoosh') to do full text searches.
 #@+node:ekr.20140920041848.17949: ** << imports >> (bigdash.py)
 import os
 import sys
+from typing import Any
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets
 # This code no longer uses leo.plugins.leofts.
@@ -326,7 +327,7 @@ class GlobalSearch:
             return
         s = ss[2:]
         for ndxc, c2 in enumerate(g.app.commanders()):
-            hits = c2.find_b(s)
+            hits: Any = c2.find_b(s)  # type:ignore
             for ndxh, h in enumerate(hits):
                 b = h[0].b
                 mlines = self.matchlines(b, h[1])  # [1] Contains matchiter

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -315,14 +315,16 @@ def openwith_rclick(c: Cmdr, p: Position, menu: Wrapper) -> None:
 
         aList = g.get_directives_dict_list(p)
         path = c.scanAtPathDirectives(aList) + "/"
-        table = [
+        filetypes = [
             ("All files", "*"),
             ("Python files", "*.py"),
         ]
         fnames = g.app.gui.runOpenFileDialog(c,
-            title="Import files", filetypes=table,
+            title="Import files",
+            filetypes=filetypes,
             defaultextension='.notused',
-            multiple=True, startpath=path)
+            multiple=True,
+            startpath=path)
         adds = [guess_file_type(pth) + " " + shorten(pth, path) for pth in fnames]
         for a in adds:
             chi = p.insertAsLastChild()

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -319,12 +319,12 @@ def openwith_rclick(c: Cmdr, p: Position, menu: Wrapper) -> None:
             ("All files", "*"),
             ("Python files", "*.py"),
         ]
-        fnames = g.app.gui.runOpenFileDialog(c,
+        fnames = g.app.gui.runOpenFilesDialog(c,
             title="Import files",
             filetypes=filetypes,
             defaultextension='.notused',
-            multiple=True,
-            startpath=path)
+            startpath=path,
+        )
         adds = [guess_file_type(pth) + " " + shorten(pth, path) for pth in fnames]
         for a in adds:
             chi = p.insertAsLastChild()

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -111,7 +111,13 @@ class textGui(leoGui.LeoGui):
         self.text_run()
     #@+node:ekr.20150107090324.16: *3* runOpenFileDialog
     def runOpenFileDialog(self,
-        c, title, filetypes, defaultextension, multiple=False, startpath=None,
+        c,
+        title,
+        *,
+        filetypes: list[tuple[str, str]],
+        defaultextension,
+        multiple=False,
+        startpath=None,
     ) -> str:
         initialdir = g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
         ret = get_input("Open which %s file (from %s?) > " % (repr(filetypes), initialdir))

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -109,20 +109,17 @@ class textGui(leoGui.LeoGui):
     #@+node:ekr.20150107090324.15: *3* runMainLoop
     def runMainLoop(self):
         self.text_run()
-    #@+node:ekr.20150107090324.16: *3* runOpenFileDialog
+    #@+node:ekr.20150107090324.16: *3* runOpenFileDialog (cursesGui2)
     def runOpenFileDialog(self,
         c,
         title,
         *,
         filetypes: list[tuple[str, str]],
         defaultextension,
-        multiple=False,
         startpath=None,
     ) -> str:
         initialdir = g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
         ret = get_input("Open which %s file (from %s?) > " % (repr(filetypes), initialdir))
-        if multiple:
-            return [ret,]
         return ret
     #@+node:ekr.20150107090324.18: *3* text_run & helper
     def text_run(self):

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1741,7 +1741,7 @@ class LeoCursesGui(leoGui.LeoGui):
         title: str,
         *,
         filetypes: list[tuple[str, str]],
-        defaultextension: str,
+        defaultextension: str = '',
         multiple: bool = False,
         startpath: str = None,
     ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1735,20 +1735,30 @@ class LeoCursesGui(leoGui.LeoGui):
         self.in_dialog = False
         return 'yes' if val else 'no'
 
-    #@+node:ekr.20171126182120.9: *5* CGui.runOpenFileDialog
+    #@+node:ekr.20171126182120.9: *5* CGui.runOpenFileDialog & runOpenFilesDialog
     def runOpenFileDialog(self,
         c: Cmdr,
         title: str,
         *,
         filetypes: list[tuple[str, str]],
         defaultextension: str = '',
-        multiple: bool = False,
         startpath: str = None,
-    ) -> Union[list[str], str]:  # Return type depends on the evil multiple keyword.
+    ) -> str:
         if not g.unitTesting:
             g.trace('not ready yet', title)
         return ''
 
+    def runOpenFilesDialog(self,
+        c: Cmdr,
+        title: str,
+        *,
+        filetypes: list[tuple[str, str]],
+        defaultextension: str = '',
+        startpath: str = None,
+    ) -> list[str]:
+        if not g.unitTesting:
+            g.trace('not ready yet', title)
+        return []
     #@+node:ekr.20171126182120.10: *5* CGui.runPropertiesDialog
     def runPropertiesDialog(
         self,

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1739,7 +1739,8 @@ class LeoCursesGui(leoGui.LeoGui):
     def runOpenFileDialog(self,
         c: Cmdr,
         title: str,
-        filetypes: list[str],
+        *,
+        filetypes: list[tuple[str, str]],
         defaultextension: str,
         multiple: bool = False,
         startpath: str = None,
@@ -1761,7 +1762,13 @@ class LeoCursesGui(leoGui.LeoGui):
             g.trace('not ready yet', title)
 
     #@+node:ekr.20171126182120.11: *5* CGui.runSaveFileDialog
-    def runSaveFileDialog(self, c: Cmdr, title: str, filetypes: list[str], defaultextension: str) -> str:
+    def runSaveFileDialog(self,
+        c: Cmdr,
+        title: str,
+        *,
+        filetypes: list[tuple[str, str]],
+        defaultextension: str,
+    ) -> str:
         if g.unitTesting:
             return None
         # Not tested.

--- a/leo/plugins/import_cisco_config.py
+++ b/leo/plugins/import_cisco_config.py
@@ -68,7 +68,7 @@ def importCiscoConfig(c):
 
     name = g.app.gui.runOpenFileDialog(c,
         title="Import Cisco Configuration File",
-        filetypes=[("All files", "*")],
+        filetypes=[("All files", "*"),],
         defaultextension='ini',
     )
 
@@ -80,7 +80,7 @@ def importCiscoConfig(c):
     c.redraw()
 
     try:
-        fh = open(name)
+        fh = open(name)  # type:ignore
         g.es("importing: %s" % name)
         linelist = fh.read().splitlines()
         fh.close()

--- a/leo/plugins/leo_babel/tests/tests.py
+++ b/leo/plugins/leo_babel/tests/tests.py
@@ -71,7 +71,8 @@ def main():
     """
 
     args = cmdLineHandler()
-    leoG.IdleTime = idle_time.IdleTime
+    # 2024/04/09: This statement is almost certainly wrong.
+    # leoG.IdleTime = idle_time.IdleTime
     bridge = leoBridge.controller(gui='nullGui', silent=True,
         verbose=False, loadPlugins=True, readSettings=True)
     cmdrT = bridge.openLeoFile(args.fpnTests)

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -225,7 +225,7 @@ def init() -> bool:
     if g.app.gui is None:
         g.app.createQtGui(__file__)
     # This plugin is now gui-independent.
-    ok = g.app.gui and g.app.gui.guiName() in ('qt', 'nullGui')
+    ok = bool(g.app.gui) and g.app.gui.guiName() in ('qt', 'nullGui')
     if ok:
         sc = 'ScriptingControllerClass'
         if (not hasattr(g.app.gui, sc) or

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -139,7 +139,7 @@ def createPluginsMenu(tag: str, keywords: Any) -> None:
         def key(aList: list) -> str:
             return aList.split('.')[-1].lower()
 
-        impModSpecList.sort(key=key)
+        impModSpecList.sort(key=key)  # type:ignore
         plgObList: list[PlugIn] = [PlugIn(lmd[impModSpec], c) for impModSpec in impModSpecList]
         c.pluginsMenu = pluginMenu = c.frame.menu.createNewMenu(menu_name)
         # 2013/12/13: Add any items in @menu plugins

--- a/leo/plugins/projectwizard.py
+++ b/leo/plugins/projectwizard.py
@@ -83,11 +83,12 @@ def project_wizard(event):
     """ Launch project wizard """
     import os
     c = event['c']
-    table = [("All files", "*"),
-        ("Python files", "*.py"),]
-
+    filetypes = [
+        ("All files", "*"),
+        ("Python files", "*.py"),
+    ]
     fname = g.app.gui.runOpenFileDialog(c,
-        title="Open", filetypes=table, defaultextension=".leo")
+        title="Open", filetypes=filetypes, defaultextension=".leo")
 
     pth = os.path.dirname(os.path.abspath(fname))
 
@@ -105,7 +106,7 @@ def rclick_path_importfile(c, p, menu):
     def importfiles_rclick_cb():
         aList = g.get_directives_dict_list(p)
         path = c.scanAtPathDirectives(aList)
-        table = [
+        filetypes = [
             ("All files", "*"),
             ("Python files", "*.py"),
         ]
@@ -113,7 +114,7 @@ def rclick_path_importfile(c, p, menu):
         # files = g.app.gui.runOpenFileDialog(c,
         g.app.gui.runOpenFileDialog(c,
             title="Import files",
-            filetypes=table,
+            filetypes=filetypes,
             defaultextension='.notused',
             multiple=True)
         print("import files from", path)

--- a/leo/plugins/projectwizard.py
+++ b/leo/plugins/projectwizard.py
@@ -90,7 +90,7 @@ def project_wizard(event):
     fname = g.app.gui.runOpenFileDialog(c,
         title="Open", filetypes=filetypes, defaultextension=".leo")
 
-    pth = os.path.dirname(os.path.abspath(fname))
+    pth = os.path.dirname(os.path.abspath(fname))  # type:ignore
 
     g.es(pth)
     tgt = c.currentPosition().insertAsLastChild()

--- a/leo/plugins/projectwizard.py
+++ b/leo/plugins/projectwizard.py
@@ -110,13 +110,11 @@ def rclick_path_importfile(c, p, menu):
             ("All files", "*"),
             ("Python files", "*.py"),
         ]
-        # This is incomplete: files is not used.
-        # files = g.app.gui.runOpenFileDialog(c,
-        g.app.gui.runOpenFileDialog(c,
+        g.app.gui.runOpenFilesDialog(c,
             title="Import files",
             filetypes=filetypes,
             defaultextension='.notused',
-            multiple=True)
+        )
         print("import files from", path)
 
     action = menu.addAction("Import files")

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -234,7 +234,7 @@ class LeoQtGui(leoGui.LeoGui):
         finally:
             c.in_qt_dialog = False
     #@+node:ekr.20110605121601.18489: *4* qt_gui.makeFilter
-    def makeFilter(self, filetypes: list[str]) -> str:
+    def makeFilter(self, filetypes: list[tuple[str, str]]) -> str:
         """Return the Qt-style dialog filter from filetypes list."""
         # Careful: the second %s is *not* replaced.
         filters = ['%s (%s)' % (z) for z in filetypes]

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -667,7 +667,8 @@ class LeoQtGui(leoGui.LeoGui):
         self,
         c: Cmdr,
         title: str,
-        filetypes: list[str],
+        *,
+        filetypes: list[tuple[str, str]],
         defaultextension: str = '',
         multiple: bool = False,
         startpath: str = None,
@@ -721,9 +722,12 @@ class LeoQtGui(leoGui.LeoGui):
         if not g.unitTesting:
             g.warning('Properties menu not supported for Qt gui')
         return 'Cancel', {}
-    #@+node:ekr.20110605121601.18502: *4* qt_gui.runSaveFileDialog (changed)
+    #@+node:ekr.20110605121601.18502: *4* qt_gui.runSaveFileDialog
     def runSaveFileDialog(self,
-        c: Cmdr, title: str = 'Save', filetypes: list[str] = None, defaultextension: str = '',
+        c: Cmdr,
+        title: str = 'Save',
+        filetypes: list[tuple[str, str]] = None,
+        defaultextension: str = '',
     ) -> str:
         """Create and run an Qt save file dialog ."""
         if g.unitTesting:

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -117,7 +117,7 @@ def dumpfocus() -> None:
     g.es("Focus: " + f)
     print("Focus: " + f)
 #@+node:ville.20090314215508.8: *3* init (quicksearch.py)
-def init() -> None:
+def init() -> bool:
     """Return True if the plugin has loaded successfully."""
     ok = g.app.gui.guiName() == "qt"
     if ok:

--- a/leo/plugins/xml_edit.py
+++ b/leo/plugins/xml_edit.py
@@ -112,7 +112,7 @@ tail_sentinel = """
 """
 
 # for file open/save dialog
-table = [
+filetypes = [
     ("XML files", "*.xml"),
     ("All files", "*"),
 ]
@@ -238,7 +238,7 @@ def leo2xml(event):
 
     cd_here(c, p)
     file_name = g.app.gui.runSaveFileDialog(
-            c, title="Open", filetypes=table, defaultextension=".xml")
+        c, title="Open", filetypes=filetypes, defaultextension=".xml")
     if not file_name:
         raise ImportError("No file selected")
 
@@ -293,7 +293,7 @@ def xml2leo(event, from_string=None):
         parser_func = etree.parse
         cd_here(c, p)
         file_name = g.app.gui.runOpenFileDialog(
-                c, title="Open", filetypes=table, defaultextension=".xml")
+                c, title="Open", filetypes=filetypes, defaultextension=".xml")
 
         if not file_name:
             raise ImportError("No file selected")

--- a/leo/plugins/zenity_file_dialogs.py
+++ b/leo/plugins/zenity_file_dialogs.py
@@ -60,12 +60,23 @@ def callZenity(title, multiple=False, save=False, test=False):
         return filename.split('|')  # type:ignore
     return filename
 #@+node:ekr.20101110095557.5894: ** runOpenFileDialog
-def runOpenFileDialog(title=None, filetypes=None, defaultextension=None, multiple=False):
+def runOpenFileDialog(
+    title,
+    *,
+    filetypes: list[tuple[str, str]] = None,
+    defaultextension=None,
+    multiple=False,
+):
     """Call zenity's open file(s) dialog."""
     # initialdir = g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
     return callZenity(title, multiple=multiple)
 #@+node:ekr.20101110095557.5896: ** runSaveFileDialog
-def runSaveFileDialog(title=None, filetypes=None, defaultextension=None) -> str:
+def runSaveFileDialog(
+    title=None,
+    *,
+    filetypes: list[tuple[str, str]] = None,
+    defaultextension=None,
+) -> str:
     """Call zenity's save file dialog."""
     # initialdir=g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
     return callZenity(title, save=True)

--- a/leo/plugins/zenity_file_dialogs.py
+++ b/leo/plugins/zenity_file_dialogs.py
@@ -12,6 +12,7 @@ tk dialogs.
 
 """
 import subprocess
+from typing import Optional
 from leo.core import leoGlobals as g
 from leo.core import leoPlugins
 trace = False
@@ -43,21 +44,21 @@ def onStart2(tag, keywords):
     g.funcToMethod(runOpenFileDialog, g.app.gui)
     g.funcToMethod(runSaveFileDialog, g.app.gui)
 #@+node:ekr.20101110095557.5892: ** callZenity
-def callZenity(title, multiple=False, save=False, test=False):
+def callZenity(title: str, save: bool = False, test: bool = False) -> Optional[bytes]:
 
     command = ['zenity', '--file-selection', '--title=%s' % title]
     if save:
         command.append('--save')
-    if multiple:
-        command.append('--multiple')
+    # if multiple:
+        # command.append('--multiple')
     o = subprocess.Popen(command, stdout=subprocess.PIPE)
     o.wait()
     filename = o.communicate()[0].rstrip()
     ret = o.returncode
     if ret:
-        return ''
-    if multiple:
-        return filename.split('|')  # type:ignore
+        return None
+    # if multiple:
+        # return filename.split('|')  # type:ignore
     return filename
 #@+node:ekr.20101110095557.5894: ** runOpenFileDialog
 def runOpenFileDialog(
@@ -65,18 +66,17 @@ def runOpenFileDialog(
     *,
     filetypes: list[tuple[str, str]] = None,
     defaultextension=None,
-    multiple=False,
 ):
     """Call zenity's open file(s) dialog."""
     # initialdir = g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
-    return callZenity(title, multiple=multiple)
+    return callZenity(title)
 #@+node:ekr.20101110095557.5896: ** runSaveFileDialog
 def runSaveFileDialog(
     title=None,
     *,
     filetypes: list[tuple[str, str]] = None,
     defaultextension=None,
-) -> str:
+) -> bytes:
     """Call zenity's save file dialog."""
     # initialdir=g.app.globalOpenDir or g.os_path_abspath(os.getcwd())
     return callZenity(title, save=True)

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -21,7 +21,7 @@ print(os.path.basename(__file__))
 os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
 
 # Beautify all, and always issue a report.
-args = '--all --beautified --write --report'
+args = '--all --beautified --write'  #  --report'
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 


### PR DESCRIPTION
This PR is a milestone in Leo's history. All annotations in `leoGlobals.py` are as accurate as they can be.

The only minor exception is the annotation of `*args` and `**kwargs`. Imo, the typing module should provide help.

- [x] Annotate `g.app` as `LeoApp`. 
    **Breakthrough**: This annotation allowed mypy to check all other Leo files more thoroughly!
- [x] Remove evil `multiple` kwarg from `runOpenFileDialog`. Add `runOpenFilesDialog`.
    This is a (minor) breaking change to Leo's API.
- [x] Fix all resulting mypy complaints.

**Significantly improved annotations**

- `leoApp.py`: Improve annotations of `g.app.db` and `g.app.global_cacher`.
- `leoConfig.py`: Improve annotations of ivars and methods related to buttons and commands.
- `leoCache.py`: Annotate `GlobalCacher.db` as `Union[dict, SqlitePickleShare]`.
- `commands/editCommands.py: dump_caches`: Add a guard.
- `leoGlobals.py`:  It is *thrilling* to be able to disambiguate the following:
  - Use `LeoKeyEvent`, `QEvent`, `QMouseEvent`, `LeoFrame`, `QFrame` as `QWidget` as appropriate.
  - Use `IO`,  `Module` and `Union` annotations as appropriate.
 
**Bugs found and fixed**

Most of the diffs involve only annotations.  Here are real bugs:

- `leoApp.py: LeoApp.finishQuit`: Add a guard.
- `checkerCommands.py: MypyCommand.check_file`: pass a string, not a list, to `bpm.start_process`.
- `spellCommands.py: DefaultWrapper. __init__`: Set `g.app.spellDict = DefaultDict().d`.
- `leo.plugins.leo_babel.tests: test.py`: Don't patch `g.IdleTime`.