### PR TITLE
PR for #4078: fix errors in PR #4077

### DIFF
--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -1,10 +1,11 @@
 #@+leo-ver=5-thin
 #@+node:tom.20240923194438.1: * @file ../plugins/qt_layout.py
 """The basic machinery to support applying layouts of the main Leo panels."""
+
+#@+<< qt_layout: imports >>
+#@+node:tom.20240923194438.2: ** << qt_layout: imports >>
 from __future__ import annotations
 
-#@+others
-#@+node:tom.20240923194438.2: ** imports
 from collections import OrderedDict
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -18,10 +19,17 @@ if TYPE_CHECKING:  # pragma: no cover
     # from typing import TypeAlias  # Requires Python 3.12+
     Args = Any
     KWargs = Any
-#@+node:tom.20240930101302.1: ** Declarations
+#@-<< qt_layout: imports >>
+
 CACHENAME = 'leo-layout-cache'
 FALLBACK_LAYOUT_NAME = 'layout-fallback-layout'
 
+#@+others
+#@+node:ekr.20241008141246.1: ** function: init
+def init() -> bool:
+    """Return True if this plugin should be enabled."""
+    return True
+#@+node:ekr.20241008141353.1: ** function: show_vr_pane
 def show_vr_pane(c, w):
     w.setUpdatesEnabled(True)
     c.doCommandByName('vr-show')

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 #@+others
 #@+node:tom.20240923194438.2: ** imports
 from collections import OrderedDict
-from typing import Any, TYPE_CHECKING
+from typing import Any, Dict, TYPE_CHECKING
 
 from leo.core.leoQt import QtWidgets, Orientation, QtCore
 from leo.core import leoGlobals as g
@@ -27,16 +27,17 @@ def show_vr_pane(c, w):
     c.doCommandByName('vr-show')
 #@+node:tom.20240923194438.3: ** FALLBACK_LAYOUT
 FALLBACK_LAYOUT = {
-    'SPLITTERS':OrderedDict(
-                    (('outlineFrame', 'secondary_splitter'),
-                    ('logFrame', 'secondary_splitter'),
-                    ('secondary_splitter', 'main_splitter'),
-                    ('bodyFrame', 'main_splitter'))
-                ),
-    'ORIENTATIONS':{
-    'main_splitter':Orientation.Horizontal,
-    'secondary_splitter':Orientation.Vertical}
+    'SPLITTERS': OrderedDict(
+        (('outlineFrame', 'secondary_splitter'),
+        ('logFrame', 'secondary_splitter'),
+        ('secondary_splitter', 'main_splitter'),
+        ('bodyFrame', 'main_splitter'))
+    ),
+    'ORIENTATIONS': {
+        'main_splitter': Orientation.Horizontal,
+        'secondary_splitter': Orientation.Vertical,
     }
+}
 
 @g.command(FALLBACK_LAYOUT_NAME)
 def fallback_layout(event: LeoKeyEvent) -> None:
@@ -64,7 +65,7 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
     else:
         layout = 'layout-' + default_layout
         if layout in c.commandsDict:
-            found_layout =True
+            found_layout = True
         elif default_layout in c.commandsDict:
             layout = default_layout
             found_layout = True
