### PR TITLE
PR: Fix regexes in two mode files

### DIFF
--- a/leo/modes/md.py
+++ b/leo/modes/md.py
@@ -352,8 +352,10 @@ def md_rule14(colorer, s, i):
 def md_rule15(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
 
-def md_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
+# Invalid regex.
+
+    def md_rule16(colorer, s, i):
+        return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="``` ruby", end="```",
@@ -403,11 +405,13 @@ def md_rule26(colorer, s, i):
           at_whitespace_end=True,
           delegate="md::link_label_definition")
 
-def md_rule27(colorer, s, i):
-    # leadin: [
-    return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-          delegate="md::link_inline_url_title",
-          no_line_break=True)
+# Invalid regex.
+
+    def md_rule27(colorer, s, i):
+        # leadin: [
+        return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
+              delegate="md::link_inline_url_title",
+              no_line_break=True)
 
 def md_rule28(colorer, s, i):
     # Leadins: [*_]
@@ -422,13 +426,17 @@ def md_rule29(colorer, s, i):
 # Rules dict for md_markdown ruleset.
 rulesDict4 = {
 # Existing leadins...
-    "!": [md_rule27],
+    # "!": [md_rule27],
     "#": [md_rule22],
     "*": [md_rule13, md_rule23, md_rule24, md_rule28, md_rule29],  # new: 23,24,28,29.
-    "\\": [md_rule15, md_rule16, md_rule26],
+    "\\": [
+        md_rule15,
+        # md_rule16,
+        md_rule26,
+    ],
     "_": [md_rule14, md_rule23, md_rule24, md_rule28, md_rule29],  # new: 23,24,28,29.
     "`": [md_rule17, md_rule18, md_rule19],  # new: 19
-    "[": [md_rule27],  # new: 27 old: 12,21,23,24,25.
+    # "[": [md_rule27],  # new: 27 old: 12,21,23,24,25.
 # Unused leadins...
     # "(": [md_rule28,md_rule29],
 # New leadins...
@@ -453,8 +461,10 @@ rulesDict4 = {
 #@+node:ekr.20241105215258.1: ** << md.py: md_link_label_definition: rules & dict >>
 # Rules for md_link_label_definition ruleset.
 
-def md_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
+if 0:  # Invalid regex.
+
+    def md_rule30(colorer, s, i):
+        return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule31(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="\"")
@@ -470,7 +480,7 @@ rulesDict5 = {
     "\"": [md_rule31],
     "(": [md_rule32],
     ")": [md_rule33],
-    "\\": [md_rule30],
+    # "\\": [md_rule30],
 }
 #@-<< md.py: md_link_label_definition: rules & dict >>
 #@+<< md.py: md_link_inline_url_title: rules & dict >>
@@ -544,9 +554,11 @@ def md_rule43(colorer, s, i):
     # leadin: backslash.
     return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
 
-def md_rule44(colorer, s, i):
-    # leadin: backslash.
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
+if 0:  # Invalid regex.
+
+    def md_rule44(colorer, s, i):
+        # leadin: backslash.
+        return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def md_rule45(colorer, s, i):
     # leadin: `
@@ -581,11 +593,13 @@ def md_rule52(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
           delegate="md::link_label_definition")
 
-def md_rule53(colorer, s, i):
-    # leadin: [
-    return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-          delegate="md::link_inline_url_title",
-          no_line_break=True)
+if 0:  # invalid regex.
+
+    def md_rule53(colorer, s, i):
+        # leadin: [
+        return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
+              delegate="md::link_inline_url_title",
+              no_line_break=True)
 
 def md_rule54(colorer, s, i):
     # leadins: [*_]
