### PR TITLE
Annotate leo/core/leoFileCommands.py

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -2008,7 +2008,7 @@ class FileCommands:
                 # This prevents the file from being written.
                 raise BadLeoFile(f"no VNode for {repr(index)}")
     #@+node:ekr.20050418161620.2: *5* fc.putUaHelper
-    def putUaHelper(self, torv: VNode, key: str, val: Any) -> str:
+    def putUaHelper(self, v: VNode, key: str, val: Any) -> str:
         """Put attribute whose name is key and value is val to the output stream."""
         # New in 4.3: leave string attributes starting with 'str_' alone.
         if key.startswith('str_'):
@@ -2017,7 +2017,7 @@ class FileCommands:
                 attr = f' {key}={xml.sax.saxutils.quoteattr(val)}'
                 return attr
             g.trace(type(val), repr(val))
-            g.warning("ignoring non-string attribute", key, "in", torv)
+            g.warning("ignoring non-string attribute", key, "in", v)
             return ''
         # Support JSON encoded attributes
         if key.startswith('json_'):
@@ -2026,11 +2026,11 @@ class FileCommands:
             except TypeError:
                 # fall back to pickle
                 g.trace(type(val), repr(val))
-                g.warning("pickling JSON incompatible attribute", key, "in", torv)
+                g.warning("pickling JSON incompatible attribute", key, "in", v)
             else:
                 attr = f' {key}={xml.sax.saxutils.quoteattr(val)}'
                 return attr
-        return self.pickle(v=torv, val=val, tag=key)
+        return self.pickle(v=v, val=val, tag=key)
     #@+node:EKR.20040526202501: *5* fc.putUnknownAttributes
     def putUnknownAttributes(self, v: VNode) -> str:
         """Put pickleable values for all keys in v.unknownAttributes dictionary."""

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
     Conn = sqlite3.Connection
+    Element = Any
 #@-<< leoFileCommands annotations >>
 #@+others
 #@+node:ekr.20150509194827.1: ** cmd (decorator)
@@ -319,7 +320,7 @@ class FastRead:
         c, fc = self.c, self.c.fileCommands
         #@+<< define v_element_visitor >>
         #@+node:ekr.20180605102822.1: *5* << define v_element_visitor >>
-        def v_element_visitor(parent_e: Any, parent_v: VNode) -> None:
+        def v_element_visitor(parent_e: Element, parent_v: VNode) -> None:
             """Visit the given element, creating or updating the parent vnode."""
             for e in parent_e:
                 assert e.tag in ('v', 'vh'), e.tag
@@ -512,7 +513,7 @@ class FastRead:
 
         c, fc = self.c, self.c.fileCommands
 
-        def v_element_visitor(parent_e: Any, parent_v: VNode) -> None:
+        def v_element_visitor(parent_e: Element, parent_v: VNode) -> None:
             """Visit the given element, creating or updating the parent vnode."""
             for i, v_dict in enumerate(parent_e):
                 # Get the gnx.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -18,7 +18,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, IO, Optional, Union, TYPE_CHECKING
 import zipfile
 import xml.etree.ElementTree as ElementTree
 import xml.sax
@@ -96,7 +96,7 @@ class FastRead:
 
     #@+others
     #@+node:ekr.20180604110143.1: *3* fast.readFile
-    def readFile(self, theFile: Any, path: str) -> VNode:
+    def readFile(self, theFile: IO, path: str) -> VNode:
         """Read the file, change splitter ratios, and return its hidden vnode."""
         s = theFile.read()
         v, g_element = self.readWithElementTree(path, s)
@@ -113,7 +113,7 @@ class FastRead:
         return v
 
     #@+node:felix.20220618164929.1: *3* fast.readJsonFile
-    def readJsonFile(self, theFile: Any, path: str) -> Optional[VNode]:
+    def readJsonFile(self, theFile: IO, path: str) -> Optional[VNode]:
         """Read the leojs JSON file, change splitter ratios, and return its hidden vnode."""
         s = theFile.read()
         v, g_dict = self.readWithJsonTree(path, s)
