### PR TITLE
PR for #3946: optional Qt modules

### DIFF
--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -74,20 +74,9 @@ else:
         from PyQt6 import uic
     except Exception:
         uic = None
-
-    # Give a hint if any optional module does not exist.
-    if (
-        not Qsci or not QtDesigner or not QtMultimedia or not QtNetwork
-        or not QtOpenGL or not printsupport or not QtWebEngineCore
-        or not QtWebEngineWidgets or not QtSvg or not uic
-    ):
-        print('')
-        print('leoQt.py: one or more optional Qt modules do not exist.')
-        print('Please run `pip install -r requirements.txt`')
-        print('')
     #@-<< import optional Qt modules >>
-#@+<< PyQt6 enumerations >>
-#@+node:ekr.20240303142509.3: ** << PyQt6 enumerations >>
+#@+<< define PyQt6 enumerations >>
+#@+node:ekr.20240303142509.3: ** << define PyQt6 enumerations >>
 AlignmentFlag = Qt.AlignmentFlag
 AlignLeft = Qt.AlignmentFlag.AlignLeft
 AlignRight = Qt.AlignmentFlag.AlignRight
@@ -136,7 +125,7 @@ WidgetAttribute = Qt.WidgetAttribute
 WindowState = Qt.WindowState
 WindowType = Qt.WindowType
 WrapMode = QtGui.QTextOption.WrapMode
-#@-<< PyQt6 enumerations >>
+#@-<< define PyQt6 enumerations >>
 #@+<< asserts for pyflakes >>
 #@+node:ekr.20240528045757.1: ** << asserts for pyflakes >>
 
@@ -160,8 +149,8 @@ assert QUrl
 # assert QtWidgets
 # assert uic
 #@-<< asserts for pyflakes >>
-
-# Standard abbreviations.
+#@+<< define standard abbreviations >>
+#@+node:ekr.20240528050716.1: ** << define standard abbreviations >>
 qt_version = QtCore.QT_VERSION_STR
 try:
     QWebEngineSettings = QtWebEngineCore.QWebEngineSettings
@@ -169,4 +158,19 @@ try:
 except Exception:
     QWebEngineSettings = None
     WebEngineAttribute = None
+#@-<< define standard abbreviations >>
+#@+<< print a hint if an optional module does not exist >>
+#@+node:ekr.20240528050657.1: ** << print a hint if an optional module does not exist >>
+if (
+    not Qsci or not QtDesigner or not QtMultimedia or not QtNetwork
+    or not QtOpenGL or not printsupport or not QtWebEngineCore
+    or not QtWebEngineWidgets or not QWebEngineSettings or not WebEngineAttribute
+    or not QtSvg or not uic
+):
+    print('')
+    print('leoQt.py: one or more optional Qt modules do not exist.')
+    print('Please run `pip install -r requirements.txt`')
+    print('')
+#@-<< print a hint if an optional module does not exist >>
+
 #@-leo

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -173,17 +173,19 @@ except Exception:
     WebEngineAttribute = None
     _missing_modules.append('QtWebEngineCore.QWebEngineSettings')
 #@-<< define standard abbreviations >>
-#@+<< print a hint if an optional module does not exist >>
-#@+node:ekr.20240528050657.1: ** << print a hint if an optional module does not exist >>
-if _missing_modules:
-    print('')
-    print('leoQt.py: the following optional Qt modules do not exist:')
-    for z in sorted(_missing_modules):
-        print(f"  {z}")
-    print('')
-    print('Please run `pip install -r requirements.txt`')
-    print('')
-#@-<< print a hint if an optional module does not exist >>
+
+if 0:  # Quickly becomes annoying.
+    #@+<< print a hint if an optional module does not exist >>
+    #@+node:ekr.20240528050657.1: ** << print a hint if an optional module does not exist >>
+    if _missing_modules:
+        print('')
+        print('leoQt.py: the following optional Qt modules do not exist:')
+        for z in sorted(_missing_modules):
+            print(f"  {z}")
+        print('')
+        print('Please run `pip install -r requirements.txt`')
+        print('')
+    #@-<< print a hint if an optional module does not exist >>
 
 del _missing_modules
 #@-leo

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -6,6 +6,8 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QUrl
 from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent
 
