### PR TITLE
PR: Improve @killcolor and the Rust colorizer

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -1990,6 +1990,11 @@
 <v t="ekr.20181018105748.1"><vh>viewrendered plugin</vh>
 <v t="ekr.20181018105800.1"><vh>@bool view-rendered-auto-create = False</vh></v>
 <v t="ekr.20240519122612.1"><vh>@bool view-rendered-keep-open = True</vh></v>
+<v t="ekr.20250102061338.1"><vh>@data view-rendered-image-template</vh></v>
+<v t="ekr.20250102061340.1"><vh>@data view-rendered-katex-template</vh></v>
+<v t="ekr.20250102061341.1"><vh>@data view-rendered-latex-template</vh></v>
+<v t="ekr.20250102061341.2"><vh>@data view-rendered-mathjax-template</vh></v>
+<v t="ekr.20250102062018.1"><vh>@data view-rendered-typst-template</vh></v>
 <v t="ekr.20181018113446.1"><vh>@string view-rendered-default-kind = rst</vh></v>
 <v t="ekr.20181018113502.1"><vh>@string view-rendered-md-extensions = extra</vh></v>
 </v>
@@ -2275,6 +2280,7 @@
 </v>
 </v>
 <v t="ekr.20140915194122.23428"></v>
+<v t="ekr.20181018105748.1"></v>
 </vnodes>
 <tnodes>
 <t tx="TL.20080702085131.2">If True: Save the Leo file and all modified derived files every time the external editor saves a modified file.
@@ -11016,7 +11022,8 @@ See https://jedi.readthedocs.io/en/latest/index.html
 <t tx="ekr.20181018105625.1"></t>
 <t tx="ekr.20181018105650.1"></t>
 <t tx="ekr.20181018105704.1"></t>
-<t tx="ekr.20181018105748.1"></t>
+<t tx="ekr.20181018105748.1">@language html
+</t>
 <t tx="ekr.20181018105800.1">True: open the VR pane automatically.</t>
 <t tx="ekr.20181018105904.1"></t>
 <t tx="ekr.20181018105945.1"></t>
@@ -11732,6 +11739,94 @@ See https://jupytext.readthedocs.io/en/latest/config.html
 # %%
 </t>
 <t tx="ekr.20241030020739.1">The maximum size of imported headlines.
+</t>
+<t tx="ekr.20250102061338.1"># The default html template for @image nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+&lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+ "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"&gt;
+&lt;html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"&gt;
+&lt;head&gt;&lt;/head&gt;
+&lt;body bgcolor=white&gt;
+&lt;img src="%s"&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</t>
+<t tx="ekr.20250102061340.1"># The default html template for @language katex nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+# Important: VR replaces [[body]] with the p.b.
+
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+    &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.css"
+        integrity="sha384-7lU0muIg/i1plk7MgygDUp3/bNRA65orrBub4/OSWHECgwEsY83HaS1x3bljA/XV"
+        crossorigin="anonymous"&gt;
+
+    &lt;!-- The loading of KaTeX is deferred to speed up page rendering --&gt;
+    &lt;script defer
+        src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/katex.min.js"
+        integrity="sha384-RdymN7NRJ+XoyeRY4185zXaxq9QWOOx3O7beyyrRK4KQZrPlCDQQpCu95FoCGPAE"
+        crossorigin="anonymous"&gt;&lt;/script&gt;
+
+    &lt;!-- To automatically render math in text elements, include the auto-render extension: --&gt;
+    &lt;script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.19/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"
+        onload="renderMathInElement(document.body);"&gt;
+    &lt;/script&gt;
+&lt;/head&gt;
+&lt;body&gt;
+[[body]]
+&lt;/body&gt;
+&lt;/html&gt;
+</t>
+<t tx="ekr.20250102061341.1"># The default html template for @language latex nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+\documentclass[12pt, letter-paper]{article}
+\usepackage{graphicx} % Images.
+\usepackage{tikz} % Evaluate expressions.
+\usepackage{hyperref} % For \href.
+\hypersetup{colorlinks=true, urlcolor=cyan}
+\urlstyle{same}
+\usepackage{pgfplots} % For inline plots.
+\usepackage{amsmath} % For alignment.
+\usepackage[
+    bindingoffset=0.2in, footskip=.25in,
+    left=0.5in, right=2.5in, top=0.5in, bottom=0.5in,
+]{geometry}
+
+\title{My Title}
+\author{A. U. Thor}
+\date{A long time ago}
+
+\pagenumbering{gobble}
+\setlength{\parskip}{6pt}
+\setlength{\parindent}{0pt}
+\pgfplotsset{compat=1.18}
+
+\begin{document}
+% \maketitle
+
+\section*{Section name}
+
+\end{document}
+</t>
+<t tx="ekr.20250102061341.2"># The default html template for @language mathjax nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
+&lt;head&gt;
+  &lt;script type="text/x-mathjax-config"&gt;
+    MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
+  &lt;/script&gt;
+  &lt;script type="text/javascript" async
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML"&gt;
+  &lt;/script&gt;
+&lt;/head&gt;
+</t>
+<t tx="ekr.20250102062018.1"># The default html template for @language typst nodes.
+# Blank lines and comments lines (lines starting with '#') are ignored.
+
 </t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2366,7 +2366,7 @@ class JEditColorizer(BaseColorizer):
             and end in "'\""
             and kind.startswith('literal')
         )
-        dots = dots and self.language not in ('lisp', 'elisp', 'rust', 'scheme')
+        dots = dots and self.language not in ('lisp', 'elisp', 'scheme')  #  'rust'
         if dots:
             kind = 'dots' + kind
         # A match

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1323,8 +1323,6 @@ class JEditColorizer(BaseColorizer):
         # Don't even *think* about changing state here.
         self.tot_time += time.process_time() - t1
     #@+node:ekr.20110605121601.18640: *3* jedit.recolor & helpers
