### PR TITLE
PR for #3970: nav shortcuts

### DIFF
--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -3487,7 +3487,7 @@ class KeyHandlerClass:
         #
         # No binding exists.
         if trace:
-            g.trace(f"{event.stroke!s} {bi.commandName}: no binding")
+            g.trace(f"{event.stroke!s}: no binding")
         return False
     #@+node:ekr.20091230094319.6240: *6* k.getPaneBinding & helper
     def getPaneBinding(self, event: LeoKeyEvent) -> Any:

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -161,8 +161,11 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
         c.frame.log.selectTab('Nav')
         wdg.scon.doTimeline()
 
+    # #3976. Hard-code the binding to find-quick-selected.
+    c.k.registerCommand('find-quick-selected', find_selected,
+        allowBinding=True, shortcut='Control-Shift-f')
+
     c.k.registerCommand('find-quick', focus_quicksearch_entry)
-    c.k.registerCommand('find-quick-selected', find_selected)
     c.k.registerCommand('focus-to-nav', focus_to_nav)
     c.k.registerCommand('find-quick-test-failures', show_unittest_failures)
     c.k.registerCommand('find-quick-timeline', timeline)
@@ -198,11 +201,15 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
             wdg.ui.lineEdit.selectAll()
             wdg.ui.lineEdit.setFocus()
 
+    g.trace(g.callers())  ###
+
     # Careful: we may be unit testing.
     if wdg and wdg.parent():
         tab_widget = wdg.parent().parent()
         tab_widget.currentChanged.connect(activate_input)
-        c.k.completeAllBindingsForWidget(wdg)  ###
+
+        # #3976: Add default bindings
+        c.k.completeAllBindingsForWidget(wdg.ui.lineEdit)
 #@+node:ekr.20111014074810.15659: *3* matchLines
 def matchlines(b: str, miter: Iterator[Match[str]]) -> list:
 
@@ -218,7 +225,8 @@ def onCreate(tag: str, keys: Any) -> None:
     c = keys.get('c')
     if not c:
         return
-    g.trace('quicksearch.py', repr(c.shortFileName()))
+    print('')  ###
+    print('quicksearch.py: on_create', repr(c.shortFileName()))  ###
     install_qt_quicksearch_tab(c)
 
 #@+node:tbrown.20111011152601.48461: *3* show_unittest_failures
@@ -255,7 +263,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
     def __init__(self, c: Cmdr, w: QListWidget, lineedit: Any) -> None:
 
         super().__init__()
-        g.trace(lineedit, c.shortFileName())
+        print('QuickSearchEventFilter.__init__', lineedit, c.shortFileName())  ###
         self.c = c
         self.listWidget = w
         self.lineEdit = lineedit
@@ -264,7 +272,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
 
         eventType = event.type()
         ev = QtCore.QEvent
-        g.trace(eventType)
+        print('QuickSearchEventFilter.eventFilter', eventType)  ###
         # QLineEdit generates ev.KeyRelease only on Windows, Ubuntu
         if not hasattr(ev, 'KeyRelease'):  # 2021/07/18.
             return False
@@ -284,6 +292,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
             if moved:
                 self.lineEdit.setFocus(True)
                 self.lineEdit.deselect()
+
         return False
     #@-others
 #@+node:ville.20090314215508.2: ** class LeoQuickSearchWidget (QWidget)
@@ -312,7 +321,7 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
         self.ui.lineEdit.textChanged.connect(self.liveUpdate)
         self.ev_filter = QuickSearchEventFilter(c, w, self.ui.lineEdit)
         self.ui.lineEdit.installEventFilter(self.ev_filter)
-        g.trace(c.shortFileName(), self.ev_filter.__class__.__name__)
+        print('QuickSearchWidget.__init__', c.shortFileName(), self.ev_filter.__class__.__name__)  ###
         self.c = c
     #@+node:ekr.20111015194452.15696: *3* quick_w.returnPressed
     def returnPressed(self) -> None:

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -202,6 +202,7 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
     if wdg and wdg.parent():
         tab_widget = wdg.parent().parent()
         tab_widget.currentChanged.connect(activate_input)
+        c.k.completeAllBindingsForWidget(wdg)  ###
 #@+node:ekr.20111014074810.15659: *3* matchLines
 def matchlines(b: str, miter: Iterator[Match[str]]) -> list:
 
@@ -254,6 +255,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
     def __init__(self, c: Cmdr, w: QListWidget, lineedit: Any) -> None:
 
         super().__init__()
