### PR TITLE
PR for #4006: url's in CheatSheet.leo

### DIFF
--- a/leo/doc/CheatSheet.leo
+++ b/leo/doc/CheatSheet.leo
@@ -1485,7 +1485,9 @@ Here is some python code::
 Here is the main page.  It contains links to individual lessons.
 https://github.com/leo-editor/leo-editor/issues/816
 </t>
-<t tx="ekr.20180405105451.1">These will work only if numpy and pyplot are installed.</t>
+<t tx="ekr.20180405105451.1">These will work only if numpy, matplotlib and pyplot are installed.
+
+The viewrendered.py plugin must also be enabled.</t>
 <t tx="ekr.20180405105738.1"></t>
 <t tx="ekr.20180503073939.1"></t>
 <t tx="ekr.20180503073954.1">@language python

--- a/leo/doc/CheatSheet.leo
+++ b/leo/doc/CheatSheet.leo
@@ -102,6 +102,7 @@
 <v t="ekr.20180405093127.32"><vh>reStructureText text example</vh></v>
 </v>
 <v t="ekr.20230716045242.1"><vh>Clickable links</vh></v>
+<v t="ekr.20180405105451.1"></v>
 </vnodes>
 <tnodes>
 <t tx="ekr.20131019184243.16683">This Cheat Sheet contains a summary of many of Leo's important features.
@@ -1022,8 +1023,8 @@ This is a comment</t>
 <t tx="ekr.20180405093127.14">#!/usr/bin/env python
 # a bar plot with errorbars
 
-# import numpy as np
-# import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib.pyplot as plt
 
 N = 5
 menMeans = (20, 35, 30, 35, 27)
@@ -1045,9 +1046,7 @@ ax.set_ylabel('Scores')
 ax.set_title('Scores by group and gender')
 ax.set_xticks(ind + width)
 ax.set_xticklabels(('G1', 'G2', 'G3', 'G4', 'G5'))
-
 ax.legend((rects1[0], rects2[0]), ('Men', 'Women'))
-
 
 def autolabel(rects):
     # attach some text labels
@@ -1060,15 +1059,15 @@ def autolabel(rects):
 autolabel(rects1)
 autolabel(rects2)
 
+# sets interactive mode. Prevents this message:
+# QCoreApplication::exec: The event loop is already running
 plt.ion()
-    # sets interactive mode. Prevents this message:
-    # QCoreApplication::exec: The event loop is already running
 plt.show()</t>
 <t tx="ekr.20180405093127.16"># https://matplotlib.org/1.5.1/examples/animation/basic_example.html
 
-# import numpy as np
-# import matplotlib.pyplot as plt
-# import matplotlib.animation as animation
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
 
 def update_line(num, data, line):
     line.set_data(data[..., :num])
@@ -1085,10 +1084,14 @@ line_ani = animation.FuncAnimation(fig1, update_line, 25,
     fargs=(data, l),
     interval=50,
     blit=True)
-</t>
-<t tx="ekr.20180405093127.17"># import numpy as np
-# import matplotlib.pyplot as plt
-# import matplotlib.animation as animation
+
+# sets interactive mode. Prevents this message:
+# QCoreApplication::exec: The event loop is already running
+plt.ion()
+plt.show()</t>
+<t tx="ekr.20180405093127.17">import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
 
 fig2 = plt.figure()
 
@@ -1106,13 +1109,16 @@ try:
 except TypeError:
     # Suppress "TypeError: 'PolyQuadMesh' object is not iterable"
     pass
-
+    
+# sets interactive mode. Prevents this message:
+# QCoreApplication::exec: The event loop is already running
+plt.ion()
 plt.show()</t>
 <t tx="ekr.20180405093127.18"># http://matplotlib.org/1.5.1/examples/animation/animate_decay.html
 
-# import numpy as np
-# import matplotlib.pyplot as plt
-# import matplotlib.animation as animation
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
 
 @others
 
