### PR TITLE
PR: Urgent changes to Leo's new layout code

### DIFF
--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -785,49 +785,44 @@ class HelpCommandsClass(BaseEditCommandsClass):
     #@+node:ekr.20240822071015.1: *3* helpForLayouts
     @cmd('help-for-layouts')
     def helpForLayouts(self, event: LeoKeyEvent = None) -> None:
-        """Print a messages telling you how to get started with Leo."""
-        # A bug in Leo: triple quotes puts indentation before each line except
-        # the first.
+        """Print a message telling you how to use Leo's layouts."""
         c = self.c
-        #@+<< create listing >>
-        #@+node:tom.20241022174807.1: *4* << create listing >>
+        #@+<< create listing list>>
+        #@+node:tom.20241022174807.1: *4* << create listing list >> (help-for-layouts)
         dw = c.frame.top
         cache = dw.layout_cache
         layouts = cache.layout_registry
 
-        # putHelpFor() messes up the format of a triple-quoted string here
-        # by indenting lines after the first.  This ruins the formatting of the 
-        # rendered display. Concatenating the string from its paragraphs somehow
-        # prevents this. Weird!
-        intro = ("A *layout* is an arrangement of the various frames and panels of Leo's interface. Each layout has a name, such as ``vertical-thirds`` and an associated command that will change to that layout, such as ``layout-vertical-thirds``\n\n"
+        intro = textwrap.dedent("""
+            A **layout** is an arrangement of the various frames and panels of Leo's
+            interface. Each layout has a name, such as **vertical-thirds**, and a
+            command that enables that layout, such as **layout-vertical-thirds**.
 
-            + 'The layout that Leo will use when starting up can be specified using the setting ``@string qt-layout-name = vertical-thirds`` (change "vertical-thirds" to whatever layout is wanted).\n\n'
+            By default, Leo uses the **legacy** layout. LeoSettings.leo contains:
 
-            + 'Most layouts include a position for either the ``viewrendered`` (VR) or the ``viewrendered3`` (VR3) plugins depending on whether VR3 has been enabled in the settings or not. The plugin may not be visible until it has been commanded to be shown or toggled.  These commands can be executed in the Minibuffer in the form ``vr-show``, ``vr-toggle``, or ``vr3-toggle``.\n\n'
+                @string qt-layout-name=legacy
 
-            + 'The available layouts can be displayed using the commands ``help-for-layouts`` (this command) or ``layout-show-layouts``.\n\n')
+            As usual, you can override this setting in myLeoSettings.leo.
 
-        listing = intro
+            Most layouts allocate screen space for the **viewrendered** (VR) or
+            **viewrendered3** (VR3) plugins, whichever you have enabled.
 
+            The plugin will not be visible until you execute one of the
+            **vr-show**, **vr-toggle**, or **vr3-toggle** commands.
+
+            The **help-for-layouts** (this command) and **layout-show-layouts**
+            commands show the avaialable layouts.
+        """)
+
+        # Append descriptions.
+        listing = [intro + '\n\n']
         for name, docstr in list(layouts.items()):
             name = name.lstrip()
-            lines = docstr.split('\n')
-            wrapped_name = f'**{name}**\n'
-            if len(lines) > 0:
-                doc_list = []
-                for line in lines:
-                    if not line.startswith(' '*4):
-                        line = ' '*4 + line.lstrip()
-                    doc_list.append(line)
-                doc = '\n'.join(doc_list)
-                listing += f'{wrapped_name}::\n\n{doc}\n\n'
-            else:
-                # Handle docstrings that are are one-liners without a layout diagram.
-                listing += f'{wrapped_name}\n'
-
-        #@-<< create listing >>
-
-        c.putHelpFor(listing)
+            doc_s = textwrap.dedent(docstr)
+            lines = doc_s.split('\n')
+            listing.append(f"**{name}**\n\n{doc_s}\n\n")
+        #@-<< create listing list>>
+        c.putHelpFor(''.join(listing))
     #@+node:ekr.20150514063305.396: *3* helpForMinibuffer
     @cmd('help-for-minibuffer')
     def helpForMinibuffer(self, event: LeoKeyEvent = None) -> None:

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -819,7 +819,6 @@ class HelpCommandsClass(BaseEditCommandsClass):
         for name, docstr in list(layouts.items()):
             name = name.lstrip()
             doc_s = textwrap.dedent(docstr)
-            lines = doc_s.split('\n')
             listing.append(f"**{name}**\n\n{doc_s}\n\n")
         #@-<< create listing list>>
         c.putHelpFor(''.join(listing))

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -215,7 +215,7 @@
 <v t="ekr.20190422173857.1"><vh>@string qt-style-name = None</vh></v>
 <v t="ekr.20210914081311.1"><vh>@bool highlight-body-line = False</vh></v>
 <v t="ekr.20210914081428.1"><vh>@string line-highlight-color = None</vh></v>
-<v t="ekr.20240726065425.1"><vh>@string qt-layout-name = vertical-thirds</vh></v>
+<v t="ekr.20240726065425.1"><vh>@string qt-layout-name = legacy</vh></v>
 <v t="ekr.20140915194122.23431"><vh>Colors</vh>
 <v t="ekr.20140912075503.19318"><vh>Body pane colors</vh>
 <v t="ekr.20140912075503.19319"><vh>@color body-bg = white</vh></v>
@@ -2279,6 +2279,7 @@
 </v>
 <v t="ekr.20140915194122.23428"></v>
 <v t="ekr.20241012050620.1"></v>
+<v t="ekr.20240726065425.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1298,7 +1298,7 @@
 <v t="tbrown.20140814090009.57475"><vh>@menu &amp;Show Settings</vh>
 <v t="ekr.20131213135427.21957"><vh>@item show-&amp;bindings</vh></v>
 <v t="ekr.20131213135427.21958"><vh>@item show-&amp;commands</vh></v>
-<v t="tom.20241023123442.1"><vh>@item layout-show-&amp;layouts</vh></v>
+<v t="tom.20241023123442.1"><vh>@item show-&amp;layouts</vh></v>
 <v t="ekr.20131213135427.21960"><vh>@item show-&amp;settings</vh></v>
 <v t="ekr.20131213135427.21959"><vh>@item show-&amp;plugins-info</vh></v>
 </v>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -49,14 +49,14 @@ def show_vr3_pane(c: Cmdr, w: QW) -> None:
     w.setUpdatesEnabled(True)
     c.doCommandByName('vr3-show')
 #@+node:tom.20241009141223.1: *3* function: is_module_loaded
-def is_module_loaded(module_name:str) -> bool:
+def is_module_loaded(module_name: str) -> bool:
     """Return True if the plugins controller has loaded the module.
     """
     controller = g.app.pluginsController
     return controller.isLoaded(module_name)
 #@+node:tom.20241015161609.1: *3* decorator:  register_layout
-def register_layout(name:str): # type: ignore
-    def decorator(func): 
+def register_layout(name: str):  # type: ignore
+    def decorator(func):
         # Register the function's name and docstring in the dictionary
         LAYOUT_REGISTRY[name] = func.__doc__
         return func  # Ensure the original function is returned
@@ -148,9 +148,9 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
     dw = c.frame.top
     cache = dw.layout_cache
     cache.restoreFromLayout(HORIZONTAL_THIRDS_LAYOUT)
-#@+node:ekr.20241008180407.1: *3* command: 'layout-quadrant'
-@g.command('layout-quadrant')
-@register_layout('layout-quadrant')
+#@+node:ekr.20241008180407.1: *3* command: 'layout-legacy'
+@g.command('layout-legacy')
+@register_layout('layout-legacy')
 def quadrants(event: LeoKeyEvent) -> None:
     """Create Leo's quadrant layout.
 
@@ -314,6 +314,7 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
     cache.restoreFromLayout(VERTICAL_THIRDS2_LAYOUT)
 #@+node:tom.20241022170042.1: *3* command: layout-show-layouts
 @g.command('layout-show-layouts')
+@g.command('show-layouts')
 def showLayouts(event) -> None:
     """Show a list of layout diagrams in a tab in the Log frame."""
     c = event.get('c')
@@ -453,7 +454,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
 
     #@+others
     #@+node:tom.20240923194438.5: *3* LayoutCacheWidget.find_splitter_by_name
-    def find_splitter_by_name(self: QW, name:str, _: Optional[QW] = None) -> QW:
+    def find_splitter_by_name(self: QW, name: str, _: Optional[QW] = None) -> QW:
         """Return a splitter instance given its objectName.
         
         This method could return other types of widgets but is intended
@@ -483,11 +484,11 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         
         The "_" argument is needed to satisfy mypy.  It is never used.
         """
-        widget:QW = g.app.gui.find_widget_by_name(self.c, name) # type: ignore[attr-defined]
+        widget: QW = g.app.gui.find_widget_by_name(self.c, name)  # type: ignore[attr-defined]
         return widget
 
     #@+node:tom.20240923194438.4: *3* LayoutCacheWidget.find_widget_in_children
-    def find_widget_in_children(self, name:str, _: Optional[QW] = None) -> QW:
+    def find_widget_in_children(self, name: str, _: Optional[QW] = None) -> QW:
         """Return a child widget if its objectName matches "name".
         
         The "_" argument is needed to satisfy mypy.  It is never used.
@@ -499,7 +500,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         return w
 
     #@+node:tom.20240923194438.6: *3* LayoutCacheWidget.restoreFromLayout
-    def restoreFromLayout(self, layout:Dict=None) -> None:
+    def restoreFromLayout(self, layout: Dict = None) -> None:
         if layout is None:
             layout = FALLBACK_LAYOUT
         #@+<< initialize data structures >>
@@ -527,7 +528,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         # If a splitter name is not known or does not exist, create one
         # and add it to self.created_splitter_dict.
         for _, name in SPLITTERS.items():
-            splitter:QW = self.find_splitter_by_name(name)
+            splitter: QW = self.find_splitter_by_name(name)
             if splitter is None:
                 splitter = QtWidgets.QSplitter(self)  # type: ignore [assignment]
                 splitter.setObjectName(name)

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -6,6 +6,7 @@
 #@+node:tom.20240923194438.2: ** << qt_layout: imports >>
 from __future__ import annotations
 
+import textwrap
 from collections import OrderedDict
 from typing import Any, Dict, TYPE_CHECKING, TypeVar, Optional
 from typing import Generic
@@ -26,9 +27,8 @@ if TYPE_CHECKING:  # pragma: no cover
     KWargs = Any
 
 #@-<< qt_layout: imports >>
-
-#@+others
-#@+node:tom.20241009141008.1: ** Declarations
+#@+<< qt_layout: declarations >>
+#@+node:tom.20241009141008.1: ** << qt_layout: declarations >>
 VR3_OBJ_NAME = 'viewrendered3_pane'
 VR_OBJ_NAME = 'viewrendered_pane'
 VRX_PLACEHOLDER_NAME = 'viewrenderedx_pane'
@@ -38,6 +38,9 @@ VR3_MODULE_NAME = 'viewrendered3.py'
 
 # Will contain {layout_name: layout_docstring}
 LAYOUT_REGISTRY = {}
+#@-<< qt_layout: declarations >>
+
+#@+others
 #@+node:ekr.20241008174359.1: ** Top-level functions
 #@+node:ekr.20241008141246.1: *3* function: init
 def init() -> bool:
@@ -63,11 +66,13 @@ def register_layout(name: str):  # type: ignore
         return func  # Ensure the original function is returned
     return decorator
 #@+node:ekr.20241008174351.1: ** Layout commands
+# The docstrings for all these commands must start with a newline.
 #@+node:tom.20240928171510.1: *3* command: 'layout-big-tree'
 @g.command('layout-big-tree')
 @register_layout('layout-big-tree')
 def big_tree(event: LeoKeyEvent) -> None:
-    """Create Leo's big-tree layout
+    """
+    Create Leo's big-tree layout:
 
         ┌──────────────────┐
         │  outline         │
@@ -136,7 +141,9 @@ def big_tree(event: LeoKeyEvent) -> None:
 @g.command('layout-horizontal-thirds')
 @register_layout('layout-horizontal-thirds')
 def horizontal_thirds(event: LeoKeyEvent) -> None:
-    """Create Leo's horizontal-thirds layout:
+    """
+    Create Leo's horizontal-thirds layout:
+
         ┌───────────┬───────┐
         │  outline  │  log  │
         ├───────────┴───────┤
@@ -153,7 +160,8 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
 @g.command('layout-legacy')
 @register_layout('layout-legacy')
 def quadrants(event: LeoKeyEvent) -> None:
-    """Create Leo's legacy layout.
+    """
+    Create Leo's legacy layout:
 
         ┌───────────────┬───────────┐
         │   outline     │   log     │
@@ -169,7 +177,9 @@ def quadrants(event: LeoKeyEvent) -> None:
 @g.command('layout-render-focused')
 @register_layout('layout-render-focused')
 def render_focused(event: LeoKeyEvent) -> None:
-    """Create Leo's render-focused layout:
+    """
+    Create Leo's render-focused layout:
+
         ┌───────────┬─────┐
         │ outline   │     │
         ├───────────┤     │
@@ -187,8 +197,8 @@ def render_focused(event: LeoKeyEvent) -> None:
 @register_layout('layout-restore-to-setting')
 def restoreDefaultLayout(event: LeoKeyEvent) -> None:
     """
-    Select the layout specified by the 'qt-layout-name' setting in effect
-    for c. Use the 'default' layout if the user's setting is erroneous.
+    Select the layout specified by the '@string qt-layout-name' setting in effect
+    for this outline. Use the **default** layout if the user's setting is erroneous.
     """
     c = event.get('c')
     if not c:
@@ -201,12 +211,12 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
         g.es_print(f"Unknown layout: {layout}; Using 'legacy' layout", color='red')
         layout = 'layout-legacy'
     c.commandsDict[layout](event)
-
 #@+node:tom.20241005163724.1: *3* command: 'layout-swap-log-panel'
 @g.command('layout-swap-log-panel')
 @register_layout('layout-swap-log-panel')
 def swapLogPanel(event: LeoKeyEvent) -> None:
-    """Move Log frame between main and secondary splitters.
+    """
+    Move Log frame between main and secondary splitters.
 
     This command does not actually create a layout of its own.  It
     should not be used as the initial layout.
@@ -263,7 +273,9 @@ def swapLogPanel(event: LeoKeyEvent) -> None:
 @g.command('layout-vertical-thirds')
 @register_layout('layout-vertical-thirds')
 def vertical_thirds(event: LeoKeyEvent) -> None:
-    """Create Leo's vertical-thirds layout:
+    """
+    Create Leo's vertical-thirds layout:
+
         ┌───────────┬────────┬────────┐
         │  outline  │        │        │
         ├───────────┤  body  │ VR/VR3 │
@@ -279,7 +291,9 @@ def vertical_thirds(event: LeoKeyEvent) -> None:
 @g.command('layout-vertical-thirds2')
 @register_layout('layout-vertical-thirds2')
 def vertical_thirds2(event: LeoKeyEvent) -> None:
-    """Create Leo's vertical-thirds2 layout:
+    """
+    Create Leo's vertical-thirds2 layout:
+
         ┌───────────┬───────┬─────────┐
         │           │  log  │         │
         │  outline  ├───────┤ VR/VR3  │
@@ -302,12 +316,14 @@ def showLayouts(event) -> None:
     dw = c.frame.top
     cache = dw.layout_cache
     layouts = cache.layout_registry
-    listing = ''
-
+    listing = []
     for name, docstr in layouts.items():
-        listing += f'{name}:\n' + '=' * len(name) + f'\n{docstr}\n'
-
-    g.es(listing, tabName='layouts')
+        # This trick is a bug in neither Leo nor textrap.
+        doc_s = textwrap.dedent(docstr.rstrip()).strip()
+        # g.printObj(doc_s, tag=f"doc_s: {name}")
+        listing.append(f'{name}\n' + '=' * len(name) + f'\n\n{doc_s}\n\n')
+    listing_s = ''.join(listing)
+    g.es(listing_s, tabName='layouts')
 #@+node:ekr.20241008174638.1: ** Layouts
 #@+node:tom.20240923194438.3: *3* FALLBACK_LAYOUT
 FALLBACK_LAYOUT = {

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -318,9 +318,8 @@ def showLayouts(event) -> None:
     layouts = cache.layout_registry
     listing = []
     for name, docstr in layouts.items():
-        # This trick is a bug in neither Leo nor textrap.
+        # This trick is *not* a bug in Leo!
         doc_s = textwrap.dedent(docstr.rstrip()).strip()
-        # g.printObj(doc_s, tag=f"doc_s: {name}")
         listing.append(f'{name}\n' + '=' * len(name) + f'\n\n{doc_s}\n\n')
     listing_s = ''.join(listing)
     g.es(listing_s, tabName='layouts')

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -186,42 +186,20 @@ def render_focused(event: LeoKeyEvent) -> None:
 @g.command('layout-restore-to-setting')
 @register_layout('layout-restore-to-setting')
 def restoreDefaultLayout(event: LeoKeyEvent) -> None:
-    """Restore the initial layout specified in @settings.
-
-    This command does not specify an actual layout itself.
-    
-    If the layout name:
-        
-        - starts with 'layout-', it is used as the name of the 
-          layout command;
-        - does not start with 'layout-', then that prefix is added
-          and the result is used as the name of the layout command.
-          
-    Use the 'default' layout if the command is not known.
+    """
+    Select the layout specified by the 'qt-layout-name' setting in effect
+    for c. Use the 'default' layout if the user's setting is erroneous.
     """
     c = event.get('c')
     if not c:
         return
     event = g.app.gui.create_key_event(c)
-
-    found_layout = False
-    default_layout = 'layout-legacy'
-    layout = c.config.getString('qt-layout-name')
-    g.trace(repr(layout))
-    if not layout:
-        layout = default_layout
-    elif layout.startswith('layout-'):
-        if layout in c.commandsDict:
-            found_layout = True
-        else:
-            layout = default_layout
-    else:
-        layout = 'layout-' + layout
-        if layout in c.commandsDict:
-            found_layout = True
-    if not found_layout:
-        g.es_print(f'Cannot find command {layout}; Using {default_layout}', color='red')
-        layout = default_layout
+    layout = c.config.getString('qt-layout-name') or 'legacy'
+    if not layout.startswith('layout-'):
+        layout = 'layout-' + layout.strip()
+    if layout not in c.commandsDict:
+        g.es_print(f"Unknown layout: {layout}; Using 'legacy' layout", color='red')
+        layout = 'layout-legacy'
     c.commandsDict[layout](event)
 
 #@+node:tom.20241005163724.1: *3* command: 'layout-swap-log-panel'

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -2,8 +2,8 @@
 #@+node:tom.20240923194438.1: * @file ../plugins/qt_layout.py
 """The basic machinery to support applying layouts of the main Leo panels."""
 
-#@+<< qt_layout: imports >>
-#@+node:tom.20240923194438.2: ** << qt_layout: imports >>
+#@+<< qt_layout: imports & annotations >>
+#@+node:tom.20240923194438.2: ** << qt_layout: imports & annotations >>
 from __future__ import annotations
 
 import textwrap
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
     Args = Any
     KWargs = Any
 
-#@-<< qt_layout: imports >>
+#@-<< qt_layout: imports & annotations >>
 #@+<< qt_layout: declarations >>
 #@+node:tom.20241009141008.1: ** << qt_layout: declarations >>
 VR3_OBJ_NAME = 'viewrendered3_pane'
@@ -304,7 +304,7 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
     dw = c.frame.top
     cache = dw.layout_cache
     cache.restoreFromLayout(VERTICAL_THIRDS2_LAYOUT)
-#@+node:tom.20241022170042.1: *3* command: 'show-layouts', aka 'layout-show-layouts'
+#@+node:tom.20241022170042.1: *3* command: 'show-layouts'
 @g.command('layout-show-layouts')
 @g.command('show-layouts')
 def showLayouts(event) -> None:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -41,8 +41,9 @@ LAYOUT_REGISTRY = {}
 #@+node:ekr.20241008174359.1: ** Top-level functions
 #@+node:ekr.20241008141246.1: *3* function: init
 def init() -> bool:
-    """Return True if this plugin should be enabled."""
-    # qt_layout is not a true plugin.
+    """
+    qt_layout is not a true plugin, but return True just in case.
+    """
     return True
 #@+node:ekr.20241008141353.1: *3* function: show_vr3_pane
 def show_vr3_pane(c: Cmdr, w: QW) -> None:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -152,7 +152,7 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
 @g.command('layout-legacy')
 @register_layout('layout-legacy')
 def quadrants(event: LeoKeyEvent) -> None:
-    """Create Leo's quadrant layout.
+    """Create Leo's legacy layout.
 
         ┌───────────────┬───────────┐
         │   outline     │   log     │
@@ -163,7 +163,7 @@ def quadrants(event: LeoKeyEvent) -> None:
     c = event.get('c')
     dw = c.frame.top
     cache = dw.layout_cache
-    cache.restoreFromLayout(QUADRANT_LAYOUT)
+    cache.restoreFromLayout(LEGACY_LAYOUT)
 #@+node:ekr.20241008174427.2: *3* command: 'layout-render-focused'
 @g.command('layout-render-focused')
 @register_layout('layout-render-focused')
@@ -182,7 +182,6 @@ def render_focused(event: LeoKeyEvent) -> None:
     cache = dw.layout_cache
     cache.restoreFromLayout(RENDERED_FOCUSED_LAYOUT)
 #@+node:tom.20240930101515.1: *3* command: 'layout-restore-to-setting'
-@g.command('layout-restore-default')
 @g.command('layout-restore-to-setting')
 @register_layout('layout-restore-to-setting')
 def restoreDefaultLayout(event: LeoKeyEvent) -> None:
@@ -196,9 +195,8 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
           layout command;
         - does not start with 'layout-', then that prefix is added
           and the result is used as the name of the layout command.
-
-    If the resulting command is not known, then the 'vertical-thirds'
-    is applied.
+          
+    Use the 'default' layout if the command is not known.
     """
     c = event.get('c')
     if not c:
@@ -206,8 +204,9 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
     event = g.app.gui.create_key_event(c)
 
     found_layout = False
-    default_layout = 'layout-vertical-thirds'
+    default_layout = 'layout-legacy'
     layout = c.config.getString('qt-layout-name')
+    g.trace(repr(layout))
     if not layout:
         layout = default_layout
     elif layout.startswith('layout-'):
@@ -220,7 +219,7 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
         if layout in c.commandsDict:
             found_layout = True
     if not found_layout:
-        g.es(f'Cannot find command {layout}; Using {default_layout}')
+        g.es_print(f'Cannot find command {layout}; Using {default_layout}', color='red')
         layout = default_layout
     c.commandsDict[layout](event)
 
@@ -238,7 +237,7 @@ def swapLogPanel(event: LeoKeyEvent) -> None:
     and secondary splitters.
 
     The effect of this command depends on the existing layout. For example,
-    if the quadrant layout is in effect, this command changes the layout
+    if the legacy layout is in effect, this command changes the layout
     from:
         ┌───────────┬──────┐
         │ outline   │ log  │
@@ -312,7 +311,7 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
     dw = c.frame.top
     cache = dw.layout_cache
     cache.restoreFromLayout(VERTICAL_THIRDS2_LAYOUT)
-#@+node:tom.20241022170042.1: *3* command: layout-show-layouts
+#@+node:tom.20241022170042.1: *3* command: 'show-layouts', aka 'layout-show-layouts'
 @g.command('layout-show-layouts')
 @g.command('show-layouts')
 def showLayouts(event) -> None:
@@ -358,8 +357,8 @@ HORIZONTAL_THIRDS_LAYOUT = {
         'main_splitter': Orientation.Vertical
     }
 }
-#@+node:tom.20240930164155.1: *3* QUADRANT_LAYOUT
-QUADRANT_LAYOUT = {
+#@+node:tom.20240930164155.1: *3* LEGACY_LAYOUT
+LEGACY_LAYOUT = {
     'SPLITTERS': OrderedDict(
         (
             ('bodyFrame', 'secondary_splitter'),


### PR DESCRIPTION
PR #4121 needs work.

Leo *must* use the name `legacy` instead of `quadrant` to avoid breaking user settings.

- [x] Change `quadrant` to `legacy` everywhere.
- [x] Change the default for `@string qt-layout-name` to `legacy`.
   This default preserves Leo's legacy look and feel.
- [x] Retire the duplicate `layout-restore-default` command.
- [x] Simplify the `restoreDefaultLayout` function and correct its docstring.
- [x] Fix long lines in `commands/helpCommands.py`.
- [x] Simplify the `show-layouts` and `help-for-layouts` commands.