### PR TITLE
Tbp vr3 refactor and cleanup, reduce technical debt

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1966,6 +1966,8 @@ def viewrendered_tab(event):
     log = c.frame.log
     if not log.findTabIndex(TABNAME):
         open_in_tab(c, vr3)
+        vr3.set_unfreeze()
+
 #@+node:TomP.20191215195433.25: *3* g.command('vr3-toggle')
 @g.command('vr3-toggle')
 def toggle_rendering_pane(event):
@@ -1997,6 +1999,7 @@ def toggle_rendering_pane(event):
         ms.addWidget(vr3)
         ms.setSizes([100_000] * len(ms.sizes()))
         vr3.show()
+        vr3.set_unfreeze()
         positions[h] = OPENED_IN_SPLITTER
 #@+node:tom.20230403190542.1: *3* g.command('vr3-toggle-tab')
 @g.command('vr3-toggle-tab')
@@ -2021,6 +2024,7 @@ def toggle_rendering_pane_tab(event):
         positions[h] = None
     else:
         open_in_tab(c, vr3)
+        vr3.set_unfreeze()
 
 #@+node:tom.20220824142721.1: *3* g.command('vr3-unfreeze')
 @g.command('vr3-unfreeze')
@@ -4691,6 +4695,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:TomP.20200329230436.6: *5* vr3.show_dock_or_pane
     def show_dock_or_pane(self):
         self.show()
+        self.set_unfreeze()
         # c.bodyWantsFocusNow()
     #@+node:TomP.20200329230436.8: *5* vr3: toolbar helpers...
     #@+node:TomP.20200329230436.9: *6* vr3.get_toolbar_label

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2100,6 +2100,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.inited = False
         self.length = 0  # The length of previous p.b.
         self.last_text = ''
+        self.last_headline = ''
         self.locked = False
 
         self.pyplot_active = False
@@ -3072,7 +3073,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 _must_update = True
             elif self.gnx != p.v.gnx:
                 _must_update = True
-            elif len(p.b) != self.length or self.last_text != p.b:
+            elif (len(p.b) != self.length
+                  or self.last_text != p.b
+                  or self.last_headline != p.h):
                 if self.get_kind(p) in ('html', 'pyplot'):
                     _must_update = False  # Only update explicitly.
                 else:
@@ -3081,6 +3084,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             self.length = len(p.b)
             self.last_text = p.b
             self.gnx = p.v.gnx
+            self.last_headline = p.v.h
 
         return _must_update
     #@+node:TomP.20191215195433.54: *4* vr3.update_asciidoc & helpers

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1524,6 +1524,7 @@ def open_in_tab(c, vr3):
     log = c.frame.log
     log.createTab(TABNAME, widget=vr3, createText=False)
     log.selectTab(TABNAME)
+    vr3.set_unfreeze()
     positions[c.hash()] = OPENED_IN_TAB
 #@+node:tom.20230403143106.1: *3* vr3.close_tab
 def close_tab(c, vr3):
@@ -1560,7 +1561,7 @@ def getVr3(event):
         return None
 
     if not (vr3 := controllers.get(h)):
-        controllers[h] = vr3 = viewrendered(event)
+        controllers[h] = vr3 = ViewRenderedController3(c)  # viewrendered(event)
         positions[h] = None
 
     return vr3
@@ -2021,6 +2022,7 @@ def toggle_rendering_pane_tab(event):
 
     if log.findTabIndex(TABNAME):
         log.deleteTab(TABNAME)
+        vr3.set_freeze()
         positions[h] = None
     else:
         open_in_tab(c, vr3)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3063,31 +3063,26 @@ class ViewRenderedController3(QtWidgets.QWidget):
         _must_update = False
         c, p = self.c, self.c.p
 