@@ -191,7 +191,8 @@ class FastRead:
         fc.descendentExpandedList = expanded
         fc.descendentMarksList = marked
     #@+node:ekr.20180606041211.1: *4* fast.resolveUa
-    def resolveUa(self, attr: Any, val: Any, kind: str = None) -> Any:  # Kind is for unit testing.
+    def resolveUa(self, attr: str, val: Any, kind: str = None) -> Any:
+        # Kind is for unit testing.
         """Parse an unknown attribute in a <v> or <t> element."""
         try:
             val = g.toEncodedString(val)
@@ -737,7 +738,7 @@ class FileCommands:
             g.error("exception deleting backup file:", fileName)
             g.es_exception()
     #@+node:ekr.20100119145629.6108: *4* fc.handleWriteLeoFileException
-    def handleWriteLeoFileException(self, fileName: str, backupName: str, f: Any) -> None:
+    def handleWriteLeoFileException(self, fileName: str, backupName: str, f: IO) -> None:
         """Report an exception. f is an open file, or None."""
         # c = self.c
         g.es("exception writing:", fileName)
@@ -1242,7 +1243,7 @@ class FileCommands:
         for p in aList:
             p.setAllAncestorAtFileNodesDirty()
     #@+node:ekr.20080805132422.3: *5* fc.resolveArchivedPosition
-    def resolveArchivedPosition(self, archivedPosition: Any, root_v: Any) -> Optional[VNode]:
+    def resolveArchivedPosition(self, archivedPosition: list[str], root_v: Any) -> Optional[VNode]:
         """
         Return a VNode corresponding to the archived position relative to root
         node root_v.
@@ -2095,7 +2096,7 @@ class FileCommands:
             else:
                 fc.put(f"{v_head}</v>\n")  # Call put only once.
     #@+node:ekr.20031218072017.1865: *6* fc.compute_attribute_bits
-    def compute_attribute_bits(self, forceWrite: Any, p: Position) -> str:
+    def compute_attribute_bits(self, forceWrite: bool, p: Position) -> str:
         """Return the initial values of v's attributes."""
         attrs = []
         if p.hasChildren() and not forceWrite and not self.usingClipboard:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
-
+    Conn = sqlite3.Connection
 #@-<< leoFileCommands annotations >>
 #@+others
 #@+node:ekr.20150509194827.1: ** cmd (decorator)
@@ -1084,7 +1084,7 @@ class FileCommands:
                 n2.setBodyString(b2)
         return root
     #@+node:vitalije.20170630152841.1: *5* fc.retrieveVnodesFromDb & helpers
