### PR TITLE
Jkn 4141 declutter

### DIFF
--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -306,18 +306,25 @@ class LeoQtTree(leoFrame.LeoTree):
 
             elif cmd == 'WEIGHT':
 
+                def weight_modifier_X(item: Item, param: str) -> None:
+                    arg = getattr(QtGui.QFont, param, None)
+                    if arg is None:
+                        arg = {"Thin": QtGui.QFont.Weight.Thin,
+                            "ExtraLight": QtGui.QFont.Weight.ExtraLight,
+                            "Light": QtGui.QFont.Weight.Light,
+                            "Normal": QtGui.QFont.Weight.Normal,
+                            "Medium": QtGui.QFont.Weight.Medium,
+                            "DemiBold": QtGui.QFont.Weight.DemiBold,
+                            "Bold": QtGui.QFont.Weight.Bold,
+                            "ExtraBold": QtGui.QFont.Weight.ExtraBold,
+                            "Black": QtGui.QFont.Weight.Black
+                            }.get(param, QtGui.QFont.Weight.Medium)
+                    font = item.font(0)
+                    font.setWeight(arg)
+                    item.setFont(0, font)
+
                 def weight_modifier(item: Item, param: str) -> None:
-                    wd = {"Thin": QtGui.QFont.Weight.Thin,
-                        "ExtraLight": QtGui.QFont.Weight.ExtraLight,
-                        "Light": QtGui.QFont.Weight.Light,
-                        "Normal": QtGui.QFont.Weight.Normal,
-                        "Medium": QtGui.QFont.Weight.Medium,
-                        "DemiBold": QtGui.QFont.Weight.DemiBold,
-                        "Bold": QtGui.QFont.Weight.Bold,
-                        "ExtraBold": QtGui.QFont.Weight.ExtraBold,
-                        "Black": QtGui.QFont.Weight.Black
-                        }
-                    arg = wd.get(param, QtGui.QFont.Weight.Medium)
+                    arg = getattr(QtGui.QFont.Weight, param, QtGui.QFont.Weight.Medium)
                     font = item.font(0)
                     font.setWeight(arg)
                     item.setFont(0, font)

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -306,23 +306,6 @@ class LeoQtTree(leoFrame.LeoTree):
 
             elif cmd == 'WEIGHT':
 
-                def weight_modifier_X(item: Item, param: str) -> None:
-                    arg = getattr(QtGui.QFont, param, None)
-                    if arg is None:
-                        arg = {"Thin": QtGui.QFont.Weight.Thin,
-                            "ExtraLight": QtGui.QFont.Weight.ExtraLight,
-                            "Light": QtGui.QFont.Weight.Light,
-                            "Normal": QtGui.QFont.Weight.Normal,
-                            "Medium": QtGui.QFont.Weight.Medium,
-                            "DemiBold": QtGui.QFont.Weight.DemiBold,
-                            "Bold": QtGui.QFont.Weight.Bold,
-                            "ExtraBold": QtGui.QFont.Weight.ExtraBold,
-                            "Black": QtGui.QFont.Weight.Black
-                            }.get(param, QtGui.QFont.Weight.Medium)
-                    font = item.font(0)
-                    font.setWeight(arg)
-                    item.setFont(0, font)
-
                 def weight_modifier(item: Item, param: str) -> None:
                     arg = getattr(QtGui.QFont.Weight, param, QtGui.QFont.Weight.Medium)
                     font = item.font(0)

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -307,7 +307,17 @@ class LeoQtTree(leoFrame.LeoTree):
             elif cmd == 'WEIGHT':
 
                 def weight_modifier(item: Item, param: str) -> None:
-                    arg = getattr(QtGui.QFont, param, 75)
+                    wd = {"Thin": QtGui.QFont.Weight.Thin,
+                        "ExtraLight": QtGui.QFont.Weight.ExtraLight,
+                        "Light": QtGui.QFont.Weight.Light,
+                        "Normal": QtGui.QFont.Weight.Normal,
+                        "Medium": QtGui.QFont.Weight.Medium,
+                        "DemiBold": QtGui.QFont.Weight.DemiBold,
+                        "Bold": QtGui.QFont.Weight.Bold,
+                        "ExtraBold": QtGui.QFont.Weight.ExtraBold,
+                        "Black": QtGui.QFont.Weight.Black
+                        }
+                    arg = wd.get(param, QtGui.QFont.Weight.Medium)
                     font = item.font(0)
                     font.setWeight(arg)
                     item.setFont(0, font)


### PR DESCRIPTION
oops, probably should have written this earlier

This is to fix issue #4141, as discussed here: https://groups.google.com/g/leo-editor/c/K9FkwGXQltA

Two points:
* the default for the getattr has been changed - the font weight scaling is different in PyQt6
* I am unsure if the original `getattr(QtGui.Qfont, param...)` ever worked properly.

Tested by myself (under Linux) and @tbpassin 

worth squashing commits BTW ;-/
