### PR TITLE
VR3 - Simplify Code For Split Layouts; Change Default Layout

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1587,11 +1587,12 @@ def viewrendered(event):
         return None
     h = c.hash()
     vr3 = controllers.get(h)
-    if vr3:
+    if vr3 and vr3.parent() is not None:
         c.bodyWantsFocusNow()
         return vr3
     # Create the VR3 frame
-    controllers[h] = vr3 = ViewRenderedController3(c)
+    if not vr3:
+        controllers[h] = vr3 = ViewRenderedController3(c)
 
     layout_kind = c.config.getString('vr3-initial-orientation') or 'in_body'
     # Use different layouts depending on the main splitter's current orientation.
@@ -1607,6 +1608,7 @@ def viewrendered(event):
         # Put the VR3 pane next to the body pane.
         main_splitter.insertWidget(2, vr3)
         gui.equalize_splitter(main_splitter)
+    vr3.show()
     c.bodyWantsFocusNow()
     return vr3
 #@+node:TomP.20200112232719.1: *3* g.command('vr3-execute')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2628,7 +2628,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
     def dbg_print(self, *args):
         if self.DEBUG:
             g.es(*args)
-    #@+node:tom.20211104105903.1: *4* vr3.plot_2d
+    #@+node:tom.20211104105903.1: *3* vr3.plot_2d
     def plot_2d(self):
         """Plot 2-column data in node.
         
@@ -2654,12 +2654,12 @@ class ViewRenderedController3(QtWidgets.QWidget):
         data_lines = []
 
         #@+others
-        #@+node:tom.20211104105903.5: *5* declarations
+        #@+node:tom.20211104105903.5: *4* declarations
         ENCODING = 'utf-8'
         STYLEFILE = 'local_mplstyle'  # Must be in site.getuserbase()
         SECTION_RE = re.compile(r'^\[([a-zA-Z0-9]+)\]')
-        #@+node:tom.20211104105903.6: *5* functions
-        #@+node:tom.20211104105903.7: *6* has_config_section()
+        #@+node:tom.20211104105903.6: *4* functions
+        #@+node:tom.20211104105903.7: *5* has_config_section()
         def has_config_section(pagelines):
             """Find config-like sections in the data page.
 
@@ -2678,7 +2678,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 if m := SECTION_RE.match(line):
                     sections[m[1]] = i
             return sections
-        #@+node:tom.20211104105903.8: *6* set custom_style()
+        #@+node:tom.20211104105903.8: *5* set custom_style()
         #@@pagewidth 65
         def set_custom_style():
             r"""Apply custom matplotlib styles from a file.
@@ -2711,7 +2711,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
             if not found_styles:
                 g.es(f'Pyplot style file "{style_file}" not found, using default styles')
-        #@+node:tom.20211104105903.12: *6* plot_plain_data()
+        #@+node:tom.20211104105903.12: *5* plot_plain_data()
         def plot_plain_data(pagelines):
             """Plot 1- or 2- column data.  Ignore all non-numeric lines."""
 
@@ -2721,7 +2721,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
             # Helper functions
             #@+<< is_numeric >>
-            #@+node:tom.20211104105903.13: *7* << is_numeric >>
+            #@+node:tom.20211104105903.13: *6* << is_numeric >>
             def is_numeric(line):
                 """Test if first or 1st and 2nd cols are numeric"""
                 fields = line.split()
@@ -2741,7 +2741,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 return numeric
             #@-<< is_numeric >>
             #@+<< get_data >>
-            #@+node:tom.20211104105903.14: *7* << get_data >>
+            #@+node:tom.20211104105903.14: *6* << get_data >>
             def get_data(pagelines):
                 num_cols = 0
 
@@ -2784,7 +2784,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
             plt.plot(x, y)
             plt.show()
-        #@+node:tom.20211104155447.1: *6* set_user_style()
+        #@+node:tom.20211104155447.1: *5* set_user_style()
         #@@pagewidth 65
         def set_user_style(style_config_lines):
             """Set special plot styles.
@@ -2838,7 +2838,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         source_start = config_sections.get('source', -1)
         if source_start > 0:
             #@+<< set_data >>
-            #@+node:tom.20211106174814.1: *5* << set_data >>
+            #@+node:tom.20211106174814.1: *4* << set_data >>
             for line in page_lines[source_start:]:
                 if not line.strip:
                     break
