### PR TITLE
PR for #4226: @language jupytext does not work in decendant nodes

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1214,7 +1214,7 @@ class Commands:
         c = self
         p = p or c.p
         language = g.findLanguageDirectives(c, p)
-        if not script and language != 'python':  # #4197.
+        if not script and language not in ('jupytext', 'python'):  # #4197, #4226.
             w = c.frame.body.wrapper
             # For non-python languages...
             valid = (

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -932,7 +932,7 @@ class LeoQtTree(leoFrame.LeoTree):
             wrapper = self.getWrapper(e, item)
             e.editingFinished.connect(editingFinished_callback)
             return wrapper  # 2011/02/12
-        g.trace('can not happen: no e')
+        # g.trace('can not happen: no e')
         return None
     #@+node:ekr.20110605121601.18419: *4* qtree.contractItem & expandItem
     def contractItem(self, item: Item) -> None:
@@ -951,7 +951,10 @@ class LeoQtTree(leoFrame.LeoTree):
         e = w.itemWidget(item, 0)  # e is a QLineEdit
         if e:
             e.setObjectName('headline')
-            self.sizeTreeEditor(c, e)
+        # Always do these!
+        wrapper = self.connectEditorWidget(e, item)
+        self.sizeTreeEditor(c, e)
+
     #@+node:ekr.20110605121601.18421: *4* qtree.createTreeItem
     def createTreeItem(self, p: Position, parent_item: Item) -> Item:
 


### PR DESCRIPTION
See #4226.

- [x] Revise the comment code for jupytext, python and md modes.
- [x] Allow executing scripts w/o a selection when `@language jupytext` is in effect.
- [x] Add a guard to `qtree.createTreeEditorForItem`.
    Same change as in PR #4228.
- [x] Verify that execute-script works w/o selected test  when `@language jupytext` is in effect.
- [x] Verify that all tests pass.