### PR TITLE
PR: Tweaks re removing leoIPython.py

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -125,7 +125,6 @@ class LeoApp:
         self.failFast = False  # True: Use the failfast option in unit tests.
         self.gui: LeoGui = None  # The gui class.
         self.guiArgName: str = None  # The gui name given in --gui option.
-        self.ipython_inited: bool = False  # True if leoIpython.py imports succeeded.
         self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
         self.loaded_session = False  # Set by startup logic to True if no files specified on the command line.
@@ -2561,9 +2560,8 @@ class LoadManager:
                 g.app.gui = None  # Enable g.app.createDefaultGui
                 g.app.createDefaultGui(__file__)
             else:
-                pass
-                # This can happen when launching Leo from IPython.
                 # This can also happen when leoID does not exist.
+                pass
         elif gui_option is None:
             if script and not windowFlag:
                 # Always use null gui for scripts.
@@ -2684,7 +2682,7 @@ class LoadManager:
 
                 A comma-separated list. Valid values are:
                 abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
-                importers, ipython, keys, layouts, plugins, save, select, sections,
+                importers, keys, layouts, plugins, save, select, sections,
                 shutdown, size, speed, startup, themes, undo, verbose, zoom.
 
           --trace-binding=KEY   trace commands bound to a key
@@ -2815,7 +2813,7 @@ class LoadManager:
             # --trace=option.
             valid = [
                 'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
-                'focus', 'git', 'gnx', 'importers', 'ipython', 'keys',
+                'focus', 'git', 'gnx', 'importers', 'keys',
                 'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
                 'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
             ]

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -1032,7 +1032,6 @@
 <v t="ekr.20101113063552.9438"><vh>trace_tags.py</vh></v>
 </v>
 <v t="ekr.20101113063552.9439"><vh>External programs</vh>
-<v t="ekr.20101113063552.9440"><vh>ipython.py</vh></v>
 <v t="ekr.20101113063552.9442"><vh>open_shell.py</vh></v>
 <v t="ekr.20101113063552.9443"><vh>tomboy_import.py</vh></v>
 <v t="ekr.20101113063552.9444"><vh>vim.py</vh></v>
@@ -9772,14 +9771,6 @@ Pudb is a full-screen Python debugger: http://pypi.python.org/pypi/pudb
 
 </t>
 <t tx="ekr.20101113063552.9439"></t>
-<t tx="ekr.20101113063552.9440">Creates a two-way communication (bridge) between Leo scripts and IPython running in the console from which Leo was launched.
-
-Using this bridge, scripts running in Leo can affect IPython, and vice versa. In particular, scripts running in IPython can alter Leo outlines!
-
-.. _`IPython Bridge Guide`: IPythonBridge.html
-
-For full details, see the `IPython Bridge Guide`.
-</t>
 <t tx="ekr.20101113063552.9442">Creates an 'Extensions' menu containing two commands: Open Console Window and Open Explorer.
 
 The Open Console Window command opens xterm on Linux. The Open Explorer command Opens a Windows explorer window.
