### PR TITLE
PR for #4116: python importer bug

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2701,8 +2701,8 @@ class LoadManager:
           --trace=LIST          add one or more strings to g.app.debug
 
                 A comma-separated list. Valid values are:
-                abbrev, beauty, cache, coloring, drawing, events, focus, git, gnx,
-                importers, keys, layouts, plugins, save, select, sections,
+                abbrev, beauty, cache, coloring, drawing, events, focus,
+                git, gnx, keys, layouts, plugins, save, select, sections,
                 shutdown, size, speed, startup, themes, undo, verbose, zoom.
 
           --trace-binding=KEY   trace commands bound to a key
@@ -2832,10 +2832,9 @@ class LoadManager:
 
             # --trace=option.
             valid = [
-                'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events',
-                'focus', 'git', 'gnx', 'importers', 'keys',
-                'layouts', 'plugins', 'save', 'select', 'sections', 'shutdown',
-                'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
+                'abbrev', 'beauty', 'cache', 'coloring', 'drawing', 'events', 'focus',
+                'git', 'gnx', 'keys', 'layouts', 'plugins', 'save', 'select', 'sections',
+                'shutdown', 'size', 'speed', 'startup', 'themes', 'undo', 'verbose', 'zoom',
             ]
             m = utils.find_complex_option(r'--trace=([\w\,]+)')
             if not m:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -116,6 +116,8 @@ class Python_Importer(Importer):
         **Important**: An @others directive will refer to the returned blocks,
                        so there must be *no gaps* between blocks!
         """
+        trace = False  # Only while debugging.
+
         i, prev_i, results = i1, i1, []
 
         def lws_n(s: str) -> int:
@@ -132,6 +134,10 @@ class Python_Importer(Importer):
                 if m := pattern.match(s):
                     # cython may include trailing whitespace.
                     name = m.group(1).strip()
+                    if trace:
+                        print('')
+                        g.trace(name, m)
+                        print('')
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
 
@@ -142,8 +148,8 @@ class Python_Importer(Importer):
                     ):
                         i = end
                     else:
-                        # Keep this trace.
-                        # g.printObj(self.lines[prev_i:end], tag=f"{prev_i}:{end} {name}")
+                        if trace:  # Keep this trace.
+                            g.printObj(self.lines[prev_i:end], tag=f"{prev_i}:{end} {name}")
                         block = Block(kind, name,
                             start=prev_i, start_body=i, end=end, lines=self.lines)
                         results.append(block)
@@ -158,10 +164,13 @@ class Python_Importer(Importer):
 
         Return the index of the line *following* the entire class/def.
         """
+        trace = False  # This would be useful only while running unit tests.
+
         def lws_n(s: str) -> int:
             """Return the length of the leading whitespace for s."""
             return len(s) - len(s.lstrip())
 
+        i0 = i - 1  # For traces.
         prev_line = self.guide_lines[i - 1]
         kinds = ('class', 'def', '->')  # '->' denotes a coffeescript function.
         assert any(z in prev_line for z in kinds), (i, repr(prev_line))
@@ -174,18 +183,20 @@ class Python_Importer(Importer):
                     break
 
         non_tail_lines = tail_lines = 0
-        angles, curlies, parens = 0, 0, 0
+        curlies, parens = 0, 0
         if i < i2:
             lws1 = lws_n(prev_line)
             while i < i2:
                 s = self.guide_lines[i]
                 if s.strip():
+                    if trace:
+                        dedent_s = lws_n(s) <= lws1
+                        g.trace(f"dedent? {int(dedent_s)} state: {(curlies, parens)} {s!r}")
                     # A code line. Test the bracket state at the *start* of the line.
-                    if lws_n(s) <= lws1 and (angles, curlies, parens) == (0, 0, 0):
+                    if lws_n(s) <= lws1 and (curlies, parens) == (0, 0):
                         # A code line that ends the block.
                         return i if non_tail_lines == 0 else i - tail_lines
                     # Update the bracket state.