-    def retrieveVnodesFromDb(self, conn: Any) -> VNode:
+    def retrieveVnodesFromDb(self, conn: Conn) -> VNode:
         """
         Recreates tree from the data contained in table vnodes.
 
@@ -1142,7 +1142,7 @@ class FileCommands:
         c.setCurrentPosition(p)
         return rootChildren[0]
     #@+node:vitalije.20170815162307.1: *6* fc.initNewDb
-    def initNewDb(self, conn: Any, path: str = None) -> VNode:
+    def initNewDb(self, conn: Conn, path: str = None) -> VNode:
         """ Initializes tables and returns None"""
         c, fc = self.c, self
         v = leoNodes.VNode(context=c)
@@ -1153,7 +1153,7 @@ class FileCommands:
         fc.exportToSqlite(path or c.mFileName)
         return v
     #@+node:vitalije.20170630200802.1: *6* fc.getWindowGeometryFromDb
-    def getWindowGeometryFromDb(self, conn: Any) -> tuple:
+    def getWindowGeometryFromDb(self, conn: Conn) -> tuple:
         geom = (600, 400, 50, 50, 0.5, 0.5, '')
         keys = ('width', 'height', 'left', 'top',
                   'ratio', 'secondary_ratio',
@@ -1442,7 +1442,7 @@ class FileCommands:
         res.append(mk % (p.gnx, p._childIndex))
         return jn.join(res)
     #@+node:vitalije.20170811130512.1: *6* fc.prepareDbTables
-    def prepareDbTables(self, conn: Any) -> None:
+    def prepareDbTables(self, conn: Conn) -> None:
         conn.execute('''drop table if exists vnodes;''')
         conn.execute(
             '''
@@ -1459,7 +1459,7 @@ class FileCommands:
         conn.execute(
             '''create table if not exists extra_infos(name primary key, value)''')
     #@+node:vitalije.20170701161851.1: *6* fc.exportVnodesToSqlite
-    def exportVnodesToSqlite(self, conn: Any, rows: Any) -> None:
+    def exportVnodesToSqlite(self, conn: Conn, rows: Any) -> None:
         conn.executemany(
             '''insert into vnodes
             (gnx, head, body, children, parents,
@@ -1468,7 +1468,7 @@ class FileCommands:
             rows,
         )
     #@+node:vitalije.20170701162052.1: *6* fc.exportGeomToSqlite
-    def exportGeomToSqlite(self, conn: Any) -> None:
+    def exportGeomToSqlite(self, conn: Conn) -> None:
         c = self.c
         data = zip(
             (
@@ -1484,11 +1484,11 @@ class FileCommands:
         )
         conn.executemany('replace into extra_infos(name, value) values(?, ?)', data)
     #@+node:vitalije.20170811130559.1: *6* fc.exportDbVersion
-    def exportDbVersion(self, conn: Any) -> None:
+    def exportDbVersion(self, conn: Conn) -> None:
         conn.execute(
             "replace into extra_infos(name, value) values('dbversion', ?)", ('1.0',))
     #@+node:vitalije.20170701162204.1: *6* fc.exportHashesToSqlite
-    def exportHashesToSqlite(self, conn: Any) -> None:
+    def exportHashesToSqlite(self, conn: Conn) -> None:
         c = self.c
 
         def md5(x: str) -> str:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -100,11 +100,11 @@ class FastRead:
     def readFile(self, theFile: IO, path: str) -> VNode:
         """Read the file, change splitter ratios, and return its hidden vnode."""
         s = theFile.read()
-        v, g_element = self.readWithElementTree(path, s)
+        v, _g_element = self.readWithElementTree(path, s)
         if not v:  # #1510.
             return None
         # #1047: only this method changes splitter sizes.
-        self.scanGlobals(g_element)
+        self.scanGlobals()
         #
         # #1111: ensure that all outlines have at least one node.
         if not v.children:
@@ -234,7 +234,7 @@ class FastRead:
                 g.trace(f"can not unpickle {attr}={val}")
                 return ''
     #@+node:ekr.20180605062300.1: *4* fast.scanGlobals & helper
-    def scanGlobals(self, g_element: Any) -> None:
+    def scanGlobals(self) -> None:
         """Get global data from the cache, with reasonable defaults."""
         c = self.c
         d = self.getGlobalData()

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1198,7 +1198,7 @@ class FileCommands:
             s_bytes = g.toEncodedString(s)  # 2011/02/22
             # Throws a TypeError if val is not a hex string.
             bin = binascii.unhexlify(s_bytes)
-            val = pickle.loads(bin)
+            val = pickle.loads(bin)  # Returns a Python object.
             return val
         except Exception:
             g.es_exception()
@@ -1243,7 +1243,11 @@ class FileCommands:
         for p in aList:
             p.setAllAncestorAtFileNodesDirty()
     #@+node:ekr.20080805132422.3: *5* fc.resolveArchivedPosition
-    def resolveArchivedPosition(self, archivedPosition: list[str], root_v: Any) -> Optional[VNode]:
+    def resolveArchivedPosition(
+        self,
+        archivedPosition: list[str],
+        root_v: VNode,
+    ) -> Optional[VNode]:
         """
         Return a VNode corresponding to the archived position relative to root
         node root_v.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
     Conn = sqlite3.Connection
-    Element = Any
+    Element = ElementTree.Element
 #@-<< leoFileCommands annotations >>
 #@+others
 #@+node:ekr.20150509194827.1: ** cmd (decorator)
@@ -294,7 +294,7 @@ class FastRead:
             'r1': 0.5, 'r2': 0.5,
         }
     #@+node:ekr.20180602062323.8: *4* fast.scanTnodes
