### PR TITLE
PR for #4233: Remove 'meta' from both requirements files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,7 @@ dependencies = [
   "jupytext",        # For paired .ipynb/.py files.
   "markdown",        # VR3 plugin.
   "matplotlib",      # VR3 plugin.
-  "meta",            # livecode.py plugin.
+  # "meta",          # livecode.py plugin.
   "numpy",           # VR3 plugin.
   "pyenchant",       # The spell tab.
   "pyflakes",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ jedi            # For autocompletion.
 jupytext        # For paired .ipynb/.py files.
 markdown        # VR3 plugin.
 matplotlib      # VR3 plugin.
-meta            # livecode.py plugin.
+# meta          # livecode.py plugin.
 numpy           # VR3 plugin.
 pyenchant       # The spell tab.
 pyflakes


### PR DESCRIPTION
See #4233.

- [x] Remove 'meta' from `pyproject.toml`.
- [x] Remove 'meta' from `requirements.txt`.