### PR TITLE
Fix quirps found by pyflakes (python 3.13)

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2840,7 +2840,6 @@ class JEditColorizer(BaseColorizer):
         """
         Return the string state corresponding to the given integer state.
         """
-        c = self.c
 
         def default_language(n: int) -> str:
             # This optimization is crucial for large text.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -868,7 +868,7 @@ class Commands:
             extension_map = scan_map('EXTENSIONS')
             return processor_map, extension_map, terminal
 
-        maps = get_external_maps()
+        ### maps = get_external_maps()
         #@+node:tom.20241014154415.9: *4* getExeKind
         def getExeKind(ext: str) -> str:
             """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -867,8 +867,6 @@ class Commands:
             processor_map = scan_map('PROCESSORS')
             extension_map = scan_map('EXTENSIONS')
             return processor_map, extension_map, terminal
-
-        ### maps = get_external_maps()
         #@+node:tom.20241014154415.9: *4* getExeKind
         def getExeKind(ext: str) -> str:
             """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3175,12 +3175,13 @@ class Commands:
         # Write the file.
         try:
             # Retain old modification time to avoid pdb problems.
-            mod_time = os.path.getmtime(path)
-            with open(path, encoding='utf-8', mode='w') as f:
+            if os.path.exists(path):
+                mod_time = os.path.getmtime(path)
+                with open(path, encoding='utf-8', mode='w+') as f:
+                    f.write(script)
+                os.utime(path, (mod_time, mod_time))
+            with open(path, encoding='utf-8', mode='w+') as f:
                 f.write(script)
-            os.utime(path, (mod_time, mod_time))
-            # mod_time2 = os.path.getmtime(path)
-            # g.trace(mod_time, mod_time2)
         except Exception:
             g.es_exception()
             g.es(f"Failed to write script to {path}")

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -771,7 +771,6 @@ class LeoFind:
         """Return a list of compiled regex patterns."""
         c = self.c
         colorer = c.frame.body.colorizer
-        p = c.p
         if not word or not colorer:
             return []
 

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -181,7 +181,6 @@ class JupytextManager:
         if not p.h.startswith('@jupytext'):
             g.trace(f"Can not happen: not an @jupytext node: {p.h!r}")
             return ''
-        path = p.h[len('@jupytext') :].strip()
         full_path = c.fullPath(p)
         return full_path
     #@+node:ekr.20241024160108.1: *3* jtm.get_jupytext_config_file

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2677,7 +2677,6 @@ class KeyHandlerClass:
             #@+node:ekr.20241210065335.1: *5* ShowCommands.show_results
             def show_results(self) -> None:
                 """Pretty-print self.d"""
-                c = self.c
 
                 # Compute the maximum length of all file names.
                 files = (self.leo_settings, self.user_settings, self.local_settings)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -170,7 +170,7 @@ class Python_Importer(Importer):
             """Return the length of the leading whitespace for s."""
             return len(s) - len(s.lstrip())
 
-        i0 = i - 1  # For traces.
+        # i0 = i - 1  # For traces.
         prev_line = self.guide_lines[i - 1]
         kinds = ('class', 'def', '->')  # '->' denotes a coffeescript function.
         assert any(z in prev_line for z in kinds), (i, repr(prev_line))

--- a/leo/plugins/nodediff.py
+++ b/leo/plugins/nodediff.py
@@ -322,11 +322,10 @@ class NodeDiffController:
         else:
             return
 
-        cmd = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        data, err = cmd.communicate()
+        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        data, err = proc.communicate()
 
-        aFile = StringIO(data)
+        aFile = StringIO(g.toUnicode(data))
         tree = leosax.get_leo_data(aFile)
         for node in tree.flat():
             if node.gnx == gnx:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -952,9 +952,8 @@ class LeoQtTree(leoFrame.LeoTree):
         if e:
             e.setObjectName('headline')
         # Always do these!
-        wrapper = self.connectEditorWidget(e, item)
+        self.connectEditorWidget(e, item)
         self.sizeTreeEditor(c, e)
-
     #@+node:ekr.20110605121601.18421: *4* qtree.createTreeItem
     def createTreeItem(self, p: Position, parent_item: Item) -> Item:
 

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -856,8 +856,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         Return a *new* QWebEngineView instance with support for pdf,
         deleting any previous instance.
         """
-        c = self.c
-
         # Create the QWebEngineView if possible and embed the widget.
         w = self.create_web_engineview()
         assert w == self.w, g.callers()
@@ -1264,7 +1262,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         The first line of `s` should be a `@pdf <path>`.
         Resolve relative paths using the outline's directory.
         """
-        p = self.c.p
         if not s.strip():
             return
 
@@ -1516,8 +1513,6 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     #@+node:ekr.20241231121247.1: *4* vr.update_typst
     def update_typst(self, s: str, keywords: Any) -> None:
         """Display the typest text in `s` in the VR pane."""
-        p = self.c.p
-
         # Create a new QWebEngineView.
         w = self.create_web_engineview_with_pdf()
         if not has_webengineview:


### PR DESCRIPTION
Most quirps are minor. However, all changes might affect LeoJS.

- [x] Don't crash if leo/test/scriptFile.py does not exist.
- [x] All tests pass with Python 3.12 and 3.13.