### PR TITLE
PR: Create modes/cweb.py

### DIFF
--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -343,6 +343,7 @@
 </v>
 <v t="ekr.20180225010850.1"><vh>In leo/modes</vh>
 <v t="ekr.20221129095254.1"><vh>@file ../modes/batch.py</vh></v>
+<v t="ekr.20250121105007.1"><vh>@file ../modes/cweb.py</vh></v>
 <v t="ekr.20150326145530.1"><vh>@file ../modes/forth.py</vh></v>
 <v t="ekr.20230419050031.1"><vh>@file ../modes/html.py</vh></v>
 <v t="ekr.20240227082119.1"><vh>@file ../modes/ini.py</vh></v>
@@ -354,6 +355,7 @@
 <v t="ekr.20210219115553.109"><vh>@file ../modes/python.py</vh></v>
 <v t="ekr.20231103124615.1"><vh>@file ../modes/rust.py</vh></v>
 <v t="ekr.20231012163843.1"><vh>@file ../modes/scheme.py</vh></v>
+<v t="ekr.20250302114419.1"><vh>@edit ../modes/tex.py</vh></v>
 </v>
 </v>
 <v t="ekr.20201012111545.1"><vh>Plugins</vh>
@@ -657,6 +659,7 @@
 <v t="ekr.20240323050520.1"><vh>@file ../scripts/beautify_all_leo.py</vh></v>
 <v t="ekr.20240322065528.1"><vh>@file ../scripts/beautify_leo.py</vh></v>
 <v t="ekr.20240322084902.1"><vh>@file ../scripts/flake8_leo.py</vh></v>
+<v t="ekr.20250227032644.1"><vh>@file ../scripts/pyflakes_leo.py</vh></v>
 <v t="ekr.20240323051724.1"><vh>@file ../scripts/full_test_leo.py</vh></v>
 <v t="ekr.20240321122413.8"><vh>@file ../scripts/mypy_leo.py</vh></v>
 <v t="ekr.20240321122413.9"><vh>@file ../scripts/pylint_leo.py</vh></v>
@@ -1604,7 +1607,7 @@ win = sys.platform.startswith('win')
 old_dir = os.getcwd()
 if win:
     new_dir = r'C:\Repos\leo-editor'
