### PR TITLE
PR for #4175: writing in the log pane

### DIFF
--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2361,8 +2361,8 @@ class LeoQtLog(leoFrame.LeoLog):
         if nodeLink:
             link = urllib.parse.quote(nodeLink)
             s = f'<a href="{link}" title="{link}">{s}</a>'
-        w.insertHtml(s)
         w.moveCursor(MoveOperation.End)
+        w.insertHtml(s)
         sb.setSliderPosition(0)  # Force the slider to the initial position.
         w.repaint()  # Slow, but essential.
     #@+node:ekr.20220411085334.1: *5* LeoQtLog.to_html


### PR DESCRIPTION
See #4175.

- [x] A one-line fix: LeoQtLog.put always writes at the end of the log.
