### PR TITLE
PR for #4137: Automatically create @jupytext children

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -658,6 +658,7 @@
 <v t="ekr.20041119041747"><vh>@string output-newline = nl</vh></v>
 </v>
 <v t="ekr.20241024123618.1"><vh>Jupytext options</vh>
+<v t="ekr.20241030020739.1"><vh>@int jupytext-max-headline-length = 60</vh></v>
 <v t="ekr.20241024123633.1"><vh>@string jupytext-fmt = py:percent</vh></v>
 <v t="ekr.20241026115515.1"><vh>@data jupyter-prefix</vh></v>
 </v>
@@ -11758,6 +11759,8 @@ See https://jupytext.readthedocs.io/en/latest/config.html
 # ---
 
 # %%
+</t>
+<t tx="ekr.20241030020739.1">The maximum size of imported headlines.
 </t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 

--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -187,6 +187,7 @@
 <v t="ekr.20031218072017.3093"><vh>@file leoGlobals.py</vh></v>
 <v t="ekr.20150514154159.1"><vh>@file leoHistory.py</vh></v>
 <v t="ekr.20031218072017.3206"><vh>@file leoImport.py</vh></v>
+<v t="ekr.20241022090855.1"><vh>@file leoJupytext.py</vh></v>
 <v t="ekr.20190515070742.1"><vh>@file leoMarkup.py</vh></v>
 <v t="ekr.20031218072017.3320"><vh>@file leoNodes.py</vh></v>
 <v t="ekr.20140821055201.18331"><vh>@file leoPersistence.py</vh></v>
@@ -2786,43 +2787,15 @@ def do_sec(i, m, s):
 </t>
 <t tx="ekr.20211020091540.1">c.backup_helper(sub_dir='leoPy')
 </t>
-<t tx="ekr.20220306092217.1">g.cls()
+<t tx="ekr.20220306092217.1">"""Invoke EKR's private test-one.cmd script."""
+
+import os
+
 if c.isChanged():
     print('Saved!')
     c.save()
