### PR TITLE
PR for #3894: crash in editpane plugin

### DIFF
--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -57,7 +57,7 @@ def DBG(text):
 
     :param str text: text to print
     """
-    print("LEP: %s" % text)
+    # print("LEP: %s" % text)
 
 #@+node:ekr.20211210174103.2: ** class ListTable
 class ListTable(QtCore.QAbstractTableModel):

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -24,7 +24,6 @@ def edit_pane_csv(event):
         w = w.parent()
     if not w:
         return
-    ### w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
     w.addWidget(LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
 #@+node:tbrown.20171028115438.4: ** class LeoEditPane
 class LeoEditPane(QtWidgets.QWidget):

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -24,7 +24,8 @@ def edit_pane_csv(event):
         w = w.parent()
     if not w:
         return
-    w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
+    ### w.insert(-1, LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
+    w.addWidget(LeoEditPane(c=c, show_control=False, lep_type='EDITOR-CSV'))
 #@+node:tbrown.20171028115438.4: ** class LeoEditPane
 class LeoEditPane(QtWidgets.QWidget):
     """

--- a/leo/plugins/editpane/leotextedit.py
+++ b/leo/plugins/editpane/leotextedit.py
@@ -17,7 +17,7 @@ def DBG(text):
     Args:
         text (str): text to print
     """
-    print(f"LEP: {text}")
+    # print(f"LEP: {text}")
 #@+node:tbrown.20171028115508.3: ** class LEP_LeoTextEdit
 class LEP_LeoTextEdit(QtWidgets.QTextEdit):
     """LEP_LeoTextEdit - Leo LeoEditorPane editor

--- a/leo/plugins/editpane/plaintextedit.py
+++ b/leo/plugins/editpane/plaintextedit.py
@@ -16,7 +16,7 @@ def DBG(text):
     Args:
         text (str): text to print
     """
-    print(f"LEP: {text}")
+    # print(f"LEP: {text}")
 #@+node:tbrown.20171028115504.3: ** class LEP_PlainTextEdit
 class LEP_PlainTextEdit(QtWidgets.QTextEdit):
     """LEP_PlainTextEdit - simple LeoEditorPane editor

--- a/leo/plugins/editpane/vanillascintilla.py
+++ b/leo/plugins/editpane/vanillascintilla.py
@@ -19,67 +19,70 @@ def DBG(text):
     Args:
         text (str): text to print
     """
-    print(f"LEP: {text}")
+    # print(f"LEP: {text}")
 #@+node:tbrown.20171028115501.3: ** class LEP_VanillaScintilla
-class LEP_VanillaScintilla(Qsci.QsciScintilla):
-    lep_type = "EDITOR"
-    lep_name = "Vanilla Scintilla"
-    #@+others
-    #@+node:tbrown.20171028115501.4: *3* __init__ (LEP_VanillaScintilla)
-    def __init__(self, c=None, lep=None, *args, **kwargs):
-        """set up"""
-        super().__init__(*args, **kwargs)
-        self.c = c
-        self.lep = lep
-        self.textChanged.connect(self.text_changed)
+if Qsci:
 
-        font = QtGui.QFont()
-        font.setFamily('Courier')
-        font.setFixedPitch(True)
-        font.setPointSize(14)
 
-        lexer = Qsci.QsciLexerPython()
-        lexer.setDefaultFont(font)
-        self.setLexer(lexer)
-        # self.SendScintilla(Qsci.QsciScintilla.SCI_STYLESETFONT, 1, 'Courier')
+    class LEP_VanillaScintilla(Qsci.QsciScintilla):
+        lep_type = "EDITOR"
+        lep_name = "Vanilla Scintilla"
+        #@+others
+        #@+node:tbrown.20171028115501.4: *3* __init__ (LEP_VanillaScintilla)
+        def __init__(self, c=None, lep=None, *args, **kwargs):
+            """set up"""
+            super().__init__(*args, **kwargs)
+            self.c = c
+            self.lep = lep
+            self.textChanged.connect(self.text_changed)
 
-        self.setCaretLineVisible(True)
-        self.setCaretLineBackgroundColor(QtGui.QColor("#ffe4e4"))
-    #@+node:tbrown.20171028115501.5: *3* focusInEvent
-    def focusInEvent(self, event):
-        Qsci.QsciScintilla.focusInEvent(self, event)
-        DBG("focusin()")
-        self.lep.edit_widget_focus()
-    #@+node:tbrown.20171028115501.6: *3* focusOutEvent
-    def focusOutEvent(self, event):
-        Qsci.QsciScintilla.focusOutEvent(self, event)
-        DBG("focusout()")
-    #@+node:tbrown.20171028115501.7: *3* new_text
-    def new_text(self, text):
-        """new_text - update for new text
+            font = QtGui.QFont()
+            font.setFamily('Courier')
+            font.setFixedPitch(True)
+            font.setPointSize(14)
 
