### PR TITLE
PR for #4187: More tweaks to the jedit class

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -78,7 +78,6 @@ class BaseColorizer:
         self.enabled = False  # Per-node enable/disable flag set by updateSyntaxColorer.
         self.highlighter: Any = g.NullObject()  # May be overridden in subclass...
         self.language = 'python'  # set by scanLanguageDirectives.
-        ### self.prev: tuple[int, int, str] = None  # Used by setTag.
         self.showInvisibles = False
         # Statistics....
         self.count = 0
@@ -693,7 +692,6 @@ class BaseColorizer:
         self.totalLeoKeywordsCalls = 0
         # Mode data...
         self.importedRulesets: dict[str, RuleSet] = {}
-        ### self.prev = None  # The previous token.
         self.fonts: dict[str, Font] = {}  # Keys are config names.  Values are actual fonts.
         self.keywords: dict[str, int] = {}  # Keys are keywords, values are 0..5.
         self.modes: dict[str, Mode] = {}  # Keys are languages, values are modes.
@@ -905,7 +903,6 @@ class JEditColorizer(BaseColorizer):
         self.nested = False  # True: allow nested comments, etc.
         self.nested_level = 0  # Nesting level if self.nested is True.
         self.nextState = 1  # Don't use 0.
-        ### self.prev: tuple[int, int, str] = None  # For traces.
         self.restartDict: dict[int, Callable] = {}  # Keys are state numbers, values are restart functions.
         self.stateDict: dict[int, str] = {}  # Keys are state numbers, values state names.
         self.stateNameDict: dict[str, int] = {}  # Keys are state names, values are state numbers.
@@ -929,8 +926,6 @@ class JEditColorizer(BaseColorizer):
             # self.restartDict = {}
         self.init_mode(self.language)
         self.clearState()
-        # Used by matchers.
-        ### self.prev = None
         # Must be done to support per-language @font/@color settings.
         self.init_section_delims()  # #2276
     #@+node:ekr.20170201082248.1: *5* jedit.init_all_state
@@ -1537,7 +1532,6 @@ class JEditColorizer(BaseColorizer):
         j = i + n
         kind = 'url'
         self.colorRangeWithTag(s, i, j, kind)
-        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return n
     #@+node:ekr.20110605121601.18593: *5* jedit.match_at_color
@@ -1759,7 +1753,6 @@ class JEditColorizer(BaseColorizer):
         if self.leoKeywordsDict.get(word):
             kind = 'leokeyword'
             self.colorRangeWithTag(s, i, j, kind)
-            ### self.prev = (i, j, kind)
             result = j - i + 1  # Bug fix: skip the last character.
             self.trace_match(kind, s, i, j)
             return result
@@ -1771,7 +1764,6 @@ class JEditColorizer(BaseColorizer):
         kind = self.keywordsDict.get(word)
         if kind:
             self.colorRangeWithTag(s, i, j, kind)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return j - i
         # Bug fix: allow rescan.  Affects @language patch.
@@ -1854,7 +1846,6 @@ class JEditColorizer(BaseColorizer):
         if n > 0:
             j = i + n
             self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return n
         return 0
@@ -1899,7 +1890,6 @@ class JEditColorizer(BaseColorizer):
             j = len(s)
             self.colorRangeWithTag(
                 s, i, j, kind, delegate=delegate, exclude_match=exclude_match)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return j  # (was j-1) With a delegate, this could clear state.
         return 0
@@ -1928,7 +1918,6 @@ class JEditColorizer(BaseColorizer):
             j = len(s)
             self.colorRangeWithTag(
                 s, i, j, kind, delegate=delegate, exclude_match=exclude_match)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return j - i
         return 0
@@ -1979,7 +1968,6 @@ class JEditColorizer(BaseColorizer):
 
         # Color this line.
         self.colorRangeWithTag(s, start, end, tag='literal1')
-        ### self.prev = (i, end, delim)
         self.trace_match(delim, s, i, end)
 
         # Continue the f-string if necessary.
@@ -2102,7 +2090,6 @@ class JEditColorizer(BaseColorizer):
         kind = self.keywordsDict.get(word)
         if kind:
             self.colorRangeWithTag(s, i, j, kind)
-            ### self.prev = (i, j, kind)
             result = j - i
             self.trace_match(kind, s, i, j)
             return result
@@ -2166,7 +2153,6 @@ class JEditColorizer(BaseColorizer):
                 self.colorRangeWithTag(s, i, j, kind, exclude_match=exclude_match)
                 self.colorRangeWithTag(s, j, k, kind, exclude_match=False)
                 j = k
-                ### self.prev = (i, j, kind)
                 self.trace_match(kind, s, i, j)
                 return j - i
         return 0
