### PR TITLE
PR for #3910: deprecate free_layout and nested_splitter plugins

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -128,6 +128,9 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
     launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
     args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
+    # Add any --trace args.
+    for z in g.app.debug:
+        args.append(f"--trace={z}")
     args_s = 'subprocess.run([\n  ' + ',\n  '.join(args) + '\n])'
     print('')
     print('Restarting Leo with:\n')

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1989,6 +1989,7 @@
 </v>
 <v t="ekr.20181018105748.1"><vh>viewrendered plugin</vh>
 <v t="ekr.20181018105800.1"><vh>@bool view-rendered-auto-create = False</vh></v>
+<v t="ekr.20240519122612.1"><vh>@bool view-rendered-keep-open = True</vh></v>
 <v t="ekr.20181018113446.1"><vh>@string view-rendered-default-kind = rst</vh></v>
 <v t="ekr.20181018113502.1"><vh>@string view-rendered-md-extensions = extra</vh></v>
 </v>
@@ -11643,6 +11644,7 @@ False:          Display only the .leo file's name in the status area.
 True:  (Recommended) Search backwards from the end of the outline.
 False: (Legacy)      Search forwards from the start of the outline.
 </t>
+<t tx="ekr.20240519122612.1">True: keep the VR pane open regardless of the body pane's content.</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2674,7 +2674,7 @@ class LoadManager:
                 A comma-separated list. Valid values are:
                 abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
                 importers, ipython, keys, layouts, plugins, save, select, sections,
-                shutdown, size, speed, splitters, startup, themes, undo, verbose, zoom.
+                shutdown, size, speed, startup, themes, undo, verbose, zoom.
 
           --trace-binding=KEY   trace commands bound to a key
           --trace-setting=NAME  trace where named setting is set
@@ -2810,7 +2810,7 @@ class LoadManager:
                 'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
                 'focus', 'git', 'gnx', 'importers', 'ipython', 'keys',
                 'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
-                'size', 'speed', 'splitters', 'startup', 'themes', 'undo', 'verbose', 'zoom',
+                'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
             ]
             m = utils.find_complex_option(r'--trace=([\w\,]+)')
             if not m:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2674,7 +2674,7 @@ class LoadManager:
                 A comma-separated list. Valid values are:
                 abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
                 importers, ipython, keys, layouts, plugins, save, select, sections,
-                shutdown, size, speed, startup, themes, undo, verbose, zoom.
+                shutdown, size, speed, splitters, startup, themes, undo, verbose, zoom.
 
           --trace-binding=KEY   trace commands bound to a key
           --trace-setting=NAME  trace where named setting is set
@@ -2810,7 +2810,7 @@ class LoadManager:
                 'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
                 'focus', 'git', 'gnx', 'importers', 'ipython', 'keys',
                 'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
-                'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
+                'size', 'speed', 'splitters', 'startup', 'themes', 'undo', 'verbose', 'zoom',
             ]
             m = utils.find_complex_option(r'--trace=([\w\,]+)')
             if not m:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1012,8 +1012,7 @@ class LeoApp:
         except Exception:
             return  # Other methods will report startup problems.
         try:
-            from leo.plugins.editpane.editpane import edit_pane_test_open, edit_pane_csv
-            g.command('edit-pane-test-open')(edit_pane_test_open)
+            from leo.plugins.editpane.editpane import edit_pane_csv
             g.command('edit-pane-csv')(edit_pane_csv)
         except ImportError:
             print('Failed to import editpane')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -391,19 +391,6 @@ class Commands:
         c.configurables = c.subCommanders[:]
         c.db = CommanderWrapper(c)
         c.free_layout = None
-        
-        ### Test later: getattr(c, 'free_layout', None):
-            # if g.allow_nested_splitter:  # #3910.
-                # # #2485: Load the free_layout plugin in the proper context.
-                # #        g.app.pluginsController.loadOnePlugin won't work here.
-                # try:
-                    # g.app.pluginsController.loadingModuleNameStack.append('leo.plugins.free_layout')
-                    # from leo.plugins import free_layout
-                    # c.free_layout = free_layout.FreeLayoutController(c)
-                # finally:
-                    # g.app.pluginsController.loadingModuleNameStack.pop()
-            # else:
-                # c.free_layout = None
             
         if hasattr(g.app.gui, 'styleSheetManagerClass'):
             self.styleSheetManager = g.app.gui.styleSheetManagerClass(c)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -391,14 +391,18 @@ class Commands:
         c.configurables = c.subCommanders[:]
         c.db = CommanderWrapper(c)
 
-        # #2485: Load the free_layout plugin in the proper context.
-        #        g.app.pluginsController.loadOnePlugin won't work here.
-        try:
-            g.app.pluginsController.loadingModuleNameStack.append('leo.plugins.free_layout')
-            from leo.plugins import free_layout
-            c.free_layout = free_layout.FreeLayoutController(c)
-        finally:
-            g.app.pluginsController.loadingModuleNameStack.pop()
+        if g.allow_nested_splitter:  # #3910.
+            # #2485: Load the free_layout plugin in the proper context.
+            #        g.app.pluginsController.loadOnePlugin won't work here.
+            try:
+                g.app.pluginsController.loadingModuleNameStack.append('leo.plugins.free_layout')
+                from leo.plugins import free_layout
+                c.free_layout = free_layout.FreeLayoutController(c)
+            finally:
+                g.app.pluginsController.loadingModuleNameStack.pop()
+        else:
+            c.free_layout = None
+            
         if hasattr(g.app.gui, 'styleSheetManagerClass'):
             self.styleSheetManager = g.app.gui.styleSheetManagerClass(c)
             self.subCommanders.append(self.styleSheetManager)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -390,18 +390,20 @@ class Commands:
         # A list of other classes that have a reloadSettings method
         c.configurables = c.subCommanders[:]
         c.db = CommanderWrapper(c)
-
-        if g.allow_nested_splitter:  # #3910.
-            # #2485: Load the free_layout plugin in the proper context.
-            #        g.app.pluginsController.loadOnePlugin won't work here.
-            try:
-                g.app.pluginsController.loadingModuleNameStack.append('leo.plugins.free_layout')
-                from leo.plugins import free_layout
-                c.free_layout = free_layout.FreeLayoutController(c)
-            finally:
-                g.app.pluginsController.loadingModuleNameStack.pop()
-        else:
-            c.free_layout = None
+        c.free_layout = None
+        
+        ### Test later: getattr(c, 'free_layout', None):
+            # if g.allow_nested_splitter:  # #3910.
+                # # #2485: Load the free_layout plugin in the proper context.
+                # #        g.app.pluginsController.loadOnePlugin won't work here.
+                # try:
+                    # g.app.pluginsController.loadingModuleNameStack.append('leo.plugins.free_layout')
+                    # from leo.plugins import free_layout
+                    # c.free_layout = free_layout.FreeLayoutController(c)
+                # finally:
+                    # g.app.pluginsController.loadingModuleNameStack.pop()
+            # else:
+                # c.free_layout = None
             
         if hasattr(g.app.gui, 'styleSheetManagerClass'):
             self.styleSheetManager = g.app.gui.styleSheetManagerClass(c)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -390,7 +390,7 @@ class Commands:
         # A list of other classes that have a reloadSettings method
         c.configurables = c.subCommanders[:]
         c.db = CommanderWrapper(c)
-        c.free_layout = None
+        c.free_layout = None  # Compatibility. Always None.
             
         if hasattr(g.app.gui, 'styleSheetManagerClass'):
             self.styleSheetManager = g.app.gui.styleSheetManagerClass(c)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -69,13 +69,6 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoGlobals: annotations >>
 #@+<< leoGlobals: global constants >>
 #@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-###
-    # allow_nested_splitter = False
-    # if 1:
-        # print('')
-        # print('g.allow_nested_splitter', allow_nested_splitter)
-        # print('')
-
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -69,11 +69,13 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoGlobals: annotations >>
 #@+<< leoGlobals: global constants >>
 #@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-allow_nested_splitter = False
-if 1:
-    print('')
-    print('g.allow_nested_splitter', allow_nested_splitter)
-    print('')
+###
+    # allow_nested_splitter = False
+    # if 1:
+        # print('')
+        # print('g.allow_nested_splitter', allow_nested_splitter)
+        # print('')
+
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -69,7 +69,11 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoGlobals: annotations >>
 #@+<< leoGlobals: global constants >>
 #@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-allow_nested_splitter = False
+allow_nested_splitter = True
+if 1:
+    print('')
+    print('g.allow_nested_splitter', allow_nested_splitter)
+    print('')
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5,8 +5,8 @@ Global constants, variables and utility functions used throughout Leo.
 
 Important: This module imports no other Leo module.
 """
-#@+<< leoGlobals imports >>
-#@+node:ekr.20050208101229: ** << leoGlobals imports >>
+#@+<< leoGlobals: imports >>
+#@+node:ekr.20050208101229: ** << leoGlobals: imports >>
 from __future__ import annotations
 import binascii
 from collections.abc import Callable
@@ -51,9 +51,9 @@ except Exception:
 #
 # Abbreviations...
 StringIO = io.StringIO
-#@-<< leoGlobals imports >>
-#@+<< leoGlobals annotations >>
-#@+node:ekr.20220824084642.1: ** << leoGlobals annotations >>
+#@-<< leoGlobals: imports >>
+#@+<< leoGlobals: annotations >>
+#@+node:ekr.20220824084642.1: ** << leoGlobals: annotations >>
 if TYPE_CHECKING:  # pragma: no cover
     from types import Module
     from leo.core import LeoGlobals
@@ -66,7 +66,10 @@ if TYPE_CHECKING:  # pragma: no cover
     # Mypy could do better with *args and **kwargs.
     Args = Any  # Good enough.
     KWargs = Any  # Good enough.
-#@-<< leoGlobals annotations >>
+#@-<< leoGlobals: annotations >>
+#@+<< leoGlobals: global constants >>
+#@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
+allow_nested_splitter = True
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'
@@ -77,6 +80,7 @@ isPython3 = python_version_tuple >= (3, 0, 0)
 isValidPython = python_version_tuple >= minimum_python_version_tuple
 isMac = sys.platform.startswith('darwin')
 isWindows = sys.platform.startswith('win')
+#@-<< leoGlobals: global constants >>
 #@+<< define g.globalDirectiveList >>
 #@+node:EKR.20040610094819: ** << define g.globalDirectiveList >>
 # Visible externally so plugins may add to the list of directives.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoGlobals: annotations >>
 #@+<< leoGlobals: global constants >>
 #@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-allow_nested_splitter = True
+allow_nested_splitter = False
 if 1:
     print('')
     print('g.allow_nested_splitter', allow_nested_splitter)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoGlobals: annotations >>
 #@+<< leoGlobals: global constants >>
 #@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-allow_nested_splitter = False
+allow_nested_splitter = True
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< leoGlobals: annotations >>
 #@+<< leoGlobals: global constants >>
 #@+node:ekr.20240515093718.1: ** << leoGlobals: global constants >>
-allow_nested_splitter = True
+allow_nested_splitter = False
 in_bridge = False  # True: leoApp object loads a null Gui.
 in_vs_code = False  # #2098.
 minimum_python_version = '3.9'

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -56,20 +56,6 @@ class LeoGui:
         self.ignoreChars: list[str] = []  # Keys that should always be ignored.
         self.FKeys: list[str] = []  # The representation of F-keys.
         self.specialChars: list[str] = []  # A list of characters/keys to be handle specially.
-    #@+node:ekr.20240515145223.1: *3* LeoGui.widget utils (dummies)
-    # The corresponding Qt methods: unl:gnx://leoPy.leo#ekr.20240515150157.1
-
-    def attach_widget(self, w: Widget, parent: Widget) -> None:
-        pass
-
-    def detach_widget(self, w: Widget) -> None:
-        pass
-
-    def get_by_name(self, c: Cmdr, name: str) -> Optional[Widget]:
-        return None
-
-    def get_top_splitter(self, c: Cmdr) -> Widget:
-        return None
     #@+node:ekr.20051206103652: *3* LeoGui.widget_name
     def widget_name(self, w: Widget) -> str:
         # First try the widget's getName method.

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -56,40 +56,43 @@ class LeoGui:
         self.ignoreChars: list[str] = []  # Keys that should always be ignored.
         self.FKeys: list[str] = []  # The representation of F-keys.
         self.specialChars: list[str] = []  # A list of characters/keys to be handle specially.
-    #@+node:ekr.20061109212618.1: *3* LeoGui: Must be defined only in base class
-    #@+node:ekr.20110605121601.18847: *4* LeoGui.create_key_event (LeoGui)
-    def create_key_event(
-        self,
-        c: Cmdr,
-        binding: str = None,
-        char: str = None,
-        event: LeoKeyEvent = None,
-        w: Wrapper = None,
-        x: int = None,
-        x_root: int = None,
-        y: int = None,
-        y_root: int = None,
-    ) -> LeoKeyEvent:
-        # Do not call strokeFromSetting here!
-        # For example, this would wrongly convert Ctrl-C to Ctrl-c,
-        # in effect, converting a user binding from Ctrl-Shift-C to Ctrl-C.
-        return LeoKeyEvent(c, char, event, binding, w, x, y, x_root, y_root)
-    #@+node:ekr.20031218072017.3740: *4* LeoGui.guiName
-    def guiName(self) -> str:
-        try:
-            return self.mGuiName
-        except Exception:
-            return "invalid gui name"
-    #@+node:ekr.20031218072017.2231: *4* LeoGui.setScript
-    def setScript(self, script: str = None, scriptFileName: str = None) -> None:
-        self.script = script
-        self.scriptFileName = scriptFileName
-    #@+node:ekr.20110605121601.18845: *4* LeoGui.event_generate (LeoGui)
-    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: Wrapper) -> None:
-        event = self.create_key_event(c, binding=shortcut, char=char, w=w)
-        c.k.masterKeyHandler(event)
-        c.outerUpdate()
-    #@+node:ekr.20061109212618: *3* LeoGu: Must be defined in subclasses
+    #@+node:ekr.20240515145223.1: *3* LeoGui.widget utils (dummies)
+    # The corresponding Qt methods: unl:gnx://leoPy.leo#ekr.20240515150157.1
+
+    def attach_widget(self, w: Widget, parent: Widget) -> None:
+        pass
+
+    def detach_widget(self, w: Widget) -> None:
+        pass
+
+    def get_top_splitter(self, c: Cmdr) -> Widget:
+        return None
+    #@+node:ekr.20051206103652: *3* LeoGui.widget_name
+    def widget_name(self, w: Widget) -> str:
+        # First try the widget's getName method.
+        if not w:
+            return '<no widget>'
+        if hasattr(w, 'getName'):
+            return w.getName()
+        if hasattr(w, '_name'):
+            return w._name
+        return repr(w)
+    #@+node:ekr.20070228154059: *3* LeoGui: May be defined in subclasses
+    def dismiss_splash_screen(self) -> None:
+        pass
+
+    def ensure_commander_visible(self, c: Cmdr) -> None:
+        """Make sure c's tab is visible"""
+
+    def finishCreate(self) -> None:
+        pass
+
+    def postPopupMenu(self, *args: str, **keys: str) -> None:
+        pass
+
+    def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
+        pass
+    #@+node:ekr.20061109212618: *3* LeoGui: Must be defined in subclasses
     #@+node:ekr.20031218072017.3725: *4* LeoGui.destroySelf
     def destroySelf(self) -> None:
         raise NotImplementedError
@@ -272,36 +275,39 @@ class LeoGui:
         silent: bool = False,
     ) -> None:
         raise NotImplementedError
-    #@+node:ekr.20070228154059: *3* LeoGui: May be defined in subclasses
-    #@+node:ekr.20110613103140.16423: *4* LeoGui.dismiss_spash_screen
-    def dismiss_splash_screen(self) -> None:
-        pass  # May be overridden in subclasses.
-    #@+node:tbrown.20110618095626.22068: *4* LeoGui.ensure_commander_visible
-    def ensure_commander_visible(self, c: Cmdr) -> None:
-        """E.g. if commanders are in tabs, make sure c's tab is visible"""
-        pass
-    #@+node:ekr.20070219084912: *4* LeoGui.finishCreate
-    def finishCreate(self) -> None:
-        # This may be overridden in subclasses.
-        pass
-    #@+node:ekr.20101028131948.5861: *4* LeoGui.killPopupMenu & postPopupMenu
-    # These definitions keep pylint happy.
-
-    def postPopupMenu(self, *args: str, **keys: str) -> None:
-        pass
-    #@+node:ekr.20170612065049.1: *4* LeoGui.put_help
-    def put_help(self, c: Cmdr, s: str, short_title: str) -> None:
-        pass
-    #@+node:ekr.20051206103652: *4* LeoGui.widget_name (LeoGui)
-    def widget_name(self, w: Widget) -> str:
-        # First try the widget's getName method.
-        if not w:
-            return '<no widget>'
-        if hasattr(w, 'getName'):
-            return w.getName()
-        if hasattr(w, '_name'):
-            return w._name
-        return repr(w)
+    #@+node:ekr.20061109212618.1: *3* LeoGui: Must be defined only in base class
+    #@+node:ekr.20110605121601.18847: *4* LeoGui.create_key_event (LeoGui)
+    def create_key_event(
+        self,
+        c: Cmdr,
+        binding: str = None,
+        char: str = None,
+        event: LeoKeyEvent = None,
+        w: Wrapper = None,
+        x: int = None,
+        x_root: int = None,
+        y: int = None,
+        y_root: int = None,
+    ) -> LeoKeyEvent:
+        # Do not call strokeFromSetting here!
+        # For example, this would wrongly convert Ctrl-C to Ctrl-c,
+        # in effect, converting a user binding from Ctrl-Shift-C to Ctrl-C.
+        return LeoKeyEvent(c, char, event, binding, w, x, y, x_root, y_root)
+    #@+node:ekr.20031218072017.3740: *4* LeoGui.guiName
+    def guiName(self) -> str:
+        try:
+            return self.mGuiName
+        except Exception:
+            return "invalid gui name"
+    #@+node:ekr.20031218072017.2231: *4* LeoGui.setScript
+    def setScript(self, script: str = None, scriptFileName: str = None) -> None:
+        self.script = script
+        self.scriptFileName = scriptFileName
+    #@+node:ekr.20110605121601.18845: *4* LeoGui.event_generate (LeoGui)
+    def event_generate(self, c: Cmdr, char: str, shortcut: str, w: Wrapper) -> None:
+        event = self.create_key_event(c, binding=shortcut, char=char, w=w)
+        c.k.masterKeyHandler(event)
+        c.outerUpdate()
     #@-others
 #@+node:ekr.20070228160107: ** class LeoKeyEvent
 class LeoKeyEvent:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -65,6 +65,9 @@ class LeoGui:
     def detach_widget(self, w: Widget) -> None:
         pass
 