+_missing_modules: list[str] = []
+
 if 0:
     #@+<< testing: set all optional Qt modules to None >>
     #@+node:ekr.20240528043206.1: ** << testing: set all optional Qt modules to None >>
@@ -29,52 +31,63 @@ else:
         assert Qsci
     except Exception:
         Qsci = None
+        _missing_modules.append('Qsci')
 
     try:
         from PyQt6 import QtDesigner
     except Exception:
         QtDesigner = None
+        _missing_modules.append('PyQt6.QtDesigner')
 
     try:
         from PyQt6 import QtMultimedia
     except Exception:
         QtMultimedia = None
+        _missing_modules.append('PyQt6.QtMultimedia')
 
     try:
         from PyQt6 import QtNetwork
     except Exception:
         QtNetwork = None
+        _missing_modules.append('PyQt6.QtNetwork')
 
     try:
         from PyQt6 import QtOpenGL
     except Exception:
         QtOpenGL = None
+        _missing_modules.append('PyQt6.QtOpenGL')
 
     try:
         from PyQt6 import QtPrintSupport as printsupport
     except Exception:
         printsupport = None
+        _missing_modules.append('PyQt6.QtPrintSupport')
 
     try:
         from PyQt6 import QtWebEngineCore  # included with PyQt6-WebEngine
     except Exception:
         QtWebEngineCore = None
+        _missing_modules.append('PyQt6.QtWebEngineCore')
 
     try:
         from PyQt6 import QtWebEngineWidgets
     except Exception:
         QtWebEngineWidgets = None
+        _missing_modules.append('PyQt6.QtWebEngineWidgets')
 
     try:
         import PyQt6.QtSvg as QtSvg
     except Exception:
         QtSvg = None
+        _missing_modules.append('PyQt6.QtSvg')
 
     try:
         from PyQt6 import uic
     except Exception:
         uic = None
+        _missing_modules.append('uic')
     #@-<< import optional Qt modules >>
+
 #@+<< define PyQt6 enumerations >>
 #@+node:ekr.20240303142509.3: ** << define PyQt6 enumerations >>
 AlignmentFlag = Qt.AlignmentFlag
@@ -158,19 +171,19 @@ try:
 except Exception:
     QWebEngineSettings = None
     WebEngineAttribute = None
+    _missing_modules.append('QtWebEngineCore.QWebEngineSettings')
 #@-<< define standard abbreviations >>
 #@+<< print a hint if an optional module does not exist >>
 #@+node:ekr.20240528050657.1: ** << print a hint if an optional module does not exist >>
-if (
-    not Qsci or not QtDesigner or not QtMultimedia or not QtNetwork
-    or not QtOpenGL or not printsupport or not QtWebEngineCore
-    or not QtWebEngineWidgets or not QWebEngineSettings or not WebEngineAttribute
-    or not QtSvg or not uic
-):
+if _missing_modules:
     print('')
-    print('leoQt.py: one or more optional Qt modules do not exist.')
+    print('leoQt.py: the following optional Qt modules do not exist:')
+    for z in sorted(_missing_modules):
+        print(f"  {z}")
+    print('')
     print('Please run `pip install -r requirements.txt`')
     print('')
 #@-<< print a hint if an optional module does not exist >>
 
+del _missing_modules
 #@-leo

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -1,30 +1,91 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20140810053602.18074: * @file leoQt.py
 """Leo's Qt import wrapper, specialized for Qt6."""
-
+from typing import Any
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QUrl
 from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent
 
