### PR TITLE
PR: Suppress invalid pyflakes complaints

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1621,35 +1621,35 @@ redirectStdOutObj = RedirectClass()
 # Redirect streams to the current log window.
 
 def redirectStderr() -> None:
-    global redirectStdErrObj
+    # global redirectStdErrObj
     redirectStdErrObj.redirect(stdout=False)
 
 def redirectStdout() -> None:
-    global redirectStdOutObj
+    # global redirectStdOutObj
     redirectStdOutObj.redirect()
 #@+node:ekr.20041012090942.1: *5* restoreStderr & restoreStdout
 # Restore standard streams.
 
 def restoreStderr() -> None:
-    global redirectStdErrObj
+    # global redirectStdErrObj
     redirectStdErrObj.undirect(stdout=False)
 
 def restoreStdout() -> None:
-    global redirectStdOutObj
+    # global redirectStdOutObj
     redirectStdOutObj.undirect()
 #@+node:ekr.20041012090942.2: *5* stdErrIsRedirected & stdOutIsRedirected
 def stdErrIsRedirected() -> bool:
-    global redirectStdErrObj
+    # global redirectStdErrObj
     return redirectStdErrObj.isRedirected()
 
 def stdOutIsRedirected() -> bool:
-    global redirectStdOutObj
+    # global redirectStdOutObj
     return redirectStdOutObj.isRedirected()
 #@+node:ekr.20041012090942.3: *5* rawPrint
 # Send output to original stdout.
 
 def rawPrint(s: str) -> None:
-    global redirectStdOutObj
+    # global redirectStdOutObj
     redirectStdOutObj.rawPrint(s)
 #@-others
 #@-<< define convenience methods for redirecting streams >>
@@ -2943,7 +2943,7 @@ def stripPathCruft(path: str) -> str:
 #@+node:ekr.20090214075058.10: *3* g.update_directives_pat
 def update_directives_pat() -> None:
     """Init/update g.directives_pat"""
