### PR TITLE
PR for #3141: restart command crashes

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -124,17 +124,10 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     # Create the command to restart Leo.
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
     launchLeo_s = fr"{leo_editor_dir}{os.sep}launchLeo.py"
-    if 1:  # Use os.execv.
-        args = ['leo', launchLeo_s] + restart_paths + ['--no-splash']
-        command = fr"{sys.executable} {' '.join(args)}"
-        print(f"{'\n'}Restarting Leo with this command:\n\n{command}")
-        os.execv(sys.executable, args)
-    else:  # Use os.system.
-        python = 'py' if g.isWindows else 'python'
-        files_s = ' '.join(restart_paths)
-        command = fr'{python} {launchLeo_s} {files_s} --no-splash'
-        print(f"{'\n'}Restarting Leo with this command:\n\n{command}\n")
-        os.system(command)
+    args = ['leo', launchLeo_s] + restart_paths + ['--no-splash']
+    command = fr"{sys.executable} {' '.join(args)}"
+    print(f"{'\n'}Restarting Leo with this command:\n\n{command}")
+    os.execv(sys.executable, args)
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -93,7 +93,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
             if veto:
                 g.es_print('Cancelling restart-leo command')
                 return
-    # Officially begin the restart process. A flag for efc.ask.
+    # Officially begin the restart process. A flag for efc.ask and efc.on_idle.
     g.app.restarting = True
     # Save session data.
     g.app.saveSession()
@@ -117,6 +117,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
         else:
             # #69.
             g.app.forgetOpenFile(fn=c.fileName())
+    g.app.windowList = []
     # Complete the shutdown.
     g.app.finishQuit()
     sys.stdout.flush()

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -78,8 +78,8 @@ def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('restart-leo')
 def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     """Restart Leo, reloading all presently open outlines."""
-    c, lm = self, g.app.loadManager
-    trace = 'shutdown' in g.app.debug
+    ### c, lm = self, g.app.loadManager
+    c = self
     # Write .leoRecentFiles.txt.
     g.app.recentFilesManager.writeRecentFilesFile(c)
     # Abort the restart if the user veto's any close.
@@ -98,8 +98,12 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     g.app.restarting = True
     # Save session data.
     g.app.saveSession()
-    # Close all unsaved outlines.
     g.app.setLog(None)  # Kill the log.
+    # #3141: Remember all open outlines.
+    restart_paths: list[str] = [
+        c.fileName() for c in g.app.commanders() if c.fileName()
+    ]
+    # Close all unsaved outlines and remember them.
     for c in g.app.commanders():
         frame = c.frame
         # This is similar to g.app.closeLeoWindow.
@@ -115,12 +119,18 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     # Complete the shutdown.
     g.app.finishQuit()
     # Restart, restoring the original command line.
-    args = ['-c'] + lm.old_argv
-    if trace:
-        g.trace('restarting with args', args)
+    ###
+        # args = ['-c'] + lm.old_argv
+        # g.trace(repr(lm.old_argv))
+        #args = lm.old_argv
+        # if trace:
+            # g.trace('restarting with args', args)
     sys.stdout.flush()
     sys.stderr.flush()
-    os.execv(sys.executable, args)
+    # os.execv(sys.executable, args)
+    command = f"leo {' '.join(restart_paths)}"
+    g.trace(command)
+    os.system(command)
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -104,6 +104,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     ]
     if g.isWindows:
         restart_paths = [z.replace('/', os.sep) for z in restart_paths]
+    g.printObj(restart_paths)
     # Close all unsaved outlines.
     for c in g.app.commanders():
         frame = c.frame
@@ -125,7 +126,8 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     # Create the command to restart Leo.
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
     launchLeo_s = fr"{leo_editor_dir}{os.sep}launchLeo.py"
-    args = ['unused-program-name', launchLeo_s] + restart_paths + ['--no-splash']
+    quoted_paths = [f'"{z}"' for z in restart_paths]
+    args = ['unused-program-name', launchLeo_s] + quoted_paths + ['--no-splash']
     command = fr"{sys.executable} {' '.join(args)}"
     print(f"{'\n'}Restarting Leo with this command:\n\n{command}")
     os.execv(sys.executable, args)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -102,6 +102,8 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     restart_paths: list[str] = [
         c.fileName() for c in g.app.commanders() if c.fileName()
     ]
+    if g.isWindows:
+        restart_paths = [z.replace('/', os.sep) for z in restart_paths]
     # Close all unsaved outlines.
     for c in g.app.commanders():
         frame = c.frame
@@ -120,15 +122,19 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Create the command to restart Leo.
-    files_s = ' '.join(restart_paths)
-    if g.isWindows:
-        files_s = files_s.replace('/', os.sep)
-    python = 'py' if g.isWindows else 'python'
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
     launchLeo_s = fr"{leo_editor_dir}{os.sep}launchLeo.py"
