### PR TITLE
PR for #4159: don't change outline when auto-beautifying Python files

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2359,9 +2359,11 @@ class AtFile:
             return False
         finally:
             sys.arg_v = old_sys_argv
+            # #4159: This may not restore the outline as it was,
+            # but it's much better than doing nothing.
             c.selectPosition(old_p)
-            # c.redraw(old_p)
-
+            c.contractAllOtherNodes()
+            c.redraw(old_p)
     #@+node:ekr.20221128123139.1: *6* at.runFlake8
     def runFlake8(self, root: Position) -> bool:  # pragma: no cover
         """Run flake8 on the selected node."""

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2339,6 +2339,7 @@ class AtFile:
         p = c.p
         if not os.path.exists(filename):
             return False
+        old_p = p.copy()
         try:
             old_sys_argv = sys.argv[:]
             sys.argv = ['tbo']  # A hack: don't run leo.core.leoTokens.main.
@@ -2352,13 +2353,15 @@ class AtFile:
                 # Reload the file immediately.
                 c.selectPosition(root)
                 c.refreshFromDisk()
-                c.redraw(p)
             return True
         except Exception:
             g.es_exception()
             return False
         finally:
             sys.arg_v = old_sys_argv
+            c.selectPosition(old_p)
+            # c.redraw(old_p)
+
     #@+node:ekr.20221128123139.1: *6* at.runFlake8
     def runFlake8(self, root: Position) -> bool:  # pragma: no cover
         """Run flake8 on the selected node."""

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -93,7 +93,7 @@ def input_tokens_to_string(tokens: list[InputToken]) -> str:  # pragma: no cover
         print('')
         return ''
     return ''.join([z.to_string() for z in tokens])
-#@+node:ekr.20240926050431.1: *3* function: beautify_file (leoTokens.py) (new)
+#@+node:ekr.20240926050431.1: *3* function: beautify_file (leoTokens.py)
 def beautify_file(filename: str) -> bool:
     """
     Beautify the given file, writing it if has changed.


### PR DESCRIPTION
See #4159.

- [x] Redraw auto-beautified files so as to cause minimal visual disruption.
  The new code executes the `contract-all-other-nodes` command before doing the final redraw.
  This scheme isn't perfect, but testing shows that it's much better than before.
- [x] Pass all tests.