### PR TITLE
PR for #4256: but in at.scanAllDirectives

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3060,11 +3060,11 @@ class AtFile:
             # No language directive.  Look for @<file> nodes.
             # Do *not* use d.get('language')!
             language = g.getLanguageFromAncestorAtFileNode(p) or 'python'
+
         at.language = language
         if delims in (None, (None, None, None)):  # #4256
             delims = g.set_delims_from_language(language)
 
-        # Previously, setting delims was sometimes skipped, depending on kwargs.
         #@+<< Set comment strings from delims >>
         #@+node:ekr.20080923070954.13: *5* << Set comment strings from delims >> (at.scanAllDirectives)
         delim1, delim2, delim3 = delims

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3048,7 +3048,7 @@ class AtFile:
         """
         at, c = self, self.c
         d = c.scanAllDirectives(p)
-        #
+
         # Language & delims: Tricky.
         lang_dict = d.get('lang-dict') or {}
         delims, language = None, None
@@ -3061,9 +3061,9 @@ class AtFile:
             # Do *not* use d.get('language')!
             language = g.getLanguageFromAncestorAtFileNode(p) or 'python'
         at.language = language
-        if not delims:
+        if delims in (None, (None, None, None)):  # #4256
             delims = g.set_delims_from_language(language)
-        #
+
         # Previously, setting delims was sometimes skipped, depending on kwargs.
         #@+<< Set comment strings from delims >>
         #@+node:ekr.20080923070954.13: *5* << Set comment strings from delims >> (at.scanAllDirectives)
@@ -3089,7 +3089,7 @@ class AtFile:
             at.startSentinelComment = "#"  # This should never happen!
             at.endSentinelComment = ""
         #@-<< Set comment strings from delims >>
-        #
+
         # Easy cases
         at.encoding = d.get('encoding') or c.config.default_derived_file_encoding
         lineending = d.get('lineending')


### PR DESCRIPTION
See #4256.

- [x] `at.scanAllDirectives`: Fix a tricky test for the presence of language delims.