### PR TITLE
PR for #4087: Remove all `allowBinding` and `shortcut` kwargs from calls to `k.registerCommand`

### DIFF
--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -105,8 +105,10 @@ class ChapterController:
             select_chapter_callback.__doc__ = "Select the main chapter"
         else:
             select_chapter_callback.__doc__ = "Select chapter \"" + chapterName + "\"."
+
+        # 4087: k.registerCommand no longer supports the 'shortcut' kwarg.
         for shortcut in bindings:
-            c.k.registerCommand(commandName, select_chapter_callback, shortcut=shortcut)
+            c.k.registerCommand(commandName, select_chapter_callback)
     #@+node:ekr.20070604165126: *3* cc: chapter-select
     @cmd('chapter-select')
     def selectChapter(self, event: LeoKeyEvent = None) -> None:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2130,14 +2130,13 @@ class KeyHandlerClass:
             return c.openWith(d=d)
 
         # Use k.registerCommand to set the shortcuts in the various binding dicts.
+        # 4087: k.registerCommand no longer supports the 'shortcut' kwarg.
 
         commandName = f"open-with-{name.lower()}"
         k.registerCommand(
-            allowBinding=True,
             commandName=commandName,
             func=openWithCallback,
             pane='all',
-            shortcut=shortcut,
         )
     #@+node:ekr.20061031131434.95: *4* k.checkBindings
     def checkBindings(self) -> None:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -232,8 +232,9 @@ class BaseLeoPlugin:
         self.commandName = commandName
         self.shortcut = shortcut
         self.handler = handler
+        # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
         self.c.k.registerCommand(commandName, handler,
-            pane=pane, shortcut=shortcut, verbose=verbose)
+            pane=pane, verbose=verbose)
     #@+node:ekr.20100908125007.6014: *3* setMenuItem
     def setMenuItem(self, menu: Wrapper, commandName: str = None, handler: Callable = None) -> None:
         """Create a menu item in 'menu' using text 'commandName' calling handler 'handler'

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -597,13 +597,12 @@ class ScriptingController:
             self.deleteButton(b, event=event)
 
         # Register the delete-x-button command.
+        # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
         deleteCommandName = 'delete-%s-button' % commandName
         c.k.registerCommand(
-            # allowBinding=True,
             commandName=deleteCommandName,
             func=deleteButtonCallback,
             pane='button',
-            shortcut=None,
         )
         # Reporting this command is way too annoying.
         return b
@@ -1063,12 +1062,11 @@ class ScriptingController:
         if trace and not g.isascii(commandName):
             g.trace(commandName)
         # Register the original function.
+        # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
         k.registerCommand(
-            allowBinding=True,
             commandName=commandName,
             func=func,
             pane=pane,
-            shortcut=shortcut,
         )
 
         # 2013/11/13 Jake Peck:
@@ -1090,11 +1088,11 @@ class ScriptingController:
                     if trace:
                         g.trace('Already in commandsDict: %r' % commandName2)
                 else:
+                    # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
                     k.registerCommand(
                         commandName=commandName2,
                         func=registerAllCommandsCallback,
                         pane=pane,
-                        shortcut=None,
                     )
     #@+node:ekr.20150402021505.1: *4* sc.setButtonColor
     def setButtonColor(self, b: Wrapper, bg: str) -> None:

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -172,10 +172,9 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
         c.frame.log.selectTab('Nav')
         wdg.scon.doTimeline()
 
-    # #3976. Hard-code the binding to find-quick-selected.
-    c.k.registerCommand('find-quick-selected', find_selected,
-        allowBinding=True, shortcut='Control-Shift-f')
-
+    # #3976: Hard-code the binding to find-quick-selected.
+    # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
+    c.k.registerCommand('find-quick-selected', find_selected)
     c.k.registerCommand('find-quick', focus_quicksearch_entry)
     c.k.registerCommand('focus-to-nav', focus_to_nav)
     c.k.registerCommand('find-quick-test-failures', show_unittest_failures)


### PR DESCRIPTION
See #4087.

- [x] Remove all `allowBinding` and `shortcut` kwargs from calls to `k.registerCommand`.
    **Note**: these are non-breaking changes.