### PR TITLE
PR: Improve installation scripts and files

### DIFF
--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -52,8 +52,8 @@ leoVersion.version:     Leo's version number.
 # 6.7.8:       March 14, 2024.
 # 6.7.8.post3: March 22, 2024.
 #@-<< version dates >>
-version = '6.7.9-devel'
-static_date = 'March 20, 2024'
+version = '6.8.0-b1'
+static_date = 'June 15, 2024'
 #@@language python
 #@@tabwidth -4
 #@-leo

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -19,6 +19,9 @@ print(os.path.basename(__file__))
 
 # cd to leo-editor.
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
+assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
+assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
 # delete leo/dist/*.*

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -5,10 +5,10 @@
 """
 build_leo.py: Build Leo as follows:
     
-- Delete all files in the `leo/dist` folder.
+- Delete all files in the `leo-editor/leo/dist` directory.
 - Run `python -m build > build_log.txt`.
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 import glob
@@ -17,7 +17,7 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# cd to leo-editor
+# cd to leo-editor.
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -6,9 +6,7 @@
 inspect_wheel.py: Inspect the metadata of wheel files.
                   Output goes to inspect_wheel.txt.
 
-pip install wheel-inspect
-
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -6,6 +6,8 @@
 inspect_wheel.py: Inspect the metadata of wheel files.
                   Output goes to inspect_wheel.txt.
 
+`pip install wheel-inspect' is not part of Leo's requirements.
+
 See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
@@ -16,9 +18,14 @@ import subprocess
 print(os.path.basename(__file__))
 
 # cd to leo-editor
-os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
+### os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
+assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
+assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
+os.chdir(leo_editor_dir)
 
-command = 'python -m wheel_inspect dist\leo-6.7.9a1-py3-none-any.whl >inspect_wheel.txt'
+command = r'python -m wheel_inspect dist\leo-6.8.0b1-py3-none-any.whl >inspect_wheel.txt'
 print(command)
 subprocess.Popen(command, shell=True).communicate()
 

--- a/leo/scripts/inspect_wheel.py
+++ b/leo/scripts/inspect_wheel.py
@@ -18,7 +18,6 @@ import subprocess
 print(os.path.basename(__file__))
 
 # cd to leo-editor
-### os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
 assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)

--- a/leo/scripts/install_leo_from_pypi.py
+++ b/leo/scripts/install_leo_from_pypi.py
@@ -5,7 +5,7 @@
 """
 install_leo_from_pypi.py: Install leo from https://pypi.org/project/leo/.
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 
@@ -14,7 +14,7 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# Do *not* install from leo-editor!
+# cd to the home directory.
 home_dir = os.path.expanduser("~")
 os.chdir(home_dir)
 

--- a/leo/scripts/install_leo_from_testpypi.py
+++ b/leo/scripts/install_leo_from_testpypi.py
@@ -5,7 +5,7 @@
 """
 install_leo_from_testpypi.py: Install leo from https://test.pypi.org/project/leo/.
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 
@@ -14,7 +14,7 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# Do *not* install from leo-editor!
+# cd to the home directory.
 home_dir = os.path.expanduser("~")
 os.chdir(home_dir)
 

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -1,38 +1,46 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20240321123214.1: * @file ../scripts/install_leo_locally.py
 #@@language python
-
 """
 install_leo_locally.py: Install leo from a wheel file in the `leo/dist` folder.
+
+Executes `python -m pip install leo-editor/dist/leo-6.8.0b1-py3-none-any.whl`
+
+*Note*: The leo-editor folder must *not* be in sys.path!
 
 Info item #3837 describes all distribution-related scripts.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
-
 import glob
 import os
 import sys
 import subprocess
 
-print(os.path.basename(__file__))
+file_name = os.path.basename(__file__)
 