@@ -2266,7 +2252,6 @@ class JEditColorizer(BaseColorizer):
         elif g.match(s, i, seq):
             j = i + len(seq)
             self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
         else:
             j = i
@@ -2294,7 +2279,6 @@ class JEditColorizer(BaseColorizer):
         j = i + n
         assert j - i == n
         self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
-        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return j - i
     #@+node:ekr.20110605121601.18622: *4* jedit.match_span & helpers
@@ -2365,7 +2349,6 @@ class JEditColorizer(BaseColorizer):
             self.colorRangeWithTag(
                 s, i, j2, kind, delegate=None, exclude_match=exclude_match)
         j = j2
-        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         # New in Leo 5.5: don't recolor everything after continued strings.
         if j > len(s) and not dots:
@@ -2580,7 +2563,6 @@ class JEditColorizer(BaseColorizer):
             else:  # avoid having to merge ranges in addTagsToList.
                 self.colorRangeWithTag(
                     s, i, j2, kind, delegate=None, exclude_match=exclude_match)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j2)
             return j2 - i
         return 0
@@ -2603,7 +2585,6 @@ class JEditColorizer(BaseColorizer):
             # Colorize the backslash plus exactly one more character.
             j = i + 2
         self.colorRangeWithTag(s, i, j, kind, delegate='')
-        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return j - i
     #@+node:ekr.20170205074106.1: *4* jedit.match_wiki_pattern
@@ -2652,7 +2633,6 @@ class JEditColorizer(BaseColorizer):
         self.colorRangeWithTag(s, i, j, kind1, exclude_match=exclude_match)
         k = j + n
         self.colorRangeWithTag(s, j, k, kind2, exclude_match=False)
-        ### self.prev = (j, k, kind2)
         self.trace_match(kind1, s, i, j)
         self.trace_match(kind2, s, j, k)
         return k - i
@@ -2663,7 +2643,6 @@ class JEditColorizer(BaseColorizer):
             return 0
         j = i + len(seq)
         self.colorRangeWithTag(s, i, j, kind)
-        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return len(seq)
     #@+node:ekr.20230420052841.1: *4* jedit.match_plain_span
@@ -2690,7 +2669,6 @@ class JEditColorizer(BaseColorizer):
         j2 = j + len(end)
         self.colorRangeWithTag(s, i, j2, kind)
         j = j2
-        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
 
         # Don't recolor everything after continued strings.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -78,7 +78,7 @@ class BaseColorizer:
         self.enabled = False  # Per-node enable/disable flag set by updateSyntaxColorer.
         self.highlighter: Any = g.NullObject()  # May be overridden in subclass...
         self.language = 'python'  # set by scanLanguageDirectives.
-        self.prev: tuple[int, int, str] = None  # Used by setTag.
+        ### self.prev: tuple[int, int, str] = None  # Used by setTag.
         self.showInvisibles = False
         # Statistics....
         self.count = 0
@@ -693,7 +693,7 @@ class BaseColorizer:
         self.totalLeoKeywordsCalls = 0
         # Mode data...
         self.importedRulesets: dict[str, RuleSet] = {}
-        self.prev = None  # The previous token.
+        ### self.prev = None  # The previous token.
         self.fonts: dict[str, Font] = {}  # Keys are config names.  Values are actual fonts.
         self.keywords: dict[str, int] = {}  # Keys are keywords, values are 0..5.
         self.modes: dict[str, Mode] = {}  # Keys are languages, values are modes.
@@ -905,7 +905,7 @@ class JEditColorizer(BaseColorizer):
         self.nested = False  # True: allow nested comments, etc.
         self.nested_level = 0  # Nesting level if self.nested is True.
         self.nextState = 1  # Don't use 0.
-        self.prev: tuple[int, int, str] = None  # For traces.
+        ### self.prev: tuple[int, int, str] = None  # For traces.
         self.restartDict: dict[int, Callable] = {}  # Keys are state numbers, values are restart functions.
         self.stateDict: dict[int, str] = {}  # Keys are state numbers, values state names.
         self.stateNameDict: dict[str, int] = {}  # Keys are state names, values are state numbers.
@@ -930,7 +930,7 @@ class JEditColorizer(BaseColorizer):
         self.init_mode(self.language)
         self.clearState()
         # Used by matchers.
-        self.prev = None
+        ### self.prev = None
         # Must be done to support per-language @font/@color settings.
         self.init_section_delims()  # #2276
     #@+node:ekr.20170201082248.1: *5* jedit.init_all_state
@@ -1537,7 +1537,7 @@ class JEditColorizer(BaseColorizer):
         j = i + n
         kind = 'url'
         self.colorRangeWithTag(s, i, j, kind)
-        self.prev = (i, j, kind)
+        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return n
     #@+node:ekr.20110605121601.18593: *5* jedit.match_at_color
