### PR TITLE
PR for #4156: two unit tests fail for Python 3.13

### DIFF
--- a/leo/external/npyscreen/__init__.py
+++ b/leo/external/npyscreen/__init__.py
@@ -1,164 +1,181 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20170428084208.443: * @file ../external/npyscreen/__init__.py
 #!/usr/bin/python
-#@+others
-#@+node:ekr.20170428084208.444: ** Declarations
-from .globals                   import DEBUG, DISABLE_RESIZE_SYSTEM
+try:  # These may fail with Python 3.13+
+    #@+<< declarations >>
+    #@+node:ekr.20170428084208.444: ** << declarations >>
+    from .globals                   import DEBUG, DISABLE_RESIZE_SYSTEM
 
-from .wgwidget                  import TEST_SETTINGS, ExhaustedTestInput, add_test_input_from_iterable, add_test_input_ch
+    from .wgwidget                  import (
+        TEST_SETTINGS, ExhaustedTestInput, add_test_input_from_iterable, add_test_input_ch
+    )
 
-from .npyssafewrapper           import wrapper, wrapper_basic
+    from .npyssafewrapper           import wrapper, wrapper_basic
 
-from   .npysThemeManagers       import ThemeManager, disableColor, enableColor
-from   . import npysThemes      as     Themes
-from   .apNPSApplication        import NPSApp
-from   .apNPSApplicationManaged import NPSAppManaged
-from   .proto_fm_screen_area    import setTheme
-from   .fmForm                  import FormBaseNew, Form, TitleForm, TitleFooterForm, SplitForm, FormExpanded, FormBaseNewExpanded, blank_terminal
-from   .fmActionForm            import ActionForm, ActionFormExpanded
-from   .fmActionFormV2          import ActionFormV2, ActionFormExpandedV2, ActionFormMinimal
-from   .fmFormWithMenus         import FormWithMenus, ActionFormWithMenus, \
-                                       FormBaseNewWithMenus, SplitFormWithMenus, \
-                                       ActionFormV2WithMenus
-from   .fmPopup                 import Popup, MessagePopup, ActionPopup, PopupWide, ActionPopupWide
-from   .fmFormMutt              import FormMutt, FormMuttWithMenus
-from   .fmFileSelector          import FileSelector, selectFile
+    from   .npysThemeManagers       import ThemeManager, disableColor, enableColor
+    from   . import npysThemes      as     Themes
+    from   .apNPSApplication        import NPSApp
+    from   .apNPSApplicationManaged import NPSAppManaged
+    from   .proto_fm_screen_area    import setTheme
+    from   .fmForm                  import (
+        FormBaseNew, Form, TitleForm, TitleFooterForm, SplitForm, FormExpanded, FormBaseNewExpanded, blank_terminal
+    )
+    from   .fmActionForm            import ActionForm, ActionFormExpanded
+    from   .fmActionFormV2          import ActionFormV2, ActionFormExpandedV2, ActionFormMinimal
+    from   .fmFormWithMenus         import FormWithMenus, ActionFormWithMenus, \
+                                           FormBaseNewWithMenus, SplitFormWithMenus, \
+                                           ActionFormV2WithMenus
+    from   .fmPopup                 import Popup, MessagePopup, ActionPopup, PopupWide, ActionPopupWide
+    from   .fmFormMutt              import FormMutt, FormMuttWithMenus
+    from   .fmFileSelector          import FileSelector, selectFile
 