-    path = r'C:\Users\Edward~1\Backup'
+    path = r'C:\Backup'
 else:
     new_dir = '/home/edward/Repos/leo-editor'
     path = '/home/edward/Backup'

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1654,6 +1654,9 @@ class JEditColorizer(BaseColorizer):
         Colorize Leo's @ and @ doc constructs.
         Matches only at the start of the line.
         """
+        if self.language == 'cweb':
+            # Let the cweb colorizer handle everything.
+            return 0
         if i != 0:
             return 0
         if g.match_word(s, i, '@doc'):

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -1,0 +1,281 @@
+#@+leo-ver=5-thin
+#@+node:ekr.20250121105007.1: * @file ../modes/cweb.py
+# Leo colorizer control file for cweb mode.
+# This file is in the public domain.
+
+import string
+
+#@+others
+#@-others
+
+#@+<< cweb: properties >>
+#@+node:ekr.20250123062334.1: ** << cweb: properties >>
+
+# Properties for cweb mode.
+properties = {
+    "commentEnd": "*/",
+    "commentStart": "/*",
+    "doubleBracketIndent": "false",
+    "indentCloseBrackets": "}",
+    "indentNextLine": "\\s*(((if|while)\\s*\\(|else\\s*|else\\s+if\\s*\\(|for\\s*\\(.*\\))[^{;]*)",
+    "indentOpenBrackets": "{",
+    "lineComment": "//",
+    "lineUpClosingBracket": "true",
+    "wordBreakChars": ",+-=<>/?^&*",
+}
+#@-<< cweb: properties >>
+#@+<< cweb: attributes & dict >>
+#@+node:ekr.20250123062356.1: ** << cweb: attributes & dict >>
+
+# Attributes dict for cweb_main ruleset.
+cweb_main_attributes_dict = {
+    "default": "null",
+    "digit_re": "(0x[[:xdigit:]]+[lL]?|[[:digit:]]+(e[[:digit:]]*)?[lLdDfF]?)",
+    "escape": "\\",
+    "highlight_digits": "true",
+    "ignore_case": "false",
+    "no_word_sep": "",
+}
+
+# Attributes dict for cweb_cpp ruleset.
+cweb_cpp_attributes_dict = {
+    "default": "KEYWORD2",
+    "digit_re": "(0x[[:xdigit:]]+[lL]?|[[:digit:]]+(e[[:digit:]]*)?[lLdDfF]?)",
+    "escape": "\\",
+    "highlight_digits": "true",
+    "ignore_case": "false",
+    "no_word_sep": "",
+}
+
+# Attributes dict for cweb_include ruleset.
+cweb_include_attributes_dict = {
+    "default": "KEYWORD2",
+    "digit_re": "(0x[[:xdigit:]]+[lL]?|[[:digit:]]+(e[[:digit:]]*)?[lLdDfF]?)",
+    "escape": "\\",
+    "highlight_digits": "true",
+    "ignore_case": "false",
+    "no_word_sep": "",
+}
+
+# Dictionary of attributes dictionaries for cweb mode.
+attributesDictDict = {
+    "cweb_cpp": cweb_cpp_attributes_dict,
+    "cweb_include": cweb_include_attributes_dict,
+    "cweb_main": cweb_main_attributes_dict,
+}
+#@-<< cweb: attributes & dict >>
+#@+<< cweb: keywords dict >>
+#@+node:ekr.20250123062431.1: ** << cweb: keywords dict >>
+
+# Keywords dict for cweb_main ruleset.
+cweb_main_keywords_dict = {
+    "NULL": "literal2",
+    "asm": "keyword2",
+    "asmlinkage": "keyword2",
+    "auto": "keyword1",
+    "break": "keyword1",
+    "case": "keyword1",
+    "char": "keyword3",
+    "const": "keyword1",
+    "continue": "keyword1",
+    "default": "keyword1",
+    "do": "keyword1",
+    "double": "keyword3",
+    "else": "keyword1",
+    "enum": "keyword3",
+    "extern": "keyword1",
+    "false": "literal2",
+    "far": "keyword2",
+    "float": "keyword3",
+    "for": "keyword1",
+    "goto": "keyword1",
+    "huge": "keyword2",
+    "if": "keyword1",
+    "inline": "keyword2",
+    "int": "keyword3",
+    "long": "keyword3",
+    "near": "keyword2",
+    "pascal": "keyword2",
+    "register": "keyword1",
+    "return": "keyword1",
+    "short": "keyword3",
+    "signed": "keyword3",
+    "sizeof": "keyword1",
+    "static": "keyword1",
+    "struct": "keyword3",
+    "switch": "keyword1",
+    "true": "literal2",
+    "typedef": "keyword3",
+    "union": "keyword3",
+    "unsigned": "keyword3",
+    "void": "keyword3",
+    "volatile": "keyword1",
+    "while": "keyword1",
+}
+
+# Dictionary of keywords dictionaries for cweb mode.
+keywordsDictDict = {
+    ### "cweb_cpp": cweb_cpp_keywords_dict,
+    ### "cweb_include": cweb_include_keywords_dict,
+    "cweb_main": cweb_main_keywords_dict,
+}
+#@-<< cweb: keywords dict >>
+#@+<< cweb: rules >>
+#@+node:ekr.20250123062533.1: ** << cweb: rules >>
+# Rules for cweb_main ruleset.
+
+#@+others
+#@+node:ekr.20250123061808.1: *3* function: cweb_rule0 /**
+def cweb_rule0(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
+          delegate="doxygen::doxygen")
+#@+node:ekr.20250123061808.2: *3* function: cweb_rule1 /*!
+def cweb_rule1(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
+          delegate="doxygen::doxygen")
+#@+node:ekr.20250123061808.3: *3* function: cweb_rule2 /*
+def cweb_rule2(colorer, s, i):
+    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
+#@+node:ekr.20250123061808.4: *3* function: cweb_rule3 "
+def cweb_rule3(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
+          no_line_break=True)
+#@+node:ekr.20250123061808.5: *3* function: cweb_rule4 '
+def cweb_rule4(colorer, s, i):
+    return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
+          no_line_break=True)
+#@+node:ekr.20250123061808.6: *3* function: cweb_rule5 ##
+def cweb_rule5(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
+#@+node:ekr.20250123061808.7: *3* function: cweb_rule6 #
+def cweb_rule6(colorer, s, i):
+
+    # #4283: Colorize the whole line.
+    return colorer.match_eol_span(s, i, kind="keyword2")
+#@+node:ekr.20250123061808.8: *3* function: cweb_rule7 // comment
+def cweb_rule7(colorer, s, i):
+    return colorer.match_eol_span(s, i, kind="comment2", seq="//")
+#@+node:ekr.20250123070417.1: *3* rules: operators
+def cweb_rule8(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="=")
+
+def cweb_rule9(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="!")
+
+def cweb_rule10(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
+
+def cweb_rule11(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
+
+def cweb_rule12(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="+")
+
+def cweb_rule13(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="-")
+
+def cweb_rule14(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="/")
+
+def cweb_rule15(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="*")
+
+def cweb_rule16(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq=">")
+
+def cweb_rule17(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="<")
+
+def cweb_rule18(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
+
+def cweb_rule19(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="&")
+
+def cweb_rule20(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="|")
+
+def cweb_rule21(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="^")
+
+def cweb_rule22(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="~")
+
+def cweb_rule23(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="}")
+
+def cweb_rule24(colorer, s, i):
+    return colorer.match_plain_seq(s, i, kind="operator", seq="{")
+
+def cweb_rule_at_sign(colorer, s, i):  # #4283.
+    return colorer.match_plain_seq(s, i, kind="operator", seq="@")
+
+def cweb_rule_semicolon(colorer, s, i):  # #4283.
+    return colorer.match_plain_seq(s, i, kind="operator", seq=";")
+
+#@+node:ekr.20250123061808.27: *3* function: cweb_rule26 (
+def cweb_rule26(colorer, s, i):
+    return colorer.match_mark_previous(s, i, kind="function", pattern="(",
+          exclude_match=True)
+#@+node:ekr.20250123061808.28: *3* function: cweb_keyword & label
+def cweb_keyword(colorer, s, i):
+    n = colorer.match_keywords(s, i)
+    if n >= 0:
+        return n
+    i2 = i + abs(n)
+    ch = s[i2] if i2 < len(s) else ''
+    if ch != ':':
+        return n
+
+    # color the label.
+    seq = s[i : i2 + 1]
+    return colorer.match_seq(s, i, kind="label", seq=seq)
+#@-others
+#@-<< cweb: rules >>
+#@+<< cweb: rules dict >>
+#@+node:ekr.20250123062712.1: ** << cweb: rules dict >>
+# Rules dict for cweb_main ruleset.
+rulesDict1 = {
+    ";": [cweb_rule_semicolon],  # #4283.
+    "@": [cweb_rule_at_sign],  # #4283.
+    "!": [cweb_rule9],
+    '"': [cweb_rule3],
+    "#": [cweb_rule5, cweb_rule6],
+    "%": [cweb_rule18],
+    "&": [cweb_rule19],
+    "'": [cweb_rule4],
+    "(": [cweb_rule26],
+    "*": [cweb_rule15],
+    "+": [cweb_rule12],
+    "-": [cweb_rule13],
+    "/": [cweb_rule0, cweb_rule1, cweb_rule2, cweb_rule7, cweb_rule14],
+    "<": [cweb_rule11, cweb_rule17],
+    "=": [cweb_rule8],
+    ">": [cweb_rule10, cweb_rule16],
+    "^": [cweb_rule21],
+    "{": [cweb_rule24],
+    "|": [cweb_rule20],
+    "}": [cweb_rule23],
+    "~": [cweb_rule22],
+}
+
+# Add *all* characters that could start a cweb identifier.
+lead_ins = string.ascii_letters + '_'
+for lead_in in lead_ins:
+    aList = rulesDict1.get(lead_in, [])
+    if cweb_keyword not in aList:
+        aList.insert(0, cweb_keyword)
+        rulesDict1[lead_in] = aList
+#@-<< cweb: rules dict >>
+
+# x.rulesDictDict for cweb mode.
+rulesDictDict = {
+    "cweb_main": rulesDict1,
+}
+
+# Import dict for cweb mode.
+importDict = {}
+
+#@@language python
+#@@tabwidth -4
+#@-leo

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -324,9 +324,9 @@ def cweb_at_sign(colorer, s, i):
     """
     global in_doc_part
 
