### PR TITLE
PR for #3809: recolor body text when moving nodes

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1612,7 +1612,8 @@ def moveOutlineRight(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.setChanged()  # #2036.
     u.afterMoveNode(p, 'Move Right', undoData)
     c.redraw(p)
-    c.recolor()
+    c.recolor()  # Moving can change syntax coloring.
+
 #@+node:ekr.20031218072017.1772: *3* c_oc.moveOutlineUp
 @g.commander_command('move-outline-up')
 def moveOutlineUp(self: Cmdr, event: LeoKeyEvent = None) -> None:
@@ -1701,6 +1702,7 @@ def moveOutlineToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.setChanged()
     u.afterMoveNode(p, 'Move To First Child', undoData)
     c.redraw(p)
+    # c.recolor()  # Moving can *not* change syntax coloring.
 #@+node:ekr.20230902051833.1: *3* c_oc.moveOutlineToLastChild
 @g.commander_command('move-outline-to-last-child')
 def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
@@ -1726,6 +1728,7 @@ def moveOutlineToLastChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.setChanged()
     u.afterMoveNode(p, 'Move To Last Child', undoData)
     c.redraw(p)
+    # c.recolor()  # Moving can *not* change syntax coloring.
 #@+node:ekr.20031218072017.1774: *3* c_oc.promote
 @g.commander_command('promote')
 def promote(self: Cmdr, event: LeoKeyEvent = None, undoFlag: bool = True) -> None:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1237,7 +1237,7 @@ class JEditColorizer(BaseColorizer):
                     aList.insert(0, wiki_rule)
                     d[ch] = aList
         self.rulesDict = d
-    #@+node:ekr.20240423042341.1: *3* jedit.colorize (NEW)
+    #@+node:ekr.20240423042341.1: *3* jedit.colorize
     def colorize(self, p: Position) -> None:
         """jedit.Colorize: fully recolor p.b."""
         if not p:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1237,6 +1237,17 @@ class JEditColorizer(BaseColorizer):
                     aList.insert(0, wiki_rule)
                     d[ch] = aList
         self.rulesDict = d
+    #@+node:ekr.20240423042341.1: *3* jedit.colorize (NEW)
+    def colorize(self, p: Position) -> None:
+        """jedit.Colorize: fully recolor p.b."""
+        if not p:
+            return
+        self.updateSyntaxColorer(p)
+        # Similar to code in jedit.recolor.
+        self.init_all_state(p.v)
+        self.init()
+        # Force QSyntaxHighligher to do a full recolor.
+        self.highlighter.rehighlight()
     #@+node:ekr.20110605121601.18638: *3* jedit.mainLoop
     last_v = None
     tot_time = 0.0

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1246,7 +1246,7 @@ class JEditColorizer(BaseColorizer):
         # Similar to code in jedit.recolor.
         self.init_all_state(p.v)
         self.init()
-        # Force QSyntaxHighligher to do a full recolor.
+        # Force QSyntaxHighlighter to do a full recolor.
         self.highlighter.rehighlight()
     #@+node:ekr.20110605121601.18638: *3* jedit.mainLoop
     last_v = None

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3611,10 +3611,10 @@ class Commands:
                 mods.clear()
     #@+node:ekr.20080514131122.13: *5* c.recolor
     def recolor(self, p: Position = None) -> None:
-        # Support QScintillaColorizer.colorize.
         c = self
         colorizer = c.frame.body.colorizer
         if colorizer and hasattr(colorizer, 'colorize'):
+            # Both jEditColorizer and QScintillaColorizer have colorizer methods.
             colorizer.colorize(p or c.p)
 
     recolor_now = recolor

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3614,7 +3614,7 @@ class Commands:
         c = self
         colorizer = c.frame.body.colorizer
         if colorizer and hasattr(colorizer, 'colorize'):
-            # Both jEditColorizer and QScintillaColorizer have colorizer methods.
+            # Both jEditColorizer and QScintillaColorizer have colorize methods.
             colorizer.colorize(p or c.p)
 
     recolor_now = recolor

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -330,7 +330,8 @@ class LeoBody:
         return self.colorizer
 
     def updateSyntaxColorer(self, p: Position) -> None:
-        return self.colorizer.updateSyntaxColorer(p.copy())
+        if p:
+            return self.colorizer.updateSyntaxColorer(p.copy())
 
     def recolor(self, p: Position) -> None:
         self.c.recolor()


### PR DESCRIPTION
See #3809.

- [x] Add `jedit.colorize`(!!). It forces `QSyntaxHighlighter` to do a full redraw.
   However, it should not cause another huge performance bug.
- [x] Add a guard to `LeoBody.updateSyntaxColorer`.
- [x] Call `c.recolor` in `c_oc.moveOutlineRight`.
- [x] Add comments to `c_oc.moveOutlineToFirst/LastChild`.