-# Previously optional imports...
+if 0:
+    #@+<< testing: set all optional Qt modules to None >>
+    #@+node:ekr.20240528043206.1: ** << testing: set all optional Qt modules to None >>
+    Qsci: Any = None
+    QtDesigner = None
+    QtMultimedia = None
+    QtNetwork = None
+    QtOpenGL = None
+    printsupport = None
+    QtWebEngineCore = None
+    QtWebEngineWidgets = None
+    QtSvg = None
+    uic = None
+    #@-<< testing: set all optional Qt modules to None >>
+else:
+    #@+<< import optional Qt modules >>
+    #@+node:ekr.20240528041831.1: ** << import optional Qt modules >>
+    # Leo 6.8.0: do *not* assume these exist.
+    try:
+        from PyQt6 import Qsci
+        assert Qsci
+    except Exception:
+        Qsci = None
 
-import PyQt6.QtSvg as QtSvg
-from PyQt6 import QtDesigner
-from PyQt6 import QtMultimedia
-from PyQt6 import QtNetwork
-from PyQt6 import QtOpenGL
-from PyQt6 import QtPrintSupport as printsupport
-from PyQt6 import QtWebEngineCore  # included with PyQt6-WebEngine
-from PyQt6 import QtWebEngineWidgets
-from PyQt6 import uic
+    try:
+        from PyQt6 import QtDesigner
+    except Exception:
+        QtDesigner = None
 
-# requirements.txt now contains PyQt6-QScintilla, so this should usually succeed.
-# But for now (until Leo 6.7.9), let's be careful.
-try:
-    from PyQt6 import Qsci  # Now required.
-    assert Qsci
-except Exception:
-    Qsci = None
+    try:
+        from PyQt6 import QtMultimedia
+    except Exception:
+        QtMultimedia = None
+
+    try:
+        from PyQt6 import QtNetwork
+    except Exception:
+        QtNetwork = None
+
+    try:
+        from PyQt6 import QtOpenGL
+    except Exception:
+        QtOpenGL = None
+
+    try:
+        from PyQt6 import QtPrintSupport as printsupport
+    except Exception:
+        printsupport = None
+
+    try:
+        from PyQt6 import QtWebEngineCore  # included with PyQt6-WebEngine
+    except Exception:
+        QtWebEngineCore = None
+
+    try:
+        from PyQt6 import QtWebEngineWidgets
+    except Exception:
+        QtWebEngineWidgets = None
+
+    try:
+        import PyQt6.QtSvg as QtSvg
+    except Exception:
+        QtSvg = None
+
+    try:
+        from PyQt6 import uic
+    except Exception:
+        uic = None
+
+    # Give a hint if any optional module does not exist.
+    if (
+        not Qsci or not QtDesigner or not QtMultimedia or not QtNetwork
+        or not QtOpenGL or not printsupport or not QtWebEngineCore
+        or not QtWebEngineWidgets or not QtSvg or not uic
+    ):
+        print('')
+        print('leoQt.py: one or more optional Qt modules do not exist.')
+        print('Please run `pip install -r requirements.txt`')
+        print('')
+    #@-<< import optional Qt modules >>
 
 #@+<< PyQt6 enumerations >>
 #@+node:ekr.20240303142509.3: ** << PyQt6 enumerations >>

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -6,6 +6,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtCore import Qt, QUrl
 from PyQt6.QtGui import QAction, QActionGroup, QCloseEvent
 
+# A public list of missing Qt modules. Good for debugging.
 _missing_modules: list[str] = []
 
 if 0:
@@ -85,6 +86,7 @@ else:
         from PyQt6 import uic
     except Exception:
         uic = None
+        # On Linux, uic may be a standalone program.
         _missing_modules.append('uic')
     #@-<< import optional Qt modules >>
 
@@ -187,5 +189,4 @@ if 0:  # Quickly becomes annoying.
         print('')
     #@-<< print a hint if an optional module does not exist >>
 