@@ -2877,7 +2877,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         label_start = config_sections.get('labels', -1)
         if label_start >= 0:
             #@+<< configure labels >>
-            #@+node:tom.20211104105903.11: *5* << configure labels >>
+            #@+node:tom.20211104105903.11: *4* << configure labels >>
             # Get lines for the labels section
             for line in page_lines[label_start:]:
                 if not line.strip:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2818,25 +2818,16 @@ class ViewRenderedController3(QtWidgets.QWidget):
                         plt.style.use(val)
                     set_style = True
                     break
-            if not set_style:
-                for line in style_config_lines:
-                    if not line.strip:
-                        break
-                    fields = line.split('=')
-                    if len(fields) < 2:
-                        continue
-                    kind, val = fields[0].strip(), fields[1].strip()
-
-                    if kind == 'stylefile':
-                        lm = g.app.loadManager
-                        style_dir = lm.computeHomeLeoDir()
-                        if g.isWindows:
-                            style_dir = style_dir.replace('/', '\\')
-                        style_file = os.path.join(style_dir, val)
-                        if os.path.exists(style_file):
-                            plt.style.use(style_file)
-                            set_style = True
-                        break
+                elif kind == 'stylefile':
+                    lm = g.app.loadManager
+                    style_dir = lm.computeHomeLeoDir()
+                    if g.isWindows:
+                        style_dir = style_dir.replace('/', '\\')
+                    style_file = os.path.join(style_dir, val)
+                    if os.path.exists(style_file):
+                        plt.style.use(style_file)
+                        set_style = True
+                    break
 
             return set_style
         #@-others

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1569,7 +1569,7 @@ def getVr3(event):
 #@+node:TomP.20191215195433.18: *3* g.command('vr3') (**weird effect**)
 @g.command('vr3')
 def viewrendered(event):
-    """Open render view for commander"""
+    """Open VR3 in this commander"""
     global controllers
     gui = g.app.gui
     if gui.guiName() != 'qt':
@@ -1582,35 +1582,23 @@ def viewrendered(event):
     if vr3:
         c.bodyWantsFocusNow()
         return vr3
-    # Create the VR frame
+    # Create the VR3 frame
     controllers[h] = vr3 = ViewRenderedController3(c)
 
-    # A prototype for supporint  arbitrarily many layouts.
-    layout_kind = c.config.getString('vr3-initial-orientation') or 'in_secondary'
-
-    # Use different layouts depending on the main splitter's *initial* orientation.
+    layout_kind = c.config.getString('vr3-initial-orientation') or 'in_body'
+    # Use different layouts depending on the main splitter's current orientation.
     main_splitter = gui.find_widget_by_name(c, 'main_splitter')
-    secondary_splitter = gui.find_widget_by_name(c, 'secondary_splitter')
+    g.es(main_splitter.orientation())
     if layout_kind == 'in_body':
-        # Share the VR pane with the body pane.
-        # Create a new splitter.
-        splitter = QtWidgets.QSplitter(orientation=Orientation.Horizontal)
-        splitter.setObjectName('vr3-horizonal-splitter')
-        main_splitter.addWidget(splitter)
-        # Add frames.
-        body_frame = gui.find_widget_by_name(c, 'bodyFrame')
-        splitter.addWidget(body_frame)
-        splitter.addWidget(vr3)
-        gui.equalize_splitter(splitter)
+        # Put the VR3 pane next to the body pane.
+        main_splitter.insertWidget(2, vr3)
         gui.equalize_splitter(main_splitter)
     elif main_splitter.orientation() == Orientation.Vertical:
-        # Put the VR pane in in the main_splitter.
-        main_splitter.insertWidget(1, vr3)  ### The weird effect happens here.
-        gui.equalize_splitter(main_splitter)
+        open_in_tab(c, vr3)
     else:
-        # Put the VR pane in the secondary splitter.
-        secondary_splitter.addWidget(vr3)
-        gui.equalize_splitter(secondary_splitter)
+        # Put the VR3 pane next to the body pane.
+        main_splitter.insertWidget(2, vr3)
+        gui.equalize_splitter(main_splitter)
     c.bodyWantsFocusNow()
     return vr3
 #@+node:TomP.20200112232719.1: *3* g.command('vr3-execute')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1566,7 +1566,7 @@ def getVr3(event):
 
     return vr3
 #@+node:TomP.20191215195433.16: ** vr3.Commands
