### PR TITLE
'tnodeList' uncommented as attribute to exclude from being unpickeld with resolveUa. Also deleted extraneous nativeVnodeAttributes object duplicate.

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -583,7 +583,6 @@ class FileCommands:
         """Ctor for FileCommands class."""
         self.c = c
         self.frame = c.frame
-        self.nativeTnodeAttributes = ('tx',)
         self.initIvars()
     #@+node:ekr.20090218115025.5: *4* fc.initIvars
     def initIvars(self) -> None:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -84,12 +84,13 @@ class BadLeoFile(Exception):
 #@+node:ekr.20180602062323.1: ** class FastRead
 class FastRead:
 
+    # Used to exclude attributes from being unpickeld as UAs with resolveUa.
     nativeVnodeAttributes = (
         'a',
         'descendentTnodeUnknownAttributes',
         'descendentVnodeUnknownAttributes',
         'expanded', 'marks', 't',
-        # 'tnodeList',  # Removed in Leo 4.7.
+        'tnodeList',  # Removed in Leo 4.7.
     )
 
     def __init__(self, c: Cmdr, gnx2vnode: dict[str, VNode]) -> None:
@@ -583,13 +584,6 @@ class FileCommands:
         self.c = c
         self.frame = c.frame
         self.nativeTnodeAttributes = ('tx',)
-        self.nativeVnodeAttributes = (
-            'a',
-            'descendentTnodeUnknownAttributes',
-            'descendentVnodeUnknownAttributes',  # New in Leo 4.5.
-            'expanded', 'marks', 't',
-            # 'tnodeList',  # Removed in Leo 4.7.
-        )
         self.initIvars()
     #@+node:ekr.20090218115025.5: *4* fc.initIvars
     def initIvars(self) -> None:


### PR DESCRIPTION
Fixes #4010

I tested this by re-opening my old files and re-saving them under a different name and comparing the XML and making sure they also opened properly in Leo. 

(I'll fix LeoJS in the same way very soon to also support old Leo files)

I also made sure to run unit tests this time :) they all pass. 