-        if g.unitTesting:
-            _must_update = False
-        elif keywords.get('force'):
-            self.active = True
-            _must_update = True
-        elif c != keywords.get('c') or not self.active:
-            _must_update = False
-        elif self.locked:
-            _must_update = False
-        elif self.gnx != p.v.gnx:
-            _must_update = True
-        elif len(p.b) != self.length or self.last_text != p.b:
-            if self.get_kind(p) in ('html', 'pyplot'):
-                _must_update = False  # Only update explicitly.
-            else:
+        if not (g.unitTesting 
+                or c != keywords.get('c')
+                or not self.active
+                or self.locked):
+            if keywords.get('force'):
+                self.active = True
                 _must_update = True
+            elif self.gnx != p.v.gnx:
+                _must_update = True
+            elif len(p.b) != self.length or self.last_text != p.b:
+                if self.get_kind(p) in ('html', 'pyplot'):
+                    _must_update = False  # Only update explicitly.
+                else:
+                    _must_update = True
+            if _must_update:
                 self.length = len(p.b)
                 self.last_text = p.b
-        else:
-            _must_update = False
-            # This trace would be called at idle time.
-            # g.trace('no change')
+                self.gnx = p.v.gnx
 
         return _must_update
-
     #@+node:TomP.20191215195433.54: *4* vr3.update_asciidoc & helpers
     def update_asciidoc(self, node_list, keywords):
         """Update asciidoc in the vr3 pane."""
@@ -4518,9 +4513,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
         for p1 in p.self_and_parents(p):
             kind = None
             language = self.get_language(p1)
-            if (got_markdown and language in ('md', 'markdown')
-                or got_docutils and language in ('rest', 'rst')
-                or language and language in self.dispatch_dict):
+            if ((got_markdown and language in ('md', 'markdown'))
+                or (got_docutils and language in ('rest', 'rst'))
+                or (language and language in self.dispatch_dict)):
                 kind = language
 
         return kind

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1694,7 +1694,7 @@ def vr3_help_for_plot_2d(event):
 @g.command('vr3-close')
 def hide_rendering_pane(event):
     """Close the rendering pane and delete the VR3 instance."""
-    global controllers
+    # global controllers
     if g.app.gui.guiName() != 'qt':
         return
 
@@ -1715,7 +1715,7 @@ def hide_rendering_pane(event):
     vr3.hide()
     vr3.setParent(None)
     vr3.deleteLater()
-    del controllers[h]
+    del vr3.controllers[h]
 
     c.bodyWantsFocus()
 
