### PR TITLE
PR for #4032: Don't mark @rst3 nodes dirty

### DIFF
--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -242,8 +242,6 @@ class RstCommands:
                     g.trace(f"ignoring nested @rst node: {p.h}")
                 else:
                     h = p.h.strip()
-                    if p.h != h:
-                        p.h = h
                     fn = h[4:].strip()
                     if fn:
                         source = self.write_rst_tree(p, fn)

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -241,8 +241,10 @@ class RstCommands:
                 if self.in_rst_tree(p):
                     g.trace(f"ignoring nested @rst node: {p.h}")
                 else:
-                    p.h = p.h.strip()
-                    fn = p.h[4:].strip()
+                    h = p.h.strip()
+                    if p.h != h:
+                        p.h = h
+                    fn = h[4:].strip()
                     if fn:
                         source = self.write_rst_tree(p, fn)
                         self.write_docutils_files(fn, p, source)


### PR DESCRIPTION
See #4032.

- [x] Fix `processTree` so that it never changes `p.h`.