-                    angles = angles + s.count('<') - s.count('>')
                     curlies = curlies + s.count('{') - s.count('}')
                     parens = parens + s.count('(') - s.count(')')
                     # A code line in the block.
@@ -210,6 +221,7 @@ class Python_Importer(Importer):
                     non_tail_lines += 1
                     tail_lines = 0
                 i += 1
+        # g.printObj(self.guide_lines[i0:i2], tag=f"find_end_of_block: {i0}:{i2}")
         return i2
     #@+node:ekr.20230825095926.1: *3* python_i.postprocess & helpers
     def postprocess(self, parent: Position, result_blocks: list[Block]) -> None:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -3,6 +3,7 @@
 """The new, tokenize based, @auto importer for Python."""
 from __future__ import annotations
 import re
+import textwrap
 from typing import Optional, TYPE_CHECKING
 import leo.core.leoGlobals as g
 from leo.plugins.importers.base_importer import Block, Importer
@@ -53,6 +54,7 @@ class Python_Importer(Importer):
             """
             if delim not in line:
                 return delim, len(line)
+            # Create a pattern so we don't have to create substrings.
             delim_pat = re.compile(delim)
             while i < len(line):
                 ch = line[i]
@@ -63,6 +65,8 @@ class Python_Importer(Importer):
                     return '', i + len(delim)
                 i += 1
             return delim, i
+
+        # g.printObj(lines, tag='delete_comments_and_strings')
 
         delim: str = ''  # The open string delim.
         result: list[str] = []
@@ -93,8 +97,13 @@ class Python_Importer(Importer):
             # End the line and append it to the result.
             if line.endswith('\n'):
                 result_line.append('\n')
-            result.append(''.join(result_line))
+            # Finally, strip blank lines.
+            result_line_s = ''.join(result_line)
+            if not result_line_s.strip():
+                result_line_s = '\n'
+            result.append(result_line_s)
         assert len(result) == len(lines)  # A crucial invariant.
+        assert textwrap.dedent(''.join(result)) == ''.join(result)  # A crucial check.
         return result
     #@+node:ekr.20230514140918.1: *3* python_i.find_blocks
     def find_blocks(self, i1: int, i2: int) -> list[Block]:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -165,15 +165,20 @@ class Python_Importer(Importer):
                     break
 
         non_tail_lines = tail_lines = 0
+        angles, curlies, parens = 0, 0, 0
         if i < i2:
             lws1 = lws_n(prev_line)
             while i < i2:
                 s = self.guide_lines[i]
                 if s.strip():
-                    # A code line.
-                    if lws_n(s) <= lws1:
+                    # A code line. Test the bracket state at the *start* of the line.
+                    if lws_n(s) <= lws1 and (angles, curlies, parens) == (0, 0, 0):
                         # A code line that ends the block.
                         return i if non_tail_lines == 0 else i - tail_lines
+                    # Update the bracket state.
+                    angles = angles + s.count('<') - s.count('>')
+                    curlies = curlies + s.count('{') - s.count('}')
+                    parens = parens + s.count('(') - s.count(')')
                     # A code line in the block.
                     non_tail_lines += 1
                     tail_lines = 0

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3298,19 +3298,19 @@ class TestPython(BaseTestImporter):
                     'class HistoryTrim(BaseIPythonApplication):\n'
                     '    @others\n'
             ),
-            (2, 'HistroyTrim.start',
+            (2, 'HistoryTrim.start',
                     'def start(self):\n'
                     '\n'
-                    '# Create the new history database.\n'
-                    'new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer\n'
-                    '                    primary key autoincrement, start timestamp,\n'
-                    '                    end timestamp, num_cmds integer, remark text)""")\n'
-                    'new_db.close()\n'
-                    'if self.backup:\n'
-                    '    print("Backed up longer history file to", backup_hist_file)\n'
-                    'else:\n'
-                    '    hist_file.unlink()\n'
-                    'new_hist_file.rename(hist_file)\n'
+                    '    # Create the new history database.\n'
+                    '    new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer\n'
+                    '                        primary key autoincrement, start timestamp,\n'
+                    '                        end timestamp, num_cmds integer, remark text)""")\n'
+                    '    new_db.close()\n'
+                    '    if self.backup:\n'
+                    '        print("Backed up longer history file to", backup_hist_file)\n'
+                    '    else:\n'
+                    '        hist_file.unlink()\n'
+                    '    new_hist_file.rename(hist_file)\n'
             ),
         )
         self.new_run_test(s, expected_results)

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -32,7 +32,7 @@ class BaseTestImporter(LeoUnitTest):
 
     #@+others
     #@+node:ekr.20230526135305.1: *3* BaseTestImporter.check_outline
