### PR TITLE
Fix for 3876 - Dropping Leo Outline File Fails

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -237,8 +237,7 @@ class AtFile:
                 at.error('can not call at.read from string for @shadow files')
                 return None, None
             at.initReadLine(fromString)
-            return None, None
-        #
+            return None, fromString  # #3876.    #
         # Not from a string. Carefully read the file.
         # Returns full path, including file name.
         fn = g.fullPath(c, at.root)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3459,11 +3459,10 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
         u.beforeChangeGroup(c.p, undoType)
         changed = False
         for z in urls:
-            url = str(QtCore.QUrl(z))
-            scheme = url.scheme()
+            url, scheme, path = z.toString(), z.scheme(), z.path()
             if scheme == 'file':
-                changed |= self.doFileUrl(p, url)
-            elif scheme in ('http',):  # 'ftp','mailto',
+                changed |= self.doFileUrl(p, path)
+            elif scheme in ('http', 'https'):  # 'ftp','mailto',
                 changed |= self.doHttpUrl(p, url)
         # Call this only once, at end.
         u.afterChangeGroup(c.p, undoType)
@@ -3475,11 +3474,12 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
 
     #@+node:ekr.20110605121601.18370: *6* LeoQTreeWidget.doFileUrl & helper
     def doFileUrl(self, p: Position, url: str) -> bool:
-        """Read the file given by the url and put it in the outline."""
-        # 2014/06/06: Work around a possible bug in QUrl.
-            # fn = str(url.path()) # Fails.
+        """Read the file given by the url and put it in the outline.
+
+        url -- the path to the file, without the "file://" scheme
+        """
         e = sys.getfilesystemencoding()
-        fn = g.toUnicode(url.path(), encoding=e)
+        fn = g.toUnicode(url, encoding=e)
         if sys.platform.lower().startswith('win') and fn.startswith('/'):
             fn = fn[1:]
         if os.path.isdir(fn):
@@ -3696,7 +3696,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
         c = self.c
         u = c.undoer
         undoType = 'Drag Url'
-        s = str(url.toString()).strip()
+        s = url.strip()
         if not s:
             return False
         undoData = u.beforeInsertNode(p, pasteAsClone=False, copiedBunchList=[])

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -3464,6 +3464,7 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
                 changed |= self.doFileUrl(p, path)
             elif scheme in ('http', 'https'):  # 'ftp','mailto',
                 changed |= self.doHttpUrl(p, url)
+
         # Call this only once, at end.
         u.afterChangeGroup(c.p, undoType)
         if changed:
@@ -3482,20 +3483,21 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
         fn = g.toUnicode(url, encoding=e)
         if sys.platform.lower().startswith('win') and fn.startswith('/'):
             fn = fn[1:]
+        if not g.os_path_exists(fn):
+            return False
         if os.path.isdir(fn):
             # Just insert an @path directory.
             self.doPathUrlHelper(fn, p)
             return True
-        if g.os_path_exists(fn):
-            try:
-                f = open(fn, 'rb')  # 2012/03/09: use 'rb'
-            except IOError:
-                f = None
-            if f:
-                b = f.read()
-                s = g.toUnicode(b)
-                f.close()
-                return self.doFileUrlHelper(fn, p, s)
+        try:
+            f = open(fn, 'rb')  # 2012/03/09: use 'rb'
+        except IOError:
+            f = None
+        if f:
+            b = f.read()
+            s = g.toUnicode(b)
+            f.close()
+            return self.doFileUrlHelper(fn, p, s)
         nodeLink = p.get_UNL()
         g.es_print(f"not found: {fn}", nodeLink=nodeLink)
         return False


### PR DESCRIPTION
This PR fixes the problem that drag-and-drop of a Leo outline fails.  

This PR is a work in progress because drag-and-drop for non-Leo files creates empty nodes instead of populated trees for non-Leo files.

See https://github.com/leo-editor/leo-editor/issues/3876.