### PR TITLE
PR 2 for #3853: Create an empty leo/doc/_static on GitHub and official distros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,8 @@ leo/doc/Using Leo's minibuffer-*
 leo/doc/What is Leo-*
 leo/doc/Whetting Your Appetite-*
 
-leo/doc/_build
+# #3853: Create an *empty* leo/doc/_build folder.
+# leo/doc/_build
 leo/doc/_build/*
 leo/doc/_static
 leo/doc/_templates

--- a/.gitignore
+++ b/.gitignore
@@ -119,7 +119,8 @@ leo/doc/Whetting Your Appetite-*
 # #3853: Create an *empty* leo/doc/_build folder.
 # leo/doc/_build
 leo/doc/_build/*
-leo/doc/_static
+# leo/doc/_static now contains an "almost empty" .gitignore file
+# leo/doc/_static
 leo/doc/_templates
 leo/doc/html/*.html
 leo/doc/html/*.html.txt

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1196,7 +1196,6 @@
 </v>
 <v t="ekr.20180403104643.1"><vh>@menu &amp;Sort Text</vh>
 <v t="ekr.20131213135427.22285"><vh>@item sort-&amp;columns</vh></v>
-<v t="ekr.20131213135427.22286"><vh>@item sort-&amp;fields</vh></v>
 <v t="ekr.20131213135427.22287"><vh>@item sort-&amp;lines</vh></v>
 </v>
 <v t="ekr.20131213135427.22306"><vh>@menu &amp;Yank/Kill Text</vh>
@@ -5694,7 +5693,6 @@ minibuffer-find-mode    use-find-dialog     mode: Ctrl-F puts focus in
 <t tx="ekr.20131213135427.22282"></t>
 <t tx="ekr.20131213135427.22283"></t>
 <t tx="ekr.20131213135427.22285"></t>
-<t tx="ekr.20131213135427.22286"></t>
 <t tx="ekr.20131213135427.22287"></t>
 <t tx="ekr.20131213135427.22289"></t>
 <t tx="ekr.20131213135427.22290"></t>
@@ -6025,7 +6023,7 @@ show-fonts                      = None
 show-invisibles                 = None  # Alt-V conflicts with scroll-up-page .
 sort-children                   = None
 sort-columns                    = None
-sort-fields                     = None
+# sort-fields                   = None
 sort-lines                      = None
 sort-siblings                   = Shift-Alt-A  # Alt-A conflicts with back-sentence.
 spell-change                    = None
@@ -6486,7 +6484,7 @@ show-invisibles                     = None
 # simulate-end-drag                 = None
 sort-children                       = None
 sort-columns                        = None
-sort-fields                         = None
+# sort-fields                       = None
 sort-lines                          = None
 sort-lines-ignoring-case            = None
 sort-recent-files                   = None

--- a/leo/doc/_static/.gitignore
+++ b/leo/doc/_static/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+# See https://stackoverflow.com/questions/115983/how-do-i-add-an-empty-directory-to-a-git-repository
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
See #3853.

Reviewers: Please save your comments until this PR is ready for review.

- [x] Remove the entry for `leo/doc/_static` in `leo-editor/.gitignore`.
- [x] Add an "almost empty" `.gitignore` in `leo/doc/_static`.

**Extra**

- [x] Update LeoSettings.leo to remove mentions of `sort-fields` command.