### PR TITLE
PR for #4284: Allow back slashes in find strings

### DIFF
--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2602,6 +2602,8 @@ class LeoFind:
                 result.append('\n')
             elif ch == 't':
                 result.append('\t')
+            elif ch == 'f':
+                result.append('\f')
             elif ch == '\\':  # 4284
                 result.append(ch)
                 result.append(ch)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2609,7 +2609,6 @@ class LeoFind:
                 result.append('\\')
                 i -= 1
             assert progress < i
-        ### g.trace(f"s: {s:10} result: {''.join(result)}")
         return ''.join(result)
     #@+node:ekr.20031218072017.3082: *3* LeoFind.Initing & finalizing
     #@+node:ekr.20031218072017.3086: *4* find.init_in_headline & helper

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -2587,7 +2587,30 @@ class LeoFind:
     #@+node:ekr.20210110073117.49: *4* find.replace_back_slashes
     def replace_back_slashes(self, s: str) -> str:
         """Replace backslash-n with a newline and backslash-t with a tab."""
-        return s.replace('\\n', '\n').replace('\\t', '\t')
+        # Compare: https://docs.python.org/3/library/ast.html#ast.literal_eval
+        i, result = 0, []
+        while i < len(s):
+            progress = i
+            ch = s[i]
+            i += 1
+            if ch != '\\' or i >= len(s):
+                result.append(ch)
+                continue
+            ch = s[i]
+            i += 1
+            if ch == 'n':
+                result.append('\n')
+            elif ch == 't':
+                result.append('\t')
+            elif ch == '\\':  # 4284
+                result.append(ch)
+                result.append(ch)
+            else:
+                result.append('\\')
+                i -= 1
+            assert progress < i
+        ### g.trace(f"s: {s:10} result: {''.join(result)}")
+        return ''.join(result)
     #@+node:ekr.20031218072017.3082: *3* LeoFind.Initing & finalizing
     #@+node:ekr.20031218072017.3086: *4* find.init_in_headline & helper
     def init_in_headline(self) -> None:

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -389,7 +389,7 @@ class TestFind(LeoUnitTest):
         assert p
         self.assertEqual(p.h, 'child 5')
         self.assertEqual(s, 'v5 =')
-        
+
         # Annotated.
         matches = x.do_find_var('va5')
         assert len(matches) == 1
@@ -933,6 +933,8 @@ class TestFind(LeoUnitTest):
         x = leoFind.LeoFind(c)
         table = (
             # Only replace \n, \\n, \t and \\t.
+
+            # Pass
             ('\\', '\\'),
             ('\\\\', '\\\\'),
             (r'a\bc', r'a\bc'),
@@ -943,8 +945,10 @@ class TestFind(LeoUnitTest):
 
             ('\\n', '\n'),
             ('\\t', '\t'),
+
             (r'a\tc', 'a\tc'),  # Replace \t by a tab.
             (r'a\nc', 'a\nc'),  # Replace \n by a newline.
+            (r'b\\\\nd', 'b\\\\\\\\nd'),  # Allow escaped backslash: #4284.
         )
         for s, expected in table:
             got = x.replace_back_slashes(s)

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -933,22 +933,22 @@ class TestFind(LeoUnitTest):
         x = leoFind.LeoFind(c)
         table = (
             # Only replace \n, \\n, \t and \\t.
-
-            # Pass
-            ('\\', '\\'),
-            ('\\\\', '\\\\'),
             (r'a\bc', r'a\bc'),
             (r'a\\bc', r'a\\bc'),
             (r'a \ b', r'a \ b'),
             (r'a \\ b', r'a \\ b'),
             (r'a \\\ b', r'a \\\ b'),
-
+            # Replace \n by newline and \t by tab.
             ('\\n', '\n'),
             ('\\t', '\t'),
-
-            (r'a\tc', 'a\tc'),  # Replace \t by a tab.
-            (r'a\nc', 'a\nc'),  # Replace \n by a newline.
-            (r'b\\\\nd', 'b\\\\\\\\nd'),  # Allow escaped backslash: #4284.
+            ('a\\tc', 'a\tc'),
+            ('a\\nc', 'a\nc'),
+            # Allow escaped backslash: #4284.
+            ('\\', '\\'),
+            ('\\\\', '\\\\'),
+            ('\\\\n', '\\\\n'),
+            ('\\\\t', '\\\\t'),
+            ('b\\\\nd', 'b\\\\nd'),
         )
         for s, expected in table:
             got = x.replace_back_slashes(s)

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -932,16 +932,14 @@ class TestFind(LeoUnitTest):
         c = self.c
         x = leoFind.LeoFind(c)
         table = (
-            # Only replace \n, \\n, \t and \\t.
-            (r'a\bc', r'a\bc'),
-            (r'a\\bc', r'a\\bc'),
-            (r'a \ b', r'a \ b'),
-            (r'a \\ b', r'a \\ b'),
-            (r'a \\\ b', r'a \\\ b'),
-            # Replace \n by newline and \t by tab.
+            # Replace \n, \t, and \f by newline, tab, and form-feed.
+            ('\\f', '\f'),
             ('\\n', '\n'),
             ('\\t', '\t'),
+            ('a\\n', 'a\n'),
+            ('\\\n', '\\\n'),  # Backslash-newline!
             ('a\\tc', 'a\tc'),
+            ('a\\t\\fc', 'a\t\fc'),
             ('a\\nc', 'a\nc'),
             # Allow escaped backslash: #4284.
             ('\\', '\\'),
@@ -949,6 +947,12 @@ class TestFind(LeoUnitTest):
             ('\\\\n', '\\\\n'),
             ('\\\\t', '\\\\t'),
             ('b\\\\nd', 'b\\\\nd'),
+            # Make no other replacements.
+            (r'a\bc', r'a\bc'),
+            (r'a\\bc', r'a\\bc'),
+            (r'a \ b', r'a \ b'),
+            (r'a \\ b', r'a \\ b'),
+            (r'a \\\ b', r'a \\\ b'),
         )
         for s, expected in table:
             got = x.replace_back_slashes(s)


### PR DESCRIPTION
See #4284.

- [x] Rewrite `find.replace_back_slashes`.
- [x] Revise `TestFind.test_replace_back_slashes`.
- [x] Test with plain and regex finds.