### PR TITLE
PR for #4012: dialog does not return proper values.

### DIFF
--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -103,7 +103,7 @@ class textGui(leoGui.LeoGui):
     def isTextWidget(self, w):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and isinstance(w, leoFrame.StringTextWrapper)
-    #@+node:ekr.20150107090324.69: *3* runAskYesNoDialog
+    #@+node:ekr.20150107090324.69: *3* runAskYesNoDialog (cursesGui.py)
     def runAskYesNoDialog(self, c, title, message=None, yes_all=False, no_all=False):
         return 'yes'
     #@+node:ekr.20150107090324.15: *3* runMainLoop

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -595,14 +595,13 @@ class LeoQtGui(leoGui.LeoGui):
             c.in_qt_dialog = True
             dialog.raise_()  # #2246.
             dialog.exec()
-            dialog.clickedButton()  # #3972.
         finally:
             c.in_qt_dialog = False
             self._restore_focus(c)
 
         # #4012: use clickedButton() to determine which button was clicked.
         button = dialog.clickedButton()
-        return button.objectName() or 'yes'
+        return button.objectName() if button else 'yes'
     #@+node:ekr.20110605121601.18498: *4* qt_gui.runAskYesNoDialog
     def runAskYesNoDialog(self,
         c: Cmdr, title: str, message: str = None, yes_all: bool = False, no_all: bool = False,


### PR DESCRIPTION
See #4012.

At last I found a strategy that does not depend on enums:

- [x] Set button names to each button's desired return value.
- [x] Use `dialog.clickedButton` to get the clicked button.
- [x] Return `dialog.clickedButton.objectName() or 'cancel'`.
- [x] Fix `qt_gui.runAskYesNoDialog`.
- [x] Simplify `qt_gui.runAskYesNoCancelDialog`.
- [x] Improve a misleading comment in `qt_gui.runSaveFileDialog`.