### PR TITLE
PR: write-at-file-nodes always reports nodes

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1135,8 +1135,7 @@ class AtFile:
             return
         if files:
             n = at.unchangedFiles
-            if n > 1:
-                g.es(f"finished: {n} unchanged file{g.plural(n)}")
+            g.es(f"finished: {n} unchanged file{g.plural(n)}")
         elif all:
             g.warning("no @<file> nodes in the selected tree")
         elif dirty:


### PR DESCRIPTION
The legacy code didn't report singleton unchanged files. That turned out to be confusing.