### PR TITLE
PR for #3973: sort-fields

### DIFF
--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1674,7 +1674,7 @@ class KeyHandlerClass:
         self.replace_meta_with_alt = False  # True: (Mac only) swap Meta and Alt keys.
         self.w = None  # Will be None for NullGui.
         # Generalize...
-        self.x_hasNumeric = ['sort-lines', 'sort-fields']
+        ### self.x_hasNumeric = ['sort-lines']  ### , 'sort-fields']
         self.altX_prompt = 'full-command: '
         # Access to data types defined in leoKeys.py
         self.KeyStroke = g.KeyStroke
@@ -1799,7 +1799,7 @@ class KeyHandlerClass:
             'simulate-begin-drag',
             'simulate-end-drag',
             'sort-columns',
-            'sort-fields',
+            # 'sort-fields',
             'sort-lines',
             'sort-lines-ignoring-case',
             'split-line',

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1674,7 +1674,6 @@ class KeyHandlerClass:
         self.replace_meta_with_alt = False  # True: (Mac only) swap Meta and Alt keys.
         self.w = None  # Will be None for NullGui.
         # Generalize...
-        ### self.x_hasNumeric = ['sort-lines']  ### , 'sort-fields']
         self.altX_prompt = 'full-command: '
         # Access to data types defined in leoKeys.py
         self.KeyStroke = g.KeyStroke

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -4165,7 +4165,7 @@ class LeoServer:
             'select-to-matching-bracket',
 
             'sort-columns',
-            'sort-fields',
+            # 'sort-fields',
             'sort-lines',
             'sort-lines-ignoring-case',
 


### PR DESCRIPTION
See #3973.

- [x] Comment out all references to `sort-fields`.
- [x] Remove unused `k.x_hasNumeric`.