### PR TITLE
PR for 6.8.0-1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,9 +12,9 @@ global-exclude *.mypy_cache, *.mypy_stubs, *.gitattributes, *.htmlcov
 include *.py
 include *.TXT
 
-# Required: Do not omit!
+# No longer required.
 # obscure pip bug fix https://github.com/pypa/setuptools/issues/1694
-### include pyproject.toml
+#include pyproject.toml
 
 # Tweaks
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,7 +14,7 @@ include *.TXT
 
 # Required: Do not omit!
 # obscure pip bug fix https://github.com/pypa/setuptools/issues/1694
-include pyproject.toml
+### include pyproject.toml
 
 # Tweaks
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,6 @@
 
 # Order matters!
 
-# obscure pip bug fix https://github.com/pypa/setuptools/issues/1694
-include pyproject.toml
-
 # Include *everything* in the leo folder.
 graft leo
 
@@ -14,6 +11,10 @@ global-exclude *.mypy_cache, *.mypy_stubs, *.gitattributes, *.htmlcov
 
 include *.py
 include *.TXT
+
+# Required: Do not omit!
+# obscure pip bug fix https://github.com/pypa/setuptools/issues/1694
+include pyproject.toml
 
 # Tweaks
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 
 # Order matters!
 
+# obscure pip bug fix https://github.com/pypa/setuptools/issues/1694
+include pyproject.toml
+
 # Include *everything* in the leo folder.
 graft leo
 

--- a/PKG-INFO.TXT
+++ b/PKG-INFO.TXT
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: leo
-Version: 6.8.0.post1
+Version: 6.8.0
 Summary: An IDE, PIM and Outliner. See http://leo-editor.github.io/leo-editor/preface.html.
 Description: See users own descriptions of Leo at leo-editor.github.io/leo-editor/testimonials.html.
 Home-page: http://leo-editor.github.io/leo-editor/

--- a/PKG-INFO.TXT
+++ b/PKG-INFO.TXT
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: leo
-Version: 6.8.0
+Version: 6.8.0.post1
 Summary: An IDE, PIM and Outliner. See http://leo-editor.github.io/leo-editor/preface.html.
 Description: See users own descriptions of Leo at leo-editor.github.io/leo-editor/testimonials.html.
 Home-page: http://leo-editor.github.io/leo-editor/

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -40,7 +40,9 @@ else:
     assert os.path.exists(dist_dir), repr(dist_dir)
     assert os.path.isdir(dist_dir), repr(dist_dir)
     wheel_file = f"leo-{version}-py3-none-any.whl"
-    command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file} --no-cache-dir"  #  --force-reinstall
+    #  --no-cache-dir  # slow
+    #  --force-reinstall
+    command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file}"
     print(command)
     subprocess.Popen(command, shell=True).communicate()
 

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -4,7 +4,7 @@
 """
 install_leo_locally.py: Install Leo from a wheel file in the `leo-editor/leo/dist` directory.
 
-Run `python -m pip install leo-editor/dist/leo-6.8.0.post1-py3-none-any.whl`
+Run f"python -m pip install leo-editor/dist/leo-{version}-py3-none-any.whl"
 from the *parent* directory of the `leo-editor` directory.
 
 *Note*: sys.path *must not* contain the `leo-editor` directory!

--- a/leo/scripts/install_leo_locally.py
+++ b/leo/scripts/install_leo_locally.py
@@ -4,7 +4,7 @@
 """
 install_leo_locally.py: Install Leo from a wheel file in the `leo-editor/leo/dist` directory.
 
-Run `python -m pip install leo-editor/dist/leo-6.8.0-py3-none-any.whl`
+Run `python -m pip install leo-editor/dist/leo-6.8.0.post1-py3-none-any.whl`
 from the *parent* directory of the `leo-editor` directory.
 
 *Note*: sys.path *must not* contain the `leo-editor` directory!
@@ -16,6 +16,8 @@ import glob
 import os
 import sys
 import subprocess
+
+version = '6.8.0.post1'
 
 file_name = os.path.basename(__file__)
 
@@ -37,7 +39,7 @@ else:
     dist_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..', 'dist'))
     assert os.path.exists(dist_dir), repr(dist_dir)
     assert os.path.isdir(dist_dir), repr(dist_dir)