-# Do *not* install from leo-editor!
-home_dir = os.path.expanduser("~")
-os.chdir(home_dir)
+if any('leo-editor' in z for z in sys.path):
+    print(f"{file_name}: remove leo-editor from sys.path!")
+    print('Note: do *not* run this script from the leo-editor directory!')
+else:
+    print(file_name)
+    # Do *not* install from leo-editor!
+    home_dir = os.path.expanduser("~")
+    os.chdir(home_dir)
+    # Install.
+    dist_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..', 'dist'))
+    assert os.path.exists(dist_dir), dist_dir
+    wheel_file = 'leo-6.8.0b1-py3-none-any.whl'
+    #  --force-reinstall
+    command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file}"
+    print(command)
+    subprocess.Popen(command, shell=True).communicate()
 
-# Install.
-dist_dir = os.path.abspath(os.path.join(__file__, '..', '..', 'dist'))
-assert os.path.exists(dist_dir), dist_dir
-wheel_file = 'leo-6.7.9a1-py3-none-any.whl'
-command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file}"
-print(command)
-subprocess.Popen(command, shell=True).communicate()
-
-# List site-packages/leo*.
-python_dir = os.path.dirname(sys.executable)
-package_dir = os.path.abspath(os.path.join(python_dir, 'Lib', 'site-packages'))
-print('')
-print('site-packages/leo*...')
-for z in glob.glob(f"{package_dir}{os.sep}leo*"):
-    print(z)
+    # List site-packages/leo*.
+    python_dir = os.path.dirname(sys.executable)
+    package_dir = os.path.abspath(os.path.join(python_dir, 'Lib', 'site-packages'))
+    print('')
+    print('package_dir:', package_dir)
+    print('site-packages/leo*...')
+    for z in glob.glob(f"{package_dir}{os.sep}leo*"):
+        print(z)
 #@-leo

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -20,7 +20,7 @@ file_name = os.path.basename(__file__)
 
 if any('leo-editor' in z for z in sys.path):
     print(f"{file_name}: remove leo-editor from sys.path!")
-    print('Note: do *not* run this script from the leo-editor directory!')
+    print('Hint: do *not* run this script from the leo-editor directory!')
 else:
     print(file_name)
     # Do *not* install from leo-editor!

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -2,13 +2,14 @@
 #@+node:ekr.20240321123214.1: * @file ../scripts/install_leo_locally.py
 #@@language python
 """
-install_leo_locally.py: Install leo from a wheel file in the `leo/dist` folder.
+install_leo_locally.py: Install Leo from a wheel file in the `leo-editor/leo/dist` directory.
 
-Executes `python -m pip install leo-editor/dist/leo-6.8.0b1-py3-none-any.whl`
+Run `python -m pip install leo-editor/dist/leo-6.8.0b1-py3-none-any.whl`
+from the *parent* directory of the `leo-editor` directory.
 
-*Note*: The leo-editor folder must *not* be in sys.path!
+*Note*: sys.path *must not* contain the `leo-editor` directory!
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 import glob
@@ -24,11 +25,12 @@ if any('leo-editor' in z for z in sys.path):
 else:
     print(file_name)
     
-    # Do *not* install from leo-editor!
+    # Install from the *parent* of the `leo-editor` directory.
     leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
     parent_dir = os.path.abspath(os.path.join(leo_editor_dir, '..'))
     assert os.path.exists(parent_dir), repr(parent_dir)
     assert os.path.isdir(parent_dir), repr(parent_dir)
+    assert not parent_dir.endswith('leo-editor'), repr(parent_dir)
     os.chdir(parent_dir)
    
     # Install Leo using `pip install leo`

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -23,15 +23,19 @@ if any('leo-editor' in z for z in sys.path):
     print('Hint: do *not* run this script from the leo-editor directory!')
 else:
     print(file_name)
+    
     # Do *not* install from leo-editor!
-    home_dir = os.path.expanduser("~")
-    os.chdir(home_dir)
-    # Install.
+    leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+    parent_dir = os.path.abspath(os.path.join(leo_editor_dir, '..'))
+    assert os.path.exists(parent_dir), repr(parent_dir)
+    assert os.path.isdir(parent_dir), repr(parent_dir)
+    os.chdir(parent_dir)
+   
+    # Install Leo using `pip install leo`
     dist_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..', 'dist'))
     assert os.path.exists(dist_dir), dist_dir
     wheel_file = 'leo-6.8.0b1-py3-none-any.whl'
-    #  --force-reinstall
-    command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file}"
+    command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file} --no-cache-dir"  #  --force-reinstall
     print(command)
     subprocess.Popen(command, shell=True).communicate()
 
@@ -42,5 +46,5 @@ else:
     print('package_dir:', package_dir)
     print('site-packages/leo*...')
     for z in glob.glob(f"{package_dir}{os.sep}leo*"):
-        print(z)
+        print(' ', z)
 #@-leo

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -35,7 +35,8 @@ else:
    
     # Install Leo using `pip install leo`
     dist_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..', 'dist'))
-    assert os.path.exists(dist_dir), dist_dir
+    assert os.path.exists(dist_dir), repr(dist_dir)
+    assert os.path.isdir(dist_dir), repr(dist_dir)
     wheel_file = 'leo-6.8.0b1-py3-none-any.whl'
     command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file} --no-cache-dir"  #  --force-reinstall
     print(command)

--- a/leo/scripts/pip_install_r.py
+++ b/leo/scripts/pip_install_r.py
@@ -16,7 +16,11 @@ import sys
 print(os.path.basename(__file__))
 
 # cd to `leo-editor`.
-os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
+assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
+assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
+os.chdir(leo_editor_dir)
 
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'

--- a/leo/scripts/pip_install_r.py
+++ b/leo/scripts/pip_install_r.py
@@ -3,7 +3,9 @@
 """
 pip_install_r.py: Install all of Leo's requirements from requirements.txt.
 
