### PR TITLE
PR: Improve Leo's Rust importer

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3876,6 +3876,20 @@ def splitLines(s: str) -> list[str]:
     return s.splitlines(True) if s else []  # This is a Python string function!
 
 splitlines = splitLines
+#@+node:ekr.20250113052850.1: *3* g.splitLinesAtNewline
+def splitLinesAtNewline(s: str) -> list[str]:
+    """
+    Split lines *only* at '\n', preserving form-feeds and other unusual line-ending characters.
+    """
+    if not s:
+        return []
+    lines = s.split(sep='\n')
+    if lines[-1] == '':
+        lines.pop()
+    lines = [f"{z}\n" for z in lines]
+    if not s.endswith('\n'):
+        lines[-1] = lines[-1][:-1]
+    return lines
 #@+node:ekr.20031218072017.3173: *3* Scanners: no error messages
 #@+node:ekr.20031218072017.3174: *4* g.escaped
 # Returns True if s[i] is preceded by an odd number of backslashes.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -510,11 +510,15 @@ class Importer:
             g.trace(f"Importer error: {e}")
             parent.deleteAllChildren()
             parent.b = ''.join(lines)
+            if g.unitTesting:
+                raise
         except Exception:
             g.trace('Unexpected exception!')
             g.es_exception()
             parent.deleteAllChildren()
             parent.b = ''.join(lines)
+            if g.unitTesting:
+                raise
 
         # Add trailing lines.
         parent.b += f"@language {self.language}\n@tabwidth {self.tab_width}\n"

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -545,7 +545,7 @@ class Importer:
 
         # Check for intermixed blanks and tabs.
         self.tab_width = c.getTabWidth(p=root)
-        lines = g.splitLines(s)
+        lines = self.split_lines(s)
         ws_ok = self.check_blanks_and_tabs(lines)  # Issues warnings.
 
         # Regularize leading whitespace
@@ -593,6 +593,21 @@ class Importer:
         Xml_Importer uses this hook to split lines.
         """
         return lines
+    #@+node:ekr.20250113013759.1: *4* i.split_lines
+    def split_lines(self, s: str) -> list[str]:
+        """
+        A hook for importers wishing to preserve form-feeds and other unusual line-ending characters.
+            https://docs.python.org/3/library/stdtypes.html#str.splitlines
+            https://docs.python.org/3/library/stdtypes.html#str.split
+
+            s.splitLines() and g.splitLines(s) removes form-feeds.
+            s.split() removes newlines and and form-feeds.
+            s.split(sep='\n') preserves form-feeds but removes newlines.
+            
+        **Warning**: Unit tests use g.splitLines to compare results,
+                     so overriding this method may cause existing tests to fail.
+        """
+        return g.splitLines(s)
     #@+node:ekr.20230529075138.39: *4* i.regularize_whitespace
     def regularize_whitespace(self, lines: list[str]) -> list[str]:  # pragma: no cover (missing test)
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -545,7 +545,7 @@ class Importer:
 
         # Check for intermixed blanks and tabs.
         self.tab_width = c.getTabWidth(p=root)
-        lines = self.split_lines(s)
+        lines = g.splitLinesAtNewline(s)
         ws_ok = self.check_blanks_and_tabs(lines)  # Issues warnings.
 
         # Regularize leading whitespace
@@ -593,21 +593,6 @@ class Importer:
         Xml_Importer uses this hook to split lines.
         """
         return lines