-&lt;&lt; test-one: test kind &gt;&gt;
-&lt;&lt; prefixes &gt;&gt;
-&lt;&lt; old commands &gt;&gt;
-assert kind in ('check-all', 'check-one', 'beautify', 'test'), repr(kind)
-if kind == 'check-all':  # Check all files.
-    command = 'python -m leo.scripts.check_leo'
-    g.execute_shell_commands(command)
-elif kind == 'check-one':
-    # path = 'plugins/qt_gui.py'
-    path = 'core/leoApp.py'
-    command = f"python -m leo.scripts.check_leo {path}"
-    g.execute_shell_commands(command)
-elif kind == 'beautify':
-    &lt;&lt; test the beautifier &gt;&gt;
-elif kind == 'test':
-    commands = (
-        ### "leo.scripts.check_leo.TestCheckLeo",
-        f"{misc}.test_check_leo.TestCheckLeo",
-        # f"{core}.test_leoserver.TestLeoServer.test_find_commands",
-        # f"{core}.test_leoFind.TestFind.test_find_var",
-        # f"{core}.test_leoTokens.TestTokenBasedOrange",
-        # f"{core}.test_leoTokens.TestTokens",
-        # f"{core}.test_leoTokens.TestTokenBasedOrange.test_blank_lines_after_function",
-        # f"{core}.test_leoAtFile.TestAtFile.test_putBody_unterminated_at_doc_part",
-    )
-    verbose_flag = ''  # -v
-    commands_s = f"python -m unittest {verbose_flag} {' '.join(commands)}"
-    g.execute_shell_commands(commands_s)
-else:
-    # command = 'run'  # run Nim tests.
-    script = 'build-leo.py'
-    command = fr"python C:\Repos\leo-editor\leo\scripts\{script}"
-    g.execute_shell_commands(command)
+
+os.system('test-one.cmd')
 </t>
 <t tx="ekr.20220318085657.1">"""
 Find and mark all nodes containing underindented trailing comments in c's outline.
@@ -3529,6 +3502,15 @@ print('Done!')
 # 'python -m mypy c:/test/mypy_test.py',
 # 'python -m ruff check c:/test/mypy_test.py',
 # 'python -m pyflakes c:/test/mypy_test.py',
+
+### "leo.scripts.check_leo.TestCheckLeo",
+# f"{misc}.test_check_leo.TestCheckLeo",
+# f"{core}.test_leoserver.TestLeoServer.test_find_commands",
+# f"{core}.test_leoFind.TestFind.test_find_var",
+# f"{core}.test_leoTokens.TestTokenBasedOrange",
+# f"{core}.test_leoTokens.TestTokens",
+# f"{core}.test_leoTokens.TestTokenBasedOrange.test_blank_lines_after_function",
+# f"{core}.test_leoAtFile.TestAtFile.test_putBody_unterminated_at_doc_part",
 </t>
 <t tx="ekr.20240528034319.1"># Can be run from the command line as follows:
 # python -c "import leo.core.leoTokens" --all --report --write leo/core/leoAst.py

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -641,7 +641,7 @@ class AtFile:
             # the first time the @jupytext has been read.
             new_private_lines = []
             root.b = ''.join(new_public_lines)
-            g.app.jupytextManager.create_outline(root)
+            g.app.jupytextManager.create_outline(c, root)
             return
         if new_private_lines == old_private_lines:
             return

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -642,6 +642,7 @@ class AtFile:
             new_private_lines = []
             root.b = ''.join(new_public_lines)
             g.app.jupytextManager.create_outline(c, root)
+            g.doHook('after-reading-external-file', c=c, p=root)
             return
         if new_private_lines == old_private_lines:
             return
@@ -651,6 +652,7 @@ class AtFile:
         gnx2vnode = at.fileCommands.gnxDict
         new_contents = '@language python\n' + ''.join(new_private_lines)
         FastAtRead(c, gnx2vnode).read_into_root(new_contents, fileName, root)
+        g.doHook('after-reading-external-file', c=c, p=root)
     #@+node:ekr.20080711093251.7: *5* at.readOneAtShadowNode & helper
     def readOneAtShadowNode(self, fn: str, p: Position) -> None:  # pragma: no cover
 
@@ -1531,7 +1533,7 @@ class AtFile:
         
         This code is adapted from at.writeOneAtCleanNode.
         """
-        at, c = self, self.c
+        at, c, p = self, self.c, self.c.p
         try:
             c.endEditing()
             fileName = at.initWriteIvars(root)
@@ -1540,6 +1542,13 @@ class AtFile:
             # Prompt for dangerous write if the file exists.
             if not fileName or not at.precheck(fileName, root):
                 return
