### PR TITLE
PR for #3932: todo plugin clears headline

### DIFF
--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -364,7 +364,7 @@ class todoController:
     #@-<< todoController data >>
 
     #@+others
-    #@+node:tbrown.20090119215428.11: *3* todoController.__init__ & helpers (todoController)
+    #@+node:tbrown.20090119215428.11: *3* todoController.__init__ & helpers
     def __init__(self, c: Cmdr) -> None:
         """ctor for todoController class."""
         self.c = c
@@ -393,7 +393,7 @@ class todoController:
         self.ui.UI.spinTime.setSuffix(" " + self.time_name)
         # #1591: patch labels if necessary.
         self.patch_1591()
-    #@+node:tbrown.20090119215428.12: *4* todoController.reloadSettings (todoController)
+    #@+node:tbrown.20090119215428.12: *4* todoController.reloadSettings
     def reloadSettings(self) -> None:
         c = self.c
         c.registerReloadSettings(self)


### PR DESCRIPTION
See #3932.

- [x] Call `c.endEditing` in the `redrawer` decorator.
- [x] Add `todoController.` to most headlines in the `todoController` class.

This issue is minor with an apparently easy fix.