### PR TITLE
PR for #4123: Fix all expand/contract-*-pane commands

### DIFF
--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4285,50 +4285,48 @@ class TabbedFrameFactory:
             c.redraw()
     #@-others
 #@+node:ekr.20200303082457.1: ** top-level commands (qt_frame.py)
-#@+node:ekr.20200303082511.6: *3* 'contract-body-pane' & 'expand-outline-pane'
+#@+node:ekr.20200303082511.6: *3* 'contract-body-pane'
 @g.command('contract-body-pane')
-@g.command('expand-outline-pane')
 def contractBodyPane(event: LeoKeyEvent) -> None:
     """Contract the body pane. Expand the outline/log splitter."""
     c = event.get('c')
-    if not c:
-        return
-    r = min(1.0, c.frame.compute_ratio() + 0.1)
-    c.frame.divideLeoSplitter1(r)
-
-expandOutlinePane = contractBodyPane
+    if c:
+        c.frame.top.layout_cache.contract_body()
 #@+node:ekr.20200303084048.1: *3* 'contract-log-pane'
 @g.command('contract-log-pane')
 def contractLogPane(event: LeoKeyEvent) -> None:
     """Contract the log pane. Expand the outline pane."""
     c = event.get('c')
-    if not c:
-        return
-    f = c.frame
-    r = min(1.0, f.compute_secondary_ratio() + 0.1)
-    f.divideLeoSplitter2(r)
-#@+node:ekr.20200303084225.1: *3* 'contract-outline-pane' & 'expand-body-pane'
+    if c:
+        c.frame.top.layout_cache.contract_log()
+#@+node:ekr.20200303084225.1: *3* 'contract-outline-pane'
 @g.command('contract-outline-pane')
-@g.command('expand-body-pane')
 def contractOutlinePane(event: LeoKeyEvent) -> None:
     """Contract the outline pane. Expand the body pane."""
     c = event.get('c')
-    if not c:
-        return
-    r = max(0.0, c.frame.compute_ratio() - 0.1)
-    c.frame.divideLeoSplitter1(r)
-
-expandBodyPane = contractOutlinePane
+    if c:
+        c.frame.top.layout_cache.contract_outline()
+#@+node:ekr.20241027124820.1: *3* 'expand-body-pane
+@g.command('expand-body-pane')
+def expandBodyPane(event: LeoKeyEvent) -> None:
+    """Expand the log pane. Contract the outline pane."""
+    c = event.get('c')
+    if c:
+        c.frame.top.layout_cache.expand_body()
 #@+node:ekr.20200303084226.1: *3* 'expand-log-pane'
 @g.command('expand-log-pane')
 def expandLogPane(event: LeoKeyEvent) -> None:
     """Expand the log pane. Contract the outline pane."""
     c = event.get('c')
-    if not c:
-        return
-    f = c.frame
-    r = max(0.0, f.compute_secondary_ratio() - 0.1)
-    f.divideLeoSplitter2(r)
+    if c:
+        c.frame.top.layout_cache.expand_log()
+#@+node:ekr.20241027124753.1: *3* 'expand-outline-pane'
+@g.command('expand-outline-pane')
+def expandOutlinePane(event: LeoKeyEvent) -> None:
+    """Expand the log pane. Contract the outline pane."""
+    c = event.get('c')
+    if c:
+        c.frame.top.layout_cache.expand_outline()
 #@+node:ekr.20200303084610.1: *3* 'hide-body-pane'
 @g.command('hide-body-pane')
 def hideBodyPane(event: LeoKeyEvent) -> None:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -4285,49 +4285,80 @@ class TabbedFrameFactory:
             c.redraw()
     #@-others
 #@+node:ekr.20200303082457.1: ** top-level commands (qt_frame.py)
-#@+node:ekr.20200303082511.6: *3* 'contract-body-pane'
+#@+node:ekr.20241027140721.1: *3* contract-*-pane commands
+#@+node:ekr.20200303082511.6: *4* 'contract-body-pane'
 @g.command('contract-body-pane')
 def contractBodyPane(event: LeoKeyEvent) -> None:
     """Contract the body pane. Expand the outline/log splitter."""
     c = event.get('c')
     if c:
         c.frame.top.layout_cache.contract_body()
-#@+node:ekr.20200303084048.1: *3* 'contract-log-pane'
+#@+node:ekr.20200303084048.1: *4* 'contract-log-pane'
 @g.command('contract-log-pane')
 def contractLogPane(event: LeoKeyEvent) -> None:
     """Contract the log pane. Expand the outline pane."""
     c = event.get('c')
     if c:
         c.frame.top.layout_cache.contract_log()
-#@+node:ekr.20200303084225.1: *3* 'contract-outline-pane'
+#@+node:ekr.20200303084225.1: *4* 'contract-outline-pane'
 @g.command('contract-outline-pane')
 def contractOutlinePane(event: LeoKeyEvent) -> None:
     """Contract the outline pane. Expand the body pane."""
     c = event.get('c')
     if c:
         c.frame.top.layout_cache.contract_outline()
-#@+node:ekr.20241027124820.1: *3* 'expand-body-pane
+#@+node:ekr.20241027140603.1: *4* 'contract-vr-pane'
+@g.command('contract-vr-pane')
+def contractVRPane(event: LeoKeyEvent) -> None:
+    """Contract the outline pane. Expand the body pane."""
+    c = event.get('c')
+    if c:
+        c.frame.top.layout_cache.contract_vr()
+#@+node:ekr.20241027140620.1: *4* 'contract-vr3-pane'
+@g.command('contract-vr3-pane')
+def contractVR3Pane(event: LeoKeyEvent) -> None:
+    """Contract the outline pane. Expand the body pane."""
+    c = event.get('c')
+    if c:
+        c.frame.top.layout_cache.contract_vr3()
+#@+node:ekr.20241027140739.1: *3* expand-*-pane commands
+#@+node:ekr.20241027124820.1: *4* 'expand-body-pane
 @g.command('expand-body-pane')
 def expandBodyPane(event: LeoKeyEvent) -> None:
     """Expand the log pane. Contract the outline pane."""
     c = event.get('c')
     if c:
         c.frame.top.layout_cache.expand_body()
-#@+node:ekr.20200303084226.1: *3* 'expand-log-pane'
+#@+node:ekr.20200303084226.1: *4* 'expand-log-pane'
 @g.command('expand-log-pane')
 def expandLogPane(event: LeoKeyEvent) -> None:
     """Expand the log pane. Contract the outline pane."""
     c = event.get('c')
     if c:
         c.frame.top.layout_cache.expand_log()
-#@+node:ekr.20241027124753.1: *3* 'expand-outline-pane'
+#@+node:ekr.20241027124753.1: *4* 'expand-outline-pane'
 @g.command('expand-outline-pane')
 def expandOutlinePane(event: LeoKeyEvent) -> None:
     """Expand the log pane. Contract the outline pane."""
     c = event.get('c')
     if c:
         c.frame.top.layout_cache.expand_outline()
-#@+node:ekr.20200303084610.1: *3* 'hide-body-pane'
+#@+node:ekr.20241027140647.1: *4* 'expand-vr-pane'
+@g.command('expand-vr-pane')
+def expandVRPane(event: LeoKeyEvent) -> None:
+    """Expand the log pane. Contract the outline pane."""
+    c = event.get('c')
+    if c:
+        c.frame.top.layout_cache.expand_vr()
+#@+node:ekr.20241027140706.1: *4* 'expand-vr3-pane'
+@g.command('expand-vr3-pane')
+def expandVR3Pane(event: LeoKeyEvent) -> None:
+    """Expand the log pane. Contract the outline pane."""
+    c = event.get('c')
+    if c:
+        c.frame.top.layout_cache.expand_vr3()
+#@+node:ekr.20241027140819.1: *3* hide-* commands
+#@+node:ekr.20200303084610.1: *4* 'hide-body-pane'
 @g.command('hide-body-pane')
 def hideBodyPane(event: LeoKeyEvent) -> None:
     """Hide the body pane. Fully expand the outline/log splitter."""
@@ -4335,32 +4366,14 @@ def hideBodyPane(event: LeoKeyEvent) -> None:
     if not c:
         return
     c.frame.divideLeoSplitter1(1.0)
