### PR TITLE
Fix for PR #4314

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -520,7 +520,6 @@
 <v t="ekr.20210506073820.1"><vh>@bool allow-text-zoom = True</vh></v>
 <v t="ekr.20241012050620.1"><vh>@bool diff-leo-files = True</vh></v>
 <v t="ekr.20131112150804.18737"><vh>@bool force-execute-entire-body = False</vh></v>
-<v t="felix.20250313171245.1"><vh>@bool allow-script-return-result = False</vh></v>
 <v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20220624062948.1"><vh>@bool redirect-execute-script-output-to-log_pane = False</vh></v>
@@ -11929,27 +11928,6 @@ False: (Recommended) The commands act as simple navigation commands, and do not 
 Leo accepts outline 'paste' data in both XML Leo format, or JSON format</t>
 <t tx="felix.20250313152228.1"></t>
 <t tx="felix.20250313152231.1"></t>
-<t tx="felix.20250313171245.1">True: Scripts to be executed (from @command, @button, CTRL+B from body pane, etc... ) will be wrapped in 
-
-def main():
-    &lt;script&gt;
-
-result = main()
-
-to allow for return values to be captured if your script tries to 'return' a value.
-
-Example: If you have an @command my-command node that contains:
-
-return 2+2
-
-then you could run a script that contains
-
-output = c.doCommandByName('my-command')
-print(output) 
-
-which would print 4.
-
-Note: By default, script execution will return the value it may have set in a global variable named "result". (or None)</t>
 <t tx="jlunz.20150821113251.1">def html_tag():
     """expand &lt;tag&gt; to 
        &lt;tag&gt;\n&lt;/tag&gt; with proper indendation"""

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1303,21 +1303,12 @@ class Commands:
         try:
             c.inCommand = False
             g.inScript = g.app.inScript = True  # g.inScript is a synonym for g.app.inScript.
-            final_script = script  # Default to straight script execution
-
-            if c.config.getBool('allow-script-return-result'):
-                # Pre-process the script to indent each line
-                indented_script = script.replace('\n', '\n    ')
-                # Use the pre-processed script in the f-string
-                final_script = f"def main():\n    {indented_script}\nresult = main()"
-
             if c.write_script_file:
-                scriptFile = self.writeScriptFile(final_script)
-                exec(compile(final_script, scriptFile, 'exec'), d)
+                scriptFile = self.writeScriptFile(script)
+                exec(compile(script, scriptFile, 'exec'), d)
             else:
-                exec(final_script, d)
-
-            # Return the optional value of a 'result' global, if defined, to be passed up the chain.
+                exec(script, d)
+            # Return the optional value of a 'result' global, if defined, to be returned.
             return d.get("result")
         finally:
             g.inScript = g.app.inScript = False

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -254,10 +254,10 @@ class CommanderCommand:
     def __call__(self, func: Callable) -> Callable:
         """Register command for all future commanders."""
 
-        def commander_command_wrapper(event: LeoKeyEvent) -> None:
+        def commander_command_wrapper(event: LeoKeyEvent) -> Any:
             c = event.get('c')
             method = getattr(c, func.__name__, None)
-            method(event=event)
+            return method(event=event)  # Return value to caller (for doCommand, doCommandByName...)
 
         # Inject ivars for plugins_menu.py.
         commander_command_wrapper.__func_name__ = func.__name__  # For leoInteg.

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -3612,8 +3612,17 @@ Three predefined symbols, **c**, **g**, and **p** give Leo scripts easy access t
 .. code-block:: python
 
     c.executeMinibufferCommand('open-outline')
+    # or
+    c.doCommandByName('open-outline')
 
-c.keyHandler.funcReturn contains the value returned from the command. In many cases, as above, this value is simply 'break'.
+This will return the value returned from the command.
+
+Commands created with @command and @button nodes can return values as well. Since top-level return statements aren't allowed in scripts executed with exec, you can define a global variable named **result**, and Leo will return its value:
+
+.. code-block:: python
+
+    global result
+    result = 42
 </t>
 <t tx="ekr.20040403173920.19" rst_http_attribute="5d71002858460000003c6120636c6173733d22746172676574222069643d22687474702d6e6f64652d6d61726b65722d323922206e616d653d22687474702d6e6f64652d6d61726b65722d3239223e710158040000003c2f613e71025d71032858390000003c64697620636c6173733d2273656374696f6e222069643d22696e766f6b696e672d636f6d6d616e64732d66726f6d2d73637269707473223e710458060000003c2f6469763e71055d710628583f0000003c64697620636c6173733d22646f63756d656e74222069643d22636861707465722d372d736372697074696e672d6c656f2d776974682d707974686f6e223e710758060000003c2f6469763e71085d71092858060000003c626f64793e710a58070000003c2f626f64793e710b5d710c2858430000003c68746d6c20786d6c6e733d22687474703a2f2f7777772e77332e6f72672f313939392f7868746d6c2220786d6c3a6c616e673d22656e22206c616e673d22656e223e710d58070000003c2f68746d6c3e710e4e6565656558070000003c2f6469763e0a710f583b0000003c64697620636c6173733d2273656374696f6e222069643d2267657474696e672d616e642d73657474696e672d707265666572656e636573223e0a711058780000003c68313e3c6120636c6173733d22746f632d6261636b7265662220687265663d22236964313522206e616d653d2267657474696e672d616e642d73657474696e672d707265666572656e636573223e47657474696e6720616e642073657474696e6720707265666572656e6365733c2f613e3c2f68313e0a7111652e">Each commander sets ivars corresponding to settings.
 
