### PR TITLE
PR for #4283: c colorizing bugs

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -274,21 +274,29 @@ def promoteBodies(event: LeoKeyEvent) -> None:
     if not c:
         return
     p = c.p
-    result = [p.b.rstrip() + '\n'] if p.b.strip() else []
-    b = c.undoer.beforeChangeNodeContents(p)
-    for child in p.subtree():
-        h = child.h.strip()
-        if child.b:
-            body = '\n'.join([f"  {z}" for z in g.splitLines(child.b)])
-            s = f"- {h}\n{body}"
-        else:
-            s = f"- {h}"
-        if s.strip():
-            result.append(s.strip())
-    if result:
-        result.append('')
-    p.b = '\n'.join(result)
-    c.undoer.afterChangeNodeContents(p, 'promote-bodies', b)
+    ### result = [p.b.rstrip() + '\n'] if p.b.strip() else []
+    bunch = c.undoer.beforeChangeNodeContents(p)
+    result = [
+        child.b.rstrip() + '\n\n'
+        for child in p.subtree()
+    ]
+
+    ###
+    # for child in p.subtree():
+        # # h = child.h.strip()
+        # s = ''.join([z for z in g.splitLines(child.b)])
+        # result.append(s.strip())
+        # if child.b:
+            # body = '\n'.join([f"  {z}" for z in g.splitLines(child.b)])
+            # s = f"- {h}\n{body}"
+        # else:
+            # s = f"- {h}"
+        # if s.strip():
+            # result.append(s.strip())
+    # if result:
+        # result.append('')
+    p.b = ''.join(result).rstrip() + '\n\n'
+    c.undoer.afterChangeNodeContents(p, 'promote-bodies', bunch)
 #@+node:ekr.20190323085410.1: *3* @g.command('promote-headlines')
 @g.command('promote-headlines')
 def promoteHeadlines(event: LeoKeyEvent) -> None:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -274,27 +274,11 @@ def promoteBodies(event: LeoKeyEvent) -> None:
     if not c:
         return
     p = c.p
-    ### result = [p.b.rstrip() + '\n'] if p.b.strip() else []
     bunch = c.undoer.beforeChangeNodeContents(p)
     result = [
         child.b.rstrip() + '\n\n'
         for child in p.subtree()
     ]
-
-    ###
-    # for child in p.subtree():
-        # # h = child.h.strip()
-        # s = ''.join([z for z in g.splitLines(child.b)])
-        # result.append(s.strip())
-        # if child.b:
-            # body = '\n'.join([f"  {z}" for z in g.splitLines(child.b)])
-            # s = f"- {h}\n{body}"
-        # else:
-            # s = f"- {h}"
-        # if s.strip():
-            # result.append(s.strip())
-    # if result:
-        # result.append('')
     p.b = ''.join(result).rstrip() + '\n\n'
     c.undoer.afterChangeNodeContents(p, 'promote-bodies', bunch)
 #@+node:ekr.20190323085410.1: *3* @g.command('promote-headlines')

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -1,5 +1,13 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20250121105007.1: * @file ../modes/c.py
 # Leo colorizer control file for c mode.
 # This file is in the public domain.
+
+#@+others
+#@-others
+
+#@+<< c: properties >>
+#@+node:ekr.20250123062334.1: ** << c: properties >>
 
 # Properties for c mode.
 properties = {
@@ -13,6 +21,9 @@ properties = {
     "lineUpClosingBracket": "true",
     "wordBreakChars": ",+-=<>/?^&*",
 }
+#@-<< c: properties >>
+#@+<< c: attributes & dict >>
+#@+node:ekr.20250123062356.1: ** << c: attributes & dict >>
 
 # Attributes dict for c_main ruleset.
 c_main_attributes_dict = {
@@ -50,6 +61,9 @@ attributesDictDict = {
     "c_include": c_include_attributes_dict,
     "c_main": c_main_attributes_dict,
 }
+#@-<< c: attributes & dict >>
+#@+<< c: keywords dict >>
+#@+node:ekr.20250123062431.1: ** << c: keywords dict >>
 
 # Keywords dict for c_main ruleset.
 c_main_keywords_dict = {
@@ -129,100 +143,132 @@ keywordsDictDict = {
     "c_include": c_include_keywords_dict,
     "c_main": c_main_keywords_dict,
 }
-
+#@-<< c: keywords dict >>
+#@+<< c: rules >>
+#@+node:ekr.20250123062533.1: ** << c: rules >>
 # Rules for c_main ruleset.
 
+#@+others
+#@+node:ekr.20250123061808.1: *3* function: c_rule0
 def c_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
           delegate="doxygen::doxygen")
+#@+node:ekr.20250123061808.2: *3* function: c_rule1
 
 def c_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
           delegate="doxygen::doxygen")
+#@+node:ekr.20250123061808.3: *3* function: c_rule2
 
 def c_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
+#@+node:ekr.20250123061808.4: *3* function: c_rule3
 
 def c_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
           no_line_break=True)