-    tot_recolor_calls = 0
-
     def recolor(self, s: str) -> None:
         """
         jEdit.recolor: Recolor a *single* line, s.

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -17,8 +17,8 @@ properties = {
     "lineComment": "#",
 }
 
-#@+<< Attributes Dicts >>
-#@+node:ekr.20230419163615.1: ** << Attributes Dicts >>
+#@+<< Python attributes dicts >>
+#@+node:ekr.20230419163615.1: ** << Python attributes dicts >>
 
 # Attributes dict for python_main ruleset.
 python_main_attributes_dict = {
@@ -34,9 +34,9 @@ python_main_attributes_dict = {
 attributesDictDict = {
     "python_main": python_main_attributes_dict,
 }
-#@-<< Attributes Dicts >>
-#@+<< Keywords Dicts >>
-#@+node:ekr.20230419163648.1: ** << Keywords Dicts >>
+#@-<< Python attributes dicts >>
+#@+<< Python keywords dicts >>
+#@+node:ekr.20230419163648.1: ** << Python keywords dicts >>
 # Keywords dict for python_main ruleset.
 python_main_keywords_dict = {
     "ArithmeticError": "keyword3",
@@ -309,9 +309,10 @@ python_main_keywords_dict = {
 keywordsDictDict = {
     "python_main": python_main_keywords_dict,
 }
-#@-<< Keywords Dicts >>
+#@-<< Python keywords dicts >>
+#@+<< Python rules >>
+#@+node:ekr.20230419163736.1: ** << Python rules >>
 #@+others
-#@+node:ekr.20230419163736.1: ** Python rules
 #@+node:ekr.20230419163819.1: *3* python_comment
 def python_comment(colorer, s, i):
     """
@@ -423,8 +424,9 @@ def python_single_quote(colorer, s, i):
 def python_single_quote_docstring(colorer, s, i):
     return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''")
 #@-others
