### PR TITLE
PR for #726: @language vue, including delegated modes

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1508,7 +1508,7 @@ class JEditColorizer(BaseColorizer):
                         i += n
                         continue
                 i += 1
-    #@+node:ekr.20241119191526.1: *4* jedit.begin/end_deletegated_mode
+    #@+node:ekr.20241119191526.1: *4* jedit.begin/end_delegated_mode
     def begin_delegated_mode(self) -> None:
         if not g.unitTesting:
             g.trace(g.callers(2))

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1508,6 +1508,14 @@ class JEditColorizer(BaseColorizer):
                         i += n
                         continue
                 i += 1
+    #@+node:ekr.20241119191526.1: *4* jedit.begin/end_deletegated_mode
+    def begin_delegated_mode(self) -> None:
+        if not g.unitTesting:
+            g.trace(g.callers(2))
+
+    def end_delegated_mode(self) -> None:
+        if not g.unitTesting:
+            g.trace(g.callers(2))
     #@+node:ekr.20110605121601.18591: *4* jedit.dump
     def dump(self, s: str) -> str:
         if s.find('\n') == -1:

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -1,8 +1,6 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20241119064750.1: * @file ../modes/css.py
-#@@language python
-# Leo colorizer control file for css mode.
-# This file is in the public domain.
+"""Leo colorizer control file for css mode"""
 
 from typing import Any
 from leo.core import leoGlobals as g
@@ -692,4 +690,6 @@ keywordsDictDict = {
     "css_main": css_main_keywords_dict,
 }
 #@-<< css.py dictionaries >>
+
+#@@language python
 #@-leo

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -1,5 +1,18 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20241119064750.1: * @file ../modes/css.py
+#@@language python
 # Leo colorizer control file for css mode.
 # This file is in the public domain.