+
+            try:
+                g.doHook('before-writing-external-file', c=c, p=p)
+            except Exception:
+                # The hook must print an error message.
+                return
+
             # Write a minimal Jupyter file if the @jupytext tree is empty.
             if not root.b.strip() and not root.hasChildren():
                 prefix_list = c.config.getData('jupyter-prefix',
@@ -1568,7 +1577,7 @@ class AtFile:
         root is the position of an @<file> node.
         sentinels will be False for @clean and @nosent nodes.
         """
-        at, c = self, self.c
+        at, c, p = self, self.c, self.c.p
         try:
             c.endEditing()
             fileName = at.initWriteIvars(root)
@@ -1576,7 +1585,11 @@ class AtFile:
             if not fileName or not at.precheck(fileName, root):
                 return
 
-            g.doHook('before-writing-external-file', c=c, p=root)
+            try:
+                g.doHook('before-writing-external-file', c=c, p=p)
+            except Exception:
+                # The hook must print an error message.
+                return
 
             at.outputList = []
             at.putFile(root, sentinels=False)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -637,10 +637,11 @@ class AtFile:
             new_private_lines = x.propagate_changed_lines(
                 new_public_lines, old_private_lines, marker, p=root)
         else:
-            # This is not an error.
-            # g.es_print('No old_public_lines!', fileName)
+            # This is not an error, it is
+            # the first time the @jupytext has been read.
             new_private_lines = []
             root.b = ''.join(new_public_lines)
+            g.app.jupytextManager.create_outline(root)
             return
         if new_private_lines == old_private_lines:
             return

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -65,7 +65,7 @@ class JupytextManager:
         width = c.config.getInt('jupytext-max-headline-length') or 60
 
         def shorten(s: str) -> str:
-            """Shorten s to width 60"""
+            """Shorten s to the configured width"""
             return textwrap.shorten(s, width=width, placeholder='')
 
         lines = g.splitLines(cell)
@@ -213,7 +213,7 @@ class JupytextManager:
             # full_path has given the error.
             return '', ''
         if not os.path.exists(path):
-            self.warn_bad_at_jupytext_node(p, path)
+            self.warn_file_not_found(p, path)
             return '', ''
 
         # Read the .ipynb file into contents.
@@ -226,7 +226,7 @@ class JupytextManager:
                 jupytext.write(notebook, f, fmt=fmt)
                 contents = f.getvalue()
         except Exception:
-            g.es_print('Exception in jupytext.read', color='red')
+            g.es_print('Exception in jupytext!', color='red')
             g.es_exception()
             with open(path, 'rb') as f:
                 raw_contents = f.read()
@@ -240,17 +240,16 @@ class JupytextManager:
         at = c.atFileCommands
         at.readOneAtJupytextNode(p)
         c.redraw()
-    #@+node:ekr.20241023165243.1: *3* jtm.warn_bad_at_jupytext_node
+    #@+node:ekr.20241023165243.1: *3* jtm.warn_file_not_found
     bad_paths: Dict[str, bool] = {}
 
-    def warn_bad_at_jupytext_node(self, p: Position, path: str) -> None:
+    def warn_file_not_found(self, p: Position, path: str) -> None:
         """Warn (once) about each bad path"""
         if path not in self.bad_paths:
             key = path if path else 'None'
             self.bad_paths[key] = True
             print('')
-            g.es_print(f"Bad @jupytext node: {p.h!r}", color='red')
-            g.es_print(f"File not found: {path!r}", color='blue')
+            g.es_print(f"File not found: {path!r}", color='red')
             print('')
     #@+node:ekr.20241023161034.1: *3* jtm.warn_no_jupytext
     warning_given = False

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -68,10 +68,11 @@ class JupytextManager:
 
         # Handle markdown sections.
         if len(lines) > 1 and '[markdown]' in lines[0]:
-            # Strip '# ' if '#' follows.
             line1 = lines[1].strip()
-            if line1.startswith('# ') and line1[2:].strip().startswith('#'):
-                return shorten(line1[2:].strip())
+            if line1.startswith('# '):
+                section = line1[2:].strip()
+                if section.startswith('#'):
+                    return shorten(section)
             return shorten(line1)
 
         # Filter blank lines.

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -50,8 +50,8 @@ class JupytextManager:
             progress = i
             i = self.make_cell(i, contents, root)
             assert i > progress
-        # Replace root.b by markup.
-        root.b = self.markup(header)
+        # Replace root.b by the computed markup.
+        root.b = self.compute_markup(header)
         c.redraw()
     #@+node:ekr.20241029153032.1: *4* jtm.compute_headline
     def compute_headline(self, cell: str, p: Position) -> str:
@@ -62,6 +62,17 @@ class JupytextManager:
             if line and not line.startswith('%%') and len(line) > 10:
                 return line
         return f"cell {p.childIndex()}"
+    #@+node:ekr.20241029160441.1: *4* jtm.compute_markup
+    def compute_markup(self, header: str) -> str:
+        """Return the proper markup for root.b"""
+        markup_list = [
+            '@others\n',
+            '@language python\n',
+            '@tabwidth -4\n',
+        ]
+        if header:
+            markup_list.insert(0, g.angleBrackets(' prefix ') + '\n')
+        return ''.join(markup_list)
     #@+node:ekr.20241029152029.1: *4* jtm.make_cell
     def make_cell(self, i: int, contents: str, root: Position) -> int:
         """
@@ -99,17 +110,6 @@ class JupytextManager:
         # The prefix starts at 0, not start.
         p.b = contents[0:end]
         return end
-    #@+node:ekr.20241029160441.1: *4* jtm.markup
-    def markup(self, header: str) -> str:
-        """Return the proper markup for root.b"""
-        markup_list = [
-            '@others\n',
-            '@language python\n',
-            '@tabwidth -4\n',
-        ]
-        if header:
-            markup_list.insert(0, g.angleBrackets(' prefix ') + '\n')
-        return ''.join(markup_list)
     #@+node:ekr.20241023162459.1: *3* jtm.dump_notebook
     def dump_notebook(self, nb: Any) -> None:
         """Dump a notebook (class nbformat.notebooknode.NotebookNode)"""

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -59,9 +59,9 @@ class JupytextManager:
         lines = g.splitLines(cell)
         for line in lines[1:]:
             line = line.replace('#', '').strip()
-            if line and not line.startswith('%%') and len(line) > 10:
+            if line and not line.startswith('%%'):
                 return line
-        return f"cell {p.childIndex()}"
+        return f"Cell {p.childIndex()}"
     #@+node:ekr.20241029160441.1: *4* jtm.compute_markup
     def compute_markup(self, header: str) -> str:
         """Return the proper markup for root.b"""

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -32,7 +32,7 @@ class JupytextManager:
 
     #@+others
     #@+node:ekr.20241029065713.1: *3* jtm.create_outline
-    def create_outline(self, root: Position) -> None:
+    def create_outline(self, c: Cmdr, root: Position) -> None:
         g.trace(root.h, g.callers(2))
     #@+node:ekr.20241023162459.1: *3* jtm.dump_notebook
     def dump_notebook(self, nb: Any) -> None:

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -69,11 +69,11 @@ class JupytextManager:
         If found, create a new node as the last child of the root.
         Return the index of the line following the cell.
         """
-        marker = '# %%'  # The start of all cells.
-        i = contents.find(marker, i)
+        cell_marker = '# %%'  # The start of all cells.
+        i = contents.find(cell_marker, i)
         if i == -1:
             return len(contents)
-        j = contents.find(marker, i + len(marker) + 1)
+        j = contents.find(cell_marker, i + len(cell_marker) + 1)
         if j == -1:
             j = len(contents)
         cell = contents[i:j]
@@ -85,18 +85,18 @@ class JupytextManager:
     def make_prefix(self, i: int, contents: str, root: Position) -> int:
         """
         Create a child node for the header.
-        Return the next index into contents.
+        Return index after the prefix, or i if there is no prefix.
         """
-        tag = '# ---\n'
-        start = contents.find(tag)
+        prefix_marker = '# ---\n'  # The start of all prefixes.
+        start = contents.find(prefix_marker)
         if start == -1:
             return i
-        end = contents.find('# ---', start + len(tag)) + len(tag)
+        end = contents.find(prefix_marker, start + len(prefix_marker)) + len(prefix_marker)
         if end == -1:
             return i
         p = root.insertAsLastChild()
         p.h = g.angleBrackets(' prefix ')
-        # The prefix starts at 0 (not start)
+        # The prefix starts at 0, not start.
         p.b = contents[0:end]
         return end
     #@+node:ekr.20241029160441.1: *4* jtm.markup

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -31,6 +31,9 @@ if TYPE_CHECKING:  # pragma: no cover
 class JupytextManager:
 
     #@+others
+    #@+node:ekr.20241029065713.1: *3* jtm.create_outline
+    def create_outline(self, root: Position) -> None:
+        g.trace(root.h, g.callers(2))
     #@+node:ekr.20241023162459.1: *3* jtm.dump_notebook
     def dump_notebook(self, nb: Any) -> None:
         """Dump a notebook (class nbformat.notebooknode.NotebookNode)"""
@@ -84,10 +87,12 @@ class JupytextManager:
     #@+node:ekr.20241023155136.1: *3* jtm.read
     def read(self, c: Cmdr, p: Position) -> Tuple[str, str]:  # pragma: no cover
         """
+        Called from at.readOneAtJupytextNode.
         p must be an @jupytext node describing an .ipynb file.
         Convert x.ipynb to a string s.
         Return (s, path)
         """
+        g.trace(p.h, g.callers(2))  ###
         path = self.full_path(c, p)
         if not path:
             # full_path has given the error.

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -1490,6 +1490,91 @@ def focusToSpell(self, event: LeoKeyEvent = None) -> None:
     # This is not a great idea. There is no indication of focus.
         # if self.handler and self.handler.tab:
             # self.handler.tab.setFocus()
+#@+node:ekr.20241029111205.1: *3* retire old testing code
+#@+node:ekr.20241029111221.1: *4* at-command test-one
+### This code no longer works, possibly because 
+### site_customize.py *MUST NOT* add the leo-editor directory to sys.path
+
+g.cls()
+if c.isChanged():
+    print('Saved!')
+    c.save()
+<< test-one: test kind >>
+<< prefixes >>
+<< old commands >>
+assert kind in ('check-all', 'check-one', 'beautify', 'test'), repr(kind)
+if kind == 'check-all':  # Check all files.
+    command = 'python -m leo.scripts.check_leo'
+    g.execute_shell_commands(command)
+elif kind == 'check-one':
+    # path = 'plugins/qt_gui.py'
+    path = 'core/leoApp.py'
+    command = f"python -m leo.scripts.check_leo {path}"
+    g.execute_shell_commands(command)
+elif kind == 'beautify':
+    << test the beautifier >>
+elif kind == 'test':
+    commands = (
+        f"{importers}.TestJupytext.test_small_file",
+    )
+    verbose_flag = ''  # -v
+    commands_s = f"python -m unittest {verbose_flag} {' '.join(commands)}"
+    g.execute_shell_commands(commands_s, trace=True)
+else:
+    # command = 'run'  # run Nim tests.
+    script = 'build-leo.py'
+    command = fr"python C:\Repos\leo-editor\leo\scripts\{script}"
+    g.execute_shell_commands(command)
+#@+node:ekr.20241029111221.2: *5* << test-one: test kind >>
+# Last one wins.
+kind = 'beautify'
+kind = 'test'  # Run unit test.
+#@+node:ekr.20241029111221.3: *5* << test the beautifier >>
+# Can be run from the command line as follows:
+# python -c "import leo.core.leoTokens" --all --report --write leo/core/leoAst.py
+args = '--all --report --write'  # --beautified --diff --write'
+for command in (
+    # f'python -c "import leo.core.leoTokens" {args} leoAst.py',
+    f'python -c "import leo.core.leoTokens" {args} leo/core',
+    'echo done!',
+):
+    print(command)
+    g.execute_shell_commands(command)
+#@+node:ekr.20241029111221.4: *5* << old commands >>
+# 'python c:/test/mypy_test.py',
+# 'python -m mypy c:/test/mypy_test.py',
+# 'python -m ruff check c:/test/mypy_test.py',
+# 'python -m pyflakes c:/test/mypy_test.py',
+
+### "leo.scripts.check_leo.TestCheckLeo",
+# f"{misc}.test_check_leo.TestCheckLeo",
+# f"{core}.test_leoserver.TestLeoServer.test_find_commands",
+# f"{core}.test_leoFind.TestFind.test_find_var",
+# f"{core}.test_leoTokens.TestTokenBasedOrange",
+# f"{core}.test_leoTokens.TestTokens",
+# f"{core}.test_leoTokens.TestTokenBasedOrange.test_blank_lines_after_function",
+# f"{core}.test_leoAtFile.TestAtFile.test_putBody_unterminated_at_doc_part",
+#@+node:ekr.20241029111221.5: *5* << prefixes >>
+commands = 'leo.unittests.commands'
+core = 'leo.unittests.core'
+gui = 'leo.unittests.test_gui'
+importers = 'leo.unittests.plugins.test_importers'
+misc = 'leo.unittests.misc_tests'
+plugins = 'leo.unittests.plugins'
+syntax = 'leo.unittests.plugins.test_syntax'
+writers = 'leo.unittests.plugins.test_writers'
+
+# f"{core}.test_leoGlobals",
+# f"{core}.test_leoTokens",
+
+# f"{misc}.test_design",
+# f"{misc}.test_doctests",
+# f"{misc}.test_syntax",
+
+# f"{plugins}.test_gui",
+# f"{plugins}.test_importers",
+# f"{plugins}.test_plugins",
+# f"{plugins}.test_writers",
 #@+node:ekr.20240820045246.1: ** To be cleared later
 # Clear after 6.8.2.
 #@+node:ekr.20110605121601.18254: *3* LeoQtFrame.destroyAllObjects (not used)

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -428,7 +428,7 @@ class TestAtFile(LeoUnitTest):
         at.putLeadInSentinel(s, 0, 2)
     #@+node:ekr.20211104142459.1: *3* TestAtFile.test_putLine
     def test_putLine(self):
-        
+
         from leo.core.leoAtFile import LeoIOStatus
 
         at, p = self.at, self.c.p

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -1860,7 +1860,7 @@ class TestJupytext(BaseTestImporter):
                     '# Another markdown cell\n'
                     '\n'
             ),
-            (1, 'cell 5',
+            (1, 'Cell 5',
                     '# %%\n'
             ),
         )

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -1841,24 +1841,26 @@ class TestJupytext(BaseTestImporter):
                     '#     language: python\n'
                     '#     name: python3\n'
                     '# ---\n'
-                    '\n'
             ),
-            (1, 'python',
+            (1, '2 + 666 + 4',
                     '# %%\n'
                     '2 + 666 + 4\n'
             ),
-            (1, 'python',
+            (1, "print('hi changed externally')",
                     '# %%\n'
                     "print('hi changed externally')\n"
             ),
-            (1, 'markdown',
+            (1, 'This is a markdown cell',
                     '# %% [markdown]\n'
                     '# This is a markdown cell\n'
+                    '\n'
             ),
-            (1, 'markdown',
+            (1, 'Another markdown cell',
                     '# %% [markdown]\n'
                     '# Another markdown cell\n'
                     '\n'
+            ),
+            (1, 'cell 5',
                     '# %%\n'
             ),
         )

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -1816,10 +1816,10 @@ class TestJupytext(BaseTestImporter):
             # %%
             print('hi changed externally')
             # %% [markdown]
-            # This is a markdown cell
+            # # This is a markdown cell
 
             # %% [markdown]
-            # Another markdown cell
+            # ## Another markdown cell
 
             # %%
         """
@@ -1850,14 +1850,14 @@ class TestJupytext(BaseTestImporter):
                     '# %%\n'
                     "print('hi changed externally')\n"
             ),
