### PR TITLE
Fix erroneous command if pyenchant library isn't present.

### DIFF
--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -182,7 +182,7 @@ class DefaultWrapper(BaseSpellWrapper):
         # pylint: disable=super-init-not-called
         self.c = c
         if not g.app.spellDict:
-            g.app.spellDict = DefaultDict().d  # 2024/04/09: bug fix.
+            g.app.spellDict = DefaultDict()  # 2024/05/15: bug fix.
         self.d: dict = g.app.spellDict
         self.user_fn = self.find_user_dict()
         if not g.os_path_exists(self.user_fn):


### PR DESCRIPTION
This bug showed up on a Mac but it would apply to any OS if the pyenchant library isn't available.