### PR TITLE
PR: Rust experiments

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -2052,6 +2052,7 @@
 <v t="ekr.20190324042831.1"><vh>@bool use-pygments-styles = True</vh></v>
 <v t="ekr.20190323043928.1"><vh>@string pygments-style-name = default</vh></v>
 <v t="ekr.20170202104705.1"><vh>@bool color-doc-parts-as-rest = True</vh></v>
+<v t="ekr.20250110165136.1"><vh>@bool color-docstrings-as-rest = True</vh></v>
 <v t="ekr.20060828110551"><vh>Default colors, used if no language-specific color are in effect</vh>
 <v t="ekr.20111024091133.16650"><vh>Colors for Leo constructs</vh>
 <v t="ekr.20111004182631.15542"><vh>@color doc-part-color = firebrick3</vh></v>
@@ -10277,7 +10278,7 @@ Put notes about each version here.
 </t>
 <t tx="ekr.20170123145248.1"></t>
 <t tx="ekr.20170202104705.1">False (legacy): color all @ and @doc parts with a uniform color.
-True: call all @ and @doc parts as reStructuredText (@language rest).</t>
+True: color all @ and @doc parts as reStructuredText (@language rest).</t>
 <t tx="ekr.20170208063901.1">'''
 A template for demonstrations based on plugins/demo.py.
 The demo;; abbreviation will create this tree.
@@ -11828,6 +11829,8 @@ See https://jupytext.readthedocs.io/en/latest/config.html
 # Blank lines and comments lines (lines starting with '#') are ignored.
 
 </t>
+<t tx="ekr.20250110165136.1">False (legacy): color all python docstring with a uniform color.
+True: color python docstrings as reStructuredText (@language rest).</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2372,6 +2372,7 @@ class JEditColorizer(BaseColorizer):
         )
         if j == -1:
             return 0  # A real failure.
+
         # A hack to handle continued strings. Should work for most languages.
         # Prepend "dots" to the kind, as a flag to setTag.
         dots = (
@@ -2380,7 +2381,9 @@ class JEditColorizer(BaseColorizer):
             and end in "'\""
             and kind.startswith('literal')
         )
-        dots = dots and self.language not in ('lisp', 'elisp', 'scheme')  #  'rust'
+
+        # These language can continue strings over multiple lines.
+        dots = dots and self.language not in ('lisp', 'elisp', 'rust', 'scheme')
         if dots:
             kind = 'dots' + kind
         # A match

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1862,15 +1862,17 @@ class JEditColorizer(BaseColorizer):
             return 0
         if at_word_start and i > 0 and s[i - 1] in self.word_chars:
             return 0
-        if at_word_start and i + len(
-            seq) + 1 < len(s) and s[i + len(seq)] in self.word_chars:
+        if (
+            at_word_start
+            and i + len(seq) + 1 < len(s)
+            and s[i + len(seq)] in self.word_chars
+        ):
             return 0
-        if g.match(s, i, seq):
-            j = len(s)
-            self.colorRangeWithTag(s, i, j, kind,
-                delegate=delegate, exclude_match=exclude_match)
-            return j  # (was j-1) With a delegate, this could clear state.
-        return 0
+        # if g.match(s, i, seq):
+        j = len(s)
+        self.colorRangeWithTag(s, i, j, kind,
+            delegate=delegate, exclude_match=exclude_match)
+        return j  # (was j-1) With a delegate, this could clear state.
     #@+node:ekr.20110605121601.18612: *4* jedit.match_eol_span_regexp
     def match_eol_span_regexp(self, s: str, i: int,
         *,
@@ -2240,6 +2242,12 @@ class JEditColorizer(BaseColorizer):
                 return j
         # For pylint.
         return -1
+    #@+node:ekr.20250109134131.1: *4* jedit.match_plain_eol_span
+    def match_plain_eol_span(self, s: str, i: int,  kind: str) -> int:
+        """Colorizer s[i:]"""
+        j = len(s)
+        self.colorRangeWithTag(s, i, j, kind)
+        return j
     #@+node:ekr.20110605121601.18619: *4* jedit.match_regexp_helper
     def match_regexp_helper(self, s: str, i: int, pattern: Any) -> int:
         """

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1416,7 +1416,7 @@ class JEditColorizer(BaseColorizer):
             for pattern, s in table:
                 name = name.replace(pattern, s)
             return name
-        g.print_unique_message(f"jedit.languageToMode. Should not happen: {name!r}")
+        g.print_unique_message(f"jedit.languageToMode. Should not happen: {name!r} {g.callers()}")
         return 'no-language'
     #@+node:ekr.20241106195155.1: *4* jedit.traceRulesDict
     def traceRulesDict(self) -> None:
@@ -1683,12 +1683,13 @@ class JEditColorizer(BaseColorizer):
                 if tag == '@language':
                     return self.match_at_language(s, 0)
                 j = len(tag)
-                self.colorRangeWithTag(s, 0, j, 'leokeyword')  # 'docpart')
+                self.colorRangeWithTag(s, 0, j, 'leokeyword')
                 # Switch languages.
-                self.language = self.after_doc_language
+                old_language = self.language
+                self.language = 'rest'
                 self.init()
                 self.clearState()
-                self.after_doc_language = None
+                self.after_doc_language = old_language
                 return j
         # Color the next line.
         self.setRestart(self.restartDocPart)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2824,6 +2824,8 @@ class JEditColorizer(BaseColorizer):
             self.n2languageDict[n] = self.language
         return n
     #@+node:ekr.20241106082615.1: *4* jedit.stateNumberToLanguage
+    state_number_cache_dict: dict[int, str] = {}
+
     def stateNumberToLanguage(self, n: int) -> str:
         """
         Return the string state corresponding to the given integer state.
@@ -2831,9 +2833,13 @@ class JEditColorizer(BaseColorizer):
         c = self.c
 
         def default_language(n: int) -> str:
+            # This optimization is crucial for large text.
+            if n in self.state_number_cache_dict:
+                return self.state_number_cache_dict.get(n)
             c = self.c
             p = c.p
             language = g.getLanguageFromAncestorAtFileNode(p)
+            self.state_number_cache_dict[n] = language or c.target_language
             return language or c.target_language
 
         state_s = self.stateNumberToStateString(n)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1693,7 +1693,7 @@ class JEditColorizer(BaseColorizer):
                     self.language = 'python'
                 self.init()
                 self.clearState()
-                self.after_doc_language = None
+                # Do not change after_doc_language.
                 return j
         # Color the next line.
         self.setRestart(self.restartDocPart)
@@ -2646,7 +2646,7 @@ class JEditColorizer(BaseColorizer):
     #@+node:ekr.20241121030605.1: *4* jedit.pop_delegate
     def pop_delegate(self) -> None:
         """Pop the delegate stack amd restart the previous delegate."""
-        trace = 'coloring' in g.app.debug and not g.unitTesting
+        trace = False  # 'coloring' in g.app.debug and not g.unitTesting
 
         if trace:
             print('')
@@ -2667,7 +2667,7 @@ class JEditColorizer(BaseColorizer):
         """
         Push the old language on the delegate stack and switch to the new language.
         """
-        trace = 'coloring' in g.app.debug and not g.unitTesting
+        trace = False  # 'coloring' in g.app.debug and not g.unitTesting
 
         if self.language == 'unknown-language':  # Defensive.
             old_language = new_language

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1088,7 +1088,7 @@ class JEditColorizer(BaseColorizer):
                 )
             return False
 
-        # A hack to give modes/forth.py access to c.
+        # A hack to give modes access to c.
         if hasattr(mode, 'pre_init_mode'):
             mode.pre_init_mode(self.c)
         self.language = language
@@ -1683,13 +1683,17 @@ class JEditColorizer(BaseColorizer):
                 if tag == '@language':
                     return self.match_at_language(s, 0)
                 j = len(tag)
+                #@verbatim
+                # @c or @code.
                 self.colorRangeWithTag(s, 0, j, 'leokeyword')
                 # Switch languages.
-                old_language = self.language
-                self.language = 'rest'
+                self.language = self.after_doc_language
+                if not self.language:
+                    g.print_unique_message('no after_doc_language')
+                    self.language = 'python'
                 self.init()
                 self.clearState()
-                self.after_doc_language = old_language
+                self.after_doc_language = None
                 return j
         # Color the next line.
         self.setRestart(self.restartDocPart)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1350,6 +1350,7 @@ class JEditColorizer(BaseColorizer):
             self.delegate_stack = []
             self.init_all_state()  # The only call to this method.
             self.init()
+            self.state_number_cache_dict = {}
             state = self.initBlock0()
         else:
             state = prev_state  # Continue the previous state by default.

--- a/leo/modes/doxygen.py
+++ b/leo/modes/doxygen.py
@@ -1,5 +1,10 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20250110042632.1: * @file ../modes/doxygen.py
 # Leo colorizer control file for doxygen mode.
 # This file is in the public domain.
+
+#@+<< doxygen: properties and attributes dicts >>
+#@+node:ekr.20250110042800.1: ** << doxygen: properties and attributes dicts >>
 
 # Properties for doxygen mode.
 properties = {
@@ -31,6 +36,7 @@ attributesDictDict = {
     "doxygen_doxygen": doxygen_doxygen_attributes_dict,
     "doxygen_main": doxygen_main_attributes_dict,
 }
+#@-<< doxygen: properties and attributes dicts >>
 
 # Keywords dict for doxygen_main ruleset.
 doxygen_main_keywords_dict = {
@@ -38,6 +44,8 @@ doxygen_main_keywords_dict = {
     "YES": "keyword2",
 }
 
+#@+<< doxygen: doxygen_doxygen_keywords_dict >>
+#@+node:ekr.20250110042847.1: ** << doxygen: doxygen_doxygen_keywords_dict >>
 # Keywords dict for doxygen_doxygen ruleset.
 doxygen_doxygen_keywords_dict = {
     "&": "label",
@@ -290,6 +298,7 @@ doxygen_doxygen_keywords_dict = {
     "\\xrefitem": "label",
     "\\~": "label",
 }
+#@-<< doxygen: doxygen_doxygen_keywords_dict >>
 
 # Dictionary of keywords dictionaries for doxygen mode.
 keywordsDictDict = {
@@ -297,6 +306,8 @@ keywordsDictDict = {
     "doxygen_main": doxygen_main_keywords_dict,
 }
 
+#@+<< doxgen: doxygen_main rules >>
+#@+node:ekr.20250110043035.1: ** << doxgen: doxygen_main rules >>
 # Rules for doxygen_main ruleset.
 
 def doxygen_rule0(colorer, s, i):
@@ -326,7 +337,9 @@ def doxygen_rule5(colorer, s, i):
 
 def doxygen_rule6(colorer, s, i):
     return colorer.match_keywords(s, i)
-
+#@-<< doxgen: doxygen_main rules >>
+#@+<< doxygen: rulesDict1 >>
+#@+node:ekr.20250110043114.1: ** << doxygen: rulesDict1 >>
 # Rules dict for doxygen_main ruleset.
 rulesDict1 = {
     "\"": [doxygen_rule3,],
@@ -409,7 +422,9 @@ rulesDict1 = {
     "z": [doxygen_rule6,],
     "~": [doxygen_rule6,],
 }
-
+#@-<< doxygen: rulesDict1 >>
+#@+<< doxygen: doxygen_doxygen rules >>
+#@+node:ekr.20250110043203.1: ** << doxygen: doxygen_doxygen rules >>
 # Rules for doxygen_doxygen ruleset.
 
 def doxygen_rule7(colorer, s, i):
@@ -434,7 +449,9 @@ def doxygen_rule12(colorer, s, i):
 
 def doxygen_rule13(colorer, s, i):
     return colorer.match_keywords(s, i)
-
+#@-<< doxygen: doxygen_doxygen rules >>
+#@+<< doxygen: rulesDict2 >>
+#@+node:ekr.20250110043345.1: ** << doxygen: rulesDict2 >>
 # Rules dict for doxygen_doxygen ruleset.
 rulesDict2 = {
     "#": [doxygen_rule13,],
@@ -513,6 +530,7 @@ rulesDict2 = {
     "z": [doxygen_rule13,],
     "~": [doxygen_rule13,],
 }
+#@-<< doxygen: rulesDict2 >>
 
 # x.rulesDictDict for doxygen mode.
 rulesDictDict = {
@@ -522,3 +540,4 @@ rulesDictDict = {
 
 # Import dict for doxygen mode.
 importDict = {}
+#@-leo

--- a/leo/modes/doxygen.py
+++ b/leo/modes/doxygen.py
@@ -310,33 +310,36 @@ keywordsDictDict = {
 #@+node:ekr.20250110043035.1: ** << doxgen: doxygen_main rules >>
 # Rules for doxygen_main ruleset.
 
+#@+others
+#@+node:ekr.20250110045205.1: *3* function: doxygen_rule0
 def doxygen_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="#")
-
+#@+node:ekr.20250110045205.2: *3* function: doxygen_rule1
 def doxygen_rule1(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword1", pattern="=",
           at_line_start=True,
           exclude_match=True)
-
+#@+node:ekr.20250110045205.3: *3* function: doxygen_rule2
 def doxygen_rule2(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="keyword1", pattern="+=",
           at_line_start=True,
           exclude_match=True)
-
+#@+node:ekr.20250110045205.4: *3* function: doxygen_rule3
 def doxygen_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
           no_line_break=True)
-
+#@+node:ekr.20250110045205.5: *3* function: doxygen_rule4
 def doxygen_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
           no_line_break=True)
-
+#@+node:ekr.20250110045205.6: *3* function: doxygen_rule5
 def doxygen_rule5(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="`", end="`",
           no_line_break=True)
-
+#@+node:ekr.20250110045205.7: *3* function: doxygen_rule6
 def doxygen_rule6(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@-others
 #@-<< doxgen: doxygen_main rules >>
 #@+<< doxygen: rulesDict1 >>
 #@+node:ekr.20250110043114.1: ** << doxygen: rulesDict1 >>
@@ -427,28 +430,31 @@ rulesDict1 = {
 #@+node:ekr.20250110043203.1: ** << doxygen: doxygen_doxygen rules >>
 # Rules for doxygen_doxygen ruleset.
 
+#@+others
+#@+node:ekr.20250110045223.1: *3* function: doxygen_rule7
 def doxygen_rule7(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="comment3", seq="*")
-
+#@+node:ekr.20250110045223.2: *3* function: doxygen_rule8
 def doxygen_rule8(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->")
-
+#@+node:ekr.20250110045223.3: *3* function: doxygen_rule9
 def doxygen_rule9(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="comment3", seq="<<")
-
+#@+node:ekr.20250110045223.4: *3* function: doxygen_rule10
 def doxygen_rule10(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="comment3", seq="<=")
-
+#@+node:ekr.20250110045223.5: *3* function: doxygen_rule11
 def doxygen_rule11(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="comment3", seq="< ")
-
+#@+node:ekr.20250110045223.6: *3* function: doxygen_rule12
 def doxygen_rule12(colorer, s, i):
     return colorer.match_span(s, i, kind="markup", begin="<", end=">",
           delegate="xml::tags",
           no_line_break=True)
-
+#@+node:ekr.20250110045223.7: *3* function: doxygen_rule13
 def doxygen_rule13(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@-others
 #@-<< doxygen: doxygen_doxygen rules >>
 #@+<< doxygen: rulesDict2 >>
 #@+node:ekr.20250110043345.1: ** << doxygen: rulesDict2 >>

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -363,7 +363,7 @@ def python_double_quote_docstring(colorer, s, i):
     seq = '"""'
     if not g.match(s, i, seq):
         return 0
-    rest_flag = c.config.getBool('color-doc-parts-as-rest', default=False)
+    rest_flag = c.config.getBool('color-docstrings-as-rest', default=False)
     delegate = 'rest' if rest_flag else None
     return colorer.match_span(s, i, kind='literal2', begin=seq, end=seq, delegate=delegate)
 #@+node:ekr.20231209010502.1: *3* python_fstring (not used)
@@ -433,7 +433,7 @@ def python_single_quote_docstring(colorer, s, i):
     seq = "'''"
     if not g.match(s, i, seq):
         return 0
