### PR TITLE
Scripts, @commands and @buttons, can now have a return value.

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -520,6 +520,7 @@
 <v t="ekr.20210506073820.1"><vh>@bool allow-text-zoom = True</vh></v>
 <v t="ekr.20241012050620.1"><vh>@bool diff-leo-files = True</vh></v>
 <v t="ekr.20131112150804.18737"><vh>@bool force-execute-entire-body = False</vh></v>
+<v t="felix.20250313171245.1"><vh>@bool allow-script-return-result = False</vh></v>
 <v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20220624062948.1"><vh>@bool redirect-execute-script-output-to-log_pane = False</vh></v>
@@ -11921,6 +11922,27 @@ False: (Recommended) The commands act as simple navigation commands, and do not 
 (In the same format as the .leojs file format)
 
 Leo accepts outline 'paste' data in both XML Leo format, or JSON format</t>
+<t tx="felix.20250313171245.1">True: Scripts to be executed (from @command, @button, CTRL+B from body pane, etc... ) will be wrapped in 
+
+def main():
+    &lt;script&gt;
+
+result = main()
+
+to allow for return values to be captured if your script tries to 'return' a value.
+
+Example: If you have an @command my-command node that contains:
+
+return 2+2
+
+then you could run a script that contains
+
+output = c.doCommandByName('my-command')
+print(output) 
+
+which would print 4.
+
+Note: By default, script execution will return the value it may have set in a global variable named "result". (or None)</t>
 <t tx="jlunz.20150821113251.1">def html_tag():
     """expand &lt;tag&gt; to 
        &lt;tag&gt;\n&lt;/tag&gt; with proper indendation"""

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1302,20 +1302,21 @@ class Commands:
         try:
             c.inCommand = False
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
+            final_script = script # Default to straight script execution
 
-            # Pre-process the script to indent each line
-            indented_script = script.replace('\n', '\n    ')
-            
-            # Use the pre-processed script in the f-string
-            wrapped_script = f"def main():\n    {indented_script}\nresult = main()"
+            if c.config.getBool('allow-script-return-result'):
+                # Pre-process the script to indent each line
+                indented_script = script.replace('\n', '\n    ')
+                # Use the pre-processed script in the f-string
+                final_script = f"def main():\n    {indented_script}\nresult = main()"
 
             if c.write_script_file:
-                scriptFile = self.writeScriptFile(wrapped_script)
-                exec(compile(wrapped_script, scriptFile, 'exec'), d)
+                scriptFile = self.writeScriptFile(final_script)
+                exec(compile(final_script, scriptFile, 'exec'), d)
             else:
-                exec(wrapped_script, d)
+                exec(final_script, d)
                 
-            # Return the result of the script.
+            # Return the optional value of a 'result' global, if defined, to be passed up the chain.
             return d.get("result")
         finally:
             g.inScript = g.app.inScript = False

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -285,11 +285,11 @@ class AtButtonCallback:
             return f"AtButtonCallback: {self.gnx}"
         raise AttributeError  # Returning None is not correct.
     #@+node:ekr.20170203043042.1: *3* AtButtonCallback.execute_script & helper
-    def execute_script(self) -> None:
+    def execute_script(self) -> Any:
         """Execute the script associated with this button."""
         script = self.find_script()
         if script:
-            self.controller.executeScriptFromButton(
+            return self.controller.executeScriptFromButton(
                 b=self.b,
                 buttonText=self.buttonText,
                 p=None,
@@ -619,7 +619,7 @@ class ScriptingController:
         p: Position,
         script: str,
         script_gnx: str = None,
-    ) -> None:
+    ) -> Any:
         """Execute an @button script in p.b or script."""
         c = self.c
         if c.disableCommandsMessage:
@@ -632,13 +632,14 @@ class ScriptingController:
         args = self.getArgs(p)
         if not script:
             script = self.getScript(p)
-        c.executeScript(args=args, p=p, script=script, silent=True)
+        result = c.executeScript(args=args, p=p, script=script, silent=True)
         # Remove the button if the script asks to be removed.
         if g.app.scriptDict.get('removeMe'):
             g.es("Removing '%s' button at its request" % buttonText)
             self.deleteButton(b)
         # Do *not* set focus here: the script may have changed the focus.
             # c.bodyWantsFocus()
+        return result
     #@+node:ekr.20130912061655.11294: *3* sc.open_gnx
     def open_gnx(self, c: Cmdr, gnx: str) -> tuple[Cmdr, Position]:
         """
@@ -818,9 +819,9 @@ class ScriptingController:
             return
         args = self.getArgs(p)
 
-        def atCommandCallback(event: Event = None, args: Any = args, c: Cmdr = c, p: Position = p.copy()) -> None:
+        def atCommandCallback(event: Event = None, args: Any = args, c: Cmdr = c, p: Position = p.copy()) -> Any:
             # pylint: disable=dangerous-default-value
-            c.executeScript(args=args, p=p, silent=True)
+            return c.executeScript(args=args, p=p, silent=True)
 
         # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252
         # Minibuffer commands created by mod_scripting.py have no docstrings
@@ -857,9 +858,9 @@ class ScriptingController:
             return
         args = self.getArgs(p)
 
-        def atCommandCallback(event: Event = None, args: Any = args, c: Cmdr = c, p: Position = p.copy()) -> None:
+        def atCommandCallback(event: Event = None, args: Any = args, c: Cmdr = c, p: Position = p.copy()) -> Any:
             # pylint: disable=dangerous-default-value
-            c.executeScript(args=args, p=p, silent=True)
+            return c.executeScript(args=args, p=p, silent=True)
         if p.b.strip():
             self.registerAllCommands(
                 args=args,
@@ -881,7 +882,7 @@ class ScriptingController:
             handlerc(rc)
 
     #@+node:ekr.20060328125248.14: *4* sc.handleAtScriptNode @script
-    def handleAtScriptNode(self, p: Position) -> None:
+    def handleAtScriptNode(self, p: Position) -> Any:
         """Handle @script nodes."""
         c = self.c
         tag = "@script"
@@ -890,7 +891,7 @@ class ScriptingController:
         args = self.getArgs(p)
         if self.atScriptNodes:
             g.blue("executing script %s" % (name))
-            c.executeScript(args=args, p=p, useSelectedText=False, silent=True)
+            return c.executeScript(args=args, p=p, useSelectedText=False, silent=True)
         else:
             g.warning("disabled @script: %s" % (name))
         if 0:
@@ -1081,8 +1082,8 @@ class ScriptingController:
                 commandName2 = commandName[len(prefix) :].strip()
                 # Create a *second* func, to avoid collision in c.commandsDict.
 
-                def registerAllCommandsCallback(event: Event = None, func: Callable = func) -> None:
-                    func()
+                def registerAllCommandsCallback(event: Event = None, func: Callable = func) -> Any:
+                    return func()
 
                 # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252
                 # Minibuffer commands created by mod_scripting.py have no docstrings.


### PR DESCRIPTION
Allows for CTRL+b in a node which contains:

```
g.es('Hi! running a command!')
a = c.doCommandByName('fil-test-cmd') + 1
g.es(a)
```

Where the node @command fil-test-cmd contains:

```
g.es('hi from cmd')
x = 2
y = 40

def mySum(a, b):
    return a+b

value = mySum(x, y)
g.es(value)
return value
```

Fixes #4313