### PR TITLE
PR Require kwargs for most pattern matchers

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2211,7 +2211,7 @@ class JEditColorizer(BaseColorizer):
                     re_obj = re.compile(pattern, flags)
             except Exception:
                 # Do not call g.es here!
-                g.trace(f"Invalid regular expression: {pattern}")
+                g.trace(f"Invalid regular expression: {pattern:<30} {g.callers(2)}")
                 return 0
         else:
             re_obj = pattern

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2211,7 +2211,8 @@ class JEditColorizer(BaseColorizer):
                     re_obj = re.compile(pattern, flags)
             except Exception:
                 # Do not call g.es here!
-                g.trace(f"Invalid regular expression: {pattern:<30} {g.callers(2)}")
+                if not g.unitTesting:
+                    g.trace(f"Invalid regular expression: {pattern:<30} {g.callers(2)}")
                 return 0
         else:
             re_obj = pattern
@@ -2561,7 +2562,8 @@ class JEditColorizer(BaseColorizer):
         1. One or more ascii letters, or
         2. Exactly one character, of any kind.
         """
-        assert s[i] == '\\'
+        if not g.unitTesting:
+            assert s[i] == '\\'
         if m := self.ascii_letters.match(s, i + 1):
             n = len(m.group(0))
             j = i + n + 1

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1448,7 +1448,7 @@ class JEditColorizer(BaseColorizer):
     # - kind                  The color tag to be applied to colored text.
     #@+node:ekr.20110605121601.18637: *4* jedit.colorRangeWithTag
     def colorRangeWithTag(self,
-        s: str, i: int, j: int, tag: str, delegate: str = '', exclude_match: bool = False,
+        s: str, i: int, j: int, tag: str, *, delegate: str = '', exclude_match: bool = False,
     ) -> None:
         """
         Pattern matchers call this helper to colorize the selected range.
@@ -1822,7 +1822,7 @@ class JEditColorizer(BaseColorizer):
                 # self.colorRangeWithTag(s, i, j, 'tab')
                 # return j - i
             # return 0
-    #@+node:tbrown.20170707150713.1: *5* jedit.match_tabs
+    #@+node:tbrown.20170707150713.1: *5* jedit.match_trailing_ws
     def match_trailing_ws(self, s: str, i: int) -> int:
         """match trailing whitespace"""
         j = i
@@ -1838,8 +1838,10 @@ class JEditColorizer(BaseColorizer):
         # Called by the main colorizer loop and colorRangeWithTag.
         return self.match_compiled_regexp(s, i, kind='url', regexp=g.unl_regex)
     #@+node:ekr.20110605121601.18609: *4* jedit.match_compiled_regexp