+    def get_by_name(self, c: Cmdr, name: str) -> Optional[Widget]:
+        return None
+
     def get_top_splitter(self, c: Cmdr) -> Widget:
         return None
     #@+node:ekr.20051206103652: *3* LeoGui.widget_name

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -842,7 +842,7 @@ class VimCommands:
             self.done()
         else:
             self.quit()
-    #@+node:ekr.20140220134748.16619: *5* vc.vim_c (to do)
+    #@+node:ekr.20140220134748.16619: *5* vc.vim_c
     def vim_c(self) -> None:
         """
         N   cc        change N lines
@@ -1282,7 +1282,7 @@ class VimCommands:
             self.done()
         else:
             self.quit()
-    #@+node:ekr.20131111171616.16497: *5* vc.vim_m (to do)
+    #@+node:ekr.20131111171616.16497: *5* vc.vim_m
     def vim_m(self) -> None:
         """m<a-zA-Z> mark current position with mark."""
         self.not_ready()
@@ -1421,7 +1421,7 @@ class VimCommands:
             self.done(add_to_dot=False, set_dot=False)
         else:
             self.quit()
-    #@+node:ekr.20140220134748.16624: *5* vc.vim_r (to do)
+    #@+node:ekr.20140220134748.16624: *5* vc.vim_r
     def vim_r(self) -> None:
         """Replace next N characters with <char>"""
         self.not_ready()
@@ -1430,11 +1430,11 @@ class VimCommands:
     def vim_r2(self) -> None:
         g.trace(self.n, self.stroke)
         self.done()
-    #@+node:ekr.20140222064735.16625: *5* vc.vim_redo (to do)
+    #@+node:ekr.20140222064735.16625: *5* vc.vim_redo
     def vim_redo(self) -> None:
         """N Ctrl-R redo last N changes"""
         self.not_ready()
-    #@+node:ekr.20140222064735.16626: *5* vc.vim_s (to do)
+    #@+node:ekr.20140222064735.16626: *5* vc.vim_s
     def vim_s(self) -> None:
         """Change N characters"""
         self.not_ready()
@@ -1718,7 +1718,7 @@ class VimCommands:
     def vim_Y(self) -> None:
         """Yank a Leo outline."""
         self.not_ready()
-    #@+node:ekr.20140220134748.16631: *5* vc.vim_z (to do)
+    #@+node:ekr.20140220134748.16631: *5* vc.vim_z
     def vim_z(self) -> None:
         """
         zb redraw current line at bottom of window
@@ -1832,7 +1832,7 @@ class VimCommands:
         self.state = 'normal'
         self.not_ready()
         # self.done(set_dot=True)
-    #@+node:ekr.20140222064735.16656: *5* vis_c (to do)
+    #@+node:ekr.20140222064735.16656: *5* vis_c
     def vis_c(self) -> None:
         """Change the highlighted text."""
         self.state = 'normal'

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -1732,35 +1732,6 @@ secondary_ratio = property(
     __get_secondary_ratio,  # no setter.
     doc="qtFrame.secondary_ratio property")
 #@+node:ekr.20240510161454.31: ** retired from VR plugin
-#@+node:ekr.20240510161454.32: *3* from g.command('vr')
-@g.command('vr')
-def viewrendered(event: Event) -> Optional[Any]:
-    """Open render view for commander"""
-    global controllers, layouts
-    if g.app.gui.guiName() != 'qt':
-        return None
-    c = event.get('c')
-    if not c:
-        return None
-    h = c.hash()
-    vr = controllers.get(h)
-    if not vr:
-        controllers[h] = vr = ViewRenderedController(c)
-    layouts[h] = c.db.get('viewrendered_default_layouts', (None, None))
-    vr._ns_id = '_leo_viewrendered'  # for free_layout load/save
-    vr.splitter = splitter = c.free_layout.get_top_splitter()
-    if splitter:
-        vr.store_layout('closed')
-        sizes = split_last_sizes(splitter.sizes())
-        ok = splitter.add_adjacent(vr, 'bodyFrame', 'right-of')
-        g.trace(ok)
-        if not ok:
-            splitter.insert(0, vr)
-        elif splitter.orientation() == Orientation.Horizontal:
-            splitter.setSizes(sizes)
-        vr.adjust_layout('open')
-    c.bodyWantsFocusNow()
-    return vr
 #@+node:ekr.20240510161454.33: *3* vr function: decorate_window
 def decorate_window(w: Wrapper) -> None:
     # Do not override the style sheet!

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -269,16 +269,17 @@ def cmd_open_node(event):
         # No need to handle url hooks here.
         g.handleUrl(url, c=c, p=p)
 
-#@+node:tbrown.20110712100955.39215: ** bookmarks-show
+#@+node:tbrown.20110712100955.39215: ** bookmarks-show (to do)
 @g.command('bookmarks-show')
 def cmd_show(event):
 
     c = event.get('c')
     bmd = BookMarkDisplay(c)
-    # Careful: we could be unit testing.
-    splitter = bmd.c.free_layout.get_top_splitter()
-    if splitter:
-        splitter.add_adjacent(bmd.w, 'bodyFrame', 'above')
+    ### To do.
+    if c.free_layout:
+        splitter = c.free_layout.get_top_splitter()
+        if splitter:
+            splitter.add_adjacent(bmd.w, 'bodyFrame', 'above')
 #@+node:tbrown.20131226095537.26309: ** bookmarks-switch
 @g.command('bookmarks-switch')
 def cmd_switch(event):
@@ -459,7 +460,7 @@ def cmd_mark_as_target(event):
     g.es("Node noted - now use\nbookmarks-use-other-outline\nin the "
         "outline you want to\nstore bookmarks in this node")
 
-#@+node:ekr.20190619132530.1: ** bookmarks-use-other-outline
+#@+node:ekr.20190619132530.1: ** bookmarks-use-other-outline (to do)
 @g.command('bookmarks-use-other-outline')
 def cmd_use_other_outline(event):
     """Set bookmarks for this outline from a list (node) in
@@ -471,10 +472,11 @@ def cmd_use_other_outline(event):
         return
     c.db['_leo_bookmarks_show'] = g._bookmarks_target
     bmd = BookMarkDisplay(c, g._bookmarks_target_v)
-    splitter = c.free_layout.get_top_splitter()
-    if splitter:
-        splitter.add_adjacent(bmd.w, 'bodyFrame', 'above')
-
+    ### To do.
+    if c.free_layout:
+        splitter = c.free_layout.get_top_splitter()
+        if splitter:
+            splitter.add_adjacent(bmd.w, 'bodyFrame', 'above')
 #@+node:ekr.20140917180536.17896: ** class FlowLayout (QLayout)
 class FlowLayout(QtWidgets.QLayout):  # type:ignore
     """
@@ -1147,11 +1149,12 @@ class BookMarkDisplay:
 #@+node:tbrown.20110712121053.19746: ** class BookMarkDisplayProvider
 class BookMarkDisplayProvider:
     #@+others
-    #@+node:tbrown.20110712121053.19747: *3* __init__
+    #@+node:tbrown.20110712121053.19747: *3* __init__ (BookMarkDisplayProvider)
     def __init__(self, c):
         self.c = c
+        if not c.free_layout:
+            return
         splitter = c.free_layout.get_top_splitter()
-        # Careful: we could be unit testing.
         if splitter:
             splitter.register_provider(self)
 

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -269,7 +269,7 @@ def cmd_open_node(event):
         # No need to handle url hooks here.
         g.handleUrl(url, c=c, p=p)
 
-#@+node:tbrown.20110712100955.39215: ** bookmarks-show 
+#@+node:tbrown.20110712100955.39215: ** bookmarks-show
 @g.command('bookmarks-show')
 def cmd_show(event):
     gui = g.app.gui

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -1,7 +1,7 @@
 #@+leo-ver=5-thin
 #@+node:tbrown.20070322113635: * @file ../plugins/bookmarks.py
-#@+<< docstring >>
-#@+node:tbrown.20070322113635.1: ** << docstring >>
+#@+<< docstring: bookmarks.py >>
+#@+node:tbrown.20070322113635.1: ** << docstring: bookmarks.py >>
 """ Manage bookmarks in a list, and show bookmarks in a pane.
 
 This plugin has two bookmark related functions.  It manages nodes that
@@ -208,10 +208,10 @@ it to edit the bookmark node itself, and delete the body text (UNL) there.
 
 """
 
-#@-<< docstring >>
+#@-<< docstring: bookmarks.py >>
 # Written by Terry Brown.
-#@+<< imports >>
-#@+node:tbrown.20070322113635.3: ** << imports >>
+#@+<< imports: bookmarks.py >>
+#@+node:tbrown.20070322113635.3: ** << imports: bookmarks.py >>
 from collections import namedtuple
 import hashlib
 from leo.core import leoGlobals as g
@@ -220,7 +220,7 @@ from leo.core.leoQt import ControlType, KeyboardModifier, MouseButton, Orientati
 
 # Fail fast, right after all imports.
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
-#@-<< imports >>
+#@-<< imports: bookmarks.py >>
 #@+others
 #@+node:ekr.20100128073941.5371: ** init (bookmarks.py)
 def init():
@@ -269,17 +269,19 @@ def cmd_open_node(event):
         # No need to handle url hooks here.
         g.handleUrl(url, c=c, p=p)
 
-#@+node:tbrown.20110712100955.39215: ** bookmarks-show (to do)
+#@+node:tbrown.20110712100955.39215: ** bookmarks-show 
 @g.command('bookmarks-show')
 def cmd_show(event):
-
+    gui = g.app.gui
     c = event.get('c')
     bmd = BookMarkDisplay(c)
-    ### To do.
-    if c.free_layout:
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.add_adjacent(bmd.w, 'bodyFrame', 'above')
+
+    # Put the bmd pane in the main splitter.
+    main_splitter = gui.find_widget_by_name(c, 'main_splitter')
+    # Add the VR pane to the secondary splitter.
+    main_splitter.insertWidget(1, bmd.w)
+    # Give equal width to the panes in the secondary splitter.
+    main_splitter.setSizes([100000] * len(main_splitter.sizes()))
 #@+node:tbrown.20131226095537.26309: ** bookmarks-switch
 @g.command('bookmarks-switch')
 def cmd_switch(event):
@@ -460,23 +462,26 @@ def cmd_mark_as_target(event):
     g.es("Node noted - now use\nbookmarks-use-other-outline\nin the "
         "outline you want to\nstore bookmarks in this node")
 
-#@+node:ekr.20190619132530.1: ** bookmarks-use-other-outline (to do)
+#@+node:ekr.20190619132530.1: ** bookmarks-use-other-outline
 @g.command('bookmarks-use-other-outline')
 def cmd_use_other_outline(event):
     """Set bookmarks for this outline from a list (node) in
     a different outline
     """
+    gui = g.app.gui
     c = event.get('c')
     if not hasattr(g, '_bookmarks_target') or not g._bookmarks_target:
         g.es("Use bookmarks-mark-as-target first")
         return
     c.db['_leo_bookmarks_show'] = g._bookmarks_target
     bmd = BookMarkDisplay(c, g._bookmarks_target_v)
-    ### To do.
-    if c.free_layout:
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.add_adjacent(bmd.w, 'bodyFrame', 'above')
+
+    # Put the bmd pane in the main splitter.
+    main_splitter = gui.find_widget_by_name(c, 'main_splitter')
+    # Add the VR pane to the secondary splitter.
+    main_splitter.insertWidget(1, bmd.w)
+    # Give equal width to the panes in the secondary splitter.
+    main_splitter.setSizes([100000] * len(main_splitter.sizes()))
 #@+node:ekr.20140917180536.17896: ** class FlowLayout (QLayout)
 class FlowLayout(QtWidgets.QLayout):  # type:ignore
     """
@@ -1152,12 +1157,6 @@ class BookMarkDisplayProvider:
     #@+node:tbrown.20110712121053.19747: *3* __init__ (BookMarkDisplayProvider)
     def __init__(self, c):
         self.c = c
-        if not c.free_layout:
-            return
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.register_provider(self)
-
     #@+node:tbrown.20110712121053.19748: *3* ns_provides
     def ns_provides(self):
         return [('Bookmarks', '_leo_bookmarks_show')]

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -64,7 +64,8 @@ def edit_pane_csv(event):
     w = c.frame.body.widget
     if not w:
         return
-    if g.allow_nested_splitter:
+    ### if g.allow_nested_splitter:
+    if getattr(c, 'free_layout', None):
         from leo.plugins.nested_splitter import NestedSplitter
         while not isinstance(w, NestedSplitter):
             w = w.parent()

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -21,41 +21,6 @@ def DBG(text):
     :param str text: text to print
     """
     print(f"LEP: {text}")
-#@+node:tbrown.20171028115438.3: ** edit_pane_test_open
-def edit_pane_test_open(event):
-    """Make a command for opening the editpane in free_layout.
-
-    This is just for testing / demoing, and will be removed eventually.
-    """
-    c = event['c']
-    if not c.free_layout:
-        return
-
-    if not hasattr(c, '__edit_pane_test'):
-        c.__edit_pane_test = True
-
-
-        class MinimalDemoProvider:
-
-            def ns_provides(self):
-                return [("Demo editor", "__demo_provider_minimal_slider")]
-
-            def ns_provide(self, id_):
-                if id_ == "__demo_provider_minimal_slider":
-                    w = LeoEditPane(c=c, mode='split')
-                    return w
-                return None
-
-            def ns_provider_id(self):
-                return "__demo_provider_minimal"
-
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.register_provider(MinimalDemoProvider())
-
-    s = c.free_layout.get_top_splitter()
-    if s:
-        s.open_window("__demo_provider_minimal_slider")
 #@+node:tbrown.20180207103918.1: ** edit_pane_csv
 def edit_pane_csv(event):
     c = event['c']
@@ -64,13 +29,9 @@ def edit_pane_csv(event):
     w = c.frame.body.widget
     if not w:
         return
-    ### if g.allow_nested_splitter:
-    if getattr(c, 'free_layout', None):
-        from leo.plugins.nested_splitter import NestedSplitter
-        while not isinstance(w, NestedSplitter):
-            w = w.parent()
-    else:
-        w = w.parent()
+    w = w.parent()
+    if not w:
+        return
     w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
 #@+node:tbrown.20171028115438.4: ** class LeoEditPane
 class LeoEditPane(QtWidgets.QWidget):

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -14,22 +14,14 @@ from leo.core import signal_manager
 from leo.plugins.editpane.clicky_splitter import ClickySplitter
 #@-<<editpane imports>>
 #@+others
-#@+node:tbrown.20171028115438.2: ** DBG
-def DBG(text):
-    """DBG - temporary debugging function
-
-    :param str text: text to print
-    """
-    print(f"LEP: {text}")
 #@+node:tbrown.20180207103918.1: ** edit_pane_csv
 def edit_pane_csv(event):
     c = event['c']
     if not c:
         return
     w = c.frame.body.widget
-    if not w:
-        return
-    w = w.parent()
+    while not isinstance(w, QtWidgets.QSplitter):
+        w = w.parent()
     if not w:
         return
     w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
@@ -56,7 +48,6 @@ class LeoEditPane(QtWidgets.QWidget):
         :param list *args: pass through
         :param dict **kwargs: pass through
         """
-        DBG("__init__ LEP")
         super().__init__(*args, **kwargs)
         self.setAttribute(WidgetAttribute.WA_DeleteOnClose)  # #2347.
 
@@ -159,7 +150,6 @@ class LeoEditPane(QtWidgets.QWidget):
         :return: None
         """
         p = self.c.vnode2position(v)
-        DBG("after body key")
         self.update_position(p)
     #@+node:tbrown.20171028115438.9: *3* _after_select
     def _after_select(self, tag, keywords):
@@ -172,9 +162,6 @@ class LeoEditPane(QtWidgets.QWidget):
         c = keywords['c']
         if c != self.c:
             return None
-
-        DBG("after select")
-
         if self.track:
             self.new_position(keywords['new_p'])
         return None
@@ -196,9 +183,6 @@ class LeoEditPane(QtWidgets.QWidget):
 
         # BUT keyboard driven position change might need some action here
         # BUT then again, textChanged in widget is probably sufficient
-
-        DBG("before select")
-
         return None
     #@+node:tbrown.20171028115438.11: *3* _find_gnx_node
     def _find_gnx_node(self, gnx):
@@ -214,7 +198,6 @@ class LeoEditPane(QtWidgets.QWidget):
     def _register_handlers(self):
         """_register_handlers - attach to Leo signals
         """
