### PR TITLE
PR for #4325: expand-body

### DIFF
--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -3739,6 +3739,7 @@ class LeoServer:
 
             'contract-body-pane',
             'contract-log-pane',
+            'contract-main-splitter',
             'contract-outline-pane',
 
             'edit-pane-csv',
@@ -3746,6 +3747,7 @@ class LeoServer:
             'equal-sized-panes',
             'expand-log-pane',
             'expand-body-pane',
+            'expand-main-splitter',
             'expand-outline-pane',
 
             'free-layout-context-menu',

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2006,6 +2006,16 @@ class LeoQtFrame(leoFrame.LeoFrame):
     def equalSizedPanes(self, event: LeoKeyEvent = None) -> None:
         """Make the outline and body panes have the same size."""
         self.resizePanesToRatio(0.5, self.compute_secondary_ratio())
+    #@+node:ekr.20250422154709.1: *5* LeoQtFrame.contract/expandMainSplitter
+    @frame_cmd('contract-main-splitter')
+    def contractMainSplitter(self, event: LeoKeyEvent = None) -> None:
+        """Decrease the size of the main splitter."""
+        self.divideLeoSplitter1(self.compute_ratio() - 0.1)
+
+    @frame_cmd('expand-main-splitter')
+    def expandMainSplitter(self, event: LeoKeyEvent = None) -> None:
+        """Increase the size of the main splitter."""
+        self.divideLeoSplitter1(self.compute_ratio() + 0.1)
     #@+node:ekr.20110605121601.18305: *5* LeoQtFrame.hideLogWindow
     def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
         """Hide the log pane."""

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2009,13 +2009,31 @@ class LeoQtFrame(leoFrame.LeoFrame):
     #@+node:ekr.20250422154709.1: *5* LeoQtFrame.contract/expandMainSplitter
     @frame_cmd('contract-main-splitter')
     def contractMainSplitter(self, event: LeoKeyEvent = None) -> None:
-        """Decrease the size of the main splitter."""
-        self.divideLeoSplitter1(self.compute_ratio() - 0.1)
+        """
+        Contract the main splitter's first widget, expanding the main splitter's second widget.
+        """
+        self.resize_main_splitter(-40)
 
     @frame_cmd('expand-main-splitter')
     def expandMainSplitter(self, event: LeoKeyEvent = None) -> None:
-        """Increase the size of the main splitter."""
-        self.divideLeoSplitter1(self.compute_ratio() + 0.1)
+        """
+        Expand the main splitter's first widget, contracting the main splitter's second widget.
+        """
+        self.resize_main_splitter(40)
+
+    def resize_main_splitter(self, delta: int) -> None:
+        """Resize the first two widgets of the main splitter."""
+        c = self.c
+        splitter = g.app.gui.find_widget_by_name(c, 'main_splitter')
+        if not splitter:
+            return
+        sizes = splitter.sizes()
+        if len(sizes) < 2:
+            return
+        sizes[0] += delta
+        sizes[1] -= delta
+        if sizes[0] >= 0 and sizes[1] >= 0:
+            splitter.setSizes(sizes)
     #@+node:ekr.20110605121601.18305: *5* LeoQtFrame.hideLogWindow
     def hideLogWindow(self, event: LeoKeyEvent = None) -> None:
         """Hide the log pane."""

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -584,19 +584,15 @@ class LayoutCacheWidget(QWidget):
         if not splitter:
             g.trace(f"Oops! no splitter for name: {widget.objectName()!r}")
             return
-        try:
-            index = splitter.indexOf(direct_child)
-            sizes = splitter.sizes()
-            widget_size = sizes[index]
-        except Exception:
-            g.trace(f"Oops! {widget} not in: {splitter!r}")
-            g.es_exception()
-            return
+
+        index = splitter.indexOf(direct_child)
         if index == -1:
             g.trace(f"Oops! direct child: {direct_child!r} not in {splitter}")
             return
 
         # Look for another *visible* widget.
+        sizes = splitter.sizes()
+        widget_size = sizes[index]
         if widget_size > 0:
             for other_index, size in enumerate(sizes):
                 if other_index != index and size > 0:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -609,20 +609,20 @@ class LayoutCacheWidget(QWidget):
         parent_splitter, _junk = g.app.gui.find_parent_splitter(splitter)
         if not parent_splitter:
             return
+
         index = parent_splitter.indexOf(splitter)
         if index == -1:
             g.trace(f"Oops! {splitter} not in {parent_splitter}")
             return
 
-        widget_size = sizes[index]
-        if widget_size > 0:
-            for other_index, size in enumerate(sizes):
-                if other_index != index and size > 0:
-                    sizes = parent_splitter.sizes()
-                    sizes[index] += delta
-                    sizes[other_index] -= delta
-                    parent_splitter.setSizes(sizes)
-                    return
+        # It's valid for the splitter's size to be zero!
+        for other_index, size in enumerate(sizes):
+            if other_index != index and size > 0:
+                sizes = parent_splitter.sizes()
+                sizes[index] += delta
+                sizes[other_index] -= delta
+                parent_splitter.setSizes(sizes)
+                return
     #@+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
     def restoreFromLayout(self, layout: Dict = None) -> None:
         self.layout_dict = layout

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -83,7 +83,7 @@ def big_tree(event: LeoKeyEvent) -> None:
 
         ┌──────────────────┐
         │  outline         │
-        ├─────────┬────────┤
+        ├─────────┬────────┤ <-- Main splitter
         │  body   │  log   │
         ├─────────┼────────┤
         │    VR   │  VR3   │
