### PR TITLE
PR for #4321: more cleanups

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -44,6 +44,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
             r'[%s%s\-_]+' % (string.ascii_letters, string.digits))
             # Not a unicode problem.
         self.n_regex = re.compile(r'(?<!\\)\\n')  # to replace \\n but not \\\\n
+        self.enabled = False
         self.expanding = False  # True: expanding abbreviations.
         self.event = None
         self.last_hit = None  # Distinguish between text and tree abbreviations.

--- a/leo/commands/baseCommands.py
+++ b/leo/commands/baseCommands.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< baseCommands imports & abbreviations >>
 
 #@+others

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_text import QTextEditWrapper
     Self = Cmdr  # For arguments to @g.commander_command.
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
     Wrapper = Union[QTextEditWrapper, StringTextWrapper]
 #@-<< commanderEditCommands imports & annotations >>
 

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -184,7 +184,6 @@ class StringTextWrapper:
     def __init__(self, c: Cmdr, name: str) -> None:
         """Ctor for the StringTextWrapper class."""
         self.c = c
-        self.leo_v = None
         self.name = name
         self.ins = 0
         self.sel = 0, 0

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -184,8 +184,6 @@ class StringTextWrapper:
     def __init__(self, c: Cmdr, name: str) -> None:
         """Ctor for the StringTextWrapper class."""
         self.c = c
-        self.leo_chapter = None
-        self.leo_p = None
         self.leo_v = None
         self.name = name
         self.ins = 0

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -415,4 +415,6 @@ class TreeAPI:
         pass
 #@-others
 #@@language python
+#@@tabwidth -4
+#@@pagewidth 60
 #@-leo

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -417,4 +417,5 @@ class TreeAPI:
     def updateHead(self, event: LeoKeyEvent, w: BaseTextAPI) -> None:
         pass
 #@-others
+#@@language python
 #@-leo

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position, VNode
     from leo.plugins.mod_scripting import ScriptingController
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoAPI.py: imports and annotations >>
 
 #@+others

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.qt_frame import LeoQtTreeTab
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextEditWrapper as Wrapper
+
 #@-<< leoChapters imports & annotations >>
 
 #@+others

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -376,26 +376,27 @@ class Chapter:
             return None
         return self.cc.findChapterNode(self.name)
     #@+node:ekr.20070317131205.1: *3* chapter.select & helpers
-    def select(self, w: Wrapper = None) -> None:
+    def select(self) -> None:
         """Restore chapter information and redraw the tree when a chapter is selected."""
         if self.selectLockout:
             return
         try:
             tt = self.cc.tt
             self.selectLockout = True
-            self.chapterSelectHelper(w)
+            self.chapterSelectHelper()
             if tt:
                 # A bad kludge: update all the chapter names *after* the selection.
                 tt.setTabLabel(self.name)
         finally:
             self.selectLockout = False
     #@+node:ekr.20070423102603.1: *4* chapter.chapterSelectHelper
-    def chapterSelectHelper(self, w: Wrapper = None) -> None:
+    def chapterSelectHelper(self) -> None:
 
         c, cc, u = self.c, self.cc, self.c.undoer
         cc.selectedChapter = self
         if self.name == 'main':
-            return  # 2016/04/20
+            return
+
         # Remember the root (it may have changed) for dehoist.
         self.root = root = self.findRootNode()
         if not root:
@@ -403,17 +404,10 @@ class Chapter:
             return
         if self.p and not c.positionExists(self.p):
             self.p = p = root.copy()
-        # Next, recompute p and possibly select a new editor.
-        if w:
-            assert w == c.frame.body.wrapper
-            assert w.leo_p
-            self.p = p = self.findPositionInChapter(w.leo_p) or root.copy()
-        else:
-            # This must be done *after* switching roots.
-            self.p = p = self.findPositionInChapter(self.p) or root.copy()
-            # Careful: c.selectPosition would pop the hoist stack.
-            w = self.findEditorInChapter(p)
-            self.p = p  # 2016/04/20: Apparently essential.
+
+        # Recompute p *after* switching roots.
+        # Careful: c.selectPosition would pop the hoist stack.
+        self.p = p = self.findPositionInChapter(self.p) or root.copy()
         if g.match_word(p.h, 0, '@chapter'):
             if p.hasChildren():
                 self.p = p = p.firstChild()
@@ -451,15 +445,6 @@ class Chapter:
             if p.v == p1.v:
                 return p.copy()
         return None
