### PR TITLE
VR3 - Fix Plugin Menu <module>/about Message Not Displaying The First Time

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -12,7 +12,7 @@ Markdown and Asciidoc text, images, movies, sounds, rst, html, jupyter notebooks
 
 #@+others
 #@+node:tom.20240521004125.1: *3* About
-About Viewrendered3 V5.03
+About Viewrendered3 V5.04
 ===========================
 
 The ViewRendered3 plugin (hereafter "VR3") renders Restructured Text (RsT),
@@ -57,6 +57,10 @@ section `Special Renderings`_.
 
 New With This Version
 ======================
+Showing a plugin's docstring using the Plugin menu now works right the first time.
+
+Previous Recent Changes
+========================
 The "vr3" command and the default opening positions have been changed:
 
 The default value of the setting *@string vr3-initial-orientation* is now _"in-body".  This will open VR3 next to the body editor (or below if Leo's layout orientation has been changed to "vertical". 
@@ -66,8 +70,6 @@ For any other value of the setting VR3 will open:
 - Next to the body editor if Leo's orientation is "horizontal";
 - In the Log frame if the orientation is "vertical".
 
-Previous Recent Changes
-========================
 Removed diagnostic line that change the clipboard contents.
 Corrected errors introduced in a complicated merge: ASCIIDOC, MD, and RsT images
 display correctly when the exported file is viewed in the browser (relative

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1483,7 +1483,7 @@ def onClose(tag, keys):
         c.bodyWantsFocus()
         del controllers[h]
         vr3.deactivate()
-#@+node:TomP.20191215195433.13: *3* vr3.show_scrolled_message
+#@+node:tom.20240918232752.1: *3* vr3.show_scrolled_message
 def show_scrolled_message(tag, kw):
     """Show "scrolled message" in VR3.
     
@@ -1497,11 +1497,13 @@ def show_scrolled_message(tag, kw):
     flags = kw.get('flags') or 'rst'
     h = c.hash()
     vr3 = controllers.get(h, None)
+    started_vr3 = False
     if not vr3:
         if positions.get(h, None) == None or OPENED_IN_SPLITTER:
             vr3 = viewrendered(event=kw)
         else:
             vr3 = viewrendered_tab(event=kw)
+        started_vr3 = True
 
     title = kw.get('short_title', '').strip()
     vr3.setWindowTitle(title)
@@ -1512,13 +1514,18 @@ def show_scrolled_message(tag, kw):
         kw.get('msg')
     ])
 
-    vr3.update(
-        tag='show-scrolled-message',
-        keywords={'c': c, 'force': True, 's': s, 'flags': flags},
-    )
+    delay = 500 if started_vr3 else 0
 
-    if not vr3.isVisible:
-        vr3.show()
+    def do_scrolled_msg(vr3, s, flags):
+        vr3.update(
+            tag='show-scrolled-message',
+            keywords={'c': c, 'force': True, 's': s, 'flags': flags},
+        )
+
+        if not vr3.isVisible:
+            vr3.show()
+
+    QtCore.QTimer.singleShot(delay, lambda: do_scrolled_msg(vr3, s, flags))
     return True
 #@+node:TomP.20191215195433.14: *3* vr3.split_last_sizes
 def split_last_sizes(sizes):


### PR DESCRIPTION
Added a time delay before rendering the message to allow for VR3 instantiation to complete.