### PR TITLE
PR: Allow rest in commets to be colored differently from @language rest

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -2132,6 +2132,26 @@
 <v t="ekr.20080703111151.14"><vh>@font forth.keyword4</vh></v>
 <v t="ekr.20080703111151.15"><vh>@font forth.keyword5</vh></v>
 </v>
+<v t="ekr.20250115101744.1"><vh>rest_comments (Python and Rust only)</vh>
+<v t="ekr.20250115101744.2"><vh>@font rest.literal3</vh></v>
+<v t="ekr.20250115101744.3"><vh>@font rest.literal4</vh></v>
+<v t="ekr.20250115101744.4"><vh>@font rest.keyword5</vh></v>
+<v t="ekr.20250115101744.5"><vh>@@@font rest_comments.literal1</vh></v>
+<v t="ekr.20250115101744.6"><vh>@color rest_comments.literal1 = #d33682</vh></v>
+<v t="ekr.20250115101744.7"><vh>@color rest_comments.literal2 = #d33682</vh></v>
+<v t="ekr.20250115101744.8"><vh>@color rest_comments.literal3 = #d33682</vh></v>
+<v t="ekr.20250115101744.9"><vh>@color rest_comments.literal4 = #d33682</vh></v>
+<v t="ekr.20250115101744.10"><vh>@color rest.literal1 = #d33682</vh></v>
+<v t="ekr.20250115101744.11"><vh>@color rest.literal2 = #d33682</vh></v>
+<v t="ekr.20250115101744.12"><vh>@color rest.literal3 = #d33682</vh></v>
+<v t="ekr.20250115101744.13"><vh>@color rest.literal4 = #d33682</vh></v>
+<v t="ekr.20250115101744.14"><vh>@color rest.operator = #d33682</vh></v>
+<v t="ekr.20250115101744.15"><vh>@@@color rest.keyword1 = #d33682</vh></v>
+<v t="ekr.20250115101744.16"><vh>@color rest.keyword2 = #d33682</vh></v>
+<v t="ekr.20250115101744.17"><vh>@color rest.keyword3 = #d33682</vh></v>
+<v t="ekr.20250115101744.18"><vh>@color rest.keyword4 = #d33682</vh></v>
+<v t="ekr.20250115101744.19"><vh>@color rest.keyword5 = #d33682</vh></v>
+</v>
 </v>
 <v t="ekr.20111004182631.15533"><vh>Options</vh>
 <v t="ekr.20111004182631.15534"><vh>@bool color-cweb-comments-with-latex = True</vh></v>
@@ -11831,6 +11851,69 @@ See https://jupytext.readthedocs.io/en/latest/config.html
 </t>
 <t tx="ekr.20250110165136.1">False (legacy): color all python docstring with a uniform color.
 True: color python docstrings as reStructuredText (@language rest).</t>
