### PR TITLE
PR: Fix a quirp in the SqlitePickleShare class

### DIFF
--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -152,9 +152,6 @@ class SqlitePickleShare:
         dbfile = ':memory:' if g.unitTesting else join(root, 'cache.sqlite')
         self.conn = sqlite3.connect(dbfile, isolation_level=None)
         self.init_dbtables(self.conn)
-        # Keys are normalized file names.
-        # Values are tuples (obj, orig_mod_time)
-        self.cache: dict[str, Value] = {}
 
         def loadz(data: Value) -> Optional[Value]:
             if data:


### PR DESCRIPTION
- [x] Remove the unused `SqlitePickleShare.cache` ivar and corresponding misleading comment.

@boltex This quirp may affect LeoJS.