### PR TITLE
PR for #3957: leoAtFile blunder

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3289,7 +3289,6 @@ class FastAtRead:
                         gnx2vnode[gnx] = v
                         # Always use the gnx in the file's root node.
                         root_v.fileIndex = gnx
-                    ###### self.root.v.fileIndex = gnx
                     v.children = []
                     continue  # End of case 1.
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3287,9 +3287,9 @@ class FastAtRead:
                         gnx = v.gnx
                         gnx2body[gnx] = gnx2body[root_v.gnx]  ### Experimental.
                         gnx2vnode[gnx] = v
+                        # Always use the gnx in the file's root node.
                         root_v.fileIndex = gnx
-                    # Always use the gnx in the file's root node.
-                    self.root.gnx == gnx
+                    ###### self.root.v.fileIndex = gnx
                     v.children = []
                     continue  # End of case 1.
 


### PR DESCRIPTION
See #3957.

The error seemingly was benign. The do-nothing statement can just be removed.

Nevertheless, the code must be thoroughly tested.