+<t tx="ekr.20250115101744.1">Colors and fonts. Only if at least one of the following is True
+
+@bool color-doc-parts-as-rest
+@bool color-docstrings-as-rest = True</t>
+<t tx="ekr.20250115101744.10"># plain word and default.</t>
+<t tx="ekr.20250115101744.11"># number</t>
+<t tx="ekr.20250115101744.12"># italic</t>
+<t tx="ekr.20250115101744.13"># bold</t>
+<t tx="ekr.20250115101744.14"># Everything else.</t>
+<t tx="ekr.20250115101744.15"># @doc plain and default
+
+#d33682</t>
+<t tx="ekr.20250115101744.16"># @doc italic
+
+#d33682</t>
+<t tx="ekr.20250115101744.17"># @doc bold</t>
+<t tx="ekr.20250115101744.18"># @doc numbers</t>
+<t tx="ekr.20250115101744.19"># @doc words</t>
+<t tx="ekr.20250115101744.2"># italic font
+
+rest_keyword2_family = DejaVu Sans Mono
+rest_keyword2_font_size = 12
+    # should be an int, or None.  Suffixes like pt or px will be ignored.
+rest_keyword2_font_slant = italic
+    # roman, italic
+rest_keyword2_font_weight = normal
+    # normal, bold
+</t>
+<t tx="ekr.20250115101744.3"># bold font
+
+rest_keyword3_family = DejaVu Sans Mono
+rest_keyword3_font_size = 12
+    # should be an int, or None.  Suffixes like pt or px will be ignored.
+rest_keyword3_font_slant = normal
+    # roman, italic
+rest_keyword3_font_weight = bold
+    # normal, bold
+</t>
+<t tx="ekr.20250115101744.4"># @doc fonts.
+
+rest_keyword5_family = DejaVu Sans Mono
+rest_keyword5_font_size = 12
+    # should be an int, or None.  Suffixes like pt or px will be ignored.
+rest_keyword5_font_slant = normal
+    # roman, italic
+rest_keyword5_font_weight = normal
+    # normal, bold
+</t>
+<t tx="ekr.20250115101744.5"># default
+
+rest_comments_literal1_family = DejaVu Sans Mono
+rest_comments_literal1_font_size = 24
+    # should be an int, or None.  Suffixes like pt or px will be ignored.
+rest_comments_literal1_font_slant = normal
+    # roman, italic
+rest_comments_literal1_font_weight = normal
+    # normal, bold
+</t>
+<t tx="ekr.20250115101744.6"># plain word and default.</t>
+<t tx="ekr.20250115101744.7"># number</t>
+<t tx="ekr.20250115101744.8"># italic</t>
+<t tx="ekr.20250115101744.9"># bold
+</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -170,7 +170,8 @@ class BaseColorizer:
         if c.config.settingsDict:
             gs: GeneralSetting
             setting_pat = re.compile(r'@font\s+(\w+)\.(\w+)')
-            valid_languages = g.app.language_delims_dict.keys()
+            valid_languages = list(g.app.language_delims_dict.keys())
+            valid_languages.append('rest_comments')
             valid_tags = self.default_font_dict.keys()
             for setting in sorted(c.config.settingsDict):
                 gs = c.config.settingsDict.get(setting)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -754,7 +754,12 @@ class BaseColorizer:
             tag = tag[len('dots') :]
         # This color name should already be valid.
         d = self.configDict
-        colorName = d.get(f"{self.language}.{tag}") or d.get(tag)
+        color_key = self.language.replace('_', '')
+        colorName = (
+            d.get(f"{self.language}.{tag}") or  # Legacy.
+            d.get(f"{color_key}.{tag}") or  # Leo 6.8.4.
+            d.get(tag)  # Legacy default.
+        )
         if not colorName:
             return
         # New in Leo 5.8.1: allow symbolic color names here.

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -364,7 +364,7 @@ def python_double_quote_docstring(colorer, s, i):
     if not g.match(s, i, seq):
         return 0
     rest_flag = c.config.getBool('color-docstrings-as-rest', default=False)
-    delegate = 'rest' if rest_flag else None
+    delegate = 'rest_comments' if rest_flag else None
     return colorer.match_span(s, i, kind='literal2', begin=seq, end=seq, delegate=delegate)
 #@+node:ekr.20231209010502.1: *3* python_fstring (not used)
 def python_fstring(colorer, s, i):
@@ -434,7 +434,7 @@ def python_single_quote_docstring(colorer, s, i):
     if not g.match(s, i, seq):
         return 0
     rest_flag = c.config.getBool('color-docstrings-as-rest', default=False)
-    delegate = 'rest' if rest_flag else None
+    delegate = 'rest_comments' if rest_flag else None
     return colorer.match_span(s, i, kind='literal2', begin=seq, end=seq, delegate=delegate)
 #@-others
 #@-<< Python rules >>

