### PR TITLE
New Leo Layout System

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -635,6 +635,7 @@
 <v t="ekr.20140907123524.18774"><vh>@file ../plugins/qt_frame.py</vh></v>
 <v t="ekr.20140907085654.18699"><vh>@file ../plugins/qt_gui.py</vh></v>
 <v t="ekr.20140907103315.18777"><vh>@file ../plugins/qt_idle_time.py</vh></v>
+<v t="tom.20240923194438.1"><vh>@file ../plugins/qt_layout.py</vh></v>
 <v t="ekr.20140907123524.18777"><vh>@file ../plugins/qt_quickheadlines.py</vh></v>
 <v t="ekr.20140831085423.18598"><vh>@file ../plugins/qt_text.py</vh></v>
 <v t="ekr.20140907131341.18707"><vh>@file ../plugins/qt_tree.py</vh></v>

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -32,6 +32,8 @@ from leo.plugins import qt_events
 from leo.plugins import qt_text
 from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
+
+from leo.plugins.qt_layout import LayoutCacheWidget
 #@-<< qt_frame imports >>
 #@+<< qt_frame annotations >>
 #@+node:ekr.20220415080427.1: ** << qt_frame annotations >>
@@ -134,6 +136,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
         self.verticalLayout: Any = None
         self.vr_parent_frame: QWidget = None
         c._style_deltas = defaultdict(lambda: 0)  # for adjusting styles dynamically
+        self.layout_cache = LayoutCacheWidget(c, self)
         self.reloadSettings()
     #@+node:ekr.20240726074809.1: *4* dw.recreateMainWindow
     def recreateMainWindow(self):

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -34,6 +34,7 @@ from leo.plugins.qt_tree import LeoQtTree
 from leo.plugins.mod_scripting import build_rclick_tree
 
 from leo.plugins.qt_layout import LayoutCacheWidget
+
 #@-<< qt_frame imports >>
 #@+<< qt_frame annotations >>
 #@+node:ekr.20220415080427.1: ** << qt_frame annotations >>

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1534,7 +1534,7 @@ class LeoQtGui(leoGui.LeoGui):
     #@+node:ekr.20240519115301.1: *4* LeoQtGui.find_widget_by_name
     def find_widget_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
         for w in self._self_and_subtree(c.frame.top):
-            if w and w.objectName() == name:
+            if w is not None and w.objectName() == name:
                 return w
         return None
     #@+node:ekr.20240519115157.1: *4* LeoQtGui.get_top_splitter

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -372,6 +372,43 @@ def quadrants(event: LeoKeyEvent) -> None:
     dw = c.frame.top
     cache = dw.layout_cache
     cache.restoreFromLayout(QUADRANT_LAYOUT)
