### PR TITLE
PR for #3905: ratio properties

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -133,7 +133,7 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     print('Restarting Leo with:\n')
     print(args_s)
     print('')
-    subprocess.run(args)
+    subprocess.run(args)  # pylint: disable=subprocess-run-check
 #@+node:ekr.20031218072017.2820: ** c_file.top level
 #@+node:ekr.20031218072017.2833: *3* c_file.close
 @g.commander_command('close-window')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -286,8 +286,8 @@ def new(self: Self, event: LeoKeyEvent = None, gui: LeoGui = None) -> Cmdr:
     frame.lift()
 
     # Resize the _new_ frame.
-    frame.resizePanesToRatio(frame.ratio, frame.secondary_ratio)
-    c.frame.createFirstTreeNode()
+    frame.resizePanesToRatio(frame.compute_ratio(), frame.compute_secondary_ratio())
+    frame.createFirstTreeNode()
 
     # Finish.
     lm.finishOpen(c)

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1000,7 +1000,7 @@ class ActiveSettingsOutline:
         # #1340: Don't do this. It is no longer needed.
             # g.app.restoreWindowState(c)
 
-        c.frame.resizePanesToRatio(c.frame.ratio, c.frame.secondary_ratio)
+        c.frame.resizePanesToRatio(c.frame.compute_ratio(), c.frame.compute_secondary_ratio())
         c.clearChanged()  # Clears all dirty bits.
 
         # Finish.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -910,7 +910,7 @@ class FileCommands:
         else:
             v = fc._getLeoFileByName(path, readAtFileNodesFlag)
         if v:
-            c.frame.resizePanesToRatio(c.frame.ratio, c.frame.secondary_ratio)
+            c.frame.resizePanesToRatio(c.frame.compute_ratio(), c.frame.compute_secondary_ratio())
             if checkOpenFiles:
                 g.app.checkForOpenFile(c, path)
         return v
@@ -1479,7 +1479,8 @@ class FileCommands:
             ),
             c.frame.get_window_info() +
             (
-                c.frame.ratio, c.frame.secondary_ratio,
+                c.frame.compute_ratio(),
+                c.frame.compute_secondary_ratio(),
                 self.encodePosition(c.p)
             )
         )
@@ -1682,29 +1683,15 @@ class FileCommands:
             self.setCachedBits()
         return result
     #@+node:ekr.20210316092313.1: *6* fc.leojs_globals (sets window_position)
-    def leojs_globals(self) -> Optional[dict[str, Any]]:
+    def leojs_globals(self) -> None:
         """Put json representation of Leo's cached globals."""
         c = self.c
         width, height, left, top = c.frame.get_window_info()
-        if 1:  # Write to the cache, not the file.
-            d = None
-            c.db['body_outline_ratio'] = str(c.frame.ratio)
-            c.db['body_secondary_ratio'] = str(c.frame.secondary_ratio)
-            c.db['window_position'] = str(top), str(left), str(height), str(width)
-            if 'size' in g.app.debug:
-                g.trace('set window_position:', c.db['window_position'], c.shortFileName())
-        else:
-            d = {
-                'body_outline_ratio': c.frame.ratio,
-                'body_secondary_ratio': c.frame.secondary_ratio,
-                'globalWindowPosition': {
-                    'top': top,
-                    'left': left,
-                    'width': width,
-                    'height': height,
-                },
-            }
-        return d
+        c.db['body_outline_ratio'] = str(c.frame.compute_ratio())
+        c.db['body_secondary_ratio'] = str(c.frame.compute_secondary_ratio())
+        c.db['window_position'] = str(top), str(left), str(height), str(width)
+        if 'size' in g.app.debug:
+            g.trace('set window_position:', c.db['window_position'], c.shortFileName())
     #@+node:ekr.20210316085413.2: *6* fc.leojs_vnodes
     def leojs_vnode(self, p: Position, gnxSet: Any, isIgnore: bool = False) -> dict[str, Any]:
         """Return a jsonized vnode."""
@@ -1912,8 +1899,8 @@ class FileCommands:
         self.put("<globals/>\n")
         if not c.mFileName:
             return
-        c.db['body_outline_ratio'] = str(c.frame.ratio)
-        c.db['body_secondary_ratio'] = str(c.frame.secondary_ratio)
+        c.db['body_outline_ratio'] = str(c.frame.compute_ratio())
+        c.db['body_secondary_ratio'] = str(c.frame.compute_secondary_ratio())
         w, h, left, t = c.frame.get_window_info()
         c.db['window_position'] = str(t), str(left), str(h), str(w)
         if trace:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -604,7 +604,6 @@ class FileCommands:
         self.descendentMarksList: list[str] = []  # List of gnx's.
         self.descendentTnodeUaDictList: list[Any] = []
         self.descendentVnodeUaDictList: list[Any] = []