--- a/leo/modes/rest_comments.py
+++ b/leo/modes/rest_comments.py
@@ -1,0 +1,238 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20250115040652.1: * @file ../modes/rest_comments.py
+#@@language python
+# Leo colorizer control file for rest_comments mode.
+# This file is in the public domain.
+
+import string
+from leo.core import leoGlobals as g
+assert g
+
+#@+<< rest_comments: properties and attributes >>
+#@+node:ekr.20250115040652.2: ** << rest_comments: properties and attributes >>
+# Properties for rest_comments mode.
+properties = {
+    "indentNextLines": ".+::$",
+    "lineComment": "..",
+}
+
+# Attributes dict for rest_comments mode.
+rest_comments_main_attributes_dict = {
+    "default": "null",
+    "digit_re": "",
+    "escape": "",
+    "highlight_digits": "false",
+    "ignore_case": "false",
+    "no_word_sep": "",
+}
+
+# Dictionary of attributes dictionaries for rest_comments mode.
+attributesDictDict = {
+    "rest_comments_main": rest_comments_main_attributes_dict,
+}
+#@-<< rest_comments: properties and attributes >>
+#@+<< rest_comments: keywords >>
+#@+node:ekr.20250115040652.3: ** << rest_comments: keywords >> (empty)
+# Dictionary of keywords dictionaries for rest_comments mode.
+keywordsDictDict = {
+    "rest_comments_main": {}
+}
+#@-<< rest_comments: keywords >>
+#@+<< rest_comments: rules >>
+#@+node:ekr.20250115040652.4: ** << rest_comments: rules >>
+# Rules for rest_comments_main ruleset.
+
+#@+others
+#@+node:ekr.20250115040652.5: *3* rest_comments underline rules
+#@+node:ekr.20250115040652.6: *4* function: rest_comments_rule2
+def rest_comments_rule2(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="={3,}")
+#@+node:ekr.20250115040652.7: *4* function: rest_comments_rule3
+def rest_comments_rule3(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="-{3,}")
+#@+node:ekr.20250115040652.8: *4* function: rest_comments_rule4
+def rest_comments_rule4(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="~{3,}")
+#@+node:ekr.20250115040652.9: *4* function: rest_comments_rule5
+def rest_comments_rule5(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="`{3,}")
+#@+node:ekr.20250115040652.10: *4* function: rest_comments_rule6
+def rest_comments_rule6(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="#{3,}")
+#@+node:ekr.20250115040652.11: *4* function: rest_comments_rule7
+def rest_comments_rule7(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp='"{3,}')
+#@+node:ekr.20250115040652.12: *4* function: rest_comments_rule8
+def rest_comments_rule8(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\^{3,}")
+#@+node:ekr.20250115040652.13: *4* function: rest_comments_rule9
+def rest_comments_rule9(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+{3,}")
+#@+node:ekr.20250115040652.14: *3* function: rest_comments_plain_word (literal1)
+def rest_comments_plain_word(colorer, s, i):
+
+    j = i
+    while j < len(s) and s[j] in string.ascii_letters:
+        j += 1
+    return colorer.match_seq(s, i, kind='literal1', seq=s[i : j + 1])
+#@+node:ekr.20250115040652.15: *3* function: rest_comments_number (literal2)
+def rest_comments_number(colorer, s, i):
+
+    j = i
+    while j < len(s) and s[j] in string.digits:
+        j += 1
+    return colorer.match_seq(s, i, kind='literal2', seq=s[i : j + 1])
+#@+node:ekr.20250115040652.16: *3* function: rest_comments_default (operator)
+def rest_comments_default(colorer, s, i):
+    ch = s[i]
+    if ch in ' \t':
+        return 1
+    return colorer.match_seq(s, i, kind='operator', seq=s[i])
+#@+node:ekr.20250115040652.17: *3* function: rest_comments_star (comment1, label, literal3, literal4)
+def rest_comments_star(colorer, s, i):
+
+    # Count the number of stars in s[i:].
+    j = 0
+    while i + j < len(s) and s[i + j] == '*':
+        j += 1
+    seq = '*' * j
+
+    # Case 1: ***
+    if j >= 3:
+        return colorer.match_seq(s, i, kind="label", seq=seq)
+
+    # Case 2: no matching '*'
+    k = s.find(seq, i + j)
+    if k == -1:
+        return colorer.match_seq(s, i, kind="comment1", seq='*')
+
+    # Case 3: * or **
+    # Use keyword2 for italics, keyword3 for bold.
+    kind = 'literal3' if len(seq) == 1 else 'literal4'
+    return colorer.match_seq(s, i, kind=kind, seq=s[i : k + j])
+
+    # Rule 10.
+    # return colorer.match_seq_regexp(s, i, kind="label", regexp="\\*{3,}")
+    # Rule 14.
+    # return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\*\\*[^*]+\\*\\*")
+    # Rule 15.
+    # return colorer.match_seq_regexp(s, i, kind="keyword4", regexp="\\*[^\\s*][^*]*\\*")
+#@+node:ekr.20250115040652.18: *3* function: rest_comments_rule0 __
+def rest_comments_rule0(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="keyword3", seq="__",
+          at_line_start=True)
+#@+node:ekr.20250115040652.19: *3* function: rest_comments_rule1 .. _
+def rest_comments_rule1(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="keyword3", seq=".. _",
+          at_line_start=True)
+#@+node:ekr.20250115040652.20: *3* function: rest_comments_rule11 .. |...|
+def rest_comments_rule11(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="literal3", regexp=r"\.\.\s\|[^|]+\|",
+          at_line_start=True)
+#@+node:ekr.20250115040652.21: *3* function: rest_comments_rule12 |...|
+def rest_comments_rule12(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="literal4", regexp=r"\|[^|]+\|")
+#@+node:ekr.20250115040652.22: *3* function: rest_comments_rule13 .. word::
+def rest_comments_rule13(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=r"\.\.\s[A-z][A-z0-9-_]+::",
+          at_line_start=True)
+#@+node:ekr.20250115040652.23: *3* function: rest_comments_rule16 ..
+def rest_comments_rule16(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="comment1", seq="..",
+          at_line_start=True)
+#@+node:ekr.20250115040652.24: *3* function: rest_comments_rule17 `word`_
+def rest_comments_rule17(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp="`[A-z0-9]+[^`]+`_{1,2}")
+#@+node:ekr.20250115040652.25: *3* function: rest_comments_rule18 [number]_
+def rest_comments_rule18(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[[0-9]+\]_")
+#@+node:ekr.20250115040652.26: *3* function: rest_comments_rule19 [#word]_
+def rest_comments_rule19(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[#[A-z0-9_]*\]_")
+#@+node:ekr.20250115040652.27: *3* function: rest_comments_rule20 []_
+def rest_comments_rule20(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[*\]_")
+#@+node:ekr.20250115040652.28: *3* function: rest_comments_rule21 [word]_
+def rest_comments_rule21(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\[[A-z][A-z0-9_-]*\]_")
+#@+node:ekr.20250115040652.29: *3* function: rest_comments_rule22 ``...``
+def rest_comments_rule22(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="``", end="``")
+#@+node:ekr.20250115040652.30: *3* function: rest_comments_rule23 `...`
+def rest_comments_rule23(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp="`[^`]+`")
+#@+node:ekr.20250115040652.31: *3* function: rest_comments_rule24 :word=:
+def rest_comments_rule24(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="keyword1", regexp=r":[A-z][A-z0-9 \t=\s\t_]*:")
+#@+node:ekr.20250115040652.32: *3* function: rest_comments_rule25 +-
+def rest_comments_rule25(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+-[+-]+")
+#@+node:ekr.20250115040652.33: *3* function: rest_comments_rule26 +=
+def rest_comments_rule26(colorer, s, i):
+    return colorer.match_seq_regexp(s, i, kind="label", regexp=r"\+=[+=]+")
+#@-others
+#@-<< rest_comments: rules >>
+#@+<< rest_comments: rulesDict1 >>
+#@+node:ekr.20250115040652.34: ** << rest_comments: rulesDict1 >>
+# Rules dict for rest_comments_main ruleset.
+rulesDict1 = {
+    "\"": [rest_comments_rule7],
+    "#": [rest_comments_rule6],
+    "*": [rest_comments_star],
+    "+": [rest_comments_rule9, rest_comments_rule25, rest_comments_rule26],
+    "-": [rest_comments_rule3],
+    ".": [
+            rest_comments_rule1,
+            rest_comments_rule11,
+            rest_comments_rule13,
+            rest_comments_rule16,
+        ],
+    ":": [rest_comments_rule24],
+    "=": [rest_comments_rule2],
+    "[": [
+            rest_comments_rule18,
+            rest_comments_rule19,
+            rest_comments_rule20,
+            rest_comments_rule21,
+        ],
+    "^": [rest_comments_rule8],
+    "_": [rest_comments_rule0],
+    "`": [
+            rest_comments_rule5,
+            rest_comments_rule17,
+            rest_comments_rule22,
+            rest_comments_rule23,
+        ],
+    "|": [rest_comments_rule12],
+    "~": [rest_comments_rule4],
+}
+
+# Color words and numbers explicitly, allowing them to have non-default colors.
+
+lead_in_table = (
+    (string.ascii_letters, rest_comments_plain_word),
+    (string.digits, rest_comments_number),
+)
+for lead_ins, matcher in lead_in_table:
+    for lead_in in lead_ins:
+        aList = rulesDict1.get(lead_in, [])
+        if matcher not in aList:
+            aList.insert(0, matcher)
+            rulesDict1[lead_in] = aList
+
+# Color everything as literal1 by default.
+for lead_in in string.printable:
+    aList = rulesDict1.get(lead_in, [])
+    aList.append(rest_comments_default)
+    rulesDict1[lead_in] = aList
+
+#@-<< rest_comments: rulesDict1 >>
+
+# x.rulesDictDict for rest_comments mode.
+rulesDictDict = {
+    "rest_comments_main": rulesDict1,
+}
+
+# Import dict for rest_comments mode.
+importDict = {}
+#@-leo

--- a/leo/modes/rust.py
+++ b/leo/modes/rust.py
@@ -134,18 +134,20 @@ def rust_slash(colorer, s, i) -> int:
         n = len(m.group(0)) if m else 0
         return n if n > 2 else 0
 
+    delegate = 'rest_comments'
+
     # Case 1: match entire line.
     if g.match(s, i, '///'):
         colorer.match_seq(s, i, kind='comment1', seq='///')
-        return colorer.match_eol_span(s, i + 3, kind=None, delegate='rest')
+        return colorer.match_eol_span(s, i + 3, kind=None, delegate=delegate)
 
     # Case 2: match_span constructs, delegated to rust.
     match_span_table = (
-        ('/**', 'comment3', 'rest'),
-        ('/*!', 'comment3', 'rest'),
-        ('/*', 'comment1', 'rest'),
+        ('/**', 'comment3'),
+        ('/*!', 'comment3'),
+        ('/*', 'comment1'),
     )
-    for begin, kind, delegate in match_span_table:
+    for begin, kind in match_span_table:
         if g.match(s, i, begin):
             return colorer.match_span(s, i,
                 kind=kind, begin=begin, end="*/", delegate=delegate)


### PR DESCRIPTION
This corrects an unbearable annoyance.

- [x] Add modes/rest_comments.py.
- [x] Delegate the body of comments (python and Rust only) to `modes/rest_comments.py instead of `modes/rest.py`.
- [x] Support delegated colors in `jEdit.setTag'.
- [x] Support delegated fonts in `jEdit.configureFonts'.
- [x] Add new settings to `leoSettings.leo`.

This PR will have no effect on existing settings. It supports the following *new* settings:

- `@color rest_comments.literal1`: The default color.
- `@color rest_comments.literal2`: The color for numbers.
- `@color rest_comments.literal3`: The color for italics.
- `@color rest_comments.literal4`: The color for bold.