### PR TITLE
PR Fix mypy complaint by converting a generator to a list

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -751,7 +751,7 @@ class Commands:
             'xterm': '-e '
         }
 
-        PREFERRED_TERMINALS = EXECUTE_ARGS.keys()
+        PREFERRED_TERMINALS = list(EXECUTE_ARGS.keys())
         #@+node:tom.20241014154415.4: *4* SETTINGS_HELP
         SETTINGS_HELP = r'''The data in the @data node body must have a
         PROCESSORS and an EXTENSIONS section, plus an optional TERMINAL

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -751,7 +751,7 @@ class Commands:
             'xterm': '-e '
         }
 
-        PREFERRED_TERMINALS = list(EXECUTE_ARGS.keys())
+        PREFERRED_TERMINALS = EXECUTE_ARGS.keys()
         #@+node:tom.20241014154415.4: *4* SETTINGS_HELP
         SETTINGS_HELP = r'''The data in the @data node body must have a
         PROCESSORS and an EXTENSIONS section, plus an optional TERMINAL
@@ -968,7 +968,7 @@ class Commands:
                         return t
             return ''
         #@+node:tom.20241014154415.15: *5* getCommonTerminal
-        def getCommonTerminal(names: Union[str, list, tuple]) -> str:
+        def getCommonTerminal(names: Union[str, Iterable[str]]) -> str:
             """Return a terminal name given candidate names.
 
             ARGUMENT


### PR DESCRIPTION
See PR #4100. mypy complains:
```console
leo\core\leoCommands.py:994: error: Argument 1 to "getCommonTerminal" has incompatible type "dict_keys[str, str]";
expected "str | list[Any] | tuple[Any, ...]"  [arg-type]
```
- [x] Change the signature of `getCommonTerminal` to:
    `def getCommonTerminal(names: Union[str, Iterable[str]]) -> str:`

I used the older `Union` syntax for compatibility with older Pythons.
This compatibility might not be needed, but it can't hurt.