### PR TITLE
PR for #3988: crash in pygments colorizer

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -18,6 +18,7 @@ import warnings
 # Third-part tools.
 try:
     import pygments  # type:ignore
+    from pygments.lexer import DelegatingLexer
 except ImportError:
     pygments = None  # type:ignore
 #
@@ -3145,6 +3146,7 @@ class PygmentsColorizer(BaseColorizer):
         """Colorize the name only if the language has a lexer."""
         from pygments.token import Name
         language = match.group(2)
+        g.trace('match', repr(match))
         # #2484:  The language is known if there is a lexer for it.
         if self.pygments_isValidLanguage(language):
             self.language = language
@@ -3175,9 +3177,10 @@ class PygmentsColorizer(BaseColorizer):
 
         from pygments.token import Comment  # type:ignore
         from pygments.lexer import inherit  # type:ignore
+        
+        g.trace('language', language, lexer.__class__.__name__)
 
-
-        class PatchedLexer(lexer.__class__):  # type:ignore
+        class PatchedLexer(DelegatingLexer, lexer.__class__):  # type:ignore
 
             leo_sec_ref_pat = r'(?-m:\<\<(.*?)\>\>)'
             tokens = {

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3199,6 +3199,9 @@ class PygmentsColorizer(BaseColorizer):
                 ],
             }
 
+            def __init__(self, **options: Any) -> None:
+                super().__init__(PatchedLexer, lexer.__class__, **options)
+
         try:
             return PatchedLexer()
         except Exception:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -3037,6 +3037,17 @@ class PygmentsColorizer(BaseColorizer):
     def setPygmentsFormat(self, index: int, length: Any, format: Any, s: str) -> None:
         """Call the base setTag to set the Qt format."""
         self.highlighter.setFormat(index, length, format)
