### PR TITLE
PR for #3823: import-any-file

### DIFF
--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -743,7 +743,7 @@ class LeoImportCommands:
         current.expand()
         c.setChanged()
         if command:
-            u.afterChangeGroup(p, command)
+            u.afterChangeGroup(c.p, command)
         c.redraw(current)
         return p
     #@+node:ekr.20031218072017.3212: *4* ic.importFilesCommand


### PR DESCRIPTION
See #3823.

- [x] Call `u.afterChangeGroup` with `c.p` instead of `p`.