@@ -1759,7 +1759,7 @@ class JEditColorizer(BaseColorizer):
         if self.leoKeywordsDict.get(word):
             kind = 'leokeyword'
             self.colorRangeWithTag(s, i, j, kind)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             result = j - i + 1  # Bug fix: skip the last character.
             self.trace_match(kind, s, i, j)
             return result
@@ -1771,7 +1771,7 @@ class JEditColorizer(BaseColorizer):
         kind = self.keywordsDict.get(word)
         if kind:
             self.colorRangeWithTag(s, i, j, kind)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return j - i
         # Bug fix: allow rescan.  Affects @language patch.
@@ -1854,7 +1854,7 @@ class JEditColorizer(BaseColorizer):
         if n > 0:
             j = i + n
             self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return n
         return 0
@@ -1899,7 +1899,7 @@ class JEditColorizer(BaseColorizer):
             j = len(s)
             self.colorRangeWithTag(
                 s, i, j, kind, delegate=delegate, exclude_match=exclude_match)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return j  # (was j-1) With a delegate, this could clear state.
         return 0
@@ -1928,7 +1928,7 @@ class JEditColorizer(BaseColorizer):
             j = len(s)
             self.colorRangeWithTag(
                 s, i, j, kind, delegate=delegate, exclude_match=exclude_match)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             return j - i
         return 0
@@ -1979,7 +1979,7 @@ class JEditColorizer(BaseColorizer):
 
         # Color this line.
         self.colorRangeWithTag(s, start, end, tag='literal1')
-        self.prev = (i, end, delim)
+        ### self.prev = (i, end, delim)
         self.trace_match(delim, s, i, end)
 
         # Continue the f-string if necessary.
@@ -2102,7 +2102,7 @@ class JEditColorizer(BaseColorizer):
         kind = self.keywordsDict.get(word)
         if kind:
             self.colorRangeWithTag(s, i, j, kind)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             result = j - i
             self.trace_match(kind, s, i, j)
             return result
@@ -2166,7 +2166,7 @@ class JEditColorizer(BaseColorizer):
                 self.colorRangeWithTag(s, i, j, kind, exclude_match=exclude_match)
                 self.colorRangeWithTag(s, j, k, kind, exclude_match=False)
                 j = k
-                self.prev = (i, j, kind)
+                ### self.prev = (i, j, kind)
                 self.trace_match(kind, s, i, j)
                 return j - i
         return 0
@@ -2266,7 +2266,7 @@ class JEditColorizer(BaseColorizer):
         elif g.match(s, i, seq):
             j = i + len(seq)
             self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
         else:
             j = i
@@ -2294,7 +2294,7 @@ class JEditColorizer(BaseColorizer):
         j = i + n
         assert j - i == n
         self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
-        self.prev = (i, j, kind)
+        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return j - i
     #@+node:ekr.20110605121601.18622: *4* jedit.match_span & helpers
@@ -2365,7 +2365,7 @@ class JEditColorizer(BaseColorizer):
             self.colorRangeWithTag(
                 s, i, j2, kind, delegate=None, exclude_match=exclude_match)
         j = j2
-        self.prev = (i, j, kind)
+        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         # New in Leo 5.5: don't recolor everything after continued strings.
         if j > len(s) and not dots:
@@ -2580,7 +2580,7 @@ class JEditColorizer(BaseColorizer):
             else:  # avoid having to merge ranges in addTagsToList.
                 self.colorRangeWithTag(
                     s, i, j2, kind, delegate=None, exclude_match=exclude_match)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j2)
             return j2 - i
         return 0
@@ -2603,7 +2603,7 @@ class JEditColorizer(BaseColorizer):
             # Colorize the backslash plus exactly one more character.
             j = i + 2
         self.colorRangeWithTag(s, i, j, kind, delegate='')
-        self.prev = (i, j, kind)
+        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return j - i
     #@+node:ekr.20170205074106.1: *4* jedit.match_wiki_pattern
@@ -2652,7 +2652,7 @@ class JEditColorizer(BaseColorizer):
         self.colorRangeWithTag(s, i, j, kind1, exclude_match=exclude_match)
         k = j + n
         self.colorRangeWithTag(s, j, k, kind2, exclude_match=False)
-        self.prev = (j, k, kind2)
+        ### self.prev = (j, k, kind2)
         self.trace_match(kind1, s, i, j)
         self.trace_match(kind2, s, j, k)
         return k - i
@@ -2663,7 +2663,7 @@ class JEditColorizer(BaseColorizer):
             return 0
         j = i + len(seq)
         self.colorRangeWithTag(s, i, j, kind)
-        self.prev = (i, j, kind)
+        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
         return len(seq)
     #@+node:ekr.20230420052841.1: *4* jedit.match_plain_span
@@ -2690,7 +2690,7 @@ class JEditColorizer(BaseColorizer):
         j2 = j + len(end)
         self.colorRangeWithTag(s, i, j2, kind)
         j = j2