-    def check_outline(self, p: Position, expected: tuple) -> None:
+    def check_outline(self, p: Position, expected: tuple, trace: bool = True) -> None:
         """
         BaseTestImporter.check_outline.
 
@@ -56,16 +56,17 @@ class BaseTestImporter(LeoUnitTest):
                 self.assertEqual(g.splitLines(e_str), g.splitLines(a_str), msg=msg)
         except AssertionError:
             # Dump actual results, including bodies.
-            print('')
-            print(f"Fail: {self.id()}")
-            self.dump_tree(p, tag='Actual results...')
-            if 1:  # Sometimes good.
-                # Dump the expected results, as in LeoUnitTest.dump_tree.
-                print('Expected results')
-                for (level, headline, body) in expected:
-                    print('')
-                    print('level:', level, headline)
-                    g.printObj(g.splitLines(body))
+            if trace:
+                print('')
+                print(f"Fail: {self.id()}")
+                self.dump_tree(p, tag='Actual results...')
+                if True:  # Usually a great trace.
+                    # Dump the expected results, as in LeoUnitTest.dump_tree.
+                    print('Expected results')
+                    for (level, headline, body) in expected:
+                        print('')
+                        print('level:', level, headline)
+                        g.printObj(g.splitLines(body))
             raise
     #@+node:ekr.20220809054555.1: *3* BaseTestImporter.check_round_trip
     def check_round_trip(self, p: Position, s: str) -> None:
@@ -105,7 +106,7 @@ class BaseTestImporter(LeoUnitTest):
         p = self.run_test(s)
         self.check_round_trip(p, expected_s or s)
     #@+node:ekr.20230526124600.1: *3* BaseTestImporter.new_run_test
-    def new_run_test(self, s: str, expected_results: tuple, brief: bool = False) -> None:
+    def new_run_test(self, s: str, expected_results: tuple, *, trace: bool = False) -> None:
         """
         Run a unit test of an import scanner,
         i.e., create a tree from string s at location p.
@@ -128,7 +129,7 @@ class BaseTestImporter(LeoUnitTest):
         c.importCommands.createOutline(parent.copy(), ext, test_s)
 
         # Dump the actual results on failure and raise AssertionError.
