### PR TITLE
PR: Further tweaks to Leo's jedit colorizer

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -77,7 +77,6 @@ class BaseColorizer:
         # Common state ivars...
         self.enabled = False  # Per-node enable/disable flag set by updateSyntaxColorer.
         self.highlighter: Any = g.NullObject()  # May be overridden in subclass...
-        self.in_full_redraw = False  # A lockout.
         self.language = 'python'  # set by scanLanguageDirectives.
         self.prev: tuple[int, int, str] = None  # Used by setTag.
         self.showInvisibles = False
@@ -1256,6 +1255,22 @@ class JEditColorizer(BaseColorizer):
                     aList.insert(0, wiki_rule)
                     d[ch] = aList
         self.rulesDict = d
+    #@+node:ekr.20241116071343.1: *3* jedit.force_recolor
+    def force_recolor(self) -> None:
+        """jedit.force_recolor: A helper for Leo's 'recolor' command."""
+        c = self.c
+        p = c.p
+        if not p:  # This guard is required.
+            return
+
+        # Only c.recolor should call this method!
+        if g.callers(1) != 'recolorCommand':
+            message = f"jedit.force_recolor: invalid caller: {g.callers()}"
+            g.print_unique_message(message)
+
+        # Tell QSyntaxHighlighter to do a full recolor.
+        g.es_print(f"recolor: `{p.h}`", color='blue')
+        self.highlighter.rehighlight()
     #@+node:ekr.20110605121601.18638: *3* jedit.mainLoop
     tot_time = 0.0
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -930,7 +930,7 @@ class JEditColorizer(BaseColorizer):
             # self.stateNameDict = {}
             # self.restartDict = {}
         self.init_mode(self.language)
-        ### self.clearState()
+        self.clearState()
         # Used by matchers.
         self.prev = None
         # Must be done to support per-language @font/@color settings.
@@ -1319,13 +1319,13 @@ class JEditColorizer(BaseColorizer):
             g.print_unique_message(message)
 
         self.recolorCount += 1
+        line_number = self.currentBlockNumber()
         state = self.prevState()
         prev_state = state
-        if state == -1:
+        if line_number == 0:  # Do not test state here!
             self.updateSyntaxColorer(p)
             self.init_all_state(p.v)
             self.init()
-            self.clearState()  ###
             state = self.initBlock0()
 
         if state != prev_state:
@@ -1346,7 +1346,7 @@ class JEditColorizer(BaseColorizer):
                 )
             g.trace(
                 f"recolorCount: {self.recolorCount} "
-                f"line number: {self.currentBlockNumber()} "
+                f"line number: {line_number} "
                 f"state: {state}: {self.stateNumberToStateString(state)}\n"
                 f"    s: {s!r}"
             )
@@ -2746,7 +2746,7 @@ class JEditColorizer(BaseColorizer):
         Create a *language-specific* default state.
         This properly forces a full recoloring when @language changes.
         """
-        if not g.unitTesting:
+        if False and not g.unitTesting:
             g.trace(g.callers())  ###
         n = self.initialStateNumber
         self.setState(n)
@@ -2806,7 +2806,7 @@ class JEditColorizer(BaseColorizer):
         return self.highlighter.previousBlockState()
 
     def setState(self, n: int) -> None:
-        if not g.unitTesting:
+        if False and not g.unitTesting:
             g.trace(n, g.callers(4))  ###
         self.highlighter.setCurrentBlockState(n)
     #@+node:ekr.20170125141148.1: *4* jedit.inColorState

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1319,17 +1319,17 @@ class JEditColorizer(BaseColorizer):
             g.print_unique_message(message)
 
         self.recolorCount += 1
-        line_number = self.currentBlockNumber()
-        state = self.prevState()
-        prev_state = state
-        if line_number == 0:  # Do not test state here!
+        ### line_number = self.currentBlockNumber()
+        prev_state = self.prevState()
+        if prev_state == -1:
             self.updateSyntaxColorer(p)
             self.init_all_state(p.v)
             self.init()
             state = self.initBlock0()
+        else:
+            state = prev_state  # Continue the previous state by default.
 
-        if state != prev_state:
-            self.setState(state)  # Continue the previous state by default.
+        self.setState(state)
 
         # #4146: Update self.language from the *previous* state.
         self.language = self.stateNumberToLanguage(state)
@@ -1341,14 +1341,12 @@ class JEditColorizer(BaseColorizer):
         if trace:
             if prev_state == -1:
                 print('')
-                g.trace(
-                    f"New node: prev_state: {prev_state} p.h: {p.h}"
-                )
+                g.trace(f"New node: prev_state: {prev_state} p.h: {p.h}")
             g.trace(
-                f"recolorCount: {self.recolorCount} "
-                f"line number: {line_number} "
-                f"state: {state}: {self.stateNumberToStateString(state)}\n"
-                f"    s: {s!r}"
+                f"recolorCount: {self.recolorCount:<4} "
+                f"line: {self.currentBlockNumber():<4} "
+                f"state: {state}: {self.stateNumberToStateString(state):<10} "
+                f"s: {s!r}"
             )
 
         # mainLoop will do nothing if s is empty.
@@ -2746,8 +2744,6 @@ class JEditColorizer(BaseColorizer):
         Create a *language-specific* default state.
         This properly forces a full recoloring when @language changes.
         """
