### PR TITLE
PR: more annotations for leoFileCommands.py

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -34,10 +34,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position, VNode
     Conn = sqlite3.Connection
     Element = ElementTree.Element
+    Obj = Any  # Denotes that 'Any' is correct.
 #@-<< leoFileCommands annotations >>
 #@+others
 #@+node:ekr.20150509194827.1: ** cmd (decorator)
-def cmd(name: Any) -> Callable:
+def cmd(name: str) -> Callable:
     """Command decorator for the FileCommands class."""
     return g.new_cmd_decorator(name, ['c', 'fileCommands',])
 #@+node:ekr.20210316035506.1: **  commands (leoFileCommands.py)
@@ -67,7 +68,7 @@ def dump_gnx_dict(event: LeoKeyEvent) -> None:
 #@+node:felix.20220618222639.1: ** class SetEncoder
 class SetJSONEncoder(json.JSONEncoder):
     # Used to encode JSON in leojs files
-    def default(self, obj: Any) -> Any:
+    def default(self, obj: Obj) -> Obj:
         if isinstance(obj, set):
             return list(obj)
         return json.JSONEncoder.default(self, obj)
@@ -153,7 +154,7 @@ class FastRead:
 
     bad_path_dict: dict[str, bool] = {}
 
-    def readWithElementTree(self, path: str, s_or_b: Union[str, bytes]) -> tuple[VNode, Any]:
+    def readWithElementTree(self, path: str, s_or_b: Union[str, bytes]) -> tuple[VNode, Obj]:
 
         contents = g.toUnicode(s_or_b)
         table = contents.maketrans(self.translate_dict)  # type:ignore #1510.
@@ -192,7 +193,7 @@ class FastRead:
         fc.descendentExpandedList = expanded
         fc.descendentMarksList = marked
     #@+node:ekr.20180606041211.1: *4* fast.resolveUa
-    def resolveUa(self, attr: str, val: Any, kind: str = None) -> Any:
+    def resolveUa(self, attr: str, val: Obj, kind: str = None) -> Obj:
         # Kind is for unit testing.
         """Parse an unknown attribute in a <v> or <t> element."""
         try:
@@ -269,7 +270,7 @@ class FastRead:
         else:
             mf.show()
     #@+node:ekr.20180708060437.1: *5* fast.getGlobalData
-    def getGlobalData(self) -> dict[str, Any]:
+    def getGlobalData(self) -> dict[str, Obj]:
         """Return a dict containing all global data."""
         c = self.c
         try:
@@ -294,7 +295,7 @@ class FastRead:
             'r1': 0.5, 'r2': 0.5,
         }
     #@+node:ekr.20180602062323.8: *4* fast.scanTnodes
-    def scanTnodes(self, t_elements: Element) -> tuple[dict[str, str], dict[str, Any]]:
+    def scanTnodes(self, t_elements: Element) -> tuple[dict[str, str], dict[str, Obj]]:
 
         gnx2body: dict[str, str] = {}
         gnx2ua: dict[str, dict] = defaultdict(dict)
@@ -409,7 +410,7 @@ class FastRead:
             v.children = [new_vnode]
         return v
     #@+node:felix.20220618165345.1: *3* fast.readWithJsonTree & helpers
-    def readWithJsonTree(self, path: str, s: str) -> tuple[VNode, Any]:
+    def readWithJsonTree(self, path: str, s: str) -> tuple[VNode, Obj]:
         try:
             d = json.loads(s)
         except Exception:
@@ -1187,7 +1188,7 @@ class FileCommands:
     # Pre Leo 4.5 Only @thin vnodes had the descendentTnodeUnknownAttributes field.
     # New in Leo 4.5: @thin & @shadow vnodes have descendentVnodeUnknownAttributes field.
 
-    def getDescendentUnknownAttributes(self, s: str, v: VNode = None) -> Any:
+    def getDescendentUnknownAttributes(self, s: str, v: VNode = None) -> Obj:
         """Unhexlify and unpickle t/v.descendentUnknownAttribute field."""
         try:
             # Changed in version 3.2: Accept only bytestring or bytearray objects as input.
@@ -1621,7 +1622,7 @@ class FileCommands:
             self.handleWriteLeoFileException(fileName, backupName, f)
             return False
     #@+node:ekr.20210316095706.1: *6* fc.leojs_outline_dict
-    def leojs_outline_dict(self, p: Position = None) -> dict[str, Any]:
+    def leojs_outline_dict(self, p: Position = None) -> dict[str, Obj]:
         """Return a dict representing the outline."""
         c = self.c
         uas = {}
@@ -1681,7 +1682,7 @@ class FileCommands:
             self.setCachedBits()
         return result
     #@+node:ekr.20210316092313.1: *6* fc.leojs_globals (sets window_position)
-    def leojs_globals(self) -> Optional[dict[str, Any]]:
+    def leojs_globals(self) -> Optional[dict[str, Obj]]:
         """Put json representation of Leo's cached globals."""
         c = self.c
         width, height, left, top = c.frame.get_window_info()
@@ -1705,7 +1706,7 @@ class FileCommands:
             }
         return d
     #@+node:ekr.20210316085413.2: *6* fc.leojs_vnodes
-    def leojs_vnode(self, p: Position, gnxSet: Any, isIgnore: bool = False) -> dict[str, Any]:
+    def leojs_vnode(self, p: Position, gnxSet: Any, isIgnore: bool = False) -> dict[str, Obj]:
         """Return a jsonized vnode."""
         # c = self.c
         fc = self