-    #@+node:ekr.20250113013759.1: *4* i.split_lines
-    def split_lines(self, s: str) -> list[str]:
-        """
-        A hook for importers wishing to preserve form-feeds and other unusual line-ending characters.
-            https://docs.python.org/3/library/stdtypes.html#str.splitlines
-            https://docs.python.org/3/library/stdtypes.html#str.split
-
-            s.splitLines() and g.splitLines(s) removes form-feeds.
-            s.split() removes newlines and and form-feeds.
-            s.split(sep='\n') preserves form-feeds but removes newlines.
-            
-        **Warning**: Unit tests use g.splitLines to compare results,
-                     so overriding this method may cause existing tests to fail.
-        """
-        return g.splitLines(s)
     #@+node:ekr.20230529075138.39: *4* i.regularize_whitespace
     def regularize_whitespace(self, lines: list[str]) -> list[str]:  # pragma: no cover (missing test)
         """

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -202,15 +202,12 @@ class Rust_Importer(Importer):
             j = i
             next_ch = s[i + 1] if i + 1 < len(s) else ''
             if next_ch == '/':  # Single-line comment.
-                ### g.trace('SINGLE LINE', s[i : i + 20])  ###
                 skip2()
-                # while i < len(s) and next() != '\n':
-                    # skip()
                 while i < len(s):
                     ch = s[i]
                     skip()
                     if ch == '\n':
-                        return  ###
+                        return
             elif next_ch == '*':  # Block comment.
                 j = i
                 level = 1  # Block comments may be nested!
@@ -288,7 +285,6 @@ class Rust_Importer(Importer):
         while i < len(s):
             ch = s[i]
             if ch == '\n':
-                # g.trace(f"{line_number:3} {s[line_start:i+1]!r}")
                 line_start = i + 1
                 line_number += 1
                 add()
@@ -305,16 +301,6 @@ class Rust_Importer(Importer):
                 skip_slash()
             elif ch == 'r':
                 skip_r()
-            ###
-            # elif experimental and ord(ch) == 12:  # Special case!
-                # # A hack.
-                # g.trace('FORM-FEED')
-                # result_lines.pop()
-                # result = []
-                # skip()
-                # result.append('\n')
-                # result_lines.append(''.join(result))
-                # result = []
             else:
                 add()
         if result:

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -464,23 +464,6 @@ class Rust_Importer(Importer):
         if 0:
             for p in parent.self_and_subtree():
                 convert_docstring(p)
-    #@+node:ekr.20250113014135.1: *3* rust_i.split_lines
-    def split_lines(self, s: str) -> list[str]:
-        """
-        Override Importer.split_lines to preserve form-feeds and other unusual line-ending characters.
-            https://docs.python.org/3/library/stdtypes.html#str.splitlines
-            https://docs.python.org/3/library/stdtypes.html#str.split
-            s.splitLines() and g.splitLines(s) removes form-feeds.
-            s.split() removes newlines and and form-feeds.
-            s.split(sep='\n') preserves form-feeds but removes newlines.
-        """
-        if not s:
-            return []
-        lines = [f"{z}\n" for z in s.split(sep='\n')]
-        # Not used by unit tests, and not important for importers.
-        if not s.endswith('\n'):
-            lines[-1] = lines[-1][:-1]
-        return lines
     #@-others
 #@-others
 

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -105,8 +105,6 @@ class Rust_Importer(Importer):
         - Raw string literals, lifetimes and characters.
         """
         i = 0
-        # A hack. s.split() and g.splitLines() consider that '\f' ends a line!
-        lines = [z.replace('\f', '\f\n') for z in lines]
         s = ''.join(lines)
         result_lines = []
         result = []
@@ -466,6 +464,23 @@ class Rust_Importer(Importer):
         if 0:
             for p in parent.self_and_subtree():
                 convert_docstring(p)
+    #@+node:ekr.20250113014135.1: *3* rust_i.split_lines
+    def split_lines(self, s: str) -> list[str]:
+        """
+        Override Importer.split_lines to preserve form-feeds and other unusual line-ending characters.
+            https://docs.python.org/3/library/stdtypes.html#str.splitlines
+            https://docs.python.org/3/library/stdtypes.html#str.split
+            s.splitLines() and g.splitLines(s) removes form-feeds.
+            s.split() removes newlines and and form-feeds.
+            s.split(sep='\n') preserves form-feeds but removes newlines.
+        """
+        if not s:
+            return []
+        lines = [f"{z}\n" for z in s.split(sep='\n')]
+        # Not used by unit tests, and not important for importers.
+        if not s.endswith('\n'):
+            lines[-1] = lines[-1][:-1]
+        return lines
     #@-others
 #@-others
 

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -31,20 +31,22 @@ class Rust_Importer(Importer):
         ('macro', re.compile(r'\s*(\w+)\!\s*\{')),
         ('use', re.compile(r'\s*use.*?\{')),  # No m.group(1).
 
