### PR TITLE
vr3 - fix failure to notice when new node is selected

### DIFF
--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3128,16 +3128,16 @@ class ViewRenderedController3(QtWidgets.QWidget):
             self.show_literal(s)
     #@+node:tom.20241116145648.1: *4* vr3 scroll methods
     # Support for saving and restoring scroll position.
-    def capture_scroll_position(self):
+    def capture_scroll_position(self) -> None:
         self.qwev.page().runJavaScript("window.pageYOffset", self.store_scroll_position)
 
-    def store_scroll_position(self, position):
+    def store_scroll_position(self, position) -> None:
         self.scroll_position = position
 
-    def store_temp_scroll_position(self, position):
+    def store_temp_scroll_position(self, position) -> None:
         self.temp_scroll_postion = position
 
-    def set_unfreeze_when_scrolled(self):
+    def set_unfreeze_when_scrolled(self) -> None:
         self.qwev.page().runJavaScript("window.pageYOffset", self.store_temp_scroll_position)
         current_scroll = self.temp_scroll_postion
         if current_scroll >= self.scroll_position:
@@ -3146,13 +3146,13 @@ class ViewRenderedController3(QtWidgets.QWidget):
             self.scrolling = False
             self.in_forced_message = False
 
-    def restore_scroll_position(self):
+    def restore_scroll_position(self) -> None:
         self.qwev.page().runJavaScript(f"window.scrollTo(0, {self.scroll_position});")
         self.scrolling = True
         self.timer.start(300)
         self.set_unfreeze_when_scrolled()
 
-    def cancel_scroll(self):
+    def cancel_scroll(self) -> None:
         self.timer.stop()
         self.set_unfreeze()
         self.scrolling = False


### PR DESCRIPTION
This very intermittent problem is fixed by making sure to reset the scroll state when the user selects a different node - unless "Lock To Tree" has been checked, since its purpose is to keep the rendered view locked to the same place regardless of the selected node.

This PR fixes https://github.com/leo-editor/leo-editor/issues/4210.

- [x] Create new method to cancel scrolling.
- [x] Check if node has changed when deciding to skip updating.
- [x] Add return type annotations for some new methods that return None.
- [x] full_test: no errors, two skipped tests.
- [x] pylint - no messages.