@@ -2011,7 +2011,6 @@ def toggle_rendering_pane_tab(event):
     If a VR3 instance exists for this controller, remove it.
     Otherwise, create it in a tab in the log pane.
     """
-    global controllers
     if g.app.gui.guiName() != 'qt':
         return
     if not (c := event.get('c')):
@@ -2024,7 +2023,7 @@ def toggle_rendering_pane_tab(event):
     if log.findTabIndex(TABNAME):
         log.deleteTab(TABNAME)
         vr3.set_freeze()
-        positions[h] = None
+        vr3.positions[h] = None
     else:
         open_in_tab(c, vr3)
         vr3.set_unfreeze()
@@ -2089,9 +2088,11 @@ class ViewRenderedController3(QtWidgets.QWidget):
         # Set the ivars.
         self.active = False
         self.badColors = []
+        self.controllers = controllers
         self.delete_callback = None
         self.gnx = None
         self.graphics_class = QtWidgets.QGraphicsWidget
+        self.positions = positions
         self.pyplot_canvas = None
 
         self.pyplot_imported = False

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1212,12 +1212,8 @@ asciidoc_dirs = {'asciidoc': {}, 'asciidoc3': {}}
 asciidoc_processors = []
 asciidoc_has_diagram = False
 #@-<< Misc Globals >>
-#@-<< declarations >>
-
-trace = False  # This global trace is convenient.
-
 #@+<< define html templates >>
-#@+node:TomP.20191215195433.6: ** << define html templates >> (vr3)
+#@+node:TomP.20191215195433.6: *3* << define html templates >> (vr3)
 image_template = '''\
 <html>
 <body bgcolor="#fffbdc">
@@ -1240,6 +1236,11 @@ latex_template = f'''\
 </html>
 '''
 #@-<< define html templates >>
+
+#@-<< declarations >>
+
+trace = False  # This global trace is convenient.
+
 
 # keys are c.hash().
 controllers = {}  # values: VR3 widets
@@ -1672,7 +1673,7 @@ def hide_rendering_pane(event):
         c.bodyWantsFocusNow()
 
     vr3.deactivate()
-    # vr3.deleteLater()
+    vr3.setParent(None) 
     del controllers[c.hash()]
 
     QtCore.QTimer.singleShot(0, at_idle)

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3075,12 +3075,14 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 _must_update = True
             elif (len(p.b) != self.length
                   or self.last_text != p.b
-                  or self.last_headline != p.h):
+                  or self.last_headline != p.h
+                  ):
                 if self.get_kind(p) in ('html', 'pyplot'):
                     _must_update = False  # Only update explicitly.
                 else:
                     _must_update = True
 
+        if _must_update:
             self.length = len(p.b)
             self.last_text = p.b
             self.gnx = p.v.gnx

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3077,10 +3077,10 @@ class ViewRenderedController3(QtWidgets.QWidget):
                     _must_update = False  # Only update explicitly.
                 else:
                     _must_update = True
-            if _must_update:
-                self.length = len(p.b)
-                self.last_text = p.b
-                self.gnx = p.v.gnx
+
+            self.length = len(p.b)
+            self.last_text = p.b
+            self.gnx = p.v.gnx
 
         return _must_update
     #@+node:TomP.20191215195433.54: *4* vr3.update_asciidoc & helpers

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1711,8 +1711,9 @@ def hide_rendering_pane(event):
 
     positions[h] = None
     vr3.deactivate()
-    vr3.setParent(None)
     vr3.hide()
+    vr3.setParent(None)
+    vr3.deleteLater()
     del controllers[h]
 
     c.bodyWantsFocus()
@@ -4689,9 +4690,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.current_tree_root = None
     #@+node:TomP.20200329230436.6: *5* vr3.show_dock_or_pane
     def show_dock_or_pane(self):
-        vr3 = self.c, self
-        vr3.activate()
-        vr3.show()
+        self.show()
         # c.bodyWantsFocusNow()
     #@+node:TomP.20200329230436.8: *5* vr3: toolbar helpers...
     #@+node:TomP.20200329230436.9: *6* vr3.get_toolbar_label

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1718,8 +1718,9 @@ def hide_rendering_pane(event):
     del controllers[h]
 
     c.bodyWantsFocus()
-# Compatibility
 
+teardown = hide_rendering_pane
+# Compatibility
 close_rendering_pane = hide_rendering_pane
 #@+node:TomP.20191215195433.22: *3* g.command('vr3-lock')
 @g.command('vr3-lock')


### PR DESCRIPTION
This is the first of a number of PRs that will be spread out over time for Issue https://github.com/leo-editor/leo-editor/issues/4026

This PR should be merged into devel now to avoid a much larger one in the future.

pytest output:
```
============================ warnings summary ============================
leo\plugins\leo_babel\tests\lib_test.py:118
  C:\Tom\git\leo-editor\leo\plugins\leo_babel\tests\lib_test.py:118: PytestCollectionWarning: cannot collect test class 'TestCmdr' because it has a __init__ constructor (from: leo/plugins/leo_babel/tests/lib_test.py)
    class TestCmdr:

leo/unittests/commands/test_editFileCommands.py::TestEditFileCommands::test_diff_two_revs
  C:\Tom\git\leo-editor\leo\core\leoCommands.py:2264: DeprecationWarning: Testing an element's truth value will raise an exception in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
    assert xroot

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============== 932 passed, 2 skipped, 2 warnings in 29.36s ===============
```