-        self.check_outline(parent, expected_results)
+        self.check_outline(parent, expected_results, trace=trace)
     #@+node:ekr.20211127042843.1: *3* BaseTestImporter.run_test
     def run_test(self, s: str) -> Position:
         """
@@ -3410,31 +3411,6 @@ class TestPython(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
-    #@+node:ekr.20241128022708.1: *3* TestPython.test_ipython_file
-    def test_ipython_file(self):
-
-        path = r'C:\Python\Python3.13\Lib\site-packages\IPython\core\historyapp.py'
-
-        if not os.path.exists(path):
-            self.skipTest(f"Requires {path}")
-
-        with open(path, 'rb') as f:
-            contents = g.toUnicode(f.read())
-
-        # g.printObj(contents, tag=path)
-
-        expected_results = (
-            (0, '',  # Ignore the first headline.
-                '@language python\n'
-                '@tabwidth -4\n'
-            ),
-        )
-
-        try:
-            # self.maxDiff = None
-            self.new_run_test(contents, expected_results)
-        except AssertionError as e:
-            print(repr(e))
     #@+node:ekr.20230612072414.1: *3* TestPython.test_long_declaration
     def test_long_declaration(self):
 

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3269,12 +3269,24 @@ class TestPython(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
-    #@+node:ekr.20241126104128.1: *3* TestPython.test_ipython_ideom
+    #@+node:ekr.20241126104128.1: *3* TestPython.test_ipython_idiom
     def test_ipython_idiom(self):
 
         s = '''
-        class AClass:
-            description = ("""<A multi-line docstring""")
+    class HistoryTrim(BaseIPythonApplication):
+
+        def start(self):
+
+            # Create the new history database.
+            new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer
+                                primary key autoincrement, start timestamp,
+                                end timestamp, num_cmds integer, remark text)""")
+            new_db.close()
+            if self.backup:
+                print("Backed up longer history file to", backup_hist_file)
+            else:
+                hist_file.unlink()
+            new_hist_file.rename(hist_file)
         '''
         expected_results = (
             (0, '',  # Ignore the first headline.
@@ -3282,17 +3294,23 @@ class TestPython(BaseTestImporter):
                     '@language python\n'
                     '@tabwidth -4\n'
             ),
-            (1, 'function: get_target_type',
-                    'def get_target_type(\n'
-                    '    tvar: TypeVarLikeType,\n'
-                    '    type: Type,\n'
-                    '    callable: CallableType,\n'
-                    ') -> Type | None:\n'
-                    '    if isinstance(tvar, ParamSpecType):\n'
-                    '        return type\n'
-                    '    if isinstance(tvar, TypeVarTupleType):\n'
-                    '        return type\n'
-                    '    return type\n'
+            (1, 'class HistoryTrim',
+                    'class HistoryTrim(BaseIPythonApplication):\n'
+                    '    @others\n'
+            ),
+            (2, 'HistroyTrim.start',
+                    'def start(self):\n'
+                    '\n'
+                    '# Create the new history database.\n'
+                    'new_db.execute("""CREATE TABLE IF NOT EXISTS sessions (session integer\n'
+                    '                    primary key autoincrement, start timestamp,\n'
+                    '                    end timestamp, num_cmds integer, remark text)""")\n'
+                    'new_db.close()\n'
+                    'if self.backup:\n'
+                    '    print("Backed up longer history file to", backup_hist_file)\n'
+                    'else:\n'
+                    '    hist_file.unlink()\n'
+                    'new_hist_file.rename(hist_file)\n'
             ),
         )
         self.new_run_test(s, expected_results)

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3269,6 +3269,33 @@ class TestPython(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
+    #@+node:ekr.20241126104128.1: *3* TestPython.test_ipython_ideom
+    def test_ipython_idiom(self):
+
+        s = '''
+        class AClass:
+            description = ("""<A multi-line docstring""")
+        '''
+        expected_results = (
+            (0, '',  # Ignore the first headline.
+                    '@others\n'
+                    '@language python\n'
+                    '@tabwidth -4\n'
+            ),
+            (1, 'function: get_target_type',
+                    'def get_target_type(\n'
+                    '    tvar: TypeVarLikeType,\n'
+                    '    type: Type,\n'
+                    '    callable: CallableType,\n'
+                    ') -> Type | None:\n'
+                    '    if isinstance(tvar, ParamSpecType):\n'
+                    '        return type\n'
+                    '    if isinstance(tvar, TypeVarTupleType):\n'
+                    '        return type\n'
+                    '    return type\n'
+            ),
+        )
+        self.new_run_test(s, expected_results)
     #@+node:ekr.20230612072414.1: *3* TestPython.test_long_declaration
     def test_long_declaration(self):
 


### PR DESCRIPTION
See #4116.

- [x] Add failing unit test that demonstrates the problem.
- [x] Fix bug in `python_i.find_end_of_block`.
    Indentation is significant only outside of all brackets and parens.
- [x] Check a new invariant in `python_i.delete_comments_and_strings`.
- [x] Improve traces in the python importer.

**Discussion**

A manual import of `Python3.13\Lib\site-packages\IPython\core\historyapp.py` was the acid test.
I created a temporary unit test that verified that this file imported correctly. I didn't think it was worth adding this test.

**Extra**

- [x] Remove unused 'importers' value for `--trace`.