### PR TITLE
PR for #4339: @path can not recognize '-'

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1742,7 +1742,7 @@ class Commands:
     #@+node:ekr.20250404014820.1: *6* c.getPathFromNode
     # Use a regex to avoid allocating temp strings.
     # https://en.wikipedia.org/wiki/Filename
-    at_path_pattern = re.compile(r'^@path\s+([\w_:/\\-]+)', re.MULTILINE)
+    at_path_pattern = re.compile(r'^@path\s+(.*+)', re.MULTILINE)
 
     def getPathFromNode(self, p: Position) -> Optional[str]:
         """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1741,7 +1741,8 @@ class Commands:
         return path
     #@+node:ekr.20250404014820.1: *6* c.getPathFromNode
     # Use a regex to avoid allocating temp strings.
-    at_path_pattern = re.compile(r'^@path\s+([\w_:/\\]+)', re.MULTILINE)
+    # https://en.wikipedia.org/wiki/Filename
+    at_path_pattern = re.compile(r'^@path\s+([\w_:/\\-]+)', re.MULTILINE)
 
     def getPathFromNode(self, p: Position) -> Optional[str]:
         """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1742,7 +1742,7 @@ class Commands:
     #@+node:ekr.20250404014820.1: *6* c.getPathFromNode
     # Use a regex to avoid allocating temp strings.
     # https://en.wikipedia.org/wiki/Filename
-    at_path_pattern = re.compile(r'^@path\s+(.*+)', re.MULTILINE)
+    at_path_pattern = re.compile(r'^@path\s+(.+)$', re.MULTILINE)
 
     def getPathFromNode(self, p: Position) -> Optional[str]:
         """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2939,7 +2939,7 @@ def stripPathCruft(path: str) -> str:
     ):
         path = path[1:-1].strip()
     # We want a *relative* path, not an absolute path.
-    return path
+    return path.strip()
 #@+node:ekr.20090214075058.10: *3* g.update_directives_pat
 def update_directives_pat() -> None:
     """Init/update g.directives_pat"""


### PR DESCRIPTION
See #4339.

- [x] Allow *all* characters in path names except trailing blanks.
   Note: Both the legacy and changed regexes make it impossible to specify path names with leading blanks.
- [x] `g.stripPathCruft` always strips blanks.

**Q & A**

**Thomas**: What I don't understand is how to know if a given space is a trailing space.  It used to be, didn't it, that a headline could have text after the path of an `@path` directive.  I never used it like that but I have been under the impression that it did.  

**EKR**: Imo, "truncating" an @path directive at a space (or any other character not matched by the legacy regex) was an unintentional Easter Egg. The [directives reference](https://leo-editor.github.io/leo-editor/directives.html#path-path) makes no mention of this truncation. Rather, the documentation clearly implies that the intended path is everything following `@path`.

**Thomas**: If so, text following a space that was intended to have been a trailing space would get included into the path.  The obvious cure is not to allow any text after the path.  Is this going to be a new restriction, or has it always been like that?

**EKR**: This question is the crux of the PR's dilemma. The PR does what Leo's legacy code intended, but yes, you could say that the PR creates a new restriction.

**Discussion**

It is impossible and unwise to define set of characters that are deemed to be valid in directory names. The new policy places all responsibility in the hands of the user, where it belongs. Specifically, the risk of allowing control characters or non-printing characters is minimal. Attempting to prohibit such characters adds nothing to Leo.

Hand tests show that `@path c:\Users\Edward Ream` works as intended.

**Summary**

This PR is unlikely to cause problems. If it does, we'll fix those problems in another PR.

This PR must be documented in the 6.8.4 Release notes and What's New notes.