-            (1, 'This is a markdown cell',
+            (1, '# This is a markdown cell',
                     '# %% [markdown]\n'
-                    '# This is a markdown cell\n'
+                    '# # This is a markdown cell\n'
                     '\n'
             ),
-            (1, 'Another markdown cell',
+            (1, '## Another markdown cell',
                     '# %% [markdown]\n'
-                    '# Another markdown cell\n'
+                    '# ## Another markdown cell\n'
                     '\n'
             ),
             (1, 'Cell 5',

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -1762,6 +1762,89 @@ class TestJavascript(BaseTestImporter):
         line1 = guide_lines[0]
         assert not line1.strip(), repr(line1)
     #@-others
+#@+node:ekr.20241029091227.1: ** class TestJupytext (BaseTextImporter) (to do)
+class TestJupytext(BaseTestImporter):
+
+    ext = '.ipynb'
+    treeType = '@jupytext'
+
+    #@+others
+    #@+node:ekr.20241029093840.1: *3* TestJupytext.run_jupytext_test
+    def run_jupytext_test(self, s: str, expected_results: tuple, brief: bool = False) -> None:
+
+        g.trace(g.callers())
+        test_s = textwrap.dedent(s).strip() + '\n'
+        g.printObj(test_s, tag='test_s')
+        g.printObj(expected_results, tag='expected_results')
+    #@+node:ekr.20241029092043.1: *3* TestJupytext.test_small_file
+    def test_small_ipynb_file(self):
+
+        # Must be in standard form, with a space after '#'.
+        s = """\
+            # %%
+            # A leading (misleading?) comment.
+            # %%
+            # ---
+            # jupyter:
+            #   kernelspec:
+            #     display_name: Python 3 (ipykernel)
+            #     language: python
+            #     name: python3
+            # ---
+
+            # %%
+            2 + 666 + 4
+            # %%
+            print('hi changed externally')
+            # %% [markdown]
+            # This is a markdown cell
+
+            # %% [markdown]
+            # Another markdown cell
+
+            # %%
+        """
+        expected_results = (
+            (0, '',  # check_outlines ignores the first headline.
+                    '<< prefix >>\n'
+                    '@others\n'
+                    '@language python\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, '<< prefix >>',
+                    '# %%\n'
+                    '# A leading (misleading?) comment.\n'
+                    '# %%\n'
+                    '# ---\n'
+                    '# jupyter:\n'
+                    '#   kernelspec:\n'
+                    '#     display_name: Python 3 (ipykernel)\n'
+                    '#     language: python\n'
+                    '#     name: python3\n'
+                    '# ---\n'
+                    '\n'
+            ),
+            (1, 'python',
+                    '# %%\n'
+                    '2 + 666 + 4\n'
+            ),
+            (1, 'python',
+                    '# %%\n'
+                    "print('hi changed externally')\n"
+            ),
+            (1, 'markdown',
+                    '# %% [markdown]\n'
+                    '# This is a markdown cell\n'
+            ),
+            (1, 'markdown',
+                    '# %% [markdown]\n'
+                    '# Another markdown cell\n'
+                    '\n'
+                    '# %%\n'
+            ),
+        )
+        self.run_jupytext_test(s, expected_results)
+    #@-others
 #@+node:ekr.20220816082603.1: ** class TestLua (BaseTestImporter)
 class TestLua(BaseTestImporter):
 


### PR DESCRIPTION
See #4137 and [this ENB](https://groups.google.com/g/leo-editor/c/h6guQO1pW2w/m/g3G-YMoFAQAJ).

Thomas's prototype script inspired this project.

**Summary**

This PR causes Leo to split `@jupytext` nodes into a *flat* list of child nodes.
This splitting happens only the *first* time Leo reads such a node.
You can disable this action by adding any child node (including an empty node) to the `@jupytext` node.

**Tasks**

- [x] Complete `at.readOneAtJupytextNode`. It calls  ` jtm.create_outline` *only* in the proper circumstances.
- [x] Create  `jtm.create_outline` and verify that Leo calls it only as expected.
- [x] Create a unit test.
- [x] Complete `jtm.create_outline`.
- [x] Check that all tests pass.
- [x] Support a new setting, `@int jupytext-max-headline-length = 60`, with the default as shown.
- [x] Test with a substantial `.ipynb` file to ensure that the importer handles typical conventions.
- [x] Recover from errors in `jupytext.read`.
    This happened after I mistakenly created a bad `.ipynb` file.
- [x] Verify that changed indentation levels persist after a reload.
    It took only a few seconds to organize the outline by apparent markdown level.
- [x] Trigger `after-reading-external-file` and `before-writing-external-file` events.
- [x] Support `refresh-from-disk`.
- [x] Update LeoPyRef.py.

<details><summary><b>Terminology and Methods</b></summary>
<br>

The context of the methods involved is all-important. Here are the details.

**Terminology**

- Let **root** denote the position of  the `@jupytext` node that Leo is reading.
- Let the **pseudo-python text** (pseudo-text for short) denote the string returned by
  `jupytext.read` (or `jtm.read` for the `.ipynb` file corresponding to the `@jupytext` node.

**jtm.read(c, p)**

This method:
- returns the pseudo-text for the `@jupytext` node at position p, the root.
- is a helper for `at.readOneAtJupytextNode`. No other method calls `jtm.read`.

**jtm.create_outline(p)**

This method will create the outline for p, the root. Constraints:
- p.b must already contain the proper pseudo-text.
- p must have no children.
- The created children must tile the original pseudo-text, without gaps or rearrangements.

**at.readOneAtJupytextNode(p)**

This method:

- uses a slight variation of Leo's `@clean` algorithm.
- *always* calls `jtm.read` to get the pseudo-text.
- calls `jtm.create_outline` to create the root node's outline,
  but *only* when `at.readOneAtJupytextNode` populates `root.b` for the first time.
  Otherwise, `at.readOneAtJupytextNode` updates root's *existing* tree using the `@clean` algorithm.

</details>