@@ -1728,7 +1729,7 @@ class FileCommands:
         if forceWrite or self.usingClipboard:
             v.setWriteBit()  # 4.2: Indicate we wrote the body text.
 
-        children: list[dict[str, Any]] = []  # Start empty
+        children: list[dict[str, Obj]] = []  # Start empty
 
         if p.hasChildren() and (forceWrite or self.usingClipboard):
             # This optimization eliminates all "recursive" copies.
@@ -1830,7 +1831,7 @@ class FileCommands:
         theFile.close()
     #@+node:ekr.20210316034532.1: *4* fc.Writing Utils
     #@+node:ekr.20080805085257.2: *5* fc.pickle
-    def pickle(self, *, v: VNode, val: Any, tag: str) -> str:
+    def pickle(self, *, v: VNode, val: Obj, tag: str) -> str:
         """Pickle val and return the hexlified result."""
         try:
             s = pickle.dumps(val, protocol=1)
@@ -2008,7 +2009,7 @@ class FileCommands:
                 # This prevents the file from being written.
                 raise BadLeoFile(f"no VNode for {repr(index)}")
     #@+node:ekr.20050418161620.2: *5* fc.putUaHelper
-    def putUaHelper(self, v: VNode, key: str, val: Any) -> str:
+    def putUaHelper(self, v: VNode, key: str, val: Obj) -> str:
         """Put attribute whose name is key and value is val to the output stream."""
         # New in 4.3: leave string attributes starting with 'str_' alone.
         if key.startswith('str_'):

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -18,7 +18,7 @@ import shutil
 import sqlite3
 import tempfile
 import time
-from typing import Any, IO, Optional, Union, TYPE_CHECKING
+from typing import Any, IO, Iterable, Optional, Union, TYPE_CHECKING
 import zipfile
 import xml.etree.ElementTree as ElementTree
 import xml.sax
@@ -314,7 +314,7 @@ class FastRead:
     def scanVnodes(self,
         gnx2body: dict[str, str],
         gnx2vnode: dict[str, VNode],
-        gnx2ua: dict[str, Any],
+        gnx2ua: dict[str, Obj],
         v_elements: Element,
     ) -> VNode:
 
@@ -435,7 +435,7 @@ class FastRead:
         return hidden_v, g_element
 
     #@+node:felix.20220618181309.1: *4* fast.scanJsonGlobals
-    def scanJsonGlobals(self, json_d: dict) -> None:
+    def scanJsonGlobals(self, json_d: Element) -> None:
         """Set the geometries from the globals dict."""
         c = self.c
 
@@ -508,7 +508,7 @@ class FastRead:
     def scanJsonVnodes(self,
         gnx2body: dict[str, str],
         gnx2vnode: dict[str, VNode],
-        gnx2ua: dict[str, Any],
+        gnx2ua: dict[str, Obj],
         v_elements: Element,
     ) -> Optional[VNode]:
 
@@ -602,8 +602,8 @@ class FileCommands:
         self.checking = False  # True: checking only: do *not* alter the outline.
         self.descendentExpandedList: list[str] = []  # List of gnx's.
         self.descendentMarksList: list[str] = []  # List of gnx's.
-        self.descendentTnodeUaDictList: list[Any] = []
-        self.descendentVnodeUaDictList: list[Any] = []
+        self.descendentTnodeUaDictList: list[Obj] = []
+        self.descendentVnodeUaDictList: list[Obj] = []
         self.ratio = 0.5
         self.currentVnode: VNode = None
         # For writing...
@@ -615,8 +615,8 @@ class FileCommands:
         # New in 3.12...
         self.copiedTree: Position = None
         # fc.gnxDict is never re-inited.
-        self.gnxDict: dict[str, VNode] = {}  # Keys are gnx strings. Values are vnodes.
-        self.vnodesDict: dict[str, Any] = {}  # keys are gnx strings; values are ignored
+        self.gnxDict: dict[str, VNode] = {}  # Keys are gnx strings.
+        self.vnodesDict: dict[str, bool] = {}  # keys are gnx strings.
     #@+node:ekr.20210316042224.1: *3* fc: Commands
     #@+node:ekr.20031218072017.2012: *4* write-at-file-nodes
     @cmd('write-at-file-nodes')
@@ -1460,7 +1460,7 @@ class FileCommands:
         conn.execute(
             '''create table if not exists extra_infos(name primary key, value)''')
     #@+node:vitalije.20170701161851.1: *6* fc.exportVnodesToSqlite
-    def exportVnodesToSqlite(self, conn: Conn, rows: Any) -> None:
+    def exportVnodesToSqlite(self, conn: Conn, rows: Iterable) -> None:
         conn.executemany(
             '''insert into vnodes
             (gnx, head, body, children, parents,
@@ -1706,7 +1706,7 @@ class FileCommands:
             }
         return d
     #@+node:ekr.20210316085413.2: *6* fc.leojs_vnodes
-    def leojs_vnode(self, p: Position, gnxSet: Any, isIgnore: bool = False) -> dict[str, Obj]:
+    def leojs_vnode(self, p: Position, gnxSet: Obj, isIgnore: bool = False) -> dict[str, Obj]:
         """Return a jsonized vnode."""
         # c = self.c
         fc = self
@@ -1743,7 +1743,7 @@ class FileCommands:
             p.moveToParent()  # Restore p in the caller.
 
         # At least will contain  the gnx
-        result: dict[str, Any] = {
+        result: dict[str, Obj] = {
             'gnx': v.fileIndex,
         }
 


### PR DESCRIPTION
- [x] Indicate general args with `Obj` instead of `Any`.