-#@+node:TomP.20191215195433.18: *3* g.command('vr3') (**weird effect**)
+#@+node:TomP.20191215195433.18: *3* g.command('vr3')
 @g.command('vr3')
 def viewrendered(event):
     """Open VR3 in this commander"""

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -12,7 +12,7 @@ Markdown and Asciidoc text, images, movies, sounds, rst, html, jupyter notebooks
 
 #@+others
 #@+node:tom.20240521004125.1: *3* About
-About Viewrendered3 V5.02
+About Viewrendered3 V5.03
 ===========================
 
 The ViewRendered3 plugin (hereafter "VR3") renders Restructured Text (RsT),
@@ -57,10 +57,18 @@ section `Special Renderings`_.
 
 New With This Version
 ======================
-Removed diagnostic line that change the clipboard contents.
+The "vr3" command and the default opening positions have been changed:
+
+The default value of the setting *@string vr3-initial-orientation* is now _"in-body".  This will open VR3 next to the body editor (or below if Leo's layout orientation has been changed to "vertical". 
+
+For any other value of the setting VR3 will open:
+
+- Next to the body editor if Leo's orientation is "horizontal";
+- In the Log frame if the orientation is "vertical".
 
 Previous Recent Changes
 ========================
+Removed diagnostic line that change the clipboard contents.
 Corrected errors introduced in a complicated merge: ASCIIDOC, MD, and RsT images
 display correctly when the exported file is viewed in the browser (relative
 paths are converted to absolute file system paths).

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1652,6 +1652,7 @@ def freeze_rendering_pane(event):
 #@+node:tom.20211103161929.1: *3* g.command('vr3-help-plot-2d')
 @g.command('vr3-help-plot-2d')
 def vr3_help_for_plot_2d(event):
+
     vr3 = getVr3(event)
     c = vr3.c
 
@@ -2627,6 +2628,21 @@ class ViewRenderedController3(QtWidgets.QWidget):
             g.es(*args)
     #@+node:tom.20211104105903.1: *4* vr3.plot_2d
     def plot_2d(self):
+        """Plot 2-column data in node.
+        
+        If the selected node contains data in one or two columns, VR3 can
+        plot the data as an X-Y graph. The labeling and appearance of the
+        plot can optionally and easily adjusted. The graph is produced
+        when the toolbar menu labeled *Other Actions* is pressed and
+        *Plot 2D* is clicked.
+
+        If the selected node has an optional section *[source]* containing the key 
+        *file*, the value of the key will be used as the path to
+        the data, instead of using the selected node itself as the data source.
+
+        Help for the plotting capability is displayed in the system
+        browser when *Other Actions/Help For Plot 2D* is clicked.
+        """
         if not matplotlib:
             g.es('VR3 -- Matplotlib is needed to plot 2D data')
             return
@@ -2672,7 +2688,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             If not found, the site.getuserbase() directory will be
             checked for the style file. On Windows, this is usually the
             %APPDATA%\Python directory. On Linux, this is usually at
-            /home/tom/.local.
+            ~/.local.
 
             """
             found_styles = False
@@ -2766,12 +2782,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
             plt.plot(x, y)
             plt.show()
-
-
-            # try:
-                # plot2d(page)
-            # except Exception as e:
-                # g.es('VR3:', e)
         #@+node:tom.20211104155447.1: *6* set_user_style()
         #@@pagewidth 65
         def set_user_style(style_config_lines):


### PR DESCRIPTION
- [x] Remove unneeded added splitter and simplify code. 
- [x] Make default layout more useful.

Previously the default layout bunched up VR3 into a small part of the secondary splitter, where it is hard to read.  Now the default is to open VR3 next to the body pane. Otherwise, when the main layout is vertical, VR3 opens in the log frame, again for better readability.

- [x] Add docstring to vr3.plot_2d() . This is displayed  by the "vr3-help-plot-2d" command.  It was a bug for it to be missing. 
- [x] Update version and What's New. 
- [x] Simplify and speed up `set_user_style()`  in the `vr3-plot-2d` minibuffer command.
- [x] "vr3" command - make sure to call show() at the end.  Don't create a new instance if the existing instance has None for parent.
- [x] Dedent `vr3.plot_2d()` node. It was inadvertently located in the `__init__()`subtree.  This did not affect functionality but was not intended.