### PR TITLE
Fix #4095. 

### DIFF
--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -673,14 +673,14 @@ class GitDiffController:
 
     def __init__(self, c: Cmdr) -> None:
         self.c = c
-        self.diff_leo_files = False
+        self.diff_leo_files = True
         self.file_node: Position = None
         self.root: Position = None
         self.reloadSettings()
 
     def reloadSettings(self) -> None:
         config = self.c.config
-        self.diff_leo_files = config.getBool('diff-leo-files', default=False)
+        self.diff_leo_files = config.getBool('diff-leo-files', default=True)
 
     #@+others
     #@+node:ekr.20180510095544.1: *3* gdc.Entries...

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1179,7 +1179,6 @@ class GitDiffController:
                 p2.b = v1.b
                 # Node 3: New node
                 assert v1.fileIndex == v2.fileIndex
-                ### p_in_c = self.find_gnx(self.c, v1.fileIndex)
                 if p_in_c:  # Make a clone, if possible.
                     p3 = p_in_c.clone()
                     p3.moveToLastChildOf(organizer)

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -518,6 +518,7 @@
 </v>
 <v t="ekr.20041119034357.10"><vh>Command options</vh>
 <v t="ekr.20210506073820.1"><vh>@bool allow-text-zoom = True</vh></v>
+<v t="ekr.20241012050620.1"><vh>@bool diff-leo-files = True</vh></v>
 <v t="ekr.20131112150804.18737"><vh>@bool force-execute-entire-body = False</vh></v>
 <v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
@@ -2275,10 +2276,7 @@
 </v>
 </v>
 <v t="ekr.20140915194122.23428"></v>
-<v t="ekr.20051101160257"></v>
-<v t="ekr.20051007200824.1"></v>
-<v t="ekr.20240726065425.1"></v>
-<v t="ekr.20240828054659.1"><vh>&lt;&lt; define s &gt;&gt;</vh></v>
+<v t="ekr.20241012050620.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11727,92 +11725,9 @@ vertical-thirds2
     │           │  body │       │
     └───────────┴───────┴───────┘
 </t>
-<t tx="ekr.20240828054659.1">@language rest
-@nowrap
-
-s = '''\
-
-About layouts
-=============
-
-The following commands create the layouts shown:
-
-use-legacy-layout
------------------
-
-::
-
-    ┌───────────┬───────┐
-    │  outline  │  log  │
-    ├───────────┼───────┤
-    │  body     │  VR   │
-    └───────────┴───────┘
-    
-use-big-tree-layout
--------------------
-
-::
-
-    ┌───────────────────┐
-    │  outline          │
-    ├──────────┬────────┤
-    │  body    │  log   │
-    ├──────────┴────────┤
-    │  VR               │
-    └───────────────────┘
-
-use-horizontal-thirds-layout
-----------------------------
-
-::
-
-    ┌───────────┬───────┐
-    │  outline  │  log  │
-    ├───────────┴───────┤
-    │  body             │
-    ├───────────────────┤
-    │  VR               │
-    └───────────────────┘
-
-use-render-focused-layout
--------------------------
-
-::
-
-    ┌───────────┬─────┐
-    │ outline   │     │
-    ├───────────┤     │
-    │ body      │ VR  │
-    ├───────────┤     │
-    │ log       │     │
-    └───────────┴─────┘
-
-use-vertical-thirds-layout
---------------------------
-
-::
-
-    ┌───────────┬────────┬──────┐
-    │  outline  │        │      │
-    ├───────────┤  body  │  VR  │
-    │  log      │        │      │
-    └───────────┴────────┴──────┘
-
-
-use-vertical-thirds2-layout
----------------------------
-
-::
-
-    ┌───────────┬───────┬───────┐
-    │           │  log  │       │
-    │  outline  ├───────┤  VR   │
-    │           │  body │       │
-    └───────────┴───────┴───────┘
-'''
-</t>
 <t tx="ekr.20240924055407.1">True: run Pylint on each saved file, but only if it has been changed.</t>
 <t tx="ekr.20240926065158.1">True: beautify all @&lt;file&gt; nodes in the outline using Leo's token-based beautifier.</t>
+<t tx="ekr.20241012050620.1">True: Leo's git-diff command will diff .leo and .leojs files.</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>


### PR DESCRIPTION
See #4095.

- [x] Generate proper `@language` directives after `@language patch`.
- [x] Support `@bool diff-leo-files` with default True for compatibility with legacy operation.

