### PR TITLE
Freewin - Use Host's Text, Background Colors For Rendered View

### DIFF
--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -16,22 +16,25 @@ is node-locked - that is, it always shows a view of its original host node
 no matter how the user navigates within or between outlines.
 
 :By: T\. B\. Passin
-:Version: 2.3
-:Date: 9 Nov 2024
+:Version: 2.4
+:Date: 14 Nov 2024
 #@+node:tom.20240811231850.1: *3* New With This Version
 New With This Version
 ======================
-1. When text is changed in the host node, the cursor position in the FW
-   editor will match the cursor position of the nost;
-2. The FW editor will scroll to put the new cursor postion into view if needed.
-
+The "Rendered" view now uses the same colors as the underlying host node's editor.
 
 Previous Recent Changes
 ========================
-1. The editor view now uses the same colors as the underlying host node's
-   editor. The CSS style sheet previously used is no longer used.
-2. The currently selected line in the editor view is highlighted using the same
-   algorithm as the standard Leo body editor.
+When text is changed in the host node, the cursor position in the FW editor will
+match the cursor position of the nost;
+
+The FW editor will scroll to put the new cursor postion into view if needed.
+
+The editor view now uses the same colors as the underlying host node's editor.
+The CSS style sheet previously used is no longer used.
+
+The currently selected line in the editor view is highlighted using the same
+algorithm as the standard Leo body editor.
 
 There are no settings that affect these new features.
 

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -21,7 +21,8 @@ no matter how the user navigates within or between outlines.
 #@+node:tom.20240811231850.1: *3* New With This Version
 New With This Version
 ======================
-The "Rendered" view now uses the same colors as the underlying host node's editor.
+The "Rendered" view now uses the same text and background colors as the
+underlying host node's editor.
 
 Previous Recent Changes
 ========================

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -628,10 +628,10 @@ def get_body_colors(c: Cmdr) -> tuple[str, str]:
     w: LeoQTextBrowser = wrapper.widget
 
     pallete: QtGui.QPalette = w.viewport().palette()
-    fg_hex: int = pallete.text().color().rgb()
-    bg_hex: int = pallete.window().color().rgb()
-    fg: str = f'#{fg_hex:x}'
-    bg: str = f'#{bg_hex:x}'
+    fg_hex: int = pallete.text().color().rgb() & 0x00ffffff
+    bg_hex: int = pallete.window().color().rgb() & 0x00ffffff
+    fg: str = f'#{fg_hex:06x}'
+    bg: str = f'#{bg_hex:06x}'
 
     return fg, bg
 #@+node:tom.20220329231604.1: ** is_body_dark
@@ -709,6 +709,10 @@ class ZEditorWin(QtWidgets.QMainWindow):
                 self.rst_stylesheet = f.read()
         else:
             self.rst_stylesheet = RST_STYLESHEET_DARK if is_dark else RST_STYLESHEET_LIGHT
+
+        css_fragment = self.get_color_css()
+        self.rst_stylesheet += css_fragment
+        g.es(css_fragment)
         #@-<<set stylesheets>>
         #@+<<set up editor>>
         #@+node:tom.20210602172856.1: *4* <<set up editor>>
@@ -799,8 +803,8 @@ class ZEditorWin(QtWidgets.QMainWindow):
         self.show()
 
     #@+node:tom.20240811000132.1: *3* get_color_font_css
-    def get_color_font_css(self):
-        """Return a CSS string declaring the body editor's actual colors and font."""
+    def get_color_font_css(self) -> str:
+        """Return CSS with body editor's colors and font."""
         fg, bg = get_body_colors(self.c)
         font = self.host_editor.font()
         color_font_style = f"""QTextEdit {{
@@ -810,8 +814,21 @@ class ZEditorWin(QtWidgets.QMainWindow):
             font-size: {font.pointSizeF()}pt;
         }}
         """
-
         return color_font_style
+
+    def get_color_css(self) -> str:
+        """Return a CSS string for RsT with body editor's colors."""
+        fg, bg = get_body_colors(self.c)
+        color_style = f"""\
+        body, th, td, pre.literal-block, pre.doctest-block,
+        pre.math, pre.code, blockquote, div.topic, blockquote > table,
+        div.topic > table, blockquote p.attribution,
+        div.topic p.attribution {{
+            color: {fg};
+            background: {bg};
+        }}
+        """
+        return color_style
     #@+node:tom.20210625205847.1: *3* reload settings
     def reloadSettings(self):
         c = self.c


### PR DESCRIPTION
- [x] Use host's body editor colors in the "rendered" (RsT) view.
- [x] Correct an error in computing the CSS colors from the editor widget's QColor colors.
- [x] Update docstring.
- [x] full_test_leo - no errors, 2 tests skipped.
- [x] pylint - no messages for FW 