-from .fmFormMuttActive          import ActionControllerSimple, TextCommandBox, \
-                                       FormMuttActive, FormMuttActiveWithMenus
-from .fmFormMuttActive          import FormMuttActiveTraditional, FormMuttActiveTraditionalWithMenus
-
-
-from .fmFormMultiPage           import FormMultiPage, FormMultiPageAction,\
-                                       FormMultiPageActionWithMenus, FormMultiPageWithMenus
-
-from .npysNPSFilteredData       import NPSFilteredDataBase, NPSFilteredDataList
-
-from .wgbutton                  import MiniButton
-from .wgbutton                  import MiniButtonPress
-from .wgbutton                  import MiniButton      as Button
-from .wgbutton                  import MiniButtonPress as ButtonPress
-
-from .wgtextbox                 import Textfield, FixedText
-from .wgtitlefield              import TitleText, TitleFixedText
-from .wgpassword                import PasswordEntry, TitlePassword
-from .wgannotatetextbox         import AnnotateTextboxBase
-from .wgannotatetextbox         import AnnotateTextboxBaseRight
-
-from .wgslider                  import Slider, TitleSlider
-from .wgslider                  import SliderNoLabel, TitleSliderNoLabel
-from .wgslider                  import SliderPercent, TitleSliderPercent
-
-from .wgwidget                  import DummyWidget, NotEnoughSpaceForWidget
-from . import wgwidget as widget
-
-from .wgmultiline               import MultiLine, Pager, TitleMultiLine, TitlePager, MultiLineAction, BufferPager, TitleBufferPager
-from .wgmultiselect             import MultiSelect, TitleMultiSelect, MultiSelectFixed, \
-                                       TitleMultiSelectFixed, MultiSelectAction
-from .wgeditmultiline           import MultiLineEdit
-from .wgcombobox                import ComboBox, TitleCombo
-from .wgcheckbox                import Checkbox, RoundCheckBox, CheckBoxMultiline, RoundCheckBoxMultiline, CheckBox, CheckboxBare
-from .wgFormControlCheckbox     import FormControlCheckbox
-from .wgautocomplete            import TitleFilename, Filename, Autocomplete
-from .muMenu                    import Menu
-from .wgselectone               import SelectOne, TitleSelectOne
-from .wgdatecombo               import DateCombo, TitleDateCombo
-
-from .npysTree import TreeData
-from .wgmultilinetree           import MLTree, MLTreeAnnotated, MLTreeAction, MLTreeAnnotatedAction
-from .wgmultilinetreeselectable import MLTreeMultiSelect, TreeLineSelectable
-from .wgmultilinetreeselectable import MLTreeMultiSelectAnnotated, TreeLineSelectableAnnotated
+    from .fmFormMuttActive          import ActionControllerSimple, TextCommandBox, \
+                                           FormMuttActive, FormMuttActiveWithMenus
+    from .fmFormMuttActive          import FormMuttActiveTraditional, FormMuttActiveTraditionalWithMenus
 
 
-# The following are maintained for compatibility with old code only. ##########################################
+    from .fmFormMultiPage           import FormMultiPage, FormMultiPageAction,\
+                                           FormMultiPageActionWithMenus, FormMultiPageWithMenus
 
-from .compatibility_code.oldtreeclasses import MultiLineTree, SelectOneTree
-from .compatibility_code.oldtreeclasses import MultiLineTreeNew, MultiLineTreeNewAction, TreeLine, TreeLineAnnotated # Experimental
-from .compatibility_code.oldtreeclasses import MultiLineTreeNewAnnotatedAction, MultiLineTreeNewAnnotated # Experimental
-from .compatibility_code.npysNPSTree import NPSTreeData
+    from .npysNPSFilteredData       import NPSFilteredDataBase, NPSFilteredDataList
 
-# End compatibility. ###########################################################################################
+    from .wgbutton                  import MiniButton
+    from .wgbutton                  import MiniButtonPress
+    from .wgbutton                  import MiniButton      as Button
+    from .wgbutton                  import MiniButtonPress as ButtonPress
 
-from .wgfilenamecombo           import FilenameCombo, TitleFilenameCombo
-from .wgboxwidget               import BoxBasic, BoxTitle
-from .wgmultiline               import MultiLineActionWithShortcuts
-from .wgmultilineeditable       import MultiLineEditable, MultiLineEditableTitle, MultiLineEditableBoxed
+    from .wgtextbox                 import Textfield, FixedText
+    from .wgtitlefield              import TitleText, TitleFixedText
+    from .wgpassword                import PasswordEntry, TitlePassword
+    from .wgannotatetextbox         import AnnotateTextboxBase
+    from .wgannotatetextbox         import AnnotateTextboxBaseRight
 