+        g.trace(lineedit, c.shortFileName())
         self.c = c
         self.listWidget = w
         self.lineEdit = lineedit
@@ -262,6 +264,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
 
         eventType = event.type()
         ev = QtCore.QEvent
+        g.trace(eventType)
         # QLineEdit generates ev.KeyRelease only on Windows, Ubuntu
         if not hasattr(ev, 'KeyRelease'):  # 2021/07/18.
             return False
@@ -309,12 +312,14 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
         self.ui.lineEdit.textChanged.connect(self.liveUpdate)
         self.ev_filter = QuickSearchEventFilter(c, w, self.ui.lineEdit)
         self.ui.lineEdit.installEventFilter(self.ev_filter)
+        g.trace(c.shortFileName(), self.ev_filter.__class__.__name__)
         self.c = c
     #@+node:ekr.20111015194452.15696: *3* quick_w.returnPressed
     def returnPressed(self) -> None:
         w = self.ui.listWidget
         self.scon.freeze()
         t = self.ui.lineEdit.text()
+        g.trace(repr(t))
         if not t.strip():
             return
         # Handle Easter eggs.

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -206,8 +206,9 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
         tab_widget = wdg.parent().parent()
         tab_widget.currentChanged.connect(activate_input)
 
-        # #3976: Add default bindings
-        c.k.completeAllBindingsForWidget(wdg.ui.lineEdit)
+        # #3976: Add default bindings.
+        #        This does not work. Maybe later.
+        # c.k.completeAllBindingsForWidget(wdg.ui.lineEdit)
 #@+node:ekr.20111014074810.15659: *3* matchLines
 def matchlines(b: str, miter: Iterator[Match[str]]) -> list:
 

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -324,7 +324,6 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
         w = self.ui.listWidget
         self.scon.freeze()
         t = self.ui.lineEdit.text()
-        g.trace(repr(t))
         if not t.strip():
             return
         # Handle Easter eggs.

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -165,6 +165,11 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
     c.k.registerCommand('find-quick-selected', find_selected,
         allowBinding=True, shortcut='Control-Shift-f')
 
+    ### Doesn't work.
+        # # A hack. Bind Alt-X.
+        # c.k.registerCommand('full-command', c.k.fullCommand,
+            # allowBinding=True, shortcut='Alt-x')
+
     c.k.registerCommand('find-quick', focus_quicksearch_entry)
     c.k.registerCommand('focus-to-nav', focus_to_nav)
     c.k.registerCommand('find-quick-test-failures', show_unittest_failures)
@@ -201,7 +206,7 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
             wdg.ui.lineEdit.selectAll()
             wdg.ui.lineEdit.setFocus()
 
-    g.trace(g.callers())  ###
+    ### g.trace(g.callers())  ###
 
     # Careful: we may be unit testing.
     if wdg and wdg.parent():
@@ -225,8 +230,6 @@ def onCreate(tag: str, keys: Any) -> None:
     c = keys.get('c')
     if not c:
         return
-    print('')  ###
-    print('quicksearch.py: on_create', repr(c.shortFileName()))  ###
     install_qt_quicksearch_tab(c)
 
 #@+node:tbrown.20111011152601.48461: *3* show_unittest_failures
@@ -263,7 +266,7 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
     def __init__(self, c: Cmdr, w: QListWidget, lineedit: Any) -> None:
 
         super().__init__()
-        print('QuickSearchEventFilter.__init__', lineedit, c.shortFileName())  ###
+        ### print('QuickSearchEventFilter.__init__', lineedit, c.shortFileName())  ###
         self.c = c
         self.listWidget = w
         self.lineEdit = lineedit
@@ -272,7 +275,8 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
 
         eventType = event.type()
         ev = QtCore.QEvent
-        print('QuickSearchEventFilter.eventFilter', eventType)  ###
+        print('***QuickSearchEventFilter.eventFilter', eventType)  ###
+
         # QLineEdit generates ev.KeyRelease only on Windows, Ubuntu
         if not hasattr(ev, 'KeyRelease'):  # 2021/07/18.
             return False
@@ -318,10 +322,12 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
             threadutil.later(self.ui.lineEdit.setFocus)
         else:
             self.ui.lineEdit.returnPressed.connect(self.returnPressed)
+
         self.ui.lineEdit.textChanged.connect(self.liveUpdate)
+        ### To be removed ???
         self.ev_filter = QuickSearchEventFilter(c, w, self.ui.lineEdit)
         self.ui.lineEdit.installEventFilter(self.ev_filter)