-    seq = s[i : i + 2]
+    seq = s[i : i + 3]
     if i == 0 or not s[:i].strip():
-        in_doc_part = seq in ('@', '@ ', '@*')  # Anything else ends the doc part.
+        in_doc_part = seq.startswith(('@', '@ ', '@**',  '@*'))  # Anything else ends the doc part.
 
     if seq in ('@<', '@.'):
         # Color sections.

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -129,87 +129,164 @@ keywordsDictDict = {
 #@+others
 #@+node:ekr.20250123061808.1: *3* function: cweb_rule0 /**
 def cweb_rule0(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
           delegate="doxygen::doxygen")
 #@+node:ekr.20250123061808.2: *3* function: cweb_rule1 /*!
 def cweb_rule1(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
           delegate="doxygen::doxygen")
 #@+node:ekr.20250123061808.3: *3* function: cweb_rule2 /*
 def cweb_rule2(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 #@+node:ekr.20250123061808.4: *3* function: cweb_rule3 "
 def cweb_rule3(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
           no_line_break=True)
 #@+node:ekr.20250123061808.5: *3* function: cweb_rule4 '
 def cweb_rule4(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
           no_line_break=True)
 #@+node:ekr.20250123061808.6: *3* function: cweb_rule5 ##
 def cweb_rule5(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
 #@+node:ekr.20250123061808.7: *3* function: cweb_rule6 #
 def cweb_rule6(colorer, s, i):
-
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     # #4283: Colorize the whole line.
     return colorer.match_eol_span(s, i, kind="keyword2")
 #@+node:ekr.20250123061808.8: *3* function: cweb_rule7 // comment
 def cweb_rule7(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 #@+node:ekr.20250123070417.1: *3* rules: operators
 def cweb_rule8(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def cweb_rule9(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def cweb_rule10(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def cweb_rule11(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def cweb_rule12(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def cweb_rule13(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def cweb_rule14(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def cweb_rule15(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def cweb_rule16(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def cweb_rule17(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def cweb_rule18(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def cweb_rule19(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def cweb_rule20(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def cweb_rule21(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def cweb_rule22(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def cweb_rule23(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def cweb_rule24(colorer, s, i):
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def cweb_rule_semicolon(colorer, s, i):  # #4283.
+    global in_doc_part
+    if in_doc_part:
+        return len(s)
     return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 #@+node:ekr.20250302054554.1: *3* function: cweb_rule_at_sign
@@ -221,12 +298,17 @@ def cweb_rule_at_sign(colorer, s, i):
 
     seq = s[i : i + 2]
     if i == 0 and s[i] == '@':
-        in_doc_part = seq in ('@', '@ ', '@*')
         if in_doc_part:
             colorer.match_seq(s, i, kind="keyword1", seq=seq)
-            return colorer.match_line(s, i + len(seq), kind="")
+            return colorer.match_doc_part(s, i + len(seq))
+        else:
+            in_doc_part = seq in ('@', '@ ', '@*')
+            if in_doc_part:
+                colorer.match_seq(s, i, kind="keyword1", seq=seq)
+                i += len(seq)
+
     if in_doc_part:
-        return colorer.match_line(s, i, kind="")
+        return colorer.match_doc_part(s, i)
     if seq in ('@<', '@.'):
         # Color sections.
         j = s.find('@>', i + 2)
@@ -244,12 +326,31 @@ def cweb_rule26(colorer, s, i):
           exclude_match=True)
 #@+node:ekr.20250123061808.28: *3* function: cweb_keyword & label
 def cweb_keyword(colorer, s, i):
+    global in_doc_part
+
+    if in_doc_part:
+        return 0
+
     # cweb_rule_at_sign handles all section references.
     seq = s[i : i + 2]
     if seq in ('@<', '@.'):
         return 0
     return  colorer.match_keywords(s, i)
 
+#@+node:ekr.20250302073158.1: *3* function: cweb_backslash
+def cweb_backslash(colorer, s, i):
+    """Handle TeX control sequences."""
+
+    global in_doc_part
+    if in_doc_part:
+        return 0
+
+    seq = s[i : i + 2]
+
+    # Non-alphabetic.
+    if seq == '@' or len(seq) > 1 and not seq[1].isalpha():
+        return colorer.match_seq(s, i, kind="keyword1", seq=seq)
+    return 0
 #@-others
 #@-<< cweb: rules >>
 #@+<< cweb: rules dict >>
@@ -277,6 +378,7 @@ rulesDict1 = {
     "|": [cweb_rule20],
     "}": [cweb_rule23],
     "~": [cweb_rule22],
+    "\\": [cweb_backslash],
 }
 
 # Add *all* characters that could start a cweb identifier.

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -316,9 +316,9 @@ def cweb_backslash(colorer, s, i):
         return colorer.match_seq(s, i1, kind="keyword1", seq=seq)
     # Alphabetic
     i += 2
-    while i <len(s) and s[i].isalpha():
+    while i < len(s) and s[i].isalpha():
         i += 1
-    seq = s[i1: i]
+    seq = s[i1:i]
     return colorer.match_seq(s, i1, kind="keyword1", seq=seq)
 #@+node:ekr.20250302054554.1: *3* function: cweb_rule_at_sign
 def cweb_rule_at_sign(colorer, s, i):

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -241,12 +241,6 @@ def cweb_rule17(colorer, s, i):
         return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
-def cweb_rule18(colorer, s, i):
-    global in_doc_part
-    if in_doc_part:
-        return 0
-    return colorer.match_plain_seq(s, i, kind="operator", seq="%")
-
 def cweb_rule19(colorer, s, i):
     global in_doc_part
     if in_doc_part:
@@ -283,7 +277,7 @@ def cweb_rule24(colorer, s, i):
         return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
-def cweb_rule_semicolon(colorer, s, i):  # #4283.
+def cweb_semicolon(colorer, s, i):  # #4283.
     global in_doc_part
     if in_doc_part:
         return 0
@@ -293,19 +287,22 @@ def cweb_rule_semicolon(colorer, s, i):  # #4283.
 def cweb_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
           exclude_match=True)
-#@+node:ekr.20250123061808.28: *3* function: cweb_keyword & label
+#@+node:ekr.20250302120359.1: *3* function: cweb_percent
+def cweb_percent(colorer, s, i):
+    return colorer.match_line(s, i, kind="comment1")
+
+#@+node:ekr.20250123061808.28: *3* function: cweb_keyword
 def cweb_keyword(colorer, s, i):
     global in_doc_part
 
     if in_doc_part:
         return 0
 
-    # cweb_rule_at_sign handles all section references.
+    # cweb_at_sign handles all section references.
     seq = s[i : i + 2]
     if seq in ('@<', '@.'):
         return 0
     return  colorer.match_keywords(s, i)
-
 #@+node:ekr.20250302073158.1: *3* function: cweb_backslash
 def cweb_backslash(colorer, s, i):
     """Handle TeX control sequences."""
@@ -320,8 +317,8 @@ def cweb_backslash(colorer, s, i):
         i += 1
     seq = s[i1:i]
     return colorer.match_seq(s, i1, kind="keyword1", seq=seq)
-#@+node:ekr.20250302054554.1: *3* function: cweb_rule_at_sign
-def cweb_rule_at_sign(colorer, s, i):
+#@+node:ekr.20250302054554.1: *3* function: cweb_at_sign
+def cweb_at_sign(colorer, s, i):
     """
     Handle cweb directives. @ continues until the next directive.
     """
@@ -339,7 +336,7 @@ def cweb_rule_at_sign(colorer, s, i):
             seq2 = s[i + 2 : j]
             colorer.match_seq(s, i + 2, kind="label", seq=seq2)
             colorer.match_line(s, j, kind="keyword1")
-            return 0
+            return len(s)
         return colorer.match_line(s, i, kind="keyword1")
     return colorer.match_seq(s, i, kind="keyword1", seq=seq)
 #@-others
@@ -348,12 +345,12 @@ def cweb_rule_at_sign(colorer, s, i):
 #@+node:ekr.20250123062712.1: ** << cweb: rules dict >>
 # Rules dict for cweb_main ruleset.
 rulesDict1 = {
-    ";": [cweb_rule_semicolon],  # #4283.
-    "@": [cweb_rule_at_sign],
+    ";": [cweb_semicolon],  # #4283.
+    "@": [cweb_at_sign],
     "!": [cweb_rule9],
     '"': [cweb_rule3],
     "#": [cweb_rule5, cweb_rule6],
-    "%": [cweb_rule18],
+    "%": [cweb_percent],
     "&": [cweb_rule19],
     "'": [cweb_rule4],
     "(": [cweb_rule26],

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -131,162 +131,162 @@ keywordsDictDict = {
 def cweb_rule0(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/",
           delegate="doxygen::doxygen")
 #@+node:ekr.20250123061808.2: *3* function: cweb_rule1 /*!
 def cweb_rule1(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/",
           delegate="doxygen::doxygen")
 #@+node:ekr.20250123061808.3: *3* function: cweb_rule2 /*
 def cweb_rule2(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/")
 #@+node:ekr.20250123061808.4: *3* function: cweb_rule3 "
 def cweb_rule3(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"",
           no_line_break=True)
 #@+node:ekr.20250123061808.5: *3* function: cweb_rule4 '
 def cweb_rule4(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_span(s, i, kind="literal1", begin="'", end="'",
           no_line_break=True)
 #@+node:ekr.20250123061808.6: *3* function: cweb_rule5 ##
 def cweb_rule5(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="keyword2", seq="##")
 #@+node:ekr.20250123061808.7: *3* function: cweb_rule6 #
 def cweb_rule6(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     # #4283: Colorize the whole line.
     return colorer.match_eol_span(s, i, kind="keyword2")
 #@+node:ekr.20250123061808.8: *3* function: cweb_rule7 // comment
 def cweb_rule7(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_eol_span(s, i, kind="comment2", seq="//")
 #@+node:ekr.20250123070417.1: *3* rules: operators
 def cweb_rule8(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="=")
 
 def cweb_rule9(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="!")
 
 def cweb_rule10(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq=">=")
 
 def cweb_rule11(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="<=")
 
 def cweb_rule12(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="+")
 
 def cweb_rule13(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="-")
 
 def cweb_rule14(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="/")
 
 def cweb_rule15(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="*")
 
 def cweb_rule16(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq=">")
 
 def cweb_rule17(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="<")
 
 def cweb_rule18(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="%")
 
 def cweb_rule19(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="&")
 
 def cweb_rule20(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="|")
 
 def cweb_rule21(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="^")
 
 def cweb_rule22(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="~")
 
 def cweb_rule23(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="}")
 
 def cweb_rule24(colorer, s, i):
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq="{")
 
 def cweb_rule_semicolon(colorer, s, i):  # #4283.
     global in_doc_part
     if in_doc_part:
-        return len(s)
+        return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
 #@+node:ekr.20250302054554.1: *3* function: cweb_rule_at_sign
@@ -298,17 +298,13 @@ def cweb_rule_at_sign(colorer, s, i):
 
     seq = s[i : i + 2]
     if i == 0 and s[i] == '@':
-        if in_doc_part:
-            colorer.match_seq(s, i, kind="keyword1", seq=seq)
-            return colorer.match_doc_part(s, i + len(seq))
-        else:
-            in_doc_part = seq in ('@', '@ ', '@*')
-            if in_doc_part:
-                colorer.match_seq(s, i, kind="keyword1", seq=seq)
-                i += len(seq)
+        old_in_doc_part = in_doc_part
+        in_doc_part = seq in ('@', '@ ', '@*')
+        if old_in_doc_part:
+            return colorer.match_seq(s, i, kind="keyword1", seq=seq)
+        elif in_doc_part:
+                return colorer.match_seq(s, i, kind="keyword1", seq=seq)
 
-    if in_doc_part:
-        return colorer.match_doc_part(s, i)
     if seq in ('@<', '@.'):
         # Color sections.
         j = s.find('@>', i + 2)
@@ -317,7 +313,7 @@ def cweb_rule_at_sign(colorer, s, i):
             seq2 = s[i + 2 : j]
             colorer.match_seq(s, i + 2, kind="label", seq=seq2)
             colorer.match_line(s, j, kind="keyword1")
-            return len(s)
+            return 0
         return colorer.match_line(s, i, kind="keyword1")
     return colorer.match_seq(s, i, kind="keyword1", seq=seq)
 #@+node:ekr.20250123061808.27: *3* function: cweb_rule26 (
@@ -340,17 +336,18 @@ def cweb_keyword(colorer, s, i):
 #@+node:ekr.20250302073158.1: *3* function: cweb_backslash
 def cweb_backslash(colorer, s, i):
     """Handle TeX control sequences."""
-
-    global in_doc_part
-    if in_doc_part:
-        return 0
-
-    seq = s[i : i + 2]
-
+    i1 = i
+    print('bs', s)
     # Non-alphabetic.
-    if seq == '@' or len(seq) > 1 and not seq[1].isalpha():
-        return colorer.match_seq(s, i, kind="keyword1", seq=seq)
-    return 0
+    seq = s[i : i + 2]
+    if seq == '\\' or len(seq) > 1 and not seq[1].isalpha():
+        return colorer.match_seq(s, i1, kind="keyword1", seq=seq)
+    # Alphabetic
+    i += 2
+    while i <len(s) and s[i].isalpha():
+        i += 1
+    seq = s[i1: i]
+    return colorer.match_seq(s, i1, kind="keyword1", seq=seq)
 #@-others
 #@-<< cweb: rules >>
 #@+<< cweb: rules dict >>

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -289,33 +289,6 @@ def cweb_rule_semicolon(colorer, s, i):  # #4283.
         return 0
     return colorer.match_plain_seq(s, i, kind="operator", seq=";")
 
-#@+node:ekr.20250302054554.1: *3* function: cweb_rule_at_sign
-def cweb_rule_at_sign(colorer, s, i):
-    """
-    Handle cweb directives. @ continues until the next directive.
-    """
-    global in_doc_part
-
-    seq = s[i : i + 2]
-    if i == 0 and s[i] == '@':
-        old_in_doc_part = in_doc_part
-        in_doc_part = seq in ('@', '@ ', '@*')
-        if old_in_doc_part:
-            return colorer.match_seq(s, i, kind="keyword1", seq=seq)
-        elif in_doc_part:
-                return colorer.match_seq(s, i, kind="keyword1", seq=seq)
-
-    if seq in ('@<', '@.'):
-        # Color sections.
-        j = s.find('@>', i + 2)
-        if j > -1:
-            colorer.match_seq(s, i, kind="keyword1", seq=seq)
-            seq2 = s[i + 2 : j]
-            colorer.match_seq(s, i + 2, kind="label", seq=seq2)
-            colorer.match_line(s, j, kind="keyword1")
-            return 0
-        return colorer.match_line(s, i, kind="keyword1")
-    return colorer.match_seq(s, i, kind="keyword1", seq=seq)
 #@+node:ekr.20250123061808.27: *3* function: cweb_rule26 (
 def cweb_rule26(colorer, s, i):
     return colorer.match_mark_previous(s, i, kind="function", pattern="(",
@@ -337,7 +310,6 @@ def cweb_keyword(colorer, s, i):
 def cweb_backslash(colorer, s, i):
     """Handle TeX control sequences."""
     i1 = i
-    print('bs', s)
     # Non-alphabetic.
     seq = s[i : i + 2]
     if seq == '\\' or len(seq) > 1 and not seq[1].isalpha():
@@ -348,6 +320,28 @@ def cweb_backslash(colorer, s, i):
         i += 1
     seq = s[i1: i]
     return colorer.match_seq(s, i1, kind="keyword1", seq=seq)
+#@+node:ekr.20250302054554.1: *3* function: cweb_rule_at_sign
+def cweb_rule_at_sign(colorer, s, i):
+    """
+    Handle cweb directives. @ continues until the next directive.
+    """
+    global in_doc_part
+
+    seq = s[i : i + 2]
+    if i == 0 or not s[:i].strip():
+        in_doc_part = seq in ('@', '@ ', '@*')  # Anything else ends the doc part.
+
+    if seq in ('@<', '@.'):
+        # Color sections.
+        j = s.find('@>', i + 2)
+        if j > -1:
+            colorer.match_seq(s, i, kind="keyword1", seq=seq)
+            seq2 = s[i + 2 : j]
+            colorer.match_seq(s, i + 2, kind="label", seq=seq2)
+            colorer.match_line(s, j, kind="keyword1")
+            return 0
+        return colorer.match_line(s, i, kind="keyword1")
+    return colorer.match_seq(s, i, kind="keyword1", seq=seq)
 #@-others
 #@-<< cweb: rules >>
 #@+<< cweb: rules dict >>


### PR DESCRIPTION
This PR contains the *minimal* code to view the `cweb.leo` study outline comfortably.

This PR does *not* attempt to handle all of `TeX`'s conventions.

- [x] Add special case to jEdit.match_doc_part.
- [x] Add `modes/cweb.py`, based on `modes/c.py`.
- [x] Handle `cweb` doc mode properly.
- [x] Handle `@**`.
- [x] Update `LeoPyRef.leo`.

**Notes**

- Only `cweb_rule_at_sign` and `cweb_backslash` are new (compared with `modes/c.py`).
- Only `cweb_keyword` has changed significantly (compared with `modes/c.py`).
  However, many matchers do nothing when the `in_doc_part` global is `True`.