-#@+node:ekr.20231102130853.1: *3* 'hide-icon-bar', 'show-icon-bar', 'toggle-icon-bar'
+#@+node:ekr.20231102130853.1: *4* 'hide-icon-bar'
 @g.command('hide-icon-bar')
 def hideIconBar(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if c:
         dw = c.frame.top
         dw.iconBar.hide()
-
-@g.command('show-icon-bar')
-def showIconBar(event: LeoKeyEvent) -> None:
-    c = event.get('c')
-    if c:
-        dw = c.frame.top
-        dw.iconBar.show()
-
-@g.command('toggle-icon-bar')
-def toggleIconBar(event: LeoKeyEvent) -> None:
-    c = event.get('c')
-    if c:
-        dw = c.frame.top
-        w = dw.iconBar
-        if w.isVisible():
-            w.hide()
-        else:
-            w.show()
-#@+node:ekr.20200303084625.1: *3* 'hide-log-pane'
+#@+node:ekr.20200303084625.1: *4* 'hide-log-pane'
 @g.command('hide-log-pane')
 def hideLogPane(event: LeoKeyEvent) -> None:
     """Hide the log pane. Fully expand the outline pane."""
@@ -4368,33 +4381,14 @@ def hideLogPane(event: LeoKeyEvent) -> None:
     if not c:
         return
     c.frame.divideLeoSplitter2(1.0)
-#@+node:ekr.20231102131048.1: *3* 'hide-minibuffer', 'show-minibuffer', 'toggle-minibuffer'
+#@+node:ekr.20231102131048.1: *4* 'hide-minibuffer'
 @g.command('hide-minibuffer')
 def hideMinibuffer(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if c:
         dw = c.frame.top
         dw.leo_minibuffer_frame.hide()
-
-@g.command('show-minibuffer')
-def showMinibuffer(event: LeoKeyEvent) -> None:
-    c = event.get('c')
-    if c:
-        dw = c.frame.top
-        dw.leo_minibuffer_frame.show()
-
-@g.command('toggle-minibuffer')
-def toggleMinibuffer(event: LeoKeyEvent) -> None:
-    c = event.get('c')
-    if c:
-        dw = c.frame.top
-        w = dw.leo_minibuffer_frame
-        if w.isVisible():
-            w.hide()
-        else:
-            w.show()
-
-#@+node:ekr.20200303082511.7: *3* 'hide-outline-pane'
+#@+node:ekr.20200303082511.7: *4* 'hide-outline-pane'
 @g.command('hide-outline-pane')
 def hideOutlinePane(event: LeoKeyEvent) -> None:
     """Hide the outline/log splitter. Fully expand the body pane."""
@@ -4403,32 +4397,29 @@ def hideOutlinePane(event: LeoKeyEvent) -> None:
         return
     c.frame.divideLeoSplitter1(0.0)
 
-#@+node:ekr.20231102130902.1: *3* 'hide-status-bar', 'show-status-bar', 'toggle-staus-bar'
+#@+node:ekr.20231102130902.1: *4* 'hide-status-bar'
 @g.command('hide-status-bar')
 def hideStatusBar(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if c:
         dw = c.frame.top
         dw.statusBar.hide()
-
-@g.command('show-status-bar')
-def showStatusBar(event: LeoKeyEvent) -> None:
+#@+node:ekr.20241027140853.1: *3* show-* commands
+#@+node:ekr.20241027140945.1: *4* 'show-icon-bar'
+@g.command('show-icon-bar')
+def showIconBar(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if c:
         dw = c.frame.top
-        dw.statusBar.show()
-
-@g.command('toggle-status-bar')
-def toggleStatusBar(event: LeoKeyEvent) -> None:
+        dw.iconBar.show()
+#@+node:ekr.20241027141052.1: *4* 'show-minibuffer'
+@g.command('show-minibuffer')
+def showMinibuffer(event: LeoKeyEvent) -> None:
     c = event.get('c')
     if c:
         dw = c.frame.top
-        w = dw.statusBar
-        if w.isVisible():
-            w.hide()
-        else:
-            w.show()
-#@+node:ekr.20240518150051.1: *3* 'show-qt-widgets'
+        dw.leo_minibuffer_frame.show()
+#@+node:ekr.20240518150051.1: *4* 'show-qt-widgets'
 @g.command('print-qt-widgets')
 @g.command('show-qt-widgets')
 def showQtWidgets(event: LeoKeyEvent) -> None:
@@ -4473,7 +4464,48 @@ def showQtWidgets(event: LeoKeyEvent) -> None:
         dump_children(w)
 
     full_dump(c.frame.top)
-#@+node:ekr.20240505045118.1: *3* 'toggle-unl-view'
+#@+node:ekr.20241027141138.1: *4* 'show-status-bar'
+@g.command('show-status-bar')
+def showStatusBar(event: LeoKeyEvent) -> None:
+    c = event.get('c')
+    if c:
+        dw = c.frame.top
+        dw.statusBar.show()
+#@+node:ekr.20241027140920.1: *3* toggle-* commands
+#@+node:ekr.20241027141012.1: *4* 'toggle-icon-bar'
+@g.command('toggle-icon-bar')
+def toggleIconBar(event: LeoKeyEvent) -> None:
+    c = event.get('c')
+    if c:
+        dw = c.frame.top
+        w = dw.iconBar
+        if w.isVisible():
+            w.hide()
+        else:
+            w.show()
+#@+node:ekr.20241027141108.1: *4* 'toggle-minibuffer'
+@g.command('toggle-minibuffer')
+def toggleMinibuffer(event: LeoKeyEvent) -> None:
+    c = event.get('c')
+    if c:
+        dw = c.frame.top
+        w = dw.leo_minibuffer_frame
+        if w.isVisible():
+            w.hide()
+        else:
+            w.show()
+#@+node:ekr.20241027141155.1: *4* 'toggle-status-bar'
+@g.command('toggle-status-bar')
+def toggleStatusBar(event: LeoKeyEvent) -> None:
+    c = event.get('c')
+    if c:
+        dw = c.frame.top
+        w = dw.statusBar
+        if w.isVisible():
+            w.hide()
+        else:
+            w.show()
+#@+node:ekr.20240505045118.1: *4* 'toggle-unl-view'
 @g.command('toggle-unl-view')
 def toggleUnlView(event: LeoKeyEvent) -> None:
     c = event.get('c')

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -1944,7 +1944,7 @@ class LeoQtFrame(leoFrame.LeoFrame):
         """Resize splitter1 and splitter2 using the given ratios."""
         self.divideLeoSplitter1(ratio)
         self.divideLeoSplitter2(ratio2)
-    #@+node:ekr.20110605121601.18283: *4* LeoQtFrame.divideLeoSplitter1/2 (to do)
+    #@+node:ekr.20110605121601.18283: *4* LeoQtFrame.divideLeoSplitter1/2
     def divideLeoSplitter1(self, frac: float) -> None:
         """Divide the main splitter."""
         gui = g.app.gui

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -11,7 +11,7 @@ import re
 import sys
 import textwrap
 from time import sleep
-from typing import Any, Generator, Optional, Union, TYPE_CHECKING
+from typing import Any, Generator, Optional, Tuple, Union, TYPE_CHECKING
 from leo.core import leoColor
 from leo.core import leoGlobals as g
 from leo.core import leoGui
@@ -1533,12 +1533,21 @@ class LeoQtGui(leoGui.LeoGui):
         else:
             g.trace(f"Not a QSplitter: {splitter.__class__.__name__}")
     #@+node:ekr.20241027183453.1: *4* LeoQtGui.find_parent_splitter
-    def find_parent_splitter(self, widget: QWidget) -> Optional[QSplitter]:
-        """Return the nearest parent QSplitter widget."""
+    def find_parent_splitter(self, widget: QWidget) -> Optional[Tuple[QSplitter, Any]]:
+        """
+        Find the nearest parent QSplitter widget for the given widget.
+        
+        Return (splitter, child) where:
+        - splitter is the QSplitter containing the widget.
+        - child is the *direct* child of the splitter that contains the widget.
+          The child might or might not be the widget itself.
+        """
+        direct_child: Any = widget
         parent = widget.parent()
         while parent:
             if isinstance(parent, QtWidgets.QSplitter):
-                return parent
+                return parent, direct_child
+            direct_child = parent
             parent = parent.parent()
         return None
     #@+node:ekr.20240519115301.1: *4* LeoQtGui.find_widget_by_name

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:  # pragma: no cover
     QPixmap = QtGui.QPixmap
     QPoint = QtCore.QPoint
     QPushButton = QtWidgets.QPushButton
+    QSplitter = QtWidgets.QSplitter
     QTabWidget = QtWidgets.QTabWidget
     QVBoxLayout = QtWidgets.QVBoxLayout
     QWidget = QtWidgets.QWidget
@@ -1517,6 +1518,29 @@ class LeoQtGui(leoGui.LeoGui):
         yield qt_obj
         for child in qt_obj.children():
             yield from self._self_and_subtree(child)
+    #@+node:ekr.20111027083744.16532: *4* LeoQtGui.enableSignalDebugging
+    import PyQt6.QtTest as QtTest
+
+    QSignalSpy = QtTest.QSignalSpy
+    assert QSignalSpy
+    #@+node:ekr.20240521171848.1: *4* LeoQtGui.equalize_splitter
+    def equalize_splitter(self, splitter):
+        """Equalize all the splitter's contents."""
+        if not splitter:
+            return
+        if isinstance(splitter, QtWidgets.QSplitter):
+            splitter.setSizes([100000] * len(splitter.sizes()))
+        else:
+            g.trace(f"Not a QSplitter: {splitter.__class__.__name__}")
+    #@+node:ekr.20241027183453.1: *4* LeoQtGui.find_parent_splitter
+    def find_parent_splitter(self, widget: QWidget) -> Optional[QSplitter]:
+        """Return the nearest parent QSplitter widget."""
+        parent = widget.parent()
+        while parent:
+            if isinstance(parent, QtWidgets.QSplitter):
+                return parent
+            parent = parent.parent()
+        return None
     #@+node:ekr.20240519115301.1: *4* LeoQtGui.find_widget_by_name
     def find_widget_by_name(self, c: Cmdr, name: str) -> Optional[QWidget]:
         for w in self._self_and_subtree(c.frame.top):
@@ -1554,20 +1578,6 @@ class LeoQtGui(leoGui.LeoGui):
         else:
             name = repr(w)
         return name
-    #@+node:ekr.20111027083744.16532: *4* LeoQtGui.enableSignalDebugging
-    import PyQt6.QtTest as QtTest
-
-    QSignalSpy = QtTest.QSignalSpy
-    assert QSignalSpy
-    #@+node:ekr.20240521171848.1: *4* LeoQtGui.equalize_splitter
-    def equalize_splitter(self, splitter):
-        """Equalize all the splitter's contents."""
-        if not splitter:
-            return
-        if isinstance(splitter, QtWidgets.QSplitter):
-            splitter.setSizes([100000] * len(splitter.sizes()))
-        else:
-            g.trace(f"Not a QSplitter: {splitter.__class__.__name__}")
     #@+node:ekr.20190819091957.1: *3* LeoQtGui:Widget constructors
     #@+node:ekr.20190819094016.1: *4* LeoQtGui.createButton
     def createButton(self, parent: QWidget, name: str, label: str) -> QPushButton:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -427,7 +427,7 @@ VERTICAL_THIRDS_LAYOUT = {
 class LayoutCacheWidget(QWidget):
     """
     Manage layouts, which may be defined by methods or by
-    a layout data structure such as the following:0
+    a layout data structure such as the following::
 
         FALLBACK_LAYOUT = {
             'SPLITTERS':OrderedDict(
@@ -556,7 +556,7 @@ class LayoutCacheWidget(QWidget):
             if kid.objectName() == name:
                 w = kid  # type: ignore [assignment]
         return w
-    #@+node:ekr.20241027181931.1: *4* LCW.resize_widget
+    #@+node:ekr.20241027181931.1: *4* LCW.resize_pane
     def resize_pane(self, widget: QWidget, delta: int) -> None:
         """Resize the pane containing the given widget."""
         c = self.c

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -8,13 +8,10 @@ from __future__ import annotations
 
 import textwrap
 from collections import OrderedDict
-from typing import Any, Dict, TYPE_CHECKING, TypeVar, Optional
-from typing import Generic
+from typing import Any, Dict, TYPE_CHECKING, Optional
 
 from leo.core.leoQt import QtWidgets, Orientation, QtCore
 from leo.core import leoGlobals as g
-
-OD = TypeVar('OD', bound=OrderedDict)
 
 QSplitter = QtWidgets.QSplitter
 QWidget = QtWidgets.QWidget
@@ -25,7 +22,6 @@ if TYPE_CHECKING:  # pragma: no cover
     # from typing import TypeAlias  # Requires Python 3.12+
     Args = Any
     KWargs = Any
-
 #@-<< qt_layout: imports & annotations >>
 #@+<< qt_layout: declarations >>
 #@+node:tom.20241009141008.1: ** << qt_layout: declarations >>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -460,65 +460,87 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
     #@+node:ekr.20241027124630.1: *4* LayoutCacheWidget.contract_body
     def contract_body(self):
         """Contract the body pane"""
-        g.trace('Not ready')
+        self.contract_pane(self.c.frame.body)
     #@+node:ekr.20241027125414.1: *4* LayoutCacheWidget.contract_log
     def contract_log(self):
         """Contract the log pane"""
-        g.trace('Not ready')
+        self.contract_pane(self.c.frame.log)
     #@+node:ekr.20241027125415.1: *4* LayoutCacheWidget.contract_outline
     def contract_outline(self):
         """Contract the outline pane"""
-        g.trace('Not ready')
+        self.contract_pane(self.c.frame.tree)
     #@+node:ekr.20241027141341.1: *4* LayoutCacheWidget.contract_vr
     def contract_vr(self):
         """Contract the VR pane if VR is running"""
-        if not is_module_loaded(VR_MODULE_NAME):
+        c = self.c
+        if is_module_loaded(VR_MODULE_NAME):
+            vr = getattr(c, 'vr', None)
+            self.expand_pane(vr)
+        else:
             g.es_print('VR is not running', color='blue')
-            return
-        g.trace('Not ready')
     #@+node:ekr.20241027141411.1: *4* LayoutCacheWidget.contract_vr3
     def contract_vr3(self):
         """Contract the VR3 pane if VR3 is running"""
-        if not is_module_loaded(VR3_MODULE_NAME):
+        c = self.c
+        if is_module_loaded(VR3_MODULE_NAME):
+            from leo.plugins.viewrendered3 import controllers
+            vr3 = controllers.get(c.hash())
+            self.contract_pane(vr3)
+        else:
             g.es_print('VR3 is not running', color='blue')
-            return
-        g.trace('Not ready')
     #@+node:ekr.20241027142605.1: *3* LayoutCacheWidget: expand_*
     #@+node:ekr.20241027124500.1: *4* LayoutCacheWidget.expand_body
     def expand_body(self):
         """Expand the body pane"""
-        g.trace('Not ready')
+        self.expand_pane(self.c.frame.body)
     #@+node:ekr.20241027125500.1: *4* LayoutCacheWidget.expand_log
     def expand_log(self):
         """Expand the log pane"""
-        g.trace('Not ready')
+        self.expand_pane(self.c.frame.log)
     #@+node:ekr.20241027124703.1: *4* LayoutCacheWidget.expand_outline
     def expand_outline(self):
         """Expand the outline pane."""
-        g.trace('Not ready')
+        self.expand_pane(self.c.frame.tree)
     #@+node:ekr.20241027141425.1: *4* LayoutCacheWidget.expand_vr
     def expand_vr(self):
         """Expand the VR pane if VR is running"""
-        if not is_module_loaded(VR_MODULE_NAME):
+        c = self.c
+        if is_module_loaded(VR_MODULE_NAME):
+            vr = getattr(c, 'vr', None)
+            self.expand_pane(vr)
+        else:
             g.es_print('VR is not running', color='blue')
-            return
-        g.trace('Not ready')
     #@+node:ekr.20241027141446.1: *4* LayoutCacheWidget.expand_vr3
     def expand_vr3(self):
         """Expand the VR3 pane if VR3 is running"""
-        if not is_module_loaded(VR3_MODULE_NAME):
+        c = self.c
+        if is_module_loaded(VR3_MODULE_NAME):
+            from leo.plugins.viewrendered3 import controllers
+            vr3 = controllers.get(c.hash())
+            self.expand_pane(vr3)
+        else:
             g.es_print('VR3 is not running', color='blue')
-            return
-        g.trace('Not ready')
     #@+node:ekr.20241027162525.1: *3* LayoutCacheWidget: utils
-    #@+node:ekr.20241027161121.1: *4* LayoutCacheWidget.contract_pane_by_name
-    def contract_pane_by_name(self, name: str) -> None:
-        """Contract the pane with the given Qt objectName."""
-        g.trace('Not ready', name)
-    #@+node:ekr.20241027161215.1: *4* LayoutCacheWidget.expand_pane_by_name
-    def expand_pane_by_name(self, name: str) -> None:
-        """Expand the pane with the given Qt objectName."""
-        g.trace('Not ready', name)
+    #@+node:ekr.20241027161121.1: *4* LayoutCacheWidget.contract_pane
+    def contract_pane(self, widget: Any) -> None:
+        """Contract the pane containing the given widget."""
+        try:
+            name = widget.objectName()
+            g.trace(name)
+        except Exception:
+            g.es_print('Oops', color='red')
+            g.trace(g.callers())
+            g.es_exception()
+    #@+node:ekr.20241027161215.1: *4* LayoutCacheWidget.expand_pane
+    def expand_pane(self, widget: Any) -> None:
+        """Expand the pane containing the given widget."""
+        try:
+            name = widget.objectName()
+            g.trace(name)
+        except Exception:
+            g.es_print('Oops', color='red')
+            g.trace(g.callers())
+            g.es_exception()
     #@+node:tom.20240923194438.5: *4* LayoutCacheWidget.find_splitter_by_name
     def find_splitter_by_name(self, name: str) -> QW:
         """Return a splitter instance given its objectName.

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -427,7 +427,7 @@ VERTICAL_THIRDS_LAYOUT = {
 class LayoutCacheWidget(QWidget):
     """
     Manage layouts, which may be defined by methods or by
-    a layout data structure such as the following:
+    a layout data structure such as the following:0
 
         FALLBACK_LAYOUT = {
             'SPLITTERS':OrderedDict(
@@ -559,13 +559,41 @@ class LayoutCacheWidget(QWidget):
     #@+node:ekr.20241027181931.1: *4* LCW.resize_widget
     def resize_pane(self, widget: QWidget, delta: int) -> None:
         """Resize the pane containing the given widget."""
-        splitter = g.app.gui.find_parent_splitter(widget)
-        if splitter:
-            index = splitter.indexOf(widget)
-            g.trace(f"to do: {splitter.objectName()}, delta: {delta}")
-        else:
-            g.trace(f"No splitter for name: {widget.objectName()!r}")
+        c = self.c
+        splitter, direct_child = g.app.gui.find_parent_splitter(widget)
+        if not splitter:
+            g.trace(f"Can not happen: no splitter for name: {widget.objectName()!r}")
+            return
+        # A complication.
+        try:
+            index = splitter.indexOf(direct_child)
+            sizes = splitter.sizes()
+            widget_size = sizes[index]
+        except Exception:
+            g.trace(f"Can not happen: {widget} not in {splitter}")
+            g.es_exception()
+            return
 
+        ### c.frame.compute_ratio()
+        ## ratio = 0.5 if n1 + n2 == 0 else float(n1) / float(n1 + n2)
+
+        ###
+        ### r = max(0, min(1.0, c.frame.compute_ratio() + delta))
+        print('')
+        g.trace('splitter:', splitter.objectName())
+        g.trace('direct_child:', direct_child.objectName())
+        g.trace('widget:', widget.objectName())
+        for i, child in enumerate(splitter.children()):
+            print(i, f"{child.objectName():35} {child.__class__.__name__}")
+        g.trace('index', index, 'sizes', sizes)
+        g.trace(f"delta: {delta} widget_size: {widget_size}")
+
+        ### Similar to c.frame.divideAnySplitter.
+        # s1, s2 = sizes
+        # s = s1 + s2
+        # s1 = int(s * frac + 0.5)
+        # s2 = s - s1
+        # splitter.setSizes([s1, s2])
     #@+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
     def restoreFromLayout(self, layout: Dict = None) -> None:
         if layout is None:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -17,6 +17,7 @@ from leo.core import leoGlobals as g
 QW = TypeVar('QW', bound=QtWidgets.QWidget)
 OD = TypeVar('OD', bound=OrderedDict)
 
+QSplitter = QtWidgets.QSplitter
 QWidget = QtWidgets.QWidget
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -457,19 +458,19 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
 
     #@+others
     #@+node:ekr.20241027142532.1: *3* LayoutCasheWidget: contract_*
-    #@+node:ekr.20241027124630.1: *4* LayoutCacheWidget.contract_body
+    #@+node:ekr.20241027124630.1: *4* LCW.contract_body
     def contract_body(self):
         """Contract the body pane"""
         self.contract_pane(self.c.frame.body.widget)
-    #@+node:ekr.20241027125414.1: *4* LayoutCacheWidget.contract_log
+    #@+node:ekr.20241027125414.1: *4* LCW.contract_log
     def contract_log(self):
         """Contract the log pane"""
         self.contract_pane(self.c.frame.log.logWidget)
-    #@+node:ekr.20241027125415.1: *4* LayoutCacheWidget.contract_outline
+    #@+node:ekr.20241027125415.1: *4* LCW.contract_outline
     def contract_outline(self):
         """Contract the outline pane"""
         self.contract_pane(self.c.frame.tree.treeWidget)
-    #@+node:ekr.20241027141341.1: *4* LayoutCacheWidget.contract_vr
+    #@+node:ekr.20241027141341.1: *4* LCW.contract_vr
     def contract_vr(self):
         """Contract the VR pane if VR is running"""
         c = self.c
@@ -478,7 +479,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
             self.expand_pane(vr)
         else:
             g.es_print('VR is not running', color='blue')
-    #@+node:ekr.20241027141411.1: *4* LayoutCacheWidget.contract_vr3
+    #@+node:ekr.20241027141411.1: *4* LCW.contract_vr3
     def contract_vr3(self):
         """Contract the VR3 pane if VR3 is running"""
         c = self.c
@@ -489,19 +490,19 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         else:
             g.es_print('VR3 is not running', color='blue')
     #@+node:ekr.20241027142605.1: *3* LayoutCacheWidget: expand_*
-    #@+node:ekr.20241027124500.1: *4* LayoutCacheWidget.expand_body
+    #@+node:ekr.20241027124500.1: *4* LCW.expand_body
     def expand_body(self):
         """Expand the body pane"""
         self.expand_pane(self.c.frame.body.widget)
-    #@+node:ekr.20241027125500.1: *4* LayoutCacheWidget.expand_log
+    #@+node:ekr.20241027125500.1: *4* LCW.expand_log
     def expand_log(self):
         """Expand the log pane"""
         self.expand_pane(self.c.frame.log.logWidget)
-    #@+node:ekr.20241027124703.1: *4* LayoutCacheWidget.expand_outline
+    #@+node:ekr.20241027124703.1: *4* LCW.expand_outline
     def expand_outline(self):
         """Expand the outline pane."""
         self.expand_pane(self.c.frame.tree.treeWidget)
-    #@+node:ekr.20241027141425.1: *4* LayoutCacheWidget.expand_vr
+    #@+node:ekr.20241027141425.1: *4* LCW.expand_vr
     def expand_vr(self):
         """Expand the VR pane if VR is running"""
         c = self.c
@@ -510,7 +511,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
             self.expand_pane(vr)
         else:
             g.es_print('VR is not running', color='blue')
-    #@+node:ekr.20241027141446.1: *4* LayoutCacheWidget.expand_vr3
+    #@+node:ekr.20241027141446.1: *4* LCW.expand_vr3
     def expand_vr3(self):
         """Expand the VR3 pane if VR3 is running"""
         c = self.c
@@ -521,7 +522,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         else:
             g.es_print('VR3 is not running', color='blue')
     #@+node:ekr.20241027162525.1: *3* LayoutCacheWidget: utils
-    #@+node:ekr.20241027161121.1: *4* LayoutCacheWidget.contract_pane & expand_pane
+    #@+node:ekr.20241027161121.1: *4* LCW.contract_pane & expand_pane
     def contract_pane(self, widget: Any) -> None:
         """Contract the pane containing the given widget."""
         self.contract_pane_by_name(widget.objectName())
@@ -529,15 +530,35 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
     def expand_pane(self, widget: Any) -> None:
         """Expand the pane containing the given widget."""
         self.expand_pane_by_name(widget.objectName())
-    #@+node:ekr.20241027161215.1: *4* LayoutCacheWidget.contract_pane_by_name
+    #@+node:ekr.20241027161215.1: *4* LCW.contract_pane_by_name
     def contract_pane_by_name(self, name: str) -> None:
         """Contract the pane whose objectName is given"""
-        g.trace(name)
-    #@+node:ekr.20241027172516.1: *4* LayoutCacheWidget.expand_pane_by_name
+        widget = self.find_widget(name)
+        if not widget:
+            g.trace(f"No widget with name: {name!r}")
+            return
+        splitter = self.find_parent_splitter(widget)
+        if splitter:
+            index = splitter.indexOf(widget)
+            self.resize_splitter(splitter, index, -10)
+        else:
+            g.trace(f"No splitter for name: {name!r}")
+
+    #@+node:ekr.20241027172516.1: *4* LCW.expand_pane_by_name
     def expand_pane_by_name(self, name: str) -> None:
         """Expand the pane whose objectName is given"""
-        g.trace(name)
-    #@+node:tom.20240923194438.5: *4* LayoutCacheWidget.find_splitter_by_name
+        widget = self.find_widget(name)
+        if not widget:
+            g.trace(f"No widget with name: {name!r}")
+            return
+        splitter = self.find_parent_splitter(widget)
+        if splitter:
+            index = splitter.indexOf(widget)
+            self.resize_splitter(splitter, index, 10)
+        else:
+            g.trace(f"No splitter for name: {name!r}")
+
+    #@+node:tom.20240923194438.5: *4* LCW.find_splitter_by_name
     def find_splitter_by_name(self, name: str) -> QW:
         """Return a splitter instance given its objectName.
         
@@ -560,11 +581,20 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                     splitter = kid  # type: ignore [assignment]
                     break
         return splitter
-    #@+node:ekr.20241008180818.1: *4* LayoutCacheWidget.find_widget
+    #@+node:ekr.20241027183453.1: *4* LCW.find_parent_splitter
+    def find_parent_splitter(self, widget: QW) -> Optional[QSplitter]:
+        """Return the nearest parent QSplitter widget."""
+        parent = widget.parent()
+        while parent:
+            if isinstance(parent, QtWidgets.QSplitter):
+                return parent
+            parent = parent.parent()
+        return None
+    #@+node:ekr.20241008180818.1: *4* LCW.find_widget
     def find_widget(self, name: str) -> QW:
         """Return a widget given it objectName."""
         return g.app.gui.find_widget_by_name(self.c, name)
-    #@+node:tom.20240923194438.4: *4* LayoutCacheWidget.find_widget_in_children
+    #@+node:tom.20240923194438.4: *4* LCW.find_widget_in_children
     def find_widget_in_children(self, name: str) -> QW:  ### : Optional[QW] = None
         """Return a child widget with the given objectName.
         """
@@ -574,7 +604,11 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                 w = kid  # type: ignore [assignment]
         return w
 
-    #@+node:tom.20240923194438.6: *4* LayoutCacheWidget.restoreFromLayout
+    #@+node:ekr.20241027181931.1: *4* LCW.resize_splitter
+    def resize_splitter(self, splitter: Any, index: int, factor: int) -> None:
+        """Resize the splitter."""
+        g.trace(splitter.objectName(), index, factor)
+    #@+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
     def restoreFromLayout(self, layout: Dict = None) -> None:
         if layout is None:
             layout = FALLBACK_LAYOUT

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -460,15 +460,15 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
     #@+node:ekr.20241027124630.1: *4* LayoutCacheWidget.contract_body
     def contract_body(self):
         """Contract the body pane"""
-        self.contract_pane(self.c.frame.body)
+        self.contract_pane(self.c.frame.body.widget)
     #@+node:ekr.20241027125414.1: *4* LayoutCacheWidget.contract_log
     def contract_log(self):
         """Contract the log pane"""
-        self.contract_pane(self.c.frame.log)
+        self.contract_pane(self.c.frame.log.logWidget)
     #@+node:ekr.20241027125415.1: *4* LayoutCacheWidget.contract_outline
     def contract_outline(self):
         """Contract the outline pane"""
-        self.contract_pane(self.c.frame.tree)
+        self.contract_pane(self.c.frame.tree.treeWidget)
     #@+node:ekr.20241027141341.1: *4* LayoutCacheWidget.contract_vr
     def contract_vr(self):
         """Contract the VR pane if VR is running"""
@@ -492,15 +492,15 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
     #@+node:ekr.20241027124500.1: *4* LayoutCacheWidget.expand_body
     def expand_body(self):
         """Expand the body pane"""
-        self.expand_pane(self.c.frame.body)
+        self.expand_pane(self.c.frame.body.widget)
     #@+node:ekr.20241027125500.1: *4* LayoutCacheWidget.expand_log
     def expand_log(self):
         """Expand the log pane"""
-        self.expand_pane(self.c.frame.log)
+        self.expand_pane(self.c.frame.log.logWidget)
     #@+node:ekr.20241027124703.1: *4* LayoutCacheWidget.expand_outline
     def expand_outline(self):
         """Expand the outline pane."""
-        self.expand_pane(self.c.frame.tree)
+        self.expand_pane(self.c.frame.tree.treeWidget)
     #@+node:ekr.20241027141425.1: *4* LayoutCacheWidget.expand_vr
     def expand_vr(self):
         """Expand the VR pane if VR is running"""
@@ -521,26 +521,22 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         else:
             g.es_print('VR3 is not running', color='blue')
     #@+node:ekr.20241027162525.1: *3* LayoutCacheWidget: utils
-    #@+node:ekr.20241027161121.1: *4* LayoutCacheWidget.contract_pane
+    #@+node:ekr.20241027161121.1: *4* LayoutCacheWidget.contract_pane & expand_pane
     def contract_pane(self, widget: Any) -> None:
         """Contract the pane containing the given widget."""
-        try:
-            name = widget.objectName()
-            g.trace(name)
-        except Exception:
-            g.es_print('Oops', color='red')
-            g.trace(g.callers())
-            g.es_exception()
-    #@+node:ekr.20241027161215.1: *4* LayoutCacheWidget.expand_pane
+        self.contract_pane_by_name(widget.objectName())
+
     def expand_pane(self, widget: Any) -> None:
         """Expand the pane containing the given widget."""
-        try:
-            name = widget.objectName()
-            g.trace(name)
-        except Exception:
-            g.es_print('Oops', color='red')
-            g.trace(g.callers())
-            g.es_exception()
+        self.expand_pane_by_name(widget.objectName())
+    #@+node:ekr.20241027161215.1: *4* LayoutCacheWidget.contract_pane_by_name
+    def contract_pane_by_name(self, name: str) -> None:
+        """Contract the pane whose objectName is given"""
+        g.trace(name)
+    #@+node:ekr.20241027172516.1: *4* LayoutCacheWidget.expand_pane_by_name
+    def expand_pane_by_name(self, name: str) -> None:
+        """Expand the pane whose objectName is given"""
+        g.trace(name)
     #@+node:tom.20240923194438.5: *4* LayoutCacheWidget.find_splitter_by_name
     def find_splitter_by_name(self, name: str) -> QW:
         """Return a splitter instance given its objectName.

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -527,28 +527,22 @@ class LayoutCacheWidget(QWidget):
         """Expand the pane containing the given widget."""
         self.resize_pane(widget, delta=-10)
     #@+node:tom.20240923194438.5: *4* LCW.find_splitter_by_name
-    def find_splitter_by_name(self, name: str) -> QWidget:
-        """Return a splitter instance given its objectName.
-        
-        This method could return other types of widgets but is intended
-        for finding known splitters.
-        """
-        foundit = False
-        splitter: QWidget = self.find_widget(name)
-        if splitter is not None:
-            foundit = True
-        if not foundit:
-            splitter = self.created_splitter_dict.get(name, None)
-            if splitter is not None:
-                foundit = True
-        if not foundit:
-            ###
-            for kid in self.children():  # type: ignore [assignment]
-                if kid.objectName() == name:
-                    foundit = True
-                    splitter = kid  # type: ignore [assignment]
-                    break
-        return splitter
+    def find_splitter_by_name(self, name: str) -> Optional[QSplitter]:
+        """Return the splitter with the given objectName."""
+
+        def is_splitter(obj: Any) -> bool:
+            return obj is not None and isinstance(obj, QSplitter)
+
+        splitter = self.find_widget(name)
+        if is_splitter(splitter):
+            return splitter  # type:ignore  # We've just checked the type.
+        splitter = self.created_splitter_dict.get(name, None)
+        if is_splitter(splitter):
+            return splitter  # type:ignore  # We've just checked the type.
+        for child in self.children():
+            if child.objectName() == name and is_splitter(child):
+                return child  # type:ignore  # We've just checked the type.
+        return None
     #@+node:ekr.20241008180818.1: *4* LCW.find_widget
     def find_widget(self, name: str) -> QWidget:
         """Return a widget given it objectName."""

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -456,6 +456,30 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         self.layout_registry = LAYOUT_REGISTRY
 
     #@+others
+    #@+node:ekr.20241027124630.1: *3* LayoutCacheWidget.contract_body
+    def contract_body(self):
+        """Contract the body pane"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027125414.1: *3* LayoutCacheWidget.contract_log
+    def contract_log(self):
+        """Contract the log pane"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027125415.1: *3* LayoutCacheWidget.contract_outline
+    def contract_outline(self):
+        """Contract the outline pane"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027124500.1: *3* LayoutCacheWidget.expand_body
+    def expand_body(self):
+        """Expand the body pane"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027125500.1: *3* LayoutCacheWidget.expand_log
+    def expand_log(self):
+        """Expand the log pane"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027124703.1: *3* LayoutCacheWidget.expand_outline
+    def expand_outline(self):
+        """Expand the outline pane."""
+        g.trace('Not ready')
     #@+node:tom.20240923194438.5: *3* LayoutCacheWidget.find_splitter_by_name
     def find_splitter_by_name(self: QW, name: str, _: Optional[QW] = None) -> QW:
         """Return a splitter instance given its objectName.
@@ -507,7 +531,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         if layout is None:
             layout = FALLBACK_LAYOUT
         #@+<< initialize data structures >>
-        #@+node:tom.20240923194438.7: *4* << initialize data structures >>
+        #@+node:tom.20240923194438.7: *4* << initialize data structures >> restoreFromLayout
         ORIENTATIONS = layout['ORIENTATIONS']
 
         has_vr3 = is_module_loaded(VR3_MODULE_NAME)
@@ -545,7 +569,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
 
         #@-<< initialize data structures >>
         #@+<< rehome body editor >>
-        #@+node:tom.20240923194438.8: *4* << rehome body editor >>
+        #@+node:tom.20240923194438.8: *4* << rehome body editor >> restoreFromLayout
         # In case the editor has been moved to e.g. a QTabWidget,
         # Move it back to its standard place.
 
@@ -556,7 +580,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         bsw.setCurrentIndex(0)
         #@-<< rehome body editor >>
         #@+<< clean up splitters >>
-        #@+node:tom.20240923194438.9: *4* << clean up splitters >>
+        #@+node:tom.20240923194438.9: *4* << clean up splitters >> restoreFromLayout
         # Remove extra (no longer wanted) widgets to the cache.
         # Then insert the required widgets into their home splitters
 
@@ -587,7 +611,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                 splitter.setParent(self)
         #@-<< clean up splitters >>
         #@+<< set default orientations >>
-        #@+node:tom.20240923194438.11: *4* << set default orientations >>
+        #@+node:tom.20240923194438.11: *4* << set default orientations >> restoreFromLayout
         # SPLITTER_DICT: {'main_splitter':ms, ...}
         # DEFAULT_ORIENTATIONS:
         # {'main_splitter':Orientation.Horizontal...}
@@ -597,7 +621,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
             splitter.setOrientation(orientation)
         #@-<< set default orientations >>
         #@+<< move widgets to targets >>
-        #@+node:tom.20240923194438.10: *4* << move widgets to targets >>
+        #@+node:tom.20240923194438.10: *4* << move widgets to targets >> restoreFromLayout
         # Move all desired widgets into their home splitters
         # SPLITTERS is an OrderedDict so the widgets will
         # be inserted in the right order.
@@ -614,7 +638,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                     dest.insertWidget(i, widget)
         #@-<< move widgets to targets >>
         #@+<< resize splitters >>
-        #@+node:tom.20240923194438.12: *4* << resize splitters >>
+        #@+node:tom.20240923194438.12: *4* << resize splitters >> restoreFromLayout
         for splt in SPLITTER_DICT.values():
             g.app.gui.equalize_splitter(splt)  # type: ignore[attr-defined]
         #@-<< resize splitters >>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -41,24 +41,24 @@ LAYOUT_REGISTRY = {}
 #@-<< qt_layout: declarations >>
 
 #@+others
-#@+node:ekr.20241008174359.1: ** Top-level functions
-#@+node:ekr.20241008141246.1: *3* function: init
+#@+node:ekr.20241008174359.1: ** Top-level functions: qt_layout.py
+#@+node:ekr.20241008141246.1: *3* function: init (qt_layout.py)
 def init() -> bool:
     """
     qt_layout is not a true plugin, but return True just in case.
     """
     return True
-#@+node:ekr.20241008141353.1: *3* function: show_vr3_pane
+#@+node:ekr.20241008141353.1: *3* function: show_vr3_pane (qt_layout.py)
 def show_vr3_pane(c: Cmdr, w: QW) -> None:
     w.setUpdatesEnabled(True)
     c.doCommandByName('vr3-show')
-#@+node:tom.20241009141223.1: *3* function: is_module_loaded
+#@+node:tom.20241009141223.1: *3* function: is_module_loaded (qt_layout.py)
 def is_module_loaded(module_name: str) -> bool:
     """Return True if the plugins controller has loaded the module.
     """
     controller = g.app.pluginsController
     return controller.isLoaded(module_name)
-#@+node:tom.20241015161609.1: *3* decorator:  register_layout
+#@+node:tom.20241015161609.1: *3* decorator:  register_layout (qt_layout.py)
 def register_layout(name: str):  # type: ignore
     def decorator(func):
         # Register the function's name and docstring in the dictionary
@@ -456,45 +456,59 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         self.layout_registry = LAYOUT_REGISTRY
 
     #@+others
-    #@+node:ekr.20241027124630.1: *3* LayoutCacheWidget.contract_body
+    #@+node:ekr.20241027142532.1: *3* LayoutCaseWidget: contract_*
+    #@+node:ekr.20241027124630.1: *4* LayoutCacheWidget.contract_body
     def contract_body(self):
         """Contract the body pane"""
         g.trace('Not ready')
-    #@+node:ekr.20241027125414.1: *3* LayoutCacheWidget.contract_log
+    #@+node:ekr.20241027125414.1: *4* LayoutCacheWidget.contract_log
     def contract_log(self):
         """Contract the log pane"""
         g.trace('Not ready')
-    #@+node:ekr.20241027125415.1: *3* LayoutCacheWidget.contract_outline
+    #@+node:ekr.20241027125415.1: *4* LayoutCacheWidget.contract_outline
     def contract_outline(self):
         """Contract the outline pane"""
         g.trace('Not ready')
-    #@+node:ekr.20241027141341.1: *3* LayoutCacheWidget.contract_vr
+    #@+node:ekr.20241027141341.1: *4* LayoutCacheWidget.contract_vr
     def contract_vr(self):
         """Contract the VR pane if VR is running"""
+        if not is_module_loaded(VR_MODULE_NAME):
+            g.es_print('VR is not running', color='blue')
+            return
         g.trace('Not ready')
-    #@+node:ekr.20241027141411.1: *3* LayoutCacheWidget.contract_vr3
+    #@+node:ekr.20241027141411.1: *4* LayoutCacheWidget.contract_vr3
     def contract_vr3(self):
         """Contract the VR3 pane if VR3 is running"""
+        if not is_module_loaded(VR3_MODULE_NAME):
+            g.es_print('VR3 is not running', color='blue')
+            return
         g.trace('Not ready')
-    #@+node:ekr.20241027124500.1: *3* LayoutCacheWidget.expand_body
+    #@+node:ekr.20241027142605.1: *3* LayoutCaseWidget: expand_*
+    #@+node:ekr.20241027124500.1: *4* LayoutCacheWidget.expand_body
     def expand_body(self):
         """Expand the body pane"""
         g.trace('Not ready')
-    #@+node:ekr.20241027125500.1: *3* LayoutCacheWidget.expand_log
+    #@+node:ekr.20241027125500.1: *4* LayoutCacheWidget.expand_log
     def expand_log(self):
         """Expand the log pane"""
         g.trace('Not ready')
-    #@+node:ekr.20241027124703.1: *3* LayoutCacheWidget.expand_outline
+    #@+node:ekr.20241027124703.1: *4* LayoutCacheWidget.expand_outline
     def expand_outline(self):
         """Expand the outline pane."""
         g.trace('Not ready')
-    #@+node:ekr.20241027141425.1: *3* LayoutCacheWidget.expand_vr
+    #@+node:ekr.20241027141425.1: *4* LayoutCacheWidget.expand_vr
     def expand_vr(self):
         """Expand the VR pane if VR is running"""
+        if not is_module_loaded(VR_MODULE_NAME):
+            g.es_print('VR is not running', color='blue')
+            return
         g.trace('Not ready')
-    #@+node:ekr.20241027141446.1: *3* LayoutCacheWidget.expand_vr3
+    #@+node:ekr.20241027141446.1: *4* LayoutCacheWidget.expand_vr3
     def expand_vr3(self):
         """Expand the VR3 pane if VR3 is running"""
+        if not is_module_loaded(VR3_MODULE_NAME):
+            g.es_print('VR3 is not running', color='blue')
+            return
         g.trace('Not ready')
     #@+node:tom.20240923194438.5: *3* LayoutCacheWidget.find_splitter_by_name
     def find_splitter_by_name(self: QW, name: str, _: Optional[QW] = None) -> QW:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -517,42 +517,15 @@ class LayoutCacheWidget(QWidget):
         else:
             g.es_print('VR3 is not running', color='blue')
     #@+node:ekr.20241027162525.1: *3* LayoutCacheWidget: utils
-    #@+node:ekr.20241027161121.1: *4* LCW.contract_pane & expand_pane
+    #@+node:ekr.20241027161121.1: *4* LCW.contract_pane
     def contract_pane(self, widget: Any) -> None:
         """Contract the pane containing the given widget."""
-        self.contract_pane_by_name(widget.objectName())
+        self.resize_pane(widget, delta=10)
 
+    #@+node:ekr.20241028045021.1: *4* LCW.expand_pane
     def expand_pane(self, widget: Any) -> None:
         """Expand the pane containing the given widget."""
-        self.expand_pane_by_name(widget.objectName())
-    #@+node:ekr.20241027161215.1: *4* LCW.contract_pane_by_name
-    def contract_pane_by_name(self, name: str) -> None:
-        """Contract the pane whose objectName is given"""
-        widget: QWidget = self.find_widget(name)
-        if not widget:
-            g.trace(f"No widget with name: {name!r}")
-            return
-        splitter = g.app.gui.find_parent_splitter(widget)
-        if splitter:
-            index = splitter.indexOf(widget)
-            self.resize_splitter(splitter, index, -10)
-        else:
-            g.trace(f"No splitter for name: {name!r}")
-
-    #@+node:ekr.20241027172516.1: *4* LCW.expand_pane_by_name
-    def expand_pane_by_name(self, name: str) -> None:
-        """Expand the pane whose objectName is given"""
-        widget: QWidget = self.find_widget(name)
-        if not widget:
-            g.trace(f"No widget with name: {name!r}")
-            return
-        splitter = g.app.gui.find_parent_splitter(widget)
-        if splitter:
-            index = splitter.indexOf(widget)
-            self.resize_splitter(splitter, index, 10)
-        else:
-            g.trace(f"No splitter for name: {name!r}")
-
+        self.resize_pane(widget, delta=-10)
     #@+node:tom.20240923194438.5: *4* LCW.find_splitter_by_name
     def find_splitter_by_name(self, name: str) -> QWidget:
         """Return a splitter instance given its objectName.
@@ -589,10 +562,16 @@ class LayoutCacheWidget(QWidget):
             if kid.objectName() == name:
                 w = kid  # type: ignore [assignment]
         return w
-    #@+node:ekr.20241027181931.1: *4* LCW.resize_splitter
-    def resize_splitter(self, splitter: Any, index: int, factor: int) -> None:
-        """Resize the splitter."""
-        g.trace(splitter.objectName(), index, factor)
+    #@+node:ekr.20241027181931.1: *4* LCW.resize_widget
+    def resize_pane(self, widget: QWidget, delta: int) -> None:
+        """Resize the pane containing the given widget."""
+        splitter = g.app.gui.find_parent_splitter(widget)
+        if splitter:
+            index = splitter.indexOf(widget)
+            g.trace(f"to do: {splitter.objectName()}, delta: {delta}")
+        else:
+            g.trace(f"No splitter for name: {widget.objectName()!r}")
+
     #@+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
     def restoreFromLayout(self, layout: Dict = None) -> None:
         if layout is None:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -456,7 +456,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         self.layout_registry = LAYOUT_REGISTRY
 
     #@+others
-    #@+node:ekr.20241027142532.1: *3* LayoutCaseWidget: contract_*
+    #@+node:ekr.20241027142532.1: *3* LayoutCasheWidget: contract_*
     #@+node:ekr.20241027124630.1: *4* LayoutCacheWidget.contract_body
     def contract_body(self):
         """Contract the body pane"""
@@ -483,7 +483,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
             g.es_print('VR3 is not running', color='blue')
             return
         g.trace('Not ready')
-    #@+node:ekr.20241027142605.1: *3* LayoutCaseWidget: expand_*
+    #@+node:ekr.20241027142605.1: *3* LayoutCacheWidget: expand_*
     #@+node:ekr.20241027124500.1: *4* LayoutCacheWidget.expand_body
     def expand_body(self):
         """Expand the body pane"""
@@ -510,14 +510,21 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
             g.es_print('VR3 is not running', color='blue')
             return
         g.trace('Not ready')
-    #@+node:tom.20240923194438.5: *3* LayoutCacheWidget.find_splitter_by_name
-    def find_splitter_by_name(self: QW, name: str, _: Optional[QW] = None) -> QW:
+    #@+node:ekr.20241027162525.1: *3* LayoutCacheWidget: utils
+    #@+node:ekr.20241027161121.1: *4* LayoutCacheWidget.contract_pane_by_name
+    def contract_pane_by_name(self, name: str) -> None:
+        """Contract the pane with the given Qt objectName."""
+        g.trace('Not ready', name)
+    #@+node:ekr.20241027161215.1: *4* LayoutCacheWidget.expand_pane_by_name
+    def expand_pane_by_name(self, name: str) -> None:
+        """Expand the pane with the given Qt objectName."""
+        g.trace('Not ready', name)
+    #@+node:tom.20240923194438.5: *4* LayoutCacheWidget.find_splitter_by_name
+    def find_splitter_by_name(self, name: str) -> QW:
         """Return a splitter instance given its objectName.
         
         This method could return other types of widgets but is intended
         for finding known splitters.
-        
-        The "_" argument is needed to satisfy mypy.  It is never used.
         """
         foundit = False
         splitter: QW = None
@@ -535,20 +542,13 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                     splitter = kid  # type: ignore [assignment]
                     break
         return splitter
-    #@+node:ekr.20241008180818.1: *3* LayoutCacheWidget.find_widget
-    def find_widget(self, name: str, _: Optional[QW] = None) -> QW:
-        """Return a widget given it objectName.
-        
-        The "_" argument is needed to satisfy mypy.  It is never used.
-        """
-        widget: QW = g.app.gui.find_widget_by_name(self.c, name)  # type: ignore[attr-defined]
-        return widget
-
-    #@+node:tom.20240923194438.4: *3* LayoutCacheWidget.find_widget_in_children
-    def find_widget_in_children(self, name: str, _: Optional[QW] = None) -> QW:
-        """Return a child widget if its objectName matches "name".
-        
-        The "_" argument is needed to satisfy mypy.  It is never used.
+    #@+node:ekr.20241008180818.1: *4* LayoutCacheWidget.find_widget
+    def find_widget(self, name: str) -> QW:
+        """Return a widget given it objectName."""
+        return g.app.gui.find_widget_by_name(self.c, name)
+    #@+node:tom.20240923194438.4: *4* LayoutCacheWidget.find_widget_in_children
+    def find_widget_in_children(self, name: str) -> QW:  ### : Optional[QW] = None
+        """Return a child widget with the given objectName.
         """
         w: QW = None
         for kid in self.children():
@@ -556,12 +556,12 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                 w = kid  # type: ignore [assignment]
         return w
 
-    #@+node:tom.20240923194438.6: *3* LayoutCacheWidget.restoreFromLayout
+    #@+node:tom.20240923194438.6: *4* LayoutCacheWidget.restoreFromLayout
     def restoreFromLayout(self, layout: Dict = None) -> None:
         if layout is None:
             layout = FALLBACK_LAYOUT
         #@+<< initialize data structures >>
-        #@+node:tom.20240923194438.7: *4* << initialize data structures >> restoreFromLayout
+        #@+node:tom.20240923194438.7: *5* << initialize data structures >> restoreFromLayout
         ORIENTATIONS = layout['ORIENTATIONS']
 
         has_vr3 = is_module_loaded(VR3_MODULE_NAME)
@@ -599,7 +599,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
 
         #@-<< initialize data structures >>
         #@+<< rehome body editor >>
-        #@+node:tom.20240923194438.8: *4* << rehome body editor >> restoreFromLayout
+        #@+node:tom.20240923194438.8: *5* << rehome body editor >> restoreFromLayout
         # In case the editor has been moved to e.g. a QTabWidget,
         # Move it back to its standard place.
 
@@ -610,7 +610,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
         bsw.setCurrentIndex(0)
         #@-<< rehome body editor >>
         #@+<< clean up splitters >>
-        #@+node:tom.20240923194438.9: *4* << clean up splitters >> restoreFromLayout
+        #@+node:tom.20240923194438.9: *5* << clean up splitters >> restoreFromLayout
         # Remove extra (no longer wanted) widgets to the cache.
         # Then insert the required widgets into their home splitters
 
@@ -641,7 +641,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                 splitter.setParent(self)
         #@-<< clean up splitters >>
         #@+<< set default orientations >>
-        #@+node:tom.20240923194438.11: *4* << set default orientations >> restoreFromLayout
+        #@+node:tom.20240923194438.11: *5* << set default orientations >> restoreFromLayout
         # SPLITTER_DICT: {'main_splitter':ms, ...}
         # DEFAULT_ORIENTATIONS:
         # {'main_splitter':Orientation.Horizontal...}
@@ -651,7 +651,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
             splitter.setOrientation(orientation)
         #@-<< set default orientations >>
         #@+<< move widgets to targets >>
-        #@+node:tom.20240923194438.10: *4* << move widgets to targets >> restoreFromLayout
+        #@+node:tom.20240923194438.10: *5* << move widgets to targets >> restoreFromLayout
         # Move all desired widgets into their home splitters
         # SPLITTERS is an OrderedDict so the widgets will
         # be inserted in the right order.
@@ -668,7 +668,7 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
                     dest.insertWidget(i, widget)
         #@-<< move widgets to targets >>
         #@+<< resize splitters >>
-        #@+node:tom.20240923194438.12: *4* << resize splitters >> restoreFromLayout
+        #@+node:tom.20240923194438.12: *5* << resize splitters >> restoreFromLayout
         for splt in SPLITTER_DICT.values():
             g.app.gui.equalize_splitter(splt)  # type: ignore[attr-defined]
         #@-<< resize splitters >>

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -468,6 +468,14 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
     def contract_outline(self):
         """Contract the outline pane"""
         g.trace('Not ready')
+    #@+node:ekr.20241027141341.1: *3* LayoutCacheWidget.contract_vr
+    def contract_vr(self):
+        """Contract the VR pane if VR is running"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027141411.1: *3* LayoutCacheWidget.contract_vr3
+    def contract_vr3(self):
+        """Contract the VR3 pane if VR3 is running"""
+        g.trace('Not ready')
     #@+node:ekr.20241027124500.1: *3* LayoutCacheWidget.expand_body
     def expand_body(self):
         """Expand the body pane"""
@@ -479,6 +487,14 @@ class LayoutCacheWidget(Generic[QW], QtWidgets.QWidget):
     #@+node:ekr.20241027124703.1: *3* LayoutCacheWidget.expand_outline
     def expand_outline(self):
         """Expand the outline pane."""
+        g.trace('Not ready')
+    #@+node:ekr.20241027141425.1: *3* LayoutCacheWidget.expand_vr
+    def expand_vr(self):
+        """Expand the VR pane if VR is running"""
+        g.trace('Not ready')
+    #@+node:ekr.20241027141446.1: *3* LayoutCacheWidget.expand_vr3
+    def expand_vr3(self):
+        """Expand the VR3 pane if VR3 is running"""
         g.trace('Not ready')
     #@+node:tom.20240923194438.5: *3* LayoutCacheWidget.find_splitter_by_name
     def find_splitter_by_name(self: QW, name: str, _: Optional[QW] = None) -> QW:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -532,7 +532,7 @@ class LayoutCacheWidget(QWidget):
         if not widget:
             g.trace(f"No widget with name: {name!r}")
             return
-        splitter = self.find_parent_splitter(widget)
+        splitter = g.app.gui.find_parent_splitter(widget)
         if splitter:
             index = splitter.indexOf(widget)
             self.resize_splitter(splitter, index, -10)
@@ -546,7 +546,7 @@ class LayoutCacheWidget(QWidget):
         if not widget:
             g.trace(f"No widget with name: {name!r}")
             return
-        splitter = self.find_parent_splitter(widget)
+        splitter = g.app.gui.find_parent_splitter(widget)
         if splitter:
             index = splitter.indexOf(widget)
             self.resize_splitter(splitter, index, 10)
@@ -576,15 +576,6 @@ class LayoutCacheWidget(QWidget):
                     splitter = kid  # type: ignore [assignment]
                     break
         return splitter
-    #@+node:ekr.20241027183453.1: *4* LCW.find_parent_splitter
-    def find_parent_splitter(self, widget: QWidget) -> Optional[QSplitter]:
-        """Return the nearest parent QSplitter widget."""
-        parent = widget.parent()
-        while parent:
-            if isinstance(parent, QtWidgets.QSplitter):
-                return parent
-            parent = parent.parent()
-        return None
     #@+node:ekr.20241008180818.1: *4* LCW.find_widget
     def find_widget(self, name: str) -> QWidget:
         """Return a widget given it objectName."""
@@ -633,7 +624,7 @@ class LayoutCacheWidget(QWidget):
         for _, name in SPLITTERS.items():
             splitter: QWidget = self.find_splitter_by_name(name)
             if splitter is None:
-                splitter = QtWidgets.QSplitter(self)  # type: ignore [assignment]
+                splitter = QSplitter(self)
                 splitter.setObjectName(name)
                 self.created_splitter_dict[name] = splitter
 

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -2219,7 +2219,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.create_pane()
 
         #@+<< Set ivars >>
-        #@+node:tom.20240919181141.1: *4* << Set ivars >>
+        #@+node:tom.20240919181141.1: *4* << Set ivars >> (VR3)
         self.active = False
         self.badColors = []
         self.controllers = controllers
@@ -2249,7 +2249,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.w = None  # The present widget in the rendering pane.
         #@-<< Set ivars >>
         #@+<< initialize configuration ivars >>
-        #@+node:tom.20240919181318.1: *4* << initialize configuration ivars >>
+        #@+node:tom.20240919181318.1: *4* << initialize configuration ivars >> (VR3)
         self.base_path = ''  # A node's base path including @path directive
         self.code_only = False
         self.code_only = False
@@ -2267,7 +2267,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         self.setObjectName('viewrendered3_pane')
         #@-<< initialize configuration ivars >>
         #@+<< asciidoc-specific >>
-        #@+node:tom.20240919181508.1: *4* << asciidoc-specific >>
+        #@+node:tom.20240919181508.1: *4* << asciidoc-specific >> (VR3)
         self.asciidoc3_internal_ok = True
         self.asciidoc_internal_ok = True
         self.using_ext_proc_msg_shown = False


### PR DESCRIPTION
See #4123.

**qt_layout.py**

- [x] Simplify mypy annotations to conform to Leo's conventions.
   class `LayoutCacheWidget` is now a subclass *only* of `QWidget`.
- [x] Rewrite `LCW.find_splitter_by_name` so that it can *only* return a `QSplitter`.
- [x] The `LCW.expand/contract_*_pane` methods call `LCW.expand/contract_pane`
   with *objects* (official ivars) instead of *object names*. There is no need to know object names!
- [x] `LCW.expand/contract_pane` call `LCW.resize_pane`, completing the infrastructure.
- [x] `LCW.resize_pane` does the work.

**Other files**

- [x] `qt_frame.py`: Define all commands by delegating all work to the `LCW` class.
- [x] `qt_gui.py`: Add `LeoQtGui.find_parent_splitter`.
- [x] `viewrendered3.py`: Add disambiguating headlines. Otherwise, this file is completely unchanged.

**Retain old splitter methods**

The `divideAnySplitter` and `divideSplitter1/2` methods methods should remain in the `LeoQtFrame`,
despite their limited relevance.