### PR TITLE
PR: Further tweaks relating to Rust

### DIFF
--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -725,6 +725,10 @@ class TestGlobals(LeoUnitTest):
         for s, expected in (
             (None, []),
             ('', []),
+            (' ', [' ']),
+            ('\t', ['\t']),
+            (' a', [' a']),
+            ('\t b', ['\t b']),
             ('a\nb', ['a\n', 'b']),
             ('a\nb\n', ['a\n', 'b\n']),
             ('\n  \n\nb\n', ['\n', '  \n', '\n', 'b\n']),


### PR DESCRIPTION

- [x] Improve the unit test for `splitLinesAtNewline`.
- [ ] Fix bug in Rust colorizer: This line is not colored properly: `c.backup_helper(sub_dir='ekr-ruff-study')`