### PR TITLE
Back out of PR #4314

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -520,7 +520,6 @@
 <v t="ekr.20210506073820.1"><vh>@bool allow-text-zoom = True</vh></v>
 <v t="ekr.20241012050620.1"><vh>@bool diff-leo-files = True</vh></v>
 <v t="ekr.20131112150804.18737"><vh>@bool force-execute-entire-body = False</vh></v>
-<v t="felix.20250313171245.1"><vh>@bool allow-script-return-result = False</vh></v>
 <v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20220624062948.1"><vh>@bool redirect-execute-script-output-to-log_pane = False</vh></v>
@@ -11922,29 +11921,8 @@ False: (Recommended) The commands act as simple navigation commands, and do not 
 (In the same format as the .leojs file format)
 
 Leo accepts outline 'paste' data in both XML Leo format, or JSON format</t>
-
-<t tx="felix.20250313171245.1">True: Scripts to be executed (from @command, @button, CTRL+B from body pane, etc... ) will be wrapped in 
-
-def main():
-    &lt;script&gt;
-
-result = main()
-
-to allow for return values to be captured if your script tries to 'return' a value.
-
-Example: If you have an @command my-command node that contains:
-
-return 2+2
-
-then you could run a script that contains
-
-output = c.doCommandByName('my-command')
-print(output) 
-
-which would print 4.
-
-Note: By default, script execution will return the value it may have set in a global variable named "result". (or None)</t>
-
+<t tx="felix.20250313152228.1"></t>
+<t tx="felix.20250313152231.1"></t>
 <t tx="jlunz.20150821113251.1">def html_tag():
     """expand &lt;tag&gt; to 
        &lt;tag&gt;\n&lt;/tag&gt; with proper indendation"""

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1227,7 +1227,7 @@ class Commands:
             if not valid:
                 message = f"Must select text to execute {language} script"
                 g.es_print(message, color='blue')
-                return None
+                return
         if runPyflakes:
             run_pyflakes = c.config.getBool('run-pyflakes-on-write', default=False)
         else:
@@ -1245,7 +1245,6 @@ class Commands:
             cc.PyflakesCommand(c).check_script(script_p, prefix + script)
         self.redirectScriptOutput()
         oldLog = g.app.log
-        ### callResult = None
         try:
             log = c.frame.log
             g.app.log = log
@@ -1258,7 +1257,7 @@ class Commands:
                         namespace = namespace or {}
                         namespace.update(script_gnx=script_p.gnx)
                     # We *always* execute the script with p = c.p.
-                    callResult = c.executeScriptHelper(args, define_g, define_name, namespace, script)
+                    c.executeScriptHelper(args, define_g, define_name, namespace, script)
                 except KeyboardInterrupt:
                     g.es('interrupted')
                 except Exception:
@@ -1274,7 +1273,6 @@ class Commands:
         finally:
             g.app.log = oldLog
             self.unredirectScriptOutput()