-        self.ratio = 0.5
         self.currentVnode: VNode = None
         # For writing...
         self.read_only = False

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -703,7 +703,7 @@ class LeoFrame:
     """The base class for all Leo windows."""
     instances = 0
     #@+others
-    #@+node:ekr.20031218072017.3679: *3* LeoFrame.__init__ & reloadSettings
+    #@+node:ekr.20031218072017.3679: *3* LeoFrame.__init__
     def __init__(self, c: Cmdr, gui: LeoGui) -> None:
         self.c = c
         self.gui = gui
@@ -764,6 +764,12 @@ class LeoFrame:
     def initCompleteHint(self) -> None:
         """A hook for Qt."""
         pass
+    #@+node:ekr.20240510091810.1: *4* LeoFrame.compute_ratio & compute_secondary_ratio
+    def compute_ratio(self) -> float:
+        return 0.5
+
+    def compute_secondary_ratio(self) -> float:
+        return 0.5
     #@+node:ekr.20061109125528.1: *3* LeoFrame.Must be defined in base class
     #@+node:ekr.20031218072017.3689: *4* LeoFrame.initialRatios
     def initialRatios(self) -> tuple[bool, float, float]:
@@ -1817,7 +1823,6 @@ class NullFrame(LeoFrame):
         self.iconBar = NullIconBarClass(self.c, self)
         self.initComplete = True
         self.isNullFrame = True
-        self.ratio = self.secondary_ratio = 0.5
         self.statusLineClass = NullStatusLineClass
         self.title = title
         # Create the component objects.
@@ -1836,6 +1841,12 @@ class NullFrame(LeoFrame):
 
     def cascade(self, event: LeoKeyEvent = None) -> None:
         pass
+
+    def compute_ratio(self) -> float:
+        return 0.5
+
+    def compute_secondary_ratio(self) -> float:
+        return 0.5
 
     def contractBodyPane(self, event: LeoKeyEvent = None) -> None:
         pass

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -331,7 +331,7 @@ class LeoBody:
 
     def updateSyntaxColorer(self, p: Position) -> None:
         if p:
-            return self.colorizer.updateSyntaxColorer(p.copy())
+            self.colorizer.updateSyntaxColorer(p.copy())
 
     def recolor(self, p: Position) -> None:
         self.c.recolor()

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5861,7 +5861,7 @@ def createScratchCommander(fileName: str = None) -> None:
     frame.createFirstTreeNode()
     assert c.rootPosition()
     frame.setInitialWindowGeometry()