-        DBG("\nregister handlers")
         for hook, handler in self.handlers:
             g.registerHandler(hook, handler)
 
@@ -224,7 +207,6 @@ class LeoEditPane(QtWidgets.QWidget):
         self, show_head=True, show_control=True, update=True, recurse=False):
         """build_layout - build layout
         """
-        DBG("build layout")
         self.setLayout(QtWidgets.QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
@@ -340,7 +322,6 @@ class LeoEditPane(QtWidgets.QWidget):
         do_close = QtWidgets.QWidget.close(self)
         if do_close:
             signal_manager.disconnect_all(self)
-            DBG("unregister handlers\n")
             for hook, handler in self.handlers:
                 g.unregisterHandler(hook, handler)
         return do_close
@@ -373,11 +354,11 @@ class LeoEditPane(QtWidgets.QWidget):
         for name in [i[0] for i in names if i[1].lower() == '.py']:
             try:
                 modules.append(import_module('leo.plugins.editpane.' + name))
-                DBG(f"Loaded module: {name}")
             except ImportError as e:
-                DBG(
+                g.trace(
                     f"{e.__class__.__name__}: "
-                    f"Module not loaded (unmet dependencies?): {name}")
+                    f"Module not loaded (unmet dependencies?): {name}"
+                )
         for module in modules:
             for key in dir(module):
                 value = getattr(module, key)
@@ -455,8 +436,6 @@ class LeoEditPane(QtWidgets.QWidget):
 
         :param position p: the new position
         """
-
-        DBG("new edit position")
         if self.mode != 'view':
             self.edit_widget.new_text(p.b)
     #@+node:tbrown.20171028115438.31: *3* new_position_view
@@ -468,7 +447,6 @@ class LeoEditPane(QtWidgets.QWidget):
 
         :param position p: the new position
         """
-        DBG("new view position")
         if self.mode != 'edit':
             if self.recurse:
                 text = g.getScript(self.c, p, useSelectedText=False, useSentinels=False)
@@ -510,8 +488,6 @@ class LeoEditPane(QtWidgets.QWidget):
 
         :param position p: the position to update to
         """
-
-        DBG("update edit position")
         if self.mode != 'view':
             self.edit_widget.update_text(p.b)
     #@+node:tbrown.20171028115438.35: *3* update_position_view
@@ -523,8 +499,6 @@ class LeoEditPane(QtWidgets.QWidget):
 
         :param position p: the position to update to
         """
-
-        DBG("update view position")
         if self.update_flag and self.mode != 'edit':
             if self.recurse:
                 text = g.getScript(self.c, p, useSelectedText=False, useSentinels=False)

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -28,6 +28,8 @@ def edit_pane_test_open(event):
     This is just for testing / demoing, and will be removed eventually.
     """
     c = event['c']
+    if not c.free_layout:
+        return
 
     if not hasattr(c, '__edit_pane_test'):
         c.__edit_pane_test = True
@@ -47,10 +49,13 @@ def edit_pane_test_open(event):
             def ns_provider_id(self):
                 return "__demo_provider_minimal"
 
-        c.free_layout.get_top_splitter().register_provider(MinimalDemoProvider())
+        splitter = c.free_layout.get_top_splitter()
+        if splitter:
+            splitter.register_provider(MinimalDemoProvider())
 
     s = c.free_layout.get_top_splitter()
-    s.open_window("__demo_provider_minimal_slider")
+    if s:
+        s.open_window("__demo_provider_minimal_slider")
 #@+node:tbrown.20180207103918.1: ** edit_pane_csv
 def edit_pane_csv(event):
     c = event['c']

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -53,10 +53,17 @@ def edit_pane_test_open(event):
     s.open_window("__demo_provider_minimal_slider")
 #@+node:tbrown.20180207103918.1: ** edit_pane_csv
 def edit_pane_csv(event):
-    from leo.plugins.nested_splitter import NestedSplitter
     c = event['c']
+    if not c:
+        return
     w = c.frame.body.widget
-    while not isinstance(w, NestedSplitter):
+    if not w:
+        return
+    if g.allow_nested_splitter:
+        from leo.plugins.nested_splitter import NestedSplitter
+        while not isinstance(w, NestedSplitter):
+            w = w.parent()
+    else:
         w = w.parent()
     w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
 #@+node:tbrown.20171028115438.4: ** class LeoEditPane

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -217,7 +217,6 @@ class FreeLayoutController:
     #@+node:tbrown.20110621120042.22914: *3* flc.get_top_splitter
     def get_top_splitter(self) -> Optional[Wrapper]:
         """Return the top splitter of c.frame.top."""
-        # Careful: we could be unit testing.
         f = self.c.frame
         if hasattr(f, 'top') and f.top:
             child = f.top.findChild(NestedSplitter)

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -60,8 +60,9 @@ Wrapper = Any
 #@+node:tbrown.20110203111907.5521: ** free_layout:init
 def init() -> bool:
     """Return True if the free_layout plugin can be loaded."""
-    print('free_layout.init', g.callers())
-    return bool(g.app.gui.guiName() == "qt" and NestedSplitter)
+    # #3910: Leo no longer supports the free_layout and nested_splitter plugins.
+    return False
+    # return bool(g.app.gui.guiName() == "qt" and NestedSplitter)
 #@+node:ekr.20110318080425.14389: ** class FreeLayoutController
 class FreeLayoutController:
 

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -485,8 +485,7 @@ def free_layout_zoom(event: LeoKeyEvent) -> None:
 #@+node:ekr.20160327060009.1: *3* free_layout:register_provider
 def register_provider(c: Cmdr, provider_instance: Any) -> None:
     """Register the provider instance with the top splitter."""
-    # Careful: c.free_layout may not exist during unit testing.
-    if c and hasattr(c, 'free_layout'):
+    if getattr(c, 'free_layout', None):
         splitter = c.free_layout.get_top_splitter()
         if splitter:
             splitter.register_provider(provider_instance)

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -60,9 +60,8 @@ Wrapper = Any
 #@+node:tbrown.20110203111907.5521: ** free_layout:init
 def init() -> bool:
     """Return True if the free_layout plugin can be loaded."""
-    # #3910: Leo no longer supports the free_layout and nested_splitter plugins.
-    return False
-    # return bool(g.app.gui.guiName() == "qt" and NestedSplitter)
+    # #3910: The free_layout and nested_splitter plugins are deprecated.
+    return bool(g.app.gui.guiName() == "qt" and NestedSplitter)
 #@+node:ekr.20110318080425.14389: ** class FreeLayoutController
 class FreeLayoutController:
 

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -60,7 +60,7 @@ Wrapper = Any
 #@+node:tbrown.20110203111907.5521: ** free_layout:init
 def init() -> bool:
     """Return True if the free_layout plugin can be loaded."""
-    g.trace(g.callers())  ##
+    print('free_layout.init', g.callers())
     return bool(g.app.gui.guiName() == "qt" and NestedSplitter)
 #@+node:ekr.20110318080425.14389: ** class FreeLayoutController
 class FreeLayoutController:

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -60,11 +60,8 @@ Wrapper = Any
 #@+node:tbrown.20110203111907.5521: ** free_layout:init
 def init() -> bool:
     """Return True if the free_layout plugin can be loaded."""
-    return bool(
-        g.allow_nested_splitter
-        and NestedSplitter
-        and g.app.gui.guiName() == "qt"
-    )
+    g.trace(g.callers())  ##
+    return bool(g.app.gui.guiName() == "qt" and NestedSplitter)
 #@+node:ekr.20110318080425.14389: ** class FreeLayoutController
 class FreeLayoutController:
 

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -60,7 +60,11 @@ Wrapper = Any
 #@+node:tbrown.20110203111907.5521: ** free_layout:init
 def init() -> bool:
     """Return True if the free_layout plugin can be loaded."""
-    return bool(NestedSplitter and g.app.gui.guiName() == "qt")
+    return bool(
+        g.allow_nested_splitter
+        and NestedSplitter
+        and g.app.gui.guiName() == "qt"
+    )
 #@+node:ekr.20110318080425.14389: ** class FreeLayoutController
 class FreeLayoutController:
 

--- a/leo/plugins/leoPluginNotes.txt
+++ b/leo/plugins/leoPluginNotes.txt
@@ -182,7 +182,7 @@ Settings
 Acknowledgments
 ================
 
-Terry Brown created this initial version of this plugin, and the free_layout and NestedSplitter plugins used by viewrendered.
+Terry Brown created this initial version of this plugin.
 
 EKR generalized this plugin and added communication and coordination between the free_layout, NestedSplitter and viewrendered plugins.
 

--- a/leo/plugins/livecode.py
+++ b/leo/plugins/livecode.py
@@ -48,18 +48,6 @@ def onCreate(tag, keys):
     c = keys.get('c')
 
     LiveCodeDisplayProvider(c)
-#@+node:tbrown.20140806084727.31749: ** livecode-show (rewrite)
-@g.command('livecode-show')
-def cmd_show(event):
-    c = event.get('c')
-    if not c:
-        return
-    if not c.free_layout:
-        return
-    splitter = c.free_layout.get_top_splitter()
-    if splitter:
-        w = splitter.get_provided('_leo_livecode_show')
-        splitter.add_adjacent(w, 'bodyFrame')
 #@+node:tbrown.20140806084727.30187: ** class LiveCodeDisplay
 class LiveCodeDisplay:
     """Manage a pane showing livecode"""

--- a/leo/plugins/livecode.py
+++ b/leo/plugins/livecode.py
@@ -48,10 +48,14 @@ def onCreate(tag, keys):
     c = keys.get('c')
 
     LiveCodeDisplayProvider(c)
-#@+node:tbrown.20140806084727.31749: ** livecode-show
+#@+node:tbrown.20140806084727.31749: ** livecode-show (to do)
 @g.command('livecode-show')
 def cmd_show(event):
     c = event.get('c')
+    if not c:
+        return
+    if not c.free_layout:
+        return
     splitter = c.free_layout.get_top_splitter()
     if splitter:
         w = splitter.get_provided('_leo_livecode_show')
@@ -217,10 +221,11 @@ class LiveCodeDisplay:
 #@+node:tbrown.20140806084727.30203: ** class LiveCodeDisplayProvider
 class LiveCodeDisplayProvider:
     #@+others
-    #@+node:tbrown.20140806084727.30204: *3* __init__
+    #@+node:tbrown.20140806084727.30204: *3* __init__ (livecode.py) (to do)
     def __init__(self, c):
         self.c = c
-
+        if not c.free_layout:
+            return  ### To do
         splitter = c.free_layout.get_top_splitter()
         if splitter:
             splitter.register_provider(self)

--- a/leo/plugins/livecode.py
+++ b/leo/plugins/livecode.py
@@ -209,14 +209,9 @@ class LiveCodeDisplay:
 #@+node:tbrown.20140806084727.30203: ** class LiveCodeDisplayProvider
 class LiveCodeDisplayProvider:
     #@+others
-    #@+node:tbrown.20140806084727.30204: *3* __init__ (livecode.py) (to do)
+    #@+node:tbrown.20140806084727.30204: *3* __init__ (livecode.py)
     def __init__(self, c):
         self.c = c
-        if not c.free_layout:
-            return  ### To do
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.register_provider(self)
     #@+node:tbrown.20140806084727.30205: *3* ns_provides
     def ns_provides(self):
         return [('Live Code', '_leo_livecode_show')]

--- a/leo/plugins/livecode.py
+++ b/leo/plugins/livecode.py
@@ -48,7 +48,7 @@ def onCreate(tag, keys):
     c = keys.get('c')
 
     LiveCodeDisplayProvider(c)
-#@+node:tbrown.20140806084727.31749: ** livecode-show (to do)
+#@+node:tbrown.20140806084727.31749: ** livecode-show (rewrite)
 @g.command('livecode-show')
 def cmd_show(event):
     c = event.get('c')

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -620,15 +620,15 @@ class NestedSplitter(QtWidgets.QSplitter):
     #@+node:ekr.20240518111804.1: *3* ns.dump_layout (new)
     def dump_layout(self, layout: dict) -> None:
         print('')
-        print(f"Dump of ns layout for NestedSplitter at {id(self)}")
+        print(f"Dump of ns layout for {self.__class__.__name__}({self.objectName()})") 
         self.dump_inner_layout(layout, level=0)
         
     def dump_inner_layout(self, content: dict, level: int) -> None:
         ws = level * 2 * ' '
         widget_seen = False
         print('\n'.join([  # Python 3.9 does not allow newlines within f-strings.
-            f"{ws}contents level {level}..."
-            f"  {ws}orientation: {content.get('orientation')}"
+            f"{ws}contents level {level}...",
+            f"  {ws}orientation: {content.get('orientation')}",
             f"  {ws}sizes: {content.get('sizes')}"
         ]))
         inner_content = content.get('content')
@@ -640,7 +640,7 @@ class NestedSplitter(QtWidgets.QSplitter):
             if not widget_seen:
                 widget_seen = True
                 print(f"  {ws}widgets level {level}...")
-            print(f"    {ws}widget {i} {id(inner)}: {inner.__class__.__name__}")
+            print(f"    {ws}widget {i} {inner.__class__.__name__}({inner.objectName()})")
     #@+node:tbrown.20120418121002.25439: *3* ns.find_child
     def find_child(self, child_class, child_name=None):
         """Like QObject.findChild, except search self.top()

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -495,7 +495,7 @@ class NestedSplitter(QtWidgets.QSplitter):
             # fail - parent is not NestedSplitter and has no layout
             pass
     #@+node:tbrown.20110621120042.22675: *3* ns.add_adjacent (finds layout)
-    def add_adjacent(self, what, widget_id, side='right-of'):
+    def add_adjacent(self, what, widget_id, side='right-of', name=None):
         """add a widget relative to another already present widget"""
         horizontal, vertical = Orientation.Horizontal, Orientation.Vertical
         layout = self.top().get_layout()
@@ -541,6 +541,9 @@ class NestedSplitter(QtWidgets.QSplitter):
                 ns = NestedSplitter(orientation=horizontal, root=self.root)
             else:
                 ns = NestedSplitter(orientation=vertical, root=self.root)
+            if name:
+                g.trace(name, ns)
+                ns.setObjectName(name)
             old = layout['content'][pos]
             if not isinstance(old, QtWidgets.QWidget):  # see get_layout()
                 old = layout['splitter']

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -494,7 +494,7 @@ class NestedSplitter(QtWidgets.QSplitter):
         else:
             # fail - parent is not NestedSplitter and has no layout
             pass
-    #@+node:tbrown.20110621120042.22675: *3* ns.add_adjacent
+    #@+node:tbrown.20110621120042.22675: *3* ns.add_adjacent (finds layout)
     def add_adjacent(self, what, widget_id, side='right-of'):
         """add a widget relative to another already present widget"""
         horizontal, vertical = Orientation.Horizontal, Orientation.Vertical

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -500,8 +500,6 @@ class NestedSplitter(QtWidgets.QSplitter):
         horizontal, vertical = Orientation.Horizontal, Orientation.Vertical
         layout = self.top().get_layout()
 
-        trace = 'splitters' in g.app.debug
-
         def hunter(layout, id_):
             """Recursively look for this widget"""
             for n, i in enumerate(layout['content']):
@@ -524,8 +522,7 @@ class NestedSplitter(QtWidgets.QSplitter):
         if l is None:
             return False
         layout, pos = l
-        if trace:
-            self.dump_layout(layout)
+        # self.dump_layout(layout)
         orient = layout['orientation']
         if (orient == horizontal and side in ('right-of', 'left-of') or
             orient == vertical and side in ('above', 'below')

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -499,6 +499,8 @@ class NestedSplitter(QtWidgets.QSplitter):
         """add a widget relative to another already present widget"""
         horizontal, vertical = Orientation.Horizontal, Orientation.Vertical
         layout = self.top().get_layout()
+        
+        trace = 'splitters' in g.app.debug
 
         def hunter(layout, id_):
             """Recursively look for this widget"""
@@ -522,6 +524,8 @@ class NestedSplitter(QtWidgets.QSplitter):
         if l is None:
             return False
         layout, pos = l
+        if trace:
+            self.dump_layout(layout)
         orient = layout['orientation']
         if (orient == horizontal and side in ('right-of', 'left-of') or
             orient == vertical and side in ('above', 'below')
@@ -613,6 +617,30 @@ class NestedSplitter(QtWidgets.QSplitter):
                 if self.widget(i).contains(widget):
                     return True
         return False
+    #@+node:ekr.20240518111804.1: *3* ns.dump_layout (new)
+    def dump_layout(self, layout: dict) -> None:
+        print('')
+        print(f"Dump of ns layout for NestedSplitter at {id(self)}")
+        self.dump_inner_layout(layout, level=0)
+        
+    def dump_inner_layout(self, content: dict, level: int) -> None:
+        ws = level * 2 * ' '
+        widget_seen = False
+        print(
+            f"{ws}contents level {level}...\n"
+            f"  {ws}orientation: {content.get('orientation')}\n"
+            f"  {ws}sizes: {content.get('sizes')}"
+        )
+        inner_content = content.get('content')
+        assert isinstance(inner_content, list)
+        for i, inner in enumerate(inner_content):
+            if isinstance(inner, dict):
+                self.dump_inner_layout(inner, level + 1)
+                continue
+            if not widget_seen:
+                widget_seen = True
+                print(f"  {ws}widgets level {level}...")
+            print(f"    {ws}widget {i} {id(inner)}: {inner.__class__.__name__}")
     #@+node:tbrown.20120418121002.25439: *3* ns.find_child
     def find_child(self, child_class, child_name=None):
         """Like QObject.findChild, except search self.top()

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -499,7 +499,7 @@ class NestedSplitter(QtWidgets.QSplitter):
         """add a widget relative to another already present widget"""
         horizontal, vertical = Orientation.Horizontal, Orientation.Vertical
         layout = self.top().get_layout()
-        
+
         trace = 'splitters' in g.app.debug
 
         def hunter(layout, id_):
@@ -623,9 +623,9 @@ class NestedSplitter(QtWidgets.QSplitter):
     #@+node:ekr.20240518111804.1: *3* ns.dump_layout (new)
     def dump_layout(self, layout: dict) -> None:
         print('')
-        print(f"Dump of ns layout for {self.__class__.__name__}({self.objectName()})") 
+        print(f"Dump of ns layout for {self.__class__.__name__}({self.objectName()})")
         self.dump_inner_layout(layout, level=0)
-        
+
     def dump_inner_layout(self, content: dict, level: int) -> None:
         ws = level * 2 * ' '
         widget_seen = False

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -626,11 +626,11 @@ class NestedSplitter(QtWidgets.QSplitter):
     def dump_inner_layout(self, content: dict, level: int) -> None:
         ws = level * 2 * ' '
         widget_seen = False
-        print(
-            f"{ws}contents level {level}...\n"
-            f"  {ws}orientation: {content.get('orientation')}\n"
+        print('\n'.join([  # Python 3.9 does not allow newlines within f-strings.
+            f"{ws}contents level {level}..."
+            f"  {ws}orientation: {content.get('orientation')}"
             f"  {ws}sizes: {content.get('sizes')}"
-        )
+        ]))
         inner_content = content.get('content')
         assert isinstance(inner_content, list)
         for i, inner in enumerate(inner_content):

--- a/leo/plugins/pyplot_backend.py
+++ b/leo/plugins/pyplot_backend.py
@@ -63,7 +63,7 @@ class LeoFigureManagerQT(FigureManager):
     """
 
     #@+others
-    #@+node:ekr.20160929050151.2: *4* __init__ (LeoFigureManagerQt)
+    #@+node:ekr.20160929050151.2: *4* __init__ (LeoFigureManagerQt) (to do)
     # Do NOT call the base class ctor. It creates a Qt MainWindow.
         # pylint: disable=super-init-not-called
         # pylint: disable=non-parent-init-called
@@ -76,7 +76,10 @@ class LeoFigureManagerQT(FigureManager):
 
         # New code for Leo: embed the canvas in the viewrendered area.
         self.vr_controller = vc = vr.controllers.get(c.hash())
-        self.splitter = c.free_layout.get_top_splitter()
+        if c.free_layout:
+            self.splitter = c.free_layout.get_top_splitter()
+        else:
+            self.splitter = None  ### To do
         self.frame = w = QtWidgets.QFrame()
         w.setLayout(QtWidgets.QVBoxLayout())
         w.layout().addWidget(self.canvas)

--- a/leo/plugins/pyplot_backend.py
+++ b/leo/plugins/pyplot_backend.py
@@ -63,23 +63,21 @@ class LeoFigureManagerQT(FigureManager):
     """
 
     #@+others
-    #@+node:ekr.20160929050151.2: *4* __init__ (LeoFigureManagerQt) (to do)
+    #@+node:ekr.20160929050151.2: *4* __init__ (LeoFigureManagerQt)
     # Do NOT call the base class ctor. It creates a Qt MainWindow.
         # pylint: disable=super-init-not-called
         # pylint: disable=non-parent-init-called
 
     def __init__(self, canvas, num):
         """Ctor for the LeoFigureManagerQt class."""
+        gui = g.app.gui
         self.c = c = g.app.log.c
         super().__init__(canvas, num)
         self.canvas = canvas
 
         # New code for Leo: embed the canvas in the viewrendered area.
         self.vr_controller = vc = vr.controllers.get(c.hash())
-        if c.free_layout:
-            self.splitter = c.free_layout.get_top_splitter()
-        else:
-            self.splitter = None  ### To do
+        self.splitter = gui.find_widget_by_name(c, 'main_splitter')
         self.frame = w = QtWidgets.QFrame()
         w.setLayout(QtWidgets.QVBoxLayout())
         w.layout().addWidget(self.canvas)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -355,7 +355,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         """Create the layout for Leo's main window."""
         # c = self.leo_c
         vLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
-        
+
         # #3910: Deprecate NestedSplitter.
         main_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
         secondary_splitter: Union[NestedSplitter, QtWidgets.QSplitter]

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2463,11 +2463,14 @@ class LeoQtFrame(leoFrame.LeoFrame):
     def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
         """Toggle the split direction in the present Leo window."""
         c = self.c
-        ### To do.
-        if getattr(c, 'free_layout', None):
-            splitter = c.free_layout.get_top_splitter()
-            if splitter:
-                splitter.rotate()
+        if g.allow_nested_splitter:
+            if getattr(c, 'free_layout', None):
+                splitter = c.free_layout.get_top_splitter()
+                if splitter:
+                    splitter.rotate()
+        else:
+            splitter = g.app.gui.get_top_splitter(c)
+            g.trace('to do: rotate splitter:', splitter)
     #@+node:ekr.20110605121601.18308: *5* qtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
     def resizeToScreen(self, event: LeoKeyEvent = None) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -12,7 +12,7 @@ import string
 import sys
 import time
 import urllib
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoColorizer
@@ -355,10 +355,22 @@ class DynamicWindow(QtWidgets.QMainWindow):
         """Create the layout for Leo's main window."""
         # c = self.leo_c
         vLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
-        main_splitter = NestedSplitter(parent)
+        
+        # #3910: Deprecate NestedSplitter.
+        main_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
+        secondary_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
+
+        if g.allow_nested_splitter:
+            main_splitter = NestedSplitter(parent)
+        else:
+            main_splitter = QtWidgets.QSplitter(parent)
         main_splitter.setObjectName('main_splitter')
         main_splitter.setOrientation(Orientation.Vertical)
-        secondary_splitter = NestedSplitter(main_splitter)
+
+        if g.allow_nested_splitter:
+            secondary_splitter = NestedSplitter(main_splitter)
+        else:
+            secondary_splitter = QtWidgets.QSplitter(main_splitter)
         secondary_splitter.setObjectName('secondary_splitter')
         secondary_splitter.setOrientation(Orientation.Horizontal)
         # Official ivar:
@@ -2348,9 +2360,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         """Resize splitter1 and splitter2 using the given ratios."""
         self.divideLeoSplitter1(ratio)
         self.divideLeoSplitter2(ratio2)
-    #@+node:ekr.20110605121601.18283: *4* qtFrame.divideLeoSplitter1/2 (*** to do)
+    #@+node:ekr.20110605121601.18283: *4* qtFrame.divideLeoSplitter1/2 (to do)
     def divideLeoSplitter1(self, frac: float) -> None:
         """Divide the main splitter."""
+        ### To do.
         layout = self.c and self.c.free_layout
         if not layout:
             return
@@ -2360,6 +2373,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
 
     def divideLeoSplitter2(self, frac: float) -> None:
         """Divide the secondary splitter."""
+        ### To do.
         layout = self.c and self.c.free_layout
         if not layout:
             return
@@ -2444,14 +2458,16 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 assert hasattr(w, 'setWindowState'), w
             else:
                 w.setWindowState(WindowState.WindowMinimized)
-    #@+node:ekr.20110605121601.18307: *5* qtFrame.toggleSplitDirection
+    #@+node:ekr.20110605121601.18307: *5* qtFrame.toggleSplitDirection (to do)
     @frame_cmd('toggle-split-direction')
     def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
         """Toggle the split direction in the present Leo window."""
         c = self.c
-        ### if hasattr(c, 'free_layout'):
+        ### To do.
         if getattr(c, 'free_layout', None):
-            c.free_layout.get_top_splitter().rotate()
+            splitter = c.free_layout.get_top_splitter()
+            if splitter:
+                splitter.rotate()
     #@+node:ekr.20110605121601.18308: *5* qtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
     def resizeToScreen(self, event: LeoKeyEvent = None) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -12,7 +12,7 @@ import string
 import sys
 import time
 import urllib
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoColor
 from leo.core import leoColorizer
@@ -32,12 +32,6 @@ from leo.plugins import qt_events
 from leo.plugins import qt_text
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
-
-### Test getattr(c, 'free_layout', None):
-    # if g.allow_nested_splitter:
-        # from leo.plugins.nested_splitter import NestedSplitter
-    # else:
-        # NestedSplitter = QtWidgets.QSplitter
 #@-<< qt_frame imports >>
 #@+<< qt_frame annotations >>
 #@+node:ekr.20220415080427.1: ** << qt_frame annotations >>
@@ -355,32 +349,17 @@ class DynamicWindow(QtWidgets.QMainWindow):
     #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout (changed)
     def createMainLayout(self, parent: QWidget) -> tuple[QWidget, QWidget]:
         """Create the layout for Leo's main window."""
-        c = self.leo_c
-        vLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
+        # c = self.leo_c
 
-        # #3910: Deprecate NestedSplitter.
-        main_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
-        secondary_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
-        
-        ###if g.allow_nested_splitter:
-        if getattr(c, 'free_layout', None):
-            from leo.plugins.nested_splitter import NestedSplitter
-            main_splitter = NestedSplitter(parent)
-        else:
-            main_splitter = QtWidgets.QSplitter(parent)
+        main_splitter = QtWidgets.QSplitter(parent)
         main_splitter.setObjectName('main_splitter')
         main_splitter.setOrientation(Orientation.Vertical)
 
-        ### if g.allow_nested_splitter:
-        if getattr(c, 'free_layout', None):
-            secondary_splitter = NestedSplitter(main_splitter)
-        else:
-            secondary_splitter = QtWidgets.QSplitter(main_splitter)
+        secondary_splitter = QtWidgets.QSplitter(main_splitter)
         secondary_splitter.setObjectName('secondary_splitter')
         secondary_splitter.setOrientation(Orientation.Horizontal)
 
-        # Official ivar:
-        self.verticalLayout = vLayout
+        self.verticalLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
         self.set_widget_size_policy(secondary_splitter)
         self.verticalLayout.addWidget(main_splitter)
         return main_splitter, secondary_splitter

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -32,7 +32,10 @@ from leo.plugins import qt_events
 from leo.plugins import qt_text
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
-from leo.plugins.nested_splitter import NestedSplitter
+if g.allow_nested_splitter:
+    from leo.plugins.nested_splitter import NestedSplitter
+else:
+    NestedSpitter = QtWidgets.QSplitter
 #@-<< qt_frame imports >>
 #@+<< qt_frame annotations >>
 #@+node:ekr.20220415080427.1: ** << qt_frame annotations >>
@@ -2345,7 +2348,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         """Resize splitter1 and splitter2 using the given ratios."""
         self.divideLeoSplitter1(ratio)
         self.divideLeoSplitter2(ratio2)
-    #@+node:ekr.20110605121601.18283: *4* qtFrame.divideLeoSplitter1/2
+    #@+node:ekr.20110605121601.18283: *4* qtFrame.divideLeoSplitter1/2 (*** to do)
     def divideLeoSplitter1(self, frac: float) -> None:
         """Divide the main splitter."""
         layout = self.c and self.c.free_layout
@@ -2445,8 +2448,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
     @frame_cmd('toggle-split-direction')
     def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
         """Toggle the split direction in the present Leo window."""
-        if hasattr(self.c, 'free_layout'):
-            self.c.free_layout.get_top_splitter().rotate()
+        c = self.c
+        ### if hasattr(c, 'free_layout'):
+        if getattr(c, 'free_layout', None):
+            c.free_layout.get_top_splitter().rotate()
     #@+node:ekr.20110605121601.18308: *5* qtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
     def resizeToScreen(self, event: LeoKeyEvent = None) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -32,10 +32,12 @@ from leo.plugins import qt_events
 from leo.plugins import qt_text
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
-if g.allow_nested_splitter:
-    from leo.plugins.nested_splitter import NestedSplitter
-else:
-    NestedSpitter = QtWidgets.QSplitter
+
+### Test getattr(c, 'free_layout', None):
+    # if g.allow_nested_splitter:
+        # from leo.plugins.nested_splitter import NestedSplitter
+    # else:
+        # NestedSplitter = QtWidgets.QSplitter
 #@-<< qt_frame imports >>
 #@+<< qt_frame annotations >>
 #@+node:ekr.20220415080427.1: ** << qt_frame annotations >>
@@ -350,29 +352,33 @@ class DynamicWindow(QtWidgets.QMainWindow):
         assert self.findTab
         self.createFindTab(self.findTab, self.findScrollArea)
         self.findScrollArea.setWidget(self.findTab)
-    #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout
+    #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout (changed)
     def createMainLayout(self, parent: QWidget) -> tuple[QWidget, QWidget]:
         """Create the layout for Leo's main window."""
-        # c = self.leo_c
+        c = self.leo_c
         vLayout = self.createVLayout(parent, 'mainVLayout', margin=3)
 
         # #3910: Deprecate NestedSplitter.
         main_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
         secondary_splitter: Union[NestedSplitter, QtWidgets.QSplitter]
-
-        if g.allow_nested_splitter:
+        
+        ###if g.allow_nested_splitter:
+        if getattr(c, 'free_layout', None):
+            from leo.plugins.nested_splitter import NestedSplitter
             main_splitter = NestedSplitter(parent)
         else:
             main_splitter = QtWidgets.QSplitter(parent)
         main_splitter.setObjectName('main_splitter')
         main_splitter.setOrientation(Orientation.Vertical)
 
-        if g.allow_nested_splitter:
+        ### if g.allow_nested_splitter:
+        if getattr(c, 'free_layout', None):
             secondary_splitter = NestedSplitter(main_splitter)
         else:
             secondary_splitter = QtWidgets.QSplitter(main_splitter)
         secondary_splitter.setObjectName('secondary_splitter')
         secondary_splitter.setOrientation(Orientation.Horizontal)
+
         # Official ivar:
         self.verticalLayout = vLayout
         self.set_widget_size_policy(secondary_splitter)
@@ -2465,11 +2471,10 @@ class LeoQtFrame(leoFrame.LeoFrame):
         Toggle the split direction in the present Leo window.
         """
         c = self.c
-        if g.allow_nested_splitter:
-            if getattr(c, 'free_layout', None):
-                splitter = c.free_layout.get_top_splitter()
-                if splitter:
-                    splitter.rotate()
+        if getattr(c, 'free_layout', None):
+            splitter = c.free_layout.get_top_splitter()
+            if splitter:
+                splitter.rotate()
         else:
             # Toggle the split direction of the primary and secondary splitters.
             gui = g.app.gui

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2458,10 +2458,12 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 assert hasattr(w, 'setWindowState'), w
             else:
                 w.setWindowState(WindowState.WindowMinimized)
-    #@+node:ekr.20110605121601.18307: *5* qtFrame.toggleSplitDirection (to do)
+    #@+node:ekr.20110605121601.18307: *5* qtFrame.toggleSplitDirection
     @frame_cmd('toggle-split-direction')
     def toggleSplitDirection(self, event: LeoKeyEvent = None) -> None:
-        """Toggle the split direction in the present Leo window."""
+        """
+        Toggle the split direction in the present Leo window.
+        """
         c = self.c
         if g.allow_nested_splitter:
             if getattr(c, 'free_layout', None):
@@ -2469,8 +2471,15 @@ class LeoQtFrame(leoFrame.LeoFrame):
                 if splitter:
                     splitter.rotate()
         else:
-            splitter = g.app.gui.get_top_splitter(c)
-            g.trace('to do: rotate splitter:', splitter)
+            # Toggle the split direction of the primary and secondary splitters.
+            gui = g.app.gui
+            splitter = gui.find_widget_by_name(c, 'main_splitter')
+            splitter2 = gui.find_widget_by_name(c, 'secondary_splitter')
+            for w in (splitter, splitter2):
+                if w.orientation() == Orientation.Vertical:
+                    w.setOrientation(Orientation.Horizontal)
+                else:
+                    w.setOrientation(Orientation.Vertical)
     #@+node:ekr.20110605121601.18308: *5* qtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
     def resizeToScreen(self, event: LeoKeyEvent = None) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -346,7 +346,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         assert self.findTab
         self.createFindTab(self.findTab, self.findScrollArea)
         self.findScrollArea.setWidget(self.findTab)
-    #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout (changed)
+    #@+node:ekr.20110605121601.18146: *5* dw.createMainLayout
     def createMainLayout(self, parent: QWidget) -> tuple[QWidget, QWidget]:
         """Create the layout for Leo's main window."""
         # c = self.leo_c
@@ -2211,15 +2211,16 @@ class LeoQtFrame(leoFrame.LeoFrame):
         Return ratio of the main Qt splitter or 0.5.
         """
         c = self.c
-        if c.free_layout:
-            w = c.free_layout.get_main_splitter()
-            if w:
-                aList = w.sizes()
-                if len(aList) == 2:
-                    n1, n2 = aList
-                    # Don't divide by zero.
-                    ratio = 0.5 if n1 + n2 == 0 else float(n1) / float(n1 + n2)
-                    return ratio
+        gui = g.app.gui
+        w = gui.find_widget_by_name(c, 'main_splitter')
+        if not w:
+            return 0.5
+        aList = w.sizes()
+        if len(aList) == 2:
+            n1, n2 = aList
+            # Don't divide by zero.
+            ratio = 0.5 if n1 + n2 == 0 else float(n1) / float(n1 + n2)
+            return ratio
         return 0.5
     #@+node:ekr.20240510093122.1: *5* qtFrame.compute_secondary_ratio
     def compute_secondary_ratio(self) -> float:
@@ -2227,15 +2228,15 @@ class LeoQtFrame(leoFrame.LeoFrame):
         Return the ratio of the Qt secondary splitter or 0.5.
         """
         c = self.c
-        free_layout = c.free_layout
-        if free_layout:
-            w = free_layout.get_secondary_splitter()
-            if w:
-                aList = w.sizes()
-                if len(aList) == 2:
-                    n1, n2 = aList
-                    ratio = float(n1) / float(n1 + n2)
-                    return ratio
+        gui = g.app.gui
+        w = gui.find_widget_by_name(c, 'secondary_splitter')
+        if not w:
+            return 0.5
+        aList = w.sizes()
+        if len(aList) == 2:
+            n1, n2 = aList
+            ratio = float(n1) / float(n1 + n2)
+            return ratio
         return 0.5
     #@+node:ekr.20110605121601.18275: *4* qtFrame.configureBar
     def configureBar(self, bar: Wrapper, verticalFlag: bool) -> None:
@@ -2348,21 +2349,17 @@ class LeoQtFrame(leoFrame.LeoFrame):
     #@+node:ekr.20110605121601.18283: *4* qtFrame.divideLeoSplitter1/2 (to do)
     def divideLeoSplitter1(self, frac: float) -> None:
         """Divide the main splitter."""
-        ### To do.
-        layout = self.c and self.c.free_layout
-        if not layout:
-            return
-        w = layout.get_main_splitter()
+        gui = g.app.gui
+        c = self.c
+        w = gui.find_widget_by_name(c, 'main_splitter')
         if w:
             self.divideAnySplitter(frac, w)
 
     def divideLeoSplitter2(self, frac: float) -> None:
         """Divide the secondary splitter."""
-        ### To do.
-        layout = self.c and self.c.free_layout
-        if not layout:
-            return
-        w = layout.get_secondary_splitter()
+        gui = g.app.gui
+        c = self.c
+        w = gui.find_widget_by_name(c, 'secondary_splitter')
         if w:
             self.divideAnySplitter(frac, w)
     #@+node:ekr.20110605121601.18284: *4* qtFrame.divideAnySplitter
@@ -2450,20 +2447,14 @@ class LeoQtFrame(leoFrame.LeoFrame):
         Toggle the split direction in the present Leo window.
         """
         c = self.c
-        if getattr(c, 'free_layout', None):
-            splitter = c.free_layout.get_top_splitter()
-            if splitter:
-                splitter.rotate()
-        else:
-            # Toggle the split direction of the primary and secondary splitters.
-            gui = g.app.gui
-            splitter = gui.find_widget_by_name(c, 'main_splitter')
-            splitter2 = gui.find_widget_by_name(c, 'secondary_splitter')
-            for w in (splitter, splitter2):
-                if w.orientation() == Orientation.Vertical:
-                    w.setOrientation(Orientation.Horizontal)
-                else:
-                    w.setOrientation(Orientation.Vertical)
+        gui = g.app.gui
+        splitter = gui.find_widget_by_name(c, 'main_splitter')
+        splitter2 = gui.find_widget_by_name(c, 'secondary_splitter')
+        for w in (splitter, splitter2):
+            if w.orientation() == Orientation.Vertical:
+                w.setOrientation(Orientation.Horizontal)
+            else:
+                w.setOrientation(Orientation.Vertical)
     #@+node:ekr.20110605121601.18308: *5* qtFrame.resizeToScreen
     @frame_cmd('resize-to-screen')
     def resizeToScreen(self, event: LeoKeyEvent = None) -> None:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -82,7 +82,7 @@ def _parents(qt_obj: Any) -> Generator:
     while parent:
         yield parent
         parent = parent.parent()
-        
+
 def _self_and_parents(qt_obj: Any) -> Generator:
     """Yields all ancestors of qt_obj, a Qt object or widget."""
     w = qt_obj
@@ -95,7 +95,7 @@ def _self_and_subtree(qt_obj: Any) -> Generator:
     yield qt_obj
     for child in qt_obj.children():
         yield from _self_and_subtree(child)
-        
+
 # Not used.
 # def _subtree(qt_obj: Any) -> Generator:
     # """Yield w and all of w's descendants."""
@@ -1655,7 +1655,7 @@ class LeoQtGui(leoGui.LeoGui):
     ### To do ###
     # def attach_widget(self, w: QWidget, parent: QWidget) -> None:
         # pass
-        
+
     detached_widgets: list[Any] = []
 
     def detach_object(self, qt_obj: Any) -> None:
@@ -1673,7 +1673,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     def find_layout_for_object(self, qt_obj: Any) -> Optional[QLayout]:
         return qt_obj.layout()  ### To do.
-        
+
     _container_classes = (QtWidgets.QSplitter, QtWidgets.QStackedWidget, QtWidgets.QStackedWidget)
 
     def _container_index(self, container: Any, target: Any) -> int:
@@ -1687,16 +1687,16 @@ class LeoQtGui(leoGui.LeoGui):
                     ### g.trace('   FOUND!', id(w2), w2.__class__.__name__)
                     return i
         return -1
-        
+
     def find_nearest_container(self, qt_obj: Any) -> Optional[tuple[int, Any]]:
         for w in _parents(qt_obj):
             ### g.trace('parent:', w.__class__.__name__)
-            if isinstance(w, self._container_classes ):
+            if isinstance(w, self._container_classes):
                 i = self._container_index(w, qt_obj)
                 if i > -1:
-                    return i, w            
+                    return i, w
         return -1, None
-        
+
     def find_nearest_object_with_stylesheet(self, qt_obj: Any) -> Optional[Any]:
         for w in _self_and_parents(qt_obj):
             if w.styleSheet():
@@ -1708,7 +1708,7 @@ class LeoQtGui(leoGui.LeoGui):
             if w.objectName() == name:
                 return w
         return None
-                
+
     # Not used.
     # def _find_ancestor_widget_by_class(self, qt_obj: Any, class_: Any):
         # """Return the widget in qt_obj's ancestors with the given class."""

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1655,12 +1655,19 @@ class LeoQtGui(leoGui.LeoGui):
     ### To do ###
     # def attach_widget(self, w: QWidget, parent: QWidget) -> None:
         # pass
+        
+    detached_widgets: list[Any] = []
 
     def detach_object(self, qt_obj: Any) -> None:
         i, w = self.find_nearest_container(qt_obj)
         if w:
             g.trace('FOUND', i, w, qt_obj)
-            ### To do!
+            qt_obj.setParent(None)
+            self.detached_widgets.append(qt_obj)
+            stylesheet_obj = self.find_nearest_object_with_stylesheet(qt_obj)
+            if stylesheet_obj:
+                g.trace(len(stylesheet_obj.styleSheet()))
+                w.setStyleSheet(stylesheet_obj.styleSheet())
         else:
             g.trace('Not found:', qt_obj)
 

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -11,7 +11,7 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, Optional, Union, TYPE_CHECKING
+from typing import Any, Generator, Optional, Union, TYPE_CHECKING
 from leo.core import leoColor
 from leo.core import leoGlobals as g
 from leo.core import leoGui
@@ -74,6 +74,19 @@ def init() -> bool:
     g.app.gui.finishCreate()
     g.plugin_signon(__name__)
     return True
+#@+node:ekr.20240515151459.1: ** gt_gui: top-level functions
+def qt_object_and_subtree(qt_obj: Any) -> Generator:
+    """Yield w and all of w's descendants."""
+    yield qt_obj
+    for child in qt_obj.children():
+        yield from qt_object_and_subtree(child)
+
+def find_by_name(qt_obj: Any, name: str) -> Optional[QWidget]:
+    """Return the widget in parent's tree with the given name."""
+    for w in qt_object_and_subtree(qt_obj):
+        if w.objectName() == name:
+            return w
+    return None
 #@+node:ekr.20140907085654.18700: ** class LeoQtGui(leoGui.LeoGui)
 class LeoQtGui(leoGui.LeoGui):
     """A class implementing Leo's Qt gui."""
@@ -1511,7 +1524,7 @@ class LeoQtGui(leoGui.LeoGui):
             gui.splashScreen.hide()
             # gui.splashScreen.deleteLater()
             gui.splashScreen = None
-    #@+node:ekr.20140825042850.18411: *3* qt_gui.Utils...
+    #@+node:ekr.20140825042850.18411: *3* qt_gui:Utils...
     #@+node:ekr.20110605121601.18522: *4* qt_gui.isTextWidget/Wrapper
     def isTextWidget(self, w: Wrapper) -> bool:
         """Return True if w is some kind of Qt text widget."""
@@ -1545,7 +1558,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     QSignalSpy = QtTest.QSignalSpy
     assert QSignalSpy
-    #@+node:ekr.20190819091957.1: *3* qt_gui.Widgets...
+    #@+node:ekr.20190819091957.1: *3* qt_gui:Widget constructors
     #@+node:ekr.20190819094016.1: *4* qt_gui.createButton
     def createButton(self, parent: QWidget, name: str, label: str) -> QPushButton:
         w = QtWidgets.QPushButton(parent)
@@ -1622,6 +1635,17 @@ class LeoQtGui(leoGui.LeoGui):
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(widget.sizePolicy().hasHeightForWidth())
         widget.setSizePolicy(sizePolicy)
+    #@+node:ekr.20240515150157.1: *3* qt_gui:Widget utils
+    # The dummy LeoGui methods: unl:gnx://leoPy.leo#ekr.20240515145223.1
+
+    def attach_widget(self, w: QWidget, parent: QWidget) -> None:
+        pass  ### To do.
+
+    def detach_widget(self, w: QWidget) -> None:
+        pass  ### To do.
+
+    def get_top_splitter(self, c: Cmdr) -> QWidget:
+        return find_by_name(c.frame.top, 'main_splitter')
     #@-others
 #@+node:tbrown.20150724090431.1: ** class StyleClassManager
 class StyleClassManager:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1561,6 +1561,12 @@ class LeoQtGui(leoGui.LeoGui):
 
     QSignalSpy = QtTest.QSignalSpy
     assert QSignalSpy
+    #@+node:ekr.20240521171848.1: *4* qt_gui.equalize_splitter
+    def equalize_splitter(self, splitter):
+        """Equalize all the splitter's contents."""
+        if not isinstance(splitter, QtWidgets.QSplitter):
+            g.trace(f"Not a QSplitter: {splitter.__class__.__name__}")
+        splitter.setSizes([100000] * len(splitter.sizes()))
     #@+node:ekr.20190819091957.1: *3* qt_gui:Widget constructors
     #@+node:ekr.20190819094016.1: *4* qt_gui.createButton
     def createButton(self, parent: QWidget, name: str, label: str) -> QPushButton:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1653,22 +1653,42 @@ class LeoQtGui(leoGui.LeoGui):
     # qt_gui utils: unl:gnx://leoPy.leo#ekr.20240515151459.1
 
     ### To do ###
-
     # def attach_widget(self, w: QWidget, parent: QWidget) -> None:
         # pass
 
-    # def detach_widget(self, w: QWidget) -> None:
-        # pass
-        
+    def detach_object(self, qt_obj: Any) -> None:
+        i, w = self.find_nearest_container(qt_obj)
+        if w:
+            g.trace('FOUND', i, w, qt_obj)
+            ### To do!
+        else:
+            g.trace('Not found:', qt_obj)
 
     def find_layout_for_object(self, qt_obj: Any) -> Optional[QLayout]:
         return qt_obj.layout()  ### To do.
         
+    _container_classes = (QtWidgets.QSplitter, QtWidgets.QStackedWidget, QtWidgets.QStackedWidget)
 
-    def find_nearest_containing_object(self, qt_obj: Any) -> Optional[Any]:
+    def _container_index(self, container: Any, target: Any) -> int:
+        """Return the index (within the container) of the child containing the target widget."""
+        g.trace('container:', id(container), container.__class__.__name__)
+        for i, child in enumerate(container.children()):
+            g.trace('child:', i, child.__class__.__name__)
+            for w2 in _self_and_subtree(child):
+                ### g.trace('  subtree:', w2.__class__.__name__)
+                if w2 == target:
+                    ### g.trace('   FOUND!', id(w2), w2.__class__.__name__)
+                    return i
+        return -1
+        
+    def find_nearest_container(self, qt_obj: Any) -> Optional[tuple[int, Any]]:
         for w in _parents(qt_obj):
-            pass  ### To do.
-        return None
+            ### g.trace('parent:', w.__class__.__name__)
+            if isinstance(w, self._container_classes ):
+                i = self._container_index(w, qt_obj)
+                if i > -1:
+                    return i, w            
+        return -1, None
         
     def find_nearest_object_with_stylesheet(self, qt_obj: Any) -> Optional[Any]:
         for w in _self_and_parents(qt_obj):

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -75,13 +75,28 @@ def init() -> bool:
     g.plugin_signon(__name__)
     return True
 #@+node:ekr.20240515151459.1: ** gt_gui: top-level functions
+def qt_ancestors(qt_obj: Any) -> Generator:
+    """Yields all ancestors of qt_obj."""
+    parent = qt_obj.parent()
+    while parent:
+        yield parent
+        parent = parent.parent()
+
 def qt_object_and_subtree(qt_obj: Any) -> Generator:
     """Yield w and all of w's descendants."""
     yield qt_obj
     for child in qt_obj.children():
         yield from qt_object_and_subtree(child)
 
-def find_by_name(qt_obj: Any, name: str) -> Optional[QWidget]:
+def find_qt_ancestor_widget_by_class(qt_obj: Any, class_: Any):
+    """Return the widget in qt_obj's ancestors with the given class."""
+    for w in qt_ancestors(qt_obj):
+        g.trace(w)
+        if issubclass(w.__class__, class_):
+            return w
+    return None
+
+def find_qt_widget_by_name(qt_obj: Any, name: str) -> Optional[QWidget]:
     """Return the widget in parent's tree with the given name."""
     for w in qt_object_and_subtree(qt_obj):
         if w.objectName() == name:
@@ -1643,9 +1658,16 @@ class LeoQtGui(leoGui.LeoGui):
 
     def detach_widget(self, w: QWidget) -> None:
         pass  ### To do.
+        
+    def get_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
+        return find_qt_widget_by_name(c.frame.top, name)
 
     def get_top_splitter(self, c: Cmdr) -> QWidget:
-        return find_by_name(c.frame.top, 'main_splitter')
+        return find_qt_widget_by_name(c.frame.top, 'main_splitter')
+        
+    def get_ancestor_widget_by_class(self, w: QWidget, class_: QWidget) -> Optional[QWidget]:
+        return find_qt_ancestor_widget_by_class(w, class_)
+
     #@-others
 #@+node:tbrown.20150724090431.1: ** class StyleClassManager
 class StyleClassManager:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:  # pragma: no cover
     QHBoxLayout = QtWidgets.QHBoxLayout
     QIcon = QtGui.QIcon
     QLabel = QtWidgets.QLabel
+    QLayout = QtWidgets.QLayout
     QMainWindow = QtWidgets.QMainWindow
     QPixmap = QtGui.QPixmap
     QPoint = QtCore.QPoint
@@ -75,30 +76,33 @@ def init() -> bool:
     g.plugin_signon(__name__)
     return True
 #@+node:ekr.20240515151459.1: ** gt_gui: top-level functions
-def qt_ancestors(qt_obj: Any) -> Generator:
-    """Yields all ancestors of qt_obj."""
+def _ancestors(qt_obj: Any) -> Generator:
+    """Yields all ancestors of qt_obj, a Qt object or widget."""
     parent = qt_obj.parent()
     while parent:
         yield parent
         parent = parent.parent()
 
-def qt_object_and_subtree(qt_obj: Any) -> Generator:
+def _object_and_subtree(qt_obj: Any) -> Generator:
     """Yield w and all of w's descendants."""
     yield qt_obj
     for child in qt_obj.children():
-        yield from qt_object_and_subtree(child)
+        yield from _object_and_subtree(child)
 
-def find_qt_ancestor_widget_by_class(qt_obj: Any, class_: Any):
-    """Return the widget in qt_obj's ancestors with the given class."""
-    for w in qt_ancestors(qt_obj):
-        g.trace(w)
-        if issubclass(w.__class__, class_):
-            return w
-    return None
+# def _find_ancestor_widget_by_class(qt_obj: Any, class_: Any):
+    # """Return the widget in qt_obj's ancestors with the given class."""
+    # for w in _ancestors(qt_obj):
+        # g.trace(w)
+        # if issubclass(w.__class__, class_):
+            # return w
+    # return None
+    
+def _find_layout_for_object(qt_obj: Any) -> Optional[Any]:
+    return None  ### To do.
 
-def find_qt_widget_by_name(qt_obj: Any, name: str) -> Optional[QWidget]:
+def _find_widget_by_name(qt_obj: Any, name: str) -> Optional[QWidget]:
     """Return the widget in parent's tree with the given name."""
-    for w in qt_object_and_subtree(qt_obj):
+    for w in _object_and_subtree(qt_obj):
         if w.objectName() == name:
             return w
     return None
@@ -1653,21 +1657,23 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20240515150157.1: *3* qt_gui:Widget utils
     # The dummy LeoGui methods: unl:gnx://leoPy.leo#ekr.20240515145223.1
 
-    def attach_widget(self, w: QWidget, parent: QWidget) -> None:
-        pass  ### To do.
+    # def attach_widget(self, w: QWidget, parent: QWidget) -> None:
+        # pass  ### To do.
 
-    def detach_widget(self, w: QWidget) -> None:
-        pass  ### To do.
+    # def detach_widget(self, w: QWidget) -> None:
+        # pass  ### To do.
         
-    def get_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
-        return find_qt_widget_by_name(c.frame.top, name)
+    # def find_ancestor_widget_by_class(self, w: QWidget, class_: QWidget) -> Optional[QWidget]:
+        # return _find_qt_ancestor_widget_by_class(w, class_)
+        
+    def find_layout_for_object(self, obj: Any) -> Optional[QLayout]:
+        return _find_layout_for_object(obj)
+
+    def find_widget_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
+        return _find_widget_by_name(c.frame.top, name)
 
     def get_top_splitter(self, c: Cmdr) -> QWidget:
-        return find_qt_widget_by_name(c.frame.top, 'main_splitter')
-        
-    def get_ancestor_widget_by_class(self, w: QWidget, class_: QWidget) -> Optional[QWidget]:
-        return find_qt_ancestor_widget_by_class(w, class_)
-
+        return _find_widget_by_name(c.frame.top, 'main_splitter')
     #@-others
 #@+node:tbrown.20150724090431.1: ** class StyleClassManager
 class StyleClassManager:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -75,37 +75,32 @@ def init() -> bool:
     g.app.gui.finishCreate()
     g.plugin_signon(__name__)
     return True
-#@+node:ekr.20240515151459.1: ** gt_gui: top-level functions
-def _ancestors(qt_obj: Any) -> Generator:
+#@+node:ekr.20240515151459.1: ** gt_gui: top-level generators
+def _parents(qt_obj: Any) -> Generator:
     """Yields all ancestors of qt_obj, a Qt object or widget."""
     parent = qt_obj.parent()
     while parent:
         yield parent
         parent = parent.parent()
+        
+def _self_and_parents(qt_obj: Any) -> Generator:
+    """Yields all ancestors of qt_obj, a Qt object or widget."""
+    w = qt_obj
+    while w:
+        yield w
+        w = w.parent()
 
-def _object_and_subtree(qt_obj: Any) -> Generator:
+def _self_and_subtree(qt_obj: Any) -> Generator:
     """Yield w and all of w's descendants."""
     yield qt_obj
     for child in qt_obj.children():
-        yield from _object_and_subtree(child)
-
-# def _find_ancestor_widget_by_class(qt_obj: Any, class_: Any):
-    # """Return the widget in qt_obj's ancestors with the given class."""
-    # for w in _ancestors(qt_obj):
-        # g.trace(w)
-        # if issubclass(w.__class__, class_):
-            # return w
-    # return None
-    
-def _find_layout_for_object(qt_obj: Any) -> Optional[Any]:
-    return None  ### To do.
-
-def _find_widget_by_name(qt_obj: Any, name: str) -> Optional[QWidget]:
-    """Return the widget in parent's tree with the given name."""
-    for w in _object_and_subtree(qt_obj):
-        if w.objectName() == name:
-            return w
-    return None
+        yield from _self_and_subtree(child)
+        
+# Not used.
+# def _subtree(qt_obj: Any) -> Generator:
+    # """Yield w and all of w's descendants."""
+    # for child in qt_obj.children():
+        # yield from _self_and_subtree(child)
 #@+node:ekr.20140907085654.18700: ** class LeoQtGui(leoGui.LeoGui)
 class LeoQtGui(leoGui.LeoGui):
     """A class implementing Leo's Qt gui."""
@@ -1655,25 +1650,48 @@ class LeoQtGui(leoGui.LeoGui):
         sizePolicy.setHeightForWidth(widget.sizePolicy().hasHeightForWidth())
         widget.setSizePolicy(sizePolicy)
     #@+node:ekr.20240515150157.1: *3* qt_gui:Widget utils
-    # The dummy LeoGui methods: unl:gnx://leoPy.leo#ekr.20240515145223.1
+    # qt_gui utils: unl:gnx://leoPy.leo#ekr.20240515151459.1
+
+    ### To do ###
 
     # def attach_widget(self, w: QWidget, parent: QWidget) -> None:
-        # pass  ### To do.
+        # pass
 
     # def detach_widget(self, w: QWidget) -> None:
-        # pass  ### To do.
+        # pass
         
-    # def find_ancestor_widget_by_class(self, w: QWidget, class_: QWidget) -> Optional[QWidget]:
-        # return _find_qt_ancestor_widget_by_class(w, class_)
+
+    def find_layout_for_object(self, qt_obj: Any) -> Optional[QLayout]:
+        return qt_obj.layout()  ### To do.
         
-    def find_layout_for_object(self, obj: Any) -> Optional[QLayout]:
-        return _find_layout_for_object(obj)
+
+    def find_nearest_containing_object(self, qt_obj: Any) -> Optional[Any]:
+        for w in _parents(qt_obj):
+            pass  ### To do.
+        return None
+        
+    def find_nearest_object_with_stylesheet(self, qt_obj: Any) -> Optional[Any]:
+        for w in _self_and_parents(qt_obj):
+            if w.styleSheet():
+                return w
+        return None
 
     def find_widget_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
-        return _find_widget_by_name(c.frame.top, name)
+        for w in _self_and_subtree(c.frame.top):
+            if w.objectName() == name:
+                return w
+        return None
+                
+    # Not used.
+    # def _find_ancestor_widget_by_class(self, qt_obj: Any, class_: Any):
+        # """Return the widget in qt_obj's ancestors with the given class."""
+        # for w in _ancestors(qt_obj):
+            # if issubclass(w.__class__, class_):
+                # return w
+        # return None
 
     def get_top_splitter(self, c: Cmdr) -> QWidget:
-        return _find_widget_by_name(c.frame.top, 'main_splitter')
+        return self.find_widget_by_name(c, 'main_splitter')
     #@-others
 #@+node:tbrown.20150724090431.1: ** class StyleClassManager
 class StyleClassManager:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -32,7 +32,7 @@ QFontMetrics = QtGui.QFontMetrics
 
 #@+others
 #@+node:ekr.20191001084541.1: **  zoom commands
-#@+node:tbrown.20130411145310.18857: *3* @g.command("zoom-in")
+#@+node:tbrown.20130411145310.18857: *3* @g.command('zoom-in')
 @g.command("zoom-in")
 def zoom_in(event: LeoKeyEvent = None, delta: int = 1) -> None:
     """increase body font size by one
@@ -40,7 +40,7 @@ def zoom_in(event: LeoKeyEvent = None, delta: int = 1) -> None:
     @font-size-body must be present in the stylesheet
     """
     zoom_helper(event, delta=1)
-#@+node:ekr.20191001084646.1: *3* @g.command("zoom-out")
+#@+node:ekr.20191001084646.1: *3* @g.command('zoom-out')
 @g.command("zoom-out")
 def zoom_out(event: LeoKeyEvent = None) -> None:
     """decrease body font size by one

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1423,7 +1423,7 @@ class QScintillaWrapper(QTextMixin):
         if sort and i > j:
             i, j = j, i
         return i, j
-    #@+node:ekr.20140901062324.18599: *4* qsciw.getX/YScrollPosition (to do)
+    #@+node:ekr.20140901062324.18599: *4* qsciw.getX/YScrollPosition
     def getXScrollPosition(self) -> int:
         # w = self.widget
         return 0  # Not ready yet.
@@ -1515,7 +1515,7 @@ class QScintillaWrapper(QTextMixin):
             w.SendScintilla(w.SCI_SETSEL, i, j)
         else:
             w.SendScintilla(w.SCI_SETSEL, j, i)
-    #@+node:ekr.20140901062324.18609: *4* qsciw.setX/YScrollPosition (to do)
+    #@+node:ekr.20140901062324.18609: *4* qsciw.setX/YScrollPosition
     def setXScrollPosition(self, pos: int) -> None:
         """Set the position of the horizontal scrollbar."""
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -213,10 +213,6 @@ from leo.core.leoQt import QtMultimedia, QtSvg
 from leo.core.leoQt import ContextMenuPolicy, Orientation, WrapMode
 from leo.plugins import qt_text
 
-###
-    # if g.allow_nested_splitter:
-        # from leo.plugins import free_layout
-
 BaseTextWidget = QtWidgets.QTextBrowser
 
 # Optional third-party imports...
@@ -346,7 +342,6 @@ def onCreate(tag: str, keys: dict) -> None:
     c = keys.get('c')
     if not c:
         return
-    ### if g.allow_nested_splitter:
     if getattr(c, 'free_layout', None):
         g.trace('*** Using free_layout ***')
         provider = ViewRenderedProvider(c)
@@ -424,6 +419,7 @@ def viewrendered(event: Event) -> Optional[Any]:
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     if main_splitter.orientation() == Orientation.Vertical:
+        # Share the VR pane with the body pane.
         # Create a new splitter.
         vr_splitter = QtWidgets.QSplitter(orientation=Orientation.Horizontal)
         vr_splitter.setObjectName('vr-splitter')
@@ -437,6 +433,7 @@ def viewrendered(event: Event) -> Optional[Any]:
         vr_splitter.setSizes([1, 1])
         main_splitter.setSizes([1, 1])
     else:
+        # Put the VR pane in the secondary splitter.
         secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
         # Add the VR pane to the secondary splitter.
         secondary_splitter.addWidget(vr)
@@ -688,7 +685,6 @@ class ViewRenderedProvider:
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.created = False
-        ### if g.allow_nested_splitter and c.free_layout:
         if getattr(c, 'free_layout', None):
             splitter = c.free_layout.get_top_splitter()
             if splitter:
@@ -1060,7 +1056,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         if self.gs and not force:
             return
         if not self.gs:
-            ### if g.allow_nested_splitter:
             if getattr(c, 'free_layout', None):
                 splitter = c.free_layout.get_top_splitter()
             else:

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -635,7 +635,7 @@ def update_rendering_pane(event: Event) -> None:
     if not vr:
         vr = viewrendered(event)
     vr.update(tag='view', keywords={'c': c, 'force': True})
-#@+node:vitalije.20170712195827.1: *3* g.command('vr-zoom')
+#@+node:vitalije.20170712195827.1: *3* g.command('vr-zoom') (rewrite)
 @g.command('vr-zoom')
 def zoom_rendering_pane(event: Event) -> None:
 
@@ -673,55 +673,6 @@ def zoom_rendering_pane(event: Event) -> None:
                     ns.setSizes(sizes)
                     break
     vr.zoomed = not vr.zoomed
-#@+node:tbrown.20110629084915.35149: ** class ViewRenderedProvider
-class ViewRenderedProvider:
-    """This class allows the free_layout plugin to insert VR panes anywhere."""
-    #@+others
-    #@+node:tbrown.20110629084915.35154: *3* vr.__init__
-    def __init__(self, c: Cmdr) -> None:
-        self.c = c
-        self.created = False
-    #@+node:tbrown.20110629084915.35151: *3* vr.ns_provide
-    def ns_provide(self, id_: str) -> Optional[Widget]:
-        global controllers, layouts
-        # #1678: duplicates in Open Window list
-        if self.created:
-            return None
-        if id_ == self.ns_provider_id():
-            self.created = True  # Suppress duplicates!
-            c = self.c
-            h = c.hash()
-            vr = controllers.get(h)
-            if not vr:
-                # Never overwrite an existing controller.
-                vr = ViewRenderedController(c)
-                controllers[h] = vr
-            # Enable, keeping the VR pane open.
-            vr.active = True
-            vr.auto_create = True
-            vr.is_visible = True
-            vr.keep_open = True
-            vr.locked = False
-            # Force an update.
-            vr.gnx = None
-            vr.length = 0
-            return vr
-        return None
-    #@+node:ekr.20200917062806.1: *3* vr.ns_provider_id
-    def ns_provider_id(self) -> str:
-        return '_leo_viewrendered'
-    #@+node:tbrown.20110629084915.35150: *3* vr.ns_provides
-    def ns_provides(self) -> list[tuple[str, str]]:
-        # #1671: Better Window names.
-        # #1678: duplicates in Open Window list
-        return [('Viewrendered', self.ns_provider_id())]
-    #@+node:ekr.20200917063221.1: *3* vr.ns_title
-    def ns_title(self, id_: str) -> Optional[str]:
-        if id_ != self.ns_provider_id():
-            return None
-        filename = self.c.shortFileName() or 'Unnamed file'
-        return f"Viewrendered: {filename}"
-    #@-others
 #@+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
 class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     """A class to control rendering in a rendering pane."""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -405,6 +405,9 @@ def viewrendered(event: Event) -> Optional[Any]:
     h = c.hash()
     vr = controllers.get(h)
     if vr:
+        vr.show()
+        vr.is_visible = True
+        g.es('VR pane on', color='red')
         c.bodyWantsFocusNow()
         return vr
     # Create the VR frame

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -342,10 +342,6 @@ def onCreate(tag: str, keys: dict) -> None:
     c = keys.get('c')
     if not c:
         return
-    if getattr(c, 'free_layout', None):
-        g.trace('*** Using free_layout ***')
-        provider = ViewRenderedProvider(c)
-        c.free_layout.register_provider(c, provider)
     vr = viewrendered(keys)
     g.registerHandler('select2', vr.update)
     g.registerHandler('idle', vr.update)
@@ -685,10 +681,6 @@ class ViewRenderedProvider:
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.created = False
-        if getattr(c, 'free_layout', None):
-            splitter = c.free_layout.get_top_splitter()
-            if splitter:
-                splitter.register_provider(self)
     #@+node:tbrown.20110629084915.35151: *3* vr.ns_provide
     def ns_provide(self, id_: str) -> Optional[Widget]:
         global controllers, layouts
@@ -1056,10 +1048,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         if self.gs and not force:
             return
         if not self.gs:
-            if getattr(c, 'free_layout', None):
-                splitter = c.free_layout.get_top_splitter()
-            else:
-                splitter = g.app.gui.get_top_splitter()
+            splitter = g.app.gui.get_top_splitter()
             # Create the widgets.
             self.gs = QtWidgets.QGraphicsScene(splitter)
             self.gv = QtWidgets.QGraphicsView(self.gs)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -400,7 +400,7 @@ def show_scrolled_message(tag: str, kw: Any) -> None:
 def preview(event: Event) -> None:
     """A synonym for the vr-toggle command."""
     toggle_rendering_pane(event)
-#@+node:tbrown.20100318101414.5998: *3* g.command('vr')
+#@+node:tbrown.20100318101414.5998: *3* g.command('vr') (to do)
 @g.command('vr')
 def viewrendered(event: Event) -> Optional[Any]:
     """Open render view for commander"""
@@ -415,10 +415,21 @@ def viewrendered(event: Event) -> Optional[Any]:
     if not vr:
         controllers[h] = vr = ViewRenderedController(c)
         # Add the pane to the splitter.
-        if c.free_layout:
-            splitter = c.free_layout.get_top_splitter()
-            if splitter:
-                splitter.add_adjacent(vr, 'bodyFrame', 'right-of')
+        if g.allow_nested_splitter:
+            if c.free_layout:
+                splitter = c.free_layout.get_top_splitter()
+                if splitter:
+                    splitter.add_adjacent(vr, 'bodyFrame', 'right-of')
+        else:
+            gui = g.app.gui
+            splitter = gui.get_top_splitter(c)
+            vr_frame = gui.get_by_name(c, 'bodyFrame')
+            g.trace(QtWidgets.QLayout)
+            layout = gui.get_ancestor_widget_by_class(vr_frame, QtWidgets.QLayout)
+            g.trace('To do: Move VR frame', vr_frame, 'to', layout)
+            ### Without adding to 
+            ### ns.add_adjacent(vr, 'bodyFrame', 'right-of')
+
     c.bodyWantsFocusNow()
     return vr
 #@+node:ekr.20130413061407.10362: *3* g.command('vr-contract')
@@ -661,7 +672,7 @@ def zoom_rendering_pane(event: Event) -> None:
 class ViewRenderedProvider:
     """This class allows the free_layout plugin to insert VR panes anywhere."""
     #@+others
-    #@+node:tbrown.20110629084915.35154: *3* vr.__init__ (test)
+    #@+node:tbrown.20110629084915.35154: *3* vr.__init__
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.created = False

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -185,12 +185,9 @@ Settings
 Acknowledgments
 ================
 
-Terry Brown created this initial version of this plugin, and the
-free_layout and NestedSplitter plugins used by viewrendered.
+Terry Brown created this initial version of this plugin.
 
-Edward K. Ream generalized this plugin and added communication and
-coordination between the free_layout, NestedSplitter and viewrendered
-plugins.
+Edward K. Ream generalized this plugin.
 
 Jacob Peck added markdown support to this plugin.
 
@@ -730,9 +727,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.change_size(100)
 
     def change_size(self, delta: int) -> None:
-        ### Test.
-        # if not hasattr(self.c, 'free_layout'):
-            # return
         splitter = self.parent()
         if not splitter:
             return
@@ -852,9 +846,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 # BaseTextWidget is a QTextBrowser.
                 pass
         return w
-    #@+node:ekr.20110320120020.14486: *4* vr.embed_widget (test)
+    #@+node:ekr.20110320120020.14486: *4* vr.embed_widget
     def embed_widget(self, w: Wrapper, delete_callback: Callable = None) -> None:
-        """Embed widget w in the free_layout splitter."""
+        """Embed widget w in the appropriate widget."""
         c = self.c
         self.w = w
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -423,10 +423,10 @@ def viewrendered(event: Event) -> Optional[Any]:
         else:
             gui = g.app.gui
             splitter = gui.get_top_splitter(c)
-            vr_frame = gui.get_by_name(c, 'bodyFrame')
+            vr_frame = gui.find_widget_by_name(c, 'bodyFrame')
             g.trace(QtWidgets.QLayout)
-            layout = gui.get_ancestor_widget_by_class(vr_frame, QtWidgets.QLayout)
-            g.trace('To do: Move VR frame', vr_frame, 'to', layout)
+            ### layout = gui.find_ancestor_widget_by_class(vr_frame, QtWidgets.QLayout)
+            g.trace('To do: Move VR frame', vr_frame)  ###, 'to', layout)
             ### Without adding to 
             ### ns.add_adjacent(vr, 'bodyFrame', 'right-of')
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -412,6 +412,7 @@ def viewrendered(event: Event) -> Optional[Any]:
         return vr
     # Create the VR frame
     controllers[h] = vr = ViewRenderedController(c)
+
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     if main_splitter.orientation() == Orientation.Vertical:
@@ -426,15 +427,15 @@ def viewrendered(event: Event) -> Optional[Any]:
         # Second, add the vr pane.
         vr_splitter.addWidget(vr)
         # Give equal width to all splitter panes.
-        vr_splitter.setSizes([1, 1])
-        main_splitter.setSizes([1, 1])
+        vr_splitter.setSizes([100000] * len(vr_splitter.sizes()))
+        main_splitter.setSizes([100000] * len(main_splitter.sizes()))
     else:
         # Put the VR pane in the secondary splitter.
         secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
         # Add the VR pane to the secondary splitter.
         secondary_splitter.addWidget(vr)
         # Give equal width to the panes in the secondary splitter.
-        secondary_splitter.setSizes([1, 1, 1])
+        secondary_splitter.setSizes([100000] * len(secondary_splitter.sizes()))
     c.bodyWantsFocusNow()
     return vr
 #@+node:ekr.20130413061407.10362: *3* g.command('vr-contract')

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -661,16 +661,14 @@ def zoom_rendering_pane(event: Event) -> None:
 class ViewRenderedProvider:
     """This class allows the free_layout plugin to insert VR panes anywhere."""
     #@+others
-    #@+node:tbrown.20110629084915.35154: *3* vr.__init__ (to do)
+    #@+node:tbrown.20110629084915.35154: *3* vr.__init__ (test)
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.created = False
-        ### To do.
-        if not c.free_layout:
-            return
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.register_provider(self)
+        if g.allow_nested_splitter and c.free_layout:
+            splitter = c.free_layout.get_top_splitter()
+            if splitter:
+                splitter.register_provider(self)
     #@+node:tbrown.20110629084915.35151: *3* vr.ns_provide
     def ns_provide(self, id_: str) -> Optional[Widget]:
         global controllers, layouts

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -210,7 +210,7 @@ from urllib.request import urlopen
 from leo.core import leoGlobals as g
 from leo.core.leoQt import QtCore, QtWidgets
 from leo.core.leoQt import QtMultimedia, QtSvg
-from leo.core.leoQt import ContextMenuPolicy, WrapMode
+from leo.core.leoQt import ContextMenuPolicy, Orientation, WrapMode
 from leo.plugins import qt_text
 
 if g.allow_nested_splitter:
@@ -423,10 +423,25 @@ def viewrendered(event: Event) -> Optional[Any]:
         else:
             gui = g.app.gui
             splitter = gui.get_top_splitter(c)
+            vr_splitter = QtWidgets.QSplitter(
+                orientation=Orientation.Horizontal,
+                parent = splitter,
+            )
+            vr_splitter.setObjectName('vr-splitter')
+            splitter.addWidget(vr_splitter)
+            vr_splitter.setParent(splitter)
             vr_frame = gui.find_widget_by_name(c, 'bodyFrame')
-            g.trace(QtWidgets.QLayout)
+            vr_splitter.addWidget(vr_frame)
+            vr_frame.setParent(vr_splitter)
+            assert vr_frame
+            # Similar to vr.ns_provide.
+            vr.active = True
+            vr.auto_create = True
+            vr.keep_open = True
+            vr.is_visible = True
+            ### g.trace(QtWidgets.QLayout)
             ### layout = gui.find_ancestor_widget_by_class(vr_frame, QtWidgets.QLayout)
-            g.trace('To do: Move VR frame', vr_frame)  ###, 'to', layout)
+            ### g.trace('To do: Move VR frame', vr_frame)  ###, 'to', layout)
             ### Without adding to 
             ### ns.add_adjacent(vr, 'bodyFrame', 'right-of')
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -383,7 +383,7 @@ def show_scrolled_message(tag: str, kw: Any) -> None:
     # Make sure we will show the message.
     vr.is_active = True
     vr.is_visible = True
-    # A hack: suppress updates until the node changes. 
+    # A hack: suppress updates until the node changes.
     vr.gnx = p.v.gnx
     vr.length = p.v.b
     # Render!
@@ -678,7 +678,7 @@ class ViewRenderedProvider:
             if not vr:
                 # Never overwrite an existing controller.
                 vr = ViewRenderedController(c)
-                controllers [h] = vr
+                controllers[h] = vr
             # Enable, keeping the VR pane open.
             vr.active = True
             vr.auto_create = True

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -635,44 +635,6 @@ def update_rendering_pane(event: Event) -> None:
     if not vr:
         vr = viewrendered(event)
     vr.update(tag='view', keywords={'c': c, 'force': True})
-#@+node:vitalije.20170712195827.1: *3* g.command('vr-zoom') (rewrite)
-@g.command('vr-zoom')
-def zoom_rendering_pane(event: Event) -> None:
-
-    global controllers
-    if g.app.gui.guiName() != 'qt':
-        return
-    c = event.get('c')
-    if not c:
-        return
-    vr = controllers.get(c.hash())
-    if not vr:
-        vr = viewrendered(event)
-    flc = c.free_layout
-    if not flc:
-        return
-    if vr.zoomed:
-        for ns in flc.get_top_splitter().top().self_and_descendants():
-            if hasattr(ns, '_unzoom'):
-                # this splitter could have been added since
-                ns.setSizes(ns._unzoom)
-    else:
-        parents = []
-        parent = vr
-        while parent:
-            parents.append(parent)
-            parent = parent.parent()
-        for ns in flc.get_top_splitter().top().self_and_descendants():
-            # FIXME - shouldn't be doing this across windows
-            ns._unzoom = ns.sizes()
-            for i in range(ns.count()):
-                w = ns.widget(i)
-                if w in parents:
-                    sizes = [0] * len(ns._unzoom)
-                    sizes[i] = sum(ns._unzoom)
-                    ns.setSizes(sizes)
-                    break
-    vr.zoomed = not vr.zoomed
 #@+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
 class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     """A class to control rendering in a rendering pane."""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1046,7 +1046,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Read the output file and return it.
         with open(o_path, 'r') as f:
             return f.read()
-    #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script (to do)
+    #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script (test)
     def update_graphics_script(self, s: str, keywords: Any) -> None:
         """Update the graphics script in the VR pane."""
         c = self.c
@@ -1059,7 +1059,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             if g.allow_nested_splitter:
                 splitter = c.free_layout.get_top_splitter()
             else:
-                splitter = None  ### To do.
+                splitter = g.app.gui.get_top_splitter()
             # Create the widgets.
             self.gs = QtWidgets.QGraphicsScene(splitter)
             self.gv = QtWidgets.QGraphicsView(self.gs)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -419,31 +419,26 @@ def viewrendered(event: Event) -> Optional[Any]:
             if c.free_layout:
                 splitter = c.free_layout.get_top_splitter()
                 if splitter:
-                    splitter.add_adjacent(vr, 'bodyFrame', 'right-of')
+                    splitter.add_adjacent(vr, 'bodyFrame', 'right-of', name='nested-vr-splitter')
         else:
             gui = g.app.gui
-            splitter = gui.get_top_splitter(c)
-            vr_splitter = QtWidgets.QSplitter(
-                orientation=Orientation.Horizontal,
-                parent = splitter,
-            )
+            # Create vr_splitter.
+            top_splitter = gui.get_top_splitter(c)
+            vr_splitter = QtWidgets.QSplitter(orientation=Orientation.Horizontal)
             vr_splitter.setObjectName('vr-splitter')
-            splitter.addWidget(vr_splitter)
-            vr_splitter.setParent(splitter)
-            vr_frame = gui.find_widget_by_name(c, 'bodyFrame')
-            vr_splitter.addWidget(vr_frame)
-            vr_frame.setParent(vr_splitter)
-            assert vr_frame
-            # Similar to vr.ns_provide.
+            top_splitter.addWidget(vr_splitter)
+            # First, add the body frame.
+            body_frame = gui.find_widget_by_name(c, 'bodyFrame')
+            vr_splitter.addWidget(body_frame)
+            # Second, add the vr pane.
+            vr_splitter.addWidget(vr)
+            # Give equal width to both panes.
+            vr_splitter.setSizes([1, 1])
+            # Set the flags.
             vr.active = True
             vr.auto_create = True
-            vr.keep_open = True
+            vr.keep_open = False
             vr.is_visible = True
-            ### g.trace(QtWidgets.QLayout)
-            ### layout = gui.find_ancestor_widget_by_class(vr_frame, QtWidgets.QLayout)
-            ### g.trace('To do: Move VR frame', vr_frame)  ###, 'to', layout)
-            ### Without adding to 
-            ### ns.add_adjacent(vr, 'bodyFrame', 'right-of')
 
     c.bodyWantsFocusNow()
     return vr

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -400,7 +400,7 @@ def show_scrolled_message(tag: str, kw: Any) -> None:
 def preview(event: Event) -> None:
     """A synonym for the vr-toggle command."""
     toggle_rendering_pane(event)
-#@+node:tbrown.20100318101414.5998: *3* g.command('vr') (to do)
+#@+node:tbrown.20100318101414.5998: *3* g.command('vr') (test)
 @g.command('vr')
 def viewrendered(event: Event) -> Optional[Any]:
     """Open render view for commander"""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -212,7 +212,9 @@ from leo.core.leoQt import QtCore, QtWidgets
 from leo.core.leoQt import QtMultimedia, QtSvg
 from leo.core.leoQt import ContextMenuPolicy, WrapMode
 from leo.plugins import qt_text
-from leo.plugins import free_layout
+
+if g.allow_nested_splitter:
+    from leo.plugins import free_layout
 
 BaseTextWidget = QtWidgets.QTextBrowser
 
@@ -629,6 +631,8 @@ def zoom_rendering_pane(event: Event) -> None:
     if not vr:
         vr = viewrendered(event)
     flc = c.free_layout
+    if not flc:
+        return
     if vr.zoomed:
         for ns in flc.get_top_splitter().top().self_and_descendants():
             if hasattr(ns, '_unzoom'):
@@ -1021,15 +1025,16 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def update_graphics_script(self, s: str, keywords: Any) -> None:
         """Update the graphics script in the VR pane."""
         c = self.c
+        if g.unitTesting:
+            return
         force = keywords.get('force')
         if self.gs and not force:
             return
         if not self.gs:
-            splitter = c.free_layout.get_top_splitter()
-            # Careful: we may be unit testing.
-            if not splitter:
-                g.trace('no splitter')
-                return
+            if g.allow_nested_splitter:
+                splitter = c.free_layout.get_top_splitter()
+            else:
+                splitter = None  ### To do.
             # Create the widgets.
             self.gs = QtWidgets.QGraphicsScene(splitter)
             self.gv = QtWidgets.QGraphicsView(self.gs)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -213,8 +213,9 @@ from leo.core.leoQt import QtMultimedia, QtSvg
 from leo.core.leoQt import ContextMenuPolicy, Orientation, WrapMode
 from leo.plugins import qt_text
 
-if g.allow_nested_splitter:
-    from leo.plugins import free_layout
+###
+    # if g.allow_nested_splitter:
+        # from leo.plugins import free_layout
 
 BaseTextWidget = QtWidgets.QTextBrowser
 
@@ -345,9 +346,11 @@ def onCreate(tag: str, keys: dict) -> None:
     c = keys.get('c')
     if not c:
         return
-    if g.allow_nested_splitter:
+    ### if g.allow_nested_splitter:
+    if getattr(c, 'free_layout', None):
+        g.trace('*** Using free_layout ***')
         provider = ViewRenderedProvider(c)
-        free_layout.register_provider(c, provider)
+        c.free_layout.register_provider(c, provider)
     vr = viewrendered(keys)
     g.registerHandler('select2', vr.update)
     g.registerHandler('idle', vr.update)
@@ -685,7 +688,8 @@ class ViewRenderedProvider:
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.created = False
-        if g.allow_nested_splitter and c.free_layout:
+        ### if g.allow_nested_splitter and c.free_layout:
+        if getattr(c, 'free_layout', None):
             splitter = c.free_layout.get_top_splitter()
             if splitter:
                 splitter.register_provider(self)
@@ -1046,7 +1050,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Read the output file and return it.
         with open(o_path, 'r') as f:
             return f.read()
-    #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script (test)
+    #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script
     def update_graphics_script(self, s: str, keywords: Any) -> None:
         """Update the graphics script in the VR pane."""
         c = self.c
@@ -1056,7 +1060,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         if self.gs and not force:
             return
         if not self.gs:
-            if g.allow_nested_splitter:
+            ### if g.allow_nested_splitter:
+            if getattr(c, 'free_layout', None):
                 splitter = c.free_layout.get_top_splitter()
             else:
                 splitter = g.app.gui.get_top_splitter()

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -939,7 +939,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return False
         if self.gnx != p.v.gnx:
             return True
-        if self.length != len(p.v.b):
+        if self.length != len(p.b):
             self.length = len(p.b)  # Suppress updates until next change.
             if self.get_kind(p) in ('html', 'pyplot'):
                 return False  # Only update explicitly.

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -345,8 +345,9 @@ def onCreate(tag: str, keys: dict) -> None:
     c = keys.get('c')
     if not c:
         return
-    provider = ViewRenderedProvider(c)
-    free_layout.register_provider(c, provider)
+    if g.allow_nested_splitter:
+        provider = ViewRenderedProvider(c)
+        free_layout.register_provider(c, provider)
     vr = viewrendered(keys)
     g.registerHandler('select2', vr.update)
     g.registerHandler('idle', vr.update)
@@ -414,9 +415,10 @@ def viewrendered(event: Event) -> Optional[Any]:
     if not vr:
         controllers[h] = vr = ViewRenderedController(c)
         # Add the pane to the splitter.
-        splitter = c.free_layout.get_top_splitter()
-        if splitter:
-            splitter.add_adjacent(vr, 'bodyFrame', 'right-of')
+        if c.free_layout:
+            splitter = c.free_layout.get_top_splitter()
+            if splitter:
+                splitter.add_adjacent(vr, 'bodyFrame', 'right-of')
     c.bodyWantsFocusNow()
     return vr
 #@+node:ekr.20130413061407.10362: *3* g.command('vr-contract')
@@ -659,15 +661,16 @@ def zoom_rendering_pane(event: Event) -> None:
 class ViewRenderedProvider:
     """This class allows the free_layout plugin to insert VR panes anywhere."""
     #@+others
-    #@+node:tbrown.20110629084915.35154: *3* vr.__init__
+    #@+node:tbrown.20110629084915.35154: *3* vr.__init__ (to do)
     def __init__(self, c: Cmdr) -> None:
         self.c = c
         self.created = False
-        # Careful: we may be unit testing.
-        if hasattr(c, 'free_layout'):
-            splitter = c.free_layout.get_top_splitter()
-            if splitter:
-                splitter.register_provider(self)
+        ### To do.
+        if not c.free_layout:
+            return
+        splitter = c.free_layout.get_top_splitter()
+        if splitter:
+            splitter.register_provider(self)
     #@+node:tbrown.20110629084915.35151: *3* vr.ns_provide
     def ns_provide(self, id_: str) -> Optional[Widget]:
         global controllers, layouts
@@ -800,8 +803,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.change_size(100)
 
     def change_size(self, delta: int) -> None:
-        if not hasattr(self.c, 'free_layout'):
-            return
+        ### Test.
+        # if not hasattr(self.c, 'free_layout'):
+            # return
         splitter = self.parent()
         if not splitter:
             return
@@ -921,7 +925,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 # BaseTextWidget is a QTextBrowser.
                 pass
         return w
-    #@+node:ekr.20110320120020.14486: *4* vr.embed_widget
+    #@+node:ekr.20110320120020.14486: *4* vr.embed_widget (test)
     def embed_widget(self, w: Wrapper, delete_callback: Callable = None) -> None:
         """Embed widget w in the free_layout splitter."""
         c = self.c
@@ -1021,7 +1025,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Read the output file and return it.
         with open(o_path, 'r') as f:
             return f.read()
-    #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script
+    #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script (to do)
     def update_graphics_script(self, s: str, keywords: Any) -> None:
         """Update the graphics script in the VR pane."""
         c = self.c

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1560,10 +1560,10 @@ def viewrendered(event):
         return vr3
     # Create the VR frame
     controllers[h] = vr3 = ViewRenderedController3(c)
-    
+
     # A prototype for supporint  arbitrarily many layouts.
     layout_kind = c.config.getString('vr3-initial-orientation') or 'in_secondary'
-    
+
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1812,7 +1812,7 @@ def lock_unlock_tree(event):
         vr3.unlock()
     else:
         vr3.lock()
-#@+node:TomP.20200923123015.1: *3* g.command('vr3-use-default-layout') (rewrite)
+#@+node:TomP.20200923123015.1: *3* g.command('vr3-use-default-layout')
 @g.command('vr3-use-default-layout')
 def open_with_layout(event):
     vr3 = getVr3(event)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1240,11 +1240,9 @@ latex_template = f'''\
 '''
 #@-<< define html templates >>
 
-# keys for all three below: c.hash()
+# keys are c.hash().
 controllers = {}  # values: VR3 widets
 positions = {}  # values: OPENED_IN_TAB or OPENED_IN_SPLITTER
-### layouts = {}  # values: tuples (layout_when_closed, layout_when_open)
-
 
 #@+others
 #@+node:TomP.20200508124457.1: ** find_exe()
@@ -1564,7 +1562,7 @@ def getVr3(event):
 @g.command('vr3')
 def viewrendered(event):
     """Open render view for commander"""
-    global controllers, layouts
+    global controllers
     gui = g.app.gui
     if gui.guiName() != 'qt':
         return None
@@ -1578,12 +1576,12 @@ def viewrendered(event):
         return vr3
     # Create the VR frame
     controllers[h] = vr3 = ViewRenderedController3(c)
-    # vr3.splitter = gui.get_top_splitter(c)
 
     # A prototype for supporint  arbitrarily many layouts.
     layout_kind = c.config.getString('vr3-initial-orientation') or 'in_secondary'
 
     # Use different layouts depending on the main splitter's *initial* orientation.
+    big = 100000
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
     if layout_kind == 'in_body':
@@ -1597,15 +1595,15 @@ def viewrendered(event):
         body_frame = gui.find_widget_by_name(c, 'bodyFrame')
         splitter.addWidget(body_frame)
         splitter.addWidget(vr3)
-        splitter.setSizes([100000] * len(splitter.sizes()))
+        splitter.setSizes([big] * len(splitter.sizes()))
     elif main_splitter.orientation() == Orientation.Vertical:
         # Put the VR pane in in the main_splitter.
         main_splitter.insertWidget(1, vr3)
-        main_splitter.setSizes([100000] * len(main_splitter.sizes()))
+        main_splitter.setSizes([big] * len(main_splitter.sizes()))
     else:
         # Put the VR pane in the secondary splitter.
         secondary_splitter.addWidget(vr3)
-        secondary_splitter.setSizes([100000] * len(secondary_splitter.sizes()))
+        secondary_splitter.setSizes([big] * len(secondary_splitter.sizes()))
     c.bodyWantsFocusNow()
     return vr3
 #@+node:tom.20230403141635.1: *3* g.command('vr3-tab')
@@ -1644,7 +1642,7 @@ def unfreeze_rendering_pane(event):
 @g.command('vr3-hide')
 def hide_rendering_pane(event):
     """Close the rendering pane."""
-    global controllers, layouts
+    global controllers
     if g.app.gui.guiName() != 'qt':
         return
 

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1446,13 +1446,7 @@ def isVisible():
     return
 #@+node:TomP.20191215195433.11: *3* vr3.onCreate
 def onCreate(tag, keys):
-    c = keys.get('c')
-    if not c:
-        return
-    if getattr(c, 'free_layout', None):
-        provider = ViewRenderedProvider3(c)
-        c.free_layout.register_provider(c, provider)
-
+    pass
 #@+node:TomP.20191215195433.12: *3* vr3.onClose
 def onClose(tag, keys):
     c = keys.get('c')
@@ -3400,7 +3394,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             g.es(message)
             return message
 
-    #@+node:TomP.20191215195433.58: *4* vr3.update_graphics_script (test)
+    #@+node:TomP.20191215195433.58: *4* vr3.update_graphics_script
     def update_graphics_script(self, s, keywords):
         """Update the graphics script in the vr3 pane."""
         pc = self; c = pc.c
@@ -3408,10 +3402,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         if pc.gs and not force:
             return
         if not pc.gs:
-            if getattr(c, 'free_layout', None):
-                splitter = c.free_layout.get_top_splitter()
-            else:
-                splitter = g.app.gui.get_top_splitter()
+            splitter = g.app.gui.get_top_splitter()
             if not splitter:
                 g.trace('no splitter')
                 return

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1558,7 +1558,7 @@ def getVr3(event):
         controllers[h] = vr3 = viewrendered(event)
     return vr3
 #@+node:TomP.20191215195433.16: ** vr3.Commands
-#@+node:TomP.20191215195433.18: *3* g.command('vr3')
+#@+node:TomP.20191215195433.18: *3* g.command('vr3') (**weird**)
 @g.command('vr3')
 def viewrendered(event):
     """Open render view for commander"""
@@ -1598,7 +1598,7 @@ def viewrendered(event):
         splitter.setSizes([big] * len(splitter.sizes()))
     elif main_splitter.orientation() == Orientation.Vertical:
         # Put the VR pane in in the main_splitter.
-        main_splitter.insertWidget(1, vr3)
+        main_splitter.insertWidget(1, vr3)  ### The weird effect happens here.
         main_splitter.setSizes([big] * len(main_splitter.sizes()))
     else:
         # Put the VR pane in the secondary splitter.
@@ -2138,8 +2138,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.asciidoc3_internal_ok = True
         self.asciidoc_internal_ok = True
         self.using_ext_proc_msg_shown = False
-
-
     #@+node:TomP.20200329223820.3: *4* vr3.create_dispatch_dict
     def create_dispatch_dict(self):
         pc = self

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1567,7 +1567,6 @@ def viewrendered(event):
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
-    big = 100000
     if layout_kind == 'in_body':
         # Share the VR pane with the body pane.
         # Create a new splitter.
@@ -1579,15 +1578,15 @@ def viewrendered(event):
         body_frame = gui.find_widget_by_name(c, 'bodyFrame')
         splitter.addWidget(body_frame)
         splitter.addWidget(vr3)
-        splitter.setSizes([big, big])
+        splitter.setSizes([100000] * len(splitter.sizes()))
     elif main_splitter.orientation() == Orientation.Vertical:
         # Put the VR pane in in the main_splitter.
         main_splitter.insertWidget(1, vr3)
-        main_splitter.setSizes([big, big, big])
+        main_splitter.setSizes([100000] * len(main_splitter.sizes()))
     else:
         # Put the VR pane in the secondary splitter.
         secondary_splitter.addWidget(vr3)
-        secondary_splitter.setSizes([big, big, big])
+        secondary_splitter.setSizes([100000] * len(secondary_splitter.sizes()))
     c.bodyWantsFocusNow()
     return vr3
 #@+node:tom.20230403141635.1: *3* g.command('vr3-tab')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2062,9 +2062,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.c = c
         # Create the widget.
         super().__init__(parent)
-            ###
-                # per http://enki-editor.org/2014/08/23/Pyqt_mem_mgmt.html
-                # QtWidgets.QWidget.__init__(self)
+            # per http://enki-editor.org/2014/08/23/Pyqt_mem_mgmt.html
+            # QtWidgets.QWidget.__init__(self)
         self.create_pane(parent)
 
         # Set the ivars.

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3400,7 +3400,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             g.es(message)
             return message
 
-    #@+node:TomP.20191215195433.58: *4* vr3.update_graphics_script (to do)
+    #@+node:TomP.20191215195433.58: *4* vr3.update_graphics_script (test)
     def update_graphics_script(self, s, keywords):
         """Update the graphics script in the vr3 pane."""
         pc = self; c = pc.c
@@ -3411,7 +3411,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             if g.allow_nested_splitter:
                 splitter = c.free_layout.get_top_splitter()
             else:
-                splitter = None  ### To do.
+                splitter = g.app.gui.get_top_splitter()
             if not splitter:
                 g.trace('no splitter')
                 return

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -953,7 +953,6 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@+node:tom.20210517102737.1: *3* << Qt Imports >> (VR3)
 try:
     from leo.plugins import qt_text
-    ### from leo.plugins import free_layout
     from leo.core.leoQt import QtCore, QtWidgets
     from leo.core.leoQt import QtMultimedia, QtSvg
     from leo.core.leoQt import KeyboardModifier, Orientation, WrapMode
@@ -2989,9 +2988,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 # except Exception:
                     # g.es_exception()
                     # pc.deactivate()
-    #@+node:TomP.20191215195433.51: *4* vr3.embed_widget & helper (test)
+    #@+node:TomP.20191215195433.51: *4* vr3.embed_widget & helper
     def embed_widget(self, w, delete_callback=None):
-        """Embed widget w in the free_layout splitter."""
+        """Embed widget w in the appropriate splitter."""
         pc = self; c = pc.c
         pc.w = w
         layout = self.layout()

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1449,7 +1449,6 @@ def onCreate(tag, keys):
     c = keys.get('c')
     if not c:
         return
-    ### if g.allow_nested_splitter:
     if getattr(c, 'free_layout', None):
         provider = ViewRenderedProvider3(c)
         c.free_layout.register_provider(c, provider)
@@ -3409,7 +3408,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
         if pc.gs and not force:
             return
         if not pc.gs:
-            ### if g.allow_nested_splitter:
             if getattr(c, 'free_layout', None):
                 splitter = c.free_layout.get_top_splitter()
             else:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1567,7 +1567,6 @@ def viewrendered(event):
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
-    
     big = 100000
     if layout_kind == 'in_body':
         # Share the VR pane with the body pane.

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4610,27 +4610,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
         pc.active = True
         g.registerHandler('select2', pc.update)
         g.registerHandler('idle', pc.update)
-    #@+node:TomP.20200329230436.3: *5* vr3.contract & expand (to do)
-    # Change zoom factor of rendering pane
-    def contract(self):
-        self.change_size(-100)
-
-    def expand(self):
-        self.change_size(100)
-
-    def change_size(self, delta):
-        if getattr(self.c, 'free_layout', None):
-            splitter = self.parent()
-            i = splitter.indexOf(self)
-            assert i > -1
-            sizes = splitter.sizes()
-            n = len(sizes)
-            for j, size in enumerate(sizes):
-                if j == i:
-                    sizes[j] = max(0, size + delta)
-                else:
-                    sizes[j] = max(0, size - int(delta / (n - 1)))
-            splitter.setSizes(sizes)
     #@+node:TomP.20200329230436.4: *5* vr3.deactivate
     def deactivate(self):
         """Deactivate the vr3 window."""

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -954,7 +954,7 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@+node:tom.20210517102737.1: *3* << Qt Imports >> (VR3)
 try:
     from leo.plugins import qt_text
-    from leo.plugins import free_layout
+    ### from leo.plugins import free_layout
     from leo.core.leoQt import QtCore, QtWidgets
     from leo.core.leoQt import QtMultimedia, QtSvg
     from leo.core.leoQt import KeyboardModifier, Orientation, WrapMode
@@ -1444,14 +1444,15 @@ def init():
 def isVisible():
     """Return True if the VR3 pane is visible."""
     return
-#@+node:TomP.20191215195433.11: *3* vr3.onCreate (test)
+#@+node:TomP.20191215195433.11: *3* vr3.onCreate
 def onCreate(tag, keys):
     c = keys.get('c')
     if not c:
         return
-    if g.allow_nested_splitter:
+    ### if g.allow_nested_splitter:
+    if getattr(c, 'free_layout', None):
         provider = ViewRenderedProvider3(c)
-        free_layout.register_provider(c, provider)
+        c.free_layout.register_provider(c, provider)
 
 #@+node:TomP.20191215195433.12: *3* vr3.onClose
 def onClose(tag, keys):
@@ -3408,7 +3409,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         if pc.gs and not force:
             return
         if not pc.gs:
-            if g.allow_nested_splitter:
+            ### if g.allow_nested_splitter:
+            if getattr(c, 'free_layout', None):
                 splitter = c.free_layout.get_top_splitter()
             else:
                 splitter = g.app.gui.get_top_splitter()

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1581,29 +1581,28 @@ def viewrendered(event):
     layout_kind = c.config.getString('vr3-initial-orientation') or 'in_secondary'
 
     # Use different layouts depending on the main splitter's *initial* orientation.
-    big = 100000
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
     if layout_kind == 'in_body':
         # Share the VR pane with the body pane.
         # Create a new splitter.
         splitter = QtWidgets.QSplitter(orientation=Orientation.Horizontal)
-        splitter.setOpaqueResize(False)
         splitter.setObjectName('vr3-horizonal-splitter')
         main_splitter.addWidget(splitter)
         # Add frames.
         body_frame = gui.find_widget_by_name(c, 'bodyFrame')
         splitter.addWidget(body_frame)
         splitter.addWidget(vr3)
-        splitter.setSizes([big] * len(splitter.sizes()))
+        gui.equalize_splitter(splitter)
+        gui.equalize_splitter(main_splitter)
     elif main_splitter.orientation() == Orientation.Vertical:
         # Put the VR pane in in the main_splitter.
         main_splitter.insertWidget(1, vr3)  ### The weird effect happens here.
-        main_splitter.setSizes([big] * len(main_splitter.sizes()))
+        gui.equalize_splitter(main_splitter)
     else:
         # Put the VR pane in the secondary splitter.
         secondary_splitter.addWidget(vr3)
-        secondary_splitter.setSizes([big] * len(secondary_splitter.sizes()))
+        gui.equalize_splitter(secondary_splitter)
     c.bodyWantsFocusNow()
     return vr3
 #@+node:tom.20230403141635.1: *3* g.command('vr3-tab')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1542,7 +1542,7 @@ def getVr3(event):
         controllers[h] = vr3 = viewrendered(event)
     return vr3
 #@+node:TomP.20191215195433.16: ** vr3.Commands
-#@+node:TomP.20191215195433.18: *3* g.command('vr3') (rewrite)
+#@+node:TomP.20191215195433.18: *3* g.command('vr3')
 @g.command('vr3')
 def viewrendered(event):
     """Open render view for commander"""
@@ -1558,39 +1558,37 @@ def viewrendered(event):
     if vr3:
         c.bodyWantsFocusNow()
         return vr3
-     # Create the VR frame
+    # Create the VR frame
     controllers[h] = vr3 = ViewRenderedController3(c)
+    
+    # A prototype for supporint  arbitrarily many layouts.
     layout_kind = c.config.getString('vr3-initial-orientation') or 'in_secondary'
+    
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
     secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
-    g.trace(layout_kind, main_splitter.orientation())  ###
+    
+    big = 100000
     if layout_kind == 'in_body':
         # Share the VR pane with the body pane.
         # Create a new splitter.
         splitter = QtWidgets.QSplitter(orientation=Orientation.Horizontal)
+        splitter.setOpaqueResize(False)
         splitter.setObjectName('vr3-horizonal-splitter')
         main_splitter.addWidget(splitter)
         # Add frames.
         body_frame = gui.find_widget_by_name(c, 'bodyFrame')
         splitter.addWidget(body_frame)
         splitter.addWidget(vr3)
-        # Equalize splitters.
-        # splitter.setSizes([1, 1])
-        # main_splitter.setSizes([1, 1])
-        # secondary_splitter.setSizes([1, 1])
+        splitter.setSizes([big, big])
     elif main_splitter.orientation() == Orientation.Vertical:
         # Put the VR pane in in the main_splitter.
         main_splitter.insertWidget(1, vr3)
-        # Equalize splitters.
-        ### main_splitter.setSizes([1, 1, 1])
+        main_splitter.setSizes([big, big, big])
     else:
         # Put the VR pane in the secondary splitter.
         secondary_splitter.addWidget(vr3)
-        # Equalize splitters.
-        ### secondary_splitter.setSizes([1, 1, 1])
-        ### main_splitter.setSizes([1, 1])
-
+        secondary_splitter.setSizes([big, big, big])
     c.bodyWantsFocusNow()
     return vr3
 #@+node:tom.20230403141635.1: *3* g.command('vr3-tab')
@@ -2085,41 +2083,6 @@ def vr3_render_html_from_clip(event):
     vr3.update_html(clip_str, {})
 
 
-#@+node:ekr.20200918085543.1: ** class ViewRenderedProvider3
-class ViewRenderedProvider3:
-    #@+others
-    #@+node:ekr.20200918085543.2: *3* vr3.__init__
-    def __init__(self, c):
-        self.c = c
-        self.vr3_instance = None
-    #@+node:ekr.20200918085543.3: *3* vr3.ns_provide
-    def ns_provide(self, id_):
-        global controllers, layouts
-        # #1678: duplicates in Open Window list
-        if id_ == self.ns_provider_id():
-            c = self.c
-            h = c.hash()
-            vr3 = controllers.get(h) or ViewRenderedController3(c)
-            controllers[h] = vr3
-            if not layouts.get(h):
-                layouts[h] = c.db.get(VR3_DEF_LAYOUT, (None, None))
-            return vr3
-        return None
-    #@+node:ekr.20200918085543.4: *3* vr3.ns_provider_id
-    def ns_provider_id(self):
-        return VR3_NS_ID
-    #@+node:ekr.20200918085543.5: *3* vr3.ns_provides
-    def ns_provides(self):
-        # #1671: Better Window names.
-        # #1678: duplicates in Open Window list
-        return [('Viewrendered 3', self.ns_provider_id())]
-    #@+node:ekr.20200918085543.6: *3* vr3.ns_title
-    def ns_title(self, id_):
-        if id_ != self.ns_provider_id():
-            return None
-        filename = self.c.shortFileName() or 'Unnamed file'
-        return f"Viewrendered 3: {filename}"
-    #@-others
 #@+node:TomP.20191215195433.36: ** class ViewRenderedController3 (QWidget)
 class ViewRenderedController3(QtWidgets.QWidget):
     """A class to control rendering in a rendering pane."""


### PR DESCRIPTION
See #3910.

Leo's core will never load these two plugins, but other plugins should be allowed to do so.
**Warning**: The free_layout may not work as expected because of changes to `dw.createMainLayout`.

- [x] `LeoQtGui`: Add `find_widget_by_name`, `get_top_splitter`, and `_self_and_subtree`.
- [x] Set `c.free_layout = None` (permanently!) in `c.init_objects`.
- [x] `dw.createMainLayout` creates `QSplitter`s, not `NestedSplitters`s.
- [x] Similarly, revise several `QtFrame` methods, especially `toggle-split-direction`.
- [x] Revise the VR plugin. The `viewrendered` method places the VR pane depending on settings.
- [x] Remove the `ViewRenderedProvider` and `ViewRenderedProvider3` classes.
- [x] Revise the VR3 plugin as a *prototype*. Thomas is entitled to change what I've done.
- [x] Revise the `bookmarks.py` plugin so that it doesn't use `free_layout`.
- [x] Similarly, revise the `editpane` plugin and `pyplot_backend` plugins.
- [ ] Create an info item that contains tips and examples for converting layouts.

**Extras**

- [x] Add `NestedSplitter.dump_layout`. This is a non-trivial method!