@@ -147,7 +147,7 @@ def quadrants(event: LeoKeyEvent) -> None:
 
         ┌───────────────┬───────────┐
         │   outline     │   log     │
-        ├───────────────┼────┬──────┤
+        ├───────────────┼────┬──────┤ <-- Main splitter
         │   body        │ VR │ VR3  │
         └───────────────┴────┴──────┘
     """
@@ -164,7 +164,7 @@ def horizontal_thirds(event: LeoKeyEvent) -> None:
 
         ┌───────────┬───────┐
         │  outline  │  log  │
-        ├───────────┴───────┤
+        ├───────────┴───────┤ <-- Main splitter
         │  body             │
         ├─────────┬─────────┤
         │   VR    │   VR3   │
@@ -188,6 +188,8 @@ def render_focused(event: LeoKeyEvent) -> None:
         ├───────────┤     │     │
         │ log       │     │     │
         └───────────┴─────┴─────┘
+        
+    Note: The expand/contract-main-splitter commands have no effect when using this layout.
     """
     c = event.get('c')
     dw = c.frame.top
@@ -220,26 +222,6 @@ def swapLogPanel(event: LeoKeyEvent) -> None:
     Move the Log frame between main and secondary splitters.
     
     **Do not use this layout as the initial layout.**
-
-    The effect of this command depends on the existing layout. For example,
-    if the legacy layout is in effect, this command changes the layout
-    from:
-
-        ┌───────────┬──────┐
-        │ outline   │ log  │
-        ├───────────┼──────┤
-        │ body      │VR/VR3│
-        └───────────┴──────┘
-
-    to:
-
-        ┌──────────────────┐
-        │  outline         │
-        ├──────────┬───────┤
-        │  body    │ VR/VR3│
-        ├──────────┴───────┤
-        │  log             │
-        └──────────────────┘
     """
     c = event.get('c')
     if not c:
@@ -280,6 +262,8 @@ def vertical_thirds(event: LeoKeyEvent) -> None:
         ├───────────┤  body  │ VR │ VR3 │
         │  log      │        │    │     │
         └───────────┴────────┴────┴─────┘
+                    |
+                    └─ Main splitter
     """
     c = event.get('c')
     dw = c.frame.top
@@ -298,6 +282,8 @@ def vertical_thirds2(event: LeoKeyEvent) -> None:
         │  outline  ├───────┤ VR │ VR3 │
         │           │  body │    │     │
         └───────────┴───────┴────┴─────┘
+                    |
+                    └─ Main splitter
     """
     c = event.get('c')
     dw = c.frame.top
@@ -600,10 +586,12 @@ class LayoutCacheWidget(QWidget):
                     sizes[other_index] -= delta
                     splitter.setSizes(sizes)
                     return
+            g.trace('Fail 1')
 
         # #4325. Try resizing a parent frame.
         parent_splitter, _junk = g.app.gui.find_parent_splitter(splitter)
         if not parent_splitter:
+            g.trace('No parent splitter')
             return
 
         index = parent_splitter.indexOf(splitter)
@@ -619,6 +607,8 @@ class LayoutCacheWidget(QWidget):
                 sizes[other_index] -= delta
                 parent_splitter.setSizes(sizes)
                 return
+
+        g.trace('Fail 2')
     #@+node:tom.20240923194438.6: *4* LCW.restoreFromLayout
     def restoreFromLayout(self, layout: Dict = None) -> None:
         self.layout_dict = layout

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -932,7 +932,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def convert_to_asciidoctor(self, s: str) -> str:
         """Convert s to html using the asciidoctor or asciidoc processor."""
         c, p = self.c, self.c.p
-        path = g.scanAllAtPathDirectives(c, p) or c.getNodePath(p)
+        path = c.getPath(p)
         if not os.path.isdir(path):
             path = os.path.dirname(path)
         if os.path.isdir(path):
@@ -1147,7 +1147,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def convert_to_markdown(self, s: str) -> str:
         """Convert s to html using the markdown processor."""
         c, p = self.c, self.c.p
-        path = g.scanAllAtPathDirectives(c, p) or c.getNodePath(p)
+        path = c.getPath(p)
         if not os.path.isdir(path):
             path = os.path.dirname(path)
         if os.path.isdir(path):
@@ -1228,7 +1228,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def convert_to_pandoc(self, s: str) -> str:
         """Convert s to html using the asciidoctor or asciidoc processor."""
         c, p = self.c, self.c.p
-        path = g.scanAllAtPathDirectives(c, p) or c.getNodePath(p)
+        path = c.getPath(p)
         if not os.path.isdir(path):
             path = os.path.dirname(path)
         if os.path.isdir(path):
@@ -1363,7 +1363,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         """Convert s to html using docutils."""
         c, p = self.c, self.c.p
         # Update the current path.
-        path = g.scanAllAtPathDirectives(c, p) or c.getNodePath(p)
+        path = c.getPath(p)
         if not os.path.isdir(path):
             path = os.path.dirname(path)
         if os.path.isdir(path):


### PR DESCRIPTION
See #4325.

- [x] Replace `g.scanAllAtPathDirectives` by `c.getPath` in several places.
- [x] Improve `LCW.resize_pane`: It resizes the nearest splitter's parent if it can't resize the nearest splitter.
- [x] Add two new commands: `expand-main-splitter` and `contract-main-splitter`.
   These new commands work regardless of what splitter contains the widget mentioned in Leo's `expand/contract` commands.
- [x] Improve the documentation of all the commands affected by this PR.
- [x] Add `expand-main-splitter` and `contract-main-splitter` to list of "bad" leoserver commands.