-    def scanTnodes(self, t_elements: Any) -> tuple[dict[str, str], dict[str, Any]]:
+    def scanTnodes(self, t_elements: Element) -> tuple[dict[str, str], dict[str, Any]]:
 
         gnx2body: dict[str, str] = {}
         gnx2ua: dict[str, dict] = defaultdict(dict)
@@ -494,7 +494,7 @@ class FastRead:
             mf.show()
 
     #@+node:felix.20220618174623.1: *4* fast.scanJsonTnodes
-    def scanJsonTnodes(self, t_elements: Any) -> dict[str, str]:
+    def scanJsonTnodes(self, t_elements: Element) -> dict[str, str]:
 
         gnx2body: dict[str, str] = {}
 
@@ -529,7 +529,6 @@ class FastRead:
                 try:
                     v = gnx2vnode.get(gnx)
                 except KeyError:
-                    # g.trace('no "t" attrib')
                     gnx = None
                     v = None
                 if v:
@@ -552,16 +551,12 @@ class FastRead:
                         fc.descendentExpandedList.append(gnx)
                     if v.isMarked():
                         fc.descendentMarksList.append(gnx)
-                    #
-
                     # Handle vnode uA's
                     uaDict = gnx2ua[gnx]  # A defaultdict(dict)
-
                     if uaDict:
                         v.unknownAttributes = uaDict
-
                     # Recursively create the children.
-                    v_element_visitor(v_dict.get('children', []), v)
+                    v_element_visitor(v_dict.get('children', []), v)  # type:ignore
 
         gnx = 'hidden-root-vnode-gnx'
         hidden_v = leoNodes.VNode(context=c, gnx=gnx)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -137,7 +137,7 @@ class FastRead:
 
         Unlike readFile above, this does not affect splitter sizes.
         """
-        hidden_v, g_element = self.readWithElementTree(path=None, s_or_b=s_or_b)
+        hidden_v, _g_element = self.readWithElementTree(path=None, s_or_b=s_or_b)
         if not hidden_v:
             return None
         #
@@ -174,9 +174,9 @@ class FastRead:
             print('')
             return None, None
 
-        g_element = xroot.find('globals')
-        v_elements = xroot.find('vnodes')
-        t_elements = xroot.find('tnodes')
+        g_element: Element = xroot.find('globals')
+        v_elements: Element = xroot.find('vnodes')
+        t_elements: Element = xroot.find('tnodes')
         gnx2body, gnx2ua = self.scanTnodes(t_elements)
         hidden_v = self.scanVnodes(gnx2body, self.gnx2vnode, gnx2ua, v_elements)
         self.handleBits()
@@ -314,7 +314,7 @@ class FastRead:
         gnx2body: dict[str, str],
         gnx2vnode: dict[str, VNode],
         gnx2ua: dict[str, Any],
-        v_elements: Any,
+        v_elements: Element,
     ) -> VNode:
 
         c, fc = self.c, self.c.fileCommands
@@ -418,9 +418,9 @@ class FastRead:
             return None, None
 
         try:
-            g_element = d.get('globals', {})  # globals is optional
-            v_elements = d.get('vnodes')
-            t_elements = d.get('tnodes')
+            g_element: Element = d.get('globals', {})  # globals is optional
+            v_elements: Element = d.get('vnodes')
+            t_elements: Element = d.get('tnodes')
             gnx2ua: dict = defaultdict(dict)
             gnx2ua.update(d.get('uas', {}))  # User attributes in their own dict for leojs files
             gnx2body = self.scanJsonTnodes(t_elements)
@@ -508,7 +508,7 @@ class FastRead:
         gnx2body: dict[str, str],
         gnx2vnode: dict[str, VNode],
         gnx2ua: dict[str, Any],
-        v_elements: Any,
+        v_elements: Element,
     ) -> Optional[VNode]:
 
         c, fc = self.c, self.c.fileCommands


### PR DESCRIPTION
- [x] Simplify `fc.pickle`, `fc.putDescendentVnodeUas`, and `fc.createUaList`:
  Replace `torv` args with `v` and pass only a list of VNodes to `fc.createUaList`.
  These are real code changes. All tests pass, including by-hand tests.
- [x] Add the typical obvious annotations.