-        ### return callResult
     #@+node:ekr.20171123135625.5: *4* c.executeScriptHelper
     def executeScriptHelper(self,
         args: list,
@@ -1303,27 +1301,11 @@ class Commands:
             c.inCommand = False
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
 
-            ###
-            # final_script = script  # Default to straight script execution
-            # if c.config.getBool('allow-script-return-result'):
-                # # Pre-process the script to indent each line
-                # indented_script = script.replace('\n', '\n    ')
-                # # Use the pre-processed script in the f-string
-                # final_script = f"def main():\n    {indented_script}\nresult = main()"
-            # if c.write_script_file:
-                # scriptFile = self.writeScriptFile(final_script)
-                # exec(compile(final_script, scriptFile, 'exec'), d)
-            # else:
-                # exec(final_script, d)
-
             if c.write_script_file:
                 scriptFile = self.writeScriptFile(script)
                 exec(compile(script, scriptFile, 'exec'), d)
             else:
                 exec(script, d)
-
-            # Return the optional value of a 'result' global, if defined, to be passed up the chain.
-            ### return d.get("result")
         finally:
             g.inScript = g.app.inScript = False
     #@+node:ekr.20171123135625.6: *4* c.redirectScriptOutput

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1193,7 +1193,7 @@ class Commands:
         namespace: dict = None,
         raiseFlag: bool = False,
         runPyflakes: bool = True,
-    ) -> Any:
+    ) -> None:
         """
         Execute a *Leo* script, written in python.
         Keyword args:
@@ -1245,7 +1245,7 @@ class Commands:
             cc.PyflakesCommand(c).check_script(script_p, prefix + script)
         self.redirectScriptOutput()
         oldLog = g.app.log
-        callResult = None
+        ### callResult = None
         try:
             log = c.frame.log
             g.app.log = log
@@ -1274,7 +1274,7 @@ class Commands:
         finally:
             g.app.log = oldLog
             self.unredirectScriptOutput()
-        return callResult
+        ### return callResult
     #@+node:ekr.20171123135625.5: *4* c.executeScriptHelper
     def executeScriptHelper(self,
         args: list,
@@ -1302,22 +1302,28 @@ class Commands:
         try:
             c.inCommand = False
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
-            final_script = script  # Default to straight script execution
 
-            if c.config.getBool('allow-script-return-result'):
-                # Pre-process the script to indent each line
-                indented_script = script.replace('\n', '\n    ')
-                # Use the pre-processed script in the f-string
-                final_script = f"def main():\n    {indented_script}\nresult = main()"
+            ###
+            # final_script = script  # Default to straight script execution
+            # if c.config.getBool('allow-script-return-result'):
+                # # Pre-process the script to indent each line
+                # indented_script = script.replace('\n', '\n    ')
+                # # Use the pre-processed script in the f-string
+                # final_script = f"def main():\n    {indented_script}\nresult = main()"
+            # if c.write_script_file:
+                # scriptFile = self.writeScriptFile(final_script)
+                # exec(compile(final_script, scriptFile, 'exec'), d)
+            # else:
+                # exec(final_script, d)
 
             if c.write_script_file:
-                scriptFile = self.writeScriptFile(final_script)
-                exec(compile(final_script, scriptFile, 'exec'), d)
+                scriptFile = self.writeScriptFile(script)
+                exec(compile(script, scriptFile, 'exec'), d)
             else:
-                exec(final_script, d)
+                exec(script, d)
 
             # Return the optional value of a 'result' global, if defined, to be passed up the chain.
-            return d.get("result")
+            ### return d.get("result")
         finally:
             g.inScript = g.app.inScript = False
     #@+node:ekr.20171123135625.6: *4* c.redirectScriptOutput

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -2508,8 +2508,6 @@
 </v>
 <v t="ekr.20241126091611.1"></v>
 <v t="ekr.20241126091524.1"><vh>Leo 6.8.3 release nodes</vh></v>
-<v t="ekr.20210402080752.1"></v>
-<v t="ekr.20250317133518.1"></v>
 </vnodes>
 <tnodes>
 <t tx="EKR.20040524104904.140">Leo stores options in **@settings trees**, outlines whose headline is ``@settings``. When opening a .leo file, Leo looks for ``@settings`` trees not only in the outline being opened but also in various ``leoSettings.leo`` files. This scheme allows for the following kinds of settings:

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -620,27 +620,27 @@ class ScriptingController:
         p: Position,
         script: str,
         script_gnx: str = None,
-    ) -> Any:
+    ) -> None:
         """Execute an @button script in p.b or script."""
         c = self.c
         if c.disableCommandsMessage:
             g.blue(c.disableCommandsMessage)
-            return None
+            return
         if not p and not script:
             g.trace('can not happen: no p and no script')
-            return None
+            return
         g.app.scriptDict = {'script_gnx': script_gnx}
-        args = self.getArgs(p)
+        self.getArgs(p)
         if not script:
             script = self.getScript(p)
-        result = c.executeScript(args=args, p=p, script=script, silent=True)
+
         # Remove the button if the script asks to be removed.
         if g.app.scriptDict.get('removeMe'):
             g.es("Removing '%s' button at its request" % buttonText)
             self.deleteButton(b)
+
         # Do *not* set focus here: the script may have changed the focus.
             # c.bodyWantsFocus()
-        return result
     #@+node:ekr.20130912061655.11294: *3* sc.open_gnx
     def open_gnx(self, c: Cmdr, gnx: str) -> tuple[Cmdr, Position]:
         """


### PR DESCRIPTION
**Status**

Closed: PR #4333 replaces this PR.

This PR will remain a draft until @boltex completes his researches.

- [x] Back out of PR #4314.
- [x] All tests pass, including pylint, pyflakes, mypy, and Leo's beautifier.

**About PR #4314**

The original PR works because, in effect, the PR executes what *appears* to be top-level code inside a wrapper function.  So the following script is valid:
```python
return 42
```

**How important is PR #4314?**

Imo, PR #4314 is unnecessary:
- Scripts may use Python's import commands to gain access to most of Leo's code.
- The PR makes debugging more difficult.
- The PR unnecessarily complicates the code, making it more difficult to maintain.

**History**

Approving PR #4314 was a mistake on my part:
- I did not read the code carefully.
- I did not request any unit test illustrating the utility of the PR.

I'll learn from these mistakes. 