@@ -14681,7 +14672,8 @@ On Windows, you can run Leo with the console window visible by `associating .leo
 
 Leo puts several files in your HOME/.leo directory: .leoID.txt, .leoRecentFiles.txt, and myLeoSettings.leo.
 </t>
-<t tx="ekr.20131008041326.16156">Leo supports the following command-line options. As usual, you can see the list by typing the following in a console window::
+<t tx="ekr.20131008041326.16156">@nowrap
+Leo supports the following command-line options. As usual, you can see the list by typing the following in a console window::
 
     leo -h
 
@@ -14689,50 +14681,40 @@ or::
 
     leo --help
 
-You will get something like the following::
-
-    usage: launchLeo.py [-h] [-b] [--diff] [--fail-fast] [--fullscreen] [--ipython] [--gui GUI] [--listen-to-log]
-                        [--load-type TYPE] [--maximized] [--minimized] [--no-plugins] [--no-splash] [--quit]
-                        [--screen-shot PATH] [--script PATH] [--script-window] [--select ID] [--silent] [--theme NAME]
-                        [--trace TRACE-KEY] [--trace-binding KEY] [--trace-setting NAME] [--window-size SIZE]
-                        [--window-spot SPOT] [-v]
-                        [FILES ...]
+You will get the following::
 
     usage: launchLeo.py [options] file1, file2, ...
 
-    positional arguments:
-      FILES                 list of files
-
     options:
       -h, --help            show this help message and exit
-      -b, --black-sentinels
-                            write black-compatible sentinel comments
+      -b, --black-sentinels write black-compatible sentinel comments
       --diff                use Leo as an external git diff
       --fail-fast           stop unit tests after the first failure
       --fullscreen          start fullscreen
-      --ipython             enable ipython support
-      --gui GUI             gui to use (qt/console/null)
+      --gui=GUI             specify gui: browser,console,curses,qt,text,null
       --listen-to-log       start log_listener.py on startup
-      --load-type TYPE      @&lt;file&gt; type for non-outlines
       --maximized           start maximized
       --minimized           start minimized
       --no-plugins          disable all plugins
       --no-splash           disable the splash screen
       --quit                quit immediately after loading
-      --screen-shot PATH    take a screen shot and then exit
-      --script PATH         execute a script and then exit
+      --save-session        always save session data when Leo closes
+      --script=PATH         execute a script and then exit
       --script-window       execute script using default gui
-      --select ID           headline or gnx of node to select
+      --select=ID           headline or gnx of node to select
       --silent              disable all log messages
-      --theme NAME          use the named theme file
-      --trace TRACE-KEY     add one or more strings to g.app.debug. One or more of...
-                            abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx
-                            importers, ipython, keys, layouts, plugins, save, select, sections,
-                            shutdown, size, speed, startup, themes, undo, verbose, zoom
-      --trace-binding KEY   trace commands bound to a key
-      --trace-setting NAME  trace where named setting is set
-      --window-size SIZE    initial window size (height x width)
-      --window-spot SPOT    initial window position (top x left)
+      --theme=NAME          use the named theme file
+      --trace=LIST          add one or more strings to g.app.debug
+
+            A comma-separated list. Valid values are:
+            abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
+            importers, keys, layouts, plugins, save, select, sections,
+            shutdown, size, speed, startup, themes, undo, verbose, zoom.
+
+      --trace-binding=KEY   trace commands bound to a key
+      --trace-setting=NAME  trace where named setting is set
+      --window-size=SIZE    initial window size: (height x width)
+      --window-spot=SPOT    initial window position: (top x left)
       -v, --version         print version number and exit
 
 **Important**
@@ -15793,8 +15775,8 @@ Leo is a fundamentally different way of using and organizing data, programs and 
 - A powerful scripting environment.
 - A tool for organizing and studying computer code.
 - Extensible via a simple plugin architecture.
-- A tool that plays well with  IPython, Vim and Emacs.
-- Written in 100% pure Python
+- A tool that plays well with Vim and Emacs.
+- Written in 100% pure Python.
 
 **Leo's unique features**
 
@@ -16314,36 +16296,39 @@ myDocument.html.txt is the **input** file for sphinx.
 </t>
 <t tx="ekr.20131028213522.17138">::
 
-    Usage: launchLeo.py [options] file1, file2, ...
+    usage: launchLeo.py [options] file1, file2, ...
 
-    Options:
+    options:
       -h, --help            show this help message and exit
-      --debug               enable debug mode
+      -b, --black-sentinels write black-compatible sentinel comments
       --diff                use Leo as an external git diff
-      --fullscreen          start fullscreen
-      --ipython             enable ipython support
       --fail-fast           stop unit tests after the first failure
-      --gui=GUI             gui to use (qt/qttabs)
-      --load-type=LOAD_TYPE
-                            @&lt;file&gt; type for loading non-outlines from command
-                            line
+      --fullscreen          start fullscreen
+      --gui=GUI             specify gui: browser,console,curses,qt,text,null
+      --listen-to-log       start log_listener.py on startup
       --maximized           start maximized
       --minimized           start minimized
-      --no-cache            disable reading of cached files
       --no-plugins          disable all plugins
       --no-splash           disable the splash screen
-      --screen-shot=SCREENSHOT_FN
-                            take a screen shot and then exit
-      --script=SCRIPT       execute a script and then exit
-      --script-window=SCRIPT_WINDOW
-                            open a window for scripts
-      --select=SELECT       headline or gnx of node to select
+      --quit                quit immediately after loading
+      --save-session        always save session data when Leo closes
+      --script=PATH         execute a script and then exit
+      --script-window       execute script using default gui
+      --select=ID           headline or gnx of node to select
       --silent              disable all log messages
-      --trace-plugins       trace imports of plugins
-      -v, --version         print version number and exit
-      --window-size=WINDOW_SIZE
-                            initial window size (height x width)
-</t>
+      --theme=NAME          use the named theme file
+      --trace=LIST          add one or more strings to g.app.debug
+
+            A comma-separated list. Valid values are:
+            abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
+            importers, keys, layouts, plugins, save, select, sections,
+            shutdown, size, speed, startup, themes, undo, verbose, zoom.
+
+      --trace-binding=KEY   trace commands bound to a key
+      --trace-setting=NAME  trace where named setting is set
+      --window-size=SIZE    initial window size: (height x width)
+      --window-spot=SPOT    initial window position: (top x left)
+      -v, --version         print version number and exit</t>
 <t tx="ekr.20131028213522.17150"></t>
 <t tx="ekr.20131030082936.17514">s = p.b
 for child in p.children():
@@ -19657,7 +19642,9 @@ So much for the theory.  The following also are important in practice:
 
 - Native scripting in Python, with full access to all of Leo's sources.
 - Leo's plugin architecture.
-- Leo's rst3 command, vim, xemacs and ILeo (IPython bridge), and leoBridge module.
+- Leo's rst3 command.
+- Leo's support for vim and xemacs.
+- Leo's leoBridge module.
 - Leo's minibuffer commands, borrowed shamelessly from Emacs.
 - @button: bringing scripts to data.
 - Leo's outline-oriented directives.
@@ -19668,7 +19655,7 @@ Acknowledgements: Working with Leo's community of Leo's developers and users has
 
 A successful software tool is one that was used to do something undreamed of by its author.' -- Stephen Johnson
 
-Leo is a wild success on this score. I foresaw none of these developments 20 years ago:  Leo's minibuffer, @button, @auto, @clean, Leo's plugin architecture, the rst3 command, the Leo bridge and the IPython bridge.  Surely many other features and uses could be added. None of these would have happened without Leo's community of brilliant people. These features create the Leonine world.  Who knows what will be the result...
+Leo is a wild success on this score. I foresaw none of these developments 20 years ago:  Leo's minibuffer, @button, @auto, @clean, Leo's plugin architecture, the rst3 command, and the Leo's bridge.  Surely many other features and uses could be added. None of these would have happened without Leo's community of brilliant people. These features create the Leonine world.  Who knows what will be the result...
 
 Edward K. Ream
 </t>
@@ -33005,7 +32992,7 @@ Leo is an [IDE, outliner and PIM](https://leo-editor.github.io/leo-editor/prefac
 - PR #4033: Add four new layouts and related code and commands.
 - PR #4068: Optionally run pylint when saving changed files.
 - PR #4071: Optionally run Leo's beautifier when saving changed files.
-- PR #4113: Retire Leo's IPython. It hasn't worked in years.
+- PR #4113: Retire ILeo, Leo's IPython bridge. It hasn't worked in years.
 - The usual assortment of small bug fixes and code cleanups.
 
 **Links**
@@ -33036,7 +33023,7 @@ Leo is an [IDE, outliner and PIM](https://leo-editor.github.io/leo-editor/prefac
 - `PR #4047`_: Delete add-editor command and all related code.
 - `PR #4068`_: Optionally run pylint when saving changed files.
 - `PR #4071`_: Optionally run Leo's beautifier when saving changed files.