-    command = fr'{python} {launchLeo_s} {files_s} --no-splash'
-    print(f"{'\n'}Restarting Leo with this command:\n\n{command}\n")
-    os.system(command)
+    if 1:  # Use os.execv.
+        args = ['leo', launchLeo_s] + restart_paths + ['--no-splash']
+        command = fr"{sys.executable} {' '.join(args)}"
+        print(f"{'\n'}Restarting Leo with this command:\n\n{command}")
+        os.execv(sys.executable, args)
+    else:  # Use os.system.
+        python = 'py' if g.isWindows else 'python'
+        files_s = ' '.join(restart_paths)
+        command = fr'{python} {launchLeo_s} {files_s} --no-splash'
+        print(f"{'\n'}Restarting Leo with this command:\n\n{command}\n")
+        os.system(command)
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -128,8 +128,16 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     quoted_paths = [f'"{z}"' for z in restart_paths]
     args = ['unused-program-name', launchLeo_s] + quoted_paths + ['--no-splash']
     executable_s = f'"{sys.executable}"'
-    command = fr"  {executable_s}{'\n'}  {'\n  '.join(args)}"
-    print(f"{'\n'}Restarting Leo with this command:\n\n{command}\n")
+    args_s = '\n  ' + '\n  '.join(args)
+    command = fr"  {executable_s}{args_s}"
+    # Python 3.9 does not allow newlines within f-strings.
+    print(
+        '\n'
+        f"Restarting Leo with this command:"
+        '\n\n'
+        f"{command}"
+        '\n'
+    )
     print('Note: You may have to hit <return> to continue!')
     os.execv(sys.executable, args)
 #@+node:ekr.20031218072017.2820: ** c_file.top level

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -78,7 +78,6 @@ def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('restart-leo')
 def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     """Restart Leo, reloading all presently open outlines."""
-    ### c, lm = self, g.app.loadManager
     c = self
     # Write .leoRecentFiles.txt.
     g.app.recentFilesManager.writeRecentFilesFile(c)
@@ -103,7 +102,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     restart_paths: list[str] = [
         c.fileName() for c in g.app.commanders() if c.fileName()
     ]
-    # Close all unsaved outlines and remember them.
+    # Close all unsaved outlines.
     for c in g.app.commanders():
         frame = c.frame
         # This is similar to g.app.closeLeoWindow.
@@ -120,7 +119,6 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     g.app.finishQuit()
     sys.stdout.flush()
     sys.stderr.flush()
-
     # Create the command to restart Leo.
     files_s = ' '.join(restart_paths)
     if g.isWindows:

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -123,32 +123,18 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     g.app.finishQuit()
     sys.stdout.flush()
     sys.stderr.flush()
-    # Create the command to restart Leo.
-    executable_s = f'"{sys.executable}"'
-    leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
-
-    print('\nRestarting Leo with this command:\n')
-    return_message = '\n' + 'Note: You may have to hit <return> to continue!'
-
+    # Restart Leo with Popen.run.
     # Warning: Python 3.9 does not allow newlines within f-strings.
-    if 1:  # Use Popen.
-        launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
-        popen_args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
-        popen_args_s = '\n  ' + '\n  '.join(popen_args)
-        popen_command_s = fr"  sys.executable {popen_args_s} --no-splash"
-        print(popen_command_s)
-        print(return_message)
-        subprocess.Popen(popen_args)
-        sys.exit()
-    else:
-        quoted_paths = [f'"{z}"' for z in restart_paths]
-        launchLeo_s = fr'"{leo_editor_dir}{os.sep}launchLeo.py"'
-        execv_args = ['unused-program-name', launchLeo_s] + quoted_paths + ['--no-splash']
-        execv_args_s = '\n  ' + '\n  '.join(execv_args)
-        execv_command_s = fr"  {executable_s}{execv_args_s}"
-        print(execv_command_s)
-        print(return_message)
-        os.execv(sys.executable, execv_args)
+    leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
+    launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
+    popen_args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
+    popen_args_s = '\n  ' + '\n  '.join(popen_args)
+    print('')
+    print('Restarting Leo with this command:')
+    print(popen_args_s)
+    print('')
+    subprocess.run(popen_args)
+    sys.exit()
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 import os
 import sys
+import subprocess
 import time
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
@@ -123,23 +124,31 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Create the command to restart Leo.
-    leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
-    launchLeo_s = fr'"{leo_editor_dir}{os.sep}launchLeo.py"'
-    quoted_paths = [f'"{z}"' for z in restart_paths]
-    args = ['unused-program-name', launchLeo_s] + quoted_paths + ['--no-splash']
     executable_s = f'"{sys.executable}"'