-    frame.resizePanesToRatio(frame.ratio, frame.secondary_ratio)
+    frame.resizePanesToRatio(frame.compute_ratio(), frame.compute_secondary_ratio())
 #@+node:ekr.20031218072017.3126: *3* g.funcToMethod (Python Cookbook)
 def funcToMethod(f: Any, theClass: Any, name: str = None) -> None:
     """

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -1669,6 +1669,68 @@ else:
 
 Weight = QtGui.QFont.Weight
 WrapMode = QtGui.QTextOption.WrapMode
+#@+node:ekr.20240510154418.1: ** retire frame.ratio, secondary_ratio, etc.
+#@+node:ekr.20160424080647.1: *3* qtFrame.Properties
+# The ratio and secondary_ratio properties are read-only.
+#@+node:ekr.20160424080815.2: *4* qtFrame.ratio property
+ratio_message_given = False
+ratio_message1 = '\nLeoQtFrame.ratio and secondary_ratio properties are deprecated'
+ratio_message2 = 'Use the compute_ratio and compute_secondary_ratio methods instead\n'
+
+def __get_ratio(self) -> float:
+    """
+    Return splitter ratio of the main splitter.
+    Deprecated: Use the compute_ratio method instead.
+                This method is not used in Leo's core.
+    """
+    c = self.c
+    free_layout = c.free_layout
+    # Give the deprecation method.
+    if not self.ratio_message_given:
+        self.ratio_message_given = True
+        print(self.ratio_message1)
+        print(self.ratio_message2)
+    if free_layout:
+        w = free_layout.get_main_splitter()
+        if w:
+            aList = w.sizes()
+            if len(aList) == 2:
+                n1, n2 = aList
+                # 2017/06/07: guard against division by zero.
+                ratio = 0.5 if n1 + n2 == 0 else float(n1) / float(n1 + n2)
+                return ratio
+    return 0.5
+
+ratio = property(
+    __get_ratio,  # No setter.
+    doc="qtFrame.ratio property")
+#@+node:ekr.20160424080815.3: *4* qtFrame.secondary_ratio property
+def __get_secondary_ratio(self) -> float:
+    """
+    Return the splitter ratio of the secondary splitter.
+    Deprecated: Use the compute_secondary_ratio method instead.
+                This method is not used in Leo's core.
+    """
+    c = self.c
+    free_layout = c.free_layout
+    # Give the deprecation method.
+    if not self.ratio_message_given:
+        self.ratio_message_given = True
+        print(self.ratio_message1)
+        print(self.ratio_message2)
+    if free_layout:
+        w = free_layout.get_secondary_splitter()
+        if w:
+            aList = w.sizes()
+            if len(aList) == 2:
+                n1, n2 = aList
+                ratio = float(n1) / float(n1 + n2)
+                return ratio
+    return 0.5
+
+secondary_ratio = property(
+    __get_secondary_ratio,  # no setter.
+    doc="qtFrame.secondary_ratio property")
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -171,7 +171,6 @@ class TextFrame(leoFrame.LeoFrame):
         super().__init__(c, gui)
         assert self.c == c
         self.top = None
-        self.ratio = self.secondary_ratio = 0.5
     #@+node:ekr.20150107090324.23: *3* createFirstTreeNode (cursesGui.py)
     def createFirstTreeNode(self):
         c = self.c

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -171,7 +171,7 @@ class TextFrame(leoFrame.LeoFrame):
         super().__init__(c, gui)
         assert self.c == c
         self.top = None
-        self.ratio = self.secondary_ratio = 0.0
+        self.ratio = self.secondary_ratio = 0.5
     #@+node:ekr.20150107090324.23: *3* createFirstTreeNode (cursesGui.py)
     def createFirstTreeNode(self):
         c = self.c

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2160,8 +2160,7 @@ class CoreFrame(leoFrame.LeoFrame):
         self.log = CoreLog(c)
         g.app.gui.log = self.log
         self.title: str = title
-        # Standard ivars.
-        self.ratio = self.secondary_ratio = 0.5
+
         # Widgets
         self.top = TopFrame(c)  # type:ignore
         self.body = CoreBody(c)
@@ -4201,6 +4200,9 @@ class StatusLineWrapper(leoFrame.StringTextWrapper):
 
     #@+others
     #@+node:ekr.20171129204751.1: *4* StatusLineWrapper.do nothings
+    def computeStatusUnl(self, p: Position) -> str:
+        return ''
+
     def disable(self, *args: Any, **kwargs: Any) -> None:
         pass
 

--- a/leo/plugins/demo.py
+++ b/leo/plugins/demo.py
@@ -681,7 +681,7 @@ class Demo:
     def get_ratios(self):
         """Return the two pane ratios."""
         f = self.c.frame
-        return f.ratio, f.secondary_ratio
+        return f.compute_ratio(), f.compute_secondary_ratio()
 
     def set_ratios(self, ratio1, ratio2):
         """Set the two pane ratios."""

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -563,7 +563,6 @@ class SaxContentHandler(xml.sax.saxutils.XMLGenerator):
         self.level = 0
         self.node = None
         self.nodeStack = []
-        self.ratio = 0.5  # body-outline ratio.
         self.rootNode = None
     #@+node:ekr.20060917185525: *4* define_disptatch_dict
     def define_dispatch_dict(self):
@@ -706,16 +705,7 @@ class SaxContentHandler(xml.sax.saxutils.XMLGenerator):
         self.doHeadAttributes(attrs)
     #@+node:ekr.20060922072852.1: *5* doHeadAttributes
     def doHeadAttributes(self, attrs):
-        ratio = 0.5
-        for bunch in self.attrsToList(attrs):
-            name = bunch.name
-            val = bunch.val
-            if name == 'leo:body_outline_ratio':
-                try:
-                    ratio = float(val)
-                except ValueError:
-                    pass
-        self.ratio = ratio
+        pass
     #@+node:ekr.20060917190349: *4* startOutline (leoOpml)
     def startOutline(self, attrs):
         if self.inElement('head'):

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2421,7 +2421,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
     @frame_cmd('equal-sized-panes')
     def equalSizedPanes(self, event: LeoKeyEvent = None) -> None:
         """Make the outline and body panes have the same size."""
-        self.resizePanesToRatio(0.5, self.secondary_ratio)
+        self.resizePanesToRatio(0.5, self.compute_secondary_ratio())
     #@+node:ekr.20110605121601.18305: *5* qtFrame.hideLogWindow
     def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
         """Hide the log pane."""
@@ -4762,7 +4762,7 @@ def contractLogPane(event: LeoKeyEvent) -> None:
     if not c:
         return
     f = c.frame
-    r = min(1.0, f.secondary_ratio + 0.1)
+    r = min(1.0, f.compute_secondary_ratio() + 0.1)
     f.divideLeoSplitter2(r)
 #@+node:ekr.20200303084225.1: *3* 'contract-outline-pane' & 'expand-body-pane'
 @g.command('contract-outline-pane')
@@ -4784,7 +4784,7 @@ def expandLogPane(event: LeoKeyEvent) -> None:
     if not c:
         return
     f = c.frame
-    r = max(0.0, f.secondary_ratio - 0.1)
+    r = max(0.0, f.compute_secondary_ratio() - 0.1)
     f.divideLeoSplitter2(r)
 #@+node:ekr.20200303084610.1: *3* 'hide-body-pane'
 @g.command('hide-body-pane')

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2461,67 +2461,6 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 assert hasattr(w, 'setWindowState'), w
             else:
                 w.setWindowState(WindowState.WindowMaximized)
-    #@+node:ekr.20160424080647.1: *3* qtFrame.Properties
-    # The ratio and secondary_ratio properties are read-only.
-    #@+node:ekr.20160424080815.2: *4* qtFrame.ratio property
-    ratio_message_given = False
-    ratio_message1 = '\nLeoQtFrame.ratio and secondary_ratio properties are deprecated'
-    ratio_message2 = 'Use the compute_ratio and compute_secondary_ratio methods instead\n'
-
-    def __get_ratio(self) -> float:
-        """
-        Return splitter ratio of the main splitter.
-        Deprecated: Use the compute_ratio method instead.
-                    This method is not used in Leo's core.
-        """
-        c = self.c
-        free_layout = c.free_layout
-        # Give the deprecation method.
-        if not self.ratio_message_given:
-            self.ratio_message_given = True
-            print(self.ratio_message1)
-            print(self.ratio_message2)
-        if free_layout:
-            w = free_layout.get_main_splitter()
-            if w:
-                aList = w.sizes()
-                if len(aList) == 2:
-                    n1, n2 = aList
-                    # 2017/06/07: guard against division by zero.
-                    ratio = 0.5 if n1 + n2 == 0 else float(n1) / float(n1 + n2)
-                    return ratio
-        return 0.5
-
-    ratio = property(
-        __get_ratio,  # No setter.
-        doc="qtFrame.ratio property")
-    #@+node:ekr.20160424080815.3: *4* qtFrame.secondary_ratio property
-    def __get_secondary_ratio(self) -> float:
-        """
-        Return the splitter ratio of the secondary splitter.
-        Deprecated: Use the compute_secondary_ratio method instead.
-                    This method is not used in Leo's core.
-        """
-        c = self.c
-        free_layout = c.free_layout
-        # Give the deprecation method.
-        if not self.ratio_message_given:
-            self.ratio_message_given = True
-            print(self.ratio_message1)
-            print(self.ratio_message2)
-        if free_layout:
-            w = free_layout.get_secondary_splitter()
-            if w:
-                aList = w.sizes()
-                if len(aList) == 2:
-                    n1, n2 = aList
-                    ratio = float(n1) / float(n1 + n2)
-                    return ratio
-        return 0.5
-
-    secondary_ratio = property(
-        __get_secondary_ratio,  # no setter.
-        doc="qtFrame.secondary_ratio property")
     #@+node:ekr.20110605121601.18311: *3* qtFrame.Qt bindings...
     #@+node:ekr.20190611053431.1: *4* qtFrame.bringToFront
     def bringToFront(self) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2204,6 +2204,39 @@ class LeoQtFrame(leoFrame.LeoFrame):
         # print('destroySelf: qtFrame: %s' % c,g.callers(4))
         top.close()
     #@+node:ekr.20110605121601.18274: *3* qtFrame.Configuration
+    #@+node:ekr.20240510092709.1: *4* qtFrame.compute_ratio & compute_secondary_ratio (new)
+    #@+node:ekr.20240510093119.1: *5* qtFrame.compute_ratio
+    def compute_ratio(self) -> float:
+        """
+        Return ratio of the main Qt splitter or 0.5.
+        """
+        c = self.c
+        if c.free_layout:
+            w = c.free_layout.get_main_splitter()
+            if w:
+                aList = w.sizes()
+                if len(aList) == 2:
+                    n1, n2 = aList
+                    # Don't divide by zero.
+                    ratio = 0.5 if n1 + n2 == 0 else float(n1) / float(n1 + n2)
+                    return ratio
+        return 0.5
+    #@+node:ekr.20240510093122.1: *5* qtFrame.compute_secondary_ratio
+    def compute_secondary_ratio(self) -> float:
+        """
+        Return the ratio of the Qt secondary splitter or 0.5.
+        """
+        c = self.c
+        free_layout = c.free_layout
+        if free_layout:
+            w = free_layout.get_secondary_splitter()
+            if w:
+                aList = w.sizes()
+                if len(aList) == 2:
+                    n1, n2 = aList
+                    ratio = float(n1) / float(n1 + n2)
+                    return ratio
+        return 0.5
     #@+node:ekr.20110605121601.18275: *4* qtFrame.configureBar
     def configureBar(self, bar: Wrapper, verticalFlag: bool) -> None:
         c = self.c
@@ -4717,9 +4750,8 @@ def contractBodyPane(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if not c:
         return
-    f = c.frame
-    r = min(1.0, f.ratio + 0.1)
-    f.divideLeoSplitter1(r)
+    r = min(1.0, c.frame.compute_ratio() + 0.1)
+    c.frame.divideLeoSplitter1(r)
 
 expandOutlinePane = contractBodyPane
 #@+node:ekr.20200303084048.1: *3* 'contract-log-pane'
@@ -4740,9 +4772,8 @@ def contractOutlinePane(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if not c:
         return
-    f = c.frame
-    r = max(0.0, f.ratio - 0.1)
-    f.divideLeoSplitter1(r)
+    r = max(0.0, c.frame.compute_ratio() - 0.1)
+    c.frame.divideLeoSplitter1(r)
 
 expandBodyPane = contractOutlinePane
 #@+node:ekr.20200303084226.1: *3* 'expand-log-pane'

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2431,10 +2431,23 @@ class LeoQtFrame(leoFrame.LeoFrame):
     #@+node:ekr.20160424080647.1: *3* qtFrame.Properties
     # The ratio and secondary_ratio properties are read-only.
     #@+node:ekr.20160424080815.2: *4* qtFrame.ratio property
+    ratio_message_given = False
+    ratio_message1 = '\nLeoQtFrame.ratio and secondary_ratio properties are deprecated'
+    ratio_message2 = 'Use the compute_ratio and compute_secondary_ratio methods instead\n'
+
     def __get_ratio(self) -> float:
-        """Return splitter ratio of the main splitter."""
+        """
+        Return splitter ratio of the main splitter.
+        Deprecated: Use the compute_ratio method instead.
+                    This method is not used in Leo's core.
+        """
         c = self.c
         free_layout = c.free_layout
+        # Give the deprecation method.
+        if not self.ratio_message_given:
+            self.ratio_message_given = True
+            print(self.ratio_message1)
+            print(self.ratio_message2)
         if free_layout:
             w = free_layout.get_main_splitter()
             if w:
@@ -2451,9 +2464,18 @@ class LeoQtFrame(leoFrame.LeoFrame):
         doc="qtFrame.ratio property")
     #@+node:ekr.20160424080815.3: *4* qtFrame.secondary_ratio property
     def __get_secondary_ratio(self) -> float:
-        """Return the splitter ratio of the secondary splitter."""
+        """
+        Return the splitter ratio of the secondary splitter.
+        Deprecated: Use the compute_secondary_ratio method instead.
+                    This method is not used in Leo's core.
+        """
         c = self.c
         free_layout = c.free_layout
+        # Give the deprecation method.
+        if not self.ratio_message_given:
+            self.ratio_message_given = True
+            print(self.ratio_message1)
+            print(self.ratio_message2)
         if free_layout:
             w = free_layout.get_secondary_splitter()
             if w:


### PR DESCRIPTION
See #3905.

This PR contains the minimal changes required to deprecate the unwanted (deprecated) proprieties.

A *later* PR will tackle bugs in `c.frame.compute_ratio` and `c.frame.compute_secondary_ratio`.

- [x] Add deprecation message to `LeoQtFrame.ratio` and `LeoQtFrame.secondary_ratio` properties.
- [x] Replace these properties with `c.frame.compute_ratio` and `c.frame.compute_secondary_ratio` methods everywhere.
- [x] Add corresponding do-nothing methods to LeoFrame class.
- [x] Remove all `ratio` and `secondary_ratio` ivars.

**Extras**

- [x] Fix recent crasher in `cursesGui2.py` by defining a do-nothing `computeStatusUnl` method.
- [x] Fix several pylint complaints.
- [x] Remove dead code in `fc.leojs_globals` and change the annotated return type to `None`.
- [x] Simplify `LeoOPML.py` by not computing the `ratio` ivar.