@@ -606,13 +620,19 @@ rulesDict9 = {
     "(": [md_rule54, md_rule55],  # 45,46
     "*": [md_rule41, md_rule49, md_rule50, md_rule54, md_rule55],  # new: 49,50,54,55
     "<": [md_rule40],
-    "\\": [md_rule43, md_rule44],  # 52,53
+    "\\": [
+        md_rule43,
+        # md_rule44,
+    ],  # 52,53
     "_": [md_rule42, md_rule49, md_rule54, md_rule55],  # new: 49,54,55
 # new leadins:
     "+": [md_rule50],
     "-": [md_rule47, md_rule49, md_rule50],
     "=": [md_rule47],
-    "[": [md_rule52, md_rule53],
+    "[": [
+            md_rule52,
+            # md_rule53,
+        ],
     "`": [md_rule45],
     "0": [md_rule50],
     "1": [md_rule50],

--- a/leo/modes/pandoc.py
+++ b/leo/modes/pandoc.py
@@ -348,12 +348,14 @@ def pandoc_rule26(colorer, s, i):
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
           at_whitespace_end=True,
           delegate="pandoc::link_label_definition")
+          
+if 0:  # Invalid regex.
 
-def pandoc_rule27(colorer, s, i):
-    # leadin: [
-    return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-          delegate="pandoc::link_inline_url_title",
-          no_line_break=True)
+    def pandoc_rule27(colorer, s, i):
+        # leadin: [
+        return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
+              delegate="pandoc::link_inline_url_title",
+              no_line_break=True)
 
 def pandoc_rule28(colorer, s, i):
     # Leadins: [*_]
@@ -378,7 +380,7 @@ rulesDict4 = {
         ],
     "_": [pandoc_rule14, pandoc_rule23, pandoc_rule24, pandoc_rule28, pandoc_rule29],  # new: 23,24,28,29.
     "`": [pandoc_rule17, pandoc_rule18, pandoc_rule19,],  # new: 19
-    "[": [pandoc_rule27,],  # new: 27 old: 12,21,23,24,25.
+    # "[": [pandoc_rule27,],  # new: 27 old: 12,21,23,24,25.
 # Unused leadins...
     # "(": [pandoc_rule28,pandoc_rule29,],
 # New leadins...