@@ -1121,15 +1127,19 @@ fig, ax = plt.subplots()
 line, = ax.plot([], [], lw=2)
 ax.grid()
 xdata, ydata = [], []
+
+# This call seems flakey. You may have to run this several times.
 ani = animation.FuncAnimation(
     fig, run, data_gen, blit=False, interval=10,
-    repeat=False, init_func=init)
-    # cache_frame_data=False)
+    repeat=False, init_func=init,
+    cache_frame_data=False,
+)
 
+# sets interactive mode. Prevents this message:
+# QCoreApplication::exec: The event loop is already running
 plt.ion()
-    # sets interactive mode. Prevents this message:
-    # QCoreApplication::exec: The event loop is already running
-plt.show()</t>
+plt.show()
+</t>
 <t tx="ekr.20180405093127.19">def data_gen(t=0):
     cnt = 0
     while cnt &lt; 1000:
@@ -1485,14 +1495,14 @@ Here is the main page.  It contains links to individual lessons.
 https://github.com/leo-editor/leo-editor/issues/816
 </t>
 <t tx="ekr.20180405105451.1">@language python
-
 @doc
 
 These will work only if numpy, matplotlib and pyplot are installed.
 
-The viewrendered.py plugin must also be enabled.
+If you use the viewrendered or viewrendered3 plugins nodes need use the imports shown.
 
-Within an @pyplot node you do not need to add the standard imports!
+*Note*: It's also possible to run these examples using Leo's execute-script command.
+Doing so shows the plots in separate windows.
 </t>
 <t tx="ekr.20180405105738.1"></t>
 <t tx="ekr.20180503073939.1"></t>

--- a/leo/doc/CheatSheet.leo
+++ b/leo/doc/CheatSheet.leo
@@ -84,9 +84,7 @@
 <v t="ekr.20131102044158.16563"><vh>~/myDocument.html.txt</vh></v>
 </v>
 <v t="ekr.20180405093127.1"><vh>Rendering examples</vh>
-<v t="ekr.20180405093127.9"><vh>@html display Leo tree using css</vh></v>
 <v t="ekr.20180405093127.11"><vh>@image LeoSplash</vh></v>
-<v t="ekr.20180405093127.12"><vh>@image splash screen</vh></v>
 <v t="ekr.20180405093127.22"><vh>@svg bubbles from sources</vh></v>
 <v t="ekr.20180405093127.23"><vh>@svg bubbles.svg from a link</vh></v>
 <v t="ekr.20180405093127.31"><vh>Markdown example</vh></v>
@@ -106,6 +104,9 @@
 <v t="ekr.20180405093127.32"><vh>reStructureText text example</vh></v>
 </v>
 <v t="ekr.20230716045242.1"><vh>Clickable links</vh></v>
+<v t="ekr.20240716202324.1"><vh>--- fix</vh>
+<v t="ekr.20180405105451.1"></v>
+</v>
 </vnodes>
 <tnodes>
 <t tx="ekr.20131019184243.16683">This Cheat Sheet contains a summary of many of Leo's important features.
@@ -176,7 +177,7 @@ Regardless of focus::
 Adding the Shift key modifier to any of the keys above
 moves the cursor and extends the selected text.
 </t>
-<t tx="ekr.20131019184243.16689">For much more information, see Leo's Commands Reference: http://leoeditor.com/commands.html
+<t tx="ekr.20131019184243.16689">For much more information, see Leo's Commands Reference: https://leo-editor.github.io/leo-editor/commands.html
 
 Copy/Paste (text)::
 
@@ -243,7 +244,7 @@ Undo::
 </t>
 <t tx="ekr.20131019184243.16690">Directives starting with '@ in the leftmost column
     
-For full details, see Leo's Directives reference: http://leoeditor.com/directives.html
+For full details, see Leo's Directives reference: https://leo-editor.github.io/leo-editor/directives.html
 
     @                       # starts doc part
     @c                      # ends doc part