-    def match_compiled_regexp(self,
-        s: str, i: int, kind: str, regexp: Any, delegate: str = '',
+    def match_compiled_regexp(self, s: str, i: int,
+        *, kind: str,
+        regexp: Any,
+        delegate: str = '',
     ) -> int:
         """Succeed if the compiled regular expression regexp matches at s[i:]."""
         n = self.match_compiled_regexp_helper(s, i, regexp)
@@ -1864,10 +1866,8 @@ class JEditColorizer(BaseColorizer):
             return 0
         return end - start
     #@+node:ekr.20110605121601.18611: *4* jedit.match_eol_span
-    def match_eol_span(
-        self,
-        s: str,
-        i: int,
+    def match_eol_span(self, s: str, i: int,
+        *,
         kind: str = None,
         seq: str = '',
         at_line_start: bool = False,
@@ -1894,10 +1894,8 @@ class JEditColorizer(BaseColorizer):
             return j  # (was j-1) With a delegate, this could clear state.
         return 0
     #@+node:ekr.20110605121601.18612: *4* jedit.match_eol_span_regexp
-    def match_eol_span_regexp(
-        self,
-        s: str,
-        i: int,
+    def match_eol_span_regexp(self, s: str, i: int,
+        *,
         kind: str = '',
         regexp: str = '',
         at_line_start: bool = False,
@@ -2095,15 +2093,18 @@ class JEditColorizer(BaseColorizer):
             return result
         return -len(word)  # An important new optimization.
     #@+node:ekr.20110605121601.18615: *4* jedit.match_line
-    def match_line(self,
-        s: str, i: int, kind: str = None, delegate: str = '', exclude_match: bool = False,
+    def match_line(self, s: str, i: int,
+        *,
+        kind: str = None,
+        delegate: str = '',
+        exclude_match: bool = False,
     ) -> int:
         """Match the rest of the line."""
         j = g.skip_to_end_of_line(s, i)
         self.colorRangeWithTag(s, i, j, kind, delegate=delegate)
         return j - i
     #@+node:ekr.20190606201152.1: *4* jedit.match_lua_literal
-    def match_lua_literal(self, s: str, i: int, kind: str) -> int:
+    def match_lua_literal(self, s: str, i: int, *, kind: str) -> int:
         """Succeed if s[i:] is a lua literal. See #1175"""
         k = self.match_span(s, i, kind=kind, begin="[[", end="]]")
         if k not in (None, 0):
@@ -2118,10 +2119,8 @@ class JEditColorizer(BaseColorizer):
             return 0
         return self.match_span(s, i, kind=kind, begin=s[i:j], end=s[i + 1 : j] + ']')
     #@+node:ekr.20110605121601.18616: *4* jedit.match_mark_following & getNextToken
-    def match_mark_following(
-        self,
-        s: str,
-        i: int,
+    def match_mark_following(self, s: str, i: int,
+        *,
         kind: str = '',
         pattern: str = '',
         at_line_start: bool = False,
@@ -2176,10 +2175,8 @@ class JEditColorizer(BaseColorizer):
             return i0
         return min(len(s), i)
     #@+node:ekr.20110605121601.18618: *4* jedit.match_mark_previous
-    def match_mark_previous(
-        self,
-        s: str,
-        i: int,
+    def match_mark_previous(self, s: str, i: int,
+        *,
         kind: str = '',
         pattern: str = '',
         at_line_start: bool = False,
@@ -2227,12 +2224,9 @@ class JEditColorizer(BaseColorizer):
             return 0
         return end - start
     #@+node:ekr.20110605121601.18620: *4* jedit.match_seq
-    def match_seq(
-        self,
-        s: str,
-        i: int,
-        kind: str = '',
+    def match_seq(self, s: str, i: int,
         *,
+        kind: str = '',
         seq: str = '',
         at_line_start: bool = False,
         at_whitespace_end: bool = False,
@@ -2257,10 +2251,8 @@ class JEditColorizer(BaseColorizer):
             j = i
         return j - i
     #@+node:ekr.20110605121601.18621: *4* jedit.match_seq_regexp
-    def match_seq_regexp(
-        self,
-        s: str,
-        i: int,
+    def match_seq_regexp(self, s: str, i: int,
+        *,
         kind: str = '',
         regexp: str = '',
         at_line_start: bool = False,
@@ -2282,10 +2274,7 @@ class JEditColorizer(BaseColorizer):
         self.trace_match(kind, s, i, j)
         return j - i
     #@+node:ekr.20110605121601.18622: *4* jedit.match_span & helpers
-    def match_span(
-        self,
-        s: str,
-        i: int,
+    def match_span(self, s: str, i: int,
         *,
         kind: str,
         begin: str,
@@ -2431,10 +2420,7 @@ class JEditColorizer(BaseColorizer):
         # For pylint.
         return -1
     #@+node:ekr.20110605121601.18624: *5* jedit.restart_match_span
-    def restart_match_span(
-        self,
-        s: str,
-        kind: str,
+    def restart_match_span(self, s: str, kind: str,
         *,
         begin: str,
         end: str,
@@ -2495,10 +2481,8 @@ class JEditColorizer(BaseColorizer):
             self.clearState()
         return j  # Return the new i, *not* the length of the match.
     #@+node:ekr.20110605121601.18625: *4* jedit.match_span_regexp
-    def match_span_regexp(
-        self,
-        s: str,
-        i: int,
+    def match_span_regexp(self, s: str, i: int,
+        *,
         kind: str = '',
         begin: Union[re.Pattern, str] = '',
         end: str = '',
@@ -2569,7 +2553,7 @@ class JEditColorizer(BaseColorizer):
     #@+node:ekr.20190623132338.1: *4* jedit.match_tex_backslash
     ascii_letters = re.compile(r'[a-zA-Z]+')
 
-    def match_tex_backslash(self, s: str, i: int, kind: str) -> int:
+    def match_tex_backslash(self, s: str, i: int, *, kind: str) -> int:
         """
         Match the tex s[i:].
 
@@ -2646,7 +2630,12 @@ class JEditColorizer(BaseColorizer):
         self.trace_match(kind, s, i, j)
         return len(seq)
     #@+node:ekr.20230420052841.1: *4* jedit.match_plain_span
-    def match_plain_span(self, s: str, i: int, kind: str, *, begin: str, end: str) -> int:
+    def match_plain_span(self, s: str, i: int,
+        *,
+        kind: str,
+        begin: str,
+        end: str,
+    ) -> int:
         """Matcher for simple span at s[i:] with no delegate."""
         if not g.match(s, i, begin):
             return 0

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2211,8 +2211,7 @@ class JEditColorizer(BaseColorizer):
                     re_obj = re.compile(pattern, flags)
             except Exception:
                 # Do not call g.es here!
-                if not g.unitTesting:
-                    g.trace(f"Invalid regular expression: {pattern:<30} {g.callers(2)}")
+                g.trace(f"Invalid regular expression: {pattern:<30} {g.callers(2)}")
                 return 0
         else:
             re_obj = pattern

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2562,7 +2562,7 @@ class JEditColorizer(BaseColorizer):
         2. Exactly one character, of any kind.
         """
         if not g.unitTesting:
-            assert s[i] == '\\'
+            assert s[i] == '\\'  # TestSyntax.slow_test_all_mode_files only tests signatures.
         if m := self.ascii_letters.match(s, i + 1):
             n = len(m.group(0))
             j = i + n + 1

--- a/leo/modes/clojure.py
+++ b/leo/modes/clojure.py
@@ -3,7 +3,7 @@
 import re
 number_pat = re.compile('\\b0x[0-9a-fA-F]+|\\b\\d*\\.\\d+|\\b\\d+\\.?')
 def clojure_match_numbers(colorer, s, i):
-    return colorer.match_compiled_regexp(s, i, 'literal4', number_pat)
+    return colorer.match_compiled_regexp(s, i, kind='literal4', regexp=number_pat)
 
 # Properties for clojure mode.
 properties = {

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -179,11 +179,11 @@ rulesDict2 = {
 # Rules for html_javascript ruleset.
 
 def html_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, "markup", seq=">",
+    return colorer.match_seq(s, i, kind="markup", seq=">",
         delegate="javascript::main")
 
 def html_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, "markup", seq="SRC=",
+    return colorer.match_seq(s, i, kind="markup", seq="SRC=",
         delegate="html::back_to_html")
 
 # Rules dict for html_javascript ruleset.
@@ -196,7 +196,7 @@ rulesDict3 = {
 # Rules for html_back_to_html ruleset.
 
 def html_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, "markup", seq=">",
+    return colorer.match_seq(s, i, kind="markup", seq=">",
         delegate="html::main")
 
 # Rules dict for html_back_to_html ruleset.
@@ -208,7 +208,7 @@ rulesDict4 = {
 # Rules for html_css ruleset.
 
 def html_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, "markup", seq=">",
+    return colorer.match_seq(s, i, kind="markup", seq=">",
         delegate="css::main")
 
 # Rules dict for html_css ruleset.

--- a/leo/modes/javascript.py
+++ b/leo/modes/javascript.py
@@ -224,12 +224,12 @@ def javascript_rule2(colorer, s, i):
 
 #@+node:ekr.20230419052250.4: *3* javascript_rule3
 def javascript_rule3(colorer, s, i):
-    return colorer.match_mark_previous(s, i, "function", pattern="(",
+    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
         exclude_match=True)
 
 #@+node:ekr.20230419052250.5: *3* javascript_rule4
 def javascript_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, "comment2", seq="//")
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 
 #@+node:ekr.20230419052250.6: *3* javascript_rule5
 def javascript_rule5(colorer, s, i):
@@ -329,7 +329,7 @@ def javascript_rule28(colorer, s, i):
 
 #@+node:ekr.20230419052250.30: *3* javascript_rule29
 def javascript_rule29(colorer, s, i):
-    return colorer.match_mark_previous(s, i, "label", pattern=":",
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
         at_whitespace_end=True, exclude_match=True)
 
 #@+node:ekr.20230419052250.31: *3* javascript_rule30

--- a/leo/modes/nim.py
+++ b/leo/modes/nim.py
@@ -678,7 +678,7 @@ def nim_unusual_single_quote(colorer, s, i):
 
     # Find the suffix.
     # assert s[i : i + 1] == "'", repr(s)
-    if s[i : i + 1] != "'": 
+    if s[i : i + 1] != "'":
         return  # TestSyntax.slow_test_all_mode_files only tests signatures.
     head = s[:i]
     for suffix in suffixes:

--- a/leo/modes/nim.py
+++ b/leo/modes/nim.py
@@ -677,7 +677,9 @@ def nim_unusual_single_quote(colorer, s, i):
         return 0
 
     # Find the suffix.
-    assert s[i : i + 1] == "'", repr(s)
+    # assert s[i : i + 1] == "'", repr(s)
+    if s[i : i + 1] != "'": 
+        return  # TestSyntax.slow_test_all_mode_files only tests signatures.
     head = s[:i]
     for suffix in suffixes:
         if head.endswith(suffix):

--- a/leo/scripts/scripts.leo
+++ b/leo/scripts/scripts.leo
@@ -454,6 +454,15 @@
 <v t="ekr.20060824111500.181"><vh>getMode</vh></v>
 </v>
 </v>
+<v t="ekr.20241117081230.1"><vh>script: scan-modes</vh>
+<v t="ekr.20241117081901.1"><vh>scan</vh></v>
+<v t="ekr.20241117082739.1"><vh>scan_def</vh></v>
+<v t="ekr.20241117125039.1"><vh>add_matcher</vh></v>
+<v t="ekr.20241117145426.1"><vh>delete_cruft</vh></v>
+<v t="ekr.20241117131431.1"><vh>delete_strings</vh></v>
+<v t="ekr.20241117125038.1"><vh>filter_line</vh></v>
+<v t="ekr.20241117125039.2"><vh>show_line</vh></v>
+</v>
 </vnodes>
 <tnodes>
 <t tx="ekr.20060824111500.108">"""
@@ -5924,6 +5933,192 @@ else:
     g.es(f"Path {direc} doesn't exist")
 
 </t>
+<t tx="ekr.20241117081230.1">"""
+This script has been mostly obsoleted by TestSyntax.slow_test_all_mode_files.
+
+It summarizes the rules in mode files.
+"""
+
+g.cls()
+g.cls()
+
+import glob
+import os
+import re
+
+join = g.os_path_finalize_join
+finalize = g.os_path_finalize
+
+@others
+
+all = True
+
+languages = (
+    '/actionscript.py',
+    # '/javascript.py',
+    # '/md.py',
+    # '/python.py',
+    # '/html.py',
+    # '/xml.py',
+)
+mode_path = join(g.app.loadDir, '..', 'modes')
+paths = glob.glob(f"{mode_path}{os.sep}*.py")
+paths = [finalize(z) for z in paths if not z.startswith('__')]
+
+summary = set()
+for path in paths:
+    if all or path.endswith(languages):
+        scan(path, summary)
+# Print the cumulative results.
+lines = sorted(list(summary))
+for i, s in enumerate(lines):
+    print(f"{i:2} {s.rstrip()}")
+</t>
+<t tx="ekr.20241117081901.1">def scan(path: str, summary: set) -&gt; None:
+    matchers: dict[str, set[str]] = {}
+    fn = os.path.basename(path)
+    with open(path, 'r') as f:
+        contents = f.read()
+    if 0:
+        print('')
+        g.trace(f"contents: {len(contents):&gt;6} {fn} ")
+        print('')
+    lines = g.splitLines(contents)
+    for i, line in enumerate(lines):
+        if line.startswith('def '):
+            scan_def(i, fn, lines, matchers)
+            
+    if 0:  # Print per-file results.
+        for fn, result_set in matchers.items():
+            g.printObj(list(sorted(list(result_set))), tag=fn)
+    if 1:  # Add the result_set to the global summary.
+        for fn, result_set in matchers.items():
+            lines = list(sorted(list(result_set)))
+            # g.printObj(lines, tag=fn)
+            for line in lines:
+                line = delete_cruft(line)
+                if line:
+                    # print(line)
+                    summary.add(line)
+</t>
+<t tx="ekr.20241117082739.1"># matcher_pat = re.compile(r'return colorer\.(match_.*?)\s*\(')
+
+def scan_def(
+    i: int,
+    fn: str,
+    lines: list[str],
+    matchers: dict[str, set[str]],
+) -&gt; None:
+    """
+    Print the definition starting at lines[i].
+    
+    Add all calls to matchers to the matchers_dict
+    """
+    show_line(i, lines[i])
+    if 0:  # Brief
+        i += 1
+        add_matcher(fn, i, i+1, lines, matchers)
+    else:
+        i += 1
+        i1 = i
+        while i &lt; len(lines) and not lines[i].startswith('def '):
+            show_line(i, lines[i])
+            i += 1
+        add_matcher(fn, i1, i, lines, matchers)
+</t>
+<t tx="ekr.20241117125038.1">def filter_line(line: str) -&gt; bool:
+    """
+    Return True if s is neither empty, nor a comment nor a dictionary
+    entry.
+    """
+    s = line.strip()
+    # This is mostly a hack, but it gets the job done.
+    return s and not s.startswith((
+        '#', '"', "'", '}',
+        'importDict', 'rulesDict'
+    ))
+</t>
+<t tx="ekr.20241117125039.1">def add_matcher(fn: str, i: int, j: int,
+    lines: list[str],
+    matchers: dict[str, set[str]],
+) -&gt; None:
+    """Add matchers to the matchers dict"""
+    filtered_lines = [z for z in lines[i: j] if filter_line(z)]
+    result_lines = [
+        z.replace('\n', ' ').replace('  ', ' ').lstrip()
+            for z in filtered_lines
+    ]
+    result_lines = [delete_strings(z) for z in result_lines]
+    result_lines = [z.rstrip() for z in result_lines if z.strip()]
+    a_set = matchers.get(fn, set())
+    result = ''.join(result_lines)
+    a_set.add(result)
+    matchers [fn] = a_set
+
+</t>
+<t tx="ekr.20241117125039.2">trace = False
+
+def show_line(i: int, line: str) -&gt; None:
+    if trace and filter_line(line):
+        print(f"{i:4}: {line.rstrip()}")</t>
+<t tx="ekr.20241117131431.1">def delete_strings(s: str) -&gt; str:
+    """
+    Replace all string kwargs by ""
+    """
+    i, result = 0, s
+    has_r = '=r"' in s
+    trace = False and has_r
+    if trace:
+        g.trace('===== Entry', s)
+    while True:
+        progress = i
+        if trace:
+            g.trace('Loop:', i, len(result), result)
+            g.trace('Loop: TAIL:', result[i:])   ###
+        for target in ('="', '=r"'):
+            i2 = result.find(target, i)
+            if i2 &gt; -1:
+                i = i2
+                j = result.find('"', i2 + len(target))
+                break
+        else:
+            if trace:
+                g.trace('Fail i', i, target, 'result:', result)
+                print('')
+            return result
+        if j == -1:
+            if has_r:
+                g.trace('Fail j', i, target, 'result', result)
+                print('')
+            return result
+        if result[j + 1] == '"':
+            j += 1
+        if trace:
+            g.trace(f" FOUND: {i}:{j} target: {target:4} result: {result}")
+            g.trace('DELETE:', result[i + len(target):j])
+        result = result[:i + len(target)] + result[j:]
+        result = result.replace('r""', '""')
+        i += len(target) + 1
+        assert i &gt; progress
+    if trace:
+        g.trace('----- Return', result)
+        print('')
+    return result
+        </t>
+<t tx="ekr.20241117145426.1">def delete_cruft(s: str) -&gt; str:
+    """
+    Return an empty string for lines that don't look like a real match.
+    Otherwise, return cruft from the end.
+    """
+    if not s.startswith('return colorer.match_'):
+        return ''
+    if s.count('colorer.match') != 1:
+        return ''
+    if s.count('(') != 1 or s.count(')') != 1:
+        return ''
+    i = s.find('(')
+    j = s.find(')')
+    return '' if j &lt;= i else s[:j+1]</t>
 <t tx="lkj.20190712002811.1"></t>
 <t tx="maphew.20190209160547.1">gnx: maphew.20130809155103.2863
 </t>

--- a/leo/unittests/misc_tests/test_syntax.py
+++ b/leo/unittests/misc_tests/test_syntax.py
@@ -61,8 +61,9 @@ class TestSyntax(LeoUnitTest):
             from leo.core.leoColorizer import JEditColorizer
             c = self.c
             module_name = module.__name__
-            # if not name.endswith('python'):
-                # return
+            # Skip modes/plain.py. It has only one rule and the rulesDict is a hack.
+            if module_name.endswith('plain'):
+                return
             colorer = JEditColorizer(c, widget=None)
             rules = []
             for ruleDict_name, ruleDict in module.rulesDictDict.items():

--- a/leo/unittests/misc_tests/test_syntax.py
+++ b/leo/unittests/misc_tests/test_syntax.py
@@ -73,7 +73,8 @@ class TestSyntax(LeoUnitTest):
                             rules.append(rule)
             rules = sorted(list(set(rules)), key=lambda z: z.__name__)
             # g.printObj([z.__name__ for z in rules], tag=f"Rules for {module_name}")
-            i, s = 0, 'def spam()'
+            i = 0
+            s = 'def spam()'
             for rule in rules:
                 rule(colorer, s, i)
         #@-others
@@ -83,8 +84,11 @@ class TestSyntax(LeoUnitTest):
         paths = [os.path.basename(z)[:-3] for z in paths]
         paths = [z for z in paths if not z.startswith('__')]
         for path in paths:
-            module = importlib.import_module(f"leo.modes.{path}")
-            test_one_mode_file(module)
+            try:
+                module = importlib.import_module(f"leo.modes.{path}")
+                test_one_mode_file(module)
+            except Exception:
+                raise AssertionError(f"{tag}:Test failed: {module.__name__}")
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
This PR is a milestone. For the first time a unit test checks all the mode files in the `leo/modes` directory.

This test does not run by default: it takes about 1/2 sec.

The unit test ensures that mode files won't raise `TypeError` by execute all the mode's rules.

- [x] Add `*,` annotation for most pattern matchers. See [PEP 3102](https://peps.python.org/pep-3102/).
- [x] Correct an inaccurate headline.
- [x] Create a new unit test: `TestSyntax.slow_test_all_mode_files`.
- [x] Fix minor problems in four mode files found by the unit test.

The unit test reveals bad regexs for `md.py` and `pandoc.py`:
```console
match_regexp_helper Invalid regular expression: \\[\Q*_\`[](){}#+.!-\E]        md_rule16,match_seq_regexp
match_regexp_helper Invalid regular expression: !?\[[\p{Alnum}\p{Blank}]*      md_rule27,match_span_regexp
match_regexp_helper Invalid regular expression: \\[\Q*_\`[](){}#+.!-\E]        md_rule30,match_seq_regexp
match_regexp_helper Invalid regular expression: \\[\Q*_\`[](){}#+.!-\E]        md_rule44,match_seq_regexp
match_regexp_helper Invalid regular expression: !?\[[\p{Alnum}\p{Blank}]*      md_rule53,match_span_regexp

match_regexp_helper Invalid regular expression: \\[\Q*_\`[](){}#+.!-\E]        pandoc_rule16,match_seq_regexp
match_regexp_helper Invalid regular expression: !?\[[\p{Alnum}\p{Blank}]*      pandoc_rule27,match_span_regexp
match_regexp_helper Invalid regular expression: \\[\Q*_\`[](){}#+.!-\E]        pandoc_rule30,match_seq_regexp
match_regexp_helper Invalid regular expression: \\[\Q*_\`[](){}#+.!-\E]        pandoc_rule44,match_seq_regexp
match_regexp_helper Invalid regular expression: !?\[[\p{Alnum}\p{Blank}]*      pandoc_rule53,match_span_regexp
```
A separate PR might fix these.