### PR TITLE
PR for #3949: crash in vr

### DIFF
--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1516,13 +1516,15 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20240519114809.1: *4* qt_gui._self_and_subtree
     def _self_and_subtree(self, qt_obj: Any) -> Generator:
         """Yield w and all of w's descendants."""
+        if not qt_obj:
+            return
         yield qt_obj
         for child in qt_obj.children():
             yield from self._self_and_subtree(child)
     #@+node:ekr.20240519115301.1: *4* qt_gui.find_widget_by_name
     def find_widget_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
         for w in self._self_and_subtree(c.frame.top):
-            if w.objectName() == name:
+            if w and w.objectName() == name:
                 return w
         return None
     #@+node:ekr.20240519115157.1: *4* qt_gui.get_top_splitter

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -415,6 +415,8 @@ def viewrendered(event: Event) -> Optional[Any]:
 
     # Use different layouts depending on the main splitter's *initial* orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
+    if not main_splitter:
+        return vr
     if main_splitter.orientation() == Orientation.Vertical:
         # Share the VR pane with the body pane.
         # Create a new splitter.


### PR DESCRIPTION
See #3949. The real cause of this crash may the `@button check-settings` script in `leoSettings.leo`, but we may as well add some guards.

- [x] Add guards to prevent an unusual crash.