### PR TITLE
PR for #4090: undo mistakes in PR #4088

### DIFF
--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2130,13 +2130,13 @@ class KeyHandlerClass:
             return c.openWith(d=d)
 
         # Use k.registerCommand to set the shortcuts in the various binding dicts.
-        # 4087: k.registerCommand no longer supports the 'shortcut' kwarg.
-
         commandName = f"open-with-{name.lower()}"
         k.registerCommand(
+            allowBinding=True,
             commandName=commandName,
             func=openWithCallback,
             pane='all',
+            shortcut=shortcut,
         )
     #@+node:ekr.20061031131434.95: *4* k.checkBindings
     def checkBindings(self) -> None:

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -597,7 +597,6 @@ class ScriptingController:
             self.deleteButton(b, event=event)
 
         # Register the delete-x-button command.
-        # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
         deleteCommandName = 'delete-%s-button' % commandName
         c.k.registerCommand(
             commandName=deleteCommandName,
@@ -1062,11 +1061,12 @@ class ScriptingController:
         if trace and not g.isascii(commandName):
             g.trace(commandName)
         # Register the original function.
-        # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
         k.registerCommand(
+            allowBinding=True,
             commandName=commandName,
             func=func,
             pane=pane,
+            shortcut=shortcut,
         )
 
         # 2013/11/13 Jake Peck:
@@ -1088,11 +1088,12 @@ class ScriptingController:
                     if trace:
                         g.trace('Already in commandsDict: %r' % commandName2)
                 else:
-                    # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
                     k.registerCommand(
+                        allowBinding=True,
                         commandName=commandName2,
                         func=registerAllCommandsCallback,
                         pane=pane,
+                        shortcut=shortcut,
                     )
     #@+node:ekr.20150402021505.1: *4* sc.setButtonColor
     def setButtonColor(self, b: Wrapper, bg: str) -> None:


### PR DESCRIPTION
See #4090 and PR #4088.

- [x] Allow bindings in `k.bindOpenWith`, deleting erroneous comment.
- [x] Allow bindings in `sc.registerAllCommands`, deleting erroneous comment.
- [x] Delete erroneous comment in `sc.createIconButton`.

I double-checked the changes using the cumulative diffs in PR #4050.