### PR TITLE
PR for #3935: fix server.is_valid

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -2293,16 +2293,14 @@ class LeoServer:
         try:
             c = self._check_c(param)
             assert c
-        except Exception:  # pragma: no cover
-            # c not found.
-            return self._make_minimal_response()
-        ap = param.get("ap")
-        if ap:
+            ap = param.get("ap")
             gnx = ap.get("gnx")
             if gnx:
                 for p in c.all_unique_positions(copy=False):
                     if p.gnx == gnx:
                         return self._make_minimal_response({'valid': True})
+        except Exception:  # pragma: no cover
+            pass
         return self._make_minimal_response()
     #@+node:felix.20210621233316.36: *5* server.get_all_open_commanders
     def get_all_open_commanders(self, param: Param) -> Response:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -2292,16 +2292,17 @@ class LeoServer:
         """
         try:
             c = self._check_c(param)
+            assert c
         except Exception:  # pragma: no cover
-            # c not found
+            # c not found.
             return self._make_minimal_response()
-        if c:  # pragma: no cover
-            ap = param.get("ap")
-            if ap:
-                gnx = ap.get("gnx")
-            for p in c.all_unique_positions(copy=False):
-                if p.gnx == gnx:
-                    return self._make_minimal_response({'valid': True})
+        ap = param.get("ap")
+        if ap:
+            gnx = ap.get("gnx")
+            if gnx:
+                for p in c.all_unique_positions(copy=False):
+                    if p.gnx == gnx:
+                        return self._make_minimal_response({'valid': True})
         return self._make_minimal_response()
     #@+node:felix.20210621233316.36: *5* server.get_all_open_commanders
     def get_all_open_commanders(self, param: Param) -> Response:
@@ -4983,7 +4984,7 @@ class LeoServer:
                             return p
                 raise ServerError(f"{tag}: position does not exist. ap: {ap!r}")
             return p  # Return the position
-        elif gnx:
+        if gnx:
             # Had no 'ap', but a 'gnx' param was passed instead.
             for p in c.all_unique_positions():
                 if p.v.gnx == gnx:


### PR DESCRIPTION
See #3935. This PR passes all tests, including pyflakes, pylint and beautifier.

- [x] `server.is_valid`: Guard `c` and  `ap` by enclosing the code in a `try/except` block.
   The guard on `gnx` is still needed to avoid incorrectly returning `self._make_minimal_response({'valid': True})`
- [x] `server._get_p`: Fix a valid pylint complaint.