+#@+node:ekr.20250123061808.5: *3* function: c_rule4
 
 def c_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
           no_line_break=True)
+#@+node:ekr.20250123061808.6: *3* function: c_rule5
 
 def c_rule5(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
+#@+node:ekr.20250123061808.7: *3* function: c_rule6
 
 def c_rule6(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
           delegate="c::cpp")
+#@+node:ekr.20250123061808.8: *3* function: c_rule7
 
 def c_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
+#@+node:ekr.20250123061808.9: *3* function: c_rule8
 
 def c_rule8(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="=")
+#@+node:ekr.20250123061808.10: *3* function: c_rule9
 
 def c_rule9(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="!")
+#@+node:ekr.20250123061808.11: *3* function: c_rule10
 
 def c_rule10(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
+#@+node:ekr.20250123061808.12: *3* function: c_rule11
 
 def c_rule11(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
+#@+node:ekr.20250123061808.13: *3* function: c_rule12
 
 def c_rule12(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="+")
+#@+node:ekr.20250123061808.14: *3* function: c_rule13
 
 def c_rule13(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="-")
+#@+node:ekr.20250123061808.15: *3* function: c_rule14
 
 def c_rule14(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="/")
+#@+node:ekr.20250123061808.16: *3* function: c_rule15
 
 def c_rule15(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="*")
+#@+node:ekr.20250123061808.17: *3* function: c_rule16
 
 def c_rule16(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq=">")
+#@+node:ekr.20250123061808.18: *3* function: c_rule17
 
 def c_rule17(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="<")
+#@+node:ekr.20250123061808.19: *3* function: c_rule18
 
 def c_rule18(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="%")
+#@+node:ekr.20250123061808.20: *3* function: c_rule19
 
 def c_rule19(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="&")
+#@+node:ekr.20250123061808.21: *3* function: c_rule20
 
 def c_rule20(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="|")
+#@+node:ekr.20250123061808.22: *3* function: c_rule21
 
 def c_rule21(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="^")
+#@+node:ekr.20250123061808.23: *3* function: c_rule22
 
 def c_rule22(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="~")
+#@+node:ekr.20250123061808.24: *3* function: c_rule23
 
 def c_rule23(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="}")
+#@+node:ekr.20250123061808.25: *3* function: c_rule24
 
 def c_rule24(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="{")
+#@+node:ekr.20250123061808.26: *3* function: c_rule25
 
 def c_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
           at_whitespace_end=True,
           exclude_match=True)
+#@+node:ekr.20250123061808.27: *3* function: c_rule26
 
 def c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
           exclude_match=True)
+#@+node:ekr.20250123061808.28: *3* function: c_rule27
 
 def c_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@+node:ekr.20250123061808.29: *3* function: c_rule28
 
 # Rules dict for c_main ruleset.
 rulesDict1 = {
@@ -316,13 +362,19 @@ rulesDict1 = {
 
 def c_rule28(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
+#@+node:ekr.20250123061808.30: *3* function: c_rule29
 
 def c_rule29(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="markup", seq="include",
           delegate="c::include")
+#@+node:ekr.20250123061808.31: *3* function: c_rule30
 
 def c_rule30(colorer, s, i):
     return colorer.match_keywords(s, i)
+#@-others
+#@-<< c: rules >>
+#@+<< c: rules dicts >>
+#@+node:ekr.20250123062712.1: ** << c: rules dicts >>
 
 # Rules dict for c_cpp ruleset.
 rulesDict2 = {
@@ -404,6 +456,11 @@ rulesDictDict = {
     "c_include": rulesDict3,
     "c_main": rulesDict1,
 }
+#@-<< c: rules dicts >>
 
 # Import dict for c mode.
 importDict = {}
+
+#@@language python
+#@@tabwidth -4
+#@-leo

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -135,12 +135,12 @@ c_cpp_keywords_dict = {
 }
 
 # Keywords dict for c_include ruleset.
-c_include_keywords_dict = {}
+### c_include_keywords_dict = {}
 
 # Dictionary of keywords dictionaries for c mode.
 keywordsDictDict = {
     "c_cpp": c_cpp_keywords_dict,
-    "c_include": c_include_keywords_dict,
+    ### "c_include": c_include_keywords_dict,
     "c_main": c_main_keywords_dict,
 }
 #@-<< c: keywords dict >>
@@ -154,122 +154,114 @@ def c_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
           delegate="doxygen::doxygen")
 #@+node:ekr.20250123061808.2: *3* function: c_rule1
-
 def c_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
           delegate="doxygen::doxygen")
-#@+node:ekr.20250123061808.3: *3* function: c_rule2
-
+#@+node:ekr.20250123061808.3: *3* function: c_rule2 /* comment
 def c_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
-#@+node:ekr.20250123061808.4: *3* function: c_rule3
+#@+node:ekr.20250123061808.4: *3* function: c_rule3 "
 
 def c_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
           no_line_break=True)
-#@+node:ekr.20250123061808.5: *3* function: c_rule4
+#@+node:ekr.20250123061808.5: *3* function: c_rule4 '
 
 def c_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
           no_line_break=True)
-#@+node:ekr.20250123061808.6: *3* function: c_rule5
-
+#@+node:ekr.20250123061808.6: *3* function: c_rule5 ##
 def c_rule5(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
-#@+node:ekr.20250123061808.7: *3* function: c_rule6
-
+#@+node:ekr.20250123061808.7: *3* function: c_rule6 #
 def c_rule6(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="keyword2", seq="#",
-          delegate="c::cpp")
-#@+node:ekr.20250123061808.8: *3* function: c_rule7
 
+    # #4283: Colorizer the whole line.
+    return colorer.match_eol_span(s, i, kind="keyword2")
+#@+node:ekr.20250123061808.8: *3* function: c_rule7 // comment
 def c_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
-#@+node:ekr.20250123061808.9: *3* function: c_rule8
-
+#@+node:ekr.20250123070417.1: *3* rules: operators
+#@+node:ekr.20250123061808.9: *4* function: c_rule8
 def c_rule8(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="=")
-#@+node:ekr.20250123061808.10: *3* function: c_rule9
-
+#@+node:ekr.20250123061808.10: *4* function: c_rule9
 def c_rule9(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="!")
-#@+node:ekr.20250123061808.11: *3* function: c_rule10
-
+#@+node:ekr.20250123061808.11: *4* function: c_rule10
 def c_rule10(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
-#@+node:ekr.20250123061808.12: *3* function: c_rule11
-
+#@+node:ekr.20250123061808.12: *4* function: c_rule11
 def c_rule11(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
-#@+node:ekr.20250123061808.13: *3* function: c_rule12
-
+#@+node:ekr.20250123061808.13: *4* function: c_rule12
 def c_rule12(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="+")
-#@+node:ekr.20250123061808.14: *3* function: c_rule13
+#@+node:ekr.20250123061808.14: *4* function: c_rule13
 
 def c_rule13(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="-")
-#@+node:ekr.20250123061808.15: *3* function: c_rule14
+#@+node:ekr.20250123061808.15: *4* function: c_rule14
 
 def c_rule14(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="/")
-#@+node:ekr.20250123061808.16: *3* function: c_rule15
+#@+node:ekr.20250123061808.16: *4* function: c_rule15
 
 def c_rule15(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="*")
-#@+node:ekr.20250123061808.17: *3* function: c_rule16
+#@+node:ekr.20250123061808.17: *4* function: c_rule16
 
 def c_rule16(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq=">")
-#@+node:ekr.20250123061808.18: *3* function: c_rule17
+#@+node:ekr.20250123061808.18: *4* function: c_rule17
 
 def c_rule17(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="<")
-#@+node:ekr.20250123061808.19: *3* function: c_rule18
+#@+node:ekr.20250123061808.19: *4* function: c_rule18
 
 def c_rule18(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="%")
-#@+node:ekr.20250123061808.20: *3* function: c_rule19
+#@+node:ekr.20250123061808.20: *4* function: c_rule19
 
 def c_rule19(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="&")
-#@+node:ekr.20250123061808.21: *3* function: c_rule20
+#@+node:ekr.20250123061808.21: *4* function: c_rule20
 
 def c_rule20(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="|")
-#@+node:ekr.20250123061808.22: *3* function: c_rule21
+#@+node:ekr.20250123061808.22: *4* function: c_rule21
 
 def c_rule21(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="^")
-#@+node:ekr.20250123061808.23: *3* function: c_rule22
+#@+node:ekr.20250123061808.23: *4* function: c_rule22
 
 def c_rule22(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="~")
-#@+node:ekr.20250123061808.24: *3* function: c_rule23
+#@+node:ekr.20250123061808.24: *4* function: c_rule23
 
 def c_rule23(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="}")
-#@+node:ekr.20250123061808.25: *3* function: c_rule24
+#@+node:ekr.20250123061808.25: *4* function: c_rule24
 
 def c_rule24(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="{")
-#@+node:ekr.20250123061808.26: *3* function: c_rule25
+#@+node:ekr.20250123061808.26: *3* function: c_rule25 : label
 
 def c_rule25(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-          at_whitespace_end=True,
-          exclude_match=True)
-#@+node:ekr.20250123061808.27: *3* function: c_rule26
-
+          at_whitespace_end=True, exclude_match=True)
+#@+node:ekr.20250123061808.27: *3* function: c_rule26 (
 def c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
           exclude_match=True)
-#@+node:ekr.20250123061808.28: *3* function: c_rule27
+#@+node:ekr.20250123061808.28: *3* function: c_rule27 keywords
 
 def c_rule27(colorer, s, i):
     return colorer.match_keywords(s, i)
-#@+node:ekr.20250123061808.29: *3* function: c_rule28
-
+#@-others
+#@-<< c: rules >>
+#@+<< c: rules dict >>
+#@+node:ekr.20250123062712.1: ** << c: rules dict >>
 # Rules dict for c_main ruleset.
 rulesDict1 = {
     "!": [c_rule9,],
@@ -357,106 +349,12 @@ rulesDict1 = {
     "}": [c_rule23,],
     "~": [c_rule22,],
 }
-
-# Rules for c_cpp ruleset.
-
-def c_rule28(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
-#@+node:ekr.20250123061808.30: *3* function: c_rule29
-
-def c_rule29(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="markup", seq="include",
-          delegate="c::include")
-#@+node:ekr.20250123061808.31: *3* function: c_rule30
-
-def c_rule30(colorer, s, i):
-    return colorer.match_keywords(s, i)
-#@-others
-#@-<< c: rules >>
-#@+<< c: rules dicts >>
-#@+node:ekr.20250123062712.1: ** << c: rules dicts >>
-
-# Rules dict for c_cpp ruleset.
-rulesDict2 = {
-    "/": [c_rule28,],
-    "0": [c_rule30,],
-    "1": [c_rule30,],
-    "2": [c_rule30,],
-    "3": [c_rule30,],
-    "4": [c_rule30,],
-    "5": [c_rule30,],
-    "6": [c_rule30,],
-    "7": [c_rule30,],
-    "8": [c_rule30,],
-    "9": [c_rule30,],
-    "@": [c_rule30,],
-    "A": [c_rule30,],
-    "B": [c_rule30,],
-    "C": [c_rule30,],
-    "D": [c_rule30,],
-    "E": [c_rule30,],
-    "F": [c_rule30,],
-    "G": [c_rule30,],
-    "H": [c_rule30,],
-    "I": [c_rule30,],
-    "J": [c_rule30,],
-    "K": [c_rule30,],
-    "L": [c_rule30,],
-    "M": [c_rule30,],
-    "N": [c_rule30,],
-    "O": [c_rule30,],
-    "P": [c_rule30,],
-    "Q": [c_rule30,],
-    "R": [c_rule30,],
-    "S": [c_rule30,],
-    "T": [c_rule30,],
-    "U": [c_rule30,],
-    "V": [c_rule30,],
-    "W": [c_rule30,],
-    "X": [c_rule30,],
-    "Y": [c_rule30,],
-    "Z": [c_rule30,],
-    "_": [c_rule30,],
-    "a": [c_rule30,],
-    "b": [c_rule30,],
-    "c": [c_rule30,],
-    "d": [c_rule30,],
-    "e": [c_rule30,],
-    "f": [c_rule30,],
-    "g": [c_rule30,],
-    "h": [c_rule30,],
-    "i": [c_rule29, c_rule30,],
-    "j": [c_rule30,],
-    "k": [c_rule30,],
-    "l": [c_rule30,],
-    "m": [c_rule30,],
-    "n": [c_rule30,],
-    "o": [c_rule30,],
-    "p": [c_rule30,],
-    "q": [c_rule30,],
-    "r": [c_rule30,],
-    "s": [c_rule30,],
-    "t": [c_rule30,],
-    "u": [c_rule30,],
-    "v": [c_rule30,],
-    "w": [c_rule30,],
-    "x": [c_rule30,],
-    "y": [c_rule30,],
-    "z": [c_rule30,],
-}
-
-# Rules for c_include ruleset.
-
-# Rules dict for c_include ruleset.
-rulesDict3 = {}
+#@-<< c: rules dict >>
 
 # x.rulesDictDict for c mode.
 rulesDictDict = {
-    "c_cpp": rulesDict2,
-    "c_include": rulesDict3,
     "c_main": rulesDict1,
 }
-#@-<< c: rules dicts >>
 
 # Import dict for c mode.
 importDict = {}

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -150,7 +150,7 @@ def c_rule5(colorer, s, i):
 #@+node:ekr.20250123061808.7: *3* function: c_rule6 #
 def c_rule6(colorer, s, i):
 
-    # #4283: Colorizer the whole line.
+    # #4283: Colorize the whole line.
     return colorer.match_eol_span(s, i, kind="keyword2")
 #@+node:ekr.20250123061808.8: *3* function: c_rule7 // comment
 def c_rule7(colorer, s, i):
@@ -259,7 +259,7 @@ rulesDict1 = {
     "~": [c_rule22],
 }
 
-# Add *all* characters that could start a Python identifier.
+# Add *all* characters that could start a c identifier.
 lead_ins = string.ascii_letters + '_'
 for lead_in in lead_ins:
     aList = rulesDict1.get(lead_in, [])

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -213,18 +213,23 @@ def c_rule_at_sign(colorer, s, i):  # #4283.
 def c_rule_semicolon(colorer, s, i):  # #4283.
     return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
-#@+node:ekr.20250123061808.26: *3* function: c_rule25 : label
-
-def c_rule25(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":",
-          at_whitespace_end=True, exclude_match=True)
 #@+node:ekr.20250123061808.27: *3* function: c_rule26 (
 def c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
           exclude_match=True)
-#@+node:ekr.20250123061808.28: *3* function: c_keyword
+#@+node:ekr.20250123061808.28: *3* function: c_keyword & label
 def c_keyword(colorer, s, i):
-    return colorer.match_keywords(s, i)
+    n = colorer.match_keywords(s, i)
+    if n >= 0:
+        return n
+    i2 = i + abs(n)
+    ch = s[i2] if i2 < len(s) else ''
+    if ch != ':':
+        return n
+
+    # color the label.
+    seq = s[i : i2 + 1]
+    return colorer.match_seq(s, i, kind="label", seq=seq)
 #@-others
 #@-<< c: rules >>
 #@+<< c: rules dict >>
@@ -244,7 +249,6 @@ rulesDict1 = {
     "+": [c_rule12],
     "-": [c_rule13],
     "/": [c_rule0, c_rule1, c_rule2, c_rule7, c_rule14],
-    ":": [c_rule25],
     "<": [c_rule11, c_rule17],
     "=": [c_rule8],
     ">": [c_rule10, c_rule16],

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -3,6 +3,8 @@
 # Leo colorizer control file for c mode.
 # This file is in the public domain.
 
+import string
+
 #@+others
 #@-others
 
@@ -111,35 +113,9 @@ c_main_keywords_dict = {
     "while": "keyword1",
 }
 
-# Keywords dict for c_cpp ruleset.
-c_cpp_keywords_dict = {
-    "assert": "markup",
-    "define": "markup",
-    "elif": "markup",
-    "else": "markup",
-    "endif": "markup",
-    "error": "markup",
-    "ident": "markup",
-    "if": "markup",
-    "ifdef": "markup",
-    "ifndef": "markup",
-    "import": "markup",
-    "include": "markup",
-    "include_next": "markup",
-    "line": "markup",
-    "pragma": "markup",
-    "sccs": "markup",
-    "unassert": "markup",
-    "undef": "markup",
-    "warning": "markup",
-}
-
-# Keywords dict for c_include ruleset.
-### c_include_keywords_dict = {}
-
 # Dictionary of keywords dictionaries for c mode.
 keywordsDictDict = {
-    "c_cpp": c_cpp_keywords_dict,
+    ### "c_cpp": c_cpp_keywords_dict,
     ### "c_include": c_include_keywords_dict,
     "c_main": c_main_keywords_dict,
 }
@@ -149,24 +125,22 @@ keywordsDictDict = {
 # Rules for c_main ruleset.
 
 #@+others
-#@+node:ekr.20250123061808.1: *3* function: c_rule0
+#@+node:ekr.20250123061808.1: *3* function: c_rule0 /**
 def c_rule0(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
           delegate="doxygen::doxygen")
-#@+node:ekr.20250123061808.2: *3* function: c_rule1
+#@+node:ekr.20250123061808.2: *3* function: c_rule1 /*!
 def c_rule1(colorer, s, i):
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
           delegate="doxygen::doxygen")
-#@+node:ekr.20250123061808.3: *3* function: c_rule2 /* comment
+#@+node:ekr.20250123061808.3: *3* function: c_rule2 /*
 def c_rule2(colorer, s, i):
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 #@+node:ekr.20250123061808.4: *3* function: c_rule3 "
-
 def c_rule3(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
           no_line_break=True)
 #@+node:ekr.20250123061808.5: *3* function: c_rule4 '
-
 def c_rule4(colorer, s, i):
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
           no_line_break=True)
@@ -182,69 +156,63 @@ def c_rule6(colorer, s, i):
 def c_rule7(colorer, s, i):
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 #@+node:ekr.20250123070417.1: *3* rules: operators
-#@+node:ekr.20250123061808.9: *4* function: c_rule8
 def c_rule8(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="=")
-#@+node:ekr.20250123061808.10: *4* function: c_rule9
+
 def c_rule9(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="!")
-#@+node:ekr.20250123061808.11: *4* function: c_rule10
+
 def c_rule10(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
-#@+node:ekr.20250123061808.12: *4* function: c_rule11
+
 def c_rule11(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
-#@+node:ekr.20250123061808.13: *4* function: c_rule12
+
 def c_rule12(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="+")
-#@+node:ekr.20250123061808.14: *4* function: c_rule13
 
 def c_rule13(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="-")
-#@+node:ekr.20250123061808.15: *4* function: c_rule14
 
 def c_rule14(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="/")
-#@+node:ekr.20250123061808.16: *4* function: c_rule15
 
 def c_rule15(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="*")
-#@+node:ekr.20250123061808.17: *4* function: c_rule16
 
 def c_rule16(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq=">")
-#@+node:ekr.20250123061808.18: *4* function: c_rule17
 
 def c_rule17(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="<")
-#@+node:ekr.20250123061808.19: *4* function: c_rule18
 
 def c_rule18(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="%")
-#@+node:ekr.20250123061808.20: *4* function: c_rule19
 
 def c_rule19(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="&")
-#@+node:ekr.20250123061808.21: *4* function: c_rule20
 
 def c_rule20(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="|")
-#@+node:ekr.20250123061808.22: *4* function: c_rule21
 
 def c_rule21(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="^")
-#@+node:ekr.20250123061808.23: *4* function: c_rule22
 
 def c_rule22(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="~")
-#@+node:ekr.20250123061808.24: *4* function: c_rule23
 
 def c_rule23(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="}")
-#@+node:ekr.20250123061808.25: *4* function: c_rule24
 
 def c_rule24(colorer, s, i):
     return colorer.match_plain_seq(s, i, kind="operator", seq="{")
+
+def c_rule_at_sign(colorer, s, i):  # #4283.
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
+
+def c_rule_semicolon(colorer, s, i):  # #4283.
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
+
 #@+node:ekr.20250123061808.26: *3* function: c_rule25 : label
 
 def c_rule25(colorer, s, i):
@@ -254,9 +222,8 @@ def c_rule25(colorer, s, i):
 def c_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
           exclude_match=True)
-#@+node:ekr.20250123061808.28: *3* function: c_rule27 keywords
-
-def c_rule27(colorer, s, i):
+#@+node:ekr.20250123061808.28: *3* function: c_keyword
+def c_keyword(colorer, s, i):
     return colorer.match_keywords(s, i)
 #@-others
 #@-<< c: rules >>
@@ -264,91 +231,37 @@ def c_rule27(colorer, s, i):
 #@+node:ekr.20250123062712.1: ** << c: rules dict >>
 # Rules dict for c_main ruleset.
 rulesDict1 = {
-    "!": [c_rule9,],
-    "\"": [c_rule3,],
-    "#": [c_rule5, c_rule6,],
-    "%": [c_rule18,],
-    "&": [c_rule19,],
-    "'": [c_rule4,],
-    "(": [c_rule26,],
-    "*": [c_rule15,],
-    "+": [c_rule12,],
-    "-": [c_rule13,],
-    "/": [c_rule0, c_rule1, c_rule2, c_rule7, c_rule14,],
-    "0": [c_rule27,],
-    "1": [c_rule27,],
-    "2": [c_rule27,],
-    "3": [c_rule27,],
-    "4": [c_rule27,],
-    "5": [c_rule27,],
-    "6": [c_rule27,],
-    "7": [c_rule27,],
-    "8": [c_rule27,],
-    "9": [c_rule27,],
-    ":": [c_rule25,],
-    "<": [c_rule11, c_rule17,],
-    "=": [c_rule8,],
-    ">": [c_rule10, c_rule16,],
-    "@": [c_rule27,],
-    "A": [c_rule27,],
-    "B": [c_rule27,],
-    "C": [c_rule27,],
-    "D": [c_rule27,],
-    "E": [c_rule27,],
-    "F": [c_rule27,],
-    "G": [c_rule27,],
-    "H": [c_rule27,],
-    "I": [c_rule27,],
-    "J": [c_rule27,],
-    "K": [c_rule27,],
-    "L": [c_rule27,],
-    "M": [c_rule27,],
-    "N": [c_rule27,],
-    "O": [c_rule27,],
-    "P": [c_rule27,],
-    "Q": [c_rule27,],
-    "R": [c_rule27,],
-    "S": [c_rule27,],
-    "T": [c_rule27,],
-    "U": [c_rule27,],
-    "V": [c_rule27,],
-    "W": [c_rule27,],
-    "X": [c_rule27,],
-    "Y": [c_rule27,],
-    "Z": [c_rule27,],
-    "^": [c_rule21,],
-    "_": [c_rule27,],
-    "a": [c_rule27,],
-    "b": [c_rule27,],
-    "c": [c_rule27,],
-    "d": [c_rule27,],
-    "e": [c_rule27,],
-    "f": [c_rule27,],
-    "g": [c_rule27,],
-    "h": [c_rule27,],
-    "i": [c_rule27,],
-    "j": [c_rule27,],
-    "k": [c_rule27,],
-    "l": [c_rule27,],
-    "m": [c_rule27,],
-    "n": [c_rule27,],
-    "o": [c_rule27,],
-    "p": [c_rule27,],
-    "q": [c_rule27,],
-    "r": [c_rule27,],
-    "s": [c_rule27,],
-    "t": [c_rule27,],
-    "u": [c_rule27,],
-    "v": [c_rule27,],
-    "w": [c_rule27,],
-    "x": [c_rule27,],
-    "y": [c_rule27,],
-    "z": [c_rule27,],
-    "{": [c_rule24,],
-    "|": [c_rule20,],
-    "}": [c_rule23,],
-    "~": [c_rule22,],
+    ";": [c_rule_semicolon],  # #4283.
+    "@": [c_rule_at_sign],  # #4283.
+    "!": [c_rule9],
+    '"': [c_rule3],
+    "#": [c_rule5, c_rule6],
+    "%": [c_rule18],
+    "&": [c_rule19],
+    "'": [c_rule4],
+    "(": [c_rule26],
+    "*": [c_rule15],
+    "+": [c_rule12],
+    "-": [c_rule13],
+    "/": [c_rule0, c_rule1, c_rule2, c_rule7, c_rule14],
+    ":": [c_rule25],
+    "<": [c_rule11, c_rule17],
+    "=": [c_rule8],
+    ">": [c_rule10, c_rule16],
+    "^": [c_rule21],
+    "{": [c_rule24],
+    "|": [c_rule20],
+    "}": [c_rule23],
+    "~": [c_rule22],
 }
+
+# Add *all* characters that could start a Python identifier.
+lead_ins = string.ascii_letters + '_'
+for lead_in in lead_ins:
+    aList = rulesDict1.get(lead_in, [])
+    if c_keyword not in aList:
+        aList.insert(0, c_keyword)
+        rulesDict1[lead_in] = aList
 #@-<< c: rules dict >>
 
 # x.rulesDictDict for c mode.

--- a/leo/unittests/misc_tests/test_modes.py
+++ b/leo/unittests/misc_tests/test_modes.py
@@ -166,6 +166,39 @@ class TestModes(LeoUnitTest):
             kind, seq = rust_char(colorer, s, i=0)
             assert kind == 'literal4', kind
             assert seq == "'", repr(seq)
+    #@+node:ekr.20250123084454.1: *4* TestModes.test_c_label
+    def test_c_label(self):
+
+        from leo.modes.c import c_keyword
+
+        c = self.c
+        jedit_colorer = JEditColorizer(c=c, widget=None)
+
+        actual_seq: str
+        actual_kind: str
+
+        class TestColorizer:
+
+            def match_keywords(self, s: str, i: int):
+                return jedit_colorer.match_keywords(s, i)
+
+            def match_seq(self, s: str, i: int, kind: str, seq: str):
+                nonlocal actual_kind, actual_seq
+                actual_kind, actual_seq = kind, seq
+                return jedit_colorer.match_seq(s, i, kind=kind, seq=seq)
+
+        test_colorer = TestColorizer()
+
+        line_table = (
+            (-4, '', '', 'goto label;\n'),
+            (6, 'label', 'label:', 'label:\n'),
+        )
+        for expected_n, expected_kind, expected_seq, s in line_table:
+            actual_kind, actual_seq = '', ''
+            n = c_keyword(test_colorer, s, 0)
+            assert n == expected_n, (expected_n, n, s)
+            assert expected_kind == actual_kind, (expected_kind, actual_kind, s)
+            assert expected_seq == actual_seq, (expected_seq, actual_seq, s)
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
See #4283.

- [x] Convert modes/c.py from `@edit` to `@file`.
- [x] Consolidate rules using the improved `promote-bodies` command.
- [x] Remove secondary rules & rules dicts.
- [x] Handle labels in `c_keyword`.
- [x] Programmatically add entries to the main rules dict for all leadins that could start an identifier.