### PR TITLE
PR for #4104: g.cls should work on Linux

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -5895,6 +5895,8 @@ def cls(event: LeoKeyEvent = None) -> None:
         # Leo 6.7.5: Two calls seem to be required!
         os.system('cls')
         os.system('cls')
+    else:
+        os.system('clear')
 #@+node:ekr.20131114124839.16665: *3* g.createScratchCommander
 def createScratchCommander(fileName: str = None) -> None:
     c = g.app.newCommander(fileName)


### PR DESCRIPTION
See #4104.

- [x] Call os.system('clear') for Linux.
- [x] Test on Linux.