-    wheel_file = 'leo-6.8.0-py3-none-any.whl'
+    wheel_file = f"leo-{version}-py3-none-any.whl"
     command = fr"python -m pip install {dist_dir}{os.sep}{wheel_file} --no-cache-dir"  #  --force-reinstall
     print(command)
     subprocess.Popen(command, shell=True).communicate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,59 @@ keywords = ["PIM", "IDE", "Outliner"]
 license = {text = "MIT License"}
 readme = "README.md"
 #@-<< description >>
-# < < dependencies > >  # Don't duplicate requirements.txt.
+# Yes, we must duplicate requirements.txt.
+# Warning: these dependencies should match those in requirements.txt.
+#@+<< pyproject.toml: dependencies >>
+#@+node:ekr.20240713074535.1: ** << pyproject.toml: dependencies >>
+dependencies = [
+
+    # For build devs.
+    "build>=1.2.1",
+    "twine>=5.1.0",
+
+    # For mypy...
+    "mypy",
+    "mypy-extensions",
+    "typing_extensions",
+    "types-docutils", 
+    "types-Markdown",
+    "types-paramiko",
+    "types-PyYAML",
+    "types-requests",
+    "types-six",
+
+    # General packages, including various plugins and commands...
+    "asttokens",        # For unit tests.
+    "beautifulsoup4",   # For link testing.
+    "black",            # For unit tests.
+    "docutils",         # various plugins and commands.
+    "flexx",            # leoflexx.py plugin.
+    "meta",             # livecode.py plugin.
+    "pyenchant",        # The spell tab.
+    "pytest",           # For coverage testing.
+    "pytest-cov",       # For coverage testing.
+    "pyflakes",         # pyflakes command.
+    "pylint",           # pylint command.
+    "ruff",             # For testing.
+    "sphinx",           # various plugins and commands.
+    "pyshortcuts",      # #1243: desktop integration.
+    "tk",               # tkinter: for emergency dialogs
+    "urllib3",
+
+    # Platform-specific packages...
+    "windows-curses; os_name == 'nt'",  # cursesGui2 plugin on Windows.
+    "Send2Trash; os_name == 'nt'",  # picture_viewer plugin on Windows.
+
+    # Gui packages...
+        
+    # Use PyQt6 on all platforms.
+    "PyQt6>= 6.6",
+    "PyQt6-WebEngine",
+    "PyQt6-QScintilla",
+    "Send2Trash; platform_system == 'Windows'",  # picture_viewer plugin.
+    "windows-curses; platform_system == 'Windows'",  # cursesGui2 plugin.
+]
+#@-<< pyproject.toml: dependencies >>
 
 [project.scripts]
 leo = "leo.core.runLeo:run"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ meta            # livecode.py plugin.
 numpy           # VR3 plugin.
 pyenchant       # The spell tab.
 pyflakes
-pylint          # Use ruff instead.
+pylint
 pytest          # For coverage testing.
 pytest-cov      # For coverage testing.
 ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,16 @@
 #@@language python
 #@@nosearch
 
+# Warning: these dependencies should match those in pyproject.toml.
+
 # For build devs.
 build>=1.2.1
 twine>=5.1.0
 
-# For mypy and ruff.
+# For mypy.
 
 mypy
 mypy-extensions
-ruff
 typing_extensions
 types-docutils
 types-Markdown
@@ -33,9 +34,10 @@ meta            # livecode.py plugin.
 numpy           # VR3 plugin.
 pyenchant       # The spell tab.
 pyflakes
-# pylint        # Use ruff instead.
+pylint          # Use ruff instead.
 pytest          # For coverage testing.
 pytest-cov      # For coverage testing.
+ruff
 sphinx
 tk              # tkinter, for emergency dialogs.
 urllib3


### PR DESCRIPTION
The culprit: `pyproject.toml` *must* contain duplicates of the dependencies in `requirements.txt`.

**Notes**

- PyPi requires that the new file be `leo-6.8.0-1-py3-none-any.whl`
  PyPi only allows **build numbers** of the form `-1`.  `.post1` is **not** allowed.

**Required changes**

- [x] `PKG-INFO.txt`: Update version to `6.8.0.post1'.
- [x] `pyproject.toml`: Duplicate dependencies from `requirements.txt`.

**Other changes**

- [x] `MANIFEST.in`: Add comment.
- [x] `install_leo_locally.py`: Add `version` string. Don't clear pip caches.
- [x] Test that `install_leo_locally.py` installs all of Leo's dependencies.
- [x] Add pylint to both sets of dependencies.

This PR will change *only* those files that affect which files are included in the distribution.

All other changes will become part of Leo 6.8.1.