### PR TITLE
VR3: ASCIIDOC, MD, and RsT images display correctly when the exported file is ...

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -3435,6 +3435,9 @@ include *.TXT
 prune leo/unittests/htmlcov
 prune leo/doc/html
 include leo/doc/html/conf.py
+
+# #3853.
+include leo/doc/_static
 </t>
 <t tx="ekr.20240321122614.1"># These are Leo's test scripts.
 


### PR DESCRIPTION
viewed in the browser (relative paths are converted to absolute file system paths).

The display code has been adapted to Leo's new splitter/layout infrastructure. It also includes a few fixes to allow the toggle-in-tab and vr3-hide commands to work.

This PR contains changes made by ekr in ekr-no-fl-ns-plugins.  It includes changes by tbp to correct Issue https://github.com/leo-editor/leo-editor/issues/3917.  

Version number and "latest changes" section of the  docstring have been updated.

I would appreciate merging these changes so that I can continue to merge ongoing changes to Leo's layout/splitter code without losing my own changes.