### PR TITLE
PR for #4335: Leo does not start with Python 3.9.

### DIFF
--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -5,11 +5,16 @@
 #@+node:ekr.20150514050411.1: ** << killBufferCommands imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-from typing import Optional, Self, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.commands.baseCommands import BaseEditCommandsClass
 
 if TYPE_CHECKING:  # pragma: no cover
+    try:
+        from typing import Self
+    except Exception:
+        from typing import Any
+        Self = Any
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 import re
 import string
 import time
-from typing import Any, Generator, Self, Sequence, Optional, Union, TYPE_CHECKING
+from typing import Any, Generator, Sequence, Optional, Union, TYPE_CHECKING
 from types import ModuleType
 import warnings
 
@@ -41,6 +41,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoNodes import Position, VNode
     from leo.core.leoGlobals import GeneralSetting
+    try:
+        from typing import Self
+    except Exception:
+        Self = Any
     KWargs = Any
     Lexer = Callable
     QWidget = QtWidgets.QWidget


### PR DESCRIPTION
See #4335.

- [x] Conditionally import 'Self'.
   All Tests pass with 3.9 and 3.13.
   There are minor mypy complaints with Python 3.9. These complaints should be ignored.