-    #@+node:ekr.20070425175522: *4* chapter.findEditorInChapter
-    def findEditorInChapter(self, p: Position) -> Wrapper:
-        """return w, an editor displaying position p."""
-        chapter, c = self, self.c
-        w = c.frame.body.wrapper
-        if w:
-            w.leo_chapter = chapter
-            w.leo_p = p and p.copy()
-        return w
     #@+node:ekr.20070615065222: *4* chapter.positionIsInChapter
     def positionIsInChapter(self, p: Position) -> bool:
         p2 = self.findPositionInChapter(p, strict=True)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2605,7 +2605,9 @@ class Commands:
     #@+node:ekr.20180503111249.2: *5* c.interactive3
     def interactive3(self, callback: Callable, event: LeoKeyEvent, prompts: Sequence) -> None:
 
-        c, d, k = self, {}, self.k
+        c = self
+        d: dict[str, str] = {}
+        k = self.k
         prompt1, prompt2, prompt3 = prompts
 
         def state1(event: LeoKeyEvent) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -66,7 +66,7 @@ if TYPE_CHECKING:  # pragma: no cover
     KWargs = Any
     RegexFlag = Union[int, re.RegexFlag]  # re.RegexFlag does not define 0
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
     Wrapper = Union[QTextEditWrapper, StringTextWrapper]
 #@-<< leoCommands annotations >>
 

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoApp import PreviousSettings
     Setting = Any
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoConfig imports & annotations >>
 #@+<< class ParserBaseClass >>
 #@+node:ekr.20041119203941.2: ** << class ParserBaseClass >>

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoExternalFiles imports & annotations >>
 
 #@+others

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.notebook import NbController
     Args = Any
     KWargs = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
     TextAPI = Union[QScintillaWrapper, QTextEditWrapper, StringTextWrapper]
 #@-<< leoFrame annotations >>
 #@+<< leoFrame: about handling events >>

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -137,20 +137,6 @@ class LeoBody:
         raise NotImplementedError
     #@+node:ekr.20060528100747: *3* LeoBody.Editors
     #@+node:ekr.20070424053629.1: *4* LeoBody.utils
-    #@+node:ekr.20070424084651: *5* LeoBody.ensurePositionExists
-    def ensurePositionExists(self, w: TextAPI) -> bool:
-        """Return True if w.leo_p exists or can be reconstituted."""
-        c = self.c
-        if c.positionExists(w.leo_p):
-            return True
-        g.trace('***** does not exist', w.leo_p)
-        for p2 in c.all_unique_positions():
-            if p2.v and p2.v == w.leo_v:
-                w.leo_p = p2.copy()
-                return True
-        # This *can* happen when selecting a deleted node.
-        w.leo_p = c.p
-        return False
     #@+node:ekr.20060530204135: *5* LeoBody.recolorWidget (QScintilla only)
     def recolorWidget(self, p: Position, w: TextAPI) -> None:
         # Support QScintillaColorizer.colorize.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -163,19 +163,6 @@ class LeoBody:
                 c.frame.body.colorizer.colorize(p)
             finally:
                 c.frame.body.wrapper = old_wrapper
-    #@+node:ekr.20070424084012: *5* LeoBody.switchToChapter
-    def switchToChapter(self, w: TextAPI) -> None:
-        """select w.leo_chapter."""
-        c = self.c
-        cc = c.chapterController
-        chapter = getattr(w, 'leo_chapter', None)
-        if chapter:
-            chapter = w.leo_chapter
-            name = chapter and chapter.name
-            oldChapter = cc.getSelectedChapter()
-            if chapter != oldChapter:
-                cc.selectChapterByName(name)
-                c.bodyWantsFocus()
     #@+node:ekr.20031218072017.4018: *3* LeoBody.Text
     #@+node:ekr.20031218072017.4030: *4* LeoBody.getInsertLines
     def getInsertLines(self) -> tuple[str, str, str]:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.plugins.qt_frame import FindTabManager
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoGui imports & annotations >>
 #@+others
 #@+node:ekr.20031218072017.3720: ** class LeoGui

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:  # pragma: no cover
     KWargs = Any
     Stroke = Any
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoKeys annotations >>
 #@+<< Key bindings, an overview >>
 #@+node:ekr.20130920121326.11281: ** << Key bindings, an overview >>

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -13,10 +13,11 @@ import string
 import sys
 import textwrap
 import time
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, Union, TYPE_CHECKING
 from types import ModuleType
 from leo.core import leoGlobals as g
 from leo.external import codewise
+from leo.core.leoFrame import NullLog
 try:
     import jedi
 except ImportError:
@@ -29,6 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGlobals import BindingInfo
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
+    from leo.plugins.qt_frame import LeoQtLog
     from leo.plugins.qt_text import QTextEditWrapper as Wrapper
     Args = Any
     KWargs = Any
