### PR TITLE
PR for #3916: Improve `restart-leo` command

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -99,12 +99,6 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     # Save session data.
     g.app.saveSession()
     g.app.setLog(None)  # Kill the log.
-    # #3141: Remember all open outlines.
-    restart_paths: list[str] = [
-        c.fileName() for c in g.app.commanders() if c.fileName()
-    ]
-    if g.isWindows:
-        restart_paths = [z.replace('/', os.sep) for z in restart_paths]
     # Close all unsaved outlines.
     for c in g.app.commanders():
         frame = c.frame
@@ -124,10 +118,19 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Restart Leo with subprocess.run.
-    if 1:
-        # #3916: retain all the command-line args.
-        args = [sys.executable] + sys.argv[:]
+    if 1:  # #3916.
+        if g.isWindows:
+            sys_args = [z.replace('/', os.sep) for z in sys.argv]
+        else:
+            sys_args = sys.argv[:]
+        args = [sys.executable] + sys_args
     else:
+        # #3141: Remember all open outlines.
+        restart_paths: list[str] = [
+            c.fileName() for c in g.app.commanders() if c.fileName()
+        ]
+        if g.isWindows:
+            restart_paths = [z.replace('/', os.sep) for z in restart_paths]
         # Warning: Python 3.9 does not allow newlines within f-strings.
         leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
         launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -124,10 +124,14 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Restart Leo with subprocess.run.
-    # Warning: Python 3.9 does not allow newlines within f-strings.
-    leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
-    launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
-    args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
+    if 1:
+        # #3916: retain all the command-line args.
+        args = [sys.executable] + sys.argv[:]
+    else:
+        # Warning: Python 3.9 does not allow newlines within f-strings.
+        leo_editor_dir = os.path.normpath(os.path.join(g.app.loadDir, '..', '..'))
+        launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
+        args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
     args_s = 'subprocess.run([\n  ' + ',\n  '.join(args) + '\n])'
     print('')
     print('Restarting Leo with:\n')

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -118,6 +118,10 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Restart Leo with subprocess.run.
+    print('')
+    print('Restarting Leo...')
+    print(f"os.chdir({g.app.initial_cwd})")
+    os.chdir(g.app.initial_cwd)
     if 1:  # #3916.
         if g.isWindows:
             sys_args = [z.replace('/', os.sep) for z in sys.argv]
@@ -136,8 +140,6 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
         launchLeo_s = fr'{leo_editor_dir}{os.sep}launchLeo.py'
         args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
     args_s = 'subprocess.run([\n  ' + ',\n  '.join(args) + '\n])'
-    print('')
-    print('Restarting Leo with:\n')
     print(args_s)
     print('')
     subprocess.run(args)  # pylint: disable=subprocess-run-check

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -173,6 +173,7 @@ class LeoApp:
         self.atFileNames: set[str] = set()  # The set of all built-in @<file> spellings.
         self.globalKillBuffer: list[str] = []  # The global kill buffer.
         self.globalRegisters: dict[str, str] = {}  # The global register list.
+        self.initial_cwd: str = os.getcwd()  # For restart-leo.
         self.leoID: str = None  # The id part of gnx's.
         self.lossage: list[LossageData] = []  # List of last 100 keystrokes.
         self.paste_c: Cmdr = None  # The commander that pasted the last outline.


### PR DESCRIPTION
See #3916.

- [x] Save `os.getcwd()` for `restart-leo`.
- [x] Use the original `sys.argv`.

This PR needs thorough testing, despite its apparent simplicity.