### PR TITLE
PR: allow lower-case f-keys in @key bindings

### DIFF
--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -4010,7 +4010,8 @@ class KeyHandlerClass:
         assert isinstance(stroke, str) or g.isStroke(stroke)
         s = stroke.s if g.isStroke(stroke) else stroke
         s = s.lower()
-        return s.startswith('f') and len(s) <= 3 and s[1:].isdigit()
+        # 4093.
+        return s.startswith(('f', 'F')) and len(s) <= 3 and s[1:].isdigit()
     #@+node:ekr.20061031131434.182: *4* k.isPlainKey
     def isPlainKey(self, stroke: Stroke) -> bool:
         """Return true if the shortcut refers to a plain (non-Alt,non-Ctl) key."""

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -1034,7 +1034,7 @@ class ScriptingController:
                 if k == -1:
                     k = len(h)
                 shortcut = h[j:k].strip()
-        # #4093: Shortcuts for F-keys must start with an uppercase 'F'.
+        # #4093: Internally, shortcuts for F-keys must start with an uppercase 'F'.
         if (shortcut and shortcut.startswith('f')
             and len(shortcut) <= 3 and shortcut[1:].isdigit()
         ):

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -1034,6 +1034,11 @@ class ScriptingController:
                 if k == -1:
                     k = len(h)
                 shortcut = h[j:k].strip()
+        # #4093: Shortcuts for F-keys must start with an uppercase 'F'.
+        if (shortcut and shortcut.startswith('f')
+            and len(shortcut) <= 3 and shortcut[1:].isdigit()
+        ):
+            shortcut = shortcut.upper()
         return shortcut
     #@+node:ekr.20150402042350.1: *4* sc.getScript
     def getScript(self, p: Position) -> str:


### PR DESCRIPTION
See #4093.

- [x]  Allow both `'f'` and `'F'` in `k.isFKey`.
- [x] Translate  `'f'` to `'F'` in `sc.getShortcut`.

My hand tests pass for both `@command` and `@button` nodes.