-del _missing_modules
 #@-leo

--- a/leo/core/leoQt.py
+++ b/leo/core/leoQt.py
@@ -86,7 +86,6 @@ else:
         print('Please run `pip install -r requirements.txt`')
         print('')
     #@-<< import optional Qt modules >>
-
 #@+<< PyQt6 enumerations >>
 #@+node:ekr.20240303142509.3: ** << PyQt6 enumerations >>
 AlignmentFlag = Qt.AlignmentFlag
@@ -138,29 +137,36 @@ WindowState = Qt.WindowState
 WindowType = Qt.WindowType
 WrapMode = QtGui.QTextOption.WrapMode
 #@-<< PyQt6 enumerations >>
+#@+<< asserts for pyflakes >>
+#@+node:ekr.20240528045757.1: ** << asserts for pyflakes >>
 
 # For pyflakes so it doesn't complain about unused imports.
 assert QAction
 assert QActionGroup
 assert QCloseEvent
 assert QUrl
+
+# assert QtCore
 # assert Qsci
-assert QtCore
-assert QtDesigner
-assert QtGui
-assert QtMultimedia
-assert QtNetwork
-assert QtOpenGL
-assert QtSvg
-assert printsupport
-assert QtWebEngineCore
-assert QtWebEngineWidgets
-assert QtWidgets
-assert uic
+# assert QtDesigner
+# assert QtGui
+# assert QtMultimedia
+# assert QtNetwork
+# assert QtOpenGL
+# assert QtSvg
+# assert printsupport
+# assert QtWebEngineCore
+# assert QtWebEngineWidgets
+# assert QtWidgets
+# assert uic
+#@-<< asserts for pyflakes >>
 
 # Standard abbreviations.
 qt_version = QtCore.QT_VERSION_STR
-
-QWebEngineSettings = QtWebEngineCore.QWebEngineSettings
-WebEngineAttribute = QWebEngineSettings.WebAttribute
+try:
+    QWebEngineSettings = QtWebEngineCore.QWebEngineSettings
+    WebEngineAttribute = QWebEngineSettings.WebAttribute
+except Exception:
+    QWebEngineSettings = None
+    WebEngineAttribute = None
 #@-leo

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -9,7 +9,8 @@ import os
 import sys
 import traceback
 
-# Override sys.excepthook
+# Override sys.excepthook.
+
 def leo_excepthook(typ, val, tb):
     # Like g.es_exception.
     lines = traceback.format_exception(typ, val, tb)
@@ -31,20 +32,24 @@ if sys.executable.endswith("pythonw.exe"):
         os.path.join(os.getenv("TEMP", default=""),  # #1557.
         "stderr-" + os.path.basename(sys.argv[0])),
         "w")
+
+# Make sure the leo directory is on sys.path.
 path = os.getcwd()
 if path not in sys.path:
     sys.path.append(path)
+
+# Do the initial imports. Leo can't continue if these fail.
 try:
     # #1472: bind to g immediately.
     from leo.core import leoGlobals as g
     from leo.core import leoApp
     g.app = leoApp.LeoApp()
-
 except Exception:
     message = (
-        '*** Leo could not be started ***\n'
+        'Error starting Leo!\n'
         "Please verify you've installed the required dependencies:\n"
-        'https://leo-editor.github.io/leo-editor/installing.html'
+        'https://leo-editor.github.io/leo-editor/installing.html\n'
+        'Please ask for help at https://groups.google.com/g/leo-editor'
     )
     # The full traceback is too important to omit!
     print(message)

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -46,12 +46,10 @@ except Exception:
         "Please verify you've installed the required dependencies:\n"
         'https://leo-editor.github.io/leo-editor/installing.html'
     )
+    # The full traceback is too important to omit!
     print(message)
-    if 1:
-        # For debugging.
-        # The full traceback would alarm users!
-        print('')
-        traceback.print_exc()
+    print('')
+    traceback.print_exc()
     sys.exit(1)
 #@-<< imports and inits >>
 #@+others