@@ -15381,6 +15390,17 @@ The Leonine World
     c.redraw(p=None)        # Redraw the screen. Select p if given.
     c.save()                # Save the present outline.
     c.selectPosition()
+
+**Using Command names**::
+
+When learning Leo's codebase, it may be easier to refer to a command by its 'command name'. You can therefore use  c.doCommandByName('command-name') instead of calling the proper method on the commander. This will return the same value as that method.
+
+**Leo Script Return Values**::
+
+Commands created with @command and @button nodes can return values as well. Since top-level return statements aren't allowed in scripts executed with exec, you can define a global variable named **result**, and Leo will return its value:
+
+    global result
+    result = 42
 
 **Official ivars** of any leoFrame f::
 

--- a/leo/doc/leoSlideShows.leo
+++ b/leo/doc/leoSlideShows.leo
@@ -1077,10 +1077,19 @@ You can invoke minibuffer commands by name.  For example:
 @color
 
     c.executeMinibufferCommand('open-outline')
+    # or
+    c.doCommandByName('open-outline')
 
 @nocolor
-c.keyHandler.funcReturn contains the value returned from the command.
-In many cases, as above, this value is simply 'break'.</t>
+This will return the value returned from the command.
+
+Commands created with @command and @button nodes can return values as well. 
+Since top-level return statements aren't allowed in scripts executed with exec,
+you can define a global variable named **result**, and Leo will return its value:
+@color
+
+    global result
+    result = 42</t>
 <t tx="ekr.20060902092341.18">@nocolor
 Any .leo file may contain an @settings tree, so settings may be different for each commander.
 Plugins and other scripts can get the value of settings as follows:

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -274,7 +274,7 @@ class AtButtonCallback:
         self.source_c = c  # For GetArgs.command_source.
         self.__doc__ = docstring  # The docstring for this callback for g.getDocStringForFunction.
     #@+node:ekr.20141031053508.10: *3* __call__ (AtButtonCallback)
-    def __call__(self, event: Event = None) -> Any:
+    def __call__(self, event: Event = None) -> Value:
         """AtButtonCallbgack.__call__. The callback for @button nodes."""
         return self.execute_script()
     #@+node:ekr.20141031053508.13: *3* __repr__ (AtButtonCallback)

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -274,9 +274,9 @@ class AtButtonCallback:
         self.source_c = c  # For GetArgs.command_source.
         self.__doc__ = docstring  # The docstring for this callback for g.getDocStringForFunction.
     #@+node:ekr.20141031053508.10: *3* __call__ (AtButtonCallback)
-    def __call__(self, event: Event = None) -> None:
+    def __call__(self, event: Event = None) -> Any:
         """AtButtonCallbgack.__call__. The callback for @button nodes."""
-        self.execute_script()
+        return self.execute_script()
     #@+node:ekr.20141031053508.13: *3* __repr__ (AtButtonCallback)
     def __repr__(self) -> str:
         """AtButtonCallback.__repr__."""

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -4,6 +4,7 @@
 # pylint: disable=no-member
 import sys
 from leo.core import leoGlobals as g
+from leo.plugins.mod_scripting import scriptingController
 from leo.core.leoTest2 import LeoUnitTest
 
 #@+others
@@ -139,7 +140,6 @@ class TestCommands(LeoUnitTest):
 
         # test an existing native Leo command such as 'convert-blanks'.
         c.selectPosition(p)
