### PR TITLE
PR for #3873: @language isn't inherited properly in .txt files

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2652,7 +2652,7 @@ def getLanguageFromAncestorAtFileNode(p: Position) -> Optional[str]:
         if len(languages) == 1:  # An unambiguous language
             return languages[0]
 
-    # Passes 3 & 4: Use file extension in @<file> nodes.
+    # Passes 3 & 4: Use the file extension in @<file> nodes.
 
     def get_language_from_headline(v: VNode) -> Optional[str]:
         """Return the extension for @<file> nodes."""


### PR DESCRIPTION
See #3873.

- [x] Rewrite `g. getLanguageFromAncestorAtFileNode` to use four passes.
  The first two passes search body text for unambiguous `@language` directives.
  The second two search for `@<file> nodes` and use the file's extension.

In practice the second two passes will rarely happen. The new code will be as fast as the old.

Imo, the new search order will never cause problems. It certainly fixes the original issue.