### PR TITLE
Add support for mathjax to VR

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1990,6 +1990,11 @@
 <v t="ekr.20181018105748.1"><vh>viewrendered plugin</vh>
 <v t="ekr.20181018105800.1"><vh>@bool view-rendered-auto-create = False</vh></v>
 <v t="ekr.20240519122612.1"><vh>@bool view-rendered-keep-open = True</vh></v>
+<v t="ekr.20250102061338.1"><vh>@data view-rendered-image-template</vh></v>
+<v t="ekr.20250102061340.1"><vh>@data view-rendered-katex-template</vh></v>
+<v t="ekr.20250102061341.1"><vh>@data view-rendered-latex-template</vh></v>
+<v t="ekr.20250102061341.2"><vh>@data view-rendered-mathjax-template</vh></v>
+<v t="ekr.20250102062018.1"><vh>@data view-rendered-typst-template</vh></v>
 <v t="ekr.20181018113446.1"><vh>@string view-rendered-default-kind = rst</vh></v>
 <v t="ekr.20181018113502.1"><vh>@string view-rendered-md-extensions = extra</vh></v>
 </v>
@@ -2275,6 +2280,7 @@
 </v>
 </v>
 <v t="ekr.20140915194122.23428"></v>
+<v t="ekr.20181018105748.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11016,7 +11022,8 @@ See https://jedi.readthedocs.io/en/latest/index.html
 <t tx="ekr.20181018105625.1"></t>
 <t tx="ekr.20181018105650.1"></t>
 <t tx="ekr.20181018105704.1"></t>
-<t tx="ekr.20181018105748.1"></t>
+<t tx="ekr.20181018105748.1">@language html
+</t>
 <t tx="ekr.20181018105800.1">True: open the VR pane automatically.</t>
 <t tx="ekr.20181018105904.1"></t>
 <t tx="ekr.20181018105945.1"></t>
@@ -11732,6 +11739,94 @@ See https://jupytext.readthedocs.io/en/latest/config.html
 # %%
 </t>
 <t tx="ekr.20241030020739.1">The maximum size of imported headlines.
+</t>
+<t tx="ekr.20250102061338.1"># The default html template for @image nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+&lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"&gt;
+&lt;html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"&gt;
+&lt;head&gt;&lt;/head&gt;
+&lt;body bgcolor=white&gt;
+&lt;img src="%s"&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</t>
+<t tx="ekr.20250102061340.1"># The default html template for @language katex nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+# Important: VR replaces [[body]] with the p.b.
+
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+    &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.css"
+        integrity="sha384-7lU0muIg/i1plk7MgygDUp3/bNRA65orrBub4/OSWHECgwEsY83HaS1x3bljA/XV"
+        crossorigin="anonymous"&gt;
+
+    &lt;!-- The loading of KaTeX is deferred to speed up page rendering --&gt;
+    &lt;script defer
+        src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.js"
+        integrity="sha384-RdymN7NRJ+XoyeRY4185zXaxq9QWOOx3O7beyyrRK4KQZrPlCDQQpCu95FoCGPAE"
+        crossorigin="anonymous"&gt;&lt;/script&gt;
+
+    &lt;!-- To automatically render math in text elements, include the auto-render extension: --&gt;
+    &lt;script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"
+        onload="renderMathInElement(document.body);"&gt;
+    &lt;/script&gt;
+&lt;/head&gt;
+&lt;body&gt;
+[[body]]
+&lt;/body&gt;
+&lt;/html&gt;
+</t>
+<t tx="ekr.20250102061341.1"># The default html template for @language latex nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+\documentclass[12pt, letter-paper]{article}
+\usepackage{graphicx} % Images.
+\usepackage{tikz} % Evaluate expressions.
+\usepackage{hyperref} % For \href.
+\hypersetup{colorlinks=true, urlcolor=cyan}
+\urlstyle{same}
+\usepackage{pgfplots} % For inline plots.
+\usepackage{amsmath} % For alignment.
+\usepackage[
+    bindingoffset=0.2in, footskip=.25in,
+    left=0.5in, right=2.5in, top=0.5in, bottom=0.5in,
+]{geometry}
+
+\title{My Title}
+\author{A. U. Thor}
+\date{A long time ago}
+
+\pagenumbering{gobble}
+\setlength{\parskip}{6pt}
+\setlength{\parindent}{0pt}
+\pgfplotsset{compat=1.18}
+
+\begin{document}
+% \maketitle
+
+\section*{Section name}
+
+\end{document}
+</t>
+<t tx="ekr.20250102061341.2"># The default html template for @language mathjax nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+&lt;head&gt;
+  &lt;script type="text/x-mathjax-config"&gt;
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+  &lt;/script&gt;
+  &lt;script type="text/javascript" async
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML"&gt;
+  &lt;/script&gt;
+&lt;/head&gt;
+</t>
+<t tx="ekr.20250102062018.1"># The default html template for @language typst nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
 </t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -288,8 +288,10 @@ class LeoApp:
             "handlebars": "html",
             "hbs": "html",
             "less": "css",
-            "mathjax": "html",  # 2024/12/24
+            "katex": "html",  # Leo 6.8.4
+            "mathjax": "html",  # Leo 6.8.4
             "toml": "ini",
+            "typst": "rest",  # Leo 6.8.4
             # Values are existing languages in leo/modes.
         }
     #@+node:ekr.20120522160137.9911: *5* app.define_extension_dict
@@ -579,7 +581,8 @@ class LeoApp:
             "jsp"                : "<%-- --%>",
             "julia"              : "#",
             "jupyter"            : "<%-- --%>", # Default to markdown?
-            "jupytext"           : "#", 
+            "jupytext"           : "#",
+            "katex"              : "%", # Leo 6.8.7.
             "kivy"               : "#", # PeckJ 2014/05/05
             "kshell"             : "#", # Leo 4.5.1.
             "latex"              : "%",
@@ -665,6 +668,7 @@ class LeoApp:
             "toml"               : "#",
             "tpl"                : "<!-- -->",
             "tsql"               : "-- /* */",
+            "typst"              : "//",
             "typescript"         : "// /* */", # For typescript import test.
             "unknown"            : "#", # Set when @comment is seen.
             "unknown_language"   : '#--unknown-language--', # For unknown extensions in @shadow files.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -593,7 +593,7 @@ class LeoApp:
             "maple"              : "//",
             "markdown"           : "<!-- -->", # EKR, 2018/03/03: html comments.
             "matlab"             : "%", # EKR: 2011/10/21
-            "mathjax"            : "<!-- -->", # EKR: 2024/12/25
+            "mathjax"            : "% <!-- -->", # EKR: 2024/12/27: latex & html comments.
             "md"                 : "<!-- -->", # PeckJ: 2013/02/08
             "ml"                 : "(* *)",
             "modula3"            : "(* *)",

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -593,6 +593,7 @@ class LeoApp:
             "maple"              : "//",
             "markdown"           : "<!-- -->", # EKR, 2018/03/03: html comments.
             "matlab"             : "%", # EKR: 2011/10/21
+            "mathjax"            : "<!-- -->", # EKR: 2024/12/25
             "md"                 : "<!-- -->", # PeckJ: 2013/02/08
             "ml"                 : "(* *)",
             "modula3"            : "(* *)",

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -288,6 +288,7 @@ class LeoApp:
             "handlebars": "html",
             "hbs": "html",
             "less": "css",
+            "mathjax": "html",  # 2024/12/24
             "toml": "ini",
             # Values are existing languages in leo/modes.
         }

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2745,7 +2745,11 @@ def isDirective(s: str) -> bool:
 #@+node:ekr.20200810074755.1: *3* g.isValidLanguage
 def isValidLanguage(language: str) -> bool:
     """True if the given language may be used as an external file."""
