### PR TITLE
PR for #4276: requirements for windows-curses package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -330,8 +330,9 @@ dependencies = [
   "PyQt6-WebEngine",
   "Send2Trash; platform_system == 'Windows'",      # picture_viewer plugin.
   
-  # For now, the windows-curses package does not exist for Python 3.13.
-  # "windows-curses[curses]; platform_system == 'Windows'; python_version < '3.13'",
+  # cursesGui2 plugin.
+  # The windows-curses package has been updated for Python 3.13.
+  "windows-curses[curses]; platform_system == 'Windows'; python_version < '3.14'",
 ]
 
 #@-<< pyproject.toml: dependencies >>

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,8 +54,9 @@ PyQt6-QScintilla
 PyQt6-WebEngine
 Send2Trash; platform_system=="Windows"      # picture_viewer plugin.
 
-# For now, the windows-curses package does not exist for Python 3.13.
-# windows-curses[curses]; platform_system=="Windows" ; python_version < "3.13"  # cursesGui2 plugin.
+# cursesGui2 plugin.
+# The windows-curses package has been updated for Python 3.13.
+windows-curses[curses]; platform_system=="Windows" ; python_version < "3.14"
 #@-<< requirements.txt: dependencies >>
 
 #@@language python


### PR DESCRIPTION
See #4276.

`leo --gui=console` now works with Python 3.13.

- [x] Update requirements files to specify windows-curses for Python < 3.14.