+#@+node:tom.20241005163724.1: *3* Swap Log Pane Location
+@g.command('layout-swap-log-panel')
+def swapLogPanel(event: LeoKeyEvent) -> None:
+    """Move Log frame between main and secondary splitters.
+
+       If the Log frame is contained in a different splitter,
+       possibly with some other widget, the entire splitter
+       will be swapped between the main and secondary splitters.
+    """
+    c = event.get('c')
+    if not c:
+        return
+    gui = g.app.gui
+
+    ms = gui.find_widget_by_name(c, 'main_splitter')
+    ss = gui.find_widget_by_name(c, 'secondary_splitter')
+    lf = gui.find_widget_by_name(c, 'logFrame')
+
+    lf_parent = lf.parent()
+    lf_parent_container = lf_parent.parent()
+    widget = None
+
+    if lf_parent in (ss, ms):
+        # Move just the lf
+        target = ms if lf_parent is ss else ss
+        widget = lf
+    elif lf_parent_container in (ms, ss):
+        # Move lf's entire container
+        target = ms if lf_parent_container is ss else ss
+        widget = lf_parent
+    else:
+        g.es("Don't know what widget or container to swap")
+
+    if widget is not None:
+        target.addWidget(widget)
+        g.app.gui.equalize_splitter(target)
+
 #@+node:tom.20240930095459.1: ** class LayoutCacheWidget
 class LayoutCacheWidget(QWidget):
 

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -1,0 +1,370 @@
+#@+leo-ver=5-thin
+#@+node:tom.20240923194438.1: * @file ../plugins/qt_layout.py
+"""The basic machinery to support applying layouts of the main Leo panels."""
+from __future__ import annotations
+#@+<< imports >>
+#@+node:tom.20240923194438.2: ** << imports >>
+from collections import OrderedDict
+from typing import Any, TYPE_CHECKING
+
+from leo.core.leoQt import QtWidgets, Orientation
+# from leo.core.leoCommands import Commands as Cmdr
+from leo.core import leoGlobals as g
+
+import leo.plugins.viewrendered as v
+
+QWidget = QtWidgets.QWidget
+if TYPE_CHECKING:  # pragma: no cover
+    from leo.core.leoCommands import Commands as Cmdr
+    from leo.core.leoGui import LeoKeyEvent
+    # from typing import TypeAlias  # Requires Python 3.12+
+    Args = Any
+    KWargs = Any
+#@-<< imports >>
+
+CACHENAME = 'leo-layout-cache'
+#@+<< FALLBACK_LAYOUT >>
+#@+node:tom.20240923194438.3: ** << FALLBACK_LAYOUT >>
+FALLBACK_LAYOUT = {
+    'SPLITTERS':OrderedDict(
+                    (('outlineFrame', 'secondary_splitter'),
+                    ('logFrame', 'secondary_splitter'),
+                    ('secondary_splitter', 'main_splitter'),
+                    ('bodyFrame', 'main_splitter'))
+                ),
+    'ORIENTATIONS':{
+    'main_splitter':Orientation.Horizontal,
+    'secondary_splitter':Orientation.Vertical}
+    }
+
+@g.command('layout-fallback-layout')
+def fallback_layout(event: LeoKeyEvent) -> None:
+    """Apply a workable layout in case the layout setting is invalid."""
+    c = event.get('c')
+    dw = c.frame.top
+    cache = dw.layout_cache
+    cache.restoreFromLayout(FALLBACK_LAYOUT)
+#@-<< FALLBACK_LAYOUT >>
+#@+<< Built-in Layouts >>
+#@+node:tom.20240928165801.1: ** << Built-in Layouts >>
+# Define commands to create some standard layouts
+#@+others
+#@+node:tom.20240928170706.1: *3* horizontal-thirds
+@g.command('layout-horizontal-thirds')
+def horizontal_thirds(event: LeoKeyEvent) -> None:
+    """Restore Leo's horizontal-thirds layout"""
+
+    c = event.get('c')
+    cache = c.frame.top.layout_cache
+    cache.restoreFromLayout()
+
+    ms = cache.find_widget('main_splitter')
+    ss = cache.find_widget('secondary_splitter')
+    lf = cache.find_widget('logFrame')
+    bf = cache.find_widget('bodyFrame')
+    of = cache.find_widget('outlineFrame')
+
+    vr = cache.find_widget('viewrendered_pane')
+    if vr is None:
+        # import leo.plugins.viewrendered as v
+        vr = v.getVr()
+
+    ms.setOrientation(Orientation.Vertical)
+    ss.setOrientation(Orientation.Horizontal)
+
+    ss.addWidget(of)
+    ss.addWidget(lf)
+    ms.addWidget(ss)
+    ms.addWidget(bf)
+    ms.addWidget(vr)
+
+    g.app.gui.equalize_splitter(ss)
+    g.app.gui.equalize_splitter(ms)
+
+    c.doCommandByName('vr-show')
+#@+node:tom.20240928171510.1: *3* big-tree
+@g.command ('layout-big-tree')
+def big_tree(event: LeoKeyEvent) -> None:
+    """Apply the "big-tree" layout.
+
+    Main splitter: tree, secondary_splitter, VR
+    Secondary splitter: body, log.
+
+    Orientations:
+        main splitter: vertical
+        secondary splitter: horizontal
+    """
+    c = event.get('c')
+    cache = c.frame.top.layout_cache
+    cache.restoreFromLayout()
+
+    ms = cache.find_widget('main_splitter')
+    ss = cache.find_widget('secondary_splitter')
+    of = cache.find_widget('outlineFrame')
+    lf = cache.find_widget('logFrame')
+    bf = cache.find_widget('bodyFrame')
+
+    # Find or create VR widget
+    vr = cache.find_widget('viewrendered_pane')
+    if not vr:
+        vr = v.getVr()
+#@+at
+#     # For VR3 instead
+#     vr = cache.find_widget('viewrendered3_pane')
+#     if not vr:
+#         import leo.plugins.viewrendered3 as v
+#         try:
+#         vr = v.getVr3({'c':c})
+#@@c
+    # Clear out splitters so we can add widgets back in the right order
+    for widget in (ss, of, lf, bf, vr):  # Don't remove ms!
+        widget.setParent(None)
+
+    # Move widgets to target splitters
+    of.setParent(ms)
+    ss.setParent(ms)
+    vr.setParent(ms)
+    bf.setParent(ss)
+    lf.setParent(ss)
+
+    # set Orientations
+    ms.setOrientation(Orientation.Vertical)
+    ss.setOrientation(Orientation.Horizontal)
+
+    # Re-parenting a widget to None hides it, so show it now
+    for widget in (ss, of, lf, bf, vr):
+        widget.show()
+    c.doCommandByName('vr-show')
+
+    # Set splitter sizes
+    ms.setSizes([100_000] * len(ms.sizes()))
+    ss.setSizes([100_000] * len(ss.sizes()))
+
+#@+node:tom.20240928195823.1: *3* legacy
+# Recreate the layout called "legacy" in the Dynamic Widnow code.
+LEGACY_LAYOUT = {
+    'SPLITTERS':OrderedDict(
+            (('outlineFrame', 'secondary_splitter'),
+            ('logFrame', 'secondary_splitter'),
+            ('bodyFrame', 'body-vr-splitter'),
+            ('viewrendered_pane', 'body-vr-splitter'),
+            ('secondary_splitter', 'main_splitter'),
+            ('body-vr-splitter', 'main_splitter'))
+        ),
+    'ORIENTATIONS':{
+        'body-vr-splitter':Orientation.Horizontal,
+        'secondary_splitter':Orientation.Horizontal,
+        'main_splitter':Orientation.Vertical
+    }
+}
+
+@g.command('layout-legacy')
+def layout_legacy(event: LeoKeyEvent) -> None:
+    """Create Leo's legacy layout."""
+    c = event.get('c')
+    dw = c.frame.top
+    cache = dw.layout_cache
+    cache.restoreFromLayout(LEGACY_LAYOUT)
+
+    # Find or create VR widget
+    vr = cache.find_widget('viewrendered_pane')
+    if not vr:
+        # import leo.plugins.viewrendered as v
+        vr = v.getVr()
+
+    bvs = cache.find_widget('body-vr-splitter')
+    bvs.addWidget(vr)
+    c.doCommandByName('vr-show')
+    g.app.gui.equalize_splitter(bvs)
+#@-others
+
+#@+at
+# From DW:
+#     layout_dict = {
+#         'big-tree': self.create_big_tree_layout,
+#         'horizontal-thirds': self.create_horizontal_thirds_layout,
+#         'legacy': self.create_legacy_layout,
+#         'render-focused': self.create_render_focused_layout,
+#         'vertical-thirds': self.create_vertical_thirds_layout,
+#         'vertical-thirds2': self.create_vertical_thirds2_layout,
+#     }
+#@-<< Built-in Layouts >>
+
+class LayoutCacheWidget(QWidget):
+
+    def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
+        super().__init__(parent)
+        self.c = c
+        self.setObjectName(CACHENAME)
+        self.created_splitter_dict = {}
+
+    #@+<< find_widget() >>
+    #@+node:tom.20240923194438.4: ** << find_widget() >>
+    def find_widget_in_children(self, name, debug=False):
+        log = [f'==== find_widget_in_children for: {name}']
+        w = None
+        for kid in self.children():
+            if kid.objectName() == name:
+                log.append(f'======== found it: {kid}')
+                w = kid
+        if debug:
+            g.es('\n'.join(log))
+        return w
+
+    def find_widget(self, name, debug=False):
+        log = ['\n']
+        log.append('Running find_widget()')
+        w = None
+        # Weird - g.app.gui.find_widget_by_name() may not find object in ourself
+        w = self.created_splitter_dict.get(name)
+        log.append(f'---- self.created_splitter_dict.get(name) returned: {w}')
+
+        w1 = self.find_widget_in_children(name, debug)
+        log.append(f'---- self.find_widget_in_children(name) returned: {w1}')
+        if w1 is not None and w is not None:
+            w = w1
+
+        w2 = g.app.gui.find_widget_by_name(self.c, name)
+        log.append(f'----g.app.gui.find_widget_by_name(self.c, name) returned: {w2}')
+        if (w1 is not None and w2 is not None) and w1 != w2:
+            log.append(f'---- Inconsistent splitter objects: w1 != w2: {w1}, {w2}')
+        elif w2 is not None and w is None:
+            w = w2
+
+
+        # if (w := self.created_splitter_dict.get(name)) is not None:
+            # log.append(f'---- self.created_splitter_dict.get(name) returned: {w}')
+        # elif (w := self.find_widget_in_children(name, debug)) is not None:
+            # log.append(f'---- self.find_widget_in_children(name) returned: {w}')
+        # elif (w := g.app.gui.find_widget_by_name(self.c, name)) is not None:
+            # log.append(f'     g.app.gui.find_widget_by_name(self.c, name) returned: {w}')
+        if debug:
+            print('\n'.join(log))
+        return w
+
+    #@-<< find_widget() >>
+    #@+<< find_splitter_by_name() >>
+    #@+node:tom.20240923194438.5: ** << find_splitter_by_name() >>
+    def find_splitter_by_name(self, name):
+        foundit = False
+        splitter = None
+        splitter = self.find_widget(name)
+        if splitter:
+            foundit = True
+        if not foundit:
+            splitter = self.created_splitter_dict.get(name)
+            if splitter:
+                foundit = True
+        if not foundit:
+            for kid in self.children():
+                if kid.objectName() == name:
+                    foundit = True
+                    splitter = kid
+                    break
+        return splitter
+    #@-<< find_splitter_by_name() >>
+
+    def restoreFromLayout(self, layout=FALLBACK_LAYOUT):
+        #@+<< restoreFromLayout >>
+        #@+node:tom.20240923194438.6: ** << restoreFromLayout >>
+        #@+<< initialize data structures >>
+        #@+node:tom.20240923194438.7: *3* << initialize data structures >>
+        SPLITTERS = layout['SPLITTERS']
+        ORIENTATIONS = layout['ORIENTATIONS']
+
+        # Make unknown splitters
+        for _, name in SPLITTERS.items():
+            splitter = self.find_splitter_by_name(name)
+            # g.es(f'self.find_splitter_by_name({name}) returned {splitter}')
+            # g.es('    splitter is None:', splitter is None)
+            if splitter is None:
+                splitter = QtWidgets.QSplitter(self)
+                splitter.setObjectName(name)
+                self.created_splitter_dict[name] = splitter
+                # g.es(f'Created splitter {splitter.objectName()=}  {splitter=}  {splitter.parent().objectName()=}')
+
+        SPLITTER_DICT = OrderedDict()
+        for name in ORIENTATIONS:
+            splitter = self.find_splitter_by_name(name)
+            if splitter is None:
+                splitter = self.created_splitter_dict[name]
+            SPLITTER_DICT[name] = splitter
+        #@-<< initialize data structures >>
+        #@+<< rehome body editor >>
+        #@+node:tom.20240923194438.8: *3* << rehome body editor >>
+        # In case the editor has been moved to e.g. a QTabWidget,
+        # Move it back to its standard place.
+
+        bsw = self.find_widget('bodyStackedWidget')
+        editor = self.find_widget('bodyPage2')
+        if bsw.indexOf(editor) == -1:
+            bsw.insertWidget(0, editor)
+        bsw.setCurrentIndex(0)
+        #@-<< rehome body editor >>
+        #@+<< clean up splitters >>
+        #@+node:tom.20240923194438.9: *3* << clean up splitters >>
+        # Remove extra (no longer wanted) widgets to the cache.
+        # Then insert the required widgets into their home splitters
+
+        # ESSENTIALS: {'outlineFrame':'secondary_splitter',...}
+        # SPLITTERS: {'main_splitter':ms, ...}
+
+        # Cache widgets we don't want
+        desired_widget_names = list(SPLITTERS.keys())
+        cache_list = []
+        for splitter in SPLITTER_DICT.values():
+            for i in range(splitter.count()):
+                widget = splitter.widget(i)
+                try:
+                    objname = widget.objectName()
+                # Probably can't happen but just in case
+                except Exception:
+                    objname = ''
+                    continue
+                if objname and objname not in desired_widget_names:
+                    cache_list.append(widget)
+
+        for widget in cache_list:
+            if widget not in self.children():
+                widget.setParent(self)
+            # if widget.objectName() == 'layout_quad_splitter':
+                # g.es('.... reparented from cache_list:', widget.objectName(), widget)
+
+        for splitter in self.created_splitter_dict.values():
+            if splitter not in self.children():
+                splitter.setParent(self)
+                # g.es('.... reparented from created_splitter_dict.values():',splitter.objectName(), splitter) 
+
+        #@-<< clean up splitters >>
+        #@+<< move widgets to targets >>
+        #@+node:tom.20240923194438.10: *3* << move widgets to targets >>
+        # Move all desired widgets into their home splitters
+        # SPLITTERS is an OrderedDict so the widgets will
+        # be inserted in the right order.
+        for i, (name, target) in enumerate(SPLITTERS.items()):
+            widget = self.find_widget(name)
+            if not widget:
+                widget = self.created_splitter_dict[name]
+            dest = SPLITTER_DICT[target]
+            dest.insertWidget(i, widget)
+        #@-<< move widgets to targets >>
+        #@+<< set default orientations >>
+        #@+node:tom.20240923194438.11: *3* << set default orientations >>
+        # SPLITTER_DICT: {'main_splitter':ms, ...}
+        # DEFAULT_ORIENTATIONS:
+        # {'main_splitter':Orientation.Horizontal...}
+
+        for splitter_name, splitter in SPLITTER_DICT.items():
+            orientation = ORIENTATIONS[splitter_name]
+            splitter.setOrientation(orientation)
+        #@-<< set default orientations >>
+        #@+<< resize splitters >>
+        #@+node:tom.20240923194438.12: *3* << resize splitters >>
+        for splt in SPLITTER_DICT.values():
+            g.app.gui.equalize_splitter(splt)
+        #@-<< resize splitters >>
+        editor.show()
+        #@-<< restoreFromLayout >>
+
+
+#@-leo

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -2,8 +2,9 @@
 #@+node:tom.20240923194438.1: * @file ../plugins/qt_layout.py
 """The basic machinery to support applying layouts of the main Leo panels."""
 from __future__ import annotations
