### PR TITLE
PR for two new quirps

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -848,25 +848,17 @@ class Commands:
             extension_map = scan_map('EXTENSIONS')
             return processor_map, extension_map, terminal
         #@+node:tom.20230308193758.7: *4* getExeKind
-        def getExeKind(pos: Position, ext: str) -> str:
-            """Return the executable kind of the external file.
+        def getExeKind(ext: str) -> str:
+            """
+            Return the executable kind (a language) of the external file.
 
             If there is a language directive in effect, return it,
             otherwise use the file extension.
-
-            Returns a language.
             """
-            language = g.getLanguageFromAncestorAtFileNode(c.p) or ''
-            # words = root.h.split(None, 1)  # Splits only on first run of spaces
-            # path = words[1] if len(words) > 1 else ""
-            # if not path:
-                # return None, None, None
-
-            # _, ext = os.path.splitext(path)
-            if not language:
-                language = LANGUAGE_EXTENSION_MAP.get(ext, None)
-
-            return language
+            return (
+                g.getLanguageFromAncestorAtFileNode(c.p)
+                or LANGUAGE_EXTENSION_MAP.get(ext, None)
+            )
 
         #@+node:tom.20230308193758.8: *4* getProcessor
         def getProcessor(language: str, path: str, extension: str) -> str:
@@ -1091,7 +1083,7 @@ class Commands:
                     g.es('Trying an alternative')
 
             path = c.fullPath(root)
-            language = getExeKind(root, ext)
+            language = getExeKind(ext)
             processor = getProcessor(language, path, ext)
             runfile(path, processor, terminal)
         else:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -836,7 +836,7 @@ class Commands:
                         d[key] = val
                 return d
 
-             # Set terminal flag.
+             # Set terminal value.
             terminal = ''
             for line in lines:
                 if 'Terminal' in line:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -781,6 +781,8 @@ class Commands:
         }
         #@+node:tom.20230308193758.6: *4* get_external_maps
         def get_external_maps() -> tuple[dict, dict, str]:
+            #@+<< get_external_maps: docstring >>
+            #@+node:ekr.20240605053105.1: *5* << get_external_maps: docstring >>
             r"""Return processor, extension maps for @data node.
 
             The data in the @data node body must have a PROCESSORS and an
@@ -807,11 +809,11 @@ class Commands:
             RETURNS
             a tuple (processor_map, extension_map, terminal)
             """
+            #@-<< get_external_maps: docstring >>
 
-            data: list[str] = c.config.getData(MAP_SETTING_NODE, None)
+            data: list[str] = c.config.getData(MAP_SETTING_NODE)
             if not data:
                 return None, None, ''
-
             processor_map: dict[str, str] = {}
             extension_map: dict[str, str] = {}
             active_map = None
@@ -819,7 +821,7 @@ class Commands:
             found_term = False
             TERM = 'TERMINAL'
             for line in data:
-                if not line or line.startswith('#'):
+                if not line:
                     continue
                 line = line.split('#', 1)[0]  # Allow in-line trailing comments
                 if 'EXTENSIONS' in line:

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1673,6 +1673,7 @@ class LocalConfigManager:
     #@+node:ekr.20120215072959.12527: *5* c.config.getData
     def getData(self,
         setting: str,
+        *,
         strip_comments: bool = True,
         strip_data: bool = True,
     ) -> list[str]:


### PR DESCRIPTION
Thanks to Félix for reporting these two quirps:

- In the `get_external_maps` helper function, the `active_map dict` is set up carefully, but serves no purpose in the end and is just discarded!
- `getExeKind` helper function ignores its position parameter (uses c.p instead of 'root' which was passed)

**Fixes**

- [x] Add '*' to signature of `c.config.getData`, thereby requiring all optional args to be given by name.
- [x] Rewrite `get_external_maps`.
- [x] `getExeKind`: Remove unused `root` arg. Simplify the docstring and the computation.