--- a/leo/core/runLeo.py
+++ b/leo/core/runLeo.py
@@ -40,17 +40,19 @@ try:
     from leo.core import leoApp
     g.app = leoApp.LeoApp()
 
-except Exception as e:
-    # The full traceback would alarm users!
-    # Note: app.createDefaultGui reports problems importing Qt.
-    print(e)
+except Exception:
     message = (
         '*** Leo could not be started ***\n'
         "Please verify you've installed the required dependencies:\n"
         'https://leo-editor.github.io/leo-editor/installing.html'
     )
     print(message)
-    sys.exit(message)
+    if 1:
+        # For debugging.
+        # The full traceback would alarm users!
+        print('')
+        traceback.print_exc()
+    sys.exit(1)
 #@-<< imports and inits >>
 #@+others
 #@+node:ekr.20031218072017.2607: ** profile_leo (runLeo.py)

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -86,13 +86,13 @@ except Exception:
     QtGui = QtWidgets = None
 #@+others
 #@+node:ekr.20140920145803.17995: ** top-level
-#@+node:ekr.20090616105756.3940: *3* init
+#@+node:ekr.20090616105756.3940: *3* init (backlink.py)
 warning_given = False
 
 def init():
     """Return True if the plugin has loaded successfully."""
     global warning_given
-    ok = QtGui and g.app.gui.guiName() == 'qt'  # #2197.
+    ok = QtGui and uic and g.app.gui.guiName() == 'qt'  # #2197.
     if not ok:
         return False
     g.registerHandler('after-create-leo-frame', onCreate)

--- a/leo/plugins/graphcanvas.py
+++ b/leo/plugins/graphcanvas.py
@@ -53,10 +53,10 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@-<< imports >>
 c_db_key = '_graph_canvas_gnx'
 #@+others
-#@+node:bob.20110119123023.7393: ** init
+#@+node:bob.20110119123023.7393: ** init (graphcanvas.py)
 def init():
     """Return True if the plugin has loaded successfully."""
-    if g.app.gui.guiName() != "qt":
+    if not uic or g.app.gui.guiName() != "qt":
         return False
     g.visit_tree_item.add(colorize_headlines_visitor)
     g.registerHandler('after-create-leo-frame', onCreate)

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -90,13 +90,24 @@ NO_TIME = datetime.date(3000, 1, 1)
 
 #@+others
 #@+node:tbrown.20090119215428.6: ** init (todo.py)
+warning_given = False
+
 def init() -> bool:
     """Return True if the plugin has loaded successfully."""
+    global warning_given
+    if warning_given:
+        return False
     name = g.app.gui.guiName()
     if name != "qt":
+        warning_given = True
         if name not in ('browser', 'curses', 'nullGui'):
-            print('todo.py plugin not loading because gui is not Qt')
+            print('todo.py plugin not loaded because gui is not Qt')
         return False
+    if not uic:
+        warning_given = True
+        print('todo.py plugin not loaded because uic can not be imported')
+        return False
+        
     g.registerHandler('after-create-leo-frame', onCreate)
     # can't use before-create-leo-frame because Qt dock's not ready
     g.plugin_signon(__name__)


### PR DESCRIPTION
See #3946.

Most of the work in this PR involves making `leoQt.py` more robust:

- [x] Add testing section that sets all optional modules to None.
   Leo loads, but after loading throws exceptions because `uic` is None.
- [x] Import all optional Qt modules in `try/except` blocks.
  Set the modules to `None` if they fail to load, and add their name to the *public* `_missing_modules` list.
- [x] Add disabled code reports the missing modules.

**Other files**

- [x] runLeo.py always give a traceback on failure-to-load.
  This traceback is to important to omit!
- [x] The `backlink`, `graphcanvas` and `todo` plugins load only if the `uic` module exists.