### PR TITLE
PR: Retain modification time when executing scripts

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3176,8 +3176,13 @@ class Commands:
 
         # Write the file.
         try:
+            # Retain old modification time to avoid pdb problems.
+            mod_time = os.path.getmtime(path)
             with open(path, encoding='utf-8', mode='w') as f:
                 f.write(script)
+            os.utime(path, (mod_time, mod_time))
+            # mod_time2 = os.path.getmtime(path)
+            # g.trace(mod_time, mod_time2)
         except Exception:
             g.es_exception()
             g.es(f"Failed to write script to {path}")

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3154,7 +3154,7 @@ class Commands:
 
     # fix bobjack's spelling error.
     universallCallback = universalCallback
-    #@+node:ekr.20070115135502: *4* c.writeScriptFile (changed: does not expand expressions)
+    #@+node:ekr.20070115135502: *4* c.writeScriptFile
     def writeScriptFile(self, script: str) -> str:
 
         # Get the path to the file.


### PR DESCRIPTION
This PR saves and restores the modification time of the **script file** (`leo/test/scriptFile.py` by default)
when executing Leonine scripts (`@button` or `@command` scripts).

This (valid!) hack prevents the `pdb` module from (incorrectly) thinking that it is debugging stale code.

Solutions based on environment variables (see [PEP 553](https://peps.python.org/pep-0553/)) might also be feasible,
but this PR is more straightforward.

**Discussion**

When running Leonine scripts, executing `g.pdb()` or `breakpoint` can generate:
```
  running stale code until the program is rerun
```
Trying to restart `pdb` with the `run` command generates:
```
  run/restart command is disabled when pdb is running in inline mode.
```

Imo, the "running stale code" message is *invalid* when executing Leonine scripts.

Indeed, `c.executeScriptHelper` ultimately executes Leonine scripts with two lines of code:
```python
scriptFile = self.writeScriptFile(script)
exec(compile(script, scriptFile, 'exec'), d)
```
The script file is *not* stale when the debugger encounters the `breakpoint` statement!

The fix, in `c.writeScriptFile`, retains the previous modification file of the script file.

This issue might be called an edge case in Python's `exec` statement,
but I shall not suggest changing Python's `pdb` module!