@@ -80,7 +81,7 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
 #@+node:tom.20240928195823.1: *3* legacy
 # Recreate the layout called "legacy" in the Dynamic Window code.
 LEGACY_LAYOUT = {
-    'SPLITTERS':OrderedDict(
+    'SPLITTERS': OrderedDict(
             (('outlineFrame', 'secondary_splitter'),
             ('logFrame', 'secondary_splitter'),
             ('bodyFrame', 'body-vr-splitter'),
@@ -88,10 +89,10 @@ LEGACY_LAYOUT = {
             ('secondary_splitter', 'main_splitter'),
             ('body-vr-splitter', 'main_splitter'))
         ),
-    'ORIENTATIONS':{
-        'body-vr-splitter':Orientation.Horizontal,
-        'secondary_splitter':Orientation.Horizontal,
-        'main_splitter':Orientation.Vertical
+    'ORIENTATIONS': {
+        'body-vr-splitter': Orientation.Horizontal,
+        'secondary_splitter': Orientation.Horizontal,
+        'main_splitter': Orientation.Vertical
     }
 }
 
@@ -114,23 +115,23 @@ def layout_legacy(event: LeoKeyEvent) -> None:
     c.doCommandByName('vr-show')
 #@+node:tom.20240928170706.1: *3* horizontal-thirds
 HORIZONTAL_THIRDS_LAYOUT = {
-    'SPLITTERS':OrderedDict(
+    'SPLITTERS': OrderedDict(
             (('outlineFrame', 'secondary_splitter'),
             ('logFrame', 'secondary_splitter'),
             ('secondary_splitter', 'main_splitter'),
             ('bodyFrame', 'main_splitter'),
             ('viewrendered3_pane', 'main_splitter'))
         ),
-    'ORIENTATIONS':{
-        'secondary_splitter':Orientation.Horizontal,
-        'main_splitter':Orientation.Vertical
+    'ORIENTATIONS': {
+        'secondary_splitter': Orientation.Horizontal,
+        'main_splitter': Orientation.Vertical
     }
 }
 
 
 @g.command('layout-horizontal-thirds')
 def horizontal_thirds(event: LeoKeyEvent) -> None:
-    """Create Leo's horizontal-thirds layout::
+    """Create Leo's horizontal-thirds layout:
         ┌───────────┬───────┐
         │  outline  │  log  │
         ├───────────┴───────┤
@@ -143,10 +144,10 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
     dw = c.frame.top
     cache = dw.layout_cache
     import leo.plugins.viewrendered3 as v3
-    v3.getVr3({'c':c})
+    v3.getVr3({'c': c})
     cache.restoreFromLayout(HORIZONTAL_THIRDS_LAYOUT)
 #@+node:tom.20240928171510.1: *3* big-tree
-@g.command ('layout-big-tree')
+@g.command('layout-big-tree')
 def big_tree(event: LeoKeyEvent) -> None:
     """Apply the "big-tree" layout.
 
@@ -215,7 +216,7 @@ def big_tree(event: LeoKeyEvent) -> None:
 
 #@+node:tom.20240929101820.1: *3* render-focused
 RENDERED_FOCUSED_LAYOUT = {
-    'SPLITTERS':OrderedDict(
+    'SPLITTERS': OrderedDict(
             (('outlineFrame', 'secondary_splitter'),
             ('bodyFrame', 'secondary_splitter'),
             ('logFrame', 'secondary_splitter'),
@@ -223,16 +224,16 @@ RENDERED_FOCUSED_LAYOUT = {
             ('secondary_splitter', 'main_splitter'),
             ('body-vr-splitter', 'main_splitter'))
         ),
-    'ORIENTATIONS':{
-        'body-vr-splitter':Orientation.Horizontal,
-        'secondary_splitter':Orientation.Vertical,
-        'main_splitter':Orientation.Horizontal
+    'ORIENTATIONS': {
+        'body-vr-splitter': Orientation.Horizontal,
+        'secondary_splitter': Orientation.Vertical,
+        'main_splitter': Orientation.Horizontal
     }
 }
 
 @g.command('layout-render-focused')
 def render_focused(event: LeoKeyEvent) -> None:
-    """Create Leo's render-focused layout::
+    """Create Leo's render-focused layout:
         ┌───────────┬─────┐
         │ outline   │     │
         ├───────────┤     │
@@ -258,23 +259,22 @@ def render_focused(event: LeoKeyEvent) -> None:
     # QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
 #@+node:tom.20240929104728.1: *3* vertical-thirds
 VERTICAL_THIRDS_LAYOUT = {
-    'SPLITTERS':OrderedDict(
+    'SPLITTERS': OrderedDict(
             (('outlineFrame', 'secondary_splitter'),
             ('logFrame', 'secondary_splitter'),
             ('secondary_splitter', 'main_splitter'),
             ('bodyFrame', 'main_splitter'),
             ('viewrendered_pane', 'main_splitter'))
         ),
-    'ORIENTATIONS':{
-        'secondary_splitter':Orientation.Vertical,
-        'main_splitter':Orientation.Horizontal
+    'ORIENTATIONS': {
+        'secondary_splitter': Orientation.Vertical,
+        'main_splitter': Orientation.Horizontal
     }
 }
 
-
 @g.command('layout-vertical-thirds')
 def vertical_thirds(event: LeoKeyEvent) -> None:
-    """Create Leo's vertical-thirds layout::
+    """Create Leo's vertical-thirds layout:
         ┌───────────┬────────┬──────┐
         │  outline  │        │      │
         ├───────────┤  body  │  VR  │
@@ -297,26 +297,25 @@ def vertical_thirds(event: LeoKeyEvent) -> None:
     # QtCore.QTimer.singleShot(60, lambda: show_vr_pane(c, vr))
 #@+node:tom.20240929115043.1: *3* vertical-thirds2
 VERTICAL_THIRDS2_LAYOUT = {
-    'SPLITTERS':OrderedDict(
-            (('logFrame', 'secondary_splitter'),
-            ('bodyFrame', 'secondary_splitter'),
-            ('outlineFrame', 'main_splitter'),
-            ('viewrendered_pane', 'vr-splitter'),
-            ('secondary_splitter', 'main_splitter'),
-            ('vr-splitter', 'main_splitter')
-            )
-        ),
-    'ORIENTATIONS':{
-        'vr-splitter':Orientation.Vertical,
-        'secondary_splitter':Orientation.Vertical,
-        'main_splitter':Orientation.Horizontal
+    'SPLITTERS': OrderedDict(
+        (('logFrame', 'secondary_splitter'),
+        ('bodyFrame', 'secondary_splitter'),
+        ('outlineFrame', 'main_splitter'),
+        ('viewrendered_pane', 'vr-splitter'),
+        ('secondary_splitter', 'main_splitter'),
+        ('vr-splitter', 'main_splitter')
+        )
+    ),
+    'ORIENTATIONS': {
+        'vr-splitter': Orientation.Vertical,
+        'secondary_splitter': Orientation.Vertical,
+        'main_splitter': Orientation.Horizontal
     }
 }
 
-
 @g.command('layout-vertical-thirds2')
 def vertical_thirds2(event: LeoKeyEvent) -> None:
-    """Create Leo's vertical-thirds2 layout::
+    """Create Leo's vertical-thirds2 layout:
         ┌───────────┬───────┬───────┐
         │           │  log  │       │
         │  outline  ├───────┤  VR   │
@@ -340,19 +339,8 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
 #@-others
 #@+node:tom.20240930164141.1: ** Other Layouts
 #@+node:tom.20240930164155.1: *3* Quadrant
-"""
-──────────────────────────┬───────────────────────────┐
-│                                                     |
-│       outline            │      log                 │
-|                                                     |
-├──────────────────────────┼──────────────────────────┤
-│                          │                          │
-│      body                │     vr                   │
-│                          │                          │
-└──────────────────────────┴──────────────────────────┘
-"""
 QUADRANT_LAYOUT = {
-    'SPLITTERS':OrderedDict(
+    'SPLITTERS': OrderedDict(
         (
             ('bodyFrame', 'secondary_splitter'),
             ('viewrendered_pane', 'secondary_splitter'),
@@ -362,17 +350,21 @@ QUADRANT_LAYOUT = {
             ('secondary_splitter', 'main_splitter'),
         )
     ),
-    'ORIENTATIONS':{
-        'outline-log-splitter':Orientation.Horizontal,
-        'secondary_splitter':Orientation.Horizontal,
-        'main_splitter':Orientation.Vertical,
+    'ORIENTATIONS': {
+        'outline-log-splitter': Orientation.Horizontal,
+        'secondary_splitter': Orientation.Horizontal,
+        'main_splitter': Orientation.Vertical,
     }
 }
 
 @g.command('layout-quadrant')
 def quadrants(event: LeoKeyEvent) -> None:
-    """Create a "quadrant layout::
-
+    """Create a "quadrant layout:
+        ┌───────────────┬───────────┐
+        │   outline     │   log     │
+        ├───────────────┼───────────┤
+        │   body        │     vr    │
+        └───────────────┴───────────┘
     """
     c = event.get('c')
     dw = c.frame.top
@@ -417,12 +409,28 @@ def swapLogPanel(event: LeoKeyEvent) -> None:
 
 #@+node:tom.20240930095459.1: ** class LayoutCacheWidget
 class LayoutCacheWidget(QWidget):
+    """
+    Manage layout such as the following:
+        
+        FALLBACK_LAYOUT = {
+            'SPLITTERS':OrderedDict(
+                            (('outlineFrame', 'secondary_splitter'),
+                            ('logFrame', 'secondary_splitter'),
+                            ('secondary_splitter', 'main_splitter'),
+                            ('bodyFrame', 'main_splitter'))
+                        ),
+            'ORIENTATIONS':{
+            'main_splitter':Orientation.Horizontal,
+            'secondary_splitter':Orientation.Vertical}
+        }
+    """
 
     def __init__(self, c: Cmdr, parent: QWidget = None) -> None:
         super().__init__(parent)
         self.c = c
         self.setObjectName(CACHENAME)
-        self.created_splitter_dict = {}
+        # maps splitter objectNames to their splitter object.
+        self.created_splitter_dict: Dict[str, Any] = {}
 
     #@+others
     #@+node:tom.20240923194438.4: *3* find_widget()
@@ -468,33 +476,17 @@ class LayoutCacheWidget(QWidget):
                     break
         return splitter
     #@+node:tom.20240923194438.6: *3* restoreFromLayout
-    def restoreFromLayout(self, layout=FALLBACK_LAYOUT):
+    def restoreFromLayout(self, layout=None):
+        if layout is None:
+            layout = FALLBACK_LAYOUT
         #@+<< initialize data structures >>
         #@+node:tom.20240923194438.7: *4* << initialize data structures >>
-        """Example layout structure:
-                
-            FALLBACK_LAYOUT = {
-                'SPLITTERS':OrderedDict(
-                                (('outlineFrame', 'secondary_splitter'),
-                                ('logFrame', 'secondary_splitter'),
-                                ('secondary_splitter', 'main_splitter'),
-                                ('bodyFrame', 'main_splitter'))
-                            ),
-                'ORIENTATIONS':{
-                'main_splitter':Orientation.Horizontal,
-                'secondary_splitter':Orientation.Vertical}
-                }
-
-        If a splitter name is not known or does not exist, create one
-        and add it to self.created_splitter_dict.
-
-        SPLITTER_DICT maps splitter objectNames to their splitter object.
-        """
-
         SPLITTERS = layout['SPLITTERS']
         ORIENTATIONS = layout['ORIENTATIONS']
 
-        # Make unknown splitters
+        # Make unknown splitters.
+        # If a splitter name is not known or does not exist, create one
+        # and add it to self.created_splitter_dict.
         for _, name in SPLITTERS.items():
             splitter = self.find_splitter_by_name(name)
             if splitter is None:
@@ -509,7 +501,7 @@ class LayoutCacheWidget(QWidget):
             # if splitter is None:
                 # splitter = self.created_splitter_dict[name]
             if splitter is not None and SPLITTER_DICT.get(name, None) is None:
-                 SPLITTER_DICT[name] = splitter
+                SPLITTER_DICT[name] = splitter
         #@-<< initialize data structures >>
         #@+<< rehome body editor >>
         #@+node:tom.20240923194438.8: *4* << rehome body editor >>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -494,7 +494,7 @@ class LayoutCacheWidget(QWidget):
                 splitter.setObjectName(name)
                 self.created_splitter_dict[name] = splitter
 
-        SPLITTER_DICT = OrderedDict()
+        SPLITTER_DICT: Dict[str, Any] = OrderedDict()
         for name in ORIENTATIONS:
             splitter = self.find_splitter_by_name(name)
             # Redundant, already checked in self.find_splitter_by_name()
@@ -562,7 +562,7 @@ class LayoutCacheWidget(QWidget):
         # SPLITTERS is an OrderedDict so the widgets will
         # be inserted in the right order.
 
-        splitter_index = {}
+        splitter_index: Dict = {}
         for name, target in SPLITTERS.items():
             widget = self.find_widget(name)
             if widget is None:

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3100,13 +3100,13 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:tom.20240725074751.1: *4* vr3.update_rendering
     def update_rendering(self, f, node_tree, p, keywords, kind):
         """Render the node tree in the VR3 pane according to its kind."""
+        s = keywords.get('s') if 's' in keywords else p.b
         if kind in (ASCIIDOC, MD, PLAIN, RST, REST, TEXT):
             f(node_tree, keywords)
         elif kind:
             # Remove Leo directives.
-            s = keywords.get('s') if 's' in keywords else p.b
-            s = self.remove_directives(s)
-            f(s, keywords)
+            s2 = self.remove_directives(s)
+            f(s2, keywords)
         else:
             self.show_literal(s)
     #@+node:tom.20240724103143.1: *4* vr3.create_node_tree

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1061,7 +1061,7 @@ import string
 import subprocess
 import sys
 import textwrap
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 import webbrowser
 from urllib.request import urlopen
 
@@ -1324,8 +1324,8 @@ asciidoc = None
 asciidoctor = None
 asciidoc_ok = False
 asciidoc3_ok = False
-asciidoc_dirs = {'asciidoc': {}, 'asciidoc3': {}}
-asciidoc_processors = []
+asciidoc_dirs: Dict[str, Dict] = {'asciidoc': {}, 'asciidoc3': {}}
+asciidoc_processors: List[Any] = []
 asciidoc_has_diagram = False
 #@-<< Misc Globals >>
 #@+<< define html templates >>
@@ -1358,8 +1358,8 @@ latex_template = f'''\
 trace = False  # This global trace is convenient.
 
 # keys are c.hash().
-controllers = {}  # values: VR3 widgets
-positions = {}  # values: OPENED_IN_TAB, OPENED_IN_SPLITTER, OPENED_SHARING_BODY
+controllers: Dict[str, Any] = {}  # values: VR3 widgets
+positions: Dict[int, Any] = {}  # values: OPENED_IN_TAB, OPENED_IN_SPLITTER, OPENED_SHARING_BODY
 
 #@+others
 #@+node:TomP.20200508124457.1: ** find_exe()
@@ -1482,7 +1482,7 @@ def configure_asciidoc():
         if dopatch:
             print('.... Patching asciidoc')
             from asciidoc.api import Options
-            AsciiDocAPI.__init__ = new_init
+            AsciiDocAPI.__init__ = new_init  # type:ignore
 
         asciidoc_ok = True
 
@@ -1503,7 +1503,7 @@ def configure_asciidoc():
     try:
         from asciidoc3.asciidoc3api import AsciiDoc3API
         from asciidoc3 import asciidoc3 as ad3
-        ad3_file = ad3.__file__
+        ad3_file = ad3.__file__  # type:ignore
         asciidoc3_ok = True
     except ImportError:
         asciidoc3_ok = False
@@ -2893,7 +2893,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             #@-<< is_numeric >>
             #@+<< get_data >>
             #@+node:tom.20211104105903.14: *6* << get_data >>
-            def get_data(pagelines):
+            def get_data(pagelines) -> Tuple[Any, Any]:
                 num_cols = 0
 
                 # Skip lines starting with """ or '''
@@ -2916,6 +2916,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
                     return None, None
 
                 # Extract x, y values into separate lists; ignore columns after col. 2
+                x: Any  # Dubious
                 if num_cols == 1:
                     x = range(len(t))
                     y = [float(b.strip()) for b in t]
@@ -3162,7 +3163,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         s = keywords['s'] = '\n'.join([l for l in lines if not l.startswith('#@')])
 
         f = self.dispatch_dict.get(node_kind)
-        f([s,], keywords)
+        f([s,], keywords)  # type:ignore
 
         # Prevent VR3 from showing the selected node at
         # the next idle-time callback,
@@ -3387,9 +3388,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
             #@+<< Find available processors >>
             #@+node:tom.20211122104636.1: *6* << Find available processors >>
             if asciidoc_ok:
-                asciidoc_processors.append(AsciiDocAPI())
+                asciidoc_processors.append(AsciiDocAPI())  # type:ignore
             if asciidoc3_ok:
-                asciidoc_processors.append(AsciiDoc3API(ad3_file))
+                asciidoc_processors.append(AsciiDoc3API(ad3_file))  # type:ignore
             if not asciidoc_processors:
                 h = '<h1>No asciidoc processors found</h1>'
                 self.rst_html = h

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1061,6 +1061,7 @@ import string
 import subprocess
 import sys
 import textwrap
+from typing import Any
 import webbrowser
 from urllib.request import urlopen
 
@@ -2414,7 +2415,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             """
 
             setattr(self, menu_var_name, False)
-            _action = QAction(label, self, checkable=True)
+            _action = QAction(label, self, checkable=True)  # type:ignore
             _action.triggered.connect(lambda: set_menu_var(menu_var_name, _action))
             menu.addAction(_action)
         #@+node:TomP.20200329223820.8: *5* function: vr3.set_default_kind
@@ -2441,7 +2442,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             nothing.
             """
 
-            _action = QAction(label, self, checkable=True)
+            _action = QAction(label, self, checkable=True)  # type:ignore
             _action.triggered.connect(lambda: set_default_kind(kind))
             group.addAction(_action)
             menu.addAction(_action)
@@ -2471,12 +2472,13 @@ class ViewRenderedController3(QtWidgets.QWidget):
         #@+node:TomP.20200329223820.13: *5* << vr3: create menus >>
         menu = QtWidgets.QMenu()
         set_action("Entire Tree", 'show_whole_tree')
-        _action = QAction('Lock to Tree Root', self, checkable=True)
+
+        _action = QAction('Lock to Tree Root', self, checkable=True)  # type:ignore
         _action.triggered.connect(lambda checked: set_tree_lock(checked))
         menu.addAction(_action)
         self.action_lock_to_tree = _action
 
-        _action = QAction('Freeze', self, checkable=True)
+        _action = QAction('Freeze', self, checkable=True)  # type:ignore
         _action.triggered.connect(lambda checked: set_freeze(checked))
         menu.addAction(_action)
         self.action_freeze = _action
@@ -2494,15 +2496,15 @@ class ViewRenderedController3(QtWidgets.QWidget):
 
         # "Other Actions"
         menu = QtWidgets.QMenu()
-        _action = QAction('Plot 2D', self, checkable=False)
+        _action = QAction('Plot 2D', self, checkable=False)  # type:ignore
         _action.triggered.connect(lambda: c.doCommandByName('vr3-plot-2d'))
         menu.addAction(_action)
 
-        _action = QAction('Help For Plot 2D', self, checkable=False)
+        _action = QAction('Help For Plot 2D', self, checkable=False)  # type:ignore
         _action.triggered.connect(lambda: c.doCommandByName('vr3-help-plot-2d'))
         menu.addAction(_action)
 
-        _action = QAction('Reload', self, checkable=False)
+        _action = QAction('Reload', self, checkable=False)  # type:ignore
         _action.triggered.connect(lambda: c.doCommandByName('vr3-update'))
         menu.addAction(_action)
 
@@ -3050,7 +3052,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         plt.rcdefaults()
     #@+node:TomP.20191215195433.49: *3* vr3.update & helpers
     # Must have this signature: called by leoPlugins.callTagHandler.
-    def update(self, tag, keywords):
+    def update(self, tag, keywords):  # type:ignore
         """Update the vr3 pane. Called at idle time.
 
         If the VR3 variable "freeze" is True, do not update.

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1617,7 +1617,7 @@ def show_scrolled_message(tag, kw):
     dw = c.frame.top
     cache = dw.layout_cache
 
-    vr3 = getVr3({'c':c})
+    vr3 = getVr3({'c': c})
     if vr3.parent() == cache:
         # Not already in another layout
         ms = cache.find_widget('main_splitter')
@@ -1633,7 +1633,7 @@ def show_scrolled_message(tag, kw):
         kw.get('msg')
     ])
 
-    delay = 500# if started_vr3 else 0
+    delay = 500  # if started_vr3 else 0
 
     def do_scrolled_msg(vr3, s, flags):
         vr3.update(
@@ -1723,7 +1723,7 @@ def viewrendered(event):
     if not c:
         return None
 
-    vr3 = getVr3({'c':c})
+    vr3 = getVr3({'c': c})
     return vr3
 #@+node:TomP.20200112232719.1: *3* g.command('vr3-execute')
 @g.command('vr3-execute')
@@ -2086,7 +2086,7 @@ def shrink_view(event):
 #@+node:tom.20230403141635.1: *3* g.command('vr3-tab')
 @g.command('vr3-tab')
 def viewrendered_tab(event):
-    """Open VR3 in a tab in commander's log framer""
+    """Open VR3 in a tab in commander's log framer"""
     # global controllers
     if g.app.gui.guiName() != 'qt':
         return

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1061,7 +1061,7 @@ import string
 import subprocess
 import sys
 import textwrap
-from typing import Any
+from typing import Any, Dict
 import webbrowser
 from urllib.request import urlopen
 
@@ -1356,7 +1356,6 @@ latex_template = f'''\
 #@-<< declarations >>
 
 trace = False  # This global trace is convenient.
-
 
 # keys are c.hash().
 controllers = {}  # values: VR3 widgets
@@ -1783,7 +1782,7 @@ def vr3_help_for_plot_2d(event):
               '=====================\n'
               + docstr)
 
-    args = {'output_encoding': 'utf-8'}
+    args: Dict[str, Any] = {'output_encoding': 'utf-8'}
     if vr3.rst_stylesheet and os.path.exists(vr3.rst_stylesheet):
         args['stylesheet_path'] = f'{vr3.rst_stylesheet}'
         args['embed_stylesheet'] = True
@@ -2260,13 +2259,12 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.last_markup = ''
         self.lock_to_tree = False
         self.qwev = self.create_web_engineview()
-        self.rst_html = ''
+        self.rst_html: Any = ''  # bytes or str.
         self.show_whole_tree = False
         self.base_url = ''
         self.positions = {}
         self.last_update_was_node_change = False
         self.setObjectName('viewrendered3_pane')
-
         #@-<< initialize configuration ivars >>
         #@+<< asciidoc-specific >>
         #@+node:tom.20240919181508.1: *4* << asciidoc-specific >>
@@ -4133,7 +4131,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 result += f'\n::\n\n{indented_err_result}\n'
         #@+node:TomP.20200105214743.1: *6* vr3.get html from docutils
         #@@language python
-        args = {'output_encoding': 'utf-8'}
+        args: Dict[str, Any] = {'output_encoding': 'utf-8'}
         if self.rst_stylesheet and os.path.exists(self.rst_stylesheet):
             args['stylesheet_path'] = f'{self.rst_stylesheet}'
             args['embed_stylesheet'] = True
@@ -5012,7 +5010,7 @@ class Action:
     @staticmethod
     def image_url2abs(sm, line, tag=None, language=None):
         """Convert MD or Asciidoc image directive's image path to an absolute one"""
-        is_image = False
+        is_image: Any = None
         if language == MD:
             is_image = MD_IMAGE_MARKER_RE.match(line)
         elif language == ASCIIDOC:
@@ -5216,7 +5214,7 @@ class StateMachine:
                 next = State.BASE
                 # _lang = self.base_lang
 
-        action(self, line, tag, language)
+        action(self, line, tag, language)  # type:ignore
         self.state = next
     #@-<< do_state >>
     #@+<< get_marker_md >>
@@ -5404,5 +5402,4 @@ class StateMachine:
     #@-<< State Table >>
 
 #@-others
-
 #@-leo

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -85,6 +85,7 @@ class TestPlugins(LeoUnitTest):
             'leoscreen.py',  # Qt imports are optional.
             'nodetags.py',  # #2031: Qt imports are optional.
             'pyplot_backend.py',  # Not a real plugin.
+            'qt_layout.py',  # Not a real plugin.
         )
         pattern = re.compile(r'\b(QtCore|QtGui|QtWidgets)\b')  # Don't search for Qt.
         for fn in files:


### PR DESCRIPTION
See #4078 and PR #4077.

**qt_layout.py**

*Note*: I plan many stylistic improvements to `qt_layout.py`, but these will happen in a separate PR.

- [x] Beautify.
- [x] Fix the following pylint complaints:
  - W0311: Bad indentation. Found 17 spaces, expected 16 (bad-indentation)
  - W0105: String statement has no effect (pointless-string-statement)
  - Dangerous default value FALLBACK_LAYOUT (builtins.dict) as argument (dangerous-default-value)
- [x] Fix or suppress all mypy complaints.
- [x] Fix a failing unit test: add a top-level `init` function.
- [x] Fix a failing unit test: Exempt `qt_layout.py` from `test_all_qt_plugins_call_g_assertUi_qt_`.

**VR3**

- [x] Fix an unterminated docstring in `g.command('vr3-tab')`!!!
- [x] Beautify.
- [x] Fix a logic error in `update_rendering` found by mypy.
- [x] Fix or suppress all mypy complaints.
   - Add dubious annotation: ` self.rst_html: Any = ''  # bytes or str.`
     **A bug may lurk here**.
