### PR TITLE
PR for #4171: speed up @killcolor

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1295,6 +1295,10 @@ class JEditColorizer(BaseColorizer):
         self.init_all_state(p.v)
         self.init()
 
+        # All done if p.b startswith @killcolor.
+        if p.b.startswith('@killcolor'):
+            return
+
         if trace:
             print('')
             g.trace(f"Start full redraw: language: {self.language} p: {p.h}")


### PR DESCRIPTION
See #4171.

- [x] Don't call `qsh.rehighlight` if `p.b` starts with `@killcolor`.
   The early return happens after initializing state, so all is well.
- [x] Verify that coloring works as expected.