### PR TITLE
PR for #3994: git-diff can corrupt an outline

### DIFF
--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1246,7 +1246,7 @@ class GitDiffController:
     def finish(self) -> None:
         """Finish execution of this command."""
         c = self.c
-        if c.validateOutlineXML(dump=True):
+        if c.checkOutlineXML(dump=True):
             # All is well.
             c.selectPosition(self.root)
             self.root.expand()
@@ -1259,7 +1259,7 @@ class GitDiffController:
             last = c.lastTopLevel()
             c.redraw(last)
             # Re-validate.
-            if not c.validateOutlineXML(dump=False):
+            if not c.checkOutlineXML(dump=False):
                 g.es_print('The outline is *still* invalid!', color='red')
                 g.es_print('Do not save the outline!', color='red')
         c.treeWantsFocusNow()

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1246,7 +1246,7 @@ class GitDiffController:
     def finish(self) -> None:
         """Finish execution of this command."""
         c = self.c
-        if c.validateOutlineXML():
+        if c.validateOutlineXML(dump=True):
             # All is well.
             c.selectPosition(self.root)
             self.root.expand()
@@ -1259,7 +1259,7 @@ class GitDiffController:
             last = c.lastTopLevel()
             c.redraw(last)
             # Re-validate.
-            if not c.validateOutlineXML():
+            if not c.validateOutlineXML(dump=False):
                 g.es_print('The outline is *still* invalid!', color='red')
                 g.es_print('Do not save the outline!', color='red')
         c.treeWantsFocusNow()

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1342,7 +1342,8 @@ class GitDiffController:
         # #1781: Allow diffs of .leo files.
         return [
             z.strip() for z in g.execGitCommand(command, directory)
-                if not z.strip().endswith(('.db', '.zip'))
+                # #3994: '.inv' and '.pdf' files can corrupt the outline.
+                if not z.strip().endswith(('.db', '.inv', '.pdf', '.zip'))
         ]
     #@+node:ekr.20170821052348.1: *4* gdc.get_revno
     def get_revno(self, revspec: str, abbreviated: bool = True) -> str:

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1246,9 +1246,22 @@ class GitDiffController:
     def finish(self) -> None:
         """Finish execution of this command."""
         c = self.c
-        c.selectPosition(self.root)
-        self.root.expand()
-        c.redraw(self.root)
+        if c.validateOutlineXML():
+            # All is well.
+            c.selectPosition(self.root)
+            self.root.expand()
+            c.redraw(self.root)
+        else:
+            # Writing the outline would create an invalid outline.
+            g.es_print('Deleting the diff. It would create an invalid outline!', color='red')
+            c.selectPosition(self.root)
+            c.deleteOutline()
+            last = c.lastTopLevel()
+            c.redraw(last)
+            # Re-validate.
+            if not c.validateOutlineXML():
+                g.es_print('The outline is *still* invalid!', color='red')
+                g.es_print('Do not save the outline!', color='red')
         c.treeWantsFocusNow()
     #@+node:ekr.20210819080657.1: *4* gdc.get_parent_of_git_directory
     def get_parent_of_git_directory(self) -> Optional[str]:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2267,7 +2267,8 @@ class Commands:
                 filename = c.fileName() + '.txt'
                 try:
                     with open(filename, 'w') as f:
-                        f.write(xml_contents)
+                        for s in g.splitLines(translated_contents):
+                            f.write(g.toUnicode(s))
                     g.es_print(f"Wrote {filename}")
                 except Exception:
                     g.es_print(f"Exception writing {filename}")

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2262,6 +2262,11 @@ class Commands:
         except Exception:
             g.es_print('The outline is invalid!', color='red')
             g.es_exception()
+            # Write the invalid ouitline to the corresponding leo.txt file.
+            filename = c.fileName() + '.txt'
+            g.es_print(f"Writing {filename}")
+            with open(filename, 'w') as f:
+                f.write(contents)
             return False
     #@+node:ekr.20040723094220: *3* c.Check Python code
     # This code is no longer used by any Leo command,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2264,13 +2264,11 @@ class Commands:
             g.es_exception()
             if dump:
                 # Write the invalid ouitline to the corresponding leo.txt file.
-                # filename = c.fileName() + '.txt'
                 filename = os.path.normpath(os.path.expanduser(f"~/BAD-{c.shortFileName()}.txt"))
                 try:
-                    with open(filename, 'w') as f:
-                        # for s in g.splitLines(xml_contents):
-                            # f.write(g.toUnicode(s))
-                        f.write('Test')
+                    with open(filename, 'rw') as f:
+                        for s in g.splitLines(xml_contents):
+                            f.write(g.toEncodedString(s, reportErrors=True))
                     g.es_print(f"Wrote {filename}")
                 except Exception:
                     g.es_print(f"Exception writing {filename}")

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2264,11 +2264,13 @@ class Commands:
             g.es_exception()
             if dump:
                 # Write the invalid ouitline to the corresponding leo.txt file.
-                filename = c.fileName() + '.txt'
+                # filename = c.fileName() + '.txt'
+                filename = os.path.normpath(os.path.expanduser(f"~/BAD-{c.shortFileName()}.txt"))
                 try:
                     with open(filename, 'w') as f:
-                        for s in g.splitLines(translated_contents):
-                            f.write(g.toUnicode(s))
+                        # for s in g.splitLines(xml_contents):
+                            # f.write(g.toUnicode(s))
+                        f.write('Test')
                     g.es_print(f"Wrote {filename}")
                 except Exception:
                     g.es_print(f"Exception writing {filename}")

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2267,7 +2267,7 @@ class Commands:
                 filename = os.path.normpath(os.path.expanduser(f"~/BAD-{c.shortFileName()}.txt"))
                 try:
                     with open(filename, 'bw') as f:
-                        for s in g.splitLines(xml_contents):
+                        for s in g.splitLines(translated_contents):
                             f.write(g.toEncodedString(s, reportErrors=True))
                     g.es_print('')
                     g.es_print(f"Wrote {filename}")

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2247,26 +2247,31 @@ class Commands:
 
 
     #@+node:ekr.20240715040734.1: *4* c.validateOutlineXML
-    def validateOutlineXML(self) -> bool:
+    def validateOutlineXML(self, dump: bool = True) -> bool:
         """Validate outline's xml."""
         c = self
         # #1510: https://en.wikipedia.org/wiki/Valid_characters_in_XML.
         translate_dict = {z: None for z in range(20) if chr(z) not in '\t\r\n'}
-        contents = c.fileCommands.outline_to_xml_string()
-        table = contents.maketrans(translate_dict)  # type:ignore #1510.
-        contents = contents.translate(table)
+        xml_contents = c.fileCommands.outline_to_xml_string()
+        table = xml_contents.maketrans(translate_dict)
+        translated_contents = xml_contents.translate(table)
         try:
-            xroot = ElementTree.fromstring(contents)
+            xroot = ElementTree.fromstring(translated_contents)
             assert xroot
             return True
         except Exception:
             g.es_print('The outline is invalid!', color='red')
             g.es_exception()
-            # Write the invalid ouitline to the corresponding leo.txt file.
-            filename = c.fileName() + '.txt'
-            g.es_print(f"Writing {filename}")
-            with open(filename, 'w') as f:
-                f.write(contents)
+            if dump:
+                # Write the invalid ouitline to the corresponding leo.txt file.
+                filename = c.fileName() + '.txt'
+                try:
+                    with open(filename, 'w') as f:
+                        f.write(xml_contents)
+                    g.es_print(f"Wrote {filename}")
+                except Exception:
+                    g.es_print(f"Exception writing {filename}")
+                    g.es_exception()
             return False
     #@+node:ekr.20040723094220: *3* c.Check Python code
     # This code is no longer used by any Leo command,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2262,7 +2262,7 @@ class Commands:
             assert xroot
             return True
         except Exception:
-            print('Failed!')
+            g.es_print('The outline is invalid!', color='red')
             g.es_exception()
             return False
     #@+node:ekr.20040723094220: *3* c.Check Python code

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2264,7 +2264,7 @@ class Commands:
             g.es_exception()
             if dump:
                 # Write the invalid ouitline to the corresponding leo.txt file.
-                filename = os.path.normpath(os.path.expanduser(f"~/BAD-{c.shortFileName()}.txt"))
+                filename = os.path.normpath(os.path.expanduser(f"~/.leo/BAD-{c.shortFileName()}.txt"))
                 try:
                     with open(filename, 'bw') as f:
                         for s in g.splitLines(translated_contents):

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2266,10 +2266,12 @@ class Commands:
                 # Write the invalid ouitline to the corresponding leo.txt file.
                 filename = os.path.normpath(os.path.expanduser(f"~/BAD-{c.shortFileName()}.txt"))
                 try:
-                    with open(filename, 'rw') as f:
+                    with open(filename, 'bw') as f:
                         for s in g.splitLines(xml_contents):
                             f.write(g.toEncodedString(s, reportErrors=True))
+                    g.es_print('')
                     g.es_print(f"Wrote {filename}")
+                    g.es_print('')
                 except Exception:
                     g.es_print(f"Exception writing {filename}")
                     g.es_exception()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2232,8 +2232,6 @@ class Commands:
         c, errors = self, 0
         for f in (c.checkVnodeLinks, c.checkGnxs):
             errors += f()
-        if not c.validateOutlineXML():
-            errors += 1
         return errors
     #@+node:ekr.20031218072017.1765: *4* c.validateOutline (compatibility only)
     # Makes sure all nodes are valid.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2246,8 +2246,8 @@ class Commands:
         return c.checkOutline() == 0
 
 
-    #@+node:ekr.20240715040734.1: *4* c.validateOutlineXML
-    def validateOutlineXML(self, dump: bool = True) -> bool:
+    #@+node:ekr.20240715040734.1: *4* c.checkOutlineXML
+    def checkOutlineXML(self, dump: bool = True) -> bool:
         """Validate outline's xml."""
         c = self
         # #1510: https://en.wikipedia.org/wiki/Valid_characters_in_XML.

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -168,6 +168,7 @@ class FastRead:
             if path:
                 self.bad_path_dict[path] = True
                 message = f"bad .leo file: {g.shortFileName(path)}"
+                g.es_exception()
             else:
                 message = 'The clipboard is not a valid .leo file'
             print('')


### PR DESCRIPTION
See #3994.  The culprit was diffing `.pdf` and `.inv` (sphinx inventory) files.

- [x] Improve 'bad .leo file' message.
- [x] Add c.validateOutlineXML.
- [x] Call c.validateOutlineXML whenever diffing files.
    This method dumps the bad outline to `~/BAD-{c.shortFileName()}.txt`.
    This dump is about the only way to figure out why the outline is corrupt.
- [x] Suppress diffing  `.pdf` and `.inv` (sphinx inventory) files.

**Discussion**

It would be safer to specify the file types that *will* be diffed, rather than those that *won't*.
However, I am willing to take the small extra risk.