-
         c.insertHeadline()
         p2 = c.p
         p2.b = self.prep(
@@ -150,31 +150,39 @@ class TestCommands(LeoUnitTest):
                 pass
         """)
         c.selectPosition(p2)
+
         # It will return True if it changed the text.
         val = c.doCommandByName('convert-blanks')
         assert val is True, f"expected: True got: {val}"
-
         
         # Call it again, it should return False.
         val = c.doCommandByName('convert-blanks')
         assert val is False, f"expected: False got: {val}"
-        print('test_c_doCommandByName_return_result test done')
+        
     #@+node:felix.20250414224344.1: *3* TestCommands.test_c_doCommandByName_return_result_from_leo_script
     def test_c_doCommandByName_return_result_from_leo_script(self):
         c, p = self.c, self.c.p
-        # test an existing native Leo command such as 'convert-blanks'.
 
+        # Creates a command from an @command node with mod_scripting's scriptingController.
         c.selectPosition(p)
         c.insertHeadline()
         p2 = c.p
-        p2.h = "@command test"
+        p2.h = "@command test-return-result"  # an @command node
         p2.b = self.prep(
         """
             g.es('test script that sets result global')
-            global result
+            global result  # pythonic way of outputing something from an 'exec' call.
             result = 42
         """)
-        print('test_c_doCommandByName_return_result_from_leo_script test done')
+        c.selectPosition(p2)
+
+        sc = getattr(c, "theScriptingController", None)
+        if not sc:
+            sc = scriptingController(c, True)  # Fakes the unused iconBar with 'True'.
+        sc.handleAtCommandNode(p2)
+
+        val = c.doCommandByName('test-return-result')
+        assert val is 42, f"expected: 42 got: {val}"
 
     #@+node:ekr.20210906075242.7: *3* TestCommands.test_c_expand_path_expression
     def test_c_expand_path_expression(self):

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -133,6 +133,49 @@ class TestCommands(LeoUnitTest):
         c.demote()  # This should do nothing.
         self.assertEqual(0, c.checkOutline())
         self.assertEqual(2, p.numberOfChildren())
+    #@+node:felix.20250414224343.1: *3* TestCommands.test_c_doCommandByName_return_result
+    def test_c_doCommandByName_return_result(self):
+        c, p = self.c, self.c.p
+
+        # test an existing native Leo command such as 'convert-blanks'.
+        c.selectPosition(p)
+
+        c.insertHeadline()
+        p2 = c.p
+        p2.b = self.prep(
+        """
+            @language python
+
+            def abc():  # this contains spaces
+                pass
+        """)
+        c.selectPosition(p2)
+        # It will return True if it changed the text.
+        val = c.doCommandByName('convert-blanks')
+        assert val is True, f"expected: True got: {val}"
+
+        
+        # Call it again, it should return False.
+        val = c.doCommandByName('convert-blanks')
+        assert val is False, f"expected: False got: {val}"
+        print('test_c_doCommandByName_return_result test done')
+    #@+node:felix.20250414224344.1: *3* TestCommands.test_c_doCommandByName_return_result_from_leo_script
+    def test_c_doCommandByName_return_result_from_leo_script(self):
+        c, p = self.c, self.c.p
+        # test an existing native Leo command such as 'convert-blanks'.
+
+        c.selectPosition(p)
+        c.insertHeadline()
+        p2 = c.p
+        p2.h = "@command test"
+        p2.b = self.prep(
+        """
+            g.es('test script that sets result global')
+            global result
+            result = 42
+        """)
+        print('test_c_doCommandByName_return_result_from_leo_script test done')
+
     #@+node:ekr.20210906075242.7: *3* TestCommands.test_c_expand_path_expression
     def test_c_expand_path_expression(self):
         import os


### PR DESCRIPTION
This PR aims at replacing completely @edreamleo 's PR #4319 (which reverted my improper PR #4314 ) By removing the problematic code, and its additional user setting in leoSettings completely. 

As @edreamleo justly noted, that problematic PR contained an error-prone 'hack' which tried to fake the javascript behavior of allowing the 'return' keyword at the top level of an evaluated piece of code (with the 'exec' python function). 

Lessons learned: I should never do non-pythonic stuff like that in Leo codebase... (I was just too excited of figuring out a hack to return values with the 'return' keyword at the top level _and I removed the 'draft' flag of this PR way too early,_ having it merged into devel before I could realize my mistakes!) This was beyond silly and I hope to clean this all up myself with this PR.

This PR also instead adresses properly my original intent of simply fixing 'doCommandByName', which did not return the value of the command called. (e.g. some commands like 'convert-blanks' and many others return something) This was done by simply adding a 'return' on the last line of _commander_command_wrapper_ in the CommanderCommand class.

A single thing remain from my original idea: The (safe and non-hacky) pythonic way to grab something programmatically from code that ran with the 'exec' function which is by capturing a 'result' named variable on the global scope after 'exec' call. 

So if this PR is accepted, the problematic code and its associated setting will be removed completely, the only two things that will be in devel would be:

1. The fix to doCommandByName to capture the returned value of existing **official commands** from Leo's codebase.
2. Having **user commands** (script in @command nodes, @button nodes, ect..) to be able to return something by setting a global named 'result'.

I've also added unit tests for those two concepts.

I will soon add a paragraph about this in the documentation, and will consult the google-group forum with a demo about those two concepts before moving on...

...and will keep this PR as draft until it's ready ! 😅 

