### PR TITLE
Fix the help-for-layouts command

### DIFF
--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -793,33 +793,49 @@ class HelpCommandsClass(BaseEditCommandsClass):
         cache = dw.layout_cache
         layouts = cache.layout_registry
 
-        intro = textwrap.dedent("""
-            A **layout** is an arrangement of the various frames and panels of Leo's
-            interface. Each layout has a name, such as **vertical-thirds**, and a
-            command that enables that layout, such as **layout-vertical-thirds**.
+        # Rendered the intro as rST
+        intro = textwrap.dedent("""\
+            =============
+            About Layouts
+            =============
 
-            By default, Leo uses the **legacy** layout. LeoSettings.leo contains:
+            A **layout** is an arrangement of the various frames and panels of
+            Leo's interface.
+            
+            Each layout has a **name**, such as ``vertical-thirds``, and a
+            **command** such as ``layout-vertical-thirds``. Such commands switch to
+            the given layout.
+
+            By default, Leo uses the ``legacy`` layout. LeoSettings.leo contains:
 
                 @string qt-layout-name=legacy
 
             As usual, you can override this setting in myLeoSettings.leo.
 
-            Most layouts allocate screen space for the **viewrendered** (VR) or
-            **viewrendered3** (VR3) plugins, whichever you have enabled.
+            Most layouts allocate screen space for the viewrendered (VR) or
+            viewrendered3 (VR3) plugins, whichever you have enabled.
 
-            The plugin will not be visible until you execute one of the
-            **vr-show**, **vr-toggle**, or **vr3-toggle** commands.
+            The plugin will not be visible until you execute one of the vr-show,
+            vr-toggle, or vr3-toggle commands.
 
-            The **help-for-layouts** (this command) and **layout-show-layouts**
-            commands show the avaialable layouts.
+            The show-layouts command and this command (help-for-layouts) show the
+            avaialable layouts.
         """)
 
-        # Append descriptions.
+        # Create lesser rST sections for each layout command.
         listing = [intro + '\n\n']
         for name, docstr in list(layouts.items()):
-            name = name.lstrip()
-            doc_s = textwrap.dedent(docstr)
-            listing.append(f"**{name}**\n\n{doc_s}\n\n")
+            name = name.strip()
+            if 1:  # Use bold lines for command names.
+                listing.append(f"\n\n**{name}**")
+            else:  # Works, but the section names are too big.
+                underline = '-' * len(name)
+                listing.append(name + '\n')
+                listing.append(underline)
+            # The show-layout command renders docstrings as plain text.
+            # That is, all docstrings start literal blocks with ':', not '::'.
+            doc_s = textwrap.dedent(docstr).replace(':\n', '::\n')
+            listing.append(f"\n\n{doc_s}\n\n")
         #@-<< create listing list>>
         c.putHelpFor(''.join(listing))
     #@+node:ekr.20150514063305.396: *3* helpForMinibuffer

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -66,7 +66,19 @@ def register_layout(name: str):  # type: ignore
         return func  # Ensure the original function is returned
     return decorator
 #@+node:ekr.20241008174351.1: ** Layout commands
-# The docstrings for all these commands must start with a newline.
+#@+at
+# Read Me or Suffer
+#
+# The help-for-layouts and show-layout commands use these docstrings,
+# so the following constraints apply to the following docstrings:
+#
+# 1. All docstrings must start with a newline.
+# 2. Use a *single* ':', followed by a blank line
+#    to denote the start of a layout diagram or
+#    any other verbatim text.
+# 3. All verbatim text must end with a blank line unless
+#    the verbatim text ends the docstring.
+#@@c
 #@+node:tom.20240928171510.1: *3* command: 'layout-big-tree'
 @g.command('layout-big-tree')
 @register_layout('layout-big-tree')
@@ -197,7 +209,7 @@ def render_focused(event: LeoKeyEvent) -> None:
 @register_layout('layout-restore-to-setting')
 def restoreDefaultLayout(event: LeoKeyEvent) -> None:
     """
-    Select the layout specified by the '@string qt-layout-name' setting in effect
+    Select the layout specified by the `@string qt-layout-name` setting in effect
     for this outline. Use the **default** layout if the user's setting is erroneous.
     """
     c = event.get('c')
@@ -216,24 +228,22 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
 @register_layout('layout-swap-log-panel')
 def swapLogPanel(event: LeoKeyEvent) -> None:
     """
-    Move Log frame between main and secondary splitters.
-
-    This command does not actually create a layout of its own.  It
-    should not be used as the initial layout.
-
-    If the Log frame is contained in a different splitter, possibly with
-    some other widget, the entire splitter will be swapped between the main
-    and secondary splitters.
+    Move the Log frame between main and secondary splitters.
+    
+    **Do not use this layout as the initial layout.**
 
     The effect of this command depends on the existing layout. For example,
     if the legacy layout is in effect, this command changes the layout
     from:
+
         ┌───────────┬──────┐
         │ outline   │ log  │
         ├───────────┼──────┤
         │ body      │VR/VR3│
         └───────────┴──────┘
+
     to:
+
         ┌──────────────────┐
         │  outline         │
         ├──────────┬───────┤
@@ -308,7 +318,7 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
 @g.command('layout-show-layouts')
 @g.command('show-layouts')
 def showLayouts(event) -> None:
-    """Show a list of layout diagrams in a tab in the Log frame."""
+    """Show all layout diagrams in the Log Frame's `layouts` tab."""
     c = event.get('c')
     if not c:
         return


### PR DESCRIPTION
See #4128.

- [x] Fix the `help-for-layouts` command.
   The necessary changes where straightforward once I understood that `c.putHelpFor`
   renders (eventually!) its arguments as restructuredText!
- [x] Document new constraints on docstrings in the `Layout commands` organizing node.
- [x] Improve several docstrings. Use active voice! Avoid implementation details!