@@ -352,7 +353,7 @@ By default, the file's extension determines the importer:
     @auto-rst           reStructuredText
     
 For full details, see Leo's Directives reference:
-http://leoeditor.com/directives.html
+https://leo-editor.github.io/leo-editor/directives.html
     </t>
 <t tx="ekr.20131019184243.16694">This section lists the ivars, properties, functions and methods most
 commonly used in Leo scripts.
@@ -460,7 +461,7 @@ Use autocompletion to explore these objects!
     
 v.u (uA's or unknownAttributes or userAttributes) allow plugins or scripts
 to associate persistent data with vnodes. For details see:
-http://leoeditor.com/customizing.html#adding-extensible-attributes-to-nodes-and-leo-files
+https://leo-editor.github.io/leo-editor/customizing.html#adding-extensible-attributes-to-nodes-and-leo-files
 
 *Important*: Generally speaking, vnode properties are fast, while the
 corresponding position properties are much slower. Nevertheless, scripts
@@ -618,7 +619,7 @@ Valid values are (case is ignored):
 actionscript,c,csharp,css,cweb,elisp,html,java,latex,
 pascal,perl,perlpod,php,plain,plsql,python,rapidq,rebol,shell,tcltk.</t>
 <t tx="ekr.20131030071311.18723">Here is an expanded version of the example from
-http://leoeditor.com/tutorial-rst3.html
+https://leo-editor.github.io/leo-editor/tutorial-rst3.html
 
 Control-click the URL above to open the page in your browser.
 
@@ -1023,9 +1024,6 @@ To see these examples:
 <t tx="ekr.20180405093127.11">../Icons/Leosplash.GIF
 
 This is a comment</t>
-<t tx="ekr.20180405093127.12">c:\leo.repo\leo-editor\leo\Icons\SplashScreen.ico
-
-</t>
 <t tx="ekr.20180405093127.14">#!/usr/bin/env python
 # a bar plot with errorbars
 import numpy as np
@@ -1443,7 +1441,7 @@ This is **bold** and *italics*.
 Control-clicks follow url's in body text.&lt;br&gt;
 Plain clicks follow url's in the VR pane.
 
-Here is [Leo's home page](&lt;http://leoeditor.com/).
+Here is [Leo's home page](&lt;https://leo-editor.github.io/leo-editor/).
 
 ### Section
 
@@ -1468,7 +1466,7 @@ Control-clicks follow url's in body text.
 
 Plain clicks follow url's in the VR pane.
 
-More info at `Leo's home page &lt;http://leoeditor.com/&gt;`_.
+More info at Leo's home page: https://leo-editor.github.io/leo-editor.
 
 Section
 =======
@@ -1482,111 +1480,6 @@ Here is some python code::
     def spam():
         '''This is a docstring.'''
         pass</t>
-<t tx="ekr.20180405093127.9">&lt;!DOCTYPE html&gt;
-&lt;html&gt;
-&lt;head&gt;
-&lt;style&gt;
-ul.leo-tree-example  {
-    background-color: #ffffec;
-    zoom: 75%; # blurs icons a bit.
-}
-ul.leo-tree-example li {
-    background-repeat: no-repeat;
-    background-position: 0px 5px;
-    padding-left: 27px;
-}
-li {
-    background-image:
-url('https://raw.github.com/vivainio/leo/master/leo/Icons/box00.GIF');
-    background-repeat: no-repeat;
-    background-position: 0px 5px;
-    padding-left: 27px;
-}
-li.selected {
-    background-color: lightgrey;
-}
-li.leaf {
-    list-style-type: none;
-}
-li.plus {
-  list-style-image: url('http://leoeditor.com/plusnode.gif')
-}
-li.minus {
-  list-style-image: url('http://leoeditor.com/minusnode.gif')
-}
-li.leaf {
-  background-image: url('http://leoeditor.com/box00.GIF')
-}
-li.body {
-  background-image: url('http://leoeditor.com/box01.GIF')
-}
-li.mark {
-  background-image: url('http://leoeditor.com/box02.GIF')
-}
-li.mark-body {
-  background-image: url('http://leoeditor.com/box03.GIF')
-}
-li.clone {
-  background-image: url('http://leoeditor.com/box04.GIF')
-}
-li.clone-body {
-  background-image: url('http://leoeditor.com/box05.GIF')
-}
-li.clone-mark {
-  background-image: url('http://leoeditor.com/box06.GIF')
-}
-li.clone-mark-body {
-  background-image: url('http://leoeditor.com/box07.GIF')
-}
-li.dirty {
-  background-image: url('http://leoeditor.com/box08.GIF')
-}
-li.dirty-body {
-  background-image: url('http://leoeditor.com/box09.GIF')
-}
-li.dirty-mark {
-  background-image: url('http://leoeditor.com/box10.GIF')
-}
-li.dirty-mark-body {
-  background-image: url('http://leoeditor.com/box11.GIF')
-}
-li.dirty-clone {
-  background-image: url('http://leoeditor.com/box12.GIF')
-}
-li.dirty-clone-body {
-  background-image: url('http://leoeditor.com/box13.GIF')
-}
-li.dirty-clone-mark {
-  background-image: url('http://leoeditor.com/box14.GIF')
-}
-&lt;/style&gt;
-&lt;/head&gt;
-&lt;body&gt;
-&lt;ul class="leo-tree-example"&gt;
-&lt;li class='plus clone-mark'&gt;
-test
-&lt;/li&gt;
-&lt;ul&gt;
-  &lt;li class='plus clone-body'&gt;
-  child
-  &lt;/li&gt;
-  &lt;ul&gt;
-    &lt;li class='leaf body'&gt;
-    grandchild
-    &lt;/li&gt;
-  &lt;/ul&gt;
-  &lt;li class='plus clone-body'&gt;
-  child
-  &lt;/li&gt;
-  &lt;ul&gt;
-    &lt;li class='leaf body'&gt;
-    grandchild
-    &lt;/li&gt;
-  &lt;/ul&gt;
-&lt;/ul&gt;
-&lt;/ul&gt;
-&lt;/body&gt;
-&lt;/html&gt;</t>
 <t tx="ekr.20180405093138.1">Leo University is a project devoted to help people become Leo developers.
 
 Here is the main page.  It contains links to individual lessons.
@@ -1766,5 +1659,6 @@ The "6.7.4 release notes" node in LeoDocs.leo.
 unl:gnx://LeoDocs.leo#ekr.20230703101804.1
 </t>
 <t tx="ekr.20230904052052.1">c.doCommandByName(command_name) executes the command with the given name.</t>
+<t tx="ekr.20240716202324.1"></t>
 </tnodes>
 </leo_file>

--- a/leo/doc/CheatSheet.leo
+++ b/leo/doc/CheatSheet.leo
@@ -90,10 +90,8 @@
 <v t="ekr.20180405093127.31"><vh>Markdown example</vh></v>
 <v t="ekr.20180405105451.1"><vh>pyplot examples</vh>
 <v t="ekr.20180405093127.14"><vh>@pyplot barchar_demo</vh></v>
-<v t="ekr.20180405093127.15"><vh>@pyplot basic_example</vh>
-<v t="ekr.20180405093127.16"><vh>Figure 1</vh></v>
-<v t="ekr.20180405093127.17"><vh>Figure 2</vh></v>
-</v>
+<v t="ekr.20180405093127.16"><vh>@pyplot basic example: Figure 1</vh></v>
+<v t="ekr.20180405093127.17"><vh>@pyplot basic example: Figure 2</vh></v>
 <v t="ekr.20180405093127.18"><vh>@pyplot matplotlib animate_decay</vh>
 <v t="ekr.20180405093127.19"><vh>data_gen</vh></v>
 <v t="ekr.20180405093127.20"><vh>init</vh></v>
@@ -104,9 +102,6 @@
 <v t="ekr.20180405093127.32"><vh>reStructureText text example</vh></v>
 </v>
 <v t="ekr.20230716045242.1"><vh>Clickable links</vh></v>
-<v t="ekr.20240716202324.1"><vh>--- fix</vh>
-<v t="ekr.20180405105451.1"></v>
-</v>
 </vnodes>
 <tnodes>
 <t tx="ekr.20131019184243.16683">This Cheat Sheet contains a summary of many of Leo's important features.
@@ -1026,8 +1021,9 @@ To see these examples:
 This is a comment</t>
 <t tx="ekr.20180405093127.14">#!/usr/bin/env python
 # a bar plot with errorbars
-import numpy as np
-import matplotlib.pyplot as plt
+
+# import numpy as np
+# import matplotlib.pyplot as plt
 
 N = 5
 menMeans = (20, 35, 30, 35, 27)
@@ -1068,53 +1064,55 @@ plt.ion()
     # sets interactive mode. Prevents this message:
     # QCoreApplication::exec: The event loop is already running
 plt.show()</t>
-<t tx="ekr.20180405093127.15"># http://matplotlib.org/1.5.1/examples/animation/basic_example.html
-if 0:
-    import numpy as np
-    import matplotlib.pyplot as plt
-    import matplotlib.animation as animation
+<t tx="ekr.20180405093127.16"># https://matplotlib.org/1.5.1/examples/animation/basic_example.html
 
-@others
+# import numpy as np
+# import matplotlib.pyplot as plt
+# import matplotlib.animation as animation
 
-if 0:
-    plt.ion()
-    # sets interactive mode. Prevents this message:
-    # QCoreApplication::exec: The event loop is already running
-plt.show()</t>
-<t tx="ekr.20180405093127.16">if 1:
-    
-    def update_line(num, data, line):
-        line.set_data(data[..., :num])
-        return line, # a tuple.
+def update_line(num, data, line):
+    line.set_data(data[..., :num])
+    return line, # a tuple.
 
-    fig1 = plt.figure()
-    data = np.random.rand(2, 25)
-    l, = plt.plot([], [], 'r-')
-    plt.xlim(0, 1)
-    plt.ylim(0, 1)
-    plt.xlabel('x')
-    plt.title('test')
-    line_ani = animation.FuncAnimation(fig1, update_line, 25,
-        fargs=(data, l),
-        interval=50,
-        blit=True)
+fig1 = plt.figure()
+data = np.random.rand(2, 25)
+l, = plt.plot([], [], 'r-')
+plt.xlim(0, 1)
+plt.ylim(0, 1)
+plt.xlabel('x')
+plt.title('test')
+line_ani = animation.FuncAnimation(fig1, update_line, 25,
+    fargs=(data, l),
+    interval=50,
+    blit=True)
 </t>
-<t tx="ekr.20180405093127.17">fig2 = plt.figure()
+<t tx="ekr.20180405093127.17"># import numpy as np
+# import matplotlib.pyplot as plt
+# import matplotlib.animation as animation
+
+fig2 = plt.figure()
+
 x = np.arange(-9, 10)
 y = np.arange(-9, 10).reshape(-1, 1)
 base = np.hypot(x, y)
 ims = []
 for add in np.arange(15):
-    ims.append((plt.pcolor(x, y, base + add, norm=plt.Normalize(0, 30)),))
-animation.ArtistAnimation(fig2, ims,
-    interval=50,
-    repeat_delay=3000,
-    blit=True)
-#im_ani.save('im.mp4', metadata={'artist':'Guido'})</t>
+    ims.append((plt.pcolor(
+        x, y, base + add, norm=plt.Normalize(0, 30))))
+
+try:
+    im_ani = animation.ArtistAnimation(
+        fig2, ims, interval=50, repeat_delay=3000, blit=True)
+except TypeError:
+    # Suppress "TypeError: 'PolyQuadMesh' object is not iterable"
+    pass
+
+plt.show()</t>
 <t tx="ekr.20180405093127.18"># http://matplotlib.org/1.5.1/examples/animation/animate_decay.html
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.animation as animation
+
+# import numpy as np
+# import matplotlib.pyplot as plt
+# import matplotlib.animation as animation
 
 @others
 
@@ -1126,6 +1124,7 @@ xdata, ydata = [], []
 ani = animation.FuncAnimation(
     fig, run, data_gen, blit=False, interval=10,
     repeat=False, init_func=init)
+    # cache_frame_data=False)
 
 plt.ion()
     # sets interactive mode. Prevents this message:
@@ -1144,8 +1143,7 @@ plt.show()</t>
     del xdata[:]
     del ydata[:]
     line.set_data(xdata, ydata)
-    return line,
-</t>
+    return line,</t>
 <t tx="ekr.20180405093127.21">def run(data):
     # update the data
     t, y = data
@@ -1156,7 +1154,8 @@ plt.show()</t>
         ax.set_xlim(xmin, 2*xmax)
         ax.figure.canvas.draw()
     line.set_data(xdata, ydata)
-    return line,</t>
+    return line,
+</t>
 <t tx="ekr.20180405093127.22">@nocolor-node
 &lt;?xml version="1.0" standalone="no"?&gt;
 &lt;!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd"&gt;
@@ -1485,9 +1484,16 @@ Here is some python code::
 Here is the main page.  It contains links to individual lessons.
 https://github.com/leo-editor/leo-editor/issues/816
 </t>
-<t tx="ekr.20180405105451.1">These will work only if numpy, matplotlib and pyplot are installed.
+<t tx="ekr.20180405105451.1">@language python
 
-The viewrendered.py plugin must also be enabled.</t>
+@doc
+
+These will work only if numpy, matplotlib and pyplot are installed.
+
+The viewrendered.py plugin must also be enabled.
+
+Within an @pyplot node you do not need to add the standard imports!
+</t>
 <t tx="ekr.20180405105738.1"></t>
 <t tx="ekr.20180503073939.1"></t>
 <t tx="ekr.20180503073954.1">@language python
@@ -1661,6 +1667,5 @@ The "6.7.4 release notes" node in LeoDocs.leo.
 unl:gnx://LeoDocs.leo#ekr.20230703101804.1
 </t>
 <t tx="ekr.20230904052052.1">c.doCommandByName(command_name) executes the command with the given name.</t>
-<t tx="ekr.20240716202324.1"></t>
 </tnodes>
 </leo_file>

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -263,7 +263,8 @@ got_pyplot = False
 try:
     from matplotlib import pyplot
     got_pyplot = True
-except ImportError:
+    assert pyplot  ###
+except Exception:
     pass
 
 # Fail fast, right after all imports.
@@ -1245,9 +1246,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
         c = self.c
 
-        if pyplot.get_backend() != 'module://leo.plugins.pyplot_backend':
-            backend = g.finalize_join(
-                g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
+        backend = pyplot.get_backend()  # Returns 'qtagg' initially.
+        if backend != 'module://leo.plugins.pyplot_backend':
+            backend = g.finalize_join(g.app.loadDir, '..', 'plugins', 'pyplot_backend.py')
             if g.os_path_exists(backend):
                 try:
                     # The order of these statements is important...


### PR DESCRIPTION
- [x] Fix most urls.

**Important extras**

- [x] Revise `pyplot_backend.py` so it works with Qt6. See the [Embedding in Qt](https://matplotlib.org/stable/gallery/user_interfaces/embedding_in_qt_sgskip.html) page.
- [x] Tweak pyplot-related code in `viewrendered.py` and `CheatSheet.leo`.
   The revised scripts work properly both in the VR pane and as stand-alone scripts.
 - [x] Mention that `@pyplot` has few (any?) over running a pyplot script directly in the body pane.
   Doing so shows the plot in a separate window. That's often a better alternative.