### PR TITLE
PR for #4056: Retire reload-outline.

### DIFF
--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -1338,6 +1338,82 @@ def updateInjectedIvars(self, w: Any, p: Position) -> None:
     else:
         w.leo_chapter = None
     w.leo_p = p.copy()
+#@+node:ekr.20240830090655.1: *3* retire reload-outline
+#@+node:ekr.20240810080628.1: *4* LeoQtFrame.reloadOutline
+@frame_cmd('reload-outline')
+def reloadOutline(self, event: LeoKeyEvent = None) -> None:
+    """reload-outline: Close the outline and reload it."""
+    c = self.c
+
+    # Commit any open edits.
+    c.endEditing()
+
+    # Make sure the file has a name.
+    if not c.fileName():
+        c.save()
+    if not c.fileName():
+        g.es_print('Please name the outline', color='red')
+        return
+
+    # Abort the reload if the user vetos closing this outline.
+    if c.changed:
+        veto = False
+        try:
+            c.promptingForClose = True
+            veto = c.frame.promptForSave()
+        finally:
+            c.promptingForClose = False
+        if veto:
+            g.es_print('Cancelling reload-outline command')
+            return
+        # Save the file.
+        c.save()
+        g.app.recentFilesManager.writeRecentFilesFile(c)
+
+    # Remember old_index, the outline's position in the QTabbledWidget.
+    dw = c.frame.top
+    stacked_widget = dw.parent()
+    tab_widget = dw.leo_master
+    stacked_layout = None
+    for w in stacked_widget.children():
+        if isinstance(w, QtWidgets.QStackedLayout):
+            stacked_layout = w
+            break
+    else:
+        g.trace('Can not happen: no QStackedLayout')
+        return
+
+    # Remember the old values.
+    old_index = stacked_layout.indexOf(dw)
+    tab_names = [tab_widget.tabText(i) for i in range(tab_widget.count())]
+
+    # Completely close the outline.
+    g.doHook("close-frame", c=c)
+    frame = c.frame
+    if frame in g.app.windowList:
+        g.app.destroyWindow(frame)
+        g.app.windowList.remove(frame)
+    else:
+        g.app.forgetOpenFile(fn=c.fileName())  # #69.
+
+    # Open the new outline.
+    g.openWithFileName(fileName=c.fileName())
+
+    # Do nothing more if the index has not changed.
+    new_index = stacked_layout.indexOf(dw)
+    if new_index == old_index:
+        return
+
+    # Put dw in the proper place.
+    stacked_layout.removeWidget(dw)
+    stacked_layout.insertWidget(old_index, dw)
+
+    # Fix all tab names.
+    for i, name in enumerate(tab_names):
+        tab_widget.setTabText(i, name)
+
+    # Select the proper tab.
+    tab_widget.setCurrentIndex(old_index)
 #@+node:ekr.20240820045246.1: ** To be cleared later
 # Clear after 6.8.2.
 #@+node:ekr.20110605121601.18254: *3* LeoQtFrame.destroyAllObjects (not used)


### PR DESCRIPTION
See #4056.

- [x] Retire `reload-outline`, moving the code to the attic.
- [x] Use `restart-leo` instead of `reload-outline`.