### PR TITLE
PR 2 for #4171: @killcolor

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1609,8 +1609,7 @@ class JEditColorizer(BaseColorizer):
         k = g.skip_c_id(s, j)
         name = s[j:k]
         ok = self.init_mode(name)
-        if 'coloring' in g.app.debug:
-            g.trace(f"old: {old_name} new: {self.language} {s}")
+        # g.trace(f"old: {old_name} new: {self.language} {s}")
         if ok:
             self.language = name
             self.colorRangeWithTag(s, i, k, 'leokeyword')
@@ -2847,9 +2846,10 @@ class JEditColorizer(BaseColorizer):
         n = self.currentState()
         state = self.stateDict.get(n, 'no-state')
         enabled = (
-            not state.endswith('@nocolor') and
-            not state.endswith('@nocolor-node') and
-            not state.endswith('@killcolor'))
+            self.enabled  # 2024/11/12
+            and not state.endswith('@nocolor')
+            and not state.endswith('@nocolor-node')
+            and not state.endswith('@killcolor'))
         return enabled
     #@+node:ekr.20110605121601.18633: *4* jedit.setRestart
     def setRestart(self, f: Any, **keys: Any) -> int:


### PR DESCRIPTION
See #4171.

This PR fixes an *ancient* bug: `jedit.colorRangeWithTag` should not colorize `@language` lines  if `@killcolor` or `@nocolor` is in effect!

Testing shows that this PR retains the expected coloring of `@color` directives:
- They are *not* colored if `@killcolor` was previously in effect.
- Otherwise, they *are* colored, including when `@nocolor` was previously in effect.

**Tasks**

- [x] `jedit.match_at_language`: remove a recent trace.
- [x] `jedit.inColorState`: test `self.enabled` (!)