-    global globalDirectiveList, directives_pat
+    global directives_pat  # globalDirectiveList
     # Use a pattern that guarantees word matches.
     aList = [
         fr"\b{z}\b" for z in globalDirectiveList if z != 'others'
@@ -5951,7 +5951,7 @@ def init_zodb(pathToZodbStorage: str, verbose: bool = True) -> Value:
     Return an ZODB.DB instance from the given path.
     return None on any error.
     """
-    global init_zodb_db, init_zodb_failed, init_zodb_import_failed
+    global init_zodb_import_failed
     db = init_zodb_db.get(pathToZodbStorage)
     if db:
         return db

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -340,7 +340,7 @@ class MarkupCommands:
         """
         Process the input file given by i_path with asciidoctor or asciidoc3.
         """
-        global asciidoctor_exec, asciidoc3_exec
+        # global asciidoctor_exec, asciidoc3_exec
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         # Call the external program to write the output file.
         # The -e option deletes css.
@@ -352,7 +352,7 @@ class MarkupCommands:
         """
          Process the input file given by i_path with pandoc.
         """
-        global pandoc_exec
+        # global pandoc_exec
         assert pandoc_exec, g.callers()
         # Call pandoc to write the output file.
         # --quiet does no harm.
@@ -479,7 +479,7 @@ class MarkupCommands:
     def adoc_command(self,
         event: LeoKeyEvent = None, preview: bool = False, verbose: bool = True,
     ) -> File_List:
-        global asciidoctor_exec, asciidoc3_exec
+        # global asciidoctor_exec, asciidoc3_exec
         if asciidoctor_exec or asciidoc3_exec:
             return self.command_helper(
                 event, kind='adoc', preview=preview, verbose=verbose)
@@ -490,7 +490,7 @@ class MarkupCommands:
     def pandoc_command(self,
         event: LeoKeyEvent = None, preview: bool = False, verbose: bool = True,
     ) -> File_List:
-        global pandoc_exec
+        # global pandoc_exec
         if pandoc_exec:
             return self.command_helper(
                 event, kind='pandoc', preview=preview, verbose=verbose)
@@ -501,7 +501,7 @@ class MarkupCommands:
     def sphinx_command(self,
         event: LeoKeyEvent = None, preview: bool = False, verbose: bool = True,
     ) -> File_List:
-        global sphinx_build
+        # global sphinx_build
         if sphinx_build:
             return self.command_helper(
                 event, kind='sphinx', preview=preview, verbose=verbose)

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -490,7 +490,7 @@ class LeoPluginsController:
 
         Using a module name allows plugins to be loaded from outside the leo/plugins directory.
         """
-        global optional_modules
+        # global optional_modules
 
         moduleName: str
 

--- a/leo/core/leoPymacs.py
+++ b/leo/core/leoPymacs.py
@@ -32,23 +32,23 @@ pymacsFile = __file__
 #@+others
 #@+node:ekr.20061024131236: ** dump (pymacs)
 def dump(anObject):
-    global g
+    # global g
     init()
     return str(g.toEncodedString(repr(anObject), encoding='ascii'))
 #@+node:ekr.20061024130957: ** getters (pymacs)
 def get_app():
     """Scripts can use g.app.scriptDict for communication with pymacs."""
-    global g
+    # global g
     init()
     return g.app
 
 def get_g():
-    global g
+    # global g
     init()
     return g
 
 def script_result():
-    global g
+    # global g
     init()
     return g.app.scriptResult
 #@+node:ekr.20061024060248.3: ** hello (pymacs)
@@ -90,7 +90,7 @@ def init():
         g.trace('gui', g.app.gui)
 #@+node:ekr.20061024075542.1: ** open (pymacs)
 def open(fileName=None):
-    global g
+    # global g
     init()
     if g.unitTesting:
         return None
@@ -106,8 +106,9 @@ def open(fileName=None):
     return c
 #@+node:ekr.20061024084200: ** run-script (pymacs)
 def run_script(c, script, p=None):
+    # global g
+
     # It is possible to use script=None, in which case p must be defined.
-    global g
     init()
     if c is None:
         c = g.app.newCommander(fileName='dummy script file')

--- a/leo/core/leoTips.py
+++ b/leo/core/leoTips.py
@@ -31,7 +31,7 @@ class TipManager:
     #@+others
     #@+node:ekr.20180121041748.1: *3* tipm.get_next_tip
     def get_next_tip(self) -> "UserTip":
-        global tips
+        # global tips
         db = g.app.db
         # Compute list of unseen tips.
         seen = db.get(self.key, [])
@@ -136,7 +136,7 @@ UserTip(
 
 def make_tip_nodes(c: Cmdr) -> None:
     """Create a list of all tips as the last top-level node."""
-    global tips
+    # global tips
     root = c.lastTopLevel().insertAfter()
     root.h = 'User Tips'
     root.b = '@language rest\n@wrap\nFrom leo.core.leoTips.py'

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -115,10 +115,8 @@ def _get_action_list():
 def _show_response(n, d):
     global n_known_response_times
     global n_unknown_response_times
-    global times_d
     global tot_response_time
-    global trace
-    global verbose
+
     # Calculate response time.
     t1 = times_d.get(n)
     t2 = time.perf_counter()

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -115,7 +115,10 @@ def _get_action_list():
 def _show_response(n, d):
     global n_known_response_times
     global n_unknown_response_times
+    # global times_d
     global tot_response_time
+    # global trace
+    # global verbose
 
     # Calculate response time.
     t1 = times_d.get(n)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -4635,7 +4635,7 @@ class LeoServer:
     #@+node:felix.20210621233316.76: *5* server.init_connection
     def _init_connection(self, web_socket: Socket) -> None:  # pragma: no cover (tested in client).
         """Begin the connection."""
-        global connectionsTotal
+        # global connectionsTotal
         if connectionsTotal == 1:
             # First connection, so "Master client" setup
             self.web_socket = web_socket
@@ -4859,7 +4859,7 @@ class LeoServer:
         that contains at least an 'id' key.
 
         """
-        global traces
+        # global traces
         tag = '_do_message'
         trace, verbose = 'request' in traces, 'verbose' in traces
         func: Callable
@@ -5178,7 +5178,7 @@ class LeoServer:
         Finally, this method returns the json string corresponding to the
         response.
         """
-        global traces
+        # global traces
         tag = '_make_response'
         trace = self.log_flag or 'response' in traces
         verbose = 'verbose' in traces
@@ -5278,7 +5278,7 @@ class LeoServer:
         toAll: bool = False,
     ) -> None:  # pragma: no cover (tested in server)
         """Output json string to the web_socket"""
-        global connectionsTotal
+        # global connectionsTotal
         tag = '_async_output'
         outputBytes = bytes(json, 'utf-8')
         if toAll:
@@ -5316,8 +5316,7 @@ class LeoServer:
 def main() -> None:  # pragma: no cover (tested in client)
     """python script for leo integration via leoBridge"""
 
-    global websockets
-    global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile
+    # global argFile, websockets, wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty,
     if not websockets:
         print('websockets not found')
         print('pip install websockets')
@@ -5506,7 +5505,7 @@ def main() -> None:  # pragma: no cover (tested in client)
         """
         Get arguments from the command line and sets them globally.
         """
-        global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile, traces
+        global wsHost, wsPort, wsLimit, wsPersist, wsSkipDirty, argFile  # traces
 
         def leo_file(s: str) -> str:
             if os.path.exists(s):
@@ -5577,7 +5576,7 @@ def main() -> None:  # pragma: no cover (tested in client)
             wsLimit = 1
     #@+node:felix.20210803174312.1: *3* function: notify_clients
     async def notify_clients(action: str, excludedConn: Any = None) -> None:
-        global connectionsTotal
+        # global connectionsTotal
         if connectionsPool:  # asyncio.wait doesn't accept an empty list
             opened = bool(controller.c)  # c can be none if no files opened
             m = json.dumps({
@@ -5595,7 +5594,7 @@ def main() -> None:  # pragma: no cover (tested in client)
                 ])
     #@+node:felix.20210803174312.2: *3* function: register_client
     async def register_client(websocket: Socket) -> None:
-        global connectionsTotal
+        # global connectionsTotal
         connectionsPool.add(websocket)
         await notify_clients("unregister", websocket)
     #@+node:felix.20210807160828.1: *3* function: save_dirty
@@ -5612,7 +5611,7 @@ def main() -> None:  # pragma: no cover (tested in client)
                 commander.close()  # Patched 'ask' methods will open dialog
     #@+node:felix.20210803174312.3: *3* function: unregister_client
     async def unregister_client(websocket: Socket) -> None:
-        global connectionsTotal
+        # global connectionsTotal
         connectionsPool.remove(websocket)
         await notify_clients("unregister")
     #@+node:felix.20210621233316.106: *3* function: ws_handler (server)
@@ -5622,7 +5621,7 @@ def main() -> None:  # pragma: no cover (tested in client)
 
         It must be a coroutine accepting two arguments: a WebSocketServerProtocol and the request URI.
         """
-        global connectionsTotal, wsLimit
+        global connectionsTotal  # wsLimit
         tag = 'server'
         trace = False
         verbose = False

--- a/leo/plugins/add_directives.py
+++ b/leo/plugins/add_directives.py
@@ -17,7 +17,7 @@ def addPluginDirectives(tag, keywords):
 
     """Add all new directives to g.globalDirectiveList"""
 
-    global directives
+    # global directives
 
     for s in directives:
         if s.startswith('@'):

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -91,7 +91,7 @@ warning_given = False
 
 def init():
     """Return True if the plugin has loaded successfully."""
-    global warning_given
+    # global warning_given
     ok = QtGui and uic and g.app.gui.guiName() == 'qt'  # #2197.
     if not ok:
         return False

--- a/leo/plugins/ctagscompleter.py
+++ b/leo/plugins/ctagscompleter.py
@@ -88,7 +88,7 @@ def start(event):
     The ctags-complete command.
     Call cc.start() where cc is the CtagsController for event's commander.
     """
-    global controllers
+    # global controllers
     c = event.get('c')
     if not c:
         return
@@ -156,8 +156,8 @@ class CtagsController:
     #@+node:ville.20090321223959.2: *3* ctags.lookup
     def lookup(self, prefix):
         """Return a list of all items starting with prefix."""
-        global tagLines
-        #
+        # global tagLines
+
         # Find all lines with the given prefix.
         if not prefix:
             return []

--- a/leo/plugins/mod_autosave.py
+++ b/leo/plugins/mod_autosave.py
@@ -39,7 +39,7 @@ def init():
 #@+node:edream.110203113231.726: ** onCreate (mod_autosave.py)
 def onCreate(tag, keywords):
     """Handle the per-Leo-file settings."""
-    global gDict
+    # global gDict
     c = keywords.get('c')
     if g.unitTesting or g.app.killed or not c or not c.exists:
         return
@@ -69,7 +69,7 @@ def onIdle(tag, keywords):
     Save the outline to a .bak file every "interval" seconds if it has changed.
     Make *no* changes to the UI and do *not* update c.changed.
     """
-    global gDict
+    # global gDict
     if g.app.killed or g.unitTesting:
         return
     c = keywords.get('c')

--- a/leo/plugins/multifile.py
+++ b/leo/plugins/multifile.py
@@ -107,12 +107,12 @@ def insertDirectoryString(c):
 #@+node:mork.20041018204908.3: ** decorated_precheck
 def decorated_precheck(self, fileName, root):
     """Call at.precheck, then add fileName to the global files list."""
-    #
+
+    # global files, original_precheck
+
     # Call the original method.
-    global files
-    global original_precheck
     val = original_precheck(self, fileName, root)
-    #
+
     # Save a pointer to the root for later.
     if val and root.isDirty():
         files[fileName] = root.copy()
@@ -145,7 +145,7 @@ def scanForMultiPath(c):
     lists of paths to which the fileName is to be written.
     New in version 0.6 of this plugin: use ';' to separate paths in @multipath statements."""
 
-    global multiprefix, multipath
+    # global multiprefix, multipath
     d: dict = {}
     sep = ';'
     for fileName in files:  # Keys are fileNames, values are root positions.

--- a/leo/plugins/nav_qt.py
+++ b/leo/plugins/nav_qt.py
@@ -45,7 +45,7 @@ def init() -> bool:
 #@+node:ville.20090518182905.5424: ** onCreate
 def onCreate(tag: str, keys: Any) -> None:
 
-    global controllers
+    # global controllers
 
     c = keys.get('c')
     if not c:
@@ -58,7 +58,7 @@ def onCreate(tag: str, keys: Any) -> None:
         controllers[h] = NavController(c)
 #@+node:vitalije.20170712192502.1: ** onClose
 def onClose(tag: str, keys: Any) -> None:
-    global controllers
+    # global controllers
     c = keys.get('c')
     h = c.hash()
     nc = controllers.get(h)

--- a/leo/plugins/niceNosent.py
+++ b/leo/plugins/niceNosent.py
@@ -30,7 +30,7 @@ def onPreSave(tag=None, keywords=None):
 
     """Before saving an @nosent file, make sure that all nodes have a blank line at the end."""
 
-    global nosentNodes
+    # global nosentNodes
     c = keywords.get('c')
     if c:
         for p in c.all_positions():

--- a/leo/plugins/open_shell.py
+++ b/leo/plugins/open_shell.py
@@ -87,7 +87,7 @@ class pluginController:
     #@+node:EKR.20040517080049.9: *3* launchCmd
     def launchCmd(self, event=None):
 
-        global pathToCmd
+        # global pathToCmd
 
         d = self._getCurrentNodePath()
         myCmd = 'cd ' + d
@@ -95,7 +95,7 @@ class pluginController:
     #@+node:EKR.20040517080049.10: *3* launchExplorer
     def launchExplorer(self, event=None):
 
-        global pathToExplorer
+        # global pathToExplorer
 
         d = self._getCurrentNodePath()
         os.spawnl(os.P_NOWAIT, pathToExplorer, ' ', d)

--- a/leo/plugins/read_only_nodes.py
+++ b/leo/plugins/read_only_nodes.py
@@ -251,7 +251,7 @@ class FTPurl:
 # disabling the body text _permanently_ stops the cursor from blinking.
 
 def enable_body(body):
-    global insertOnTime, insertOffTime
+    # global insertOnTime, insertOffTime
     if body.cget("state") == "disabled":
         try:
             g.es("enable")

--- a/leo/plugins/rpcalc.py
+++ b/leo/plugins/rpcalc.py
@@ -210,7 +210,7 @@ def copyToClip(text):
 
 #@+node:tom.20230428180647.1: ** onCreate
 def onCreate(tag: str, keys: Any) -> None:
-    global CMDR
+    # global CMDR
     c = keys.get('c')
     if c:
         sc = scriptingController(c)

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -85,7 +85,7 @@ def init():
 #@+node:ekr.20040910070811.12: *3* OnBodyKey
 def OnBodyKey(tag, keywords):
 
-    global RunNode, In
+    # global RunNode, In
 
     c = keywords.get('c')
     if not c or not c.exists:
@@ -107,7 +107,7 @@ def OnBodyKey(tag, keywords):
 #@+node:ekr.20040910070811.13: *3* OnIconDoubleClick
 def OnIconDoubleClick(tag, keywords):
 
-    global RunNode, RunList, OwnIdleHook, ExitCode
+    global ExitCode, OwnIdleHook, RunList  # RunNode
 
     c = keywords.get('c')
     if not c or not c.exists:
@@ -146,9 +146,8 @@ def OnIconDoubleClick(tag, keywords):
 #@+node:ekr.20040910070811.14: *3* OnIdle
 def OnIdle(tag, keywords):
 
-    global RunNode, RunList
-    global ErrThread, OutThread
-    global ExitCode, OwnIdleHook
+    global OwnIdleHook
+    # global ErrThread, ExitCode, OutThread, RunNode, RunList
 
     c = keywords.get('c')
     if not c or not c.exists:
@@ -171,7 +170,8 @@ def OnIdle(tag, keywords):
 #@+node:ekr.20040910070811.15: *3* OnQuit (run_nodes.py)
 def OnQuit(tag, keywords=None):
 
-    global RunNode, RunList
+    global RunList  # RunNode
+
     c = keywords.get('c')
     if c and RunList:
         RunList = None
@@ -193,7 +193,7 @@ class readingThread(threading.Thread):
 
         """Called automatically when the thread is created."""
 
-        global Encoding
+        # global Encoding
 
         if not self.File:
             return
@@ -214,7 +214,7 @@ class readingThread(threading.Thread):
 def CloseProcess(c):
 
     global RunNode, ExitCode, WorkDir
-    global In, OutThread, ErrThread
+    # global In, OutThread, ErrThread
 
     # Close file and get error code.
     In.close()
@@ -241,7 +241,7 @@ def CloseProcess(c):
 #@+node:ekr.20040910070811.9: ** FindRunChildren (no longer used)
 def FindRunChildren(p):
 
-    global RunList
+    # global RunList
 
     for child in p.children():
         if g.match_word(child.h, 0, "@run"):
@@ -251,7 +251,7 @@ def FindRunChildren(p):
 def OpenProcess(p):
 
     global RunNode, WorkDir
-    global In, OutThread, ErrThread, ExitCode
+    global In, OutThread, ErrThread  # ExitCode
 
     command = p.h[4:].strip()  # Remove @run
     if not command:
@@ -327,7 +327,7 @@ def OpenProcess(p):
 #@+node:ekr.20040910070811.11: ** UpdateText
 def UpdateText(t, wcolor="black"):
 
-    global RunNode, Encoding
+    # global RunNode, Encoding
 
     if t.TextLock.acquire(0) == 1:
         if t.Text:

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -420,7 +420,7 @@ def take_local_screenshot():
 
 def screenshot_helper(window_id):
     """Take a screenshot of the given window."""
-    global screenshot_number
+    # global screenshot_number
     app = g.app.gui.qtApp
     screen = app.primaryScreen()
     if screen is not None:

--- a/leo/plugins/stickynotes.py
+++ b/leo/plugins/stickynotes.py
@@ -109,7 +109,7 @@ def init():
 #@+node:ekr.20220310040820.1: ** onCloseFrame
 def onCloseFrame(tag, kwargs):
     """Close all stickynotes in c's outline."""
-    global outer_dict
+    # global outer_dict
     c = kwargs.get('c')
     if not c:
         return
@@ -150,7 +150,7 @@ def stickynoter_f(event):
     Launch editable 'sticky note' for the node.
     The result is saved as rich text, that is, html...
     """
-    global outer_dict
+    # global outer_dict
     c = event['c']
     p = c.p
     v = p.v
@@ -501,7 +501,7 @@ def get_workbook():
 #@+node:ville.20100703194946.5587: *3* mknote
 def mknote(c, p, parent=None, focusin=None, focusout=None):
     """ Launch editable 'sticky note' for the node """
-    global outer_dict
+    # global outer_dict
     v = p.v
     if focusin is None:
         def mknote_focusin():

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -295,7 +295,8 @@ pandoc_exec = shutil.which('pandoc')
 #@+node:tbrown.20100318101414.5995: *3* vr function: init
 def init() -> bool:
     """Return True if the plugin has loaded successfully."""
-    global got_docutils
+    # global got_docutils
+
     if not g.app.gui.guiName().startswith('qt'):
         return False
     if not got_docutils:
@@ -914,7 +915,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     #@+node:ekr.20191004143229.1: *4* vr.update_asciidoc & helpers
     def update_asciidoc(self, s: str, keywords: Any) -> None:
         """Update asciidoc in the VR pane."""
-        global asciidoctor_exec, asciidoc3_exec
+        # global asciidoctor_exec, asciidoc3_exec
+
         # Do this regardless of whether we show the widget or not.
         w = self.get_base_text_widget()
         assert self.w
@@ -946,7 +948,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         return the contents of the html file.
         The caller handles all exceptions.
         """
-        global asciidoctor_exec, asciidoc3_exec
+        # global asciidoctor_exec, asciidoc3_exec
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         home = g.os.path.expanduser('~')
         i_path = g.finalize_join(home, 'vr_input.adoc')
@@ -1211,7 +1213,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         
         This code has been disabled.
         """
-        global pandoc_exec
+        # global pandoc_exec
         w = self.get_base_text_widget()
         assert self.w
         if s:
@@ -1242,7 +1244,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         return the contents of the html file.
         The caller handles all exceptions.
         """
-        global pandoc_exec
+        # global pandoc_exec
         assert pandoc_exec, g.callers()
         home = g.os.path.expanduser('~')
         i_path = g.finalize_join(home, 'vr_input.pandoc')

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1442,8 +1442,8 @@ def configure_asciidoc():
     #@-<< asciidoc docstring >>
     """
     global AsciiDocAPI, AsciiDoc3API, ad3, ad3_file
-    global asciidoc_ok, asciidoc3_ok, asciidoc_processors
-    global asciidoc_dirs
+    global asciidoc_ok, asciidoc3_ok  # asciidoc_processors
+    # global asciidoc_dirs
     global asciidoc_has_diagram
 
     asciidoc_ok = False
@@ -1677,7 +1677,7 @@ def getVr3(event):
     RETURNS
     The active ViewRenderedController3 or None.
     """
-    global controllers
+    # global controllers
     if g.app.gui.guiName() != 'qt':
         return None
     if (c := event.get('c')):
@@ -1704,7 +1704,7 @@ def viewrendered(event):
     The VR3 instance will not become visible until the vr3-show or vr3-toggle
     commands are executed.
     """
-    global controllers
+    # global controllers
     gui = g.app.gui
     if gui.guiName() != 'qt':
         return None
@@ -3424,7 +3424,8 @@ class ViewRenderedController3(QtWidgets.QWidget):
         the html returned by the processor, or an error message.
         #@-<< convert asciidoc docstring >>
         """
-        global AsciiDocAPI, AsciiDoc3, API, ad3_file, asciidoc_processors
+        global asciidoc_processors
+        # global AsciiDocAPI, AsciiDoc3, API, ad3_file
         h = ''
         if self.asciidoctor:
             h = self.convert_to_asciidoc_external(s)
@@ -3887,7 +3888,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         There is no such thing as @language pandoc,
         so only @pandoc nodes trigger this code.
         """
-        global pandoc_exec
+        # global pandoc_exec
         w = self.ensure_text_widget()
         assert self.w
         if s:
@@ -3922,7 +3923,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         return the contents of the html file.
         The caller handles all exceptions.
         """
-        global pandoc_exec
+        # global pandoc_exec
         assert pandoc_exec, g.callers()
         home = g.os.path.expanduser('~')
         i_path = g.finalize_join(home, 'vr3_input.pandoc')

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -4,11 +4,12 @@
 full_test_leo.py: Run all these tests scripts in this order:
     
 - beautify_leo.py.
-- pyflakes_leo.py
 - run_test_leo.py.
 - flake8_leo.py.
+- pyflakes_leo.py
 - mypy_leo.py.
 - ruff_leo.py.
+- pylint_leo.py.
 
 Devs: *please* run this script before pushing!
 
@@ -52,8 +53,7 @@ python = 'py' if isWindows else 'python'
 for command in [
     fr'{python} -m leo.scripts.beautify_all_leo',
     fr'{python} -m leo.scripts.flake8_leo',
-    # Don't run pyflakes_leo.py until we have resolved pyflakes issues.
-    # fr'{python} -m leo.scripts.pyflakes_leo',
+    fr'{python} -m leo.scripts.pyflakes_leo',
     fr'{python} -m leo.scripts.run_test_leo',
     fr'{python} -m leo.scripts.mypy_leo',
     fr'{python} -m leo.scripts.ruff_leo',

--- a/leo/scripts/pyflakes_leo.py
+++ b/leo/scripts/pyflakes_leo.py
@@ -5,6 +5,10 @@ pyflakes.py: Run pyflakes on (most) .py files in LeoPyRef.leo.
 
 Info item #3867 describes all of Leo's test scripts:
 https://github.com/leo-editor/leo-editor/issues/2867
+
+EKR's pyflakes-leo.cmd:
+    cd {path-to-leo-editor}
+    python -m leo.scripts.pyflakes_leo
 """
 
 import glob
@@ -27,6 +31,7 @@ directories = (
     'plugins',
 )
 suppress = (
+    'leoflexx.py',  # Can't handle the 'undefined' and 'window' JS vars.
     'qt_main.py',  # Generated automaticlly.
 )
 if api and reporter:

--- a/leo/scripts/remove_duplicate_pictures.py
+++ b/leo/scripts/remove_duplicate_pictures.py
@@ -273,7 +273,7 @@ class RemoveDuplicates:
 
     def delete_file(self, filename):
         """Issue a prompt and delete the file if the user agrees."""
-        global gWindow
+        # global gWindow
         if not send2trash:
             if not self.send_to_trash_warning_given:
                 self.send_to_trash_warning_given = True

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -82,7 +82,7 @@ class TestGotoCommands(LeoUnitTest):
         #@+node:ekr.20230804094419.1: *4* test1
         def test1() -> None:
 
-            nonlocal clean_contents
+            nonlocal clean_contents  # noqa # pyflakes and ruff conflict.
 
             # test the helper for show-file-line
             for node_i, p in enumerate(c.all_positions()):
@@ -98,7 +98,7 @@ class TestGotoCommands(LeoUnitTest):
         #@+node:ekr.20230804094514.1: *4* test2
         def test2() -> None:
 
-            nonlocal clean_contents
+            nonlocal clean_contents  # noqa # pyflakes and ruff conflict.
 
             # test the helper for goto-global-line.
             for i, clean_line in enumerate(clean_contents):

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -1314,7 +1314,7 @@ class Optional_TestFiles(BaseTest):
             return f"{token.index:2} {atok_name(token):12} {atok_value(token):20} {node_list}"
         #@+node:ekr.20200124024159.6: *5* function: postvisit
         def postvisit(node, par_value, value):
-            nonlocal stack
+            nonlocal stack  # noqa
             stack.pop()
             return par_value or []
         #@+node:ekr.20200124024159.7: *5* function: previsit
@@ -2652,7 +2652,7 @@ class TestTokens(BaseTest):
             return f"{token.index:2} {atok_name(token):12} {atok_value(token):20} {node_list}"
         #@+node:ekr.20200122170337.1: *5* function: postvisit
         def postvisit(node, par_value, value):
-            nonlocal stack
+            nonlocal stack  # noqa
             stack.pop()
             return par_value or []
         #@+node:ekr.20200122170101.4: *5* function: previsit

--- a/leo/unittests/core/test_leoserver.py
+++ b/leo/unittests/core/test_leoserver.py
@@ -30,7 +30,7 @@ class TestLeoServer(LeoUnitTest):
 
     @classmethod
     def tearDownClass(cls):
-        global g_leoserver, g_server
+        # global g_leoserver, g_server
         try:
             g_server.shut_down({})
             print('===== server did not terminate properly ====')  # pragma:no cover
@@ -40,7 +40,7 @@ class TestLeoServer(LeoUnitTest):
             pass
 
     def setUp(self):
-        global g_server
+        # global g_server
         self.server = g_server
         g.unitTesting = True
 


### PR DESCRIPTION
A refactoring of PR #4345 containing only those changes required to suppress what I consider to be *invalid* pyflakes complaints.

My hope is that the pyflakes dev will roll back [pyflakes PR #825](https://github.com/PyCQA/pyflakes/pull/825), thereby making this PR unnecessary.

Yikes! A pyflakes dev rejected and locked [pyflakes issue #837](https://github.com/PyCQA/pyflakes/issues/837) within minutes of its being opened.

There seem to be only two choices left to me:
- Close this PR. This means that I Leo's test scripts won't ever run pyflakes in batch mode.
- Merge this PR and accept the consequences.

I don't like either choice, but I am leaning towards merging this PR.

There was a third choice, namely continuing the conversation via [pyflakes issue #838](https://github.com/PyCQA/pyflakes/issues/838). However, the pyflakes devs summarily closed this new issue, accusing me of wasting their time. I'm disappointed and displeased.

**I am going to merge this PR**

I am not happy about these enforced changes, but I believe merging this PR is best:

- This PRs changes are undoubtedly safe *for now*.
- It is unlikely that missing `global` or `nonlocal` statements will cause problems in the future.
  If they do, we'll deal with the problems as always.
- Heroic plans such as monkey-patching pyflakes or filtering pyflakes messages would be unwise.
  Yes, such schemes might work *now*, but they inevitably will create maintenance problems in the future.