-        Args:
-            text (str): new text
-        """
-        self.setText(text)
-    #@+node:tbrown.20171028115501.8: *3* text_changed
-    def text_changed(self):
-        """text_changed - text editor text changed"""
-        if QtWidgets.QApplication.focusWidget() == self:
-            DBG("text changed, focused")
-            self.lep.text_changed(self.text())
-        else:
-            DBG("text changed, NOT focused")
-    #@+node:tbrown.20171028115501.9: *3* update_text
-    def update_text(self, text):
-        """update_text - update for current text
+            lexer = Qsci.QsciLexerPython()
+            lexer.setDefaultFont(font)
+            self.setLexer(lexer)
+            # self.SendScintilla(Qsci.QsciScintilla.SCI_STYLESETFONT, 1, 'Courier')
 
-        Args:
-            text (str): current text
-        """
-        DBG("update editor text")
-        self.setText(text)
-    #@-others
+            self.setCaretLineVisible(True)
+            self.setCaretLineBackgroundColor(QtGui.QColor("#ffe4e4"))
+        #@+node:tbrown.20171028115501.5: *3* focusInEvent
+        def focusInEvent(self, event):
+            Qsci.QsciScintilla.focusInEvent(self, event)
+            DBG("focusin()")
+            self.lep.edit_widget_focus()
+        #@+node:tbrown.20171028115501.6: *3* focusOutEvent
+        def focusOutEvent(self, event):
+            Qsci.QsciScintilla.focusOutEvent(self, event)
+            DBG("focusout()")
+        #@+node:tbrown.20171028115501.7: *3* new_text
+        def new_text(self, text):
+            """new_text - update for new text
+
+            Args:
+                text (str): new text
+            """
+            self.setText(text)
+        #@+node:tbrown.20171028115501.8: *3* text_changed
+        def text_changed(self):
+            """text_changed - text editor text changed"""
+            if QtWidgets.QApplication.focusWidget() == self:
+                DBG("text changed, focused")
+                self.lep.text_changed(self.text())
+            else:
+                DBG("text changed, NOT focused")
+        #@+node:tbrown.20171028115501.9: *3* update_text
+        def update_text(self, text):
+            """update_text - update for current text
+
+            Args:
+                text (str): current text
+            """
+            DBG("update editor text")
+            self.setText(text)
+        #@-others
 #@-others
 #@@language python
 #@@tabwidth -4


### PR DESCRIPTION
See #3894.

The **reported crash** happened because Qsci.QScintilla was not installed. This PR also fixes a **secondary crash**.

`PyQt6-QScintilla` is part of Leo's dependencies, so this crash is unlikely to be common.

- [x] Define `LEP_VanillaScintilla` class only if `Qsci.QsciScintilla` can be imported. This fixes the primary crash.
- [x] Use `addWidget`, not `insert` to add a widget to the splitter. This fixes the secondary crash.
- [x] Disable print statements in various "DBG" functions.