@@ -1057,7 +1059,7 @@ class FileNameChooser:
         self.c = c
         self.k = c.k
         assert c and c.k
-        self.log = c.frame.log or g.NullObject()
+        self.log: Union[NullLog, LeoQtLog] = c.frame.log or NullLog(frame=c.frame, parentFrame=None)
         self.callback: Callable = None
         self.filterExt: list[str] = None
         self.prompt: str = None
@@ -1166,7 +1168,7 @@ class FileNameChooser:
         char = event.char if event else ''
         if state == 0:
             # Re-init all ivars.
-            self.log = c.frame.log or g.NullObject()
+            self.log = c.frame.log or NullLog(frame=c.frame, parentFrame=None)
             self.callback = callback
             self.filterExt = filterExt or ['.pyc', '.bin',]
             self.prompt = prompt
@@ -4271,7 +4273,7 @@ class KeyHandlerClass:
         elif c.vim_mode and c.vimCommands:
             c.vimCommands.show_status()
             return
-        else:
+        else:  # pylint: disable=no-else-return
             s = f"{state.capitalize()} State"
             if c.editCommands.extendMode:
                 s = s + ' (Extend Mode)'

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     Menu = Any
     Value = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoMenu imports & annotations >>
 #@+others
 #@+node:ekr.20031218072017.3750: ** class LeoMenu

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:  # pragma: no cover
     KWargs = Any
     QEvent: TypeAlias = QtCore.QEvent
     Stroke = Any
-    Widget = Any
+    Widget = Any  # 'Any' is the correct annotation for base class widgets.
 #@-<< leoVim imports & annotations >>
 
 def cmd(name: str) -> Callable:

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2451,7 +2451,32 @@ def createChapterIvar(self, w: Wrapper) -> None:
             w.leo_chapter = cc.getSelectedChapter()
         else:
             w.leo_chapter = None
-#@+node:ekr.20250331151305.15: *3* LeoBody.switchToChapter
+#@+node:ekr.20250401051638.1: *3* deleted via PR #4322
+https://github.com/leo-editor/leo-editor/pull/4322
+#@+node:ekr.20250401051709.27: *4* chapter.findEditorInChapter
+def findEditorInChapter(self, p: Position) -> Wrapper:
+    """return w, an editor displaying position p."""
+    chapter, c = self, self.c
+    w = c.frame.body.wrapper
+    if w:
+        w.leo_chapter = chapter
+        w.leo_p = p and p.copy()
+    return w
+#@+node:ekr.20250401051710.23: *4* LeoBody.ensurePositionExists
+def ensurePositionExists(self, w: TextAPI) -> bool:
+    """Return True if w.leo_p exists or can be reconstituted."""
+    c = self.c
+    if c.positionExists(w.leo_p):
+        return True
+    g.trace('***** does not exist', w.leo_p)
+    for p2 in c.all_unique_positions():
+        if p2.v and p2.v == w.leo_v:
+            w.leo_p = p2.copy()
+            return True
+    # This *can* happen when selecting a deleted node.
+    w.leo_p = c.p
+    return False
+#@+node:ekr.20250331151305.15: *4* LeoBody.switchToChapter
 def switchToChapter(self, w: TextAPI) -> None:
     """select w.leo_chapter."""
     c = self.c

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2451,6 +2451,19 @@ def createChapterIvar(self, w: Wrapper) -> None:
             w.leo_chapter = cc.getSelectedChapter()
         else:
             w.leo_chapter = None
+#@+node:ekr.20250331151305.15: *3* LeoBody.switchToChapter
+def switchToChapter(self, w: TextAPI) -> None:
+    """select w.leo_chapter."""
+    c = self.c
+    cc = c.chapterController
+    chapter = getattr(w, 'leo_chapter', None)
+    if chapter:
+        chapter = w.leo_chapter
+        name = chapter and chapter.name
+        oldChapter = cc.getSelectedChapter()
+        if chapter != oldChapter:
+            cc.selectChapterByName(name)
+            c.bodyWantsFocus()
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -3992,7 +3992,6 @@ class TextMixin:
     #@+node:ekr.20170511053143.3: *5* tm.injectIvars (cursesGui2)
     def injectIvars(self, c: Cmdr) -> Wrapper:
         """Inject standard leo ivars into the QTextEdit or QsciScintilla widget."""
-        self.leo_p = c.p.copy() if c.p else None
         self.leo_active = True
         # Inject the scrollbar items into the text widget.
         self.leo_bodyBar = None
