### PR TITLE
PR for #4306: quirp involving write-zip-archive

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -660,7 +660,7 @@ class FileCommands:
         c = self.c
         leo_file = c.fileName()
         if not leo_file:
-            print('Please save this outline first')
+            g.es_print('Please save this outline first')
             return
 
         # Compute the timestamp.
@@ -672,6 +672,7 @@ class FileCommands:
         try:
             directory = os.environ['LEO_ARCHIVE'].strip()
             if not directory or not os.path.exists(directory):
+                g.es_print(f"Does not exist (LEO_ARCHIVE directory): {directory!r}")
                 raise KeyError
             archive_path = rf"{directory}{os.sep}{g.shortFileName(leo_file)}-{time_s}.zip"
         except KeyError:
@@ -681,7 +682,7 @@ class FileCommands:
         try:
             n = 1
             with zipfile.ZipFile(archive_path, 'w') as f:
-                f.write(leo_file)
+                f.write(leo_file, arcname=os.path.basename(leo_file))
                 for p in c.all_unique_positions():
                     if p.isAnyAtFileNode():
                         fn = c.fullPath(p)
@@ -692,7 +693,6 @@ class FileCommands:
         except Exception:
             g.es_print(f"Error writing {archive_path}")
             g.es_exception()
-
     #@+node:ekr.20210316034350.1: *3* fc: File Utils
     #@+node:ekr.20031218072017.3047: *4* fc.createBackupFile
     def createBackupFile(self, fileName: str) -> tuple[bool, str]:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -668,22 +668,19 @@ class FileCommands:
         time = datetime.fromtimestamp(timestamp)
         time_s = time.strftime('%Y-%m-%d-%H-%M-%S')
 
-        # Compute archive_name.
-        archive_name = None
+        # Compute the path to the archive.
         try:
-            directory = os.environ['LEO_ARCHIVE']
-            if not os.path.exists(directory):
-                g.es_print(f"Not found: {directory!r}")
-                archive_name = rf"{directory}{os.sep}{g.shortFileName(leo_file)}-{time_s}.zip"
+            directory = os.environ['LEO_ARCHIVE'].strip()
+            if not directory or not os.path.exists(directory):
+                raise KeyError
+            archive_path = rf"{directory}{os.sep}{g.shortFileName(leo_file)}-{time_s}.zip"
         except KeyError:
-            pass
-        if not archive_name:
-            archive_name = rf"{leo_file}-{time_s}.zip"
+            archive_path = rf"{leo_file}-{time_s}.zip"
 
         # Write the archive.
         try:
             n = 1
-            with zipfile.ZipFile(archive_name, 'w') as f:
+            with zipfile.ZipFile(archive_path, 'w') as f:
                 f.write(leo_file)
                 for p in c.all_unique_positions():
                     if p.isAnyAtFileNode():
@@ -691,9 +688,9 @@ class FileCommands:
                         if os.path.exists(fn):
                             n += 1
                             f.write(fn)
-            g.es_print(f"Wrote {archive_name} containing {n} file{g.plural(n)}")
+            g.es_print(f"Wrote {archive_path} containing {n} file{g.plural(n)}")
         except Exception:
-            g.es_print(f"Error writing {archive_name}")
+            g.es_print(f"Error writing {archive_path}")
             g.es_exception()
 
     #@+node:ekr.20210316034350.1: *3* fc: File Utils


### PR DESCRIPTION
See #4306.

This PR will remain a draft while we discuss the subtleties.

Leo's existing `write-zip-archive` command is arguably good enough.  [`zipfile.ZipFile.write`](https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile.write) puts files in folders to avoid problems with name clashes.

- [x] Simplify the logic and error handling.
- [x] Use the `arcname` kwarg to suppress the folder for the `.leo` file itself.

