### PR TITLE
PR for 6.8.1

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1108,7 +1108,6 @@ class Commands:
                 self.execute_single_pytest(p)
         except ImportError:
             g.es('pytest needs to be installed')
-            return
 
     def execute_single_pytest(self, p: Position) -> None:
         c = self

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5529,7 +5529,7 @@ def get_ctor_name(self: Any, file_name: str, width: int = 25) -> str:
 #@+node:ekr.20040731204831: *3* g.getLastTracebackFileAndLineNumber
 def getLastTracebackFileAndLineNumber() -> tuple[str, int]:
     typ, val, tb = sys.exc_info()
-    if typ == SyntaxError:
+    if typ is SyntaxError:
         # IndentationError is a subclass of SyntaxError.
         return val.filename, val.lineno
     #

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -224,7 +224,7 @@ class Undoer:
             print(f"u.pushBead: {len(u.beads):3} {bunch.undoType}")
     #@+node:ekr.20031218072017.3613: *4* u.redoMenuName, undoMenuName
     def redoMenuName(self, name: str) -> str:
-        if name == "Can't Redo":
+        if name.startswith("Can't Redo"):
             return name
         return "Redo " + name
 

--- a/leo/core/leoVersion.py
+++ b/leo/core/leoVersion.py
@@ -52,7 +52,7 @@ leoVersion.version:     Leo's version number.
 # 6.7.8:  March 22, 2024.
 # 6.8.0:  July 3, 2024.
 #@-<< version dates >>
-version = '6.8.0'
+version = '6.8.1-devel'
 static_date = 'July 3, 2024'
 #@@language python
 #@@tabwidth -4

--- a/leo/dist/leoDist.leo
+++ b/leo/dist/leoDist.leo
@@ -1411,7 +1411,7 @@ g.es_print('done')
 </t>
 <t tx="ekr.20180405171433.1">Overview
 
-Create the **release branch**: 6.8.0.
+Create the **release branch**: 6.8.1.
 Change version in this checklist to match.
 
 It's ok to merge devel into release branch
@@ -1431,7 +1431,7 @@ It's ok to merge devel into release branch
 
 </t>
 <t tx="ekr.20180405171433.3" __bookmarks="7d7100580700000069735f6475706571014930300a732e">- git checkout `gh-pages`.
-- git merge 6.8.0
+- git merge 6.8.1
 - Run the `make-sphinx` from LeoDocs.leo
   This script copies files from leo/doc/html/_build/html to leo-editor/docs
 - Commit the changes and push.
@@ -1450,7 +1450,7 @@ It's ok to merge devel into release branch
 <t tx="ekr.20180405171433.7" __bookmarks="7d7100580700000069735f6475706571014930300a732e">Create a git tag **last**
 
 git checkout master
-git tag -a v6.8.0 -m "Added v6.8.0 tag"
+git tag -a v6.8.1 -m "Added v6.8.1 tag"
 git push --follow-tags
 </t>
 <t tx="ekr.20180828095843.1" __bookmarks="7d7100580700000069735f6475706571014930300a732e">leoVersion.py:
@@ -1459,15 +1459,15 @@ git push --follow-tags
 - Update date of the release, in &lt;&lt; version dates &gt;&gt; section.
 </t>
 <t tx="ekr.20181001112218.1" __bookmarks="7d7100580700000069735f6475706571014930300a732e">- git checkout devel
-- git merge 6.8.0
+- git merge 6.8.1
 - update version in leoVersion.py.
 </t>
-<t tx="ekr.20190618104430.1" __bookmarks="7d7100580700000069735f6475706571014930300a732e">From 6.8.0 branch:
+<t tx="ekr.20190618104430.1" __bookmarks="7d7100580700000069735f6475706571014930300a732e">From 6.8.1 branch:
 
 - git merge master
 - Fix any conflicts and push.
 - git checkout master
-- git merge 6.8.0</t>
+- git merge 6.8.1</t>
 <t tx="ekr.20190618104622.1" __bookmarks="7d7100580700000069735f6475706571014930300a732e">Update the *GitHub* release at https://github.com/leo-editor/leo-editor/releases
 
 This must be done *soon* after the release's actual commit.
@@ -1558,7 +1558,7 @@ python -m pip uninstall leo
 <t tx="ekr.20230301070404.1">LeoDist.leo:
 - Make sure copyright dates are correct.
 - Update version numbers. Search for 6.7.
-  The final version in PKG-INFO.TXT must be called 6.8.0, not 6.8.0-final.
+  The final version in PKG-INFO.TXT must be called 6.8.1, not 6.8.1-final.
   See Pep 440: https://www.python.org/dev/peps/pep-0440/
 - Update readme.md.
 - Update version in 'PKG-INFO.TXT'
@@ -1574,7 +1574,7 @@ python -m pip uninstall leo
 - Create LeoPyRef.leo by copying leoPy.leo to it, then deleting unwanted nodes.
 - Open LeoPyRef.leo. Verify the diff after saving.
 </t>
-<t tx="ekr.20230301084201.1">- Change 6.8.0 (the old version) to 6.8.1.
+<t tx="ekr.20230301084201.1">- Change 6.8.1 (the old version) to 6.8.2.
   Be careful about the new version in this node!
 </t>
 <t tx="ekr.20240206185544.1"></t>
@@ -1987,7 +1987,7 @@ packages = [
 
 [project]
 requires-python = "&gt;= 3.9"
-version = "6.8.0b1"  # No space.
+version = "6.8.0"  # No space.
 name = "leo"
 
 #@+&lt;&lt; developer info &gt;&gt;

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2420,10 +2420,11 @@ class CoreLog(leoFrame.LeoLog):
     #@+node:ekr.20170419143731.16: *4* CLog.putnl
     def putnl(self, tabName: str = 'Log') -> None:
         """Put a newline to the Qt log."""
-        # This is not called normally.
-        # print('CLog.put: %s' % g.callers())
         if g.app.quitting:
             return
+        if 0:
+            # This is not called normally.
+            print('CLog.put: %s' % g.callers())
     #@-others
 #@+node:ekr.20170419111515.1: *3* class CoreMenu (leoMenu.LeoMenu)
 class CoreMenu(leoMenu.LeoMenu):

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -4698,8 +4698,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
             _toolbar.setVisible(False)
         except RuntimeError as e:
             g.es(f'show_toolbar(): no toolbar; {type(e)}: {e}')
-            return
-
     #@+node:TomP.20200329230436.11: *6* vr3.show_toolbar
     def show_toolbar(self):
         try:
@@ -4707,9 +4705,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
             _toolbar.setVisible(True)
         except RuntimeError as e:
             g.es(f'show_toolbar(): no toolbar; {type(e)}: {e}')
-            return
-
-
     #@+node:TomP.20200329230436.12: *5* vr3: zoom helpers...
     #@+node:TomP.20200329230436.13: *6* vr3.shrinkView
     def shrinkView(self):


### PR DESCRIPTION
- [ ] Make sure `pip install leo` installs all of Leo's dependencies.
- [ ] Update LeoDocs.leo and LeoDist.leo for the new release.
- [x] Fix a quirp in `leoUndo.py`.
- [x] Fix new pylint complaints.