-    return bool(language and language in g.app.language_delims_dict)
+    return bool(language and (
+        language in g.app.language_delims_dict
+        or
+        language in g.app.delegate_language_dict
+    ))
 #@+node:ekr.20080827175609.52: *3* g.scanAtCommentAndLanguageDirectives
 def scanAtCommentAndAtLanguageDirectives(aList: list) -> Optional[dict[str, str]]:
     """

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -65,9 +65,12 @@ def html_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="comment", begin="<", end=">")
 #@+node:ekr.20230419050050.8: *3* html_rule5 &..;
 def html_rule5(colorer, s, i):
+    c = colorer.c
+    if c.p.b.startswith(('@language latex', '@language mathjax')):
+        # This rule interferes with LaTeX coloring.
+        return 0
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
         no_word_break=True)
-
 #@+node:ekr.20230419050050.9: *3* html_rule_handlebar {{..}}
 # New rule for handlebar markup, colored with the literal3 color.
 def html_rule_handlebar(colorer, s, i):
@@ -90,6 +93,17 @@ def html_rule_end_template(colorer, s, i):
     # Restart any previous delegate.
     colorer.pop_delegate()
     return len(s)  # Success.
+#@+node:ekr.20241227074125.1: *3* html_rule_percent
+def html_rule_percent(colorer, s, i):
+    # A hack for @language latex/mathjax.
+    c = colorer.c
+    if c.p.b.startswith(('@language latex', '@language mathjax')):
+        if i == 0 and s and s[i] == '%':
+            # Color '%' as a whole-line comment.
+            colorer.match_eol_span(s, i, kind="comment1", seq="%")
+            return len(s)
+    return 0
+
 #@-others
 
 #@+node:ekr.20230419050351.1: ** html_tags ruleset
@@ -199,6 +213,7 @@ keywordsDictDict = {
 #@+node:ekr.20241120012542.1: *3* html.py: Rules dicts
 # Rules dict for html_main ruleset.
 rulesDict1 = {
+    "%": [html_rule_percent],
     "&": [html_rule5],
     "@": [html_rule_at_language],
     "<": [

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -66,7 +66,7 @@ def html_rule4(colorer, s, i):
 #@+node:ekr.20230419050050.8: *3* html_rule5 &..;
 def html_rule5(colorer, s, i):
     c = colorer.c
-    if c.p.b.startswith(('@language latex', '@language mathjax')):
+    if c.p.b.startswith(('@language katex', '@language latex', '@language mathjax')):
         # This rule interferes with LaTeX coloring.
         return 0
     return colorer.match_span(s, i, kind="literal2", begin="&", end=";",
@@ -97,7 +97,7 @@ def html_rule_end_template(colorer, s, i):
 def html_rule_percent(colorer, s, i):
     # A hack for @language latex/mathjax.
     c = colorer.c
-    if c.p.b.startswith(('@language latex', '@language mathjax')):
+    if c.p.b.startswith(('@language katex', '@language latex', '@language mathjax')):
         if i == 0 and s and s[i] == '%':
             # Color '%' as a whole-line comment.
             colorer.match_eol_span(s, i, kind="comment1", seq="%")

--- a/leo/plugins/pyplot_backend.py
+++ b/leo/plugins/pyplot_backend.py
@@ -101,6 +101,7 @@ class LeoFigureManagerQT(FigureManager):
         self.toolbar = NavigationToolbar(self.canvas, self.frame)
         w.layout().addWidget(self.toolbar)
         if vc:
+            vc.w = w
             vc.embed_widget(w)
         self.window = DummyWindow(c)
         self.canvas.setFocusPolicy(FocusPolicy.StrongFocus)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -902,19 +902,15 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Compute the contents.
         h = f"<h3>{p.h.strip()}</h3>\n"
         if has_webengineview:
-            if 1:
-                # Replace whole-line latex comments with html comments.
-                # Don't make any other changes!
-                result_s = ''.join([
-                    f"<!-- {z} -->" if z.strip().startswith('%') else z
-                    for z in g.splitLines(s)
-                ])
-                contents = mathjax_template + '\n\n' + h + result_s
-            else:
-                contents = mathjax_template + '\n\n' + h + s
+            # Replace whole-line latex comments with html comments.
+            # Don't make any other changes!
+            result_s = ''.join([
+                f"<!-- {z} -->" if z.strip().startswith('%') else z
+                for z in g.splitLines(s)
+            ])
+            contents = mathjax_template + '\n\n' + h + result_s
         else:
             contents = h + s
-        g.trace('len(contents)', len(contents))
         w.setHtml(contents)
         self.show()
     #@+node:ekr.20241224072334.1: *4* vr.update_mathjax

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -835,8 +835,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def update_html(self, s: str, keywords: Any) -> None:
         """Update html in the VR pane."""
         c = self.c
-        if self.must_change_widget(BaseTextWidget):
-            w = self.create_base_text_widget()
+        if self.must_change_widget(has_webengineview):
+            w = self.create_web_engineview()  # Gives error message.
             self.embed_widget(w)
             assert w == self.w
         else:

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1247,39 +1247,49 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     # http://doc.trolltech.com/4.4/painting-svgviewer.html
     def update_svg(self, s: str, keywords: Any) -> None:
 
-        if hasattr(QtSvg, "QSvgWidget"):  # #2134
-            QSvgWidget = QtSvg.QSvgWidget
-        else:
-            try:
-                from PyQt6 import QtSvgWidgets
-                QSvgWidget = QtSvgWidgets.QSvgWidget
-            except Exception:
-                QSvgWidget = None
-        if not QSvgWidget:
-            w = self.ensure_text_widget()
-            w.setPlainText(s)
-            return
-        if self.must_change_widget(QSvgWidget):
-            w = QSvgWidget()
-            self.embed_widget(w)
-            assert w == self.w
-        else:
-            w = self.w
-        if s.strip().startswith('<'):
-            # Assume it is the svg (xml) source.
-            # Sensitive to leading blank lines.
-            s = textwrap.dedent(s).strip()
-            s_bytes = g.toEncodedString(s)
-            self.show()
-            w.load(QtCore.QByteArray(s_bytes))
+        if 0:  # Use webengine. Works, but scaling is big.
+            if self.must_change_widget(has_webengineview):
+                w = self.create_web_engineview()  # Gives error message.
+                self.embed_widget(w)
+                assert w == self.w
+            else:
+                w = self.w
+            w.setHtml(s)
             w.show()
-        else:
-            # Get a filename from the headline or body text.
-            ok, path = self.get_fn(s, '@svg')
-            if ok:
+        else:  # Legacy:  Better scaling.
+            if hasattr(QtSvg, "QSvgWidget"):  # #2134
+                QSvgWidget = QtSvg.QSvgWidget
+            else:
+                try:
+                    from PyQt6 import QtSvgWidgets
+                    QSvgWidget = QtSvgWidgets.QSvgWidget
+                except Exception:
+                    QSvgWidget = None
+            if not QSvgWidget:
+                w = self.ensure_text_widget()
+                w.setPlainText(s)
+                return
+            if self.must_change_widget(QSvgWidget):
+                w = QSvgWidget()
+                self.embed_widget(w)
+                assert w == self.w
+            else:
+                w = self.w
+            if s.strip().startswith('<'):
+                # Assume it is the svg (xml) source.
+                # Sensitive to leading blank lines.
+                s = textwrap.dedent(s).strip()
+                s_bytes = g.toEncodedString(s)
                 self.show()
-                w.load(path)
+                w.load(QtCore.QByteArray(s_bytes))
                 w.show()
+            else:
+                # Get a filename from the headline or body text.
+                ok, path = self.get_fn(s, '@svg')
+                if ok:
+                    self.show()
+                    w.load(path)
+                    w.show()
     #@+node:ekr.20110321005148.14537: *4* vr.update_url
     def update_url(self, s: str, keywords: Any) -> None:
         c, p = self.c, self.c.p

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -687,24 +687,20 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.default_kind = c.config.getString('view-rendered-default-kind') or 'rst'
         self.pdf_zoom = c.config.getInt('view-rendered-pdf-zoom') or 100
 
-        # Templates
-        self.image_template = (
-            c.config.getString('view-rendered-image-template')
-            or self.default_image_template
-        )
-        self.katex_template = (
-            c.config.getString('view-rendered-katex-template')
-            or self.default_katex_template
-        )
-        self.latex_template = (
-            c.config.getString('view-rendered-latex-template')
-            or self.default_latex_template
-        )
-        self.mathjax_template = (
-            c.config.getString('view-rendered-mathjax-template')
-            or self.default_mathjax_template
-        )
-        self.typst_template = c.config.getString('view-rendered-typst-template') or ''
+        # Templates...
+
+        def get_template(kind: str) -> str:
+            setting_name = f"view-rendered-{kind}-template"
+            aList = c.config.getData(setting_name, strip_comments=True, strip_data=True)
+            if aList is None:
+                return getattr(self, f"default_{kind}_template")
+            return '\n'.join(aList)
+
+        self.image_template = get_template('image')
+        self.katex_template = get_template('katex')
+        self.latex_template = get_template('latex')
+        self.mathjax_template = get_template('mathjax')
+        self.typst_template = get_template('typst')
     #@+node:ekr.20190614065659.1: *4* vr.create_pane
     def create_pane(self, parent: Position) -> None:
         """Create the VR pane."""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -773,9 +773,11 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         """Destroy all widgets."""
         # g.trace(g.shortFileName(self.c.fileName()))
         for ivar in ('gs', 'gv', 'pdf_qwv', 'qwv', 'vp'):
-            var = getattr(self, ivar)
-            del var
+            var = getattr(self, ivar, None)
+            if var is not None:
+                del var
             setattr(self, ivar, None)
+        self.w = None
     #@+node:ekr.20110320120020.14486: *5* vr.embed_widget
     def embed_widget(self, w: Wrapper) -> None:
         """Embed widget w in the layout."""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -582,7 +582,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
     \end{document}
     '''
-    #@+node:ekr.20241224072714.1: *4* vr.default_mathjax template
+    #@+node:ekr.20241224072714.1: *4* vr.default_mathjax_template
     default_mathjax_template = '''
     <head>
       <script type="text/x-mathjax-config">
@@ -593,6 +593,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
       </script>
     </head>
     '''
+    #@+node:ekr.20241231180612.1: *4* vr.default_typst_template
+    default_typst_template = None
     #@-others
     #@-<< vr: default templates >>
     #@+others
@@ -610,6 +612,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.katex_template: str = None
         self.latex_template: str = None
         self.mathjax_template: str = None
+        self.typst_template = None
         self.pdf_zoom: int = None
         # Widgets managed by destroy_widgets.
         self.browser: Widget = None
@@ -693,6 +696,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             c.config.getString('view-rendered-mathjax-template')
             or self.default_mathjax_template
         )
+        self.typst_template = c.config.getString('view-rendered-typst-template') or ''
     #@+node:ekr.20190614065659.1: *4* vr.create_pane
     def create_pane(self, parent: Position) -> None:
         """Create the VR pane."""
@@ -1539,20 +1543,16 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             self.show()
             return
 
-        ### h = f"=== {p.h.strip()}\n\n"
-
+        # Render as pdf.
         tex_path = g.os_path_finalize_join(os.getcwd(), f"{p.gnx}.tex")
         pdf_path = tex_path.replace('.tex', '.pdf')
-        contents = s.strip() + '\n'
+        contents = self.typst_template + '\n\n' + s.strip() + '\n'
         with open(tex_path, 'w') as f:
             f.write(contents)
-            print(f"Wrote {tex_path}")
-
-        # Render and open.
+            # print(f"Wrote {tex_path}")
         g.execute_shell_commands([
             f"typst compile {tex_path}",  # Invoke the typst app.
         ])
-        # g.trace(f"Loading {pdf_path}")
         url = QUrl.fromLocalFile(pdf_path)
         # https://www.rfc-editor.org/rfc/rfc8118
         url.setFragment(f"zoom={self.pdf_zoom}")

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -612,7 +612,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.katex_template: str = None
         self.latex_template: str = None
         self.mathjax_template: str = None
-        self.typst_template = None
+        self.typst_template: str = None
         self.pdf_zoom: int = None
         # Widgets managed by destroy_widgets.
         self.browser: Widget = None

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -533,7 +533,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     </html>
     '''
     #@+node:ekr.20241231121842.1: *4* vr.default_katex_template
-    default_katex_template = textwrap.dedent('''
+    default_katex_template = textwrap.dedent(r'''
     <!DOCTYPE html>
     <html>
     <head>

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -968,7 +968,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         p = self.c.p
         h = f"<h3>{p.h.strip()}</h3>\n\n"
         if has_webengineview:
-            contents = mathjax_template + '\n\n' + h + s
+            # Replace whole-line latex comments with html comments.
+            result_s = ''.join([
+                f"<!-- {z} -->" if z.strip().startswith('%') else z
+                for z in g.splitLines(s)
+            ])
+            contents = mathjax_template + '\n\n' + h + result_s
         else:
             contents = h + s
         w.setHtml(contents)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -748,45 +748,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         else:
             self.hide()
     #@+node:ekr.20241227053437.1: *4* vr.update: helpers
-    #@+node:ekr.20190424083049.1: *5* vr.get_base_text_widget
-    def get_base_text_widget(self) -> QWidget:
-        """Create a QTextBrowser."""
-        c = self.c
-        if isinstance(self.w, QtWidgets.QTextBrowser):
-            return self.w
-
-        self.destroy_widgets()
-        self.browser = self.w = w = QtWidgets.QTextBrowser()
-        self.embed_widget(w)  # Creates w.wrapper
-
-        text_name = 'body-text-renderer'
-        w.setObjectName(text_name)
-        w.setReadOnly(True)
-        # Create the standard Leo bindings.
-        wrapper_name = 'rendering-pane-wrapper'
-        wrapper = qt_text.QTextEditWrapper(w, wrapper_name, c)
-        w.leo_wrapper = wrapper
-        c.k.completeAllBindingsForWidget(wrapper)
-        w.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
-
-        def contextMenuCallback(point: Any) -> None:
-            """LeoQtTree: Callback for customContextMenuRequested events."""
-            # #1286.
-            w = self  # Required.
-            g.app.gui.onContextMenu(c, w, point)
-
-        # #1286.
-        w.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
-        w.customContextMenuRequested.connect(contextMenuCallback)
-
-        def handleClick(url: str, w: Widget = w) -> None:
-            wrapper = qt_text.QTextEditWrapper(w, name='vr-body', c=c)
-            event = g.Bunch(c=c, w=wrapper)
-            g.openUrlOnClick(event, url=url)
-
-        w.anchorClicked.connect(handleClick)
-        w.setOpenLinks(False)
-        return w
     #@+node:ekr.20241224074331.1: *5* vr.create_web_engineview
     def create_web_engineview(self) -> QWidget:
         """