-         # Patterns that do *not* require '{' on the same line...
-
-        ('fn', re.compile(r'\s*fn\s+(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s+fn\s+(\w+)\s*\(')),
-
         # https://doc.rust-lang.org/stable/reference/visibility-and-privacy.html
         # 2018 edition+, paths for pub(in path) must start with crate, self, or super.
-        ('fn', re.compile(r'\s*pub\s*\(\s*crate\s*\)\s*fn\s+(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s*\(\s*self\s*\)\s*fn\s+(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s*\(\s*super\s*\)\s*fn\s+(\w+)\s*\(')),
 
-        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*crate::.*?\)\s*fn\s+(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*self::.*?\)\s*fn\s+(\w+)\s*\(')),
-        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*super::.*?\)\s*fn\s+(\w+)\s*\(')),
+        # Function patterns require *neither* '(' nor '{' on the same line...
+
+        # Ruff starts some lines with  fn name< (!)
+        ('fn', re.compile(r'\s*fn\s+(\w+)')),
+        ('fn', re.compile(r'\s*pub\s+fn\s+(\w+)')),
+
+        ('fn', re.compile(r'\s*pub\s*\(\s*crate\s*\)\s*fn\s+(\w+)')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*self\s*\)\s*fn\s+(\w+)')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*super\s*\)\s*fn\s+(\w+)')),
+
+        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*crate::.*?\)\s*fn\s+(\w+)')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*self::.*?\)\s*fn\s+(\w+)')),
+        ('fn', re.compile(r'\s*pub\s*\(\s*in\s*super::.*?\)\s*fn\s+(\w+)')),
 
         ('impl', re.compile(r'\s*impl\b(.*?)$')),  # Use the rest of the line.
 

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -720,6 +720,19 @@ class TestGlobals(LeoUnitTest):
         ):
             result = g.removeBlankLines(s)
             self.assertEqual(result, expected, msg=repr(s))