+
+from typing import Any
+from leo.core import leoGlobals as g
+assert g
+
+# This file calls colorizer.end_delegated_mode().
+supports_nested_modes = True
+
+#@+<< css.py: properties >>
+#@+node:ekr.20241119185615.1: ** << css.py: properties >>
 
 # Properties for css mode.
 properties = {
@@ -10,6 +23,9 @@ properties = {
     "lineUpClosingBracket": "true",
     "noWordSep": "_",
 }
+#@-<< css.py: properties >>
+#@+<< css.py: attributes dicts >>
+#@+node:ekr.20241119185711.1: ** << css.py: attributes dicts >>
 
 # Attributes dict for css_main ruleset.
 css_main_attributes_dict = {
@@ -36,6 +52,9 @@ attributesDictDict = {
     "css_literal": css_literal_attributes_dict,
     "css_main": css_main_attributes_dict,
 }
+#@-<< css.py: attributes dicts >>
+#@+<< css.py: keywords dict for css_main ruleset >>
+#@+node:ekr.20241119185813.1: ** << css.py: keywords dict for css_main ruleset >>
 
 # Keywords dict for css_main ruleset.
 css_main_keywords_dict = {
@@ -510,16 +529,9 @@ css_main_keywords_dict = {
     "yellowgreen": "keyword3",
     "z-index": "keyword2",
 }
-
-# Keywords dict for css_literal ruleset.
-css_literal_keywords_dict = {}
-
-# Dictionary of keywords dictionaries for css mode.
-keywordsDictDict = {
-    "css_literal": css_literal_keywords_dict,
-    "css_main": css_main_keywords_dict,
-}
-
+#@-<< css.py: keywords dict for css_main ruleset >>
+#@+<< css.py: rules for css_main ruleset >>
+#@+node:ekr.20241119185920.1: ** << css.py: rules for css_main ruleset >>
 # Rules for css_main ruleset.
 
 def css_rule0(colorer, s, i):
@@ -564,13 +576,22 @@ def css_rule8C(colorer, s, i):
 def css_rule8D(colorer, s, i):
     return colorer.match_mark_following(s, i, kind="literal2", pattern="~")
 
-
 def css_rule9(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 
 def css_rule10(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@-<< css.py: rules for css_main ruleset >>
 
+# New rule for css_main ruleset.
+def css_end_css(colorer: Any, s: str, i: int) -> int:
+    if not g.unitTesting:
+        g.trace(i, s)
+    colorer.end_delegated_mode()
+    return 0
+
+#@+<< css.py: rules dict for css_main ruleset >>
+#@+node:ekr.20241119190054.1: ** << css.py: rules dict for css_main ruleset >>
 # Rules dict for css_main ruleset.
 rulesDict1 = {
     "!": [css_rule7,],
@@ -579,7 +600,7 @@ rulesDict1 = {
     ",": [css_rule5,],
     "-": [css_rule10,],
     ".": [css_rule8A,],  # Fix #585. Was css_rule6
-    ">": [css_rule8B,],  # Fix #585.
+    ">": [css_rule8B, css_end_css],  # Fix #585.
     "+": [css_rule8C,],  # Fix #585.
     "~": [css_rule8D,],  # Fix #585.
     "/": [css_rule9,],
@@ -651,11 +672,18 @@ rulesDict1 = {
     "{": [css_rule3,],
     "}": [css_rule4,],
 }
-
+#@-<< css.py: rules dict for css_main ruleset >>
+#@+<< css.py: css_literal ruleset (empty) >>
+#@+node:ekr.20241119190259.1: ** << css.py: css_literal ruleset (empty) >>
 # Rules for css_literal ruleset.
 
 # Rules dict for css_literal ruleset.
 rulesDict2 = {}
+
+# Keywords dict for css_literal ruleset.
+css_literal_keywords_dict = {}
+#@-<< css.py: css_literal ruleset (empty) >>
+
 
 # x.rulesDictDict for css mode.
 rulesDictDict = {
@@ -665,3 +693,10 @@ rulesDictDict = {
 
 # Import dict for css mode.
 importDict = {}
+
+# Dictionary of keywords dictionaries for css mode.
+keywordsDictDict = {
+    "css_literal": css_literal_keywords_dict,
+    "css_main": css_main_keywords_dict,
+}
+#@-leo

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -9,7 +9,7 @@ from leo.core import leoGlobals as g
 assert g
 
 # This file calls colorizer.end_delegated_mode().
-supports_nested_modes = True
+supports_delegated_modes = True
 
 #@+<< css.py: properties >>
 #@+node:ekr.20241119185615.1: ** << css.py: properties >>

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -1,10 +1,15 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20241119064750.1: * @file ../modes/css.py
-"""Leo colorizer control file for css mode"""
-
+"""
+leo/modes/css.py: Leo's mode file for @language css.
+"""
+#@+<< css.py: imports >>
+#@+node:ekr.20241120011923.1: ** << css.py: imports >>
+from __future__ import annotations
 from typing import Any
 from leo.core import leoGlobals as g
 assert g
+#@-<< css.py: imports >>
 
 # This file calls colorizer.end_delegated_mode().
 supports_delegated_modes = True
@@ -692,4 +697,5 @@ keywordsDictDict = {
 #@-<< css.py dictionaries >>
 
 #@@language python
+#@@tabwidth -4
 #@-leo

--- a/leo/modes/css.py
+++ b/leo/modes/css.py
@@ -11,22 +11,72 @@ assert g
 # This file calls colorizer.end_delegated_mode().
 supports_delegated_modes = True
 
-#@+<< css.py: properties >>
-#@+node:ekr.20241119185615.1: ** << css.py: properties >>
+#@+<< css.py rules >>
+#@+node:ekr.20241120010414.1: ** << css.py rules >>
+#@+others
+#@+node:ekr.20241119185920.1: *3* css.py: rules for css_main ruleset
+# Rules for css_main ruleset.
 
-# Properties for css mode.
-properties = {
-    "commentEnd": "*/",
-    "commentStart": "/*",
-    "indentCloseBrackets": "}",
-    "indentOpenBrackets": "{",
-    "lineUpClosingBracket": "true",
-    "noWordSep": "_",
-}
-#@-<< css.py: properties >>
-#@+<< css.py: attributes dicts >>
-#@+node:ekr.20241119185711.1: ** << css.py: attributes dicts >>
+def css_rule0(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
 
+def css_rule1(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="null", seq=";")
+
+def css_rule2(colorer, s, i):
+    return colorer.match_span(s, i, kind="null", begin="(", end=")",
+          delegate="css::literal")
+
+def css_rule3(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
+
+def css_rule4(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
+
+def css_rule5(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="null", seq=",")
+
+def css_rule6(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="null", seq=".")
+
+def css_rule7(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
+
+def css_rule8(colorer, s, i):
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="#")
+
+# For selectors...
+
+def css_rule8A(colorer, s, i):
+    return colorer.match_mark_following(s, i, kind="literal2", pattern=".")
+
+def css_rule8B(colorer, s, i):
+    return colorer.match_mark_following(s, i, kind="literal2", pattern=">")
+
+def css_rule8C(colorer, s, i):
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="+")
+
+def css_rule8D(colorer, s, i):
+    return colorer.match_mark_following(s, i, kind="literal2", pattern="~")
+
+def css_rule9(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
+
+def css_rule10(colorer, s, i):
+    return colorer.match_keywords(s, i)
+#@+node:ekr.20241120011035.1: *3* ccc.py: css_end_css
+# New rule for css_main ruleset.
+def css_end_css(colorer: Any, s: str, i: int) -> int:
+    if not g.unitTesting:
+        g.trace(i, s)
+    colorer.end_delegated_mode()
+    return 0
+#@-others
+#@-<< css.py rules >>
+#@+<< css.py dictionaries >>
+#@+node:ekr.20241120010446.1: ** << css.py dictionaries >>
+#@+others
+#@+node:ekr.20241119185711.1: *3* css.py: attributes dicts
 # Attributes dict for css_main ruleset.
 css_main_attributes_dict = {
     "default": "null",
@@ -52,10 +102,17 @@ attributesDictDict = {
     "css_literal": css_literal_attributes_dict,
     "css_main": css_main_attributes_dict,
 }
-#@-<< css.py: attributes dicts >>
-#@+<< css.py: keywords dict for css_main ruleset >>
-#@+node:ekr.20241119185813.1: ** << css.py: keywords dict for css_main ruleset >>
-
+#@+node:ekr.20241119185615.1: *3* css.py: properties dict
+# Properties for css mode.
+properties = {
+    "commentEnd": "*/",
+    "commentStart": "/*",
+    "indentCloseBrackets": "}",
+    "indentOpenBrackets": "{",
+    "lineUpClosingBracket": "true",
+    "noWordSep": "_",
+}
+#@+node:ekr.20241119185813.1: *3* css.py: keywords dict for css_main ruleset
 # Keywords dict for css_main ruleset.
 css_main_keywords_dict = {
     ":after": "keyword3",
@@ -529,69 +586,7 @@ css_main_keywords_dict = {
     "yellowgreen": "keyword3",
     "z-index": "keyword2",
 }
-#@-<< css.py: keywords dict for css_main ruleset >>
-#@+<< css.py: rules for css_main ruleset >>
-#@+node:ekr.20241119185920.1: ** << css.py: rules for css_main ruleset >>
-# Rules for css_main ruleset.
-
-def css_rule0(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
-
-def css_rule1(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="null", seq=";")
-
-def css_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="null", begin="(", end=")",
-          delegate="css::literal")
-
-def css_rule3(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
-
-def css_rule4(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
-
-def css_rule5(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="null", seq=",")
-
-def css_rule6(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="null", seq=".")
-
-def css_rule7(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
-
-def css_rule8(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="#")
-
-# For selectors...
-
-def css_rule8A(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern=".")
-
-def css_rule8B(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern=">")
-
-def css_rule8C(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="+")
-
-def css_rule8D(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="literal2", pattern="~")
-
-def css_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
-
-def css_rule10(colorer, s, i):
-    return colorer.match_keywords(s, i)
-#@-<< css.py: rules for css_main ruleset >>
-
-# New rule for css_main ruleset.
-def css_end_css(colorer: Any, s: str, i: int) -> int:
-    if not g.unitTesting:
-        g.trace(i, s)
-    colorer.end_delegated_mode()
-    return 0
-
-#@+<< css.py: rules dict for css_main ruleset >>
-#@+node:ekr.20241119190054.1: ** << css.py: rules dict for css_main ruleset >>
+#@+node:ekr.20241119190054.1: *3* css.py: rules dict for css_main ruleset
 # Rules dict for css_main ruleset.
 rulesDict1 = {
     "!": [css_rule7,],
@@ -672,9 +667,7 @@ rulesDict1 = {
     "{": [css_rule3,],
     "}": [css_rule4,],
 }
-#@-<< css.py: rules dict for css_main ruleset >>
-#@+<< css.py: css_literal ruleset (empty) >>
-#@+node:ekr.20241119190259.1: ** << css.py: css_literal ruleset (empty) >>
+#@+node:ekr.20241119190259.1: *3* css.py: css_literal ruleset (empty)
 # Rules for css_literal ruleset.
 
 # Rules dict for css_literal ruleset.
@@ -682,8 +675,10 @@ rulesDict2 = {}
 
 # Keywords dict for css_literal ruleset.
 css_literal_keywords_dict = {}
-#@-<< css.py: css_literal ruleset (empty) >>
+#@-others
 
+# Import dict for css mode.
+importDict = {}
 
 # x.rulesDictDict for css mode.
 rulesDictDict = {
@@ -691,12 +686,10 @@ rulesDictDict = {
     "css_main": rulesDict1,
 }
 
-# Import dict for css mode.
-importDict = {}
-
 # Dictionary of keywords dictionaries for css mode.
 keywordsDictDict = {
     "css_literal": css_literal_keywords_dict,
     "css_main": css_main_keywords_dict,
 }
+#@-<< css.py dictionaries >>
 #@-leo

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -5,6 +5,9 @@
 
 from typing import Any
 
+# This file calls colorizer.end_delegated_mode().
+supports_nested_modes = True
+
 # Properties for html mode.
 properties = {
     "commentEnd": "-->",

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -6,7 +6,7 @@
 from typing import Any
 
 # This file calls colorizer.end_delegated_mode().
-supports_nested_modes = True
+supports_delegated_modes = True
 
 # Properties for html mode.
 properties = {

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -1,21 +1,112 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20230419050031.1: * @file ../modes/html.py
-# Leo colorizer control file for html mode.
-# This file is in the public domain.
-
+"""
+leo/modes/html.py: Leo's mode file for @language html.
+"""
+#@+<< html.py: imports >>
+#@+node:ekr.20241120013234.1: ** << html.py: imports >>
+from __future__ import annotations
 from typing import Any
+from leo.core import leoGlobals as g
+assert g
+#@-<< html.py: imports >>
 
 # This file calls colorizer.end_delegated_mode().
 supports_delegated_modes = True
 
+#@+<< html.py: rules >>
+#@+node:ekr.20241120012017.1: ** << html.py: rules >>
+#@+others
+#@+node:ekr.20230419051223.1: *3* main ruleset
+#@+others
+#@+node:ekr.20230419050050.1: *4* html_rule0
+def html_rule0(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
+
+#@+node:ekr.20230419050050.2: *4* html_rule1 <script..</script>
+def match(s: str, i: int, pattern: str) -> bool:
+    """Same as g.match."""
+    return s and s.find(pattern, i, i + len(pattern)) == i
+
+def html_rule1(colorer: Any, s: str, i: int) -> int:
+
+    # Do quick check first.
+    if not match(s, i, '<script') and not match(s, i, '<SCRIPT'):
+        return 0
+
+    return colorer.match_span(s, i, kind="markup", begin="<script", end="</script>",
+        delegate='javascript')  # "html::javascript"
+#@+node:ekr.20230419050050.4: *4* html_rule2 <style..</style>
+def html_rule2(colorer, s, i):
+    return colorer.match_span(s, i, kind="markup", begin="<style", end="</style>",
+        delegate="html::css")
+
+#@+node:ekr.20230419050050.6: *4* html_rule3 <!..>
+def html_rule3(colorer, s, i):
+    return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">")
+
+#@+node:ekr.20230419050050.7: *4* html_rule4 <..>
+def html_rule4(colorer, s, i):
+    return colorer.match_span(s, i, kind="markup", begin="<", end=">",
+        delegate="html::tags")
+
+#@+node:ekr.20230419050050.8: *4* html_rule5 &..;
+def html_rule5(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
+        no_word_break=True)
+
+#@+node:ekr.20230419050050.9: *4* html_rule_handlebar {{..}}
+# New rule for handlebar markup, colored with the literal3 color.
+def html_rule_handlebar(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal3", begin="{{", end="}}")
+#@-others
+
+#@+node:ekr.20230419050351.1: *3* html_tags ruleset
+# Rules for html_tags ruleset.
+
+def html_rule6(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
+
+def html_rule7(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
+
+def html_rule8(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
+#@+node:ekr.20230419050529.1: *3* html_javascript ruleset (to be removed)
+# Rules for html_javascript ruleset.
+
+def html_rule9(colorer, s, i):
+    return colorer.match_seq(s, i, kind="markup", seq=">",
+        delegate="javascript::main")
+
+def html_rule10(colorer, s, i):
+    return colorer.match_seq(s, i, kind="markup", seq="SRC=",
+        delegate="html::back_to_html")
+#@+node:ekr.20230419050552.1: *3* back_to_html ruleset (to be removed)
+# Rules for html_back_to_html ruleset.
+
+def html_rule11(colorer, s, i):
+    return colorer.match_seq(s, i, kind="markup", seq=">",
+        delegate="html::main")
+
+#@+node:ekr.20230419051037.1: *3* html_css ruleset (to be removed)
+# Rules for html_css ruleset.
+
+def html_rule12(colorer, s, i):
+    return colorer.match_seq(s, i, kind="markup", seq=">",
+        delegate="css::main")
+#@-others
+#@-<< html.py: rules >>
+#@+<< html.py: dictionaries >>
+#@+node:ekr.20241120012038.1: ** << html.py: dictionaries >>
+#@+others
+#@+node:ekr.20241120012226.1: *3* html.py: Properties dict
 # Properties for html mode.
 properties = {
     "commentEnd": "-->",
     "commentStart": "<!--",
 }
-
-#@+<< Attributes dicts >>
-#@+node:ekr.20230419050200.1: ** << Attributes dicts >>
+#@+node:ekr.20230419050200.1: *3* html.py: Attributes dicts
 # Attributes dict for html_main ruleset.
 html_main_attributes_dict = {
     "default": "null",
@@ -74,10 +165,7 @@ attributesDictDict = {
     "html_main": html_main_attributes_dict,
     "html_tags": html_tags_attributes_dict,
 }
-
-#@-<< Attributes dicts >>
-#@+<< Keywords dicts >>
-#@+node:ekr.20230419050229.1: ** << Keywords dicts >>
+#@+node:ekr.20230419050229.1: *3* html.py: Keywords dicts
 # Keywords dict for html_main ruleset.
 html_main_keywords_dict = {}
 
@@ -101,75 +189,13 @@ keywordsDictDict = {
     "html_main": html_main_keywords_dict,
     "html_tags": html_tags_keywords_dict,
 }
-#@-<< Keywords dicts >>
-
-# Rules for html_main ruleset.
-
-#@+others
-#@+node:ekr.20230419051223.1: ** main ruleset
-#@+others
-#@+node:ekr.20230419050050.1: *3* html_rule0
-def html_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
-
-#@+node:ekr.20230419050050.2: *3* html_rule1 <script..</script>
-def match(s: str, i: int, pattern: str) -> bool:
-    """Same as g.match."""
-    return s and s.find(pattern, i, i + len(pattern)) == i
-
-def html_rule1(colorer: Any, s: str, i: int) -> int:
-
-    # Do quick check first.
-    if not match(s, i, '<script') and not match(s, i, '<SCRIPT'):
-        return 0
-
-    return colorer.match_span(s, i, kind="markup", begin="<script", end="</script>",
-        delegate='javascript')  # "html::javascript"
-
-#@+node:ekr.20230419050050.4: *3* html_rule2 <style..</style>
-def html_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<style", end="</style>",
-        delegate="html::css")
-
-#@+node:ekr.20230419050050.6: *3* html_rule3 <!..>
-def html_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="<!", end=">")
-
-#@+node:ekr.20230419050050.7: *3* html_rule4 <..>
-def html_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">",
-        delegate="html::tags")
-
-#@+node:ekr.20230419050050.8: *3* html_rule5 &..;
-def html_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
-        no_word_break=True)
-
-#@+node:ekr.20230419050050.9: *3* html_rule_handlebar {{..}}
-# New rule for handlebar markup, colored with the literal3 color.
-def html_rule_handlebar(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="{{", end="}}")
-
-#@-others
-
+#@+node:ekr.20241120012542.1: *3* html.py: Rules dicts
 # Rules dict for html_main ruleset.
 rulesDict1 = {
     "&": [html_rule5],
     "<": [html_rule0, html_rule1, html_rule2, html_rule3, html_rule4],
     "{": [html_rule_handlebar],
 }
-
-#@+node:ekr.20230419050351.1: ** html_tags ruleset
-# Rules for html_tags ruleset.
-
-def html_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
-
-def html_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
-
-def html_rule8(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 # Rules dict for html_tags ruleset.
 rulesDict2 = {
@@ -178,48 +204,27 @@ rulesDict2 = {
     "=": [html_rule8],
 }
 
-#@+node:ekr.20230419050529.1: ** html_javascript ruleset
-# Rules for html_javascript ruleset.
-
-def html_rule9(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">",
-        delegate="javascript::main")
-
-def html_rule10(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="SRC=",
-        delegate="html::back_to_html")
-
 # Rules dict for html_javascript ruleset.
 rulesDict3 = {
     ">": [html_rule9],
     "S": [html_rule10],
 }
 
-#@+node:ekr.20230419050552.1: ** back_to_html ruleset
-# Rules for html_back_to_html ruleset.
-
-def html_rule11(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">",
-        delegate="html::main")
-
 # Rules dict for html_back_to_html ruleset.
 rulesDict4 = {
     ">": [html_rule11],
 }
-
-#@+node:ekr.20230419051037.1: ** html_css ruleset
-# Rules for html_css ruleset.
-
-def html_rule12(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq=">",
-        delegate="css::main")
 
 # Rules dict for html_css ruleset.
 rulesDict5 = {
     ">": [html_rule12],
 }
 
+
 #@-others
+
+# Import dict for html mode.
+importDict = {}
 
 # x.rulesDictDict for html mode.
 rulesDictDict = {
@@ -229,9 +234,8 @@ rulesDictDict = {
     "html_main": rulesDict1,
     "html_tags": rulesDict2,
 }
+#@-<< html.py: dictionaries >>
 
-# Import dict for html mode.
-importDict = {}
 #@@language python
 #@@tabwidth -4
 #@-leo

--- a/leo/modes/javascript.py
+++ b/leo/modes/javascript.py
@@ -1,10 +1,164 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20230419052236.1: * @file ../modes/javascript.py
-# Leo colorizer control file for javascript mode.
-# This file is in the public domain.
+"""
+leo/modes/javascript.py: Leo's mode file for @language javascript.
+"""
+#@+<< javascript.py: imports >>
+#@+node:ekr.20241120014425.1: ** << javascript.py: imports >>
+from __future__ import annotations
+# from typing import Any
+from leo.core import leoGlobals as g
+assert g
+#@-<< javascript.py: imports >>
 
-#@+<< properties dict >>
-#@+node:ekr.20230419052315.1: ** << properties dict >>
+# This file calls colorizer.end_delegated_mode().
+supports_delegated_modes = True
+
+#@+<< javascript.py: rules >>
+#@+node:ekr.20241120014525.1: ** << javascript.py: rules >>
+#@+others
+#@+node:ekr.20230419052628.1: *3* javascript_main ruleset
+# Rules for javascript_main ruleset.
+
+
+#@+node:ekr.20230419052250.1: *4* javascript_rule0
+def javascript_rule0(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
+
+#@+node:ekr.20230419052250.2: *4* javascript_rule1
+def javascript_rule1(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
+        no_line_break=True)
+
+#@+node:ekr.20230419052250.3: *4* javascript_rule2
+def javascript_rule2(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
+        no_line_break=True)
+
+#@+node:ekr.20230419052250.4: *4* javascript_rule3
+def javascript_rule3(colorer, s, i):
+    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
+        exclude_match=True)
+
+#@+node:ekr.20230419052250.5: *4* javascript_rule4
+def javascript_rule4(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
+
+#@+node:ekr.20230419052250.6: *4* javascript_rule5
+def javascript_rule5(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="comment1", seq="<!--")
+
+#@+node:ekr.20230419052250.7: *4* javascript_rule6
+def javascript_rule6(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
+
+#@+node:ekr.20230419052250.8: *4* javascript_rule7
+def javascript_rule7(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
+
+#@+node:ekr.20230419052250.9: *4* javascript_rule8
+def javascript_rule8(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
+
+#@+node:ekr.20230419052250.10: *4* javascript_rule9
+def javascript_rule9(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
+
+#@+node:ekr.20230419052250.11: *4* javascript_rule10
+def javascript_rule10(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
+
+#@+node:ekr.20230419052250.12: *4* javascript_rule11
+def javascript_rule11(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
+
+#@+node:ekr.20230419052250.13: *4* javascript_rule12
+def javascript_rule12(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
+
+#@+node:ekr.20230419052250.14: *4* javascript_rule13
+def javascript_rule13(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
+
+#@+node:ekr.20230419052250.15: *4* javascript_rule14
+def javascript_rule14(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
+
+#@+node:ekr.20230419052250.16: *4* javascript_rule15
+def javascript_rule15(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
+
+#@+node:ekr.20230419052250.17: *4* javascript_rule16
+def javascript_rule16(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
+
+#@+node:ekr.20230419052250.18: *4* javascript_rule17
+def javascript_rule17(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
+
+#@+node:ekr.20230419052250.19: *4* javascript_rule18
+def javascript_rule18(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
+
+#@+node:ekr.20230419052250.20: *4* javascript_rule19
+def javascript_rule19(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
+
+#@+node:ekr.20230419052250.21: *4* javascript_rule20
+def javascript_rule20(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
+
+#@+node:ekr.20230419052250.22: *4* javascript_rule21
+def javascript_rule21(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
+
+#@+node:ekr.20230419052250.23: *4* javascript_rule22
+def javascript_rule22(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
+
+#@+node:ekr.20230419052250.24: *4* javascript_rule23
+def javascript_rule23(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
+
+#@+node:ekr.20230419052250.25: *4* javascript_rule24
+def javascript_rule24(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
+
+#@+node:ekr.20230419052250.26: *4* javascript_rule25
+def javascript_rule25(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
+
+#@+node:ekr.20230419052250.27: *4* javascript_rule26
+def javascript_rule26(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
+
+#@+node:ekr.20230419052250.28: *4* javascript_rule27
+def javascript_rule27(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
+
+#@+node:ekr.20230419052250.29: *4* javascript_rule28
+def javascript_rule28(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
+
+#@+node:ekr.20230419052250.30: *4* javascript_rule29
+def javascript_rule29(colorer, s, i):
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
+        at_whitespace_end=True, exclude_match=True)
+
+#@+node:ekr.20230419052250.31: *4* javascript_rule30
+def javascript_rule30(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
+
+#@+node:ekr.20230419052250.32: *4* javascript_rule31
+def javascript_rule31(colorer, s, i):
+    return colorer.match_keywords(s, i)
+
+#@-others
+#@-<< javascript.py: rules >>
+#@+<< javascript.py: dictionaries >>
+#@+node:ekr.20241120014546.1: ** << javascript.py: dictionaries >>
+#@+others
+#@+node:ekr.20230419052315.1: *3* javascript.py: properties dict
 # Properties for javascript mode.
 properties = {
     "commentEnd": "*/",
@@ -18,9 +172,7 @@ properties = {
     "wordBreakChars": ",+-=<>/?^&*",
 }
 
-#@-<< properties dict >>
-#@+<< attributes dicts >>
-#@+node:ekr.20230419052414.1: ** << attributes dicts >>
+#@+node:ekr.20230419052414.1: *3* javascript.py: attributes dicts
 # Attributes dict for javascript_main ruleset.
 javascript_main_attributes_dict = {
     "default": "null",
@@ -36,9 +188,7 @@ attributesDictDict = {
     "javascript_main": javascript_main_attributes_dict,
 }
 
-#@-<< attributes dicts >>
-#@+<< keywords dicts >>
-#@+node:ekr.20230419053014.1: ** << keywords dicts >>
+#@+node:ekr.20230419053014.1: *3* javascript.py: keywords dicts
 # Keywords dict for javascript_main ruleset.
 javascript_main_keywords_dict = {
     "Array": "keyword3",
@@ -197,153 +347,7 @@ javascript_main_keywords_dict = {
     "with": "keyword1",
 }
 
-# Dictionary of keywords dictionaries for javascript mode.
-keywordsDictDict = {
-    "javascript_main": javascript_main_keywords_dict,
-}
-
-#@-<< keywords dicts >>
-#@+others
-#@+node:ekr.20230419052628.1: ** javascript_main ruleset
-# Rules for javascript_main ruleset.
-
-#@+others
-#@+node:ekr.20230419052250.1: *3* javascript_rule0
-def javascript_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
-
-#@+node:ekr.20230419052250.2: *3* javascript_rule1
-def javascript_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
-        no_line_break=True)
-
-#@+node:ekr.20230419052250.3: *3* javascript_rule2
-def javascript_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
-        no_line_break=True)
-
-#@+node:ekr.20230419052250.4: *3* javascript_rule3
-def javascript_rule3(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-        exclude_match=True)
-
-#@+node:ekr.20230419052250.5: *3* javascript_rule4
-def javascript_rule4(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
-
-#@+node:ekr.20230419052250.6: *3* javascript_rule5
-def javascript_rule5(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="comment1", seq="<!--")
-
-#@+node:ekr.20230419052250.7: *3* javascript_rule6
-def javascript_rule6(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
-
-#@+node:ekr.20230419052250.8: *3* javascript_rule7
-def javascript_rule7(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
-
-#@+node:ekr.20230419052250.9: *3* javascript_rule8
-def javascript_rule8(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
-
-#@+node:ekr.20230419052250.10: *3* javascript_rule9
-def javascript_rule9(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
-
-#@+node:ekr.20230419052250.11: *3* javascript_rule10
-def javascript_rule10(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
-
-#@+node:ekr.20230419052250.12: *3* javascript_rule11
-def javascript_rule11(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
-
-#@+node:ekr.20230419052250.13: *3* javascript_rule12
-def javascript_rule12(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
-
-#@+node:ekr.20230419052250.14: *3* javascript_rule13
-def javascript_rule13(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
-
-#@+node:ekr.20230419052250.15: *3* javascript_rule14
-def javascript_rule14(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
-
-#@+node:ekr.20230419052250.16: *3* javascript_rule15
-def javascript_rule15(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
-
-#@+node:ekr.20230419052250.17: *3* javascript_rule16
-def javascript_rule16(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
-
-#@+node:ekr.20230419052250.18: *3* javascript_rule17
-def javascript_rule17(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
-
-#@+node:ekr.20230419052250.19: *3* javascript_rule18
-def javascript_rule18(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
-
-#@+node:ekr.20230419052250.20: *3* javascript_rule19
-def javascript_rule19(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
-
-#@+node:ekr.20230419052250.21: *3* javascript_rule20
-def javascript_rule20(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
-
-#@+node:ekr.20230419052250.22: *3* javascript_rule21
-def javascript_rule21(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=".")
-
-#@+node:ekr.20230419052250.23: *3* javascript_rule22
-def javascript_rule22(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
-
-#@+node:ekr.20230419052250.24: *3* javascript_rule23
-def javascript_rule23(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
-
-#@+node:ekr.20230419052250.25: *3* javascript_rule24
-def javascript_rule24(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=",")
-
-#@+node:ekr.20230419052250.26: *3* javascript_rule25
-def javascript_rule25(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
-
-#@+node:ekr.20230419052250.27: *3* javascript_rule26
-def javascript_rule26(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="]")
-
-#@+node:ekr.20230419052250.28: *3* javascript_rule27
-def javascript_rule27(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="[")
-
-#@+node:ekr.20230419052250.29: *3* javascript_rule28
-def javascript_rule28(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="?")
-
-#@+node:ekr.20230419052250.30: *3* javascript_rule29
-def javascript_rule29(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-        at_whitespace_end=True, exclude_match=True)
-
-#@+node:ekr.20230419052250.31: *3* javascript_rule30
-def javascript_rule30(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=":")
-
-#@+node:ekr.20230419052250.32: *3* javascript_rule31
-def javascript_rule31(colorer, s, i):
-    return colorer.match_keywords(s, i)
-
-#@-others
-
-#@+<< Rules dict for javascript_main ruleset >>
-#@+node:ekr.20230419052844.1: *3* << Rules dict for javascript_main ruleset >>
+#@+node:ekr.20230419052844.1: *3* javascript.py: Rules dict for javascript_main ruleset
 # Rules dict for javascript_main ruleset.
 rulesDict1 = {
     "!": [javascript_rule7,],
@@ -436,16 +440,22 @@ rulesDict1 = {
     "~": [javascript_rule20,],
 }
 
-#@-<< Rules dict for javascript_main ruleset >>
+#@-others
+
+# Import dict for javascript mode.
+importDict = {}
+
+# Dictionary of keywords dictionaries for javascript mode.
+keywordsDictDict = {
+    "javascript_main": javascript_main_keywords_dict,
+}
 
 # x.rulesDictDict for javascript mode.
 rulesDictDict = {
     "javascript_main": rulesDict1,
 }
+#@-<< javascript.py: dictionaries >>
 
-#@-others
-# Import dict for javascript mode.
-importDict = {}
 #@@language python
 #@@tabwidth -4
 #@-leo

--- a/leo/modes/javascript.py
+++ b/leo/modes/javascript.py
@@ -11,8 +11,8 @@ from leo.core import leoGlobals as g
 assert g
 #@-<< javascript.py: imports >>
 
-# This file calls colorizer.end_delegated_mode().
-supports_delegated_modes = True
+# This file does *not* call colorizer.end_delegated_mode().
+supports_delegated_modes = False
 
 #@+<< javascript.py: rules >>
 #@+node:ekr.20241120014525.1: ** << javascript.py: rules >>

--- a/leo/modes/vue.py
+++ b/leo/modes/vue.py
@@ -1,0 +1,67 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20241119063015.1: * @file ../modes/vue.py
+"""
+leo/modes/vue.py, Leo's colorizer for @language vue.
+"""
+#@+<< vue.py: imports >>
+#@+node:ekr.20241119063015.2: ** << vue.py: imports >>
+from __future__ import annotations
+
+from typing import Any
+
+from leo.core import leoGlobals as g
+assert g
+#@-<< vue.py: imports >>
+
+#@+others  # Define rules.
+#@+node:ekr.20241119063015.4: ** vue_directive
+def vue_directive(colorer: Any, s: str, i: int) -> int:
+    return colorer.match_leo_keywords(s, i)
+#@+node:ekr.20241119063015.3: ** vue_element
+def vue_element(colorer: Any, s: str, i: int) -> int:
+    """
+    Handle `<`, the start of an element.
+    Switch between modes provided that c.p.b contains @language vue.
+    
+    New in Leo 6.8.3.
+    """
+    try:
+        c = colorer.c
+    except Exception:
+        return 0  # Fail, allowing other matches.
+
+    # Prototype.
+    # g.trace(i, s)
+    n = colorer.match_span(s, i, kind="comment1",
+        begin="<", end=">", at_line_start=True)
+
+    # # *Always* colorize the comment line as a *vue* comment.
+    # n = colorer.match_eol_span(s, i, kind="comment1", seq="#")
+    # is_any_vue_comment = (
+        # i == 0
+        # and s.startswith('# %%')
+        # and any(z.startswith('@language vue')
+            # for z in g.splitLines(c.p.b))
+    # )
+    # if is_any_vue_comment:
+        # # Simulate @language md or @language python.
+        # language = 'md' if s.startswith('# %% [markdown]') else 'python'
+        # colorer.init_mode(language)
+        # state_i = colorer.setInitialStateNumber()
+        # colorer.setState(state_i)
+
+    return n  # Succeed. Do not allow other matches.
+#@-others
+
+rulesDict1 = {
+    "<": [vue_element],
+    "@": [vue_directive],
+}
+
+# x.rulesDictDict for vue mode.
+rulesDictDict = {
+    "vue_main": rulesDict1,
+}
+
+#@@language python
+#@-leo

--- a/leo/modes/vue.py
+++ b/leo/modes/vue.py
@@ -1,23 +1,26 @@
 #@+leo-ver=5-thin
 #@+node:ekr.20241119063015.1: * @file ../modes/vue.py
 """
-leo/modes/vue.py, Leo's colorizer for @language vue.
+leo/modes/vue.py: Leo's mode file for @language vue.
 """
 #@+<< vue.py: imports >>
 #@+node:ekr.20241119063015.2: ** << vue.py: imports >>
 from __future__ import annotations
-
 from typing import Any
-
 from leo.core import leoGlobals as g
 assert g
 #@-<< vue.py: imports >>
 
-#@+others  # Define rules.
-#@+node:ekr.20241119063015.4: ** vue_directive
+# This file does *not* call colorizer.end_delegated_mode().
+supports_delegated_modes = False
+
+#@+<< vue.py: rules >>
+#@+node:ekr.20241120011456.1: ** << vue.py: rules >>
+#@+others
+#@+node:ekr.20241119063015.4: *3* vue_directive
 def vue_directive(colorer: Any, s: str, i: int) -> int:
     return colorer.match_leo_keywords(s, i)
-#@+node:ekr.20241119063015.3: ** vue_element
+#@+node:ekr.20241119063015.3: *3* vue_element
 def vue_element(colorer: Any, s: str, i: int) -> int:
     """
     Handle `<`, the start of an element.
@@ -52,6 +55,9 @@ def vue_element(colorer: Any, s: str, i: int) -> int:
 
     return n  # Succeed. Do not allow other matches.
 #@-others
+#@-<< vue.py: rules >>
+#@+<< vue.py: dictionaries >>
+#@+node:ekr.20241120011610.1: ** << vue.py: dictionaries >>
 
 rulesDict1 = {
     "<": [vue_element],
@@ -62,6 +68,8 @@ rulesDict1 = {
 rulesDictDict = {
     "vue_main": rulesDict1,
 }
+#@-<< vue.py: dictionaries >>
 
 #@@language python
+#@@tabwidth -4
 #@-leo


### PR DESCRIPTION
See #726.

- [x] Add `jedit.begin/end_delegated_mode`.
- [x] Convert `css.py` to `@file`.
- [x] Add new `css_end_css` rule.
- [x] Add `vue.py` file.
- [x] Add `supports_delegated_modes` top-level vars to `css.py`, `javascript.py`, `jupytext.py` and `html.py`.