-from .wgmonthbox                import MonthBox
-from .wggrid                    import SimpleGrid
-from .wggridcoltitles           import GridColTitles
+    from .wgslider                  import Slider, TitleSlider
+    from .wgslider                  import SliderNoLabel, TitleSliderNoLabel
+    from .wgslider                  import SliderPercent, TitleSliderPercent
 
-from .muNewMenu                 import NewMenu, MenuItem
-from .wgNMenuDisplay            import MenuDisplay, MenuDisplayScreen
+    from .wgwidget                  import DummyWidget, NotEnoughSpaceForWidget
+    from . import wgwidget as widget
 
-from .npyspmfuncs               import CallSubShell
+    from .wgmultiline               import (
+        MultiLine, Pager, TitleMultiLine, TitlePager, MultiLineAction, BufferPager, TitleBufferPager
+    )
+    from .wgmultiselect             import (
+        MultiSelect, TitleMultiSelect, MultiSelectFixed, TitleMultiSelectFixed, MultiSelectAction
+    )
+    from .wgeditmultiline           import MultiLineEdit
+    from .wgcombobox                import ComboBox, TitleCombo
+    from .wgcheckbox                import (
+        Checkbox, RoundCheckBox, CheckBoxMultiline, RoundCheckBoxMultiline, CheckBox, CheckboxBare
+    )
+    from .wgFormControlCheckbox     import FormControlCheckbox
+    from .wgautocomplete            import TitleFilename, Filename, Autocomplete
+    from .muMenu                    import Menu
+    from .wgselectone               import SelectOne, TitleSelectOne
+    from .wgdatecombo               import DateCombo, TitleDateCombo
 
-from .utilNotify                 import notify, notify_confirm, notify_wait, notify_ok_cancel, notify_yes_no
+    from .npysTree import TreeData
+    from .wgmultilinetree           import MLTree, MLTreeAnnotated, MLTreeAction, MLTreeAnnotatedAction
+    from .wgmultilinetreeselectable import MLTreeMultiSelect, TreeLineSelectable
+    from .wgmultilinetreeselectable import MLTreeMultiSelectAnnotated, TreeLineSelectableAnnotated
 
-# Base classes for overriding:
+    # The following are maintained for compatibility with old code only.
 
-# Standard Forms:
-from . import stdfmemail
+    from .compatibility_code.oldtreeclasses import MultiLineTree, SelectOneTree
+    from .compatibility_code.oldtreeclasses import (
+        MultiLineTreeNew, MultiLineTreeNewAction, TreeLine, TreeLineAnnotated
+    )
+    from .compatibility_code.oldtreeclasses import (
+        MultiLineTreeNewAnnotatedAction, MultiLineTreeNewAnnotated
+    )
+    from .compatibility_code.npysNPSTree import NPSTreeData
 
-# Experimental Only
-from .wgtextboxunicode import TextfieldUnicode
-from .wgtexttokens     import TextTokens, TitleTextTokens
+    # End compatibility.
 