@@ -1482,6 +1443,45 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             self.show()
             w.setPlainText('')
     #@+node:ekr.20110322031455.5765: *3* vr: utils...
+    #@+node:ekr.20190424083049.1: *4* vr.get_base_text_widget
+    def get_base_text_widget(self) -> QWidget:
+        """Create a QTextBrowser."""
+        c = self.c
+        if isinstance(self.w, QtWidgets.QTextBrowser):
+            return self.w
+
+        self.destroy_widgets()
+        self.browser = self.w = w = QtWidgets.QTextBrowser()
+        self.embed_widget(w)  # Creates w.wrapper
+
+        text_name = 'body-text-renderer'
+        w.setObjectName(text_name)
+        w.setReadOnly(True)
+        # Create the standard Leo bindings.
+        wrapper_name = 'rendering-pane-wrapper'
+        wrapper = qt_text.QTextEditWrapper(w, wrapper_name, c)
+        w.leo_wrapper = wrapper
+        c.k.completeAllBindingsForWidget(wrapper)
+        w.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
+
+        def contextMenuCallback(point: Any) -> None:
+            """LeoQtTree: Callback for customContextMenuRequested events."""
+            # #1286.
+            w = self  # Required.
+            g.app.gui.onContextMenu(c, w, point)
+
+        # #1286.
+        w.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
+        w.customContextMenuRequested.connect(contextMenuCallback)
+
+        def handleClick(url: str, w: Widget = w) -> None:
+            wrapper = qt_text.QTextEditWrapper(w, name='vr-body', c=c)
+            event = g.Bunch(c=c, w=wrapper)
+            g.openUrlOnClick(event, url=url)
+
+        w.anchorClicked.connect(handleClick)
+        w.setOpenLinks(False)
+        return w
     #@+node:ekr.20110320120020.14483: *4* vr.get_kind
     def get_kind(self, p: Position) -> Optional[str]:
         """Return the proper rendering kind for node p."""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1201,6 +1201,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
         # Create a URL to the file.
         url = QUrl.fromLocalFile(path)
