### PR TITLE
Do not use polyfill scripts from polyfill.io

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1089,7 +1089,6 @@ REST = 'rest'
 RST = 'rst'
 
 ASCIIDOC_CONF_FILENAME = 'html5.conf'
-MATHJAX_POLYFILL_URL = 'https://polyfill.io/v3/polyfill.min.js?features=es5'
 MATHJAX_URL = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js'
 
 #@+<< RsT Error styles>>
@@ -1230,7 +1229,6 @@ latex_template = f'''\
  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-    <script src="{MATHJAX_POLYFILL_URL}"></script>
     <script src='{MATHJAX_URL}'></script>
 </head>
 <body bgcolor="#fffbdc">

--- a/leo/plugins/viewrendered3/asciidoc/html5.conf
+++ b/leo/plugins/viewrendered3/asciidoc/html5.conf
@@ -693,7 +693,6 @@ endif::icons[]
 endif::badges[]
 </div>
 ifdef::mathjax[]
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es5"></script>
 <script id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"></script>
 endif::mathjax[]
 </body>

--- a/leo/plugins/viewrendered3/asciidoc3/html5.conf
+++ b/leo/plugins/viewrendered3/asciidoc3/html5.conf
@@ -708,7 +708,6 @@ endif::icons[]
 endif::badges[]
 </div>
 ifdef::mathjax[]
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es5"></script>
 <script id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"></script>
 endif::mathjax[]
 </body>


### PR DESCRIPTION
The `polyfill.io` domain is under the control of a bad actor, see https://sansec.io/research/polyfill-supply-chain-attack

Removing it completely should be fine, it is no more needed for browsers that are severely outdated.