-Info item #3837 describes all distribution-related scripts.
+This script does *not* install Leo itself.
+
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 
@@ -13,7 +15,7 @@ import sys
 
 print(os.path.basename(__file__))
 
-# cd to leo-editor
+# cd to `leo-editor`.
 os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
 
 isWindows = sys.platform.startswith('win')

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -16,6 +16,9 @@ print(os.path.basename(__file__))
 
 # cd to `leo-editor`.
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
+assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
+assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
 isWindows = sys.platform.startswith('win')

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -8,11 +8,7 @@ Don't use this script unless you know what you are doing!
 Info item #3837 describes all distribution-related scripts.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
-
-# Don't use this script unless you know what you are doing!
-
 import os
-import shutil
 import subprocess
 import sys
 
@@ -24,11 +20,6 @@ os.chdir(leo_editor_dir)
 
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
-
-# A hack: delete leo/leo.egg-info
-egg_dir = os.path.abspath(os.path.join(leo_editor_dir, 'leo', 'leo.egg-info'))
-if os.path.exists(egg_dir):
-    shutil.rmtree(egg_dir)
 
 for command in [
     f"{python} -m pip freeze > temp_requirements.txt",
@@ -42,5 +33,9 @@ for command in [
     subprocess.Popen(command, shell=True).communicate()
 
 if os.path.exists('temp_requirements.txt'):
+    print('remove temp_requirements.txt')
     os.remove('temp_requirements.txt')
+
+# cd to the leo-editor directory.
+os.chdir(leo_editor_dir)
 #@-leo

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -1,11 +1,11 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20240322173731.1: * @file ../scripts/pip_uninstall_all.py
 """
-pip_uninstall_leo.py: Uninstall *all* installed files.
+pip_uninstall_all.py: Use pip to uninstall *all* python packages.
 
 Don't use this script unless you know what you are doing!
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 import os
@@ -14,7 +14,7 @@ import sys
 
 print(os.path.basename(__file__))
 
-# cd to leo-editor
+# cd to `leo-editor`.
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 

--- a/leo/scripts/pip_uninstall_all.py
+++ b/leo/scripts/pip_uninstall_all.py
@@ -33,6 +33,7 @@ for command in [
     subprocess.Popen(command, shell=True).communicate()
 
 if os.path.exists('temp_requirements.txt'):
+    print('')
     print('remove temp_requirements.txt')
     os.remove('temp_requirements.txt')
 

--- a/leo/scripts/run_installed_leo.py
+++ b/leo/scripts/run_installed_leo.py
@@ -3,9 +3,9 @@
 #@@language python
 
 """
-run_installed_leo.py: Run leo from Python's `site-packages` folder.
+run_installed_leo.py: Run leo from Python's `site-packages` directory.
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 
@@ -15,7 +15,7 @@ import sys
 
 file_name = os.path.basename(__file__)
 
-# Do *not* install from leo-editor!
+# cd to the home directory.
 home_dir = os.path.expanduser("~")
 os.chdir(home_dir)
 

--- a/leo/scripts/run_installed_leo.py
+++ b/leo/scripts/run_installed_leo.py
@@ -11,15 +11,22 @@ https://github.com/leo-editor/leo-editor/issues/3837
 
 import os
 import subprocess
+import sys
 
-print(os.path.basename(__file__))
+file_name = os.path.basename(__file__)
 
 # Do *not* install from leo-editor!
 home_dir = os.path.expanduser("~")
 os.chdir(home_dir)
 
-# Run.
-command = 'python -m leo.core.runLeo'
-print(command)
-subprocess.Popen(command, shell=True).communicate()
+if any('leo-editor' in z for z in sys.path):
+    print(f"{file_name}: remove leo-editor from sys.path!")
+    print('Hint: do *not* run this script from the leo-editor directory!')
+else:
+    # Run.
+    print(file_name)
+    command = 'python -m leo.core.runLeo'
+    print(command)
+    print('')
+    subprocess.Popen(command, shell=True).communicate()
 #@-leo

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -5,21 +5,30 @@
 """
 uninstall_leo.py: Run `pip uninstall leo`.
 
+*Note*: The leo-editor folder must *not* be in sys.path!
+
 Info item #3837 describes all distribution-related scripts.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
-
 import os
+import sys
 import subprocess
 
-print(os.path.basename(__file__))
+file_name = os.path.basename(__file__)
 
-# Do *not* install from leo-editor!
-home_dir = os.path.expanduser("~")
-os.chdir(home_dir)
+if any('leo-editor' in z for z in sys.path):
+    print(f"{file_name}: remove leo-editor from sys.path!")
+    print('Hint: do *not* run this script from the leo-editor directory!')
+else:
+    print(os.path.basename(__file__))
 
-# Uninstall.
-command = 'python -m pip uninstall leo'
-print(command)
-subprocess.Popen(command, shell=True).communicate()
+    # Do *not* install from leo-editor!
+    home_dir = os.path.expanduser("~")
+    os.chdir(home_dir)
+
+    # Uninstall.
+    # --yes: Don’t ask for confirmation of uninstall deletions.
+    command = 'python -m pip uninstall leo'
+    print(command)
+    subprocess.Popen(command, shell=True).communicate()
 #@-leo

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -11,6 +11,7 @@ Info item #3837 describes all distribution-related scripts.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 import os
+import shutil
 import sys
 import subprocess
 
@@ -21,14 +22,25 @@ if any('leo-editor' in z for z in sys.path):
     print('Hint: do *not* run this script from the leo-editor directory!')
 else:
     print(os.path.basename(__file__))
+    
+    # Do *not* uninstall from the leo-editor directory.
+    leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+    parent_dir = os.path.abspath(os.path.join(leo_editor_dir, '..'))
+    assert os.path.exists(parent_dir), repr(parent_dir)
+    assert os.path.isdir(parent_dir), repr(parent_dir)
+    os.chdir(parent_dir)
 
-    # Do *not* install from leo-editor!
-    home_dir = os.path.expanduser("~")
-    os.chdir(home_dir)
-
-    # Uninstall.
+    # Uninstall Leo from Python's site-packages directory.
     # --yes: Don’t ask for confirmation of uninstall deletions.
     command = 'python -m pip uninstall leo'
     print(command)
     subprocess.Popen(command, shell=True).communicate()
+    
+    if 0:  # This hack should no longer be necessary.
+        # Delete the leo/leo.egg-info directory.
+        egg_dir = os.path.abspath(os.path.join(leo_editor_dir, 'leo.egg-info'))
+        print('')
+        if os.path.exists(egg_dir):
+            print(f"removed: {egg_dir}")
+            shutil.rmtree(egg_dir)
 #@-leo

--- a/leo/scripts/uninstall_leo.py
+++ b/leo/scripts/uninstall_leo.py
@@ -3,11 +3,11 @@
 #@@language python
 
 """
-uninstall_leo.py: Run `pip uninstall leo`.
+uninstall_leo.py: Run `pip uninstall leo` from the *parent* directory of the `leo-editor` directory.
 
-*Note*: The leo-editor folder must *not* be in sys.path!
+*Note*: sys.path *must not* contain the `leo-editor` directory!
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 import os
@@ -23,14 +23,15 @@ if any('leo-editor' in z for z in sys.path):
 else:
     print(os.path.basename(__file__))
     
-    # Do *not* uninstall from the leo-editor directory.
+    # Uninstall from the *parent* of the `leo-editor` directory.
     leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
     parent_dir = os.path.abspath(os.path.join(leo_editor_dir, '..'))
     assert os.path.exists(parent_dir), repr(parent_dir)
     assert os.path.isdir(parent_dir), repr(parent_dir)
+    assert not parent_dir.endswith('leo-editor'), repr(parent_dir)
     os.chdir(parent_dir)
 
-    # Uninstall Leo from Python's site-packages directory.
+    # Remove Leo from Python's site-packages directory.
     # --yes: Don’t ask for confirmation of uninstall deletions.
     command = 'python -m pip uninstall leo'
     print(command)

--- a/leo/scripts/upload_leo_to_pypi.py
+++ b/leo/scripts/upload_leo_to_pypi.py
@@ -14,9 +14,11 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# cd to the `leo-editor` directory.
+# cd to `leo-editor`.
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
-assert leo_editor_dir.endswith('leo-editor')
+assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
+assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
+assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
 # Upload.

--- a/leo/scripts/upload_leo_to_pypi.py
+++ b/leo/scripts/upload_leo_to_pypi.py
@@ -5,7 +5,7 @@
 """
 upload_leo_to_pypi.py: Run `python -m twine upload -r pypi dist/*.*`.
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 
@@ -14,8 +14,10 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# cd to leo-editor
-os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
+# cd to the `leo-editor` directory.
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+assert leo_editor_dir.endswith('leo-editor')
+os.chdir(leo_editor_dir)
 
 # Upload.
 if 0:  # Don't do this until we are ready to release.

--- a/leo/scripts/upload_leo_to_testpypi.py
+++ b/leo/scripts/upload_leo_to_testpypi.py
@@ -14,9 +14,11 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# cd to the `leo-editor` directory.
+# cd to `leo-editor`.
 leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
-assert leo_editor_dir.endswith('leo-editor')
+assert leo_editor_dir.endswith('leo-editor'), repr(leo_editor_dir)
+assert os.path.exists(leo_editor_dir), repr(leo_editor_dir)
+assert os.path.isdir(leo_editor_dir), repr(leo_editor_dir)
 os.chdir(leo_editor_dir)
 
 # Upload

--- a/leo/scripts/upload_leo_to_testpypi.py
+++ b/leo/scripts/upload_leo_to_testpypi.py
@@ -5,7 +5,7 @@
 """
 upload_leo_to_testpypi.py: Run `python -m twine upload -r testpypi dist/*.*`.
 
-Info item #3837 describes all distribution-related scripts.
+See info item #3837 for full documentation.
 https://github.com/leo-editor/leo-editor/issues/3837
 """
 
@@ -14,8 +14,10 @@ import subprocess
 
 print(os.path.basename(__file__))
 
-# cd to leo-editor
-os.chdir(os.path.abspath(os.path.join(__file__, '..', '..', '..')))
+# cd to the `leo-editor` directory.
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+assert leo_editor_dir.endswith('leo-editor')
+os.chdir(leo_editor_dir)
 
 # Upload
 if 0:  # Don't do this until we are ready to release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,7 @@ packages = [
 
 [project]
 requires-python = ">= 3.9"
-version = "6.8.0 a1
+version = "6.8.0 b1"
 name = "leo"
 
 #@+<< developer info >>
@@ -272,58 +272,7 @@ keywords = ["PIM", "IDE", "Outliner"]
 license = {text = "MIT License"}
 readme = "README.md"
 #@-<< description >>
-#@+<< dependencies >>
-#@+node:ekr.20240229082807.1: ** << dependencies >> (pyproject.toml)
-dependencies = [
-    # For mypy...
-    "mypy",
-    "mypy-extensions",
-    "typing_extensions",
-    "types-docutils", 
-    "types-Markdown",
-    "types-paramiko",
-    "types-PyYAML",
-    "types-requests",
-    "types-six",
-
-    # General packages, including various plugins and commands...
-    "asttokens",        # For unit tests.
-    "beautifulsoup4",   # For link testing.
-    "black",            # For unit tests.
-    "docutils",         # various plugins and commands.
-    "flexx",            # leoflexx.py plugin.
-    "meta",             # livecode.py plugin.
-    "pyenchant",        # The spell tab.
-    "pytest",           # For coverage testing.
-    "pytest-cov",       # For coverage testing.
-    "pyflakes",         # pyflakes command.
-    "pylint",           # pylint command.
-    "sphinx",           # various plugins and commands.
-    "pyshortcuts",      # #1243: desktop integration.
-    "tk",               # tkinter: for emergency dialogs
-    "urllib3",
-
-    # Platform-specific packages...
-    "windows-curses; os_name == 'nt'",  # cursesGui2 plugin on Windows.
-    "Send2Trash; os_name == 'nt'",  # picture_viewer plugin on Windows.
-
-    # Gui packages...
-
-    # Use PyQt6 only on Windows.
-        # "PyQt5>= 5.15; os_name != 'nt'",
-        # "PyQtWebEngine; os_name != 'nt'",
-
-        # # Use PyQt6 on Windows.
-        # "PyQt6>= 6.6; os_name == 'nt'",
-        # "PyQt6-WebEngine; os_name == 'nt'",
-        
-    # Use PyQt6 on all platforms.
-    "PyQt6>= 6.6",
-    "PyQt6-WebEngine",
-]
-
-# [project.optional-dependencies]
-#@-<< dependencies >>
+# < < dependencies > >
 
 [project.scripts]
 leo = "leo.core.runLeo:run"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,7 +231,7 @@ packages = [
 
 [project]
 requires-python = ">= 3.9"
-version = "6.8.0 b1"
+version = "6.8.0b1"  # No space.
 name = "leo"
 
 #@+<< developer info >>
@@ -272,7 +272,7 @@ keywords = ["PIM", "IDE", "Outliner"]
 license = {text = "MIT License"}
 readme = "README.md"
 #@-<< description >>
-# < < dependencies > >
+# < < dependencies > >  # Don't duplicate requirements.txt.
 
 [project.scripts]
 leo = "leo.core.runLeo:run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@
 #@@language python
 #@@nosearch
 
+# For build devs.
+build>=1.2.1
+
 # For mypy and ruff.
 
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ urllib3
 
 # Gui packages...
 
-PyQt6 >= 6.6
+PyQt6>= 6.6
 PyQt6-QScintilla
 PyQt6-WebEngine
 Send2Trash; platform_system=="Windows"  # picture_viewer plugin.


### PR DESCRIPTION
See info issue #3837 for full installation instructions.

This PR makes relatively minor changes:

- [x] Remove requirements from `pyproject.toml`.
- [x] Update version number and date.
- [x] Three Python scripts abort if `leo-editor` is in `sys.path`.
    `pip` would think that `leo-editor/leo` has already been installed if `leo-editor` is in `sys.path`.
- [x] All Python scripts set the cwd as appropriate.

I continue to test these files in preparation for Leo 6.8.0.