### PR TITLE
PR: Don't write characters that are invalid in xml

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -576,6 +576,11 @@ class FastRead:
 #@+node:ekr.20160514120347.1: ** class FileCommands
 class FileCommands:
     """A class creating the FileCommands subcommander."""
+
+    # https://github.com/leo-editor/leo-editor/pull/4292
+    # Remove (almost) all invalid characters.
+    entities = {chr(z): '' for z in range(32) if chr(z) not in ('\t', '\n', '\r')}
+
     #@+others
     #@+node:ekr.20090218115025.4: *3* fc.Birth
     #@+node:ekr.20031218072017.3019: *4* fc.ctor
@@ -1945,18 +1950,11 @@ class FileCommands:
         if sheet:
             self.put(f"<?xml-stylesheet {sheet} ?>\n")
 
-    #@+node:ekr.20031218072017.1577: *5* fc.put_t_element (changed)
+    #@+node:ekr.20031218072017.1577: *5* fc.put_t_element
     def put_t_element(self, v: VNode) -> None:
         b, gnx = v.b, v.fileIndex
         ua = self.putUnknownAttributes(v)
-        body = b or ''
-        # Translate invalid characters to the corresponding 4-character string.
-        body = xml.sax.saxutils.escape(body, entities={
-            '\x1a': '\\x1a',  # Sub.
-            '\x1b': '\\x1b',  # Escape.
-            '\u200B':  '\\u200B',  # Zero-width space.
-            # '\r': '\\r',  # Carriage return.
-        })
+        body = xml.sax.saxutils.escape(b or '', entities=self.entities)
         self.put(f'<t tx="{gnx}"{ua}>{body}</t>\n')
     #@+node:ekr.20031218072017.1575: *5* fc.put_t_elements
     def put_t_elements(self) -> None:
@@ -2028,7 +2026,7 @@ class FileCommands:
             return val
         g.warning("ignoring non-dictionary unknownAttributes for", v)
         return ''
-    #@+node:ekr.20031218072017.1863: *5* fc.put_v_element & helper (changed)
+    #@+node:ekr.20031218072017.1863: *5* fc.put_v_element & helper
     def put_v_element(self, p: Position, isIgnore: bool = False) -> None:
         """Write a <v> element corresponding to a VNode."""
         fc = self
@@ -2059,14 +2057,7 @@ class FileCommands:
             fc.put(v_head + '</v>\n')
         else:
             fc.vnodesDict[gnx] = True
-            # Translate invalid characters to the corresponding 4-character string.
-            h = p.v.headString() or ''
-            h = xml.sax.saxutils.escape(h, entities={
-                '\x1a': '\\x1a',  # Sub.
-                '\x1b': '\\x1b',  # Escape.
-                '\u200B':  '\\u200B',  # Zero-width space.
-                # '\r': '\\r',  # Carriage return.
-            })
+            h = xml.sax.saxutils.escape(p.v.headString() or '', entities=self.entities)
             v_head += f"<vh>{h}</vh>"
 
             # New in 4.2: don't write child nodes of @file-thin trees


### PR DESCRIPTION
This PR removes almost all invalid xml characters when writing an outline. Notes:

- This change should not affect encoding-related issues in any way.
- In particular, there should be no effect on [BOMs](https://en.wikipedia.org/wiki/Byte_order_mark).

This PR deals with several subtle issues. Please read the following notes *carefully* before commenting.

**The problem**

Leo can't read an outline that contains any invalid xml character. Leo's read code will (rightly!) complain that the `.leo` file is not a well-formed xml file. See the [XML Standard](https://www.w3.org/TR/2008/REC-xml-20081126/#charsets) for the list of characters that may appear in any XML file, including Leo outlines.

**The solution**

Leo calls [xml.sax.saxutils.escape](https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils.escape) to perform the standard xml escapes.  `escape` does not eliminate invalid characters by default, but an **entities** dict can specify translations to be performed.

This PR computes an `fc.entities` dict that has the effect of deleting almost all invalid xml characters.

**Background**

Pylint's unit tests contain five files that intentionally contain invalid characters. All these files reside in the `tests/functional/b` directory. These files are: `bad_char_backspace.py`, `bad_char_carriage_return.py`, `bad_char_esc.py`, `bad_char_sub.py`, and `bad_char_zero_width_space.py`.

`bad_char_carriage_return.py` is a special case. Tests show that Leo can handle carriage returns: Python's universal newline feature handles this case. Furthermore, scite converts carriage returns to newlines when pasting!

Adding `@file` nodes for any of the other four files creates an invalid `.leo` file!

**Workarounds**

1: Leo's log pane contains a clearly tells why the `.leo` file is invalid. For example:
```console
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 141686, column 6
```
Leonistas can use the [scite](https://scintilla.org/SciTE.html) text editor to delete the offending characters.

2: Tests show that using `@edit` nodes instead of `@file` nodes insulates the containing `.leo` file from the invalid characters.
However, converting `@edit` to `@file` will change the external file.

3: The workaround I am using is to create nodes that only *describe* the problematic test files. These nodes replace the invalid characters with (safe) text representations.  For example, one node replaces the escape character with the string `ESC`.

**Bad ideas**

The worst approach would be to convert bad characters into a valid **escape sequence** on write, and convert such escape sequences to invalid characters on reading `.leo` files. That is a recipe for disastrous confusion.

Converting a single character to a multi-character string is less harmful, but isn't very useful either.

Deleting only the three invalid characters contained in pylint's unit tests would be a confusing hack.

**Tasks**

- [x] Compute `fc.entities`. The effect of this dict is to delete almost all invalid xml characters.
- [x] Pass `fc.entities` to `xml.sax.saxutils.escape`.