-- `PR #4113`_: Retire Leo's IPython. It hasn't worked in years.
+- `PR #4113`_: Retire ILeo, Leo's IPython bridge. It hasn't worked in years.
 </t>
 <t tx="ekr.20240919055407.1"></t>
 <t tx="felix.20210825213137.1">Since a WebSocket server can receive events from clients, process them to update the
@@ -33196,12 +33183,12 @@ If you run into difficulties see https://asciidoc3.org/pypi.html#_asciidoc3_pip_
 
 - Document any new commands with a proper docstring. This allows the minibuffer command `help-for-command` to provide help for the command.
 
-- In ``leo/doc/sphinx-docs/sphinxDocs.leo``, to the node ``@file leo.plugins.rst``, add the following snippet (preferably in alphabetical order), with the name of the plugin modified to the name of your plugin (here `ipython`). This allows the API docs to be automatically updated::
+- In ``leo/doc/sphinx-docs/sphinxDocs.leo``, to the node ``@file leo.plugins.rst``, add the following snippet (preferably in alphabetical order), with the name of the plugin modified to the name of your plugin (here `xxx`). This allows the API docs to be automatically updated::
 
-    :mod:`ipython` Module
-    ---------------------
+    :mod:`xxx` Module
+    -----------------
 
-    .. automodule:: leo.plugins.ipython
+    .. automodule:: leo.plugins.xxx
         :members:
         :undoc-members:
         :show-inheritance:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1370,7 +1370,6 @@ class LeoQtGui(leoGui.LeoGui):
         else:
             # This can be alarming when using Python's -i option.
             sys.exit(self.qtApp.exec())
-    #@+node:ekr.20110605121601.18483: *3* LeoQtGui.runMainLoop & runWithIpythonKernel
     #@+node:ekr.20180117053546.1: *3* LeoQtGui.show_tips & helpers
     @g.command('show-tips')
     def show_next_tip(self, event: LeoKeyEvent = None) -> None:

--- a/leo/unittests/core/test_leoApp.py
+++ b/leo/unittests/core/test_leoApp.py
@@ -88,7 +88,7 @@ class TestApp(LeoUnitTest):
             '--fail-fast',
             '--fullscreen',
             '--gui=console', '--gui=curses', '--gui=null', '--gui=qt', '--gui=text',
-            '--ipython',
+            '--ipython',  # Obsolete, but does not cause a crash.
             '--listen-to-log',
             '--maximized', '--minimized',
             '--no-plugins', '--no-splash',


### PR DESCRIPTION
A minor follow-on to PR #4105.

- [x] `leoApp.py`: Remove `g.app.self.ipython_inited`.
- [x] `leoApp.py`: Update the help message:
    Remove `--ipython` from the list of command-line arguments.
    Remove `ipython` from the list of valid `--trace` values.
- [x] `qt_gui.py`: Remove an empty node.
- [x] Update `LeoDocs.leo`:
  Update discussions of command-line arguments.
  Remove most references to ipython and ileo.
- [x] Ensure that all tests pass.