--- a/leo/modes/pandoc.py
+++ b/leo/modes/pandoc.py
@@ -295,9 +295,11 @@ def pandoc_rule14(colorer, s, i):
 
 def pandoc_rule15(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
+    
+if 0:  # Invalid regular expression.
 
-def pandoc_rule16(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
+    def pandoc_rule16(colorer, s, i):
+        return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule17(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="``` ruby", end="```",
@@ -366,10 +368,14 @@ def pandoc_rule29(colorer, s, i):
 # Rules dict for pandoc_markdown ruleset.
 rulesDict4 = {
 # Existing leadins...
-    "!": [pandoc_rule27,],
+    # "!": [pandoc_rule27,],
     "#": [pandoc_rule22,],
     "*": [pandoc_rule13, pandoc_rule23, pandoc_rule24, pandoc_rule28, pandoc_rule29],  # new: 23,24,28,29.
-    "\\": [pandoc_rule15, pandoc_rule16, pandoc_rule26,],
+    "\\": [
+            pandoc_rule15,
+            # pandoc_rule16,
+            pandoc_rule26,
+        ],
     "_": [pandoc_rule14, pandoc_rule23, pandoc_rule24, pandoc_rule28, pandoc_rule29],  # new: 23,24,28,29.
     "`": [pandoc_rule17, pandoc_rule18, pandoc_rule19,],  # new: 19
     "[": [pandoc_rule27,],  # new: 27 old: 12,21,23,24,25.
@@ -395,8 +401,10 @@ rulesDict4 = {
 
 # Rules for pandoc_link_label_definition ruleset.
 
-def pandoc_rule30(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
+if 0:  # Invalid regular expression.
+
+    def pandoc_rule30(colorer, s, i):
+        return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule31(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="\"")
@@ -412,7 +420,7 @@ rulesDict5 = {
     "\"": [pandoc_rule31,],
     "(": [pandoc_rule32,],
     ")": [pandoc_rule33,],
-    "\\": [pandoc_rule30,],
+    # "\\": [pandoc_rule30],
 }
 
 # Rules for pandoc_link_inline_url_title ruleset.
@@ -477,10 +485,12 @@ def pandoc_rule42(colorer, s, i):
 def pandoc_rule43(colorer, s, i):
     # leadin: backslash.
     return colorer.match_plain_seq(s, i, kind="null", seq="\\][")
+    
+if 0:  # Invalid regular expression.
 
-def pandoc_rule44(colorer, s, i):
-    # leadin: backslash.
-    return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
+    def pandoc_rule44(colorer, s, i):
+        # leadin: backslash.
+        return colorer.match_seq_regexp(s, i, kind="null", regexp="\\\\[\\Q*_\\`[](){}#+.!-\\E]")
 
 def pandoc_rule45(colorer, s, i):
     # leadin: `
@@ -514,12 +524,14 @@ def pandoc_rule52(colorer, s, i):
     # leadin: [
     return colorer.match_eol_span_regexp(s, i, kind="label", regexp="\\[(.*?)\\]\\:",
           delegate="pandoc::link_label_definition")
+          
+if 0:  # Invalid regular expression.
 
-def pandoc_rule53(colorer, s, i):
-    # leadin: [
-    return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
-          delegate="pandoc::link_inline_url_title",
-          no_line_break=True)
+    def pandoc_rule53(colorer, s, i):
+        # leadin: [
+        return colorer.match_span_regexp(s, i, kind="keyword4", begin="!?\\[[\\p{Alnum}\\p{Blank}]*", end="\\]",
+              delegate="pandoc::link_inline_url_title",
+              no_line_break=True)
 
 def pandoc_rule54(colorer, s, i):
     # leadins: [*_]
@@ -540,13 +552,19 @@ rulesDict9 = {
     "(": [pandoc_rule54, pandoc_rule55,],  # 45,46
     "*": [pandoc_rule41, pandoc_rule49, pandoc_rule50, pandoc_rule54, pandoc_rule55,],  # new: 49,50,54,55
     "<": [pandoc_rule40,],
-    "\\": [pandoc_rule43, pandoc_rule44,],  # 52,53
+    "\\": [
+            pandoc_rule43,
+            # pandoc_rule44,
+        ],  # 52,53
     "_": [pandoc_rule42, pandoc_rule49, pandoc_rule54, pandoc_rule55,],  # new: 49,54,55
 # new leadins:
     "+": [pandoc_rule50,],
     "-": [pandoc_rule47, pandoc_rule49, pandoc_rule50,],
     "=": [pandoc_rule47,],
-    "[": [pandoc_rule52, pandoc_rule53],
+    "[": [
+            pandoc_rule52,
+            # pandoc_rule53,
+        ],
     "`": [pandoc_rule45,],
     "0": [pandoc_rule50,],
     "1": [pandoc_rule50,],

--- a/leo/unittests/misc_tests/test_syntax.py
+++ b/leo/unittests/misc_tests/test_syntax.py
@@ -49,8 +49,8 @@ class TestSyntax(LeoUnitTest):
                     fn = g.shortFileName(z)
                     s, e = g.readFileIntoString(z)
                     self.assertTrue(self.check_syntax(fn, s), msg=fn)
-    #@+node:ekr.20241118022857.1: *4* TestSyntax.slow_test_all_mode_files
-    def slow_test_all_mode_files(self):
+    #@+node:ekr.20241118022857.1: *4* TestSyntax.test_all_mode_files
+    def test_all_mode_files(self):
 
         tag = 'slow_test_all_mode_files'
 


### PR DESCRIPTION
Continue PR #4190 by disabling (*not* fixing) rules containing invalid regexes.

Someone, it doesn't matter who, edited the two mode files by hand.

It appears that nobody has noticed that their regexes were invalid.
I have no interest in fixing the regexes.

- [x] Disable markdown (`md.py`) rules containing invalid regexes.
- [x] Disable pandoc rules containing invalid regexes.
- [x] Rename `TestSyntax.slow_test_all_mode_files` so that it runs by default.

**Disabled rules**

For reference, here are the disabled rules:
```
md_rule16,match_seq_regexp
md_rule27,match_span_regexp
md_rule30,match_seq_regexp
md_rule44,match_seq_regexp
md_rule53,match_span_regexp

pandoc_rule16,match_seq_regexp
pandoc_rule27,match_span_regexp
pandoc_rule30,match_seq_regexp
pandoc_rule44,match_seq_regexp
pandoc_rule53,match_span_regexp
```