-    rest_flag = c.config.getBool('color-doc-parts-as-rest', default=False)
+    rest_flag = c.config.getBool('color-docstrings-as-rest', default=False)
     delegate = 'rest' if rest_flag else None
     return colorer.match_span(s, i, kind='literal2', begin=seq, end=seq, delegate=delegate)
 #@-others

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -359,7 +359,13 @@ def python_double_quote(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"")
 #@+node:ekr.20230419163819.2: *3* python_double_quote_docstring
 def python_double_quote_docstring(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"\"\"", end="\"\"\"")
+    c = colorer.c
+    seq = '"""'
+    if not g.match(s, i, seq):
+        return 0
+    rest_flag = c.config.getBool('color-doc-parts-as-rest', default=False)
+    delegate = 'rest' if rest_flag else None
+    return colorer.match_span(s, i, kind='literal2', begin=seq, end=seq, delegate=delegate)
 #@+node:ekr.20231209010502.1: *3* python_fstring (not used)
 def python_fstring(colorer, s, i):
     return colorer.match_fstring(s, i)
@@ -423,7 +429,13 @@ def python_single_quote(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'")
 #@+node:ekr.20230419163819.3: *3* python_single_quote_docstring
 def python_single_quote_docstring(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="'''", end="'''")
+    c = colorer.c
+    seq = "'''"
+    if not g.match(s, i, seq):
+        return 0
+    rest_flag = c.config.getBool('color-doc-parts-as-rest', default=False)
+    delegate = 'rest' if rest_flag else None
+    return colorer.match_span(s, i, kind='literal2', begin=seq, end=seq, delegate=delegate)
 #@-others
 #@-<< Python rules >>
 #@+<< Python rules dicts >>

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -73,7 +73,7 @@ def rest_rule8(colorer, s, i):
 #@+node:ekr.20250109073551.10: *4* function: rest_rule9
 def rest_rule9(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+{3,}")
-#@+node:ekr.20250109074353.1: *3* rest_star
+#@+node:ekr.20250109074353.1: *3* function: rest_star
 def rest_star(colorer, s, i):
     if i > 0 and s[i - 1] == '*':
         return 0

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -4,8 +4,6 @@
 # Leo colorizer control file for rest mode.
 # This file is in the public domain.
 
-from leo.core import leoGlobals as g
-
 #@+<< rest: properties and attributes >>
 #@+node:ekr.20250109073208.1: ** << rest: properties and attributes >>
 

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -54,9 +54,8 @@ def rest_star(colorer, s, i):
         j += 1
     if j >= 3:
         return colorer.match_seq(s, i, kind="label", seq='*' * j)
-
-    g.trace(i, s)
     return colorer.match_span(s, i, kind="keyword2", begin='*', end='*')
+
     # 10.
     # return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
 
@@ -99,9 +98,6 @@ def rest_rule8(colorer, s, i):
 #@+node:ekr.20250109073551.10: *3* function: rest_rule9
 def rest_rule9(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+{3,}")
-#@+node:ekr.20250109073551.11: *3* function: rest_rule10 (not used)
-def rest_rule10(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
 #@+node:ekr.20250109073551.12: *3* function: rest_rule11
 def rest_rule11(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\.\\.\\s\\|[^|]+\\|",
@@ -113,12 +109,6 @@ def rest_rule12(colorer, s, i):
 def rest_rule13(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\.\\.\\s[A-z][A-z0-9-_]+::",
           at_line_start=True)
-#@+node:ekr.20250109073551.15: *3* function: rest_rule14 (not used)
-def rest_rule14(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\*\\*[^*]+\\*\\*")
-#@+node:ekr.20250109073551.16: *3* function: rest_rule15 (not used)
-def rest_rule15(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*")
 #@+node:ekr.20250109073551.17: *3* function: rest_rule16
 def rest_rule16(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="..",

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -1,5 +1,13 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20250109073005.1: * @file ../modes/rest.py
+#@@language python
 # Leo colorizer control file for rest mode.
 # This file is in the public domain.
+
+from leo.core import leoGlobals as g
+
+#@+<< rest: properties and attributes >>
+#@+node:ekr.20250109073208.1: ** << rest: properties and attributes >>
 
 # Properties for rest mode.
 properties = {
@@ -21,6 +29,9 @@ rest_main_attributes_dict = {
 attributesDictDict = {
     "rest_main": rest_main_attributes_dict,
 }
+#@-<< rest: properties and attributes >>
+#@+<< rest: keywords >>
+#@+node:ekr.20250109073231.1: ** << rest: keywords >> (empty)
 
 # Keywords dict for rest_main ruleset.
 rest_main_keywords_dict = {}
@@ -29,112 +40,142 @@ rest_main_keywords_dict = {}
 keywordsDictDict = {
     "rest_main": rest_main_keywords_dict,
 }
+#@-<< rest: keywords >>
+#@+<< rest: rules >>
+#@+node:ekr.20250109073256.1: ** << rest: rules >>
+# Rules for rest_main ruleset.
 
+#@+others
+#@+node:ekr.20250109074353.1: *3* rest_star
+def rest_star(colorer, s, i):
+
+    j = i
+    while j < len(s) and s[j] == '*':
+        j += 1
+    if j >= 3:
+        return colorer.match_seq(s, i, kind="label", seq='*' * j)
+
+    g.trace(i, s)
+    return colorer.match_span(s, i, kind="keyword2", begin='*', end='*')
+    # 10.
+    # return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
+
+    # # 14.
+    # return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\*\\*[^*]+\\*\\*")
+
+    # # 15.
+    # return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*")
+#@+node:ekr.20250109073551.1: *3* function: rest_rule0
 # Rules for rest_main ruleset.
 
 def rest_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="__",
           at_line_start=True)
-
+#@+node:ekr.20250109073551.2: *3* function: rest_rule1
 def rest_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq=".. _",
           at_line_start=True)
-
+#@+node:ekr.20250109073551.3: *3* function: rest_rule2
 def rest_rule2(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="={3,}")
-
+#@+node:ekr.20250109073551.4: *3* function: rest_rule3
 def rest_rule3(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="-{3,}")
-
+#@+node:ekr.20250109073551.5: *3* function: rest_rule4
 def rest_rule4(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="~{3,}")
-
+#@+node:ekr.20250109073551.6: *3* function: rest_rule5
 def rest_rule5(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="`{3,}")
-
+#@+node:ekr.20250109073551.7: *3* function: rest_rule6
 def rest_rule6(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="#{3,}")
-
+#@+node:ekr.20250109073551.8: *3* function: rest_rule7
 def rest_rule7(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\"{3,}")
-
+#@+node:ekr.20250109073551.9: *3* function: rest_rule8
 def rest_rule8(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\^{3,}")
-
+#@+node:ekr.20250109073551.10: *3* function: rest_rule9
 def rest_rule9(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+{3,}")
-
+#@+node:ekr.20250109073551.11: *3* function: rest_rule10 (not used)
 def rest_rule10(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
-
+#@+node:ekr.20250109073551.12: *3* function: rest_rule11
 def rest_rule11(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\.\\.\\s\\|[^|]+\\|",
           at_line_start=True)
-
+#@+node:ekr.20250109073551.13: *3* function: rest_rule12
 def rest_rule12(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal4", regexp="\\|[^|]+\\|")
-
+#@+node:ekr.20250109073551.14: *3* function: rest_rule13
 def rest_rule13(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\.\\.\\s[A-z][A-z0-9-_]+::",
           at_line_start=True)
-
+#@+node:ekr.20250109073551.15: *3* function: rest_rule14 (not used)
 def rest_rule14(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\*\\*[^*]+\\*\\*")
-
+#@+node:ekr.20250109073551.16: *3* function: rest_rule15 (not used)
 def rest_rule15(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*")
-
+#@+node:ekr.20250109073551.17: *3* function: rest_rule16
 def rest_rule16(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="..",
           at_line_start=True)
-
+#@+node:ekr.20250109073551.18: *3* function: rest_rule17
 def rest_rule17(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="`[A-z0-9]+[^`]+`_{1,2}")
-
+#@+node:ekr.20250109073551.19: *3* function: rest_rule18
 def rest_rule18(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[0-9]+\\]_")
-
+#@+node:ekr.20250109073551.20: *3* function: rest_rule19
 def rest_rule19(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[#[A-z0-9_]*\\]_")
-
+#@+node:ekr.20250109073551.21: *3* function: rest_rule20
 def rest_rule20(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[*\\]_")
-
+#@+node:ekr.20250109073551.22: *3* function: rest_rule21
 def rest_rule21(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[A-z][A-z0-9_-]*\\]_")
-
+#@+node:ekr.20250109073551.23: *3* function: rest_rule22
 def rest_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="``", end="``")
-
+#@+node:ekr.20250109073551.24: *3* function: rest_rule23
 def rest_rule23(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="`[^`]+`")
-
+#@+node:ekr.20250109073551.25: *3* function: rest_rule24
 def rest_rule24(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=":[A-z][A-z0-9 \t=\\s\\t_]*:")
-
+#@+node:ekr.20250109073551.26: *3* function: rest_rule25
 def rest_rule25(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+-[+-]+")
-
+#@+node:ekr.20250109073551.27: *3* function: rest_rule26
 def rest_rule26(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+=[+=]+")
-
+#@-others
+#@-<< rest: rules >>
+#@+<< rest: rulesDict1 >>
+#@+node:ekr.20250109073509.1: ** << rest: rulesDict1 >>
 # Rules dict for rest_main ruleset.
 rulesDict1 = {
-    "\"": [rest_rule7,],
-    "#": [rest_rule6,],
-    "*": [rest_rule10, rest_rule14, rest_rule15,],
-    "+": [rest_rule9, rest_rule25, rest_rule26,],
-    "-": [rest_rule3,],
-    ".": [rest_rule1, rest_rule11, rest_rule13, rest_rule16,],
-    ":": [rest_rule24,],
-    "=": [rest_rule2,],
-    "[": [rest_rule18, rest_rule19, rest_rule20, rest_rule21,],
-    "^": [rest_rule8,],
-    "_": [rest_rule0,],
-    "`": [rest_rule5, rest_rule17, rest_rule22, rest_rule23,],
-    "|": [rest_rule12,],
-    "~": [rest_rule4,],
+    "\"": [rest_rule7],
+    "#": [rest_rule6],
+    "*": [rest_star],
+        # rest_rule10, rest_rule14, rest_rule15],
+    "+": [rest_rule9, rest_rule25, rest_rule26],
+    "-": [rest_rule3],
+    ".": [rest_rule1, rest_rule11, rest_rule13, rest_rule16],
+    ":": [rest_rule24],
+    "=": [rest_rule2],
+    "[": [rest_rule18, rest_rule19, rest_rule20, rest_rule21],
+    "^": [rest_rule8],
+    "_": [rest_rule0],
+    "`": [rest_rule5, rest_rule17, rest_rule22, rest_rule23],
+    "|": [rest_rule12],
+    "~": [rest_rule4],
 }
+#@-<< rest: rulesDict1 >>
 
 # x.rulesDictDict for rest mode.
 rulesDictDict = {
@@ -143,3 +184,4 @@ rulesDictDict = {
 
 # Import dict for rest mode.
 importDict = {}
+#@-leo

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -48,13 +48,13 @@ keywordsDictDict = {
 #@+others
 #@+node:ekr.20250109074353.1: *3* rest_star
 def rest_star(colorer, s, i):
-
-    j = i
-    while j < len(s) and s[j] == '*':
+    j = 0
+    while i + j < len(s) and s[i + j] == '*':
         j += 1
+    seq = '*' * j
     if j >= 3:
-        return colorer.match_seq(s, i, kind="label", seq='*' * j)
-    return colorer.match_span(s, i, kind="keyword2", begin='*', end='*')
+        return colorer.match_seq(s, i, kind="label", seq=seq)
+    return colorer.match_span(s, i, kind="keyword2", begin=seq, end=seq)
 
     # 10.
     # return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -4,6 +4,10 @@
 # Leo colorizer control file for rest mode.
 # This file is in the public domain.
 
+import string
+from leo.core import leoGlobals as g
+assert g
+
 #@+<< rest: properties and attributes >>
 #@+node:ekr.20250109073208.1: ** << rest: properties and attributes >>
 
@@ -44,15 +48,48 @@ keywordsDictDict = {
 # Rules for rest_main ruleset.
 
 #@+others
+#@+node:ekr.20250110185142.1: *3* rest underline rules
+#@+node:ekr.20250109073551.3: *4* function: rest_rule2
+def rest_rule2(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="={3,}")
+#@+node:ekr.20250109073551.4: *4* function: rest_rule3
+def rest_rule3(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="-{3,}")
+#@+node:ekr.20250109073551.5: *4* function: rest_rule4
+def rest_rule4(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="~{3,}")
+#@+node:ekr.20250109073551.6: *4* function: rest_rule5
+def rest_rule5(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="`{3,}")
+#@+node:ekr.20250109073551.7: *4* function: rest_rule6
+def rest_rule6(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="#{3,}")
+#@+node:ekr.20250109073551.8: *4* function: rest_rule7
+def rest_rule7(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp='"{3,}')
+#@+node:ekr.20250109073551.9: *4* function: rest_rule8
+def rest_rule8(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\^{3,}")
+#@+node:ekr.20250109073551.10: *4* function: rest_rule9
+def rest_rule9(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+{3,}")
 #@+node:ekr.20250109074353.1: *3* rest_star
 def rest_star(colorer, s, i):
+    if i > 0 and s[i - 1] == '*':
+        return 0
     j = 0
     while i + j < len(s) and s[i + j] == '*':
         j += 1
     seq = '*' * j
     if j >= 3:
         return colorer.match_seq(s, i, kind="label", seq=seq)
-    return colorer.match_span(s, i, kind="keyword2", begin=seq, end=seq)
+
+    # Use keyword2 for italics, keyword3 for bold.
+    kind = 'keyword2' if len(seq) == 1 else 'keyword3'
+    k = s.find(seq, i + j)
+    if k == -1:
+        return 0
+    return colorer.match_seq(s, i, kind=kind, seq=s[i : k + j])
 
     # 10.
     # return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
@@ -62,85 +99,66 @@ def rest_star(colorer, s, i):
 
     # # 15.
     # return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*")
-#@+node:ekr.20250109073551.1: *3* function: rest_rule0
-# Rules for rest_main ruleset.
+#@+node:ekr.20250110190212.1: *3* function: rest_plain_word
+def rest_plain_word(colorer, s, i):
 
+    j = i
+    while j < len(s) and s[j] in string.ascii_letters:
+        j += 1
+    return colorer.match_seq(s, i, kind='keyword5', seq=s[i : j + 1])
+#@+node:ekr.20250109073551.1: *3* function: rest_rule0 __
 def rest_rule0(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq="__",
           at_line_start=True)
-#@+node:ekr.20250109073551.2: *3* function: rest_rule1
+#@+node:ekr.20250109073551.2: *3* function: rest_rule1 .. _
 def rest_rule1(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword3", seq=".. _",
           at_line_start=True)
-#@+node:ekr.20250109073551.3: *3* function: rest_rule2
-def rest_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="={3,}")
-#@+node:ekr.20250109073551.4: *3* function: rest_rule3
-def rest_rule3(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="-{3,}")
-#@+node:ekr.20250109073551.5: *3* function: rest_rule4
-def rest_rule4(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="~{3,}")
-#@+node:ekr.20250109073551.6: *3* function: rest_rule5
-def rest_rule5(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="`{3,}")
-#@+node:ekr.20250109073551.7: *3* function: rest_rule6
-def rest_rule6(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="#{3,}")
-#@+node:ekr.20250109073551.8: *3* function: rest_rule7
-def rest_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\"{3,}")
-#@+node:ekr.20250109073551.9: *3* function: rest_rule8
-def rest_rule8(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\^{3,}")
-#@+node:ekr.20250109073551.10: *3* function: rest_rule9
-def rest_rule9(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+{3,}")
-#@+node:ekr.20250109073551.12: *3* function: rest_rule11
+#@+node:ekr.20250109073551.12: *3* function: rest_rule11 .. |...|
 def rest_rule11(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="\\.\\.\\s\\|[^|]+\\|",
+    return colorer.match_seq_regexp(s, i, kind="literal3", regexp=r"\.\.\s\|[^|]+\|",
           at_line_start=True)
-#@+node:ekr.20250109073551.13: *3* function: rest_rule12
+#@+node:ekr.20250109073551.13: *3* function: rest_rule12 |...|
 def rest_rule12(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal4", regexp="\\|[^|]+\\|")
-#@+node:ekr.20250109073551.14: *3* function: rest_rule13
+    return colorer.match_seq_regexp(s, i, kind="literal4", regexp=r"\|[^|]+\|")
+#@+node:ekr.20250109073551.14: *3* function: rest_rule13 .. word::
 def rest_rule13(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp="\\.\\.\\s[A-z][A-z0-9-_]+::",
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=r"\.\.\s[A-z][A-z0-9-_]+::",
           at_line_start=True)
-#@+node:ekr.20250109073551.17: *3* function: rest_rule16
+#@+node:ekr.20250109073551.17: *3* function: rest_rule16 ..
 def rest_rule16(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment1", seq="..",
           at_line_start=True)
-#@+node:ekr.20250109073551.18: *3* function: rest_rule17
+#@+node:ekr.20250109073551.18: *3* function: rest_rule17 `word`_
 def rest_rule17(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="label", regexp="`[A-z0-9]+[^`]+`_{1,2}")
-#@+node:ekr.20250109073551.19: *3* function: rest_rule18
+#@+node:ekr.20250109073551.19: *3* function: rest_rule18 [number]_
 def rest_rule18(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[0-9]+\\]_")
-#@+node:ekr.20250109073551.20: *3* function: rest_rule19
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[[0-9]+\]_")
+#@+node:ekr.20250109073551.20: *3* function: rest_rule19 [#word]_
 def rest_rule19(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[#[A-z0-9_]*\\]_")
-#@+node:ekr.20250109073551.21: *3* function: rest_rule20
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[#[A-z0-9_]*\]_")
+#@+node:ekr.20250109073551.21: *3* function: rest_rule20 []_
 def rest_rule20(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[*\\]_")
-#@+node:ekr.20250109073551.22: *3* function: rest_rule21
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[*\]_")
+#@+node:ekr.20250109073551.22: *3* function: rest_rule21 [word]_
 def rest_rule21(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\[[A-z][A-z0-9_-]*\\]_")
-#@+node:ekr.20250109073551.23: *3* function: rest_rule22
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[[A-z][A-z0-9_-]*\]_")
+#@+node:ekr.20250109073551.23: *3* function: rest_rule22 ``...``
 def rest_rule22(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="``", end="``")
-#@+node:ekr.20250109073551.24: *3* function: rest_rule23
+#@+node:ekr.20250109073551.24: *3* function: rest_rule23 `...`
 def rest_rule23(colorer, s, i):
     return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="`[^`]+`")
-#@+node:ekr.20250109073551.25: *3* function: rest_rule24
+#@+node:ekr.20250109073551.25: *3* function: rest_rule24 :word=:
 def rest_rule24(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=":[A-z][A-z0-9 \t=\\s\\t_]*:")
-#@+node:ekr.20250109073551.26: *3* function: rest_rule25
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=r":[A-z][A-z0-9 \t=\s\t_]*:")
+#@+node:ekr.20250109073551.26: *3* function: rest_rule25 +-
 def rest_rule25(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+-[+-]+")
-#@+node:ekr.20250109073551.27: *3* function: rest_rule26
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+-[+-]+")
+#@+node:ekr.20250109073551.27: *3* function: rest_rule26 +=
 def rest_rule26(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\+=[+=]+")
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+=[+=]+")
 #@-others
 #@-<< rest: rules >>
 #@+<< rest: rulesDict1 >>
@@ -163,6 +181,14 @@ rulesDict1 = {
     "|": [rest_rule12],
     "~": [rest_rule4],
 }
+
+# Add *all* characters that could a plain word.
+lead_ins = string.ascii_letters
+for lead_in in lead_ins:
+    aList = rulesDict1.get(lead_in, [])
+    if rest_plain_word not in aList:
+        aList.insert(0, rest_plain_word)
+        rulesDict1[lead_in] = aList
 #@-<< rest: rulesDict1 >>
 
 # x.rulesDictDict for rest mode.

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -127,7 +127,7 @@ keywordsDictDict = {
 def rust_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 #@+node:ekr.20250106054207.1: *3* function: rust_slash
-slash_pat = re.compile(r'(//*)')  # Does not match '/*'...
+slash_pat = re.compile(r'(///)')  # Does not match '/*'...
 star2_pat = re.compile(r'\*\*(.*?)\*\*')
 star_pat = re.compile(r'\*(.*?)\*')
 tick2_pat = re.compile(r'``(.*?)``')
@@ -140,9 +140,10 @@ def rust_slash(colorer, s, i) -> int:
         n = len(m.group(0)) if m else 0
         return n if n > 2 else 0  # Don't
 
+    # Special case for ///
     m = slash_pat.match(s, i)
     if m:
-        seq = m.group(1)
+        seq = '///'
         colorer.match_seq(s, i, kind='comment1', seq=seq)
         i += len(seq)
         # Support only a few rest patterns.

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -137,13 +137,13 @@ def rust_slash(colorer, s, i) -> int:
     # Case 1: match entire line.
     if g.match(s, i, '///'):
         colorer.match_seq(s, i, kind='comment1', seq='///')
-        return colorer.match_eol_span(s, i + 3, kind=None, delegate='rust::rest')
+        return colorer.match_eol_span(s, i + 3, kind=None, delegate='rest')
 
-    # Case 2: match_span constructs, delegated to rust::rest.
+    # Case 2: match_span constructs, delegated to rust.
     match_span_table = (
-        ('/**', 'comment3', 'rust::rest'),
-        ('/*!', 'comment3', 'rust::rest'),
-        ('/*', 'comment1', 'rust::rest'),
+        ('/**', 'comment3', 'rest'),
+        ('/*!', 'comment3', 'rest'),
+        ('/*', 'comment1', 'rest'),
     )
     for begin, kind, delegate in match_span_table:
         if g.match(s, i, begin):
@@ -310,61 +310,11 @@ for lead_in in lead_ins:
         aList.insert(0, rust_keywords)
         rulesDict1[lead_in] = aList
 #@-<< rust: rules dicts >>
-#@+<< rust::rest: rules & dict >>
-#@+node:ekr.20250110050443.1: ** << rust::rest: rules & dict >>
-star2_pat = re.compile(r'\*\*(.*?)\*\*')
-star_pat = re.compile(r'\*(.*?)\*')
-star_end_pat = re.compile(r'\*/')
-tick2_pat = re.compile(r'``(.*?)``')
-tick_pat = re.compile(r'`(.*?)`')
-
-def rust_rest_star_and_tick(colorer, s, i):
-
-    def has_tag(i: int, pattern: str) -> int:
-        m = pattern.match(s, i)
-        n = len(m.group(0)) if m else 0
-        return n if n > 2 else 0  # Don't
-
-    patterns = (star2_pat, star_pat, tick2_pat, tick_pat)
-    i0 = i
-    while i < len(s):
-        progress = i
-        # Case 1: end of comment.
-        n = has_tag(i, star_end_pat)
-        if n > 0:
-            colorer.match_seq(s, i, kind="comment1", seq='*/')
-            i += 2
-            break
-        # Case 2: ' *' at start of line.
-        if i == 1 and g.match(s, i, '*'):
-            colorer.match_seq(s, i, kind="comment1", seq='*')
-            i += 1
-            break
-        # General case: all other patterns.
-        for pattern in patterns:
-            # Prevent false matches.
-            if s[i] in '`*' and s[i - 1] != s[i]:
-                n = has_tag(i, pattern)
-                if n > 0:
-                    seq = s[i : i + n + 1]
-                    colorer.match_seq(s, i, kind="keyword2", seq=seq)
-                    i += n
-                    break
-        else:
-            i += 1
-        assert i > progress
-    return i - i0
-
-rust_rest_rules_dict = {
-    '*': [rust_rest_star_and_tick],
-    '`': [rust_rest_star_and_tick],
-}
-#@-<< rust::rest: rules & dict >>
 
 # x.rulesDictDict for rust mode.
 rulesDictDict = {
     "rust_main": rulesDict1,
-    "rust_rest": rust_rest_rules_dict,
+    # "rust_rest": rust_rest_rules_dict,
 }
 
 # Import dict for rust mode.

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -184,26 +184,21 @@ def rust_colon(colorer, s, i):
 #@+node:ekr.20250106042808.9: *3* function: rust_raw_string_literal
 # #3631
 # https://doc.rust-lang.org/reference/tokens.html#raw-string-literals
-# Up to 255 '#' are allowed. Ruff only uses 1 and 3.
+# Up to 255 '#' are allowed.
 
 def rust_raw_string_literal(colorer, s, i):
-    if i + 1 >= len(s):
-        return len(s)
-    if s[i + 1] != '#':
-        return i + 1
-    for n in (4, 3, 2, 1):
-        begin = 'r' + '#' * n
-        end = '#' * n
-        if g.match(s, i, begin):
-            return colorer.match_span(s, i, kind="literal2", begin=begin, end=end)
-    return i + 1
 
-# def rust_raw_string_literal3(colorer, s, i):
-    # return colorer.match_span(s, i, kind="literal2", begin='r###"', end='"###')
-# def rust_raw_string_literal2(colorer, s, i):
-    # return colorer.match_span(s, i, kind="literal2", begin='r##"', end='"##')
-# def rust_raw_string_literal1(colorer, s, i):
-    # return colorer.match_span(s, i, kind="literal2", begin='r#"', end='"#')
+    # Count the '#' characters after the 'r'
+    j = 0
+    while i + 1 + j < len(s) and s[i + 1 + j] == '#':
+        j += 1
+    delims = '#' * j
+    begin = 'r' + delims + '"'
+    end = '"' + delims
+    if len(delims) <= 256:
+        return colorer.match_span(s, i, kind="literal2", begin=begin, end=end)
+    return 0
+
 #@+node:ekr.20250106042808.12: *3* function: rust_at_operator
 def rust_at_operator(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="@")
@@ -281,7 +276,7 @@ rulesDict1 = {
     "'": [rust_char],
     "<": [rust_open_angle],
     "#": [rust_pound],
-    "r": [rust_raw_string_literal],
+    "r": [rust_raw_string_literal, rust_keywords],
     "/": [rust_slash],
     '"': [rust_string],
     ':': [rust_colon],

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -127,7 +127,7 @@ keywordsDictDict = {
 def rust_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 #@+node:ekr.20250106054207.1: *3* function: rust_slash
-slash_pat = re.compile(r'(/)+ ')  # Does not match '/*'...
+slash_pat = re.compile(r'(//*)')  # Does not match '/*'...
 star2_pat = re.compile(r'\*\*(.*?)\*\*')
 star_pat = re.compile(r'\*(.*?)\*')
 tick2_pat = re.compile(r'``(.*?)``')

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -195,7 +195,8 @@ def rust_raw_string_literal(colorer, s, i):
     delims = '#' * j
     begin = 'r' + delims + '"'
     end = '"' + delims
-    if len(delims) <= 256:
+    if len(delims) < 256:
+        # Return 0 if there is no opening '"'.
         return colorer.match_span(s, i, kind="literal2", begin=begin, end=end)
     return 0
 

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -234,12 +234,7 @@ def rust_at_operator(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="@")
 #@+node:ekr.20250106054547.1: *3* function: rust_pound
 def rust_pound(colorer, s, i):
-    return 0  ###
-
-# def rust_rule5(colorer, s, i):
-    # return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
-# def rust_rule6(colorer, s, i):
-    # return colorer.match_eol_span(s, i, kind="keyword2", seq="#")
+    return colorer.match_plain_eol_span(s, i, kind="keyword2")
 #@+node:ekr.20250106054731.1: *3* function: rust_open_angle & rust_close_angle
 def rust_open_angle(colorer, s, i):
     seq = '<=' if i + i < len(s) and s[i + 1] == '=' else '<'

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -7,8 +7,8 @@ import re
 import string
 from leo.core import leoGlobals as g
 
-#@+<< Rust properties dict >>
-#@+node:ekr.20250106042726.1: ** << Rust properties dict >>
+#@+<< rust: properties dict >>
+#@+node:ekr.20250106042726.1: ** << rust: properties dict >>
 # Properties for rust mode.
 properties = {
     "commentEnd": "*/",
@@ -21,9 +21,9 @@ properties = {
     "lineUpClosingBracket": "true",
     "wordBreakChars": ",+-=<>/?^&*",
 }
-#@-<< Rust properties dict >>
-#@+<< Rust attributes dicts >>
-#@+node:ekr.20250105164117.1: ** << Rust attributes dicts >>
+#@-<< rust: properties dict >>
+#@+<< rust: attributes dicts >>
+#@+node:ekr.20250105164117.1: ** << rust: attributes dicts >>
 # Attributes dict for rust_main ruleset.
 rust_main_attributes_dict = {
     "default": "null",
@@ -38,9 +38,9 @@ rust_main_attributes_dict = {
 attributesDictDict = {
     "rust_main": rust_main_attributes_dict,
 }
-#@-<< Rust attributes dicts >>
-#@+<< Rust keywords dicts >>
-#@+node:ekr.20250106043953.1: ** << Rust keywords dicts >>
+#@-<< rust: attributes dicts >>
+#@+<< rust: keywords dicts >>
+#@+node:ekr.20250106043953.1: ** << rust: keywords dicts >>
 # Keywords dict for rust_main ruleset.
 rust_main_keywords_dict = {
     'Self': 'keyword1',
@@ -118,9 +118,9 @@ rust_main_keywords_dict = {
 keywordsDictDict = {
     "rust_main": rust_main_keywords_dict,
 }
-#@-<< Rust keywords dicts >>
-#@+<< Rust rules >>
-#@+node:ekr.20250105163810.1: ** << Rust rules >>
+#@-<< rust: keywords dicts >>
+#@+<< rust: rules >>
+#@+node:ekr.20250105163810.1: ** << rust: rules >>
 # Rules for rust_main ruleset.
 #@+others
 #@+node:ekr.20250106042808.3: *3* function: rust_rule2
@@ -271,9 +271,9 @@ def rust_rule26(colorer, s, i):
 def rust_keywords(colorer, s, i):
     return colorer.match_keywords(s, i)
 #@-others
-#@-<< Rust rules >>
-#@+<< Rust rules dicts >>
-#@+node:ekr.20231103125350.1: ** << Rust rules dicts >>
+#@-<< rust: rules >>
+#@+<< rust: rules dicts >>
+#@+node:ekr.20231103125350.1: ** << rust: rules dicts >>
 # Rules dict for rust.
 rulesDict1 = {
     # New rules...
@@ -309,7 +309,7 @@ for lead_in in lead_ins:
     if rust_keywords not in aList:
         aList.insert(0, rust_keywords)
         rulesDict1[lead_in] = aList
-#@-<< Rust rules dicts >>
+#@-<< rust: rules dicts >>
 #@+<< rust::rest: rules & dict >>
 #@+node:ekr.20250110050443.1: ** << rust::rest: rules & dict >>
 star2_pat = re.compile(r'\*\*(.*?)\*\*')

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -27,6 +27,7 @@ class Rust_Importer(Importer):
         # Patterns that *do* require '{' on the same line...
 
         ('enum', re.compile(r'\s*enum\s+(\w+)\s*\{')),
+        ('enum', re.compile(r'\s*pub\s+enum\s+(\w+)\s*\{')),
         ('macro', re.compile(r'\s*(\w+)\!\s*\{')),
         ('use', re.compile(r'\s*use.*?\{')),  # No m.group(1).
 


### PR DESCRIPTION
An experimental PR for Rust experiments.

It is *much* easier to read Rust code with the new syntax coloring conventions!

- [x] Convert `doxygen.py` to `@file`, adding nodes.
  It is functionally unchanged and this PR does not use it.
- [x] Convert `rest.py` to `@file`, adding nodes.
- [x] Add `rust_slash`: It delegates most coloring to `rust::rest`.
  A case could be made for delegating to `doxygen`, but `modes/doxygen` appears buggy.
  This is a milestone&mdash; it's the first time I've added a useful delegate!
- [x] Add `rest_star`. Uses `keyword2` for italics, `keyword3` for bold.
- [x] Support `@bool color-doc-parts-as-rest` in python docstrings.
- [x] Fix a bug in `jedit.restartDocPart`.

**Rust importer**

- [x] Fix bug. Recognize `pub enum`.

**Won't do**

I played around with using the `pre_init_mode` function in `modes/python`, but it is too complex:

<details>
<br>

```python
# Keys are f"{c.hash()}:{setting_name}"
# This machinery is too complicated.

# Values are f"{c.hash()}:{setting_name.replace('-', '_')}"
settings_dict = {}

def get_setting(c, setting_name):
    key = f"{c.hash()}:{setting_name.replace('-', '_')}"
    return settings_dict.get(key)

def init_setting(c, setting_name):
    key = f"{c.hash()}:{setting_name.replace('-', '_')}"
    value = c.config.getBool(setting_name, default=False)
    settings_dict[key] = value
    assert value in (True, False), (setting_name, repr(value))

def pre_init_mode(c):
    init_setting(c, 'color-doc-parts-as-rest')
    init_setting(c, 'color-docstrings-as-rest')
    g.printObj(settings_dict, tag=f"{g.shortFileName(__file__)}:{g.shortFileName(c.fileName())}")
 ```

</details>