+    #@+node:ekr.20240716051511.1: *3* pyg_c.force_recolor
+    def force_recolor(self) -> None:
+        """
+        Force a complete recolor. A hook for the 'recolor' command.
+        """
+        c = self.c
+        p = c.p
+        self.updateSyntaxColorer(p)
+        self.color_enabled = self.enabled
+        self.old_v = p.v  # Fix a major performance bug.
+        self.init()
     #@+node:ekr.20220316200022.1: *3* pyg_c.pygments_isValidLanguage
     def pygments_isValidLanguage(self, language: str) -> bool:
         """

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -827,7 +827,7 @@ class BaseColorizer:
     def useSyntaxColoring(self, p: Position) -> bool:
         """True if syntax coloring is enabgled in p."""
         #@verbatim
-        # @nocolor-node only applies the p.
+        # @nocolor-node only applies to p.
         d = self.findColorDirectives(p)
         if 'nocolor-node' in d:
             return False

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -15,7 +15,7 @@ import time
 from typing import Any, Generator, Sequence, Optional, Union, TYPE_CHECKING
 import warnings
 #
-# Third-part tools.
+# Third-party tools.
 try:
     import pygments  # type:ignore
     from pygments.lexer import DelegatingLexer
@@ -828,7 +828,7 @@ class BaseColorizer:
         return language or c.target_language
     #@+node:ekr.20170127142001.7: *4* BaseColorizer.useSyntaxColoring & helper
     def useSyntaxColoring(self, p: Position) -> bool:
-        """True if syntax coloring is enabgled in p."""
+        """True if syntax coloring is enabled in p."""
         #@verbatim
         # @nocolor-node only applies to p.
         d = self.findColorDirectives(p)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -817,7 +817,6 @@ class BaseColorizer:
             try:
                 self.enabled = self.useSyntaxColoring(p)
                 self.language = self.scanLanguageDirectives(p)
-                ### g.trace('enabled:', int(self.enabled), p.h)  ###
             except Exception:
                 g.es_print('unexpected exception in updateSyntaxColorer')
                 g.es_exception()
@@ -3152,7 +3151,6 @@ class PygmentsColorizer(BaseColorizer):
         from pygments.token import Name, Text  # type: ignore
         kind = match.group(0)
         self.color_enabled = kind == '@color'
-        g.trace('color_enabled:', self.color_enabled)  ###
         if self.color_enabled:
             yield match.start(), Name.Decorator, kind
         else:
@@ -3162,10 +3160,6 @@ class PygmentsColorizer(BaseColorizer):
         """Colorize the name only if the language has a lexer."""
         from pygments.token import Name
         language = match.group(2)
-        if 1:  ###
-            print('')
-            g.trace('match', repr(match))
-            print('')
         # #2484:  The language is known if there is a lexer for it.
         if self.pygments_isValidLanguage(language):
             self.language = language
@@ -3196,8 +3190,6 @@ class PygmentsColorizer(BaseColorizer):
 
         from pygments.token import Comment  # type:ignore
         from pygments.lexer import inherit  # type:ignore
-
-        g.trace('language', language, repr(lexer))  ###
 
         class PatchedLexer(DelegatingLexer, lexer.__class__):  # type:ignore
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -57,7 +57,11 @@ def make_colorizer(c: Cmdr, widget: Widget) -> Any:
     return JEditColorizer(c, widget)
 #@+node:ekr.20170127141855.1: ** class BaseColorizer
 class BaseColorizer:
-    """The base class for all Leo colorizers."""
+    """
+    The base class for all Leo colorizers.
+    
+    c.frame.body.colorizer is the actual colorizer.
+    """
     #@+others
     #@+node:ekr.20220317050513.1: *3*  BaseColorizer: birth
     #@+node:ekr.20190324044744.1: *4* BaseColorizer.__init__
@@ -3181,8 +3185,8 @@ class PygmentsColorizer(BaseColorizer):
 
         from pygments.token import Comment  # type:ignore
         from pygments.lexer import inherit  # type:ignore
-        
-        g.trace('language', language, lexer.__class__.__name__)
+
+        g.trace('language', language, repr(lexer))  ###
 
         class PatchedLexer(DelegatingLexer, lexer.__class__):  # type:ignore
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -745,7 +745,7 @@ class BaseColorizer:
         self.n_setTag += 1
         if i == j:
             return
-        if not tag.strip():
+        if not tag or not tag.strip():
             return
         tag = tag.lower().strip()
         # A hack to allow continuation dots on any tag.
@@ -3177,7 +3177,7 @@ class PygmentsColorizer(BaseColorizer):
 
         from pygments.token import Comment  # type:ignore
         from pygments.lexer import inherit  # type:ignore
-        
+
         g.trace('language', language, lexer.__class__.__name__)
 
         class PatchedLexer(DelegatingLexer, lexer.__class__):  # type:ignore

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -813,6 +813,7 @@ class BaseColorizer:
             try:
                 self.enabled = self.useSyntaxColoring(p)
                 self.language = self.scanLanguageDirectives(p)
+                ### g.trace('enabled:', int(self.enabled), p.h)  ###
             except Exception:
                 g.es_print('unexpected exception in updateSyntaxColorer')
                 g.es_exception()
@@ -824,19 +825,18 @@ class BaseColorizer:
         return language or c.target_language
     #@+node:ekr.20170127142001.7: *4* BaseColorizer.useSyntaxColoring & helper
     def useSyntaxColoring(self, p: Position) -> bool:
-        """True if p's parents enable coloring in p."""
-        # Special cases for the selected node.
+        """True if syntax coloring is enabgled in p."""
+        #@verbatim
+        # @nocolor-node only applies the p.
         d = self.findColorDirectives(p)
-        if 'killcolor' in d:
-            return False
         if 'nocolor-node' in d:
             return False
-        # Now look at the parents.
-        for p in p.parents():
+        # Bug fix 2024/07/15: Examine p, then its parents.
+        for p in p.self_and_parents():
             d = self.findColorDirectives(p)
-            #@verbatim
-            # @killcolor anywhere disables coloring.
             if 'killcolor' in d:
+                #@verbatim
+                # @killcolor anywhere disables coloring.
                 return False
             # unambiguous @color enables coloring.
             if 'color' in d and 'nocolor' not in d:
@@ -3137,6 +3137,7 @@ class PygmentsColorizer(BaseColorizer):
         from pygments.token import Name, Text  # type: ignore
         kind = match.group(0)
         self.color_enabled = kind == '@color'
+        g.trace('color_enabled:', self.color_enabled)  ###
         if self.color_enabled:
             yield match.start(), Name.Decorator, kind
         else:
@@ -3146,7 +3147,10 @@ class PygmentsColorizer(BaseColorizer):
         """Colorize the name only if the language has a lexer."""
         from pygments.token import Name
         language = match.group(2)
-        g.trace('match', repr(match))
+        if 1:  ###
+            print('')
+            g.trace('match', repr(match))
+            print('')
         # #2484:  The language is known if there is a lexer for it.
         if self.pygments_isValidLanguage(language):
             self.language = language
@@ -3177,7 +3181,7 @@ class PygmentsColorizer(BaseColorizer):
 
         from pygments.token import Comment  # type:ignore
         from pygments.lexer import inherit  # type:ignore
-
+        
         g.trace('language', language, lexer.__class__.__name__)
 
         class PatchedLexer(DelegatingLexer, lexer.__class__):  # type:ignore

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1289,8 +1289,12 @@ class Commands:
     def recolorCommand(self, event: LeoKeyEvent = None) -> None:
         """Force a full recolor."""
         c = self
-        wrapper = c.frame.body.wrapper
+        # Call colorer.force_recolor for pygments.
+        colorer = c.frame.body.colorizer
+        if hasattr(colorer, 'force_recolor'):
+            colorer.force_recolor()
         # Setting all text appears to be the only way.
+        wrapper = c.frame.body.wrapper
         i, j = wrapper.getSelectionRange()
         ins = wrapper.getInsertPoint()
         wrapper.setAllText(c.p.b)

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -16,23 +16,33 @@ class TestColorizer(LeoUnitTest):
     #@+others
     #@+node:ekr.20210905161336.1: *3* TestColorizer.color
     def color(self, language_name, text):
-        """Run the test by colorizing a node with the given text."""
+        """
+        Run the test by colorizing a node with the given text.
+        
+        Colorize using the jEdit and pygments colorizers.
+        """
         c = self.c
         p = c.p
         text = text.replace('> >', '>>').replace('< <', '<<')
         p.b = f"@language {language_name}\n{text}"
 
-        # Instatiate the colorizer and init it.
+        # Test 1: test the jEdit colorizer.
         x = leoColorizer.JEditColorizer(c, None)
         x.language = language_name
         x.enabled = True
         x.init()
         x.init_all_state(p.v)
         n = x.initBlock0()
-
-        # Colorize all the lines!
         for s in g.splitLines(text):
             x.mainLoop(n, s)
+            
+        # Test 2: test the pygments colorizer.
+        x = leoColorizer.PygmentsColorizer(c, None)
+        x.language = language_name
+        x.enabled = True
+        x.init()
+        for s in g.splitLines(text):
+            x.mainLoop(s)
     #@+node:ekr.20210905170507.2: *3* TestColorizer.test__comment_after_language_plain
     def test__comment_after_language_plain(self):
         text = self.prep(


### PR DESCRIPTION
See #3988.

**Long standing bugs that affect LeoJS**

- [x] Fix long-standing bug in `BaseColorizer.useSyntaxColoring`.

**Newly-discovered bugs that do not affect LeoJS**

- `@nocolor` could crash pygments.
- The pygments colorizer does not recolor when an `@language` directive changes.
  The `JEditColorizer` class works as desired via the Leo-specific matcher `match_at_language`.
  Similarly, for matchers for `@killcolor`, `@color`, etc.

**Other changes**

- [x] Make `PatchedLexer` a subclass of `pygments.DelegatingLexer`.
   This change *might* be the only change needed to fix the original issue.
- [x] Add a guard to `BaseColorizer.setTag`.
- [x] Leo's `recolor` command now calls `colorizer.force-recolor` as a hook for the pygments colorizer.
   This forces a full recolor. It's not as smooth as the jEdit colorizer, but it's an improvement.
- [x] All coloring unit tests now test both the jEdit and pygments colorizers.