@@ -4124,12 +4123,10 @@ class BodyWrapper(StringTextWrapper):
     #@+node:ekr.20170504034655.3: *4* bw.injectIvars (cursesGui2)
     def injectIvars(self, c: Cmdr) -> None:
         """Inject standard leo ivars into the QTextEdit or QsciScintilla widget."""
-        self.leo_p = c.p.copy() if c.p else None
         self.leo_active = True
         # Inject the scrollbar items into the text widget.
         self.leo_bodyBar = None
         self.leo_bodyXBar = None
-        self.leo_chapter = None
         self.leo_frame = None
     #@+node:ekr.20170504034655.6: *4* bw.onCursorPositionChanged
     def onCursorPositionChanged(self, event: Event = None) -> None:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1326,8 +1326,6 @@ class QScintillaWrapper(QTextMixin):
         self.name = name
         self.useScintilla = True
         self.widget = widget
-        # Injected ivars.
-        self.leo_v = None
         # Complete the init.
         self.set_config()
         # Set the signal.
@@ -1550,8 +1548,6 @@ class QTextEditWrapper(QTextMixin):
         self.name = name
         self.widget = widget
         self.useScintilla = False
-        # Define injected ivars.
-        self.leo_v = None
         # Complete the init.
         if c and widget:
             self.widget.setUndoRedoEnabled(False)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoGui import LeoKeyEvent
     from leo.plugins.leoAPI import BaseTextAPI
     Args = Any
-    ComplexUnion = Any
     KWargs = Any
     QEvent = QtCore.QEvent
     QFrame = QtWidgets.QFrame
@@ -152,8 +151,7 @@ class QTextMixin:
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!
         self.virtualInsertPoint = None
-        # This default annotation may mask bugs, but it probably doesn't!
-        self.widget: ComplexUnion = None
+        self.widget: Any = None  # Any is correct.
         if c:
             self.injectIvars(c)
     #@+node:ekr.20140901062324.18721: *4* QTextMixin.injectIvars

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -160,12 +160,10 @@ class QTextMixin:
     def injectIvars(self, c: Cmdr) -> QTextMixin:
         """Inject standard leo ivars into the QTextEdit or QsciScintilla widget."""
         w = self
-        w.leo_p = c.p.copy() if c.p else None
         w.leo_active = True
         # New in Leo 4.4.4 final: inject the scrollbar items into the text widget.
         w.leo_bodyBar = None
         w.leo_bodyXBar = None
-        w.leo_chapter = None
         w.leo_frame = None
         return w
     #@+node:ekr.20140901062324.18825: *3* QTextMixin.getName
@@ -1329,8 +1327,6 @@ class QScintillaWrapper(QTextMixin):
         self.useScintilla = True
         self.widget = widget
         # Injected ivars.
-        self.leo_chapter = None
-        self.leo_p = None
         self.leo_v = None
         # Complete the init.
         self.set_config()
@@ -1555,8 +1551,6 @@ class QTextEditWrapper(QTextMixin):
         self.widget = widget
         self.useScintilla = False
         # Define injected ivars.
-        self.leo_chapter = None
-        self.leo_p = None
         self.leo_v = None
         # Complete the init.
         if c and widget:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -151,7 +151,7 @@ class QTextMixin:
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!
         self.virtualInsertPoint = None
-        self.widget: Any = None  # Any is correct.
+        self.widget: Any = None  # 'Any' is correct for the QTextMixin class.
         if c:
             self.injectIvars(c)
     #@+node:ekr.20140901062324.18721: *4* QTextMixin.injectIvars


### PR DESCRIPTION
See #4321.

**Remove unused methods and ivars**

- [x] Remove unused `LeoBody.ensurePositionExists` method.
- [x] Remove unused `LeoBody.switchToChapter` method.
- [x] Remove unused `chapter.findEditorInChapter` method.
- [x] Move the above three unused methods to the attic.
- [x] Remove `w` args from the signatures of `chapter.select` and `chapter.selectHelper`.
- [x] Remove all mentions of injected `leo_chapter`, `leo_p` and `leo_v` vars from Leo.

**Improve annotations**

- [x] In `leoKeys.py`, annotate `fnc.log` with an explicit union. Use `NullLog` as the default instead of `g.NullObject`.
- [x] Add two minor annotations that mypy requested after  changing the annotation of `fnc.log`.
- [x] Replace the last `ComplexUnion` annotation with `Any`. `Any` is correct.
- [x] Add comments to all remaining `Widget = Any`.
    `Any` is the correct annotation for base-class widgets, including the `QTextMixin` class.
    More concrete annotation would be **wrong**.