+    #@+node:ekr.20250113053113.1: *4* TestGlobals.test_g_splitLinesAtNewline
+    def test_g_splitLinesAtNewline(self):
+        for s, expected in (
+            (None, []),
+            ('', []),
+            ('a\nb', ['a\n', 'b']),
+            ('a\nb\n', ['a\n', 'b\n']),
+            ('\n  \n\nb\n', ['\n', '  \n', '\n', 'b\n']),
+            ('\fa\n', ['\fa\n']),
+            ('c\fd', ['c\fd']),
+        ):
+            result = g.splitLinesAtNewline(s)
+            self.assertEqual(result, expected, msg=repr(s))
     #@+node:ekr.20210905203541.30: *4* TestGlobals.test_g_removeLeadingBlankLines
     def test_g_removeLeadingBlankLines(self):
         for s, expected in (

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -4390,8 +4390,8 @@ class TestRust(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
-    #@+node:ekr.20250112152227.1: *3* TestRust.test_rust_form_feed
-    def test_rust_form_feed(self):
+    #@+node:ekr.20250112152227.1: *3* TestRust.xxx_test_rust_form_feed
+    def xxx_test_rust_form_feed(self):
         # This is a local unit test.
         c = self.c
         p = c.p
@@ -4407,6 +4407,28 @@ class TestRust(BaseTestImporter):
         parent = p.insertAfter()
         parent.h = 'import parent'
         importer.import_from_string(parent, s)
+    #@+node:ekr.20250113015615.1: *3* TestRust.test_rust_form_feed
+    def test_rust_form_feed(self):
+
+        s = """
+            let contents = r"
+            class FormFeedIndent:
+               \fdef __init__(self, a=[]):
+                    print(a)
+            ";
+        """.replace(' print', '\fprint')
+        expected_results = (
+            (0, '',  # Ignore the first headline.
+                'let contents = r"\n'
+                'class FormFeedIndent:\n'
+                '   \fdef __init__(self, a=[]):\n'
+                '       \fprint(a)\n'
+                '";\n'
+                '@language rust\n'
+                '@tabwidth -4\n'
+            ),
+        )
+        self.new_run_test(s, expected_results, trace=True)
     #@-others
 #@+node:ekr.20231012142113.1: ** class TestScheme (BaseTestImporter)
 class TestScheme(BaseTestImporter):

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -4390,23 +4390,6 @@ class TestRust(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
-    #@+node:ekr.20250112152227.1: *3* TestRust.xxx_test_rust_form_feed
-    def xxx_test_rust_form_feed(self):
-        # This is a local unit test.
-        c = self.c
-        p = c.p
-        from leo.plugins.importers.rust import Rust_Importer
-        importer = Rust_Importer(c)
-        path = r'c:/Repos/ekr-ruff/crates/ruff_python_codegen/src/stylist.rs'
-        if not os.path.exists(path):
-            self.skipTest('EKR local test')
-            return
-        with open(path, 'rb') as f:
-            b = f.read()
-        s = g.toUnicode(b)
-        parent = p.insertAfter()
-        parent.h = 'import parent'
-        importer.import_from_string(parent, s)
     #@+node:ekr.20250113015615.1: *3* TestRust.test_rust_form_feed
     def test_rust_form_feed(self):
 

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -4199,7 +4199,7 @@ class TestRust(BaseTestImporter):
 
     #@+others
     #@+node:ekr.20220814095025.1: *3* TestRust.test_rust_1
-    def test_1(self):
+    def test_rust_1(self):
 
         s = """
             fn main() {
@@ -4390,6 +4390,23 @@ class TestRust(BaseTestImporter):
             ),
         )
         self.new_run_test(s, expected_results)
+    #@+node:ekr.20250112152227.1: *3* TestRust.test_rust_form_feed
+    def test_rust_form_feed(self):
+        # This is a local unit test.
+        c = self.c
+        p = c.p
+        from leo.plugins.importers.rust import Rust_Importer
+        importer = Rust_Importer(c)
+        path = r'c:/Repos/ekr-ruff/crates/ruff_python_codegen/src/stylist.rs'
+        if not os.path.exists(path):
+            self.skipTest('EKR local test')
+            return
+        with open(path, 'rb') as f:
+            b = f.read()
+        s = g.toUnicode(b)
+        parent = p.insertAfter()
+        parent.h = 'import parent'
+        importer.import_from_string(parent, s)
     #@-others
 #@+node:ekr.20231012142113.1: ** class TestScheme (BaseTestImporter)
 class TestScheme(BaseTestImporter):


### PR DESCRIPTION
Fix all remaining significant bugs in Leo's Rust importer.

For the first time, *importing Rust files can be done without annoying problems*.
In particular, the Rust importer now correctly assigns *all* functions to separate nodes!
The Rust importer appears to correctly import *all* the `.rs` files in the [Ruff repo](https://github.com/astral-sh/ruff)!

This PR does *not* try to "correct" underindented Rust strings.
Such strings happen mostly in Ruff unit tests.
They aren't annoying now that the Rust importer assigns *all* functions to separate nodes.

- [x] Add `g.splitLinesAtNewline` and corresponding unit test.
    This does *not* split lines at form-feeds (`\t`) and other unusual line-ending characters.
    See https://docs.python.org/3/library/stdtypes.html#str.splitlines
- [x] Use `g.splitLinesAtNewline` instead of `g.splitLines` in all importers.
- [x] Re-raise importer exceptions when unit testing.
- [x] Create a unit test for Rust files containing form-feed ('\t') characters.

The following fixes allow the Rust importer to assign all functions to separate nodes.

- [x] Simplify (generalize) patterns that match the start of rust functions.
- [x] Fix multiple bugs in `rust_i.delete_comments_and_strings`:
    - Add lifetime pattern in strings.
    - Allow raw strings without leading/trailing '#' characters.