-        self.prev = (i, j, kind)
+        ### self.prev = (i, j, kind)
         self.trace_match(kind, s, i, j)
 
         # Don't recolor everything after continued strings.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -915,7 +915,9 @@ class JEditColorizer(BaseColorizer):
         self.reloadSettings()
     #@+node:ekr.20110605121601.18580: *5* jedit.init
     def init(self) -> None:
-        """Init the colorizer, but *not* state."""
+        """
+        Init the colorizer to match self.language.
+        """
         # These *must* be recomputed.
         self.initialStateNumber = self.setInitialStateNumber()
 
@@ -924,8 +926,9 @@ class JEditColorizer(BaseColorizer):
             # self.stateDict = {}
             # self.stateNameDict = {}
             # self.restartDict = {}
+
         self.init_mode(self.language)
-        self.clearState()
+
         # Must be done to support per-language @font/@color settings.
         self.init_section_delims()  # #2276
     #@+node:ekr.20170201082248.1: *5* jedit.init_all_state
@@ -1668,8 +1671,8 @@ class JEditColorizer(BaseColorizer):
             # Switch languages.
             self.after_doc_language = self.language
             self.language = 'rest'
-            self.clearState()
             self.init()
+            self.clearState()
             # Restart.
             self.setRestart(self.restartDocPart)
             # Do *not* color the text here!
@@ -1692,8 +1695,8 @@ class JEditColorizer(BaseColorizer):
                 self.colorRangeWithTag(s, 0, j, 'leokeyword')  # 'docpart')
                 # Switch languages.
                 self.language = self.after_doc_language
-                self.clearState()
                 self.init()
+                self.clearState()
                 self.after_doc_language = None
                 return j
         # Color the next line.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -917,19 +917,16 @@ class JEditColorizer(BaseColorizer):
     def init(self) -> None:
         """
         Init the colorizer to match self.language.
+        
+        The caller must set or clear state after calling this method.
         """
-        # These *must* be recomputed.
+        # Init the *per-language* initial state number.
         self.initialStateNumber = self.setInitialStateNumber()
 
-        # Fix #389. Only jedit.stateNameToStateNumber should change these!
-            # self.nextState = 1 # Don't use 0.
-            # self.stateDict = {}
-            # self.stateNameDict = {}
-            # self.restartDict = {}
-
+        # Init mode-related ivars.
         self.init_mode(self.language)
 
-        # Must be done to support per-language @font/@color settings.
+        # Support per-language @font/@color settings.
         self.init_section_delims()  # #2276
     #@+node:ekr.20170201082248.1: *5* jedit.init_all_state
     def init_all_state(self) -> None:

--- a/leo/plugins/patch_python_colorizer.py
+++ b/leo/plugins/patch_python_colorizer.py
@@ -43,7 +43,6 @@ def python_rule_global(colorer, s, i):
         if m.start() == i:
             j = i + len(m.group(0))
             self.colorRangeWithTag(s, i, j, kind, delegate=None)
-            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             break
     else:

--- a/leo/plugins/patch_python_colorizer.py
+++ b/leo/plugins/patch_python_colorizer.py
@@ -43,7 +43,7 @@ def python_rule_global(colorer, s, i):
         if m.start() == i:
             j = i + len(m.group(0))
             self.colorRangeWithTag(s, i, j, kind, delegate=None)
-            self.prev = (i, j, kind)
+            ### self.prev = (i, j, kind)
             self.trace_match(kind, s, i, j)
             break
     else:

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -31,7 +31,7 @@ class TestColorizer(LeoUnitTest):
         x.language = language_name
         x.enabled = True
         x.init()
-        x.init_all_state(p.v)
+        x.init_all_state()
         n = x.initBlock0()
         for s in g.splitLines(text):
             x.mainLoop(n, s)


### PR DESCRIPTION
See #4187.

**Non-controversial changes**

- [x] Retire unused `old_v` ivar.
- [x] Retire unused `v` arg to `init_all_state`, updating a unit test accordingly.
- [x] Add an internal unit test to `init_all_state`.
- [x] Retire unused `prev` ivar.

**Understanding all calls to init**

There are three calls to `init`. 

- In the `prev_state == -1` logic in `recolor`.
- In `match_doc_part`.
- In `restartDocPart`.

I re-studied all three methods. Here are my conclusions:

1. All three methods change the `@language` in effect, so all three *must* call `init`!
2. All three methods set/clear the state *after* calling `init`
3. Therefore,  `init` need not clear the state: the callers will also set/clear state.
   Clearing state in `init` isn't exactly wrong, but imo it is bad style.

- [x] Do not call `clearState` in `init`.
- [x] Improve `init`'s docstring. Setting or clearing state should happen explicitly!