-        print('QuickSearchWidget.__init__', c.shortFileName(), self.ev_filter.__class__.__name__)  ###
+        print('QuickSearchWidget.__init__', c.shortFileName())  ###, self.ev_filter.__class__.__name__)  ###
         self.c = c
     #@+node:ekr.20111015194452.15696: *3* quick_w.returnPressed
     def returnPressed(self) -> None:
@@ -346,6 +352,7 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
     def liveUpdate(self) -> None:
 
         t = self.ui.lineEdit.text()
+        g.trace(repr(t))
         if not t.strip():
             if self.scon.frozen:
                 self.scon.freeze(False)

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -165,11 +165,6 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
     c.k.registerCommand('find-quick-selected', find_selected,
         allowBinding=True, shortcut='Control-Shift-f')
 
-    ### Doesn't work.
-        # # A hack. Bind Alt-X.
-        # c.k.registerCommand('full-command', c.k.fullCommand,
-            # allowBinding=True, shortcut='Alt-x')
-
     c.k.registerCommand('find-quick', focus_quicksearch_entry)
     c.k.registerCommand('focus-to-nav', focus_to_nav)
     c.k.registerCommand('find-quick-test-failures', show_unittest_failures)
@@ -205,8 +200,6 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
         ):
             wdg.ui.lineEdit.selectAll()
             wdg.ui.lineEdit.setFocus()
-
-    ### g.trace(g.callers())  ###
 
     # Careful: we may be unit testing.
     if wdg and wdg.parent():
@@ -266,7 +259,6 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
     def __init__(self, c: Cmdr, w: QListWidget, lineedit: Any) -> None:
 
         super().__init__()
-        ### print('QuickSearchEventFilter.__init__', lineedit, c.shortFileName())  ###
         self.c = c
         self.listWidget = w
         self.lineEdit = lineedit
@@ -275,7 +267,6 @@ class QuickSearchEventFilter(QtCore.QObject):  # type:ignore
 
         eventType = event.type()
         ev = QtCore.QEvent
-        print('***QuickSearchEventFilter.eventFilter', eventType)  ###
 
         # QLineEdit generates ev.KeyRelease only on Windows, Ubuntu
         if not hasattr(ev, 'KeyRelease'):  # 2021/07/18.
@@ -324,10 +315,8 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
             self.ui.lineEdit.returnPressed.connect(self.returnPressed)
 
         self.ui.lineEdit.textChanged.connect(self.liveUpdate)
-        ### To be removed ???
         self.ev_filter = QuickSearchEventFilter(c, w, self.ui.lineEdit)
         self.ui.lineEdit.installEventFilter(self.ev_filter)
-        print('QuickSearchWidget.__init__', c.shortFileName())  ###, self.ev_filter.__class__.__name__)  ###
         self.c = c
     #@+node:ekr.20111015194452.15696: *3* quick_w.returnPressed
     def returnPressed(self) -> None:

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -125,7 +125,6 @@ def init() -> bool:
         g.registerHandler('after-create-leo-frame', onCreate)
         g.plugin_signon(__name__)
     return ok
-
 #@+node:tbrown.20111011152601.48462: *3* install_qt_quicksearch_tab (Creates commands)
 def install_qt_quicksearch_tab(c: Cmdr) -> None:
 
@@ -218,7 +217,7 @@ def onCreate(tag: str, keys: Any) -> None:
     c = keys.get('c')
     if not c:
         return
-
+    g.trace('quicksearch.py', repr(c.shortFileName()))
     install_qt_quicksearch_tab(c)
 
 #@+node:tbrown.20111011152601.48461: *3* show_unittest_failures

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -341,7 +341,6 @@ class LeoQuickSearchWidget(QtWidgets.QWidget):  # type:ignore
     def liveUpdate(self) -> None:
 
         t = self.ui.lineEdit.text()
-        g.trace(repr(t))
         if not t.strip():
             if self.scon.frozen:
                 self.scon.freeze(False)


### PR DESCRIPTION
See #3970.

**Background and summary**

The `new-file` command generates an `after-create-leo-frame` event, so event handling is not likely an issue.

Within the plugin `Ctrl-g` works, but `Alt-x` does not. This PR does *not* add this binding because doing so requires changes to Leo's general key-handling code. It's too late to make such changes for Leo 6.8.0.

- [x] Make a hard binding of `find-quick-selected` to the `Shift-Control-f`.
- [x] Extra: Fix crasher in key-binding tracing code.