-# Very experimental. Don't use for anything serious
-from .apOptions import SimpleOptionForm
-from .apOptions import OptionListDisplay, OptionChanger, OptionList, OptionLimitedChoices, OptionListDisplayLine
-from .apOptions import OptionFreeText, OptionSingleChoice, OptionMultiChoice, OptionMultiFreeList, \
-                       OptionBoolean, OptionFilename, OptionDate, OptionMultiFreeText
+    from .wgfilenamecombo           import FilenameCombo, TitleFilenameCombo
+    from .wgboxwidget               import BoxBasic, BoxTitle
+    from .wgmultiline               import MultiLineActionWithShortcuts
+    from .wgmultilineeditable       import MultiLineEditable, MultiLineEditableTitle, MultiLineEditableBoxed
+
+    from .wgmonthbox                import MonthBox
+    from .wggrid                    import SimpleGrid
+    from .wggridcoltitles           import GridColTitles
+
+    from .muNewMenu                 import NewMenu, MenuItem
+    from .wgNMenuDisplay            import MenuDisplay, MenuDisplayScreen
+
+    from .npyspmfuncs               import CallSubShell
+
+    from .utilNotify                 import notify, notify_confirm, notify_wait, notify_ok_cancel, notify_yes_no
+
+    # Base classes for overriding:
+
+    # Standard Forms:
+    from . import stdfmemail
+
+    # Experimental Only
+    from .wgtextboxunicode import TextfieldUnicode
+    from .wgtexttokens     import TextTokens, TitleTextTokens
+
+    # Very experimental. Don't use for anything serious
+    from .apOptions import SimpleOptionForm
+    from .apOptions import OptionListDisplay, OptionChanger, OptionList, OptionLimitedChoices, OptionListDisplayLine
+    from .apOptions import OptionFreeText, OptionSingleChoice, OptionMultiChoice, OptionMultiFreeList, \
+                           OptionBoolean, OptionFilename, OptionDate, OptionMultiFreeText
+
+    # This really is about as experimental as it gets
+    from .apNPSApplicationEvents import StandardApp
+    from .eveventhandler import Event
 
 
-# This really is about as experimental as it gets
-from .apNPSApplicationEvents import StandardApp
-from .eveventhandler import Event
-
-
-#@+node:vitalije.20170717124737.1: ** pyflake silencer
-assert (DEBUG, DISABLE_RESIZE_SYSTEM, TEST_SETTINGS) != (ExhaustedTestInput,
-    add_test_input_from_iterable, add_test_input_ch, wrapper, wrapper_basic,
-    ThemeManager, disableColor, enableColor, Themes, NPSApp, NPSAppManaged,
-    setTheme, FormBaseNew, Form, TitleForm, TitleFooterForm, SplitForm,
-    FormExpanded, FormBaseNewExpanded, blank_terminal, ActionForm,
-    ActionFormExpanded, ActionFormV2, ActionFormExpandedV2,
-    ActionFormMinimal, FormWithMenus, ActionFormWithMenus, Popup,
-    MessagePopup, ActionPopup, PopupWide, ActionPopupWide, FormMutt,
-    FormMuttWithMenus, FileSelector, selectFile, ActionControllerSimple,
-    TextCommandBox, FormMuttActiveTraditional,
-    FormMuttActiveTraditionalWithMenus, FormMultiPage, FormMultiPageAction,
-    NPSFilteredDataBase, NPSFilteredDataList, MiniButton, MiniButtonPress,
-    Button, ButtonPress, Textfield, FixedText, TitleText, TitleFixedText,
-    PasswordEntry, TitlePassword, AnnotateTextboxBase,
-    AnnotateTextboxBaseRight, Slider, TitleSlider, SliderNoLabel,
-    TitleSliderNoLabel, SliderPercent, TitleSliderPercent, DummyWidget,
-    NotEnoughSpaceForWidget, widget, MultiLine, Pager, TitleMultiLine,
-    TitlePager, MultiLineAction, BufferPager, TitleBufferPager, MultiSelect,
-    TitleMultiSelect, MultiSelectFixed, MultiLineEdit, ComboBox,
-    TitleCombo, Checkbox, RoundCheckBox, CheckBoxMultiline,
-    RoundCheckBoxMultiline, CheckBox, CheckboxBare, FormControlCheckbox,
-    TitleFilename, Filename, Autocomplete, Menu, SelectOne, TitleSelectOne,
-    DateCombo, TitleDateCombo, TreeData, MLTree, MLTreeAnnotated,
-    MLTreeAction, MLTreeAnnotatedAction, MLTreeMultiSelect,
-    TreeLineSelectable, MLTreeMultiSelectAnnotated,
-    TreeLineSelectableAnnotated, MultiLineTree, SelectOneTree,
-    MultiLineTreeNew, MultiLineTreeNewAction, TreeLine, TreeLineAnnotated,
-    MultiLineTreeNewAnnotatedAction, MultiLineTreeNewAnnotated, NPSTreeData,
-    FilenameCombo, TitleFilenameCombo, BoxBasic, BoxTitle,
-    MultiLineActionWithShortcuts, MultiLineEditable, MultiLineEditableTitle,
-    MultiLineEditableBoxed, MonthBox, SimpleGrid, GridColTitles, NewMenu,
-    MenuItem, MenuDisplay, MenuDisplayScreen, CallSubShell, notify,
-    notify_confirm, notify_wait, notify_ok_cancel, notify_yes_no,
-    stdfmemail, TextfieldUnicode, TextTokens, TitleTextTokens,
-    SimpleOptionForm, OptionListDisplay, OptionChanger, OptionList,
-    OptionLimitedChoices, OptionListDisplayLine, OptionFreeText,
-    OptionSingleChoice, OptionMultiChoice, OptionMultiFreeList, StandardApp,
-    Event, ActionFormV2WithMenus, SplitFormWithMenus, FormBaseNewWithMenus,
-    FormMuttActiveWithMenus, FormMuttActive, FormMultiPageActionWithMenus,
-    FormMultiPageWithMenus, TitleMultiSelectFixed, MultiSelectAction,
-    OptionBoolean, OptionMultiFreeText, OptionFilename, OptionDate)
-#@-others
+    #@-<< declarations >>
+    #@+<< pyflake silencer >>
+    #@+node:vitalije.20170717124737.1: ** << pyflake silencer >>
+    assert(DEBUG, DISABLE_RESIZE_SYSTEM, TEST_SETTINGS) != (ExhaustedTestInput,
+        add_test_input_from_iterable, add_test_input_ch, wrapper, wrapper_basic,
+        ThemeManager, disableColor, enableColor, Themes, NPSApp, NPSAppManaged,
+        setTheme, FormBaseNew, Form, TitleForm, TitleFooterForm, SplitForm,
+        FormExpanded, FormBaseNewExpanded, blank_terminal, ActionForm,
+        ActionFormExpanded, ActionFormV2, ActionFormExpandedV2,
+        ActionFormMinimal, FormWithMenus, ActionFormWithMenus, Popup,
+        MessagePopup, ActionPopup, PopupWide, ActionPopupWide, FormMutt,
+        FormMuttWithMenus, FileSelector, selectFile, ActionControllerSimple,
+        TextCommandBox, FormMuttActiveTraditional,
+        FormMuttActiveTraditionalWithMenus, FormMultiPage, FormMultiPageAction,
+        NPSFilteredDataBase, NPSFilteredDataList, MiniButton, MiniButtonPress,
+        Button, ButtonPress, Textfield, FixedText, TitleText, TitleFixedText,
+        PasswordEntry, TitlePassword, AnnotateTextboxBase,
+        AnnotateTextboxBaseRight, Slider, TitleSlider, SliderNoLabel,
+        TitleSliderNoLabel, SliderPercent, TitleSliderPercent, DummyWidget,
+        NotEnoughSpaceForWidget, widget, MultiLine, Pager, TitleMultiLine,
+        TitlePager, MultiLineAction, BufferPager, TitleBufferPager, MultiSelect,
+        TitleMultiSelect, MultiSelectFixed, MultiLineEdit, ComboBox,
+        TitleCombo, Checkbox, RoundCheckBox, CheckBoxMultiline,
+        RoundCheckBoxMultiline, CheckBox, CheckboxBare, FormControlCheckbox,
+        TitleFilename, Filename, Autocomplete, Menu, SelectOne, TitleSelectOne,
+        DateCombo, TitleDateCombo, TreeData, MLTree, MLTreeAnnotated,
+        MLTreeAction, MLTreeAnnotatedAction, MLTreeMultiSelect,
+        TreeLineSelectable, MLTreeMultiSelectAnnotated,
+        TreeLineSelectableAnnotated, MultiLineTree, SelectOneTree,
+        MultiLineTreeNew, MultiLineTreeNewAction, TreeLine, TreeLineAnnotated,
+        MultiLineTreeNewAnnotatedAction, MultiLineTreeNewAnnotated, NPSTreeData,
+        FilenameCombo, TitleFilenameCombo, BoxBasic, BoxTitle,
+        MultiLineActionWithShortcuts, MultiLineEditable, MultiLineEditableTitle,
+        MultiLineEditableBoxed, MonthBox, SimpleGrid, GridColTitles, NewMenu,
+        MenuItem, MenuDisplay, MenuDisplayScreen, CallSubShell, notify,
+        notify_confirm, notify_wait, notify_ok_cancel, notify_yes_no,
+        stdfmemail, TextfieldUnicode, TextTokens, TitleTextTokens,
+        SimpleOptionForm, OptionListDisplay, OptionChanger, OptionList,
+        OptionLimitedChoices, OptionListDisplayLine, OptionFreeText,
+        OptionSingleChoice, OptionMultiChoice, OptionMultiFreeList, StandardApp,
+        Event, ActionFormV2WithMenus, SplitFormWithMenus, FormBaseNewWithMenus,
+        FormMuttActiveWithMenus, FormMuttActive, FormMultiPageActionWithMenus,
+        FormMultiPageWithMenus, TitleMultiSelectFixed, MultiSelectAction,
+        OptionBoolean, OptionMultiFreeText, OptionFilename, OptionDate,
+    )
+    #@-<< pyflake silencer >>
+except Exception:
+    pass
 #@@language python
 #@@tabwidth -4
 #@-leo

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2779,12 +2779,7 @@ class TestTokens(BaseTest):
         remove = [
             'Interactive', 'Suite',  # Not necessary.
             'AST',  # The base class,
-            # Constants...
-            'PyCF_ALLOW_TOP_LEVEL_AWAIT',
-            'PyCF_ONLY_AST',
-            'PyCF_TYPE_COMMENTS',
-            # New ast nodes for Python 3.8.
-            # We can ignore these nodes because:
+            # We can ignore the newast nodes for Python 3.8 because:
             # 1. ast.parse does not generate them by default.
             # 2. The type comments are ordinary comments.
             #    They do not need to be specially synced.
@@ -2795,7 +2790,8 @@ class TestTokens(BaseTest):
         aList = [z for z in aList if not z[0].islower()]
             # Remove base classes.
         aList = [z for z in aList
-            if not z.startswith('_') and z not in remove]
+            # Constants start with 'PyCF_'.
+            if not z.startswith(('_', 'PyCF_')) and z not in remove]
         # Now test them.
         table = (
             TokenOrderGenerator,

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -2800,22 +2800,21 @@ class TestTokens(BaseTest):
         table = (
             TokenOrderGenerator,
         )
+        missing_names: list[str] = []
         for class_ in table:
+            nodes, ops = 0, 0
             traverser = class_()
-            errors, nodes, ops = 0, 0, 0
             for z in aList:
                 if hasattr(traverser, 'do_' + z):
                     nodes += 1
                 elif _op_names.get(z):
                     ops += 1
                 else:  # pragma: no cover
-                    errors += 1
+                    missing_name = f"{traverser.__class__.__name__}.{z}"
+                    missing_names.append(missing_name)
                     print('')
-                    print(
-                        f"Missing visitor: "
-                        f"{traverser.__class__.__name__}.{z}")
-        msg = f"{nodes} node types, {ops} op types, {errors} errors"
-        assert not errors, msg
+                    print(f"Missing visitor: {missing_name}")
+        assert not missing_names, '\n'.join(missing_names)
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -666,7 +666,7 @@ class TestTokenBasedOrange(BaseTest):
         table = (
             ### Duplicate entry to fail first.
             """f(a[1 + 2])""",
-        
+
             # Assignments...
             """a = b * c""",
             """a = b + c""",

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -112,6 +112,10 @@ class TestPlugins(LeoUnitTest):
         # New unit test for #3008
         # https://github.com/leo-editor/leo-editor/issues/3008
 
+        # Suppress this test for Python 3.13+
+        if g.python_version_tuple >= (3, 13, 0):
+            self.skipTest('_curses not available on Python 3.13+')
+
         # #3017: Skip the test if npyscreen, curses (_curses) or tkinter are missing.
         try:
             import leo.plugins.cursesGui2 as cursesGui2


### PR DESCRIPTION
See #4156.

- [x] Fix `TT.test_visitors_exist` by ignoring all constants that start with `PyCF_`.
- [x] Skip `test_cursesGui2` if Python >= 3.13.
- [x] `leo/external/npyscreen/__init__.py`: protect all imports.
   This change is necessary so that `unittest discover` will not raise an error.
- [x] Verify that `--gui=console` still works with Python < 3.13.