-    args_s = '\n  ' + '\n  '.join(args)
-    command = fr"  {executable_s}{args_s}"
-    # Python 3.9 does not allow newlines within f-strings.
-    print(
-        '\n'
-        f"Restarting Leo with this command:"
-        '\n\n'
-        f"{command}"
-        '\n'
-    )
-    print('Note: You may have to hit <return> to continue!')
-    os.execv(sys.executable, args)
+    leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
+
+    print('\nRestarting Leo with this command:\n')
+    return_message = '\n' + 'Note: You may have to hit <return> to continue!'
+
+    # Warning: Python 3.9 does not allow newlines within f-strings.
+    if 1:  # Use Popen.
+        launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
+        popen_args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
+        popen_args_s = '\n  ' + '\n  '.join(popen_args)
+        popen_command_s = fr"  sys.executable {popen_args_s} --no-splash"
+        print(popen_command_s)
+        print(return_message)
+        subprocess.Popen(popen_args)
+        sys.exit()
+    else:
+        quoted_paths = [f'"{z}"' for z in restart_paths]
+        launchLeo_s = fr'"{leo_editor_dir}{os.sep}launchLeo.py"'
+        execv_args = ['unused-program-name', launchLeo_s] + quoted_paths + ['--no-splash']
+        execv_args_s = '\n  ' + '\n  '.join(execv_args)
+        execv_command_s = fr"  {executable_s}{execv_args_s}"
+        print(execv_command_s)
+        print(return_message)
+        os.execv(sys.executable, execv_args)
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -118,18 +118,18 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
             g.app.forgetOpenFile(fn=c.fileName())
     # Complete the shutdown.
     g.app.finishQuit()
-    # Restart, restoring the original command line.
-    ###
-        # args = ['-c'] + lm.old_argv
-        # g.trace(repr(lm.old_argv))
-        #args = lm.old_argv
-        # if trace:
-            # g.trace('restarting with args', args)
     sys.stdout.flush()
     sys.stderr.flush()
-    # os.execv(sys.executable, args)
-    command = f"leo {' '.join(restart_paths)}"
-    g.trace(command)
+
+    # Create the command to restart Leo.
+    files_s = ' '.join(restart_paths)
+    if g.isWindows:
+        files_s = files_s.replace('/', os.sep)
+    python = 'py' if g.isWindows else 'python'
+    leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
+    launchLeo_s = fr"{leo_editor_dir}{os.sep}launchLeo.py"
+    command = fr'{python} {launchLeo_s} {files_s} --no-splash'
+    print(f"{'\n'}Restarting Leo with this command:\n\n{command}\n")
     os.system(command)
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -128,9 +128,9 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
     launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
     popen_args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
-    popen_args_s = '\n  ' + '\n  '.join(popen_args)
+    popen_args_s = 'Popen.run([\n  ' + ',\n  '.join(popen_args) + '\n])'
     print('')
-    print('Restarting Leo with this command:')
+    print('Restarting Leo with:\n')
     print(popen_args_s)
     print('')
     subprocess.run(popen_args)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -124,7 +124,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     # Create the command to restart Leo.
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
     launchLeo_s = fr"{leo_editor_dir}{os.sep}launchLeo.py"
-    args = ['leo', launchLeo_s] + restart_paths + ['--no-splash']
+    args = ['unused-program-name', launchLeo_s] + restart_paths + ['--no-splash']
     command = fr"{sys.executable} {' '.join(args)}"
     print(f"{'\n'}Restarting Leo with this command:\n\n{command}")
     os.execv(sys.executable, args)

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -104,7 +104,6 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     ]
     if g.isWindows:
         restart_paths = [z.replace('/', os.sep) for z in restart_paths]
-    g.printObj(restart_paths)
     # Close all unsaved outlines.
     for c in g.app.commanders():
         frame = c.frame
@@ -125,11 +124,13 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stderr.flush()
     # Create the command to restart Leo.
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
-    launchLeo_s = fr"{leo_editor_dir}{os.sep}launchLeo.py"
+    launchLeo_s = fr'"{leo_editor_dir}{os.sep}launchLeo.py"'
     quoted_paths = [f'"{z}"' for z in restart_paths]
     args = ['unused-program-name', launchLeo_s] + quoted_paths + ['--no-splash']
-    command = fr"{sys.executable} {' '.join(args)}"
-    print(f"{'\n'}Restarting Leo with this command:\n\n{command}")
+    executable_s = f'"{sys.executable}"'
+    command = fr"  {executable_s}{'\n'}  {'\n  '.join(args)}"
+    print(f"{'\n'}Restarting Leo with this command:\n\n{command}\n")
+    print('Note: You may have to hit <return> to continue!')
     os.execv(sys.executable, args)
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -499,7 +499,7 @@ class ExternalFilesController:
 
         Return one of ('yes', 'no', 'yes-all', 'no-all')
         """
-        if g.unitTesting:
+        if g.unitTesting or g.app.restarting:
             return ''
         if c not in g.app.commanders():
             return ''


### PR DESCRIPTION
See #3141.

- [x] Use `Popen.run` to do the restart.
- [x] Add print statements showing the arguments to `Popen.run`.

**Note**: The revised code calculates the files to be reloaded from the open outlines, not the original invocation of Leo.