-        if False and not g.unitTesting:
-            g.trace(g.callers())  ###
         n = self.initialStateNumber
         self.setState(n)
         return n
@@ -2806,8 +2802,6 @@ class JEditColorizer(BaseColorizer):
         return self.highlighter.previousBlockState()
 
     def setState(self, n: int) -> None:
-        if False and not g.unitTesting:
-            g.trace(n, g.callers(4))  ###
         self.highlighter.setCurrentBlockState(n)
     #@+node:ekr.20170125141148.1: *4* jedit.inColorState
     def inColorState(self) -> bool:

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1263,7 +1263,7 @@ class JEditColorizer(BaseColorizer):
         if not p:  # This guard is required.
             return
 
-        # Only c.recolor should call this method!
+        # Only the 'recolor' command should call this method!
         if g.callers(1) != 'recolorCommand':
             message = f"jedit.force_recolor: invalid caller: {g.callers()}"
             g.print_unique_message(message)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2038,6 +2038,7 @@ class JEditColorizer(BaseColorizer):
                 return self.restart_fstring(s, delim)
 
             self.setRestart(fstring_restarter)
+
         else:
             self.clearState()
         return j  # Return the new i, *not* the length of the match.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1334,7 +1334,6 @@ class JEditColorizer(BaseColorizer):
             g.print_unique_message(message)
 
         self.recolorCount += 1
-        ### line_number = self.currentBlockNumber()
         prev_state = self.prevState()
         if prev_state == -1:
             self.updateSyntaxColorer(p)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3674,9 +3674,8 @@ class Commands:
         c = self
         colorizer = c.frame.body.colorizer
         if colorizer and hasattr(colorizer, 'colorize'):
-            # Both jEditColorizer and QScintillaColorizer have colorize methods.
-            p = p or c.p
-            colorizer.colorize(p)
+            # Only the QScintillaColorizer class has a colorize method.
+            colorizer.colorize(p or c.p)
 
     recolor_now = recolor
     #@+node:ekr.20080514131122.14: *5* c.redrawing...


### PR DESCRIPTION
Further tweaks to PR #4182.

Unless qualified, all ivars and methods mentioned here are members of the `JEditColorizer` class.

- [x] Bug fix: Add `force_recolor` to support Leo's `recolor` command.
- [x] Fix a comment in `c.recolor`.
- [x] Retire the unused `in_full_redraw` ivar.
- [x] `redraw` tests the previous state, not the line number.
  This tweak aligns the code with the documentation for `QSyntaxHighlighter`.
- [x] Improve the traces in `redraw`.
  These traces are active with `--trace=coloring` is in effect.
- [x] Improve several important comments in `redraw`.
- [x] All my private syntax coloring tests pass.
- [x] All official tests pass.