-#@+<< imports >>
-#@+node:tom.20240923194438.2: ** << imports >>
+
+#@+others
+#@+node:tom.20240923194438.2: ** imports
 from collections import OrderedDict
 from typing import Any, TYPE_CHECKING
 
@@ -17,17 +18,14 @@ if TYPE_CHECKING:  # pragma: no cover
     # from typing import TypeAlias  # Requires Python 3.12+
     Args = Any
     KWargs = Any
-#@-<< imports >>
-
+#@+node:tom.20240930101302.1: ** Declarations
 CACHENAME = 'leo-layout-cache'
+FALLBACK_LAYOUT_NAME = 'layout-fallback-layout'
 
 def show_vr_pane(c, w):
     w.setUpdatesEnabled(True)
     c.doCommandByName('vr-show')
-
-
-#@+<< FALLBACK_LAYOUT >>
-#@+node:tom.20240923194438.3: ** << FALLBACK_LAYOUT >>
+#@+node:tom.20240923194438.3: ** FALLBACK_LAYOUT
 FALLBACK_LAYOUT = {
     'SPLITTERS':OrderedDict(
                     (('outlineFrame', 'secondary_splitter'),
@@ -40,16 +38,44 @@ FALLBACK_LAYOUT = {
     'secondary_splitter':Orientation.Vertical}
     }
 
-@g.command('layout-fallback-layout')
+@g.command(FALLBACK_LAYOUT_NAME)
 def fallback_layout(event: LeoKeyEvent) -> None:
     """Apply a workable layout in case the layout setting is invalid."""
     c = event.get('c')
     dw = c.frame.top
     cache = dw.layout_cache
     cache.restoreFromLayout(FALLBACK_LAYOUT)
-#@-<< FALLBACK_LAYOUT >>
-#@+<< Built-in Layouts >>
-#@+node:tom.20240928165801.1: ** << Built-in Layouts >>
+#@+node:tom.20240930101515.1: ** restoreDefaultLayout
+@g.command('layout-restore-default')
+def restoreDefaultLayout(event: LeoKeyEvent) -> None:
+    """Restore the default layout specified in @settings, if known."""
+    c = event.get('c')
+    if not c:
+        return
+    event = g.app.gui.create_key_event(c)
+
+    found_layout = False
+    layout = default_layout = c.config.getString('qt-layout-name')
+    if not layout:
+        layout = FALLBACK_LAYOUT_NAME
+    elif default_layout.startswith('layout-'):
+        if default_layout in c.commandsDict:
+            found_layout = True
+    else:
+        layout = 'layout-' + default_layout
+        if layout in c.commandsDict:
+            found_layout =True
+        elif default_layout in c.commandsDict:
+            layout = default_layout
+            found_layout = True
+        else:
+            g.es(f'Cannot find command {layout} or {default_layout}')
+
+    if found_layout:
+        g.es(f'Restoring {layout} layout')
+        c.commandsDict[layout](event)
+
+#@+node:tom.20240928165801.1: ** Built-in Layouts
 # Define commands to create some standard layouts
 #@+others
 #@+node:tom.20240928195823.1: *3* legacy
@@ -120,42 +146,6 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
     import leo.plugins.viewrendered3 as v3
     v3.getVr3({'c':c})
     cache.restoreFromLayout(HORIZONTAL_THIRDS_LAYOUT)
-#@+node:tom.20240929125857.1: *3* xhorizontal-thirds
-@g.command('xlayout-horizontal-thirds')
-def xhorizontal_thirds(event: LeoKeyEvent) -> None:
-    """Restore Leo's horizontal-thirds layout"""
-
-    c = event.get('c')
-    cache = c.frame.top.layout_cache
-    cache.restoreFromLayout()
-
-    ms = cache.find_widget('main_splitter')
-    ss = cache.find_widget('secondary_splitter')
-    lf = cache.find_widget('logFrame')
-    bf = cache.find_widget('bodyFrame')
-    of = cache.find_widget('outlineFrame')
-
-    vr = cache.find_widget('viewrendered_pane')
-    if vr is None:
-        import leo.plugins.viewrendered as v
-        vr = v.getVr()
-
-    ms.setOrientation(Orientation.Vertical)
-    ss.setOrientation(Orientation.Horizontal)
-
-    ss.addWidget(of)
-    ss.addWidget(lf)
-    ms.addWidget(ss)
-    ms.addWidget(bf)
-    ms.addWidget(vr)
-
-    # c.doCommandByName('vr-show')
-    g.app.gui.equalize_splitter(ss)
-    g.app.gui.equalize_splitter(ms)
-
-    # Avoid flash each time VR pane is re-opened.
-    QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
-
 #@+node:tom.20240928171510.1: *3* big-tree
 @g.command ('layout-big-tree')
 def big_tree(event: LeoKeyEvent) -> None:
@@ -343,8 +333,47 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
     # ms.addWidget(vr)
     # QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
 #@-others
-#@-<< Built-in Layouts >>
+#@+node:tom.20240930164141.1: ** Other Layouts
+#@+node:tom.20240930164155.1: *3* Quadrant
+"""
+──────────────────────────┬───────────────────────────┐
+│                                                     |
+│       outline            │      log                 │
+|                                                     |
+├──────────────────────────┼──────────────────────────┤
+│                          │                          │
+│      body                │     vr                   │
+│                          │                          │
+└──────────────────────────┴──────────────────────────┘
+"""
+QUADRANT_LAYOUT = {
+    'SPLITTERS':OrderedDict(
+        (
+            ('bodyFrame', 'secondary_splitter'),
+            ('viewrendered_pane', 'secondary_splitter'),
+            ('outlineFrame', 'outline-log-splitter'),
+            ('logFrame', 'outline-log-splitter'),
+            ('outline-log-splitter', 'main_splitter'),
+            ('secondary_splitter', 'main_splitter'),
+        )
+    ),
+    'ORIENTATIONS':{
+        'outline-log-splitter':Orientation.Horizontal,
+        'secondary_splitter':Orientation.Horizontal,
+        'main_splitter':Orientation.Vertical,
+    }
+}
 
+@g.command('layout-quadrant')
+def quadrants(event: LeoKeyEvent) -> None:
+    """Create a "quadrant layout::
+
+    """
+    c = event.get('c')
+    dw = c.frame.top
+    cache = dw.layout_cache
+    cache.restoreFromLayout(QUADRANT_LAYOUT)
+#@+node:tom.20240930095459.1: ** class LayoutCacheWidget
 class LayoutCacheWidget(QWidget):
 
     def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
@@ -353,62 +382,39 @@ class LayoutCacheWidget(QWidget):
         self.setObjectName(CACHENAME)
         self.created_splitter_dict = {}
 
-    #@+<< find_widget() >>
-    #@+node:tom.20240923194438.4: ** << find_widget() >>
-    def find_widget_in_children(self, name, debug=False):
-        log = [f'==== find_widget_in_children for: {name}']
+    #@+others
+    #@+node:tom.20240923194438.4: *3* find_widget()
+    def find_widget_in_children(self, name):
         w = None
         for kid in self.children():
             if kid.objectName() == name:
-                log.append(f'======== found it: {kid}')
                 w = kid
-        if debug:
-            g.es('\n'.join(log))
         return w
 
-    def find_widget(self, name, debug=False):
-        log = ['\n']
-        log.append('Running find_widget()')
+    def find_widget(self, name):
         w = None
         # Weird - g.app.gui.find_widget_by_name() may not find object in ourself
         w = self.created_splitter_dict.get(name)
-        log.append(f'---- self.created_splitter_dict.get(name) returned: {w}')
 
-        w1 = self.find_widget_in_children(name, debug)
-        log.append(f'---- self.find_widget_in_children(name) returned: {w1}')
+        w1 = self.find_widget_in_children(name)
         if w1 is not None and w is not None:
             w = w1
 
         w2 = g.app.gui.find_widget_by_name(self.c, name)
-        log.append(f'----g.app.gui.find_widget_by_name(self.c, name) returned: {w2}')
-        if (w1 is not None and w2 is not None) and w1 != w2:
-            log.append(f'---- Inconsistent splitter objects: w1 != w2: {w1}, {w2}')
-        elif w2 is not None and w is None:
+        if w2 is not None and w is None:
             w = w2
-
-
-        # if (w := self.created_splitter_dict.get(name)) is not None:
-            # log.append(f'---- self.created_splitter_dict.get(name) returned: {w}')
-        # elif (w := self.find_widget_in_children(name, debug)) is not None:
-            # log.append(f'---- self.find_widget_in_children(name) returned: {w}')
-        # elif (w := g.app.gui.find_widget_by_name(self.c, name)) is not None:
-            # log.append(f'     g.app.gui.find_widget_by_name(self.c, name) returned: {w}')
-        if debug:
-            print('\n'.join(log))
         return w
 
-    #@-<< find_widget() >>
-    #@+<< find_splitter_by_name() >>
-    #@+node:tom.20240923194438.5: ** << find_splitter_by_name() >>
+    #@+node:tom.20240923194438.5: *3* find_splitter_by_name()
     def find_splitter_by_name(self, name):
         foundit = False
         splitter = None
         splitter = self.find_widget(name)
-        if splitter:
+        if splitter is not None:
             foundit = True
         if not foundit:
             splitter = self.created_splitter_dict.get(name)
-            if splitter:
+            if splitter is not None:
                 foundit = True
         if not foundit:
             for kid in self.children():
@@ -417,26 +423,20 @@ class LayoutCacheWidget(QWidget):
                     splitter = kid
                     break
         return splitter
-    #@-<< find_splitter_by_name() >>
-
+    #@+node:tom.20240923194438.6: *3* restoreFromLayout
     def restoreFromLayout(self, layout=FALLBACK_LAYOUT):
-        #@+<< restoreFromLayout >>
-        #@+node:tom.20240923194438.6: ** << restoreFromLayout >>
         #@+<< initialize data structures >>
-        #@+node:tom.20240923194438.7: *3* << initialize data structures >>
+        #@+node:tom.20240923194438.7: *4* << initialize data structures >>
         SPLITTERS = layout['SPLITTERS']
         ORIENTATIONS = layout['ORIENTATIONS']
 
         # Make unknown splitters
         for _, name in SPLITTERS.items():
             splitter = self.find_splitter_by_name(name)
-            # g.es(f'self.find_splitter_by_name({name}) returned {splitter}')
-            # g.es('    splitter is None:', splitter is None)
             if splitter is None:
                 splitter = QtWidgets.QSplitter(self)
                 splitter.setObjectName(name)
                 self.created_splitter_dict[name] = splitter
-                # g.es(f'Created splitter {splitter.objectName()=}  {splitter=}  {splitter.parent().objectName()=}')
 
         SPLITTER_DICT = OrderedDict()
         for name in ORIENTATIONS:
@@ -447,7 +447,7 @@ class LayoutCacheWidget(QWidget):
                  SPLITTER_DICT[name] = splitter
         #@-<< initialize data structures >>
         #@+<< rehome body editor >>
-        #@+node:tom.20240923194438.8: *3* << rehome body editor >>
+        #@+node:tom.20240923194438.8: *4* << rehome body editor >>
         # In case the editor has been moved to e.g. a QTabWidget,
         # Move it back to its standard place.
 
@@ -458,7 +458,7 @@ class LayoutCacheWidget(QWidget):
         bsw.setCurrentIndex(0)
         #@-<< rehome body editor >>
         #@+<< clean up splitters >>
-        #@+node:tom.20240923194438.9: *3* << clean up splitters >>
+        #@+node:tom.20240923194438.9: *4* << clean up splitters >>
         # Remove extra (no longer wanted) widgets to the cache.
         # Then insert the required widgets into their home splitters
 
@@ -483,31 +483,14 @@ class LayoutCacheWidget(QWidget):
         for widget in cache_list:
             if widget not in self.children():
                 widget.setParent(self)
-            # if widget.objectName() == 'layout_quad_splitter':
-                # g.es('.... reparented from cache_list:', widget.objectName(), widget)
 
         for splitter in self.created_splitter_dict.values():
             if splitter not in self.children():
                 splitter.setParent(self)
-                # g.es('.... reparented from created_splitter_dict.values():',splitter.objectName(), splitter) 
 
         #@-<< clean up splitters >>
-        #@+<< move widgets to targets >>
-        #@+node:tom.20240923194438.10: *3* << move widgets to targets >>
-        # Move all desired widgets into their home splitters
-        # SPLITTERS is an OrderedDict so the widgets will
-        # be inserted in the right order.
-        for i, (name, target) in enumerate(SPLITTERS.items()):
-            widget = self.find_widget(name)
-            if not widget:
-                g.es('===', name)
-                widget = self.created_splitter_dict[name]
-            dest = SPLITTER_DICT.get(target)
-            if dest:
-                dest.insertWidget(i, widget)
-        #@-<< move widgets to targets >>
         #@+<< set default orientations >>
-        #@+node:tom.20240923194438.11: *3* << set default orientations >>
+        #@+node:tom.20240923194438.11: *4* << set default orientations >>
         # SPLITTER_DICT: {'main_splitter':ms, ...}
         # DEFAULT_ORIENTATIONS:
         # {'main_splitter':Orientation.Horizontal...}
@@ -516,13 +499,32 @@ class LayoutCacheWidget(QWidget):
             orientation = ORIENTATIONS[splitter_name]
             splitter.setOrientation(orientation)
         #@-<< set default orientations >>
+        #@+<< move widgets to targets >>
+        #@+node:tom.20240923194438.10: *4* << move widgets to targets >>
+        # Move all desired widgets into their home splitters
+        # SPLITTERS is an OrderedDict so the widgets will
+        # be inserted in the right order.
+
+        splitter_index = {}
+        for name, target in SPLITTERS.items():
+            widget = self.find_widget(name)
+            if widget is None:
+                widget = self.created_splitter_dict[name]
+            dest = SPLITTER_DICT.get(target)
+            i = splitter_index[dest] = splitter_index.get(dest, -1) + 1
+            if dest is not None:
+                dest.insertWidget(i, widget)
+        #@-<< move widgets to targets >>
         #@+<< resize splitters >>
-        #@+node:tom.20240923194438.12: *3* << resize splitters >>
+        #@+node:tom.20240923194438.12: *4* << resize splitters >>
         for splt in SPLITTER_DICT.values():
+            g.es('Resizing', splt.objectName())
             g.app.gui.equalize_splitter(splt)
+
         #@-<< resize splitters >>
         editor.show()
-        #@-<< restoreFromLayout >>
+    #@-others
 
+#@-others
 
 #@-leo

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -391,7 +391,7 @@ class LayoutCacheWidget(QWidget):
                 w = kid
         return w
 
-    def find_widget(self, name):
+    def xfind_widget(self, name):
         w = None
         # Weird - g.app.gui.find_widget_by_name() may not find object in ourself
         w = self.created_splitter_dict.get(name)
@@ -405,6 +405,8 @@ class LayoutCacheWidget(QWidget):
             w = w2
         return w
 
+    def find_widget(self, name):
+        return g.app.gui.find_widget_by_name(self.c, name)
     #@+node:tom.20240923194438.5: *3* find_splitter_by_name()
     def find_splitter_by_name(self, name):
         foundit = False
@@ -518,7 +520,6 @@ class LayoutCacheWidget(QWidget):
         #@+<< resize splitters >>
         #@+node:tom.20240923194438.12: *4* << resize splitters >>
         for splt in SPLITTER_DICT.values():
-            g.es('Resizing', splt.objectName())
             g.app.gui.equalize_splitter(splt)
 
         #@-<< resize splitters >>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -53,6 +53,41 @@ def fallback_layout(event: LeoKeyEvent) -> None:
 #@+node:tom.20240928165801.1: ** << Built-in Layouts >>
 # Define commands to create some standard layouts
 #@+others
+#@+node:tom.20240928195823.1: *3* legacy
+# Recreate the layout called "legacy" in the Dynamic Window code.
+LEGACY_LAYOUT = {
+    'SPLITTERS':OrderedDict(
+            (('outlineFrame', 'secondary_splitter'),
+            ('logFrame', 'secondary_splitter'),
+            ('bodyFrame', 'body-vr-splitter'),
+            ('viewrendered_pane', 'body-vr-splitter'),
+            ('secondary_splitter', 'main_splitter'),
+            ('body-vr-splitter', 'main_splitter'))
+        ),
+    'ORIENTATIONS':{
+        'body-vr-splitter':Orientation.Horizontal,
+        'secondary_splitter':Orientation.Horizontal,
+        'main_splitter':Orientation.Vertical
+    }
+}
+
+@g.command('layout-legacy')
+def layout_legacy(event: LeoKeyEvent) -> None:
+    """Create Leo's legacy layout."""
+    c = event.get('c')
+    dw = c.frame.top
+    cache = dw.layout_cache
+    cache.restoreFromLayout(LEGACY_LAYOUT)
+
+    # Find or create VR widget
+    vr = cache.find_widget('viewrendered_pane')
+    if not vr:
+        import leo.plugins.viewrendered as v
+        vr = v.getVr()
+
+    bvs = cache.find_widget('body-vr-splitter')
+    bvs.addWidget(vr)
+    c.doCommandByName('vr-show')
 #@+node:tom.20240928170706.1: *3* horizontal-thirds
 @g.command('layout-horizontal-thirds')
 def horizontal_thirds(event: LeoKeyEvent) -> None:
@@ -151,31 +186,38 @@ def big_tree(event: LeoKeyEvent) -> None:
     # Avoid flash each time VR pane is re-opened.
     QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
 
-#@+node:tom.20240928195823.1: *3* legacy
-# Recreate the layout called "legacy" in the Dynamic Widnow code.
-LEGACY_LAYOUT = {
+#@+node:tom.20240929101820.1: *3* render-focused
+RENDERED_FOCUSED_LAYOUT = {
     'SPLITTERS':OrderedDict(
             (('outlineFrame', 'secondary_splitter'),
+            ('bodyFrame', 'secondary_splitter'),
             ('logFrame', 'secondary_splitter'),
-            ('bodyFrame', 'body-vr-splitter'),
             ('viewrendered_pane', 'body-vr-splitter'),
             ('secondary_splitter', 'main_splitter'),
             ('body-vr-splitter', 'main_splitter'))
         ),
     'ORIENTATIONS':{
         'body-vr-splitter':Orientation.Horizontal,
-        'secondary_splitter':Orientation.Horizontal,
-        'main_splitter':Orientation.Vertical
+        'secondary_splitter':Orientation.Vertical,
+        'main_splitter':Orientation.Horizontal
     }
 }
 
-@g.command('layout-legacy')
-def layout_legacy(event: LeoKeyEvent) -> None:
-    """Create Leo's legacy layout."""
+@g.command('layout-render-focused')
+def render_focused(event: LeoKeyEvent) -> None:
+    """Create Leo's render-focused layout::
+        ┌───────────┬─────┐
+        │ outline   │     │
+        ├───────────┤     │
+        │ body      │ VR  │
+        ├───────────┤     │
+        │ log       │     │
+        └───────────┴─────┘
+    """
     c = event.get('c')
     dw = c.frame.top
     cache = dw.layout_cache
-    cache.restoreFromLayout(LEGACY_LAYOUT)
+    cache.restoreFromLayout(RENDERED_FOCUSED_LAYOUT)
 
     # Find or create VR widget
     vr = cache.find_widget('viewrendered_pane')
@@ -185,20 +227,90 @@ def layout_legacy(event: LeoKeyEvent) -> None:
 
     bvs = cache.find_widget('body-vr-splitter')
     bvs.addWidget(vr)
-    c.doCommandByName('vr-show')
-    g.app.gui.equalize_splitter(bvs)
-#@-others
 
-#@+at
-# From DW:
-#     layout_dict = {
-#         'big-tree': self.create_big_tree_layout,
-#         'horizontal-thirds': self.create_horizontal_thirds_layout,
-#         'legacy': self.create_legacy_layout,
-#         'render-focused': self.create_render_focused_layout,
-#         'vertical-thirds': self.create_vertical_thirds_layout,
-#         'vertical-thirds2': self.create_vertical_thirds2_layout,
-#     }
+    QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
+#@+node:tom.20240929104728.1: *3* vertical-thirds
+VERTICAL_THIRDS_LAYOUT = {
+    'SPLITTERS':OrderedDict(
+            (('outlineFrame', 'secondary_splitter'),
+            ('logFrame', 'secondary_splitter'),
+            ('secondary_splitter', 'main_splitter'),
+            ('bodyFrame', 'main_splitter'),
+            ('viewrendered_pane', 'main_splitter'))
+        ),
+    'ORIENTATIONS':{
+        'secondary_splitter':Orientation.Vertical,
+        'main_splitter':Orientation.Horizontal
+    }
+}
+
+
+@g.command('layout-vertical-thirds')
+def vertical_thirds(event: LeoKeyEvent) -> None:
+    """Create Leo's vertical-thirds layout::
+        ┌───────────┬────────┬──────┐
+        │  outline  │        │      │
+        ├───────────┤  body  │  VR  │
+        │  log      │        │      │
+        └───────────┴────────┴──────┘
+    """
+    c = event.get('c')
+    dw = c.frame.top
+    cache = dw.layout_cache
+    cache.restoreFromLayout(VERTICAL_THIRDS_LAYOUT)
+
+    # Find or create VR widget
+    vr = cache.find_widget('viewrendered_pane')
+    if not vr:
+        import leo.plugins.viewrendered as v
+        vr = v.getVr()
+
+    ms = cache.find_widget('main_splitter')
+    ms.addWidget(vr)
+    QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
+#@+node:tom.20240929115043.1: *3* vertical-thirds2
+VERTICAL_THIRDS2_LAYOUT = {
+    'SPLITTERS':OrderedDict(
+            (('logFrame', 'secondary_splitter'),
+            ('bodyFrame', 'secondary_splitter'),
+            ('outlineFrame', 'main_splitter'),
+            ('viewrendered_pane', 'vr-splitter'),
+            ('secondary_splitter', 'main_splitter'),
+            ('vr-splitter', 'main_splitter')
+            )
+        ),
+    'ORIENTATIONS':{
+        'vr-splitter':Orientation.Vertical,
+        'secondary_splitter':Orientation.Vertical,
+        'main_splitter':Orientation.Horizontal
+    }
+}
+
+
+@g.command('layout-vertical-thirds2')
+def vertical_thirds2(event: LeoKeyEvent) -> None:
+    """Create Leo's vertical-thirds2 layout::
+        ┌───────────┬───────┬───────┐
+        │           │  log  │       │
+        │  outline  ├───────┤  VR   │
+        │           │  body │       │
+        └───────────┴───────┴───────┘
+    """
+    c = event.get('c')
+    dw = c.frame.top
+    cache = dw.layout_cache
+    cache.restoreFromLayout(VERTICAL_THIRDS2_LAYOUT)
+
+    # Find or create VR widget
+    vr = cache.find_widget('viewrendered_pane')
+    if not vr:
+        import leo.plugins.viewrendered as v
+        vr = v.getVr()
+
+    ms = cache.find_widget('vr-splitter')
+    ms.addWidget(vr)
+    QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
+#@-others
 #@-<< Built-in Layouts >>
 
 class LayoutCacheWidget(QWidget):

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -72,7 +72,6 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
             g.es(f'Cannot find command {layout} or {default_layout}')
 
     if found_layout:
-        g.es(f'Restoring {layout} layout')
         c.commandsDict[layout](event)
 
 #@+node:tom.20240928165801.1: ** Built-in Layouts

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 from collections import OrderedDict
 from typing import Any, TYPE_CHECKING
 
-from leo.core.leoQt import QtWidgets, Orientation
+from leo.core.leoQt import QtWidgets, Orientation, QtCore
 # from leo.core.leoCommands import Commands as Cmdr
 from leo.core import leoGlobals as g
-
-import leo.plugins.viewrendered as v
 
 QWidget = QtWidgets.QWidget
 if TYPE_CHECKING:  # pragma: no cover
@@ -23,6 +21,12 @@ if TYPE_CHECKING:  # pragma: no cover
 #@-<< imports >>
 
 CACHENAME = 'leo-layout-cache'
+
+def show_vr_pane(c, w):
+    w.setUpdatesEnabled(True)
+    c.doCommandByName('vr-show')
+
+
 #@+<< FALLBACK_LAYOUT >>
 #@+node:tom.20240923194438.3: ** << FALLBACK_LAYOUT >>
 FALLBACK_LAYOUT = {
@@ -66,7 +70,7 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
 
     vr = cache.find_widget('viewrendered_pane')
     if vr is None:
-        # import leo.plugins.viewrendered as v
+        import leo.plugins.viewrendered as v
         vr = v.getVr()
 
     ms.setOrientation(Orientation.Vertical)
@@ -78,10 +82,13 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
     ms.addWidget(bf)
     ms.addWidget(vr)
 
+    # c.doCommandByName('vr-show')
     g.app.gui.equalize_splitter(ss)
     g.app.gui.equalize_splitter(ms)
 
-    c.doCommandByName('vr-show')
+    # Avoid flash each time VR pane is re-opened.
+    QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
+
 #@+node:tom.20240928171510.1: *3* big-tree
 @g.command ('layout-big-tree')
 def big_tree(event: LeoKeyEvent) -> None:
@@ -107,6 +114,7 @@ def big_tree(event: LeoKeyEvent) -> None:
     # Find or create VR widget
     vr = cache.find_widget('viewrendered_pane')
     if not vr:
+        import leo.plugins.viewrendered as v
         vr = v.getVr()
 #@+at
 #     # For VR3 instead
@@ -140,6 +148,9 @@ def big_tree(event: LeoKeyEvent) -> None:
     ms.setSizes([100_000] * len(ms.sizes()))
     ss.setSizes([100_000] * len(ss.sizes()))
 
+    # Avoid flash each time VR pane is re-opened.
+    QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
+
 #@+node:tom.20240928195823.1: *3* legacy
 # Recreate the layout called "legacy" in the Dynamic Widnow code.
 LEGACY_LAYOUT = {
@@ -169,7 +180,7 @@ def layout_legacy(event: LeoKeyEvent) -> None:
     # Find or create VR widget
     vr = cache.find_widget('viewrendered_pane')
     if not vr:
-        # import leo.plugins.viewrendered as v
+        import leo.plugins.viewrendered as v
         vr = v.getVr()
 
     bvs = cache.find_widget('body-vr-splitter')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2086,7 +2086,7 @@ def shrink_view(event):
 #@+node:tom.20230403141635.1: *3* g.command('vr3-tab')
 @g.command('vr3-tab')
 def viewrendered_tab(event):
-    """Open VR3 in a tab in commander's log framer"""
+    """Open VR3 in a tab in commander's log framer""
     # global controllers
     if g.app.gui.guiName() != 'qt':
         return

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1547,12 +1547,11 @@ def decorate_window(w):
     g.app.gui.attachLeoIcon(w)
     w.resize(600, 300)
 #@+node:TomP.20191215195433.9: *3* vr3.init
-def init():
+def init() -> bool:
     """Return True if the plugin has loaded successfully."""
     # global got_docutils
-    if g.app.gui.guiName() != 'qt':
-        return False  # #1248.
-    # if g.app.gui.guiName()
+    if not g.app.gui.guiName().startswith('qt'):
+        return False
     if not QtWidgets or not g.app.gui.guiName().startswith('qt'):
         if (
             not g.unitTesting
@@ -1562,8 +1561,8 @@ def init():
             g.es_print('viewrendered3 requires Qt')
         return False
     if not has_webengineview:
-        g.es_print('viewrendered3.py requires PyQtWebEngine')
-        g.es_print('pip install PyQtWebEngine')
+        g.es_print('viewrendered3.py requires PyQt6-WebEngine')
+        g.es_print('pip install PyQt6-WebEngine')
         return False
     if not got_docutils:
         g.es_print('Warning: viewrendered3.py running without docutils.')
@@ -1572,6 +1571,7 @@ def init():
     g.registerHandler('after-create-leo-frame', onCreate)
     g.registerHandler('close-frame', onClose)
     g.registerHandler('scrolledMessage', show_scrolled_message)
+
     return True
 #@+node:TomP.20191215195433.10: *3* vr3.isVisible
 def xisVisible():
@@ -1580,6 +1580,18 @@ def xisVisible():
 #@+node:TomP.20191215195433.11: *3* vr3.onCreate
 def onCreate(tag, keys):
     pass
+
+#@+at
+# def onCreate(tag: str, keys: dict) -> None:
+#     c = keys.get('c')
+#     if not c:
+#         return
+#     vr = getVr(c=c)
+#     g.registerHandler('select2', vr.update)
+#     g.registerHandler('idle', vr.update)
+#     vr.active = True
+#     vr.is_visible = False
+#     vr.hide()
 #@+node:TomP.20191215195433.12: *3* vr3.onClose
 def onClose(tag, keys):
     c = keys.get('c')
@@ -1594,23 +1606,23 @@ def onClose(tag, keys):
 def show_scrolled_message(tag, kw):
     """Show "scrolled message" in VR3.
 
-    If not already open, open in last opened position,
-    or in splitter if none.
+    If not already open, open in last opened splitter,
+    or in main splitter if none.
     """
     if g.unitTesting:
         return None  # This just slows the unit tests.
 
     c = kw.get('c')
     flags = kw.get('flags') or 'rst'
-    h = c.hash()
-    vr3 = controllers.get(h, None)
-    started_vr3 = False
-    if not vr3:
-        if positions.get(h, None) is None or OPENED_IN_SPLITTER:
-            vr3 = viewrendered(event=kw)
-        else:
-            vr3 = viewrendered_tab(event=kw)
-        started_vr3 = True
+    dw = c.frame.top
+    cache = dw.layout_cache
+
+    vr3 = getVr3({'c':c})
+    if vr3.parent() == cache:
+        # Not already in another layout
+        ms = cache.find_widget('main_splitter')
+        ms.addWidget(vr3)
+        g.app.gui.equalize_splitter(ms)
 
     title = kw.get('short_title', '').strip()
     vr3.setWindowTitle(title)
@@ -1621,16 +1633,18 @@ def show_scrolled_message(tag, kw):
         kw.get('msg')
     ])
 
-    delay = 500 if started_vr3 else 0
+    delay = 500# if started_vr3 else 0
 
     def do_scrolled_msg(vr3, s, flags):
         vr3.update(
             tag='show-scrolled-message',
             keywords={'c': c, 'force': True, 's': s, 'flags': flags},
         )
+        vr3.setVisible(True)
+        vr3.show()
 
-        if not vr3.isVisible:
-            vr3.show()
+        # if not vr3.isVisible:
+            # vr3.show()
 
     QtCore.QTimer.singleShot(delay, lambda: do_scrolled_msg(vr3, s, flags))
     return True
@@ -1684,14 +1698,23 @@ def getVr3(event):
 
     if not (vr3 := controllers.get(h)):
         controllers[h] = vr3 = ViewRenderedController3(c)
-        positions[h] = None
+        dw = c.frame.top
+        vr3.setParent(dw.layout_cache)
 
     return vr3
 #@+node:TomP.20191215195433.16: ** vr3.Commands
 #@+node:TomP.20191215195433.18: *3* g.command('vr3')
 @g.command('vr3')
 def viewrendered(event):
-    """Open VR3 in this commander"""
+    """Create VR3 in this commander in not already created.
+    
+    The VR3 instance will be created as a child of the widget cache splitter
+    of the Dynamic Window that represents the Entire window of this outline.
+
+    The VR3 instance will not be visible until the 
+    vr3-show or vr3-toggle commands are executed, or until vr3.show() is
+    called.
+    """
     global controllers
     gui = g.app.gui
     if gui.guiName() != 'qt':
@@ -1699,16 +1722,8 @@ def viewrendered(event):
     c = event.get('c')
     if not c:
         return None
-    h = c.hash()
-    vr3 = controllers.get(h)
-    if vr3 and vr3.parent() is not None:
-        c.bodyWantsFocusNow()
-        return vr3
-    # Create the VR3 frame
-    controllers[h] = vr3 = ViewRenderedController3(c)
-    # Insert the VR3 pane into the layout.
-    dw = c.frame.top
-    dw.insert_vr_frame(vr3)
+
+    vr3 = getVr3({'c':c})
     return vr3
 #@+node:TomP.20200112232719.1: *3* g.command('vr3-execute')
 @g.command('vr3-execute')
@@ -2100,29 +2115,22 @@ def toggle_rendering_pane(event):
 
     h = c.hash()
     vr3 = controllers.get(h)
-    if vr3:
-        had_vr3 = True
-    else:
+    if not vr3:
         vr3 = getVr3({'c': c})
-        had_vr3 = False
 
-    if had_vr3:
-        if vr3.isVisible():
-            vr3.hide()
-            vr3.set_freeze()
-        elif vr3.parent() is None or vr3.parent().objectName() == 'leo-layout-cache':
-            c.doCommandByName('vr3-toggle-tab')
-        else:
-            vr3.setVisible(True)
-            vr3.show()
-            vr3.set_unfreeze()
-    else:
+    if vr3.isVisible():
+        vr3.hide()
+        vr3.set_freeze()
+    elif vr3.parent() is None or vr3.parent().objectName() == 'leo-layout-cache':
         ms = g.app.gui.find_widget_by_name(c, 'main_splitter')
         ms.addWidget(vr3)
         ms.setSizes([100_000] * len(ms.sizes()))
         vr3.show()
         vr3.set_unfreeze()
-        positions[h] = OPENED_IN_SPLITTER
+    else:
+        vr3.setVisible(True)
+        vr3.show()
+        vr3.set_unfreeze()
 #@+node:tom.20230403190542.1: *3* g.command('vr3-toggle-tab')
 @g.command('vr3-toggle-tab')
 def toggle_rendering_pane_tab(event):
@@ -2256,6 +2264,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.base_url = ''
         self.positions = {}
         self.last_update_was_node_change = False
+        self.setObjectName('viewrendered3_pane')
+
         #@-<< initialize configuration ivars >>
         #@+<< asciidoc-specific >>
         #@+node:tom.20240919181508.1: *4* << asciidoc-specific >>
@@ -2353,7 +2363,6 @@ class ViewRenderedController3(QtWidgets.QWidget):
         if g.unitTesting:
             return
         # Create the inner contents.
-        self.setObjectName('viewrendered3_pane')
         self.setLayout(QtWidgets.QVBoxLayout())
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.create_toolbar()
@@ -4804,6 +4813,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             self.inited = self.active = True
             g.registerHandler('select2', self.update)
             g.registerHandler('idle', self.update)
+            self.hide()
     #@+node:TomP.20200329230436.4: *5* vr3.deactivate
     def deactivate(self):
         """Deactivate the vr3 window."""


### PR DESCRIPTION
Implements a new layout system:
- [x] Adds a new _LayoutCacheWidget_ class to cache unused splitters and widgets for reuse;
- [x] Dynamic Window  hosts an instance of _LayoutCacheWidget_;
- [x]  _LayoutCacheWidget_ contains methods to create layouts from layout descriptors;
- [x] New file _plugins/qt_layout.py_ contains _LayoutCacheWidget_ and all the current built-in layouts;
- [x] All layouts can be applied without restarting the outline;
- [x] The default layout specified in the applicable @settings tree can be re-applied without restarting the outline.
- [x] The _DynamicWindow_ startup sequence that creates the initial layout is unchanged;
- [x] `g.app.gui.find_widgets_by_name()` is fixed so it no longer fails to find some widgets;
- [x] Some VR3 commands are adjusted to work better with this new system.
- [ ] For layouts that can take either VR or VR3, generalize the layout structure to allow user to choose which of these alternatives to use in a layout.
- [ ] Decide if VR/VR3 should be visible when a layout that contains them is applied.

qt_layout.py contains minibuffer commands to create all the layouts.  They all start with "layout-".  For the time being, layouts that expect to have VR or VR3 in one of the frames create the frame but do not actually open VR/VR3. They can be displayed in their frame by "vrx-toggle" or "vrx-show" commands.

A companion outline containing a custom menu with many of the new commands, and other layout commands, will be supplied separately.

This PR satisfies Issue https://github.com/leo-editor/leo-editor/issues/4076.
