### PR TITLE
PR for #4224: Support .m and .ipynb files in @jupytext

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -618,6 +618,13 @@ class AtFile:
             g.internalError(f"does not exist: {fileName!r}")
             return
 
+        if fileName.endswith(('ipynb', '.m')):
+            language = 'm' if fileName.endswith('.m') else 'python'
+            # Put the whole file into the node.
+            root.deleteAllChildren()
+            root.b = f"@language {language}\n\n" + contents
+            return
+
         at.rememberReadPath(fileName, root)
         at.initReadIvars(root, fileName)
 


### PR DESCRIPTION
See #4224.

This PR and the related issue were brain spikes.

- [x] Treat `@jupytext x.y` as a kind of `@clean` node when `y` is `.m` or `.ipynb`.
   This special case is significantly (and surprisingly) better than using `@clean` directly.