### PR TITLE
PR for #3884: TypeAlias does not exist before Python 3.12

### DIFF
--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -22,14 +22,16 @@ from __future__ import annotations
 from collections.abc import Callable
 import os
 import string
-from typing import Any, TypeAlias, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias  # Requires Python 3.12+
     from leo.core.leoGui import QtCore
     from leo.core.leoCommands import Commands as Cmdr
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     from leo.core.leoGui import LeoKeyEvent
+
     QEvent: TypeAlias = QtCore.QEvent
     Stroke = Any
     Widget = Any

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2,7 +2,7 @@
 #@+node:ekr.20140907123524.18774: * @file ../plugins/qt_frame.py
 """Leo's qt frame classes."""
 #@+<< qt_frame imports >>
-#@+node:ekr.20110605121601.18003: **  << qt_frame imports >>
+#@+node:ekr.20110605121601.18003: ** << qt_frame imports >>
 from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
@@ -12,7 +12,7 @@ import string
 import sys
 import time
 import urllib
-from typing import Any, Optional, TypeAlias, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoColorizer
@@ -37,6 +37,7 @@ from leo.plugins.nested_splitter import NestedSplitter
 #@+<< qt_frame annotations >>
 #@+node:ekr.20220415080427.1: ** << qt_frame annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias  # Requires Python 3.12+
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoGui
     from leo.core.leoGui import LeoKeyEvent

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -11,7 +11,7 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, Optional, Union, TypeAlias, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 from leo.core import leoColor
 from leo.core import leoGlobals as g
 from leo.core import leoGui
@@ -35,6 +35,7 @@ assert qt_commands
 #@+<< qt_gui annotations >>
 #@+node:ekr.20220415183421.1: ** << qt_gui annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias  # Requires Python 3.12+
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -5,7 +5,7 @@
 #@+node:ekr.20220416085845.1: ** << qt_text imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Any, Optional, TypeAlias, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtGui, Qsci, QtWidgets
 from leo.core.leoQt import ContextMenuPolicy, Key, KeyboardModifier
@@ -13,6 +13,7 @@ from leo.core.leoQt import MouseButton, MoveMode, MoveOperation
 from leo.core.leoQt import Shadow, Shape, SliderAction, SolidLine, WindowType, WrapMode
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias  # Requires Python 3.12+
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     Args = Any

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -83,7 +83,7 @@ from collections.abc import Callable
 import fnmatch
 import itertools
 import re
-from typing import Any, Iterable, Iterator, TypeAlias, Union
+from typing import Any, Iterable, Iterator, Union
 from typing import TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core.leoQt import Qt, QtCore, QtWidgets
@@ -97,6 +97,7 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@+<< quicksearch annotations >>
 #@+node:ekr.20220828094201.1: ** << quicksearch annotations >>
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias  # Requires Python 3.12+
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position
     from leo.core.leoGui import LeoKeyEvent


### PR DESCRIPTION
See #3884.

- [x] Move 'from typing import TypeAlias' into the range of 'if TYPE_CHECKING'.

These changes allow Leo to run on all version of Python >= 3.9.

mypy checks may be degraded on versions of Python < 3.12, but that does not concern me:
I *only* require that mypy pass on Python 3.12.

**Summary**: the changes shown suffice.