### PR TITLE
PR: Fix bug in python-to-rust

### DIFF
--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -1969,7 +1969,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             # Regex replacements.
             table = (
                 # Annotations.
-                ('str', 'String:'),
+                ('str', 'String'),
                 ('int', 'i32'),
                 ('float', 'f64'),
                 # Constants.


### PR DESCRIPTION
- [x] Remove extraneous ':' after "String" annotation.