### PR TITLE
PR 2 for #3957: Fix Leo's read code

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -373,7 +373,7 @@ def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
         g.es_print(f"Unknown @<file> node: {p.h!r}")
         return
     if p.v.gnx != old_gnx and not g.unitTesting:
-        g.trace(f"Changing gnx! old: {old_gnx} new: {p.v.gnx} in {p.h}")
+        print(f"refresh-from-disk: gnx for `{p.h}` changed from: `{old_gnx}` to: `{p.v.gnx}`")
     c.selectPosition(p)
     # Create the 'Recovered Nodes' tree.
     c.fileCommands.handleNodeConflicts()

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -352,6 +352,7 @@ def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
     at = c.atFileCommands
     c.nodeConflictList = []
     c.recreateGnxDict()
+    old_gnx = p.v.gnx
     if p.isAtAutoNode() or p.isAtAutoRstNode():
         p.v._deleteAllChildren()
         p = at.readOneAtAutoNode(p)  # Changes p!
@@ -371,6 +372,8 @@ def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
     else:
         g.es_print(f"Unknown @<file> node: {p.h!r}")
         return
+    if p.v.gnx != old_gnx and not g.unitTesting:
+        g.trace(f"Changing gnx! old: {old_gnx} new: {p.v.gnx} in {p.h}")
     c.selectPosition(p)
     # Create the 'Recovered Nodes' tree.
     c.fileCommands.handleNodeConflicts()

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -373,7 +373,8 @@ def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
         g.es_print(f"Unknown @<file> node: {p.h!r}")
         return
     if p.v.gnx != old_gnx and not g.unitTesting:
-        print(f"refresh-from-disk: gnx for `{p.h}` changed from: `{old_gnx}` to: `{p.v.gnx}`")
+        g.es_print(f"refresh-from-disk changed the gnx for `{p.h}`")
+        g.es_print(f"from `{old_gnx}` to: `{p.v.gnx}`")
     c.selectPosition(p)
     # Create the 'Recovered Nodes' tree.
     c.fileCommands.handleNodeConflicts()

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3279,7 +3279,7 @@ class FastAtRead:
                             del gnx2body[root_v.gnx]
                         if root_v.gnx in gnx2vnode:
                             del gnx2vnode[root_v.gnx]
-                        # Only Leo's refresh-from-disk command does issue this messages.
+                        # `refresh-from-disk` issues this messages, but 'git-diff' should not.
                         # g.trace(f"Changing gnx! old: {root_v.gnx} new: {gnx} in {head}")
                         root_v.fileIndex = gnx
                     gnx2vnode[gnx] = root_v

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3274,7 +3274,7 @@ class FastAtRead:
                     clone_v = None
                     v = root_v
                     if root_v.gnx != gnx:
-                        # Delete all traces of the root_v.gnx.
+                        # Delete all traces of root_v.gnx.
                         if root_v.gnx in gnx2body:
                             del gnx2body[root_v.gnx]
                         if root_v.gnx in gnx2vnode:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3268,27 +3268,22 @@ class FastAtRead:
                 v = gnx2vnode.get(gnx)
 
                 # Case 1: The root @file node. Don't change the headline.
+                #         #3931: Always use root_v, but use the gnx from external file!
                 if not root_seen:
-                    # #1064: The node represents the root, regardless of the gnx!
-                    # #3931: The gnx in the external file overrides p.v.gnx.
                     root_seen = True
                     clone_v = None
-                    if not v:
-                        # Special case for unit tests and git-diff.
-                        v = root_v
-                        gnx = v.gnx
-                        gnx2vnode[gnx] = v
-                        gnx2body[gnx] = gnx2body[v.gnx]
-                    elif root_v.gnx == v.gnx:
-                        gnx2body[gnx] = body = []
-                    else:
-                        # refresh-from-disk
-                        # #3931: Prefer the gnx in the external file.
-                        gnx = v.gnx
-                        gnx2body[gnx] = gnx2body[root_v.gnx]
-                        gnx2vnode[gnx] = v
-                        # Always use the gnx in the file's root node.
+                    v = root_v
+                    if root_v.gnx != gnx:
+                        # Delete all traces of the root_v.gnx.
+                        if root_v.gnx in gnx2body:
+                            del gnx2body[root_v.gnx]
+                        if root_v.gnx in gnx2vnode:
+                            del gnx2vnode[root_v.gnx]
+                        # Only Leo's refresh-from-disk command does issue this messages.
+                        # g.trace(f"Changing gnx! old: {root_v.gnx} new: {gnx} in {head}")
                         root_v.fileIndex = gnx
+                    gnx2vnode[gnx] = root_v
+                    gnx2body[gnx] = body = []
                     v.children = []
                     continue  # End of case 1.
 


### PR DESCRIPTION
See #3957.

These changes must be *carefully* reviewed by as many Leonine experts as possible.

- [x] `refresh-from-disk` when the file's gnx overrides `p.v.gnx`.
- [x] Rewrite case 1 of the section << handle node start >>`.
   The new code removes all traces of `root_v.gnx` if it conflicts from the file's gnx.