-#@+<< Rules Dicts >>
-#@+node:ekr.20230419164059.1: ** << Rules Dicts >>
+#@-<< Python rules >>
+#@+<< Python rules dicts >>
+#@+node:ekr.20230419164059.1: ** << Python rules dicts >>
 # Rules dict for python_main ruleset.
 rulesDict1 = {
     # Operators of length 1.
@@ -450,7 +452,6 @@ rulesDict1 = {
     "#": [python_comment],
 
     # Numbers...
-    "@": [python_keyword],  # A special case.
     ".": [python_number],
     "0": [python_number],
     "1": [python_number],
@@ -462,62 +463,16 @@ rulesDict1 = {
     "7": [python_number],
     "8": [python_number],
     "9": [python_number],
-
-    # names or keywords.
-    "A": [python_keyword],
-    "B": [python_keyword],
-    "C": [python_keyword],
-    "D": [python_keyword],
-    "E": [python_keyword],
-    "F": [python_keyword],  # python_f_url
-    "G": [python_keyword],
-    "H": [python_keyword],  # python_h_url
-    "I": [python_keyword],
-    "J": [python_keyword],
-    "K": [python_keyword],
-    "L": [python_keyword],
-    "M": [python_keyword],
-    "N": [python_keyword],
-    "O": [python_keyword],
-    "P": [python_keyword],
-    "Q": [python_keyword],
-    "R": [python_keyword],  # python_f_url
-    "S": [python_keyword],
-    "T": [python_keyword],
-    "U": [python_keyword],
-    "V": [python_keyword],
-    "W": [python_keyword],
-    "X": [python_keyword],
-    "Y": [python_keyword],
-    "Z": [python_keyword],
-    "_": [python_keyword],
-    "a": [python_keyword],
-    "b": [python_keyword],
-    "c": [python_keyword],
-    "d": [python_keyword],
-    "e": [python_keyword],
-    "f": [python_keyword],  # python_f_url
-    "g": [python_keyword],
-    "h": [python_keyword],  # python_h_url
-    "i": [python_keyword],
-    "j": [python_keyword],
-    "k": [python_keyword],
-    "l": [python_keyword],
-    "m": [python_keyword],
-    "n": [python_keyword],
-    "o": [python_keyword],
-    "p": [python_keyword],
-    "q": [python_keyword],
-    "r": [python_keyword],
-    "s": [python_keyword],
-    "t": [python_keyword],
-    "u": [python_keyword],
-    "v": [python_keyword],
-    "w": [python_keyword],
-    "x": [python_keyword],
-    "y": [python_keyword],
-    "z": [python_keyword],
 }
+
+# Prepend entries for python_keyword to rulesDict1.
+lead_ins = list(sorted(set(key[0] for key in python_main_keywords_dict)))
+# print('python lead-ins', lead_ins)
+for lead_in in lead_ins:
+    aList = rulesDict1.get(lead_in, [])
+    if python_keyword not in aList:
+        aList.insert(0, python_keyword)
+        rulesDict1[lead_in] = aList
 
 if False:  # #3770: Revert colorizing of PEP 701 f-strings.
     if (v1, v2) >= (3, 12):
@@ -529,7 +484,7 @@ if False:  # #3770: Revert colorizing of PEP 701 f-strings.
 rulesDictDict = {
     "python_main": rulesDict1,
 }
-#@-<< Rules Dicts >>
+#@-<< Python rules dicts >>
 
 # Import dict for python mode.
 importDict = {}

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -3,7 +3,6 @@
 # Leo colorizer control file for rust mode.
 # This file is in the public domain.
 
-import re
 from leo.core import leoGlobals as g
 
 #@+<< Rust properties dict >>
@@ -302,8 +301,9 @@ lead_ins = list(sorted(set(key[0] for key in rust_main_keywords_dict)))
 # print('rust lead-ins', lead_ins)
 for lead_in in lead_ins:
     aList = rulesDict1.get(lead_in, [])
-    aList.insert(0, rust_keywords)
-    rulesDict1[lead_in] = aList
+    if rust_keywords not in aList:
+        aList.insert(0, rust_keywords)
+        rulesDict1[lead_in] = aList
 
 # g.printObj(rulesDict1, tag='rulesDict1')
 

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -5,9 +5,7 @@
 
 import re
 
-#@+<< Rust dictionaries >>
-#@+node:ekr.20231103125350.1: ** << Rust dictionaries >>
-# Properties for c mode.
+# Properties for rust mode.
 properties = {
     "commentEnd": "*/",
     "commentStart": "/*",
@@ -20,7 +18,9 @@ properties = {
     "wordBreakChars": ",+-=<>/?^&*",
 }
 
-# Attributes dict for c_main ruleset.
+#@+<< Rust attributes dicts >>
+#@+node:ekr.20250105164117.1: ** << Rust attributes dicts >>
+# Attributes dict for rust_main ruleset.
 rust_main_attributes_dict = {
     "default": "null",
     "digit_re": "(0x[[:xdigit:]_]+[lL]?|[[:digit:]_]+(e[[:digit:]]*)?[lLdDfF]?)",
@@ -30,91 +30,13 @@ rust_main_attributes_dict = {
     "no_word_sep": "",
 }
 
-# Dictionary of attributes dictionaries for c mode.
+# Dictionary of attributes dictionaries for rust mode.
 attributesDictDict = {
     "rust_main": rust_main_attributes_dict,
 }
-
-# Keywords dict for c_main ruleset.
-rust_main_keywords_dict = {
-    'Self': 'keyword1',
-    'abstract': 'keyword1',
-    'as': 'keyword1',
-    'async': 'keyword1',
-    'become': 'keyword1',
-    'bool': 'keyword2',
-    'box': 'keyword1',
-    'break': 'keyword1',
-    'const': 'keyword1',
-    'continue': 'keyword1',
-    'crate': 'keyword1',
-    'do': 'keyword1',
-    'dyn': 'keyword1',
-    'else': 'keyword1',
-    'enum': 'keyword1',
-    'extern': 'keyword1',
-    'false': 'keyword1',
-    'final': 'keyword1',
-    'fn': 'keyword1',
-    'for': 'keyword1',
-    'i16': 'keyword2',
-    'i32': 'keyword2',
-    'i64': 'keyword2',
-    'i8': 'keyword2',
-    'if': 'keyword1',
-    'impl': 'keyword1',
-    'in': 'keyword1',
-    'let': 'keyword1',
-    'loop': 'keyword1',
-    'macro': 'keyword1',
-    'match': 'keyword1',
-    'mod': 'keyword1',
-    'move': 'keyword1',
-    'mut': 'keyword1',
-    'override': 'keyword1',
-    'priv': 'keyword1',
-    'pub': 'keyword1',
-    'ref': 'keyword1',
-    'return': 'keyword1',
-    'self': 'keyword1',
-    'static': 'keyword1',
-    'str': 'keyword2',
-    'struct': 'keyword1',
-    'super': 'keyword1',
-    'trait': 'keyword1',
-    'true': 'keyword1',
-    'try': 'keyword1',
-    'type': 'keyword1',
-    'typeof': 'keyword1',
-    'u16': 'keyword2',
-    'u32': 'keyword2',
-    'u64': 'keyword2',
-    'u8': 'keyword2',
-    'unsafe': 'keyword1',
-    'unsized': 'keyword1',
-    'use': 'keyword1',
-    'usize': 'keyword2',
-    'vec!': 'keyword2',
-    'virtual': 'keyword1',
-    'where': 'keyword1',
-    'while': 'keyword1',
-    'yield': 'keyword1',
-    'Some': 'keyword3',
-    'None': 'keyword3',
-    'Result': 'keyword3',
-    'Err': 'keyword3',
-    'Ok': 'keyword3',
-    'include_bytes': 'keyword2',
-    'include_str': 'keyword2',
-}
-
-
-# Dictionary of keywords dictionaries for c mode.
-keywordsDictDict = {
-    "rust_main": rust_main_keywords_dict,
-}
-#@-<< Rust dictionaries >>
-
+#@-<< Rust attributes dicts >>
+#@+<< Rust rules >>
+#@+node:ekr.20250105163810.1: ** << Rust rules >>
 # Rules for rust_main ruleset.
 
 def rust_rule0(colorer, s, i):
@@ -239,8 +161,88 @@ def rust_rule26(colorer, s, i):
 
 def rust_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@-<< Rust rules >>
+#@+<< Rust dictionaries >>
+#@+node:ekr.20231103125350.1: ** << Rust dictionaries >>
+# Keywords dict for rust_main ruleset.
+rust_main_keywords_dict = {
+    'Self': 'keyword1',
+    'abstract': 'keyword1',
+    'as': 'keyword1',
+    'async': 'keyword1',
+    'become': 'keyword1',
+    'bool': 'keyword2',
+    'box': 'keyword1',
+    'break': 'keyword1',
+    'const': 'keyword1',
+    'continue': 'keyword1',
+    'crate': 'keyword1',
+    'do': 'keyword1',
+    'dyn': 'keyword1',
+    'else': 'keyword1',
+    'enum': 'keyword1',
+    'extern': 'keyword1',
+    'false': 'keyword1',
+    'final': 'keyword1',
+    'fn': 'keyword1',
+    'for': 'keyword1',
+    'i16': 'keyword2',
+    'i32': 'keyword2',
+    'i64': 'keyword2',
+    'i8': 'keyword2',
+    'if': 'keyword1',
+    'impl': 'keyword1',
+    'in': 'keyword1',
+    'let': 'keyword1',
+    'loop': 'keyword1',
+    'macro': 'keyword1',
+    'match': 'keyword1',
+    'mod': 'keyword1',
+    'move': 'keyword1',
+    'mut': 'keyword1',
+    'override': 'keyword1',
+    'priv': 'keyword1',
+    'pub': 'keyword1',
+    'ref': 'keyword1',
+    'return': 'keyword1',
+    'self': 'keyword1',
+    'static': 'keyword1',
+    'str': 'keyword2',
+    'struct': 'keyword1',
+    'super': 'keyword1',
+    'trait': 'keyword1',
+    'true': 'keyword1',
+    'try': 'keyword1',
+    'type': 'keyword1',
+    'typeof': 'keyword1',
+    'u16': 'keyword2',
+    'u32': 'keyword2',
+    'u64': 'keyword2',
+    'u8': 'keyword2',
+    'unsafe': 'keyword1',
+    'unsized': 'keyword1',
+    'use': 'keyword1',
+    'usize': 'keyword2',
+    'vec!': 'keyword2',
+    'virtual': 'keyword1',
+    'where': 'keyword1',
+    'while': 'keyword1',
+    'yield': 'keyword1',
+    'Some': 'keyword3',
+    'None': 'keyword3',
+    'Result': 'keyword3',
+    'Err': 'keyword3',
+    'Ok': 'keyword3',
+    'include_bytes': 'keyword2',
+    'include_str': 'keyword2',
+}
 
-# Rules dict for c_main ruleset.
+# Dictionary of keywords dictionaries for rust mode.
+keywordsDictDict = {
+    "rust_main": rust_main_keywords_dict,
+}
+
+# Rules dict for rust.
 rulesDict1 = {
     "!": [rust_rule9],
     "\"": [rust_rule3],
@@ -340,7 +342,6 @@ rulesDict1 = {
     "~": [rust_rule22],
 }
 
-
 # x.rulesDictDict for rust mode.
 rulesDictDict = {
     "rust_main": rulesDict1,
@@ -348,4 +349,5 @@ rulesDictDict = {
 
 # Import dict for rust mode.
 importDict = {}
+#@-<< Rust dictionaries >>
 #@-leo

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -307,14 +307,16 @@ def rust_keywords(colorer, s, i):
 #@+node:ekr.20231103125350.1: ** << Rust rules dicts >>
 # Rules dict for rust.
 rulesDict1 = {
-    "!": [rust_rule9],
+    # New rules...
+    ">": [rust_close_angle],
+    "'": [rust_char],
+    "<": [rust_open_angle],
     "#": [rust_pound],
+    "r": [rust_raw_string_literal],
     "/": [rust_slash],
-    "r": [rust_raw_string_literal],  # New.
-    '"': [rust_string],  # New.
-    "'": [rust_char],  # New.
-    "<": [rust_open_angle],  # New.
-    ">": [rust_close_angle],  # New.
+    '"': [rust_string],
+    # Existing rules...
+    "!": [rust_rule9],
     "&": [rust_rule19],
     "%": [rust_rule18],
     "(": [rust_rule26],

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -4,7 +4,10 @@
 # This file is in the public domain.
 
 import re
+from leo.core import leoGlobals as g
 
+#@+<< Rust properties dict >>
+#@+node:ekr.20250106042726.1: ** << Rust properties dict >>
 # Properties for rust mode.
 properties = {
     "commentEnd": "*/",
@@ -17,7 +20,7 @@ properties = {
     "lineUpClosingBracket": "true",
     "wordBreakChars": ",+-=<>/?^&*",
 }
-
+#@-<< Rust properties dict >>
 #@+<< Rust attributes dicts >>
 #@+node:ekr.20250105164117.1: ** << Rust attributes dicts >>
 # Attributes dict for rust_main ruleset.
@@ -35,135 +38,8 @@ attributesDictDict = {
     "rust_main": rust_main_attributes_dict,
 }
 #@-<< Rust attributes dicts >>
-#@+<< Rust rules >>
-#@+node:ekr.20250105163810.1: ** << Rust rules >>
-# Rules for rust_main ruleset.
-
-def rust_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
-          delegate="doxygen::doxygen")
-
-def rust_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
-          delegate="doxygen::doxygen")
-
-def rust_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
-
-def rust_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"")
-
-# A single quote does not always denote a character literal.
-
-# These patterns are the same as in the rust importer:
-
-char10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
-char6_pat = re.compile(r"'\\x[0-7][0-7a-fA-F]'")  # '\x7F'
-char4_pat = re.compile(r"'\\[\\\"'nrt0]'")  # '\n', '\r', '\t', '\\', '\0', '\'', '\"'
-char3_pat = re.compile(r"'.'", re.UNICODE)  # 'x' where x is any unicode character.
-
-def rust_char10(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="literal2", begin=char10_pat)
-
-def rust_char6(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="literal2", begin=char6_pat)
-
-def rust_char4(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="literal2", begin=char4_pat)
-
-def rust_char3(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="literal2", begin=char3_pat)
-
-# #3631
-# https://doc.rust-lang.org/reference/tokens.html#raw-string-literals
-# Up to 255 '#' are allowed. Ruff only uses 1 and 3.
-
-def rust_raw_string_literal3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin='r###"', end='"###')
-
-def rust_raw_string_literal2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin='r##"', end='"##')
-
-def rust_raw_string_literal1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin='r#"', end='"#')
-
-def rust_at_operator(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
-
-def rust_rule5(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
-
-def rust_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
-
-def rust_rule7(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
-
-def rust_rule8(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
-
-def rust_rule9(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
-
-def rust_rule10(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
-
-def rust_rule11(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
-
-def rust_rule12(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
-
-def rust_rule13(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
-
-def rust_rule14(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
-
-def rust_rule15(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
-
-def rust_rule16(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
-
-def rust_rule17(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
-
-def rust_rule18(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
-
-def rust_rule19(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
-
-def rust_rule20(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
-
-def rust_rule21(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
-
-def rust_rule22(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
-
-def rust_rule23(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
-
-def rust_rule24(colorer, s, i):
-    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
-
-def rust_rule25(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-          at_whitespace_end=True,
-          exclude_match=True)
-
-def rust_rule26(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
-          exclude_match=True)
-
-def rust_rule27(colorer, s, i):
-    return colorer.match_keywords(s, i)
-#@-<< Rust rules >>
-#@+<< Rust dictionaries >>
-#@+node:ekr.20231103125350.1: ** << Rust dictionaries >>
+#@+<< Rust keywords dicts >>
+#@+node:ekr.20250106043953.1: ** << Rust keywords dicts >>
 # Keywords dict for rust_main ruleset.
 rust_main_keywords_dict = {
     'Self': 'keyword1',
@@ -241,113 +117,195 @@ rust_main_keywords_dict = {
 keywordsDictDict = {
     "rust_main": rust_main_keywords_dict,
 }
+#@-<< Rust keywords dicts >>
+#@+<< Rust rules >>
+#@+node:ekr.20250105163810.1: ** << Rust rules >>
+# Rules for rust_main ruleset.
+#@+others
+#@+node:ekr.20250106042808.1: *3* function: rust_rule0
+def rust_rule0(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
+          delegate="doxygen::doxygen")
+#@+node:ekr.20250106042808.2: *3* function: rust_rule1
+def rust_rule1(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
+          delegate="doxygen::doxygen")
+#@+node:ekr.20250106042808.3: *3* function: rust_rule2
+def rust_rule2(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
+#@+node:ekr.20250106052237.1: *3* function: rust_string (to do: char escapes)
+def rust_string(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"")
+#@+node:ekr.20250106042808.5: *3* function: rust_char
+# A single quote does not always denote a character literal.
 
+# These patterns are the same as in the rust importer:
+
+char10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")  # '\u{7FFF}'
+char6_pat = re.compile(r"'\\x[0-7][0-7a-fA-F]'")  # '\x7F'
+char4_pat = re.compile(r"'\\[\\\"'nrt0]'")  # '\n', '\r', '\t', '\\', '\0', '\'', '\"'
+char3_pat = re.compile(r"'.'", re.UNICODE)  # 'x' where x is any unicode character.
+
+def rust_char(colorer, s, i):
+    if i + 1 >= len(s):
+        return len(s)
+    if i + 1 == '\\':
+        for pat in char10_pat, char6_pat, char4_pat, char3_pat:
+            if pat.match(s, i):
+                return colorer.match_span_regexp(s, i, kind="literal2", begin=pat)
+    return i + 1
+
+# def rust_char10(colorer, s, i):
+    # return colorer.match_span_regexp(s, i, kind="literal2", begin=char10_pat)
+# def rust_char6(colorer, s, i):
+    # return colorer.match_span_regexp(s, i, kind="literal2", begin=char6_pat)
+# def rust_char4(colorer, s, i):
+    # return colorer.match_span_regexp(s, i, kind="literal2", begin=char4_pat)
+# def rust_char3(colorer, s, i):
+    # return colorer.match_span_regexp(s, i, kind="literal2", begin=char3_pat)
+#@+node:ekr.20250106042808.9: *3* function: rust_raw_string_literal
+# #3631
+# https://doc.rust-lang.org/reference/tokens.html#raw-string-literals
+# Up to 255 '#' are allowed. Ruff only uses 1 and 3.
+
+def rust_raw_string_literal(colorer, s, i):
+    if i + 1 >= len(s):
+        return len(s)
+    if s[i + 1] != '#':
+        return i + 1
+    for n in (3, 2, 1):
+        begin = 'r' + '#' * n
+        end = '#' * n
+        if g.match(s, i, begin):
+            return colorer.match_span(s, i, kind="literal2", begin=begin, end=end)
+    return i + 1
+
+# def rust_raw_string_literal3(colorer, s, i):
+    # return colorer.match_span(s, i, kind="literal2", begin='r###"', end='"###')
+# def rust_raw_string_literal2(colorer, s, i):
+    # return colorer.match_span(s, i, kind="literal2", begin='r##"', end='"##')
+# def rust_raw_string_literal1(colorer, s, i):
+    # return colorer.match_span(s, i, kind="literal2", begin='r#"', end='"#')
+#@+node:ekr.20250106042808.12: *3* function: rust_at_operator
+def rust_at_operator(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
+#@+node:ekr.20250106042808.13: *3* function: rust_rule5
+def rust_rule5(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
+#@+node:ekr.20250106042808.14: *3* function: rust_rule6
+def rust_rule6(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
+#@+node:ekr.20250106042808.15: *3* function: rust_rule7
+def rust_rule7(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
+#@+node:ekr.20250106042808.16: *3* function: rust_rule8
+def rust_rule8(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
+#@+node:ekr.20250106042808.17: *3* function: rust_rule9
+def rust_rule9(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
+#@+node:ekr.20250106042808.18: *3* function: rust_rule10
+def rust_rule10(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
+#@+node:ekr.20250106042808.19: *3* function: rust_rule11
+def rust_rule11(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
+#@+node:ekr.20250106042808.20: *3* function: rust_rule12
+def rust_rule12(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
+#@+node:ekr.20250106042808.21: *3* function: rust_rule13
+def rust_rule13(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
+#@+node:ekr.20250106042808.22: *3* function: rust_rule14
+def rust_rule14(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
+#@+node:ekr.20250106042808.23: *3* function: rust_rule15
+def rust_rule15(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
+#@+node:ekr.20250106042808.24: *3* function: rust_rule16
+def rust_rule16(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
+#@+node:ekr.20250106042808.25: *3* function: rust_rule17
+def rust_rule17(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
+#@+node:ekr.20250106042808.26: *3* function: rust_rule18
+def rust_rule18(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
+#@+node:ekr.20250106042808.27: *3* function: rust_rule19
+def rust_rule19(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
+#@+node:ekr.20250106042808.28: *3* function: rust_rule20
+def rust_rule20(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
+#@+node:ekr.20250106042808.29: *3* function: rust_rule21
+def rust_rule21(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
+#@+node:ekr.20250106042808.30: *3* function: rust_rule22
+def rust_rule22(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
+#@+node:ekr.20250106042808.31: *3* function: rust_rule23
+def rust_rule23(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
+#@+node:ekr.20250106042808.32: *3* function: rust_rule24
+def rust_rule24(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
+#@+node:ekr.20250106042808.33: *3* function: rust_rule25
+def rust_rule25(colorer, s, i):
+    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
+          at_whitespace_end=True,
+          exclude_match=True)
+#@+node:ekr.20250106042808.34: *3* function: rust_rule26
+def rust_rule26(colorer, s, i):
+    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
+          exclude_match=True)
+#@+node:ekr.20250106042808.35: *3* function: rust_keywords
+def rust_keywords(colorer, s, i):
+    return colorer.match_keywords(s, i)
+#@-others
+#@-<< Rust rules >>
+#@+<< Rust rules dicts >>
+#@+node:ekr.20231103125350.1: ** << Rust rules dicts >>
 # Rules dict for rust.
 rulesDict1 = {
     "!": [rust_rule9],
-    "\"": [rust_rule3],
+    ### "\"": [rust_rule3],
     "#": [rust_rule5, rust_rule6],
-    "%": [rust_rule18],
+    "/": [rust_rule0, rust_rule1, rust_rule2, rust_rule7, rust_rule14],  ### To do.
+    "r": [rust_raw_string_literal],  # New.
+    '"': [rust_string],  # New.
+    "'": [rust_char],  # New.
     "&": [rust_rule19],
-
-    "'": [
-        rust_char10,
-        rust_char6,
-        rust_char4,
-        rust_char3,
-    ],
-
+    "%": [rust_rule18],
     "(": [rust_rule26],
     "*": [rust_rule15],
     "+": [rust_rule12],
     "-": [rust_rule13],
-    "/": [rust_rule0, rust_rule1, rust_rule2, rust_rule7, rust_rule14],
-    "0": [rust_rule27],
-    "1": [rust_rule27],
-    "2": [rust_rule27],
-    "3": [rust_rule27],
-    "4": [rust_rule27],
-    "5": [rust_rule27],
-    "6": [rust_rule27],
-    "7": [rust_rule27],
-    "8": [rust_rule27],
-    "9": [rust_rule27],
     ":": [rust_rule25],
     "<": [rust_rule11, rust_rule17],
     "=": [rust_rule8],
     ">": [rust_rule10, rust_rule16],
     "@": [rust_at_operator],
-    "A": [rust_rule27],
-    "B": [rust_rule27],
-    "C": [rust_rule27],
-    "D": [rust_rule27],
-    "E": [rust_rule27],
-    "F": [rust_rule27],
-    "G": [rust_rule27],
-    "H": [rust_rule27],
-    "I": [rust_rule27],
-    "J": [rust_rule27],
-    "K": [rust_rule27],
-    "L": [rust_rule27],
-    "M": [rust_rule27],
-    "N": [rust_rule27],
-    "O": [rust_rule27],
-    "P": [rust_rule27],
-    "Q": [rust_rule27],
-    "R": [rust_rule27],
-    "S": [rust_rule27],
-    "T": [rust_rule27],
-    "U": [rust_rule27],
-    "V": [rust_rule27],
-    "W": [rust_rule27],
-    "X": [rust_rule27],
-    "Y": [rust_rule27],
-    "Z": [rust_rule27],
     "^": [rust_rule21],
-    "_": [rust_rule27],
-    "a": [rust_rule27],
-    "b": [rust_rule27],
-    "c": [rust_rule27],
-    "d": [rust_rule27],
-    "e": [rust_rule27],
-    "f": [rust_rule27],
-    "g": [rust_rule27],
-    "h": [rust_rule27],
-    "i": [rust_rule27],
-    "j": [rust_rule27],
-    "k": [rust_rule27],
-    "l": [rust_rule27],
-    "m": [rust_rule27],
-    "n": [rust_rule27],
-    "o": [rust_rule27],
-    "p": [rust_rule27],
-    "q": [rust_rule27],
-    "r": [
-        rust_raw_string_literal3,
-        rust_raw_string_literal2,
-        rust_raw_string_literal1,
-        rust_rule27,
-    ],
-    "s": [rust_rule27],
-    "t": [rust_rule27],
-    "u": [rust_rule27],
-    "v": [rust_rule27],
-    "w": [rust_rule27],
-    "x": [rust_rule27],
-    "y": [rust_rule27],
-    "z": [rust_rule27],
     "{": [rust_rule24],
     "|": [rust_rule20],
     "}": [rust_rule23],
     "~": [rust_rule22],
 }
 
+# Prepend entries for rust_keyword to rulesDict1.
+lead_ins = list(sorted(set(key[0] for key in rust_main_keywords_dict)))
+# print('rust lead-ins', lead_ins)
+for lead_in in lead_ins:
+    aList = rulesDict1.get(lead_in, [])
+    aList.insert(0, rust_keywords)
+    rulesDict1[lead_in] = aList
+
 # x.rulesDictDict for rust mode.
 rulesDictDict = {
     "rust_main": rulesDict1,
 }
+#@-<< Rust rules dicts >>
 
 # Import dict for rust mode.
 importDict = {}
-#@-<< Rust dictionaries >>
 #@-leo

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -151,7 +151,7 @@ def rust_slash(colorer, s, i):
     # Fail.
     return i + 1
 #@+node:ekr.20250106062326.1: *3* rust: strings and chars, with escapes
-#@+node:ekr.20250106062904.1: *4* function: get_escaped_char (more work needed!)
+#@+node:ekr.20250106062904.1: *4* function: get_escaped_char
 # '\u{7FFF}'
 char10_pat = re.compile(r"'\\u\{[0-7][0-7a-fA-F]{3}\}'")
 # '\x7F'
@@ -172,11 +172,11 @@ def get_escaped_char(s, i) -> str:
     for pat in char10_pat, char6_pat, char4_pat, char3_pat, char2_pat:
         m = pat.match(s, i)
         if m:
-            # g.trace(m.group(0))
             return m.group(0)
-    # Colorize the starting single quote.
+
+    # Return the opening single quote.
     return "'"
-#@+node:ekr.20250106042808.5: *4* function: rust_char
+#@+node:ekr.20250106042808.5: *4* function: rust_char (** inaccurate)
 def rust_char(colorer, s, i):
     """Colorizer a Rust character literal."""
     if s[i] != "'":
@@ -188,7 +188,7 @@ def rust_char(colorer, s, i):
     # Unterminated character.
     # This is inaccurate: the restarter does not handle escapes!
     return colorer.match_span(s, i, kind="literal2", begin="'", end="'")
-#@+node:ekr.20250106052237.1: *4* function: rust_string (to do: char escapes)
+#@+node:ekr.20250106052237.1: *4* function: rust_string (** inaccurate)
 def rust_string(colorer, s, i):
     if s[i] != '"':
         return 0
@@ -216,7 +216,7 @@ def rust_raw_string_literal(colorer, s, i):
         return len(s)
     if s[i + 1] != '#':
         return i + 1
-    for n in (3, 2, 1):
+    for n in (4, 3, 2, 1):
         begin = 'r' + '#' * n
         end = '#' * n
         if g.match(s, i, begin):

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -177,8 +177,8 @@ def get_escaped_char(s, i):
 
 # These patterns are the same as in the rust importer:
 def rust_char(colorer, s, i):
-    ### assert s[i] == "'"
-    g.trace(s[i:])  ###
+    if s[i] != "'":
+        return 0
     if i + 1 >= len(s):
         return len(s)
     if i + 1 == '\\':
@@ -316,21 +316,21 @@ rulesDict1 = {
     "/": [rust_slash],
     '"': [rust_string],
     # Existing rules...
+    "@": [rust_at_operator],
+    "=": [rust_rule8],
     "!": [rust_rule9],
-    "&": [rust_rule19],
-    "%": [rust_rule18],
-    "(": [rust_rule26],
-    "*": [rust_rule15],
     "+": [rust_rule12],
     "-": [rust_rule13],
-    ":": [rust_rule25],
-    "=": [rust_rule8],
-    "@": [rust_at_operator],
-    "^": [rust_rule21],
-    "{": [rust_rule24],
+    "*": [rust_rule15],
+    "%": [rust_rule18],
+    "&": [rust_rule19],
     "|": [rust_rule20],
-    "}": [rust_rule23],
+    "^": [rust_rule21],
     "~": [rust_rule22],
+    "}": [rust_rule23],
+    "{": [rust_rule24],
+    ":": [rust_rule25],
+    "(": [rust_rule26],
 }
 
 # Prepend entries for rust_keyword to rulesDict1.

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -197,6 +197,22 @@ def rust_char(colorer, s, i):
     # return colorer.match_span_regexp(s, i, kind="literal2", begin=char3_pat)
 #@+node:ekr.20250106052237.1: *4* function: rust_string (to do: char escapes)
 def rust_string(colorer, s, i):
+    if s[i] != '"':
+        return 0
+    if 0:
+        j = i + 1
+        kind = 'literal2'
+        while j < len(s):
+            progress = j
+            if s[j] == "'":
+                seq = get_escaped_char(s, j)
+                j += len(seq)
+            elif s[j] == '"':
+                return colorer.match_seq(s, i, kind=kind, seq=s[i : j + 1])
+            else:
+                j += 1
+            assert progress < j, repr(s[j])
+    ### Does not handle escapes in continued strings.
     return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"")
 #@+node:ekr.20250106042808.9: *3* function: rust_raw_string_literal
 # #3631

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -687,24 +687,20 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.default_kind = c.config.getString('view-rendered-default-kind') or 'rst'
         self.pdf_zoom = c.config.getInt('view-rendered-pdf-zoom') or 100
 
-        # Templates
-        self.image_template = (
-            c.config.getString('view-rendered-image-template')
-            or self.default_image_template
-        )
-        self.katex_template = (
-            c.config.getString('view-rendered-katex-template')
-            or self.default_katex_template
-        )
-        self.latex_template = (
-            c.config.getString('view-rendered-latex-template')
-            or self.default_latex_template
-        )
-        self.mathjax_template = (
-            c.config.getString('view-rendered-mathjax-template')
-            or self.default_mathjax_template
-        )
-        self.typst_template = c.config.getString('view-rendered-typst-template') or ''
+        # Templates...
+
+        def get_template(kind: str) -> str:
+            setting_name = f"view-rendered-{kind}-template"
+            aList = c.config.getData(setting_name, strip_comments=True, strip_data=True)
+            if aList is None:
+                return getattr(self, f"default_{kind}_template")
+            return '\n'.join(aList)
+
+        self.image_template = get_template('image')
+        self.katex_template = get_template('katex')
+        self.latex_template = get_template('latex')
+        self.mathjax_template = get_template('mathjax')
+        self.typst_template = get_template('typst')
     #@+node:ekr.20190614065659.1: *4* vr.create_pane
     def create_pane(self, parent: Position) -> None:
         """Create the VR pane."""

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -789,7 +789,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     # Must have this signature: called by leoPlugins.callTagHandler.
 
     def update(self, tag: str, keywords: Any) -> None:  # type:ignore
-        """Update the VR pane. Called at idle time."""
+        """
+        vr.update: Update the VR pane.
+        Called at idle time and by the vr-update command.
+        """
         p = self.c.p
         if not self.active:
             try:
@@ -845,10 +848,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.qwv = self.w = w = qwv()
         self.embed_widget(w)
         if isinstance(w, QtWidgets.QTextBrowser):
-            g.print_unique_message(
-                'VR can not render latex or mathjax:\n'
-                'pip install PyQt6-WebEngine\n'
-            )
             return w
 
         # Allow remote access.
@@ -975,7 +974,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return f.read()
     #@+node:ekr.20110321151523.14463: *4* vr.update_graphics_script
     def update_graphics_script(self, s: str, keywords: Any) -> None:
-        """Update the graphics script in the VR pane."""
+        """Display the graphics script in `s` in the VR pane."""
         c = self.c
         if g.unitTesting:
             return
@@ -999,10 +998,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     update_html_count = 0
 
     def update_html(self, s: str, keywords: Any) -> None:
-        """Update html in the VR pane."""
+        """Display the html text in `s` in the VR pane."""
         c = self.c
 
-        # Create a new QWebEngineView, deleting the old if it exists.
+        # Create a new QWebEngineView.
         w = self.create_web_engineview()
 
         # Set the html.
@@ -1011,7 +1010,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         c.bodyWantsFocusNow()
     #@+node:ekr.20110320120020.14482: *4* vr.update_image
     def update_image(self, s: str, keywords: Any) -> None:
-        """Update an image in the VR pane."""
+        """
+        Display an image in the VR pane.
+        The first line of `s` should be a `@image <path>`.
+        """
         if not s.strip():
             return
         lines = g.splitLines(s) or []
@@ -1021,20 +1023,18 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         w = self.get_base_text_widget()
         ok, path = self.get_fn(fn, '@image')
         if not ok:
-            w.setPlainText('@image: file not found: %s' % (path))
+            w.setPlainText(f"@image: file not found: {path!r}")
             return
         path = path.replace('\\', '/')
         template = self.image_template % (path)
         template = textwrap.dedent(template).strip()
         self.show()
-        # w.setReadOnly(False)
         w.setHtml(template)
-        # w.setReadOnly(True)
     #@+node:ekr.20170105124347.1: *4* vr.update_jupyter & helper
     update_jupyter_count = 0
 
     def update_jupyter(self, s: str, keywords: Any) -> None:
-        """Update @jupyter node in the VR pane."""
+        """Update an @jupyter node in the VR pane."""
         c = self.c
         w = self.get_base_text_widget()
         s = self.get_jupyter_source(c)
@@ -1075,11 +1075,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         return s
     #@+node:ekr.20241231121212.1: *4* vr.update_katex
     def update_katex(self, s: str, keywords: Any) -> None:
-        """Update katex text in the VR pane."""
+        """Display the katex text `s` in the VR pane."""
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
         if not has_webengineview:
+            g.print_unique_message('katex rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1093,11 +1094,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20170324064811.1: *4* vr.update_latex
     def update_latex(self, s: str, keywords: Any) -> None:
-        """Update LaTeX text in the VR pane."""
+        """Display the LaTeX text `s` in the VR pane."""
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
         if not has_webengineview:
+            g.print_unique_message('LaTeX rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1111,11 +1113,12 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20241224072334.1: *4* vr.update_mathjax
     def update_mathjax(self, s: str, keywords: Any) -> None:
-        """Update mathhjax text in the VR pane."""
+        """Display the mathjax text `s` in the VR pane."""
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview()
         if not has_webengineview:
+            g.print_unique_message('mathjax rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1129,7 +1132,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:peckj.20130207132858.3671: *4* vr.update_md & helper
     def update_md(self, s: str, keywords: Any) -> None:
-        """Update markdown text in the VR pane."""
+        """Display the markdown text in `s` in the VR pane."""
         c = self.c
         p = c.p
         s = s.strip().strip('"""').strip("'''").strip()
@@ -1173,7 +1176,11 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     movie_warning = False
 
     def update_movie(self, s: str, keywords: Any) -> None:
-        """Update a movie in the VR pane."""
+        """
+        Show an @movie in the VR pane.
+        
+        The first line of `s` should be the path to the movie.
+        """
         ok, path = self.get_fn(s, '@movie')
         if not ok:
             w = self.get_base_text_widget()
@@ -1203,19 +1210,16 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
 
     #@+node:ekr.20110320120020.14484: *4* vr.update_networkx
     def update_networkx(self, s: str, keywords: Any) -> None:
-        """Update a networkx graphic in the VR pane."""
+        """Dispaly a networkx graphic in `s` in the VR pane."""
         w = self.get_base_text_widget()
         w.setPlainText('')  # 'Networkx: len: %s' % (len(s)))
         self.show()
     #@+node:ekr.20191006155748.1: *4* vr.update_pandoc & helpers (disabled)
     def update_pandoc(self, s: str, keywords: Any) -> None:
         """
-        Update an @pandoc in the VR pane.
+        Display an @pandoc node in the VR pane.
         
         This code has been disabled.
-
-        There is no such thing as @language pandoc,
-        so only @pandoc nodes trigger this code.
         """
         global pandoc_exec
         w = self.get_base_text_widget()
@@ -1265,7 +1269,10 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             return f.read()
     #@+node:ekr.20241226011006.1: *4* vr.update_pdf
     def update_pdf(self, s: str, keywords: Any) -> None:
-        """Load a pdf file and show it in the VR pane."""
+        """
+        Display a pdf file in the VR pane.
+        The first line of `s` should be a `@pdf <path>`.
+        """
         p = self.c.p
         if not s.strip():
             return
@@ -1277,7 +1284,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         # Create a new QWebEngineView.
         w = self.create_web_engineview_with_pdf()
         if not has_webengineview:
-            g.print_unique_message('@pdf requires PyQt6-WebEngine')
+            g.print_unique_message('@pdf rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1291,7 +1298,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     #@+node:ekr.20160928023915.1: *4* vr.update_pyplot
     def update_pyplot(self, s: str, keywords: Any) -> None:
         """
-        Get the pyplot script at c.p.b and show it in the VR pane.
+        Execute the pyplot script in `s` and show the results in the VR pane.
         """
         c = self.c
         try:
@@ -1343,7 +1350,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         matplotlib.use('QtAgg')
     #@+node:ekr.20110320120020.14477: *4* vr.update_rst & helpers
     def update_rst(self, s: str, keywords: Any) -> None:
-        """Update rst in the VR pane."""
+        """Show the rst text in `s` in the VR pane."""
         s = s.strip().strip('"""').strip("'''").strip()
         isHtml = s.startswith('<') and not s.startswith('<<')
 
@@ -1466,7 +1473,11 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     # http://doc.trolltech.com/4.4/qtsvg.html
     # http://doc.trolltech.com/4.4/painting-svgviewer.html
     def update_svg(self, s: str, keywords: Any) -> None:
-
+        """
+        Show an svg image in the VR pane.
+        
+        `s` may be a path to the image or the image itself.
+        """
         if 0:  # Use webengine. Works, but scaling is too big.
             w = self.create_web_engineview()
             w.setHtml(s)
@@ -1481,6 +1492,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                 except Exception:
                     QSvgWidget = None
             if not QSvgWidget:
+                g.print_unique_message('svg rendering requires PyQt6-WebEngine')
                 w = self.get_base_text_widget()
                 w.setPlainText(s)
                 return
@@ -1508,13 +1520,13 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
                     w.show()
     #@+node:ekr.20241231121247.1: *4* vr.update_typst
     def update_typst(self, s: str, keywords: Any) -> None:
-        """Update mathhjax text in the VR pane."""
+        """Display the typest text in `s` in the VR pane."""
         p = self.c.p
 
         # Create a new QWebEngineView.
         w = self.create_web_engineview_with_pdf()
         if not has_webengineview:
-            g.print_unique_message('@pdf requires PyQt6-WebEngine')
+            g.print_unique_message('typst rendering requires PyQt6-WebEngine')
             w.setHtml(s)
             self.show()
             return
@@ -1543,6 +1555,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.show()
     #@+node:ekr.20110321005148.14537: *4* vr.update_url
     def update_url(self, s: str, keywords: Any) -> None:
+        """Display the url in `s` in the VR pane."""
         c, p = self.c, self.c.p
         colorizer = c.frame.body.colorizer
         language = colorizer.scanLanguageDirectives(p)

--- a/leo/unittests/misc_tests/test_syntax.py
+++ b/leo/unittests/misc_tests/test_syntax.py
@@ -90,6 +90,7 @@ class TestSyntax(LeoUnitTest):
                 test_one_mode_file(module)
             except Exception as e:
                 # raise AssertionError(f"{tag}:Test failed: {module.__name__}")
+                g.trace(repr(e))
                 fails.append(f"{module.__name__:<20} {e!r}")
         if fails:
             fails_s = '\n'.join(fails)


### PR DESCRIPTION
**Bugs**

- `@killcolor` is extremely slow when `c.p` contained no `@language` directive.
- The Rust colorizer is buggy and slow.

**Changes to leoColorizer.py**

- [x] Add `in_killcolor ivar` and related logic.
- [x] Change `addLeoRules` so that Leo executes `match_at_killcolor` before other color matchers.

**Changes to modes/rust.py**

- [x] Add entries for `rust_keywords` only for characters that begin a keyword.
- [x] Call a single matcher function for most lead-in characters.
- [x] Simplify handling of strings and character literals.

**Changes to modes/python.py**

- [x] Add entries for `python_keyword` only for characters that begin a keyword.