+        # https://www.rfc-editor.org/rfc/rfc8118
+        url.setFragment("zoom=200")
         w.load(url)
         self.show()
     #@+node:ekr.20160928023915.1: *4* vr.update_pyplot

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -890,8 +890,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         if pyperclip:
             pyperclip.copy(s)
     #@+node:ekr.20170324064811.1: *4* vr.update_latex
-    latex_comment_pat = re.compile(r'\%(.*?)$')
-
     def update_latex(self, s: str, keywords: Any) -> None:
         """Update latex text in the VR pane."""
         p = self.c.p
@@ -904,22 +902,19 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Compute the contents.
         h = f"<h3>{p.h.strip()}</h3>\n"
         if has_webengineview:
-            # Replace latex comments with html comments
-            result = []
-            for line in g.splitLines(s):
-                i = line.find('%')
-                if i > -1:
-                    result.append(line[:i] + '<!--' + line[i + 1 :] + '-->')
-                elif line.strip():
-                    result.append(line)
-                else:
-                    result.append('<p>')  # Works only outside math mode!
-            # Do *not* replace \\: It would interfere with alignment!
-            # Replacing \\ with <br> works outside of math mode!
-            result_s = ''.join(result)
-            contents = mathjax_template + '\n\n' + h + result_s
+            if 1:
+                # Replace whole-line latex comments with html comments.
+                # Don't make any other changes!
+                result_s = ''.join([
+                    f"<!-- {z} -->" if z.strip().startswith('%') else z
+                    for z in g.splitLines(s)
+                ])
+                contents = mathjax_template + '\n\n' + h + result_s
+            else:
+                contents = mathjax_template + '\n\n' + h + s
         else:
             contents = h + s
+        g.trace('len(contents)', len(contents))
         w.setHtml(contents)
         self.show()
     #@+node:ekr.20241224072334.1: *4* vr.update_mathjax

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -910,9 +910,11 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 i = line.find('%')
                 if i > -1:
                     result.append(line[:i] + '<!--' + line[i + 1 :] + '-->')
-                else:
+                elif line.strip():
                     result.append(line)
-            # Replace \\ with <br>, but this hack only works outside of math mode!
+                else:
+                    result.append('<p>')  # Works only outside math mode!
+            # Replacing \\ with <br> works outside of math mode!
             result_s = ''.join(result).replace(r'\\', '<br>')
             contents = mathjax_template + '\n\n' + h + result_s
         else:

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -789,7 +789,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     # Must have this signature: called by leoPlugins.callTagHandler.
 
     def update(self, tag: str, keywords: Any) -> None:  # type:ignore
-        """Update the VR pane. Called at idle time."""
+        """
+        vr.update: Update the VR pane.
+        Called at idle time and by the vr-update command.
+        """
         p = self.c.p
         if not self.active:
             try:
@@ -845,10 +848,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.qwv = self.w = w = qwv()
         self.embed_widget(w)
         if isinstance(w, QtWidgets.QTextBrowser):
-            g.print_unique_message(
-                'VR can not render latex or mathjax:\n'
-                'pip install PyQt6-WebEngine\n'
-            )
             return w
 
         # Allow remote access.
@@ -975,7 +974,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return f.read()
     #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script
     def update_graphics_script(self, s: str, keywords: Any) -> None:
-        """Update the graphics script in the VR pane."""
+        """Display the graphics script in `s` in the VR pane."""
         c = self.c
         if g.unitTesting:
             return
@@ -999,10 +998,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     update_html_count = 0
 
     def update_html(self, s: str, keywords: Any) -> None:
-        """Update html in the VR pane."""
+        """Display the html text in `s` in the VR pane."""
         c = self.c
 
-        # Create a new QWebEngineView, deleting the old if it exists.
+        # Create a new QWebEngineView.
         w = self.create_web_engineview()
 
         # Set the html.
@@ -1011,7 +1010,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         c.bodyWantsFocusNow()
     #@+node:ekr.20110320120020.14482: *4* vr.update_image
     def update_image(self, s: str, keywords: Any) -> None:
-        """Update an image in the VR pane."""
+        """
+        Display an image in the VR pane.
+        The first line of `s` should be a `@image <path>`.
+        """
         if not s.strip():
             return
         lines = g.splitLines(s) or []
@@ -1021,20 +1023,18 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         w = self.get_base_text_widget()
         ok, path = self.get_fn(fn, '@image')
         if not ok:
-            w.setPlainText('@image: file not found: %s' % (path))
+            w.setPlainText(f"@image: file not found: {path!r}")
             return
         path = path.replace('\\', '/')
         template = self.image_template % (path)
         template = textwrap.dedent(template).strip()
         self.show()
-        # w.setReadOnly(False)
         w.setHtml(template)
-        # w.setReadOnly(True)
     #@+node:ekr.20170105124347.1: *4* vr.update_jupyter & helper
     update_jupyter_count = 0
 
     def update_jupyter(self, s: str, keywords: Any) -> None:
-        """Update @jupyter node in the VR pane."""
+        """Update an @jupyter node in the VR pane."""
         c = self.c
         w = self.get_base_text_widget()
         s = self.get_jupyter_source(c)
@@ -1075,11 +1075,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         return s
     #@+node:ekr.20241231121212.1: *4* vr.update_katex
     def update_katex(self, s: str, keywords: Any) -> None:
-        """Update katex text in the VR pane."""
+        """Display the katex text `s` in the VR pane."""
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
         if not has_webengineview:
+            g.print_unique_message('katex rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1093,11 +1094,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20170324064811.1: *4* vr.update_latex
     def update_latex(self, s: str, keywords: Any) -> None:
-        """Update LaTeX text in the VR pane."""
+        """Display the LaTeX text `s` in the VR pane."""
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
         if not has_webengineview:
+            g.print_unique_message('LaTeX rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1111,11 +1113,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20241224072334.1: *4* vr.update_mathjax
     def update_mathjax(self, s: str, keywords: Any) -> None:
-        """Update mathhjax text in the VR pane."""
+        """Display the mathjax text `s` in the VR pane."""
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
         if not has_webengineview:
+            g.print_unique_message('mathjax rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1129,7 +1132,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:peckj.20130207132858.3671: *4* vr.update_md & helper
     def update_md(self, s: str, keywords: Any) -> None:
-        """Update markdown text in the VR pane."""
+        """Display the markdown text in `s` in the VR pane."""
         c = self.c
         p = c.p
         s = s.strip().strip('"""').strip("'''").strip()
@@ -1173,7 +1176,11 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     movie_warning = False
 
     def update_movie(self, s: str, keywords: Any) -> None:
-        """Update a movie in the VR pane."""
+        """
+        Show an @movie in the VR pane.
+        
+        The first line of `s` should be the path to the movie.
+        """
         ok, path = self.get_fn(s, '@movie')
         if not ok:
             w = self.get_base_text_widget()
@@ -1203,19 +1210,16 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
     #@+node:ekr.20110320120020.14484: *4* vr.update_networkx
     def update_networkx(self, s: str, keywords: Any) -> None:
-        """Update a networkx graphic in the VR pane."""
+        """Dispaly a networkx graphic in `s` in the VR pane."""
         w = self.get_base_text_widget()
         w.setPlainText('')  # 'Networkx: len: %s' % (len(s)))
         self.show()
     #@+node:ekr.20191006155748.1: *4* vr.update_pandoc & helpers (disabled)
     def update_pandoc(self, s: str, keywords: Any) -> None:
         """
-        Update an @pandoc in the VR pane.
+        Display an @pandoc node in the VR pane.
         
         This code has been disabled.
-
-        There is no such thing as @language pandoc,
-        so only @pandoc nodes trigger this code.
         """
         global pandoc_exec
         w = self.get_base_text_widget()
@@ -1265,7 +1269,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return f.read()
     #@+node:ekr.20241226011006.1: *4* vr.update_pdf
     def update_pdf(self, s: str, keywords: Any) -> None:
-        """Load a pdf file and show it in the VR pane."""
+        """
+        Display a pdf file in the VR pane.
+        The first line of `s` should be a `@pdf <path>`.
+        """
         p = self.c.p
         if not s.strip():
             return
@@ -1277,7 +1284,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Create a new QWebEngineView.
         w = self.create_web_engineview_with_pdf()
         if not has_webengineview:
-            g.print_unique_message('@pdf requires PyQt6-WebEngine')
+            g.print_unique_message('@pdf rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1291,7 +1298,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     #@+node:ekr.20160928023915.1: *4* vr.update_pyplot
     def update_pyplot(self, s: str, keywords: Any) -> None:
         """
-        Get the pyplot script at c.p.b and show it in the VR pane.
+        Execute the pyplot script in `s` and show the results in the VR pane.
         """
         c = self.c
         try:
@@ -1343,7 +1350,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         matplotlib.use('QtAgg')
     #@+node:ekr.20110320120020.14477: *4* vr.update_rst & helpers
     def update_rst(self, s: str, keywords: Any) -> None:
-        """Update rst in the VR pane."""
+        """Show the rst text in `s` in the VR pane."""
         s = s.strip().strip('"""').strip("'''").strip()
         isHtml = s.startswith('<') and not s.startswith('<<')
 
@@ -1466,7 +1473,11 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     # http://doc.trolltech.com/4.4/qtsvg.html
     # http://doc.trolltech.com/4.4/painting-svgviewer.html
     def update_svg(self, s: str, keywords: Any) -> None:
-
+        """
+        Show an svg image in the VR pane.
+        
+        `s` may be a path to the image or the image itself.
+        """
         if 0:  # Use webengine. Works, but scaling is too big.
             w = self.create_web_engineview()
             w.setHtml(s)
@@ -1481,6 +1492,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 except Exception:
                     QSvgWidget = None
             if not QSvgWidget:
+                g.print_unique_message('svg rendering requires PyQt6-WebEngine')
                 w = self.get_base_text_widget()
                 w.setPlainText(s)
                 return
@@ -1508,13 +1520,13 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                     w.show()
     #@+node:ekr.20241231121247.1: *4* vr.update_typst
     def update_typst(self, s: str, keywords: Any) -> None:
-        """Update mathhjax text in the VR pane."""
+        """Display the typest text in `s` in the VR pane."""
         p = self.c.p
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview_with_pdf()
         if not has_webengineview:
-            g.print_unique_message('@pdf requires PyQt6-WebEngine')
+            g.print_unique_message('typst rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1543,6 +1555,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20110321005148.14537: *4* vr.update_url
     def update_url(self, s: str, keywords: Any) -> None:
+        """Display the url in `s` in the VR pane."""
         c, p = self.c, self.c.p
         colorizer = c.frame.body.colorizer
         language = colorizer.scanLanguageDirectives(p)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1117,19 +1117,16 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
+        if not has_webengineview:
+            w.setHtml(s)
+            self.show()
+            return
 
-        # Compute the contents.
-        p = self.c.p
-        h = f"<h3>{p.h.strip()}</h3>\n\n"
-        if has_webengineview:
-            # Replace whole-line latex comments with html comments.
-            result_s = ''.join([
-                f"<!-- {z} -->" if z.strip().startswith('%') else z
-                for z in g.splitLines(s)
-            ])
-            contents = self.mathjax_template + '\n\n' + h + result_s
-        else:
-            contents = h + s
+        # Replace whole-line latex comments with html comments.
+        s = ''.join([
+            z for z in g.splitLines(s) if not z.strip().startswith('%')
+        ])
+        contents = self.mathjax_template + '\n\n' + result_s
         w.setHtml(contents)
         self.show()
     #@+node:peckj.20130207132858.3671: *4* vr.update_md & helper

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -657,7 +657,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             'image': self.update_image,
             'jinja': self.update_jinja,
             'jupyter': self.update_jupyter,
-            'katex': self.update_katex,  # New.
+            'katex': self.update_katex,
             'latex': self.update_latex,
             'markdown': self.update_md,
             'mathjax': self.update_mathjax,
@@ -670,7 +670,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             'rst': self.update_rst,
             'svg': self.update_svg,
             'plantuml': self.update_plantuml,
-            'typst': self.update_typst,  # New.
+            'typst': self.update_typst,
             # 'url': self.update_url,
             # 'xml': self.update_xml,
         }
@@ -1078,12 +1078,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     #@+node:ekr.20241231121212.1: *4* vr.update_katex
     def update_katex(self, s: str, keywords: Any) -> None:
         """Update katex text in the VR pane."""
-        p = self.c.p
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
-
-        # Compute the contents.
         if not has_webengineview:
             w.setHtml(s)
             self.show()
@@ -1098,28 +1095,20 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20170324064811.1: *4* vr.update_latex
     def update_latex(self, s: str, keywords: Any) -> None:
-        """
-        Update latex text in the VR pane.
-        
-        This code has been disabled. Use @language mathjax instead.
-        """
-        p = self.c.p
+        """Update LaTeX text in the VR pane."""
 
-        # Create a new QWebEngineView, deleting the old if it exists.
+        # Create a new QWebEngineView.
         w = self.create_web_engineview()
+        if not has_webengineview:
+            w.setHtml(s)
+            self.show()
+            return
 
-        # Compute the contents.
-        h = f"<h3>{p.h.strip()}</h3>\n"
-        if has_webengineview:
-            # Replace whole-line latex comments with html comments.
-            # Don't make any other changes!
-            result_s = ''.join([
-                f"<!-- {z} -->" if z.strip().startswith('%') else z
-                for z in g.splitLines(s)
-            ])
-            contents = self.latex_template + '\n\n' + h + result_s
-        else:
-            contents = h + s
+        # Replace whole-line latex comments with html comments.
+        s = ''.join([
+            z for z in g.splitLines(s) if not z.strip().startswith('%')
+        ])
+        contents = self.latex_template + '\n\n' + s
         w.setHtml(contents)
         self.show()
     #@+node:ekr.20241224072334.1: *4* vr.update_mathjax

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -298,32 +298,6 @@ trace = False  # This global trace is convenient.
 asciidoctor_exec = shutil.which('asciidoctor')
 asciidoc3_exec = shutil.which('asciidoc3')
 pandoc_exec = shutil.which('pandoc')
-#@+<< vr: image template >>
-#@+node:ekr.20170324090828.1: ** << vr: image template >>
-image_template = '''\
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
- "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head></head>
-<body bgcolor=white>
-<img src="%s">
-</body>
-</html>
-'''
-#@-<< vr: image template >>
-#@+<< vr: mathjax template >>
-#@+node:ekr.20241224072714.1: ** << vr: mathjax template >>
-mathjax_template = '''
-<head>
-  <script type="text/x-mathjax-config">
-    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
-  </script>
-  <script type="text/javascript" async
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML">
-  </script>
-</head>
-'''
-#@-<< vr: mathjax template >>
 #@+others
 #@+node:ekr.20110320120020.14491: ** vr.Top-level functions
 #@+node:tbrown.20100318101414.5995: *3* vr function: init
@@ -544,6 +518,83 @@ def update_rendering_pane(event: Event) -> None:
 #@+node:ekr.20110317024548.14375: ** class ViewRenderedController (QWidget)
 class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     """A class to control rendering in a rendering pane."""
+    #@+<< vr: default templates >>
+    #@+node:ekr.20241231164944.1: *3* << vr: default templates >>
+    #@+others
+    #@+node:ekr.20170324090828.1: *4* vr.default_image template
+    default_image_template = '''\
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    <head></head>
+    <body bgcolor=white>
+    <img src="%s">
+    </body>
+    </html>
+    '''
+    #@+node:ekr.20241231121842.1: *4* vr.default_katex_template
+    default_katex_template = '''
+    <!DOCTYPE html>
+    <!-- KaTeX requires the use of the HTML5 doctype. Without it, KaTeX may not render properly -->
+    <html>
+      <head>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.css" integrity="sha384-7lU0muIg/i1plk7MgygDUp3/bNRA65orrBub4/OSWHECgwEsY83HaS1x3bljA/XV" crossorigin="anonymous">
+
+        <!-- The loading of KaTeX is deferred to speed up page rendering -->
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.js" integrity="sha384-RdymN7NRJ+XoyeRY4185zXaxq9QWOOx3O7beyyrRK4KQZrPlCDQQpCu95FoCGPAE" crossorigin="anonymous"></script>
+
+        <!-- To automatically render math in text elements, include the auto-render extension: -->
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"
+            onload="renderMathInElement(document.body);"></script>
+      </head>
+      ...
+    </html>
+    '''
+    #@+node:ekr.20241231122327.1: *4* vr.default_latex template
+    default_latex_template = r'''
+    \documentclass[12pt, letter-paper]{article}
+    \usepackage{graphicx} % Images.
+    \usepackage{tikz} % Evaluate expressions.
+    \usepackage{hyperref} % For \href.
+    \hypersetup{colorlinks=true, urlcolor=cyan}
+    \urlstyle{same}
+    \usepackage{pgfplots} % For inline plots.
+    \usepackage{amsmath} % For alignment.
+    \usepackage[
+        bindingoffset=0.2in, footskip=.25in,
+        left=0.5in, right=2.5in, top=0.5in, bottom=0.5in,
+    ]{geometry}
+
+    \title{My Title}
+    \author{Edward K. Ream}
+    \date{December 2024}
+
+    \pagenumbering{gobble}
+    \setlength{\parskip}{6pt}
+    \setlength{\parindent}{0pt}
+    \pgfplotsset{compat=1.18}
+
+    \begin{document}
+    % \maketitle
+
+    \section*{Section name}
+
+
+    \end{document}
+    '''
+    #@+node:ekr.20241224072714.1: *4* vr.default_mathjax template
+    default_mathjax_template = '''
+    <head>
+      <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+      </script>
+      <script type="text/javascript" async
+        src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML">
+      </script>
+    </head>
+    '''
+    #@-others
+    #@-<< vr: default templates >>
     #@+others
     #@+node:ekr.20110317080650.14380: *3*  vr.ctor & helpers
     def __init__(self, c: Cmdr, parent: Widget = None) -> None:
@@ -554,7 +605,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.create_pane(parent)
         # Ivars set by reloadSettings.
         self.auto_create: bool = None
+        self.background_color: str = None
         self.keep_open: bool = None
+        self.katex_template: str = None
+        self.latex_template: str = None
+        self.mathjax_template: str = None
+        self.pdf_zoom: int = None
         # Widgets managed by destroy_widgets.
         self.browser: Widget = None
         self.gs: Widget = None  # For @graphics-script: a QGraphicsScene
@@ -591,19 +647,21 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             'image': self.update_image,
             'jinja': self.update_jinja,
             'jupyter': self.update_jupyter,
-            # 'latex': self.update_latex,
+            'katex': self.update_katex,  # New.
+            'latex': self.update_latex,
             'markdown': self.update_md,
             'mathjax': self.update_mathjax,
             'md': self.update_md,
             'movie': self.update_movie,
             'networkx': self.update_networkx,
             # 'pandoc': self.update_pandoc,
-            'pdf': self.update_pdf,
+            # 'pdf': self.update_pdf,  # Replaced by katex or typst.
             'pyplot': self.update_pyplot,
             'rest': self.update_rst,
             'rst': self.update_rst,
             'svg': self.update_svg,
             'plantuml': self.update_plantuml,
+            'typst': self.update_typst,  # New.
             # 'url': self.update_url,
             # 'xml': self.update_xml,
         }
@@ -617,7 +675,24 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.keep_open = c.config.getBool('view-rendered-keep-open', True)
         self.background_color = c.config.getColor('rendering-pane-background-color') or 'white'
         self.default_kind = c.config.getString('view-rendered-default-kind') or 'rst'
-
+        self.pdf_zoom = c.config.getInt('view-rendered-pdf-zoom') or 100
+        # Templates
+        self.image_template = (
+            c.config.getString('view-rendered-image-template')
+            or self.default_image_template
+        )
+        self.katex_template = (
+            c.config.getString('view-rendered-katex-template')
+            or self.default_katex_template
+        )
+        self.latex_template = (
+            c.config.getString('view-rendered-latex-template')
+            or self.default_latex_template
+        )
+        self.mathjax_template = (
+            c.config.getString('view-rendered-mathjax-template')
+            or self.default_mathjax_template
+        )
     #@+node:ekr.20190614065659.1: *4* vr.create_pane
     def create_pane(self, parent: Position) -> None:
         """Create the VR pane."""
@@ -734,6 +809,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         s = self.remove_directives(s)
         # Dispatch based on the computed kind.
         kind = keywords.get('flags') if 'flags' in keywords else self.get_kind(p)
+        # g.trace('kind', repr(kind))
         if kind or keywords.get('force'):
             f = self.dispatch_dict.get(kind)
         else:
@@ -940,7 +1016,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             w.setPlainText('@image: file not found: %s' % (path))
             return
         path = path.replace('\\', '/')
-        template = image_template % (path)
+        template = self.image_template % (path)
         template = textwrap.dedent(template).strip()
         self.show()
         # w.setReadOnly(False)
@@ -989,7 +1065,30 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         except nbformat.reader.NotJSONError:
             pass  # Assume the result is html.
         return s
-    #@+node:ekr.20170324064811.1: *4* vr.update_latex (disabled)
+    #@+node:ekr.20241231121212.1: *4* vr.update_katex (new)
+    def update_katex(self, s: str, keywords: Any) -> None:
+        """Update katex text in the VR pane."""
+        p = self.c.p
+        g.trace(p.h)  ###
+
+        # Create a new QWebEngineView.
+        w = self.create_web_engineview()
+
+
+        # Compute the contents.
+        h = f"<h3>{p.h.strip()}</h3>\n\n"
+        if has_webengineview:
+            # # Replace whole-line latex comments with html comments.
+            # result_s = ''.join([
+                # f"<!-- {z} -->" if z.strip().startswith('%') else z
+                # for z in g.splitLines(s)
+            # ])
+            contents = self.katex_template + '\n\n' + h + s
+        else:
+            contents = h + s
+        w.setHtml(contents)
+        self.show()
+    #@+node:ekr.20170324064811.1: *4* vr.update_latex
     def update_latex(self, s: str, keywords: Any) -> None:
         """
         Update latex text in the VR pane.
@@ -1010,7 +1109,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 f"<!-- {z} -->" if z.strip().startswith('%') else z
                 for z in g.splitLines(s)
             ])
-            contents = mathjax_template + '\n\n' + h + result_s
+            contents = self.latex_template + '\n\n' + h + result_s
         else:
             contents = h + s
         w.setHtml(contents)
@@ -1031,7 +1130,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 f"<!-- {z} -->" if z.strip().startswith('%') else z
                 for z in g.splitLines(s)
             ])
-            contents = mathjax_template + '\n\n' + h + result_s
+            contents = self.mathjax_template + '\n\n' + h + result_s
         else:
             contents = h + s
         w.setHtml(contents)
@@ -1172,18 +1271,23 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Read the output file and return it.
         with open(o_path, 'r') as f:
             return f.read()
-    #@+node:ekr.20241226011006.1: *4* vr.update_pdf
+    #@+node:ekr.20241226011006.1: *4* vr.update_pdf (Disabled)
     def update_pdf(self, s: str, keywords: Any) -> None:
         """Update latex text in the VR pane."""
         p = self.c.p
         if not s.strip():
             return
-        lines = g.splitLines(s) or []
-        fn = lines and lines[0].strip()
-        if not fn:
-            g.trace(f"No file name in {p.h}")
-            self.hide()
-            return
+        if 1:  # New: create a temp file from p.gnx.
+
+            fn = f"{p.gnx}.pdf"
+        else:  # Legacy
+            lines = g.splitLines(s) or []
+            fn = lines and lines[0].strip()
+            if not fn:
+                g.trace(f"No file name in {p.h}")
+                self.hide()
+                return
+
         if not has_webengineview:
             g.trace('@pdf requires PyQt6-WebEngine')
             self.hide()
@@ -1191,9 +1295,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
         # Create a new QWebEngineView, deleting the old if it exists.
         w = self.create_web_engineview_with_pdf()
-
-        # Check the path.
-        ok, path = self.get_fn(fn, '@image')
+        ok, path = self.get_fn(fn, tag=None)
         if not ok:
             g.trace(f"@pdf: file not found: {path!r}")
             self.hide()
@@ -1202,7 +1304,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Create a URL to the file.
         url = QUrl.fromLocalFile(path)
         # https://www.rfc-editor.org/rfc/rfc8118
-        url.setFragment("zoom=200")
+        url.setFragment(f"zoom={self.pdf_zoom}")
         w.load(url)
         self.show()
     #@+node:ekr.20160928023915.1: *4* vr.update_pyplot
@@ -1307,7 +1409,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             f.write(s)
         pth_plantuml_jar = "~/.leo"
         os.system("cat temp.plantuml | java -jar %s/plantuml.jar -pipe > %s" % (pth_plantuml_jar, path))
-        template = image_template % (path)
+        template = self.image_template % (path)
         template = textwrap.dedent(template).strip()
         self.show()
         w.setReadOnly(False)
@@ -1423,6 +1525,39 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                     self.show()
                     w.load(path)
                     w.show()
+    #@+node:ekr.20241231121247.1: *4* vr.update_typst (new)
+    def update_typst(self, s: str, keywords: Any) -> None:
+        """Update mathhjax text in the VR pane."""
+        p = self.c.p
+
+        # Create a new QWebEngineView.
+        w = self.create_web_engineview_with_pdf()
+
+        # Compute the contents.
+        if not has_webengineview:
+            w.setHtml(s)
+            self.show()
+            return
+
+        ### h = f"=== {p.h.strip()}\n\n"
+
+        tex_path = g.os_path_finalize_join(os.getcwd(), f"{p.gnx}.tex")
+        pdf_path = tex_path.replace('.tex', '.pdf')
+        contents = s.strip() + '\n'
+        with open(tex_path, 'w') as f:
+            f.write(contents)
+            print(f"Wrote {tex_path}")
+
+        # Render and open.
+        g.execute_shell_commands([
+            f"typst compile {tex_path}",  # Invoke the typst app.
+        ])
+        # g.trace(f"Loading {pdf_path}")
+        url = QUrl.fromLocalFile(pdf_path)
+        # https://www.rfc-editor.org/rfc/rfc8118
+        url.setFragment(f"zoom={self.pdf_zoom}")
+        w.load(url)
+        self.show()
     #@+node:ekr.20110321005148.14537: *4* vr.update_url
     def update_url(self, s: str, keywords: Any) -> None:
         c, p = self.c, self.c.p
@@ -1535,7 +1670,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         c = self.c
         fn = s or c.p.h[len(tag) :]
         fn = fn.strip()
-        # Similar to code in g.computeFileUrl
+        # Similar to code in g.computeFileUrl.
         if fn.startswith('~'):
             fn = fn[1:]
             fn = g.finalize(fn)

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -281,17 +281,6 @@ try:
 except Exception:
     pyperclip = None
 
-# matplotlib, pyplot, numpy.
-got_pyplot = False
-try:
-    import matplotlib.pyplot as pyplot
-    import numpy as np
-    got_pyplot = True
-    assert np
-    assert pyplot
-except Exception:
-    pass
-
 # Fail fast, right after all imports.
 g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 #@-<< vr: imports >>
@@ -612,7 +601,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             'image': self.update_image,
             'jinja': self.update_jinja,
             'jupyter': self.update_jupyter,
-            'latex': self.update_latex,  # Doesn't work.
+            'latex': self.update_latex,
             'markdown': self.update_md,
             'mathjax': self.update_mathjax,
             'md': self.update_md,
@@ -754,8 +743,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return True
         if self.length != len(p.b):
             self.length = len(p.b)  # Suppress updates until next change.
-            if self.get_kind(p) == 'pyplot':
-                return False  # Only update explicitly.
             return True
         return False
     #@+node:ekr.20191004143229.1: *4* vr.update_asciidoc & helpers

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1126,7 +1126,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         s = ''.join([
             z for z in g.splitLines(s) if not z.strip().startswith('%')
         ])
-        contents = self.mathjax_template + '\n\n' + result_s
+        contents = self.mathjax_template + '\n\n' + s
         w.setHtml(contents)
         self.show()
     #@+node:peckj.20130207132858.3671: *4* vr.update_md & helper

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -747,7 +747,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return True
         if self.length != len(p.b):
             self.length = len(p.b)  # Suppress updates until next change.
-            if self.get_kind(p) in ('html', 'pyplot'):
+            if self.get_kind(p) == 'pyplot':
                 return False  # Only update explicitly.
             return True
         return False
@@ -914,8 +914,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                     result.append(line)
                 else:
                     result.append('<p>')  # Works only outside math mode!
+            # Do *not* replace \\: It would interfere with alignment!
             # Replacing \\ with <br> works outside of math mode!
-            result_s = ''.join(result).replace(r'\\', '<br>')
+            result_s = ''.join(result)
             contents = mathjax_template + '\n\n' + h + result_s
         else:
             contents = h + s

--- a/leo/test/test.leo
+++ b/leo/test/test.leo
@@ -673,16 +673,6 @@
 <v t="ekr.20241206101345.482"><vh>css</vh></v>
 </v>
 </v>
-<v t="ekr.20241206101345.483"><vh>Jupytext tests</vh>
-<v t="ekr.20241206101345.484"><vh>@button test.ipynb</vh></v>
-<v t="ekr.20241206101345.485"><vh>@jupytext C:/Users/Dev/EKR-Study/python/CODE_PYTHON/CH01/CH01_SEC02.ipynb</vh>
-<v t="ekr.20241206101345.486"><vh>&lt;&lt; prefix &gt;&gt;</vh></v>
-<v t="ekr.20241206101345.487"><vh>imports</vh></v>
-<v t="ekr.20241206101345.488"><vh>Graphs</vh></v>
-<v t="ekr.20241206101345.489"><vh>Images</vh></v>
-<v t="ekr.20241206101345.490"><vh>Figures 1 &amp; 2</vh></v>
-</v>
-</v>
 <v t="ekr.20241206101345.491"><vh>ai script</vh>
 <v t="ekr.20241206101345.492"><vh>function: summarize_and_reformat</vh></v>
 <v t="ekr.20241206101345.493"><vh>function: process_node_with_openai</vh></v>
@@ -13675,79 +13665,6 @@ p    {color: red;}
 &lt;/style&gt;
 
 </t>
-<t tx="ekr.20241206101345.483"># The</t>
-<t tx="ekr.20241206101345.484"># This @button script works only on EKR's machine.
-
-g.cls()
-g.cls()
-
-import os
-
-h = '@jupytext C:/Users/Dev/EKR-Study/python/CODE_PYTHON/CH01/CH01_SEC02.ipynb'
-root = g.findNodeAnywhere(c, h)
-assert root, h
-
-c.selectPosition(root)
-c.executeScript()
-</t>
-<t tx="ekr.20241206101345.485">&lt;&lt; prefix &gt;&gt;
-@others
-@language jupytext
-@tabwidth -4
-</t>
-<t tx="ekr.20241206101345.486"># ---
-# jupyter:
-#   jupytext:
-#     text_representation:
-#       extension: .py
-#       format_name: percent
-#       format_version: '1.3'
-#       jupytext_version: 1.16.4
-#   kernelspec:
-#     display_name: Python 3
-#     language: python
-#     name: python3
-# ---
-
-</t>
-<t tx="ekr.20241206101345.487"># %%
-
-from matplotlib.image import imread
-import matplotlib.pyplot as plt
-import numpy as np
-import os
-
-# c:/Users/Data is the data folder.</t>
-<t tx="ekr.20241206101345.488"># %%
-
-plt.rcParams['figure.figsize'] = [16, 8]
-A = imread(os.path.join('..', 'DATA', 'dog.jpg'))
-X = np.mean(A, -1); # Convert RGB to grayscale
-
-img = plt.imshow(X)
-img.set_cmap('gray')
-plt.axis('off')
-plt.show()
-
-</t>
-<t tx="ekr.20241206101345.489"># %%
-
-U, S, VT = np.linalg.svd(X,full_matrices=False)
-S = np.diag(S)
-
-j = 0
-for r in (5, 20, 100):
-    # Construct approximate image
-    Xapprox = U[:,:r] @ S[0:r,:r] @ VT[:r,:]
-    plt.figure(j+1)
-    j += 1
-    img = plt.imshow(Xapprox)
-    img.set_cmap('gray')
-    plt.axis('off')
-    plt.title('r = ' + str(r))
-    plt.show()
-
-</t>
 <t tx="ekr.20241206101345.49">def metadata_to_text(language_or_title, metadata=None, plain_json=False):
     """Write the cell metadata in the format key=value"""
     # Was metadata the first argument?
@@ -13778,19 +13695,6 @@ for r in (5, 20, 100):
             else:
                 text.append(f"{key}={dumps(metadata[key])}")
     return " ".join(text)
-</t>
-<t tx="ekr.20241206101345.490"># %%
-
-plt.figure(1)
-plt.semilogy(np.diag(S))
-plt.title('Singular Values')
-plt.show()
-
-plt.figure(2)
-plt.plot(np.cumsum(np.diag(S))/np.sum(np.diag(S)))
-plt.title('Singular Values: Cumulative Sum')
-plt.show()
-
 </t>
 <t tx="ekr.20241206101345.491">import leo.core.leoGlobals as g
 from openai import OpenAI


### PR DESCRIPTION
This PR enhances VR to render more kinds of nodes.

**Overview**

- Use `QWebEngineView` for more languages, with `pdf` support where necessary.
- Add support for `@language katex`, `@language mathjax`, and `@language typst`.
  `c.p.b` should contain the text to be rendered.
  - Delegate syntax coloring for these languages to `html`.
  - Add special cases for these language in `leo/modes/html.py`.
- Add `@data view-rendered-{kind}-template` for `kind` in `image`, `katex`, `latex`, `mathjax`, `typst`.
- Add support for `@pdf`. `c.p.b` should contain a path to a `pdf` file.
- Remove support for `@pandoc`.
- Many minor improvements and refactorings.

<details>
<br>

**Changes to the VR plugin**

- [x] Use `src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML">`
    in the mathjax template for maximum compatibility.
- [x] Use `white` as the background color in `<< vr: image template >>`.
- [x] Add `vr.create_web_engineview`, based on the same VR3 method. It allocates a singleton `qwv` instance.
- [x] Add `vr.create_web_engineview_with_pdf`.
- [x] Connect the `onClose` function and add the `vr.destroy_widgets` method.
- [x] Add support for `@language mathjax.
- [x] Add support for `@pdf` (`vr.update_pdf`), but the Qt code is not configurable enough to be very useful.
- [x] Remove support for `@pandoc`.
- [x] Remove support for `@language latex`, retaining the unused `update_latex` method.

**Minor changes**

- [x] `leoApp.py`: Delegate `@language mathjax` to `html` and use `html` comment delims for `@language mathjax`.
- [x] `leoGlobals.py`: Consider delegated languages to be valid `@language` languages.
- [x] `test.leo`: Remove references to files on EKR's machine. Unit tests failed when these files disappeared.
- [x] `modes/html.py`: Add special cases for when `@language mathjax` is in effect.

**About the weird VR3 behavior**

Using an instance of `QWebEngineView` to render mathjax caused the same weird messages as in VR3.
I tracked this message to a notification in the NVidia GE Force Experience app.
Disabling this notification sufficed. I have no idea why a link existed between the NVidia drivers and Qt.

</details>