### PR TITLE
PR for #4346: fix bugs in beautifier

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -157,7 +157,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         c.abbrev_subst_end = c.config.getString('abbreviations-subst-end')
         # The environment for all substitutions.
         # May be augmented in init_env.
-        c.abbrev_subst_env = {'c': c, 'g': g, '_values': {},}
+        c.abbrev_subst_env = {'c': c, 'g': g, '_values': {}, }
         c.abbrev_subst_start = c.config.getString('abbreviations-subst-start') or ''
         # Local settings.
         self.enabled = (

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -341,7 +341,7 @@ class To_Python:  # pragma: no cover
                     i += len(changeList)
                 else:
                     i += 1
-        else:  #use self.match
+        else:  # use self.match
             while i < len(lines):
                 if self.match(lines, i, findString):
                     lines[i : i + len(findString)] = changeList
@@ -1049,7 +1049,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             lastWord = []
             if self.class_name:
                 for item in list("self,"):
-                    result.append(item)  #can put extra comma
+                    result.append(item)  # can put extra comma
             i = 1
             while i < len(args):
                 i = self.skip_ws_and_nl(args, i)
@@ -3232,7 +3232,7 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 lastWord = []
                 if self.class_name:
                     for item in list("self,"):
-                        result.append(item)  #can put extra comma
+                        result.append(item)  # can put extra comma
                 i = 1
                 while i < len(args):
                     i = self.skip_ws_and_nl(args, i)

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2218,7 +2218,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         s = s[i : j - 1]
         # Add the leading whitespace to the present line.
         junk, width = g.skip_leading_ws_with_indent(s, 0, tab_width)
-        if s.rstrip() and (s.rstrip()[-1] == ':' or self.trailing_colon_pat.match(s)):  #2040.
+        if s.rstrip() and (s.rstrip()[-1] == ':' or self.trailing_colon_pat.match(s)):  # 2040.
             # For Python: increase auto-indent after colons.
             if g.findLanguageDirectives(c, p) == 'python':
                 width += abs(tab_width)

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1359,7 +1359,7 @@ class GitDiffController:
                     '.bmp', '.db', '.exe', '.gif', '.gz',
                     '.inv',  # Sphinx inventory file.
                     '.jpg', '.mov', '.mp4', '.pdf', '.png',
-                    '.tar', '.tif',  '.tar', '.whl', '.zip',
+                    '.tar', '.tif', '.tar', '.whl', '.zip',
                 ))
         ]
     #@+node:ekr.20170821052348.1: *4* gdc.get_revno

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -801,7 +801,7 @@ class HelpCommandsClass(BaseEditCommandsClass):
 
             A **layout** is an arrangement of the various frames and panels of
             Leo's interface.
-            
+
             Each layout has a **name**, such as ``vertical-thirds``, and a
             **command** such as ``layout-vertical-thirds``. Such commands switch to
             the given layout.

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -117,16 +117,16 @@ class DefaultDict:
         """Add a word to the dictionary."""
         self.words.add(word)
         self.added_words.add(word)
+    #@+node:ekr.20180207075751.1: *3* DefaultDict.add_to_session
+    def add_to_session(self, word: str) -> None:
+
+        self.ignored_words.add(word)
     #@+node:ekr.20180207101513.1: *3* DefaultDict.add_words_from_dict
     def add_words_from_dict(self, kind: str, fn: str, words: list[str]) -> None:
         """For use by DefaultWrapper."""
         for word in words or []:
             self.words.add(word)
             self.words.add(word.lower())
-    #@+node:ekr.20180207075751.1: *3* DefaultDict.add_to_session
-    def add_to_session(self, word: str) -> None:
-
-        self.ignored_words.add(word)
     #@+node:ekr.20180207080007.1: *3* DefaultDict.check
     def check(self, word: str) -> bool:
         """Return True if the word is in the dict."""
@@ -134,6 +134,22 @@ class DefaultDict:
             if s in self.words or s in self.ignored_words:
                 return True
         return False
+    #@+node:ekr.20180207085717.1: *3* DefaultDict.edits1 & edits2
+    #@@nobeautify
+
+    def edits1(self, word: str) -> list[str]:
+        "All edits that are one edit away from `word`."
+        letters    = 'abcdefghijklmnopqrstuvwxyz'
+        splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]
+        deletes    = [L + R[1:]               for L, R in splits if R]
+        transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R) > 1]
+        replaces   = [L + c + R[1:]           for L, R in splits if R for c in letters]
+        inserts    = [L + c + R               for L, R in splits for c in letters]
+        return list(set(deletes + transposes + replaces + inserts))
+
+    def edits2(self, word: str) -> list[str]:
+        "All edits that are two edits away from `word`."
+        return [e2 for e1 in self.edits1(word) for e2 in self.edits1(e1)]
     #@+node:ekr.20180207081634.1: *3* DefaultDict.suggest & helpers
     def suggest(self, word: str) -> list[str]:
 
@@ -148,22 +164,6 @@ class DefaultDict:
             # [word] # Fall back to the unknown word itself.
         )
         return suggestions
-    #@+node:ekr.20180207085717.1: *4* dict.edits1 & edits2
-    #@@nobeautify
-
-    def edits1(self, word: str) -> list[str]:
-        "All edits that are one edit away from `word`."
-        letters    = 'abcdefghijklmnopqrstuvwxyz'
-        splits     = [(word[:i], word[i:])    for i in range(len(word) + 1)]
-        deletes    = [L + R[1:]               for L, R in splits if R]
-        transposes = [L + R[1] + R[0] + R[2:] for L, R in splits if len(R)>1]
-        replaces   = [L + c + R[1:]           for L, R in splits if R for c in letters]
-        inserts    = [L + c + R               for L, R in splits for c in letters]
-        return list(set(deletes + transposes + replaces + inserts))
-
-    def edits2(self, word: str) -> list[str]:
-        "All edits that are two edits away from `word`."
-        return [e2 for e1 in self.edits1(word) for e2 in self.edits1(e1)]
     #@-others
 #@+node:ekr.20180207071114.1: ** class DefaultWrapper (BaseSpellWrapper)
 class DefaultWrapper(BaseSpellWrapper):

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -304,15 +304,15 @@ class LeoApp:
         # Keys are extensions, values are languages
         self.extension_dict: dict[str, str] = {
             # "ada":    "ada",
-            "ada":      "ada95", # modes/ada95.py exists.
+            "ada":      "ada95",  # modes/ada95.py exists.
             "ahk":      "autohotkey",
             "aj":       "aspect_j",
             "apdl":     "apdl",
-            "as":       "actionscript", # jason 2003-07-03
+            "as":       "actionscript",  # jason 2003-07-03
             "asp":      "asp",
             "awk":      "awk",
             "b":        "b",
-            "bas":      "rapidq", # fil 2004-march-11
+            "bas":      "rapidq",  # fil 2004-march-11
             "bash":     "shellscript",
             "bat":      "batch",
             "bbj":      "bbj",
@@ -320,12 +320,12 @@ class LeoApp:
             "bib":      "bibtex",
             "c":        "c",
             "c++":      "cplusplus",
-            "cbl":      "cobol", # Only one extension is valid: .cob
+            "cbl":      "cobol",  # Only one extension is valid: .cob
             "cc":       "cplusplus",
             "cfg":      "config",
             "cfm":      "coldfusion",
-            "ch":       "chill", # Other extensions, .c186,.c286
-            "clj":      "clojure", # 2013/09/25: Fix bug 879338.
+            "ch":       "chill",    # Other extensions, .c186,.c286
+            "clj":      "clojure",  # 2013/09/25: Fix bug 879338.
             "cljc":     "clojure",
             "cljs":     "clojure",
             "cmd":      "batch",
@@ -333,7 +333,7 @@ class LeoApp:
             "coffee":   "coffeescript",
             "comp":     "glsl",
             "conf":     "apacheconf",
-            "cpp":      "cplusplus", # 2020/08/12: was cpp.
+            "cpp":      "cplusplus",  # 2020/08/12: was cpp.
             "css":      "css",
             "d":        "d",
             "dart":     "dart",
@@ -352,10 +352,10 @@ class LeoApp:
             "glsl":     "glsl",
             "go":       "go",
             "groovy":   "groovy",
-            "h":        "c", # 2012/05/23.
+            "h":        "c",  # 2012/05/23.
             "hh":       "cplusplus",
-            "handlebars": "html", # McNab.
-            "hbs":      "html", # McNab.
+            "handlebars": "html",  # McNab.
+            "hbs":      "html",    # McNab.
             "hs":       "haskell",
             "html":     "html",
             "hx":       "haxe",
@@ -373,31 +373,31 @@ class LeoApp:
             "jhtml":    "jhtml",
             "jl":       "julia",
             "jmk":      "jmk",
-            "js":       "javascript", # For javascript import test.
+            "js":       "javascript",  # For javascript import test.
             "jsp":      "javaserverpage",
             "json":     "json",
             # "jsp":      "jsp",
             "ksh":      "kshell",
-            "kv":       "kivy", # PeckJ 2014/05/05
+            "kv":       "kivy",  # PeckJ 2014/05/05
             "latex":    "latex",
-            "less":     "css", # McNab
-            "lua":      "lua", # ddm 13/02/06
+            "less":     "css",  # McNab
+            "lua":      "lua",  # ddm 13/02/06
             "ly":       "lilypond",
             "m":        "matlab",
             "mak":      "makefile",
             "md":       "md",  # PeckJ 2013/02/07
             "ml":       "ml",  # Also ocaml.
-            "mm":       "objective_c", # Only one extension is valid: .m
+            "mm":       "objective_c",  # Only one extension is valid: .m
             "mod":      "modula3",
             "mpl":      "maple",
             "mqsc":     "mqsc",
             "nqc":      "nqc",
             "nim":      "nim",
-            "nsi":      "nsi", # EKR: 2010/10/27
+            "nsi":      "nsi",  # EKR: 2010/10/27
             # "nsi":      "nsis2",
             "nw":       "noweb",
             "occ":      "occam",
-            "otl":      "vimoutline", # TL 8/25/08 Vim's outline plugin
+            "otl":      "vimoutline",  # TL 8/25/08 Vim's outline plugin
             "p":        "pascal",
             # "p":      "pop11", # Conflicts with pascal.
             "php":      "php",
@@ -413,32 +413,32 @@ class LeoApp:
             "psp":      "psp",
             "ptl":      "ptl",
             "py":       "python",
-            "pyx":      "cython", # Other extensions, .pyd,.pyi
+            "pyx":      "cython",  # Other extensions, .pyd,.pyi
             # "pyx":    "pyrex",
             # "r":      "r", # modes/r.py does not exist.
-            "r":        "rebol", # jason 2003-07-03
-            "rb":       "ruby", # thyrsus 2008-11-05
+            "r":        "rebol",  # jason 2003-07-03
+            "rb":       "ruby",  # thyrsus 2008-11-05
             "rest":     "rst",
             "rex":      "objectrexx",
             "rhtml":    "rhtml",
             "rib":      "rib",
-            "rs":       "rust", # EKR: 2019/08/11
+            "rs":       "rust",  # EKR: 2019/08/11
             "sas":      "sas",
-            "scad":     "openscad", # PeckJ 2024/11/13
+            "scad":     "openscad",  # PeckJ 2024/11/13
             "scala":    "scala",
             "scm":      "scheme",
             "scpt":     "applescript",
             "sgml":     "sgml",
-            "sh":       "shell", # DS 4/1/04. modes/shell.py exists.
+            "sh":       "shell",  # DS 4/1/04. modes/shell.py exists.
             "shtml":    "shtml",
             "sm":       "smalltalk",
             "splus":    "splus",
-            "sql":      "plsql", # qt02537 2005-05-27
+            "sql":      "plsql",  # qt02537 2005-05-27
             "sqr":      "sqr",
             "ss":       "ssharp",
             "ssi":      "shtml",
             "sty":      "latex",
-            "tcl":      "tcl", # modes/tcl.py exists.
+            "tcl":      "tcl",  # modes/tcl.py exists.
             # "tcl":    "tcltk",
             "tesc":     "glsl",
             "tese":     "glsl",
@@ -510,7 +510,7 @@ class LeoApp:
         self.language_delims_dict: dict[str, str] = {
             # Internally, lower case is used for all language names.
             # Keys are languages, values are strings that contain 1, 2 or 3 delims separated by spaces.
-            "actionscript"       : "// /* */", # jason 2003-07-03
+            "actionscript"       : "// /* */",  # jason 2003-07-03
             "ada"                : "--",
             "ada95"              : "--",
             "ahk"                : ";",
@@ -526,36 +526,36 @@ class LeoApp:
             "assembly_parrot"    : "#",
             "assembly_r2000"     : "#",
             "assembly_x86"       : ";",
-            "autohotkey"         : "; /* */", # TL - AutoHotkey language
+            "autohotkey"         : "; /* */",  # TL - AutoHotkey language
             "awk"                : "#",
             "b"                  : "// /* */",
-            "batch"              : "REM_", # Use the REM hack.
+            "batch"              : "REM_",  # Use the REM hack.
             "bbj"                : "/* */",
             "bcel"               : "// /* */",
             "bibtex"             : "%",
-            "c"                  : "// /* */", # C, C++ or objective C.
+            "c"                  : "// /* */",  # C, C++ or objective C.
             "chill"              : "/* */",
-            "clojure"            : ";", # 2013/09/25: Fix bug 879338.
+            "clojure"            : ";",  # 2013/09/25: Fix bug 879338.
             "cobol"              : "*",
             "codon"              : "#",
             "coldfusion"         : "<!-- -->",
-            "coffeescript"       : "#", # 2016/02/26.
-            "config"             : "#", # Leo 4.5.1
+            "coffeescript"       : "#",  # 2016/02/26.
+            "config"             : "#",  # Leo 4.5.1
             "cplusplus"          : "// /* */",
-            "cpp"                : "// /* */", # C++.
-            "csharp"             : "// /* */", # C#
-            "css"                : "/* */", # 4/1/04
-            "cweb"               : "@q@ @>", # Use the "cweb hack"
+            "cpp"                : "// /* */",  # C++.
+            "csharp"             : "// /* */",  # C#
+            "css"                : "/* */",   # 4/1/04
+            "cweb"               : "@q@ @>",  # Use the "cweb hack"
             "cython"             : "#",
             "d"                  : "// /* */",
-            "dart"               : "// /* */", # Leo 5.0.
+            "dart"               : "// /* */",  # Leo 5.0.
             "doxygen"            : "#",
             "eiffel"             : "--",
             "elisp"              : ";",
             "erlang"             : "%",
             "elixir"             : "#",
-            "factor"             : "!_ ( )", # Use the rem hack.
-            "forth"              : "\\_ _(_ _)", # Use the "REM hack"
+            "factor"             : "!_ ( )",  # Use the rem hack.
+            "forth"              : "\\_ _(_ _)",  # Use the "REM hack"
             "fortran"            : "C",
             "fortran90"          : "!",
             "foxpro"             : "&&",
@@ -563,10 +563,10 @@ class LeoApp:
             "glsl"               : "// /* */",  # Same as C.
             "go"                 : "//",
             "groovy"             : "// /* */",
-            "handlebars"         : "<!-- -->", # McNab: delegate to html.
+            "handlebars"         : "<!-- -->",  # McNab: delegate to html.
             "haskell"            : "--_ {-_ _-}",
             "haxe"               : "// /* */",
-            "hbs"                : "<!-- -->", # McNab: delegate to html.
+            "hbs"                : "<!-- -->",  # McNab: delegate to html.
             "html"               : "<!-- -->",
             "i4gl"               : "-- { }",
             "icon"               : "#",
@@ -577,40 +577,40 @@ class LeoApp:
             "interlis"           : "/* */",
             "io"                 : "// */",
             "java"               : "// /* */",
-            "javascript"         : "// /* */", # EKR: 2011/11/12: For javascript import test.
-            "javaserverpage"     : "<%-- --%>", # EKR: 2011/11/25 (See also, jsp)
+            "javascript"         : "// /* */",   # EKR: 2011/11/12: For javascript import test.
+            "javaserverpage"     : "<%-- --%>",  # EKR: 2011/11/25 (See also, jsp)
             "jhtml"              : "<!-- -->",
             "jmk"                : "#",
-            "json"               : "#", # EKR: 2020/07/27: Json has no delims. This is a dummy entry.
+            "json"               : "#",  # EKR: 2020/07/27: Json has no delims. This is a dummy entry.
             "jsp"                : "<%-- --%>",
             "julia"              : "#",
-            "jupyter"            : "<%-- --%>", # Default to markdown?
+            "jupyter"            : "<%-- --%>",  # Default to markdown?
             "jupytext"           : "#",
-            "katex"              : "%", # Leo 6.8.7.
-            "kivy"               : "#", # PeckJ 2014/05/05
-            "kshell"             : "#", # Leo 4.5.1.
+            "katex"              : "%",  # Leo 6.8.7.
+            "kivy"               : "#",  # PeckJ 2014/05/05
+            "kshell"             : "#",  # Leo 4.5.1.
             "latex"              : "%",
-            "less"               : "/* */", # NcNab: delegate to css.
+            "less"               : "/* */",  # NcNab: delegate to css.
             "lilypond"           : "% %{ %}",
-            "lisp"               : ";", # EKR: 2010/09/29
+            "lisp"               : ";",  # EKR: 2010/09/29
             "lotos"              : "(* *)",
-            "lua"                : "--", # ddm 13/02/06
+            "lua"                : "--",  # ddm 13/02/06
             "mail"               : ">",
             "makefile"           : "#",
             "maple"              : "//",
-            "markdown"           : "<!-- -->", # EKR, 2018/03/03: html comments.
-            "matlab"             : "%", # EKR: 2011/10/21
-            "mathjax"            : "% <!-- -->", # EKR: 2024/12/27: latex & html comments.
-            "md"                 : "<!-- -->", # PeckJ: 2013/02/08
+            "markdown"           : "<!-- -->",  # EKR, 2018/03/03: html comments.
+            "matlab"             : "%",  # EKR: 2011/10/21
+            "mathjax"            : "% <!-- -->",  # EKR: 2024/12/27: latex & html comments.
+            "md"                 : "<!-- -->",  # PeckJ: 2013/02/08
             "ml"                 : "(* *)",
             "modula3"            : "(* *)",
             "moin"               : "##",
             "mqsc"               : "*",
             "netrexx"            : "-- /* */",
             "nim"                : "#",
-            "noweb"              : "%", # EKR: 2009-01-30. Use Latex for doc chunks.
+            "noweb"              : "%",  # EKR: 2009-01-30. Use Latex for doc chunks.
             "nqc"                : "// /* */",
-            "nsi"                : ";", # EKR: 2010/10/27
+            "nsi"                : ";",  # EKR: 2010/10/27
             "nsis2"              : ";",
             "objective_c"        : "// /* */",
             "objectrexx"         : "-- /* */",
@@ -618,15 +618,15 @@ class LeoApp:
             "ocaml"              : "(* *)",
             "omnimark"           : ";",
             "pandoc"             : "<!-- -->",
-            "openscad"           : "// /* */", # EKR: 2024/11/13: same as "C".
+            "openscad"           : "// /* */",  # EKR: 2024/11/13: same as "C".
             "pascal"             : "// { }",
             "perl"               : "#",
-            "perlpod"            : "# __=pod__ __=cut__", # 9/25/02: The perlpod hack.
-            "php"                : "// /* */", # 6/23/07: was "//",
+            "perlpod"            : "# __=pod__ __=cut__",  # 9/25/02: The perlpod hack.
+            "php"                : "// /* */",  # 6/23/07: was "//",
             "pike"               : "// /* */",
             "pl1"                : "/* */",
-            "plain"              : "#", # We must pick something.
-            "plsql"              : "-- /* */", # SQL scripts qt02537 2005-05-27
+            "plain"              : "#",  # We must pick something.
+            "plsql"              : "-- /* */",  # SQL scripts qt02537 2005-05-27
             "pop11"              : ";;; /* */",
             "postscript"         : "%",
             "povray"             : "// /* */",
@@ -638,8 +638,8 @@ class LeoApp:
             "pyrex"              : "#",
             "python"             : "#",
             "r"                  : "#",
-            "rapidq"             : "'", # fil 2004-march-11
-            "rebol"              : ";", # jason 2003-07-03
+            "rapidq"             : "'",  # fil 2004-march-11
+            "rebol"              : ";",  # jason 2003-07-03
             "redcode"            : ";",
             "rest"               : ".._",
             "rhtml"              : "<%# %>",
@@ -647,17 +647,17 @@ class LeoApp:
             "rpmspec"            : "#",
             "rst"                : ".._",
             "rust"               : "// /* */",
-            "ruby"               : "#", # thyrsus 2008-11-05
+            "ruby"               : "#",  # thyrsus 2008-11-05
             "rview"              : "// /* */",
             "sas"                : "* /* */",
             "scala"              : "// /* */",
             "scheme"             : "; #| |#",
             "sdl_pr"             : "/* */",
             "sgml"               : "<!-- -->",
-            "shell"              : "#",     # shell scripts
+            "shell"              : "#",  # shell scripts
             "shellscript"        : "#",
             "shtml"              : "<!-- -->",
-            "smalltalk"          : '" "', # Comments are enclosed in double quotes(!!)
+            "smalltalk"          : '" "',  # Comments are enclosed in double quotes(!!)
             "smi_mib"            : "--",
             "splus"              : "#",
             "sqr"                : "!",
@@ -666,23 +666,23 @@ class LeoApp:
             "swig"               : "// /* */",
             "tcl"                : "#",
             "tcltk"              : "#",
-            "tex"                : "%", # Bug fix: 2008-1-30: Fixed Mark Edginton's bug.
-            "text"               : "#", # We must pick something.
+            "tex"                : "%",  # Bug fix: 2008-1-30: Fixed Mark Edginton's bug.
+            "text"               : "#",  # We must pick something.
             "texinfo"            : "@c",
             "toml"               : "#",
             "tpl"                : "<!-- -->",
             "tsql"               : "-- /* */",
             "typst"              : "//",
-            "typescript"         : "// /* */", # For typescript import test.
-            "unknown"            : "#", # Set when @comment is seen.
-            "unknown_language"   : '#--unknown-language--', # For unknown extensions in @shadow files.
+            "typescript"         : "// /* */",  # For typescript import test.
+            "unknown"            : "#",  # Set when @comment is seen.
+            "unknown_language"   : '#--unknown-language--',  # For unknown extensions in @shadow files.
             "uscript"            : "// /* */",
             "vbscript"           : "'",
             "velocity"           : "## #* *#",
             "verilog"            : "// /* */",
             "vhdl"               : "--",
             "vim"                : "\"",
-            "vimoutline"         : "#", # TL 8/25/08 Vim's outline plugin
+            "vimoutline"         : "#",  # TL 8/25/08 Vim's outline plugin
             "xml"                : "<!-- -->",
             "xsl"                : "<!-- -->",
             "xslt"               : "<!-- -->",
@@ -713,7 +713,7 @@ class LeoApp:
 
         # Keys are languages, values are extensions.
         self.language_extension_dict: dict[str, str] = {
-            "actionscript"  : "as", # jason 2003-07-03
+            "actionscript"  : "as",  # jason 2003-07-03
             "ada"           : "ada",
             "ada95"         : "ada",
             "ahk"           : "ahk",
@@ -723,26 +723,26 @@ class LeoApp:
             "applescript"   : "scpt",
             "asp"           : "asp",
             "aspect_j"      : "aj",
-            "autohotkey"    : "ahk", # TL - AutoHotkey language
+            "autohotkey"    : "ahk",  # TL - AutoHotkey language
             "awk"           : "awk",
             "b"             : "b",
-            "batch"         : "bat", # Leo 4.5.1.
+            "batch"         : "bat",  # Leo 4.5.1.
             "bbj"           : "bbj",
             "bcel"          : "bcel",
             "bibtex"        : "bib",
             "c"             : "c",
-            "chill"         : "ch",  # Only one extension is valid: .c186, .c286
-            "clojure"       : "clj", # 2013/09/25: Fix bug 879338.
-            "cobol"         : "cbl", # Only one extension is valid: .cob
+            "chill"         : "ch",   # Only one extension is valid: .c186, .c286
+            "clojure"       : "clj",  # 2013/09/25: Fix bug 879338.
+            "cobol"         : "cbl",  # Only one extension is valid: .cob
             "codon"         : "codon",
             "coldfusion"    : "cfm",
             "coffeescript"  : "coffee",
             "config"        : "cfg",
             "cplusplus"     : "c++",
             "cpp"           : "cpp",
-            "css"           : "css", # 4/1/04
+            "css"           : "css",
             "cweb"          : "w",
-            "cython"        : "pyx", # Only one extension is valid at present: .pyi, .pyd.
+            "cython"        : "pyx",  # Only one extension is valid at present: .pyi, .pyd.
             "d"             : "d",
             "dart"          : "dart",
             "eiffel"        : "e",
@@ -769,24 +769,24 @@ class LeoApp:
             "inno_setup"    : "iss",
             "io"            : "io",
             "java"          : "java",
-            "javascript"    : "js", # EKR: 2011/11/12: For javascript import test.
-            "javaserverpage": "jsp", # EKR: 2011/11/25
+            "javascript"    : "js",   # EKR: 2011/11/12: For javascript import test.
+            "javaserverpage": "jsp",  # EKR: 2011/11/25
             "jhtml"         : "jhtml",
             "jmk"           : "jmk",
             "json"          : "json",
             "jsp"           : "jsp",
             "julia"         : "jl",
             "jupytext"      : "ipynb",
-            "kivy"          : "kv", # PeckJ 2014/05/05
-            "kshell"        : "ksh", # Leo 4.5.1.
-            "latex"         : "tex", # 1/8/04
+            "kivy"          : "kv",   # PeckJ 2014/05/05
+            "kshell"        : "ksh",  # Leo 4.5.1.
+            "latex"         : "tex",  # 1/8/04
             "lilypond"      : "ly",
-            "lua"           : "lua", # ddm 13/02/06
+            "lua"           : "lua",  # ddm 13/02/06
             "mail"          : "eml",
             "makefile"      : "mak",
             "maple"         : "mpl",
             "matlab"        : "m",
-            "md"            : "md", # PeckJ: 2013/02/07
+            "md"            : "md",  # PeckJ: 2013/02/07
             "ml"            : "ml",  # Also ocaml.
             "modula3"       : "mod",
             "moin"          : "wiki",
@@ -794,14 +794,14 @@ class LeoApp:
             "nim"           : "nim",
             "noweb"         : "nw",
             "nqc"           : "nqc",
-            "nsi"           : "nsi", # EKR: 2010/10/27
+            "nsi"           : "nsi",  # EKR: 2010/10/27
             "nsis2"         : "nsi",
-            "objective_c"   : "mm", # Only one extension is valid: .m
+            "objective_c"   : "mm",  # Only one extension is valid: .m
             "objectrexx"    : "rex",
             "occam"         : "occ",
             "ocaml"         : "ml",
             "omnimark"      : "xom",
-            "openscad"      : "scad", # EKR, per PeckJ 2024/11/13
+            "openscad"      : "scad",  # EKR, per PeckJ 2024/11/13
             "pascal"        : "p",
             "perl"          : "pl",
             "perlpod"       : "pod",
@@ -809,7 +809,7 @@ class LeoApp:
             "pike"          : "pike",
             "pl1"           : "pl1",
             "plain"         : "txt",
-            "plsql"         : "sql", # qt02537 2005-05-27
+            "plsql"         : "sql",  # qt02537 2005-05-27
             # "pop11"       : "p", # Conflicts with pascal.
             "postscript"    : "ps",
             "povray"        : "pov",
@@ -819,20 +819,20 @@ class LeoApp:
             "pyrex"         : "pyx",
             "python"        : "py",
             "r"             : "r",
-            "rapidq"        : "bas", # fil 2004-march-11
-            "rebol"         : "r", # jason 2003-07-03
+            "rapidq"        : "bas",  # fil 2004-march-11
+            "rebol"         : "r",  # jason 2003-07-03
             "rhtml"         : "rhtml",
             "rib"           : "rib",
             "rst"           : "rest",
-            "ruby"          : "rb", # thyrsus 2008-11-05
-            "rust"          : "rs", # EKR: 2019/08/11
+            "ruby"          : "rb",  # thyrsus 2008-11-05
+            "rust"          : "rs",  # EKR: 2019/08/11
             "sas"           : "sas",
             "scala"         : "scala",
             "scheme"        : "scm",
             "sgml"          : "sgml",
-            "shell"         : "sh", # DS 4/1/04
+            "shell"         : "sh",  # DS 4/1/04
             "shellscript"   : "bash",
-            "shtml"         : "ssi", # Only one extension is valid: .shtml
+            "shtml"         : "ssi",  # Only one extension is valid: .shtml
             "smalltalk"     : "sm",
             "splus"         : "splus",
             "sqr"           : "sqr",
@@ -845,17 +845,17 @@ class LeoApp:
             "text"          : "txt",
             "toml"          : "toml",
             "tpl"           : "tpl",
-            "tsql"          : "sql", # A guess.
+            "tsql"          : "sql",  # A guess.
             "typescript"    : "ts",
             "typst"         : "typ",
-            "unknown"       : "txt", # Set when @comment is seen.
+            "unknown"       : "txt",  # Set when @comment is seen.
             "uscript"       : "uc",
             "vbscript"      : "vbs",
             "velocity"      : "vtl",
             "verilog"       : "v",
-            "vhdl"          : "vhd", # Only one extension is valid: .vhdl
+            "vhdl"          : "vhd",  # Only one extension is valid: .vhdl
             "vim"           : "vim",
-            "vimoutline"    : "otl", # TL 8/25/08 Vim's outline plugin
+            "vimoutline"    : "otl",  # TL 8/25/08 Vim's outline plugin
             "xml"           : "xml",
             "xsl"           : "xsl",
             "xslt"          : "xsl",
@@ -2508,7 +2508,7 @@ class LoadManager:
                 # Make entries for each extension.
                 d = g.app.classDispatchDict
                 for ext in extensions:
-                    d[ext] = scanner_func  #importer_d.get('func')#scanner_class
+                    d[ext] = scanner_func  # importer_d.get('func')#scanner_class
         elif sfn not in (
             # This is a base class, not a real plugin.
             'base_importer.py',

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1668,7 +1668,7 @@ class Orange:  # Orange is the new Black.
         tag = 'diff-beautify-file'
         self.filename = filename
 
-        if 1:  ### Legacy: use parse trees.
+        if 1:  # Legacy: use parse trees.
             tog = TokenOrderGenerator()
             contents, encoding, tokens, tree = tog.init_from_file(filename)
             if not contents or not tokens or not tree:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -48,7 +48,7 @@ class AtFile:
         # Shadow files.
         'private_s', 'public_s',
         # Writing.
-        'indent',  'sentinels',
+        'indent', 'sentinels',
         'section_delim1', 'section_delim2',
         'outputFile', 'outputList',
         'targetFileName', 'unchangedFiles',  # For messages.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3189,19 +3189,19 @@ class FastAtRead:
         # Doing so will break Leo!
         table = (
             # These patterns must be mutually exclusive.
-            ('after',       fr'^\s*{delim1}@afterref{delim2}$'),             # @afterref
-            ('all',         fr'^(\s*){delim1}@(\+|-)all\b(.*){delim2}$'),    # @all
-            ('code',        fr'^\s*{delim1}@@c(ode)?\b(.*){delim2}$'),       # @c and @code
-            ('comment',     fr'^\s*{delim1}@@comment(.*){delim2}'),          # @comment
-            ('delims',      fr'^\s*{delim1}@delims(.*){delim2}'),            # @delims
-            ('doc',         fr'^\s*{delim1}@\+(at|doc)?(\s.*?)?{delim2}\n'), # @doc or @
-            ('first',       fr'^\s*{delim1}@@first{delim2}$'),               # @first
-            ('last',        fr'^\s*{delim1}@@last{delim2}$'),                # @last
+            ('after',       fr'^\s*{delim1}@afterref{delim2}$'),              # @afterref
+            ('all',         fr'^(\s*){delim1}@(\+|-)all\b(.*){delim2}$'),     # @all
+            ('code',        fr'^\s*{delim1}@@c(ode)?\b(.*){delim2}$'),        # @c and @code
+            ('comment',     fr'^\s*{delim1}@@comment(.*){delim2}'),           # @comment
+            ('delims',      fr'^\s*{delim1}@delims(.*){delim2}'),             # @delims
+            ('doc',         fr'^\s*{delim1}@\+(at|doc)?(\s.*?)?{delim2}\n'),  # @doc or @
+            ('first',       fr'^\s*{delim1}@@first{delim2}$'),                # @first
+            ('last',        fr'^\s*{delim1}@@last{delim2}$'),                 # @last
             #@verbatim
             # @node
             ('node_start',  fr'^(\s*){delim1}@\+node:([^:]+): \*(\d+)?(\*?) (.*){delim2}$'),
-            ('others',      fr'^(\s*){delim1}@(\+|-)others\b(.*){delim2}$'), # @others
-            ('ref',         fr'^(\s*){delim1}@(\+|-){ref}\s*{delim2}$'),     # section ref
+            ('others',      fr'^(\s*){delim1}@(\+|-)others\b(.*){delim2}$'),  # @others
+            ('ref',         fr'^(\s*){delim1}@(\+|-){ref}\s*{delim2}$'),      # section ref
             #@verbatim
             # @section-delims
             ('section_delims', fr'^\s*{delim1}@@section-delims[ \t]+([^ \w\n\t]+)[ \t]+([^ \w\n\t]+)[ \t]*{delim2}$'),

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -672,7 +672,7 @@ class AtFile:
         p must be an @jupytext node.
         - Convert the .ipynb file to a string s.
         - Update p.b's tree using s.
-        
+
         This code is adapted from at.readOneAtCleanNode.
         """
         at, c, x = self, self.c, self.c.shadowController
@@ -1590,7 +1590,7 @@ class AtFile:
         """
         p must be an @jupytext node.
         Write the corresponding .ipynb file from p and all p's descendants.
-        
+
         This code is adapted from at.writeOneAtCleanNode.
         """
         at, c, p = self, self.c, self.c.p

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2390,7 +2390,7 @@ class AtFile:
                 g.es_print(f"{j+1:5}: {line}")
     #@+node:ekr.20240926044644.1: *6* at.runTokenBasedBeautifier
     def runTokenBasedBeautifier(self, root: Position, filename: str) -> bool:
-        """Run Leo's token-based beautifier on the selecte position."""
+        """Run Leo's token-based beautifier on the selected position."""
         c = self.c
         p = c.p
         if not os.path.exists(filename):

--- a/leo/core/leoCache.py
+++ b/leo/core/leoCache.py
@@ -8,7 +8,7 @@ import fnmatch
 import os
 import pickle
 import sqlite3
-from typing import Any, Generator, Optional,  TYPE_CHECKING, Union
+from typing import Any, Generator, Optional, TYPE_CHECKING, Union
 import zlib
 from leo.core import leoGlobals as g
 
@@ -347,7 +347,7 @@ class SqlitePickleShare:
         pass
     #@-others
 #@+node:ekr.20180627050237.1: ** function: dump_cache
-def dump_cache(db: Union[dict,  SqlitePickleShare], tag: str) -> None:
+def dump_cache(db: Union[dict, SqlitePickleShare], tag: str) -> None:
     """Dump the given cache."""
     print(f'\n===== {tag} =====\n')
     if db is None:

--- a/leo/core/leoColor.py
+++ b/leo/core/leoColor.py
@@ -37,7 +37,7 @@ will return None.
 # See BaseColorizer.normalize().
 leo_color_database = {
     # leo colors
-    "leoblue": "#F0F8FF",  #alice blue
+    "leoblue": "#F0F8FF",  # alice blue
     "leoyellow": "#ffffec",
     "leopink": "#FFE4E1",  # misty rose
     # Solarized colors

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -2264,7 +2264,7 @@ class JEditColorizer(BaseColorizer):
         # For pylint.
         return -1
     #@+node:ekr.20250109134131.1: *4* jedit.match_plain_eol_span
-    def match_plain_eol_span(self, s: str, i: int,  kind: str) -> int:
+    def match_plain_eol_span(self, s: str, i: int, kind: str) -> int:
         """Colorizer s[i:]"""
         j = len(s)
         self.colorRangeWithTag(s, i, j, kind)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -350,20 +350,20 @@ class BaseColorizer:
 
             # Used in Leo rules...
             # tag name      : ( option name,                   default color),
-            'blank'         : ('show_invisibles_space_color',  '#E5E5E5'), # gray90
+            'blank'         : ('show_invisibles_space_color',  '#E5E5E5'),  # gray90
             'docpart'       : ('doc_part_color',               'red'),
             'leokeyword'    : ('leo_keyword_color',            'blue'),
             'link'          : ('section_name_color',           'red'),
             'name'          : ('undefined_section_name_color', 'red'),
             'namebrackets'  : ('section_name_brackets_color',  'blue'),
-            'tab'           : ('show_invisibles_tab_color',    '#CCCCCC'), # gray80
+            'tab'           : ('show_invisibles_tab_color',    '#CCCCCC'),  # gray80
             'url'           : ('url_color',                    'purple'),
 
             # Pygments tags.  Non-default values are taken from 'default' style.
 
             # Top-level...
             # tag name          : ( option name,         default color),
-            'error'             : ('error',              '#FF0000'), # border
+            'error'             : ('error',              '#FF0000'),  # border
             'other'             : ('other',              'white'),
             'punctuation'       : ('punctuation',        'white'),
             'whitespace'        : ('whitespace',         '#bbbbbb'),
@@ -371,34 +371,34 @@ class BaseColorizer:
 
             # Comment...
             # tag name          : ( option name,         default color),
-            'comment'           : ('comment',            '#408080'), # italic
+            'comment'           : ('comment',            '#408080'),  # italic
             'comment.hashbang'  : ('comment.hashbang',   '#408080'),
             'comment.multiline' : ('comment.multiline',  '#408080'),
             'comment.special'   : ('comment.special',    '#408080'),
-            'comment.preproc'   : ('comment.preproc',    '#BC7A00'), # noitalic
-            'comment.single'    : ('comment.single',     '#BC7A00'), # italic
+            'comment.preproc'   : ('comment.preproc',    '#BC7A00'),  # noitalic
+            'comment.single'    : ('comment.single',     '#BC7A00'),  # italic
 
             # Generic...
             # tag name          : ( option name,         default color),
             'generic'           : ('generic',            '#A00000'),
             'generic.deleted'   : ('generic.deleted',    '#A00000'),
-            'generic.emph'      : ('generic.emph',       '#000080'), # italic
+            'generic.emph'      : ('generic.emph',       '#000080'),  # italic
             'generic.error'     : ('generic.error',      '#FF0000'),
-            'generic.heading'   : ('generic.heading',    '#000080'), # bold
+            'generic.heading'   : ('generic.heading',    '#000080'),  # bold
             'generic.inserted'  : ('generic.inserted',   '#00A000'),
             'generic.output'    : ('generic.output',     '#888'),
-            'generic.prompt'    : ('generic.prompt',     '#000080'), # bold
-            'generic.strong'    : ('generic.strong',     '#000080'), # bold
-            'generic.subheading': ('generic.subheading', '#800080'), # bold
+            'generic.prompt'    : ('generic.prompt',     '#000080'),  # bold
+            'generic.strong'    : ('generic.strong',     '#000080'),  # bold
+            'generic.subheading': ('generic.subheading', '#800080'),  # bold
             'generic.traceback' : ('generic.traceback',  '#04D'),
             #
             # Keyword...
             # tag name              : ( option name,             default color),
-            'keyword'               : ('keyword',                '#008000'), # bold
+            'keyword'               : ('keyword',                '#008000'),  # bold
             'keyword.constant'      : ('keyword.constant',       '#008000'),
             'keyword.declaration'   : ('keyword.declaration',    '#008000'),
             'keyword.namespace'     : ('keyword.namespace',      '#008000'),
-            'keyword.pseudo'        : ('keyword.pseudo',         '#008000'), # nobold
+            'keyword.pseudo'        : ('keyword.pseudo',         '#008000'),  # nobold
             'keyword.reserved'      : ('keyword.reserved',       '#008000'),
             'keyword.type'          : ('keyword.type',           '#B00040'),
 
@@ -410,22 +410,22 @@ class BaseColorizer:
             # Name...
             # tag name              : ( option name,          default color
             # 'name' defined below.
-            'name.attribute'        : ('name.attribute',      '#7D9029'), # bold
+            'name.attribute'        : ('name.attribute',      '#7D9029'),  # bold
             'name.builtin'          : ('name.builtin',        '#008000'),
             'name.builtin.pseudo'   : ('name.builtin.pseudo', '#008000'),
-            'name.class'            : ('name.class',          '#0000FF'), # bold
+            'name.class'            : ('name.class',          '#0000FF'),  # bold
             'name.constant'         : ('name.constant',       '#880000'),
             'name.decorator'        : ('name.decorator',      '#AA22FF'),
-            'name.entity'           : ('name.entity',         '#999999'), # bold
-            'name.exception'        : ('name.exception',      '#D2413A'), # bold
+            'name.entity'           : ('name.entity',         '#999999'),  # bold
+            'name.exception'        : ('name.exception',      '#D2413A'),  # bold
             'name.function'         : ('name.function',       '#0000FF'),
             'name.function.magic'   : ('name.function.magic', '#0000FF'),
             'name.label'            : ('name.label',          '#A0A000'),
-            'name.namespace'        : ('name.namespace',      '#0000FF'), # bold
+            'name.namespace'        : ('name.namespace',      '#0000FF'),  # bold
             'name.other'            : ('name.other',          'red'),
             # A hack: getLegacyFormat returns name.pygments instead of name.
             'name.pygments'         : ('name.pygments',          'white'),
-            'name.tag'              : ('name.tag',               '#008000'), # bold
+            'name.tag'              : ('name.tag',               '#008000'),  # bold
             'name.variable'         : ('name.variable',          '#19177C'),
             'name.variable.class'   : ('name.variable.class',    '#19177C'),
             'name.variable.global'  : ('name.variable.global',   '#19177C'),
@@ -445,7 +445,7 @@ class BaseColorizer:
             # Operator...
             # tag name          : ( option name,         default color
             # 'operator' defined below.
-            'operator.word'     : ('operator.Word',      '#AA22FF'), # bold
+            'operator.word'     : ('operator.Word',      '#AA22FF'),  # bold
 
             # String...
             # tag name          : ( option name,         default color
@@ -454,11 +454,11 @@ class BaseColorizer:
             'string.backtick'   : ('string.backtick',    '#BA2121'),
             'string.char'       : ('string.char',        '#BA2121'),
             'string.delimiter'  : ('string.delimiter',   '#BA2121'),
-            'string.doc'        : ('string.doc',         '#BA2121'), # italic
+            'string.doc'        : ('string.doc',         '#BA2121'),  # italic
             'string.double'     : ('string.double',      '#BA2121'),
-            'string.escape'     : ('string.escape',      '#BB6622'), # bold
+            'string.escape'     : ('string.escape',      '#BB6622'),  # bold
             'string.heredoc'    : ('string.heredoc',     '#BA2121'),
-            'string.interpol'   : ('string.interpol',    '#BB6688'), # bold
+            'string.interpol'   : ('string.interpol',    '#BB6688'),  # bold
             'string.other'      : ('string.other',       '#008000'),
             'string.regex'      : ('string.regex',       '#BB6688'),
             'string.single'     : ('string.single',      '#BA2121'),
@@ -495,13 +495,13 @@ class BaseColorizer:
 
             # Used in Leo rules...
             # tag name      :  option name
-            'blank'         : 'show_invisibles_space_font', # 2011/10/24.
+            'blank'         : 'show_invisibles_space_font',  # 2011/10/24.
             'docpart'       : 'doc_part_font',
             'leokeyword'    : 'leo_keyword_font',
             'link'          : 'section_name_font',
             'name'          : 'undefined_section_name_font',
             'namebrackets'  : 'section_name_brackets_font',
-            'tab'           : 'show_invisibles_tab_font', # 2011/10/24.
+            'tab'           : 'show_invisibles_tab_font',  # 2011/10/24.
             'url'           : 'url_font',
 
             # Pygments tags (lower case)...
@@ -593,7 +593,7 @@ class BaseColorizer:
         self.showInvisibles      = getBool("show-invisibles-by-default")
         self.underline_undefined = getBool("underline-undefined-section-names")
         self.use_hyperlinks      = getBool("use-hyperlinks")
-        self.use_pygments        = None # Set in report_changes.
+        self.use_pygments        = None  # Set in report_changes.
         self.use_pygments_styles = getBool('use-pygments-styles', default=True)
         #
         # Report changes to pygments settings.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -62,7 +62,7 @@ def make_colorizer(c: Cmdr, widget: QWidget) -> Union[JEditColorizer, PygmentsCo
 class BaseColorizer:
     """
     The base class for all Leo colorizers.
-    
+
     c.frame.body.colorizer is the actual colorizer.
     """
     #@+others
@@ -879,7 +879,7 @@ class JEditColorizer(BaseColorizer):
     """
     This class colorizes p.b using Qt's QSyntaxHighlighter (qsh) class:
     https://doc.qt.io/qt-6/qsyntaxhighlighter.html
-    
+
     Each commander creates a single instance of this class: c.frame.body.colorizer.
 
     Use Leo's `--tracing=coloring` command-line option to see this class in action.
@@ -930,7 +930,7 @@ class JEditColorizer(BaseColorizer):
     def init(self) -> None:
         """
         Init the colorizer to match self.language.
-        
+
         The caller must set or clear state after calling this method.
         """
         # Init the *per-language* initial state number.
@@ -1298,9 +1298,9 @@ class JEditColorizer(BaseColorizer):
     def mainLoop(self, state: int, s: str, i0: int, j: int) -> None:
         """
         Colorize a *single* line s[i:j] starting in state n.
-        
+
         Except for traces, do not change this method in any way!
-        
+
         Any substantial change would break all the pattern matchers!
         """
         # Do not remove this unit test!
@@ -1339,7 +1339,7 @@ class JEditColorizer(BaseColorizer):
         """
         jEdit.recolor: Recolor a *single* line, s.
         QSyntaxHighligher calls this method repeatedly and automatically.
-        
+
         Don't even *think* about changing this method unless you
         understand *every word* of the Theory of Operation:
         https://github.com/leo-editor/leo-editor/issues/4158
@@ -1475,7 +1475,7 @@ class JEditColorizer(BaseColorizer):
     ) -> None:
         """
         Pattern matchers call this helper to colorize the selected range.
-        
+
         Mode files should not call this helper directly!
         """
         # setTag does most tracing.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -347,144 +347,144 @@ class BaseColorizer:
 
         # These defaults are sure to exist.
         self.default_colors_dict = {
-            #
+
             # Used in Leo rules...
-            # tag name      :( option name,                  default color),
-            'blank'         :('show_invisibles_space_color', '#E5E5E5'), # gray90
-            'docpart'       :('doc_part_color',              'red'),
-            'leokeyword'    :('leo_keyword_color',           'blue'),
-            'link'          :('section_name_color',          'red'),
-            'name'          :('undefined_section_name_color','red'),
-            'namebrackets'  :('section_name_brackets_color', 'blue'),
-            'tab'           :('show_invisibles_tab_color',   '#CCCCCC'), # gray80
-            'url'           :('url_color',                   'purple'),
-            #
+            # tag name      : ( option name,                   default color),
+            'blank'         : ('show_invisibles_space_color',  '#E5E5E5'), # gray90
+            'docpart'       : ('doc_part_color',               'red'),
+            'leokeyword'    : ('leo_keyword_color',            'blue'),
+            'link'          : ('section_name_color',           'red'),
+            'name'          : ('undefined_section_name_color', 'red'),
+            'namebrackets'  : ('section_name_brackets_color',  'blue'),
+            'tab'           : ('show_invisibles_tab_color',    '#CCCCCC'), # gray80
+            'url'           : ('url_color',                    'purple'),
+
             # Pygments tags.  Non-default values are taken from 'default' style.
-            #
+
             # Top-level...
-            # tag name          :( option name,         default color),
-            'error'             :('error',              '#FF0000'), # border
-            'other'             :('other',              'white'),
-            'punctuation'       :('punctuation',        'white'),
-            'whitespace'        :('whitespace',         '#bbbbbb'),
-            'xt'                :('xt',                 '#bbbbbb'),
-            #
+            # tag name          : ( option name,         default color),
+            'error'             : ('error',              '#FF0000'), # border
+            'other'             : ('other',              'white'),
+            'punctuation'       : ('punctuation',        'white'),
+            'whitespace'        : ('whitespace',         '#bbbbbb'),
+            'xt'                : ('xt',                 '#bbbbbb'),
+
             # Comment...
-            # tag name          :( option name,         default color),
-            'comment'           :('comment',            '#408080'), # italic
-            'comment.hashbang'  :('comment.hashbang',   '#408080'),
-            'comment.multiline' :('comment.multiline',  '#408080'),
-            'comment.special'   :('comment.special',    '#408080'),
-            'comment.preproc'   :('comment.preproc',    '#BC7A00'), # noitalic
-            'comment.single'    :('comment.single',     '#BC7A00'), # italic
-            #
+            # tag name          : ( option name,         default color),
+            'comment'           : ('comment',            '#408080'), # italic
+            'comment.hashbang'  : ('comment.hashbang',   '#408080'),
+            'comment.multiline' : ('comment.multiline',  '#408080'),
+            'comment.special'   : ('comment.special',    '#408080'),
+            'comment.preproc'   : ('comment.preproc',    '#BC7A00'), # noitalic
+            'comment.single'    : ('comment.single',     '#BC7A00'), # italic
+
             # Generic...
-            # tag name          :( option name,         default color),
-            'generic'           :('generic',            '#A00000'),
-            'generic.deleted'   :('generic.deleted',    '#A00000'),
-            'generic.emph'      :('generic.emph',       '#000080'), # italic
-            'generic.error'     :('generic.error',      '#FF0000'),
-            'generic.heading'   :('generic.heading',    '#000080'), # bold
-            'generic.inserted'  :('generic.inserted',   '#00A000'),
-            'generic.output'    :('generic.output',     '#888'),
-            'generic.prompt'    :('generic.prompt',     '#000080'), # bold
-            'generic.strong'    :('generic.strong',     '#000080'), # bold
-            'generic.subheading':('generic.subheading', '#800080'), # bold
-            'generic.traceback' :('generic.traceback',  '#04D'),
+            # tag name          : ( option name,         default color),
+            'generic'           : ('generic',            '#A00000'),
+            'generic.deleted'   : ('generic.deleted',    '#A00000'),
+            'generic.emph'      : ('generic.emph',       '#000080'), # italic
+            'generic.error'     : ('generic.error',      '#FF0000'),
+            'generic.heading'   : ('generic.heading',    '#000080'), # bold
+            'generic.inserted'  : ('generic.inserted',   '#00A000'),
+            'generic.output'    : ('generic.output',     '#888'),
+            'generic.prompt'    : ('generic.prompt',     '#000080'), # bold
+            'generic.strong'    : ('generic.strong',     '#000080'), # bold
+            'generic.subheading': ('generic.subheading', '#800080'), # bold
+            'generic.traceback' : ('generic.traceback',  '#04D'),
             #
             # Keyword...
-            # tag name              :( option name,             default color),
-            'keyword'               :('keyword',                '#008000'), # bold
-            'keyword.constant'      :('keyword.constant',       '#008000'),
-            'keyword.declaration'   :('keyword.declaration',    '#008000'),
-            'keyword.namespace'     :('keyword.namespace',      '#008000'),
-            'keyword.pseudo'        :('keyword.pseudo',         '#008000'), # nobold
-            'keyword.reserved'      :('keyword.reserved',       '#008000'),
-            'keyword.type'          :('keyword.type',           '#B00040'),
-            #
+            # tag name              : ( option name,             default color),
+            'keyword'               : ('keyword',                '#008000'), # bold
+            'keyword.constant'      : ('keyword.constant',       '#008000'),
+            'keyword.declaration'   : ('keyword.declaration',    '#008000'),
+            'keyword.namespace'     : ('keyword.namespace',      '#008000'),
+            'keyword.pseudo'        : ('keyword.pseudo',         '#008000'), # nobold
+            'keyword.reserved'      : ('keyword.reserved',       '#008000'),
+            'keyword.type'          : ('keyword.type',           '#B00040'),
+
             # Literal...
-            # tag name              :( option name,         default color),
-            'literal'               :('literal',            'white'),
-            'literal.date'          :('literal.date',       'white'),
-            #
+            # tag name              : ( option name,         default color),
+            'literal'               : ('literal',            'white'),
+            'literal.date'          : ('literal.date',       'white'),
+
             # Name...
-            # tag name              :( option name,         default color
+            # tag name              : ( option name,          default color
             # 'name' defined below.
-            'name.attribute'        :('name.attribute',     '#7D9029'), # bold
-            'name.builtin'          :('name.builtin',       '#008000'),
-            'name.builtin.pseudo'   :('name.builtin.pseudo','#008000'),
-            'name.class'            :('name.class',         '#0000FF'), # bold
-            'name.constant'         :('name.constant',      '#880000'),
-            'name.decorator'        :('name.decorator',     '#AA22FF'),
-            'name.entity'           :('name.entity',        '#999999'), # bold
-            'name.exception'        :('name.exception',     '#D2413A'), # bold
-            'name.function'         :('name.function',      '#0000FF'),
-            'name.function.magic'   :('name.function.magic','#0000FF'),
-            'name.label'            :('name.label',         '#A0A000'),
-            'name.namespace'        :('name.namespace',     '#0000FF'), # bold
-            'name.other'            :('name.other',         'red'),
+            'name.attribute'        : ('name.attribute',      '#7D9029'), # bold
+            'name.builtin'          : ('name.builtin',        '#008000'),
+            'name.builtin.pseudo'   : ('name.builtin.pseudo', '#008000'),
+            'name.class'            : ('name.class',          '#0000FF'), # bold
+            'name.constant'         : ('name.constant',       '#880000'),
+            'name.decorator'        : ('name.decorator',      '#AA22FF'),
+            'name.entity'           : ('name.entity',         '#999999'), # bold
+            'name.exception'        : ('name.exception',      '#D2413A'), # bold
+            'name.function'         : ('name.function',       '#0000FF'),
+            'name.function.magic'   : ('name.function.magic', '#0000FF'),
+            'name.label'            : ('name.label',          '#A0A000'),
+            'name.namespace'        : ('name.namespace',      '#0000FF'), # bold
+            'name.other'            : ('name.other',          'red'),
             # A hack: getLegacyFormat returns name.pygments instead of name.
-            'name.pygments'         :('name.pygments',      'white'),
-            'name.tag'              :('name.tag',               '#008000'), # bold
-            'name.variable'         :('name.variable',          '#19177C'),
-            'name.variable.class'   :('name.variable.class',    '#19177C'),
-            'name.variable.global'  :('name.variable.global',   '#19177C'),
-            'name.variable.instance':('name.variable.instance', '#19177C'),
-            'name.variable.magic'   :('name.variable.magic',    '#19177C'),
-            #
+            'name.pygments'         : ('name.pygments',          'white'),
+            'name.tag'              : ('name.tag',               '#008000'), # bold
+            'name.variable'         : ('name.variable',          '#19177C'),
+            'name.variable.class'   : ('name.variable.class',    '#19177C'),
+            'name.variable.global'  : ('name.variable.global',   '#19177C'),
+            'name.variable.instance': ('name.variable.instance', '#19177C'),
+            'name.variable.magic'   : ('name.variable.magic',    '#19177C'),
+
             # Number...
-            # tag name              :( option name,         default color
-            'number'                :('number',             '#666666'),
-            'number.bin'            :('number.bin',         '#666666'),
-            'number.float'          :('number.float',       '#666666'),
-            'number.hex'            :('number.hex',         '#666666'),
-            'number.integer'        :('number.integer',     '#666666'),
-            'number.integer.long'   :('number.integer.long','#666666'),
-            'number.oct'            :('number.oct',         '#666666'),
-            #
+            # tag name              : ( option name,          default color
+            'number'                : ('number',              '#666666'),
+            'number.bin'            : ('number.bin',          '#666666'),
+            'number.float'          : ('number.float',        '#666666'),
+            'number.hex'            : ('number.hex',          '#666666'),
+            'number.integer'        : ('number.integer',      '#666666'),
+            'number.integer.long'   : ('number.integer.long', '#666666'),
+            'number.oct'            : ('number.oct',          '#666666'),
+
             # Operator...
-            # tag name          :( option name,         default color
+            # tag name          : ( option name,         default color
             # 'operator' defined below.
-            'operator.word'     :('operator.Word',      '#AA22FF'), # bold
-            #
+            'operator.word'     : ('operator.Word',      '#AA22FF'), # bold
+
             # String...
-            # tag name          :( option name,         default color
-            'string'            :('string',             '#BA2121'),
-            'string.affix'      :('string.affix',       '#BA2121'),
-            'string.backtick'   :('string.backtick',    '#BA2121'),
-            'string.char'       :('string.char',        '#BA2121'),
-            'string.delimiter'  :('string.delimiter',   '#BA2121'),
-            'string.doc'        :('string.doc',         '#BA2121'), # italic
-            'string.double'     :('string.double',      '#BA2121'),
-            'string.escape'     :('string.escape',      '#BB6622'), # bold
-            'string.heredoc'    :('string.heredoc',     '#BA2121'),
-            'string.interpol'   :('string.interpol',    '#BB6688'), # bold
-            'string.other'      :('string.other',       '#008000'),
-            'string.regex'      :('string.regex',       '#BB6688'),
-            'string.single'     :('string.single',      '#BA2121'),
-            'string.symbol'     :('string.symbol',      '#19177C'),
+            # tag name          : ( option name,         default color
+            'string'            : ('string',             '#BA2121'),
+            'string.affix'      : ('string.affix',       '#BA2121'),
+            'string.backtick'   : ('string.backtick',    '#BA2121'),
+            'string.char'       : ('string.char',        '#BA2121'),
+            'string.delimiter'  : ('string.delimiter',   '#BA2121'),
+            'string.doc'        : ('string.doc',         '#BA2121'), # italic
+            'string.double'     : ('string.double',      '#BA2121'),
+            'string.escape'     : ('string.escape',      '#BB6622'), # bold
+            'string.heredoc'    : ('string.heredoc',     '#BA2121'),
+            'string.interpol'   : ('string.interpol',    '#BB6688'), # bold
+            'string.other'      : ('string.other',       '#008000'),
+            'string.regex'      : ('string.regex',       '#BB6688'),
+            'string.single'     : ('string.single',      '#BA2121'),
+            'string.symbol'     : ('string.symbol',      '#19177C'),
             #
             # jEdit tags.
-            # tag name  :( option name,     default color),
-            'comment1'  :('comment1_color', 'red'),
-            'comment2'  :('comment2_color', 'red'),
-            'comment3'  :('comment3_color', 'red'),
-            'comment4'  :('comment4_color', 'red'),
-            'function'  :('function_color', 'black'),
-            'keyword1'  :('keyword1_color', 'blue'),
-            'keyword2'  :('keyword2_color', 'blue'),
-            'keyword3'  :('keyword3_color', 'blue'),
-            'keyword4'  :('keyword4_color', 'blue'),
-            'keyword5'  :('keyword5_color', 'blue'),
-            'label'     :('label_color',    'black'),
-            'literal1'  :('literal1_color', '#00aa00'),
-            'literal2'  :('literal2_color', '#00aa00'),
-            'literal3'  :('literal3_color', '#00aa00'),
-            'literal4'  :('literal4_color', '#00aa00'),
-            'markup'    :('markup_color',   'red'),
-            'null'      :('null_color',     None),  # 'black'
-            'operator'  :('operator_color', 'black'),
-            'trailing_whitespace': ('trailing_whitespace_color', '#808080'),
+            # tag name  : ( option name,     default color),
+            'comment1'  : ('comment1_color', 'red'),
+            'comment2'  : ('comment2_color', 'red'),
+            'comment3'  : ('comment3_color', 'red'),
+            'comment4'  : ('comment4_color', 'red'),
+            'function'  : ('function_color', 'black'),
+            'keyword1'  : ('keyword1_color', 'blue'),
+            'keyword2'  : ('keyword2_color', 'blue'),
+            'keyword3'  : ('keyword3_color', 'blue'),
+            'keyword4'  : ('keyword4_color', 'blue'),
+            'keyword5'  : ('keyword5_color', 'blue'),
+            'label'     : ('label_color',    'black'),
+            'literal1'  : ('literal1_color', '#00aa00'),
+            'literal2'  : ('literal2_color', '#00aa00'),
+            'literal3'  : ('literal3_color', '#00aa00'),
+            'literal4'  : ('literal4_color', '#00aa00'),
+            'markup'    : ('markup_color',   'red'),
+            'null'      : ('null_color',     None),  # 'black'
+            'operator'  : ('operator_color', 'black'),
+            'trailing_whitespace':  ('trailing_whitespace_color', '#808080'),
         }
     #@+node:ekr.20110605121601.18575: *4* BaseColorizer.defineDefaultFontDict
     #@@nobeautify
@@ -492,85 +492,85 @@ class BaseColorizer:
     def defineDefaultFontDict(self) -> None:
 
         self.default_font_dict = {
-            #
+
             # Used in Leo rules...
-            # tag name      : option name
-            'blank'         :'show_invisibles_space_font', # 2011/10/24.
-            'docpart'       :'doc_part_font',
-            'leokeyword'    :'leo_keyword_font',
-            'link'          :'section_name_font',
-            'name'          :'undefined_section_name_font',
-            'namebrackets'  :'section_name_brackets_font',
-            'tab'           :'show_invisibles_tab_font', # 2011/10/24.
-            'url'           :'url_font',
-            #
+            # tag name      :  option name
+            'blank'         : 'show_invisibles_space_font', # 2011/10/24.
+            'docpart'       : 'doc_part_font',
+            'leokeyword'    : 'leo_keyword_font',
+            'link'          : 'section_name_font',
+            'name'          : 'undefined_section_name_font',
+            'namebrackets'  : 'section_name_brackets_font',
+            'tab'           : 'show_invisibles_tab_font', # 2011/10/24.
+            'url'           : 'url_font',
+
             # Pygments tags (lower case)...
-            # tag name          : option name
-            "comment"           :'comment1_font',
-            "comment.preproc"   :'comment2_font',
-            "comment.single"    :'comment1_font',
-            "error"             :'null_font',
-            "generic.deleted"   :'literal4_font',
-            "generic.emph"      :'literal4_font',
-            "generic.error"     :'literal4_font',
-            "generic.heading"   :'literal4_font',
-            "generic.inserted"  :'literal4_font',
-            "generic.output"    :'literal4_font',
-            "generic.prompt"    :'literal4_font',
-            "generic.strong"    :'literal4_font',
-            "generic.subheading":'literal4_font',
-            "generic.traceback" :'literal4_font',
-            "keyword"           :'keyword1_font',
-            "keyword.pseudo"    :'keyword2_font',
-            "keyword.type"      :'keyword3_font',
-            "name.attribute"    :'null_font',
-            "name.builtin"      :'null_font',
-            "name.class"        :'null_font',
-            "name.constant"     :'null_font',
-            "name.decorator"    :'null_font',
-            "name.entity"       :'null_font',
-            "name.exception"    :'null_font',
-            "name.function"     :'null_font',
-            "name.label"        :'null_font',
-            "name.namespace"    :'null_font',
-            "name.tag"          :'null_font',
-            "name.variable"     :'null_font',
-            "number"            :'null_font',
-            "operator.word"     :'keyword4_font',
-            "string"            :'literal1_font',
-            "string.doc"        :'literal1_font',
-            "string.escape"     :'literal1_font',
-            "string.interpol"   :'literal1_font',
-            "string.other"      :'literal1_font',
-            "string.regex"      :'literal1_font',
-            "string.single"     :'literal1_font',
-            "string.symbol"     :'literal1_font',
-            'xt'                :'text_font',
-            "whitespace"        :'text_font',
-            #
+            # tag name          :  option name
+            "comment"           : 'comment1_font',
+            "comment.preproc"   : 'comment2_font',
+            "comment.single"    : 'comment1_font',
+            "error"             : 'null_font',
+            "generic.deleted"   : 'literal4_font',
+            "generic.emph"      : 'literal4_font',
+            "generic.error"     : 'literal4_font',
+            "generic.heading"   : 'literal4_font',
+            "generic.inserted"  : 'literal4_font',
+            "generic.output"    : 'literal4_font',
+            "generic.prompt"    : 'literal4_font',
+            "generic.strong"    : 'literal4_font',
+            "generic.subheading": 'literal4_font',
+            "generic.traceback" : 'literal4_font',
+            "keyword"           : 'keyword1_font',
+            "keyword.pseudo"    : 'keyword2_font',
+            "keyword.type"      : 'keyword3_font',
+            "name.attribute"    : 'null_font',
+            "name.builtin"      : 'null_font',
+            "name.class"        : 'null_font',
+            "name.constant"     : 'null_font',
+            "name.decorator"    : 'null_font',
+            "name.entity"       : 'null_font',
+            "name.exception"    : 'null_font',
+            "name.function"     : 'null_font',
+            "name.label"        : 'null_font',
+            "name.namespace"    : 'null_font',
+            "name.tag"          : 'null_font',
+            "name.variable"     : 'null_font',
+            "number"            : 'null_font',
+            "operator.word"     : 'keyword4_font',
+            "string"            : 'literal1_font',
+            "string.doc"        : 'literal1_font',
+            "string.escape"     : 'literal1_font',
+            "string.interpol"   : 'literal1_font',
+            "string.other"      : 'literal1_font',
+            "string.regex"      : 'literal1_font',
+            "string.single"     : 'literal1_font',
+            "string.symbol"     : 'literal1_font',
+            'xt'                : 'text_font',
+            "whitespace"        : 'text_font',
+
             # jEdit tags.
-            # tag name     : option name
-            'comment1'      :'comment1_font',
-            'comment2'      :'comment2_font',
-            'comment3'      :'comment3_font',
-            'comment4'      :'comment4_font',
-            # 'default'     :'default_font',
-            'function'      :'function_font',
-            'keyword1'      :'keyword1_font',
-            'keyword2'      :'keyword2_font',
-            'keyword3'      :'keyword3_font',
-            'keyword4'      :'keyword4_font',
-            'keyword5'      :'keyword5_font',
-            'label'         :'label_font',
-            'literal1'      :'literal1_font',
-            'literal2'      :'literal2_font',
-            'literal3'      :'literal3_font',
-            'literal4'      :'literal4_font',
-            'markup'        :'markup_font',
+            # tag name      :  option name
+            'comment1'      : 'comment1_font',
+            'comment2'      : 'comment2_font',
+            'comment3'      : 'comment3_font',
+            'comment4'      : 'comment4_font',
+            # 'default'     : 'default_font',
+            'function'      : 'function_font',
+            'keyword1'      : 'keyword1_font',
+            'keyword2'      : 'keyword2_font',
+            'keyword3'      : 'keyword3_font',
+            'keyword4'      : 'keyword4_font',
+            'keyword5'      : 'keyword5_font',
+            'label'         : 'label_font',
+            'literal1'      : 'literal1_font',
+            'literal2'      : 'literal2_font',
+            'literal3'      : 'literal3_font',
+            'literal4'      : 'literal4_font',
+            'markup'        : 'markup_font',
             # 'nocolor' This tag is used, but never generates code.
-            'null'          :'null_font',
-            'operator'      :'operator_font',
-            'trailing_whitespace' :'trailing_whitespace_font',
+            'null'          : 'null_font',
+            'operator'      : 'operator_font',
+            'trailing_whitespace' : 'trailing_whitespace_font',
         }
     #@+node:ekr.20110605121601.18573: *4* BaseColorizer.defineLeoKeywordsDict
     def defineLeoKeywordsDict(self) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -397,7 +397,7 @@ class Commands:
         c.db = CommanderWrapper(c)
         c.free_layout = None  # Compatibility. Always None.
         c.quicksearch_controller = None  # Leo 6.8.0: Set by quicksearch plugin.
-            
+
         if hasattr(g.app.gui, 'styleSheetManagerClass'):
             self.styleSheetManager = g.app.gui.styleSheetManagerClass(c)
             self.subCommanders.append(self.styleSheetManager)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3095,8 +3095,8 @@ class Commands:
         ext: str,
         language: str,
         root: Position,
-        directory: str=None,
-        regex: str=None,
+        directory: str = None,
+        regex: str = None,
     ) -> None:
         """
         The official helper for the execute-general-script command.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -263,7 +263,7 @@ class Commands:
         self.import_error_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
         self.last_dir: str = None  # The last used directory.
         self.mFileName: str = fileName or ''  # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
-        self.mRelativeFileName = relativeFileName or ''  #
+        self.mRelativeFileName = relativeFileName or ''
         self.orphan_at_file_nodes: list[Position] = []  # List of orphaned nodes for c.raise_error_dialogs.
     #@+node:ekr.20120217070122.10470: *5* c.initObjects
     #@@nobeautify
@@ -283,7 +283,7 @@ class Commands:
         from leo.core import leoHistory
         self.nodeHistory = leoHistory.NodeHistory(c)
         self.initConfigSettings()
-        c.setWindowPosition() # Do this after initing settings.
+        c.setWindowPosition()  # Do this after initing settings.
 
         # Break circular import dependencies by doing imports here.
         # All these imports take almost 3/4 sec in the leoBridge.
@@ -910,7 +910,7 @@ class Commands:
             cmd = f'assoc {extension}'
             # pylint: disable=subprocess-run-check
             proc = subprocess.run(cmd, shell=True, capture_output=True)
-            filetype = proc.stdout.decode('utf-8')  #e.g., ".py=Python.File"
+            filetype = proc.stdout.decode('utf-8')  # e.g., ".py=Python.File"
             filetype = filetype.split('=')[1] if filetype else ''
             return filetype
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2780,7 +2780,7 @@ class Commands:
         # This pathetic code should be generalized,
         # but it's not as easy as one might imagine.
         c = self
-        d = {1: c.interactive1, 2: c.interactive2, 3: c.interactive3,}
+        d = {1: c.interactive1, 2: c.interactive2, 3: c.interactive3, }
         f = d.get(len(prompts))
         if f:
             f(callback, event, prompts)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1597,7 +1597,7 @@ class Commands:
     def getEncoding(self, p: Position) -> str:
         """
         Scan p and all ancestors for the first @encoding direcive.
-        
+
         Return c.config.default_derived_file_encoding or 'utf-8' by default.
         """
         c = self
@@ -1704,7 +1704,7 @@ class Commands:
     def getPageWidth(self, p: Position) -> int:
         """
         Scan p.b and all ancestors for the first @pagewith direcive.
-        
+
         Return c.page_width by default.
         """
         c = self
@@ -1722,7 +1722,7 @@ class Commands:
     def getPath(self, p: Position) -> str:
         """
         Scan for @path directives in p and all its direct ancestors.
-        
+
         Return an absolute path or a reasonable default.
         """
         c = self
@@ -1779,7 +1779,7 @@ class Commands:
     def getTabWidth(self, p: Position) -> int:
         """
         Scan p.b and all ancestors for the first @encoding direcive.
-        
+
         Return c.tab_width by default.
         """
         c = self
@@ -2693,7 +2693,7 @@ class Commands:
     def fullPath(self, p: Position) -> str:
         """
         Return the absolute path in effect at p.
-        
+
         Return the path to an external file if p is an @<file> node.
         Otherwise the return the path to the enclosing directory.
         """

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -657,7 +657,7 @@ class Commands:
             return None
 
         # Get the language and extension.
-        language =  c.getLanguage(p)
+        language = c.getLanguage(p)
         ext = g.app.language_extension_dict.get(language)
         if not ext:
             print(f"{tag}: No extension for {language}")

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -80,26 +80,26 @@ class ParserBaseClass:
         # Keys are canonicalized names.
         self.dispatchDict = {
             'bool':         self.doBool,
-            'buttons':      self.doButtons, # New in 4.4.4
+            'buttons':      self.doButtons,  # New in 4.4.4
             'color':        self.doColor,
-            'commands':     self.doCommands, # New in 4.4.8.
-            'data':         self.doData, # New in 4.4.6
+            'commands':     self.doCommands,  # New in 4.4.8.
+            'data':         self.doData,  # New in 4.4.6
             'directory':    self.doDirectory,
             'enabledplugins': self.doEnabledPlugins,
             'font':         self.doFont,
-            'ifenv':        self.doIfEnv, # New in 5.2 b1.
+            'ifenv':        self.doIfEnv,  # New in 5.2 b1.
             'ifhostname':   self.doIfHostname,
             'ifplatform':   self.doIfPlatform,
             'ignore':       self.doIgnore,
             'int':          self.doInt,
             'ints':         self.doInts,
             'float':        self.doFloat,
-            'menus':        self.doMenus, # New in 4.4.4
+            'menus':        self.doMenus,  # New in 4.4.4
             'menuat':       self.doMenuat,
-            'popup':        self.doPopup, # New in 4.4.8
-            'mode':         self.doMode, # New in 4.4b1.
-            'openwith':     self.doOpenWith, # New in 4.4.3 b1.
-            'outlinedata':  self.doOutlineData, # New in 4.11.1.
+            'popup':        self.doPopup,  # New in 4.4.8
+            'mode':         self.doMode,  # New in 4.4b1.
+            'openwith':     self.doOpenWith,  # New in 4.4.3 b1.
+            'outlinedata':  self.doOutlineData,  # New in 4.11.1.
             'path':         self.doPath,
             'ratio':        self.doRatio,
             'shortcuts':    self.doShortcuts,

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -448,7 +448,7 @@ class ExternalFilesController:
                 vtuple.append(fn)
                 command = f"os.spawnv({vtuple})"
                 if not testing:
-                    os.spawnv(os.P_NOWAIT, arg[0], vtuple)  #???
+                    os.spawnv(os.P_NOWAIT, arg[0], vtuple)  # ???
             elif kind == 'subprocess.Popen':
                 c_arg = self.join(arg, fn)
                 command = f"subprocess.Popen({c_arg})"

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -662,7 +662,7 @@ class LeoFind:
     def _find_all_matches(self, patterns: list[re.Pattern]) -> list[tuple[int, Position, str]]:
         """
         Search all nodes for any of the given compiled regex patterns.
-        
+
         Return a list of tuples (starting-index, p, matching-string) describing the matches.
         """
         c = self.c

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1802,7 +1802,7 @@ class Tracer:
         g.pr('\ncallDict...')
         for key in sorted(self.callDict):
             # Print the calling function.
-            g.pr(f"{self.calledDict.get(key,0):d}", key)
+            g.pr(f"{self.calledDict.get(key,0):d}", key)  # noqa  # conflict between flake8 and black.
             # Print the called functions.
             d = self.callDict.get(key)
             for key2 in sorted(d):  # type:ignore

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1874,7 +1874,7 @@ tracing_tags: dict[int, str] = {}  # Keys are id's, values are tags.
 
 class NullObject:
     """An object that does nothing, and does it very well."""
-    def __init__(self, ivars: list[str]=None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(self, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
         pass
     def __call__(self, *args: Args, **kwargs: KWargs) -> "NullObject":
         return self
@@ -1909,7 +1909,7 @@ class NullObject:
 
 class TracingNullObject:
     """Tracing NullObject."""
-    def __init__(self, tag: str, ivars: list[str]=None, *args: Args, **kwargs: KWargs) -> None:
+    def __init__(self, tag: str, ivars: list[str] = None, *args: Args, **kwargs: KWargs) -> None:
         tracing_tags [id(self)] = tag  # noqa  # conflict between flake8 and black.
     def __call__(self, *args: Args, **kwargs: KWargs) -> "TracingNullObject":
         return self

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1910,7 +1910,7 @@ class NullObject:
 class TracingNullObject:
     """Tracing NullObject."""
     def __init__(self, tag: str, ivars: list[str]=None, *args: Args, **kwargs: KWargs) -> None:
-        tracing_tags [id(self)] = tag
+        tracing_tags [id(self)] = tag  # noqa  # conflict between flake8 and black.
     def __call__(self, *args: Args, **kwargs: KWargs) -> "TracingNullObject":
         return self
     def __repr__(self) -> str:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1415,7 +1415,7 @@ class MatchBrackets:
             return
 
         # Find the bracket nearest the cursor.
-        max_right = len(s) - 1 # insert point can be past last char.
+        max_right = len(s) - 1  # insert point can be past last char.
         left = right = min(max_right, w.getInsertPoint())
         left, right, ch, index = self.expand_range(s, left, right, max_right)
         if left is None:
@@ -1886,7 +1886,7 @@ class NullObject:
     def __delattr__(self, attr: str) -> None:
         return None
     def __getattr__(self, attr: str) -> Value:
-        return self # Required.
+        return self  # Required.
     def __setattr__(self, attr: str, val: Value) -> None:
         return None
     # Container methods..
@@ -1923,7 +1923,7 @@ class TracingNullObject:
         return None
     def __getattr__(self, attr: str) -> "TracingNullObject":
         g.null_object_print(id(self), f"attr: {attr}")
-        return self # Required.
+        return self  # Required.
     def __setattr__(self, attr: str, val: Value) -> None:
         g.null_object_print(id(self), f"__setattr__: {attr} {val!r}")
 

--- a/leo/core/leoJupytext.py
+++ b/leo/core/leoJupytext.py
@@ -173,7 +173,7 @@ class JupytextManager:
     def full_path(self, c: Cmdr, p: Position) -> str:
         """
         Return the full path in effect for the `@jupytext x.ipynb` node at p.
-        
+
         On errors, print an error message and return ''.
         """
         if not has_jupytext:
@@ -189,7 +189,7 @@ class JupytextManager:
         """
         Print the name and contents of the jupytext config file in effect.
         Call this method with this Leonine script:
-        
+
             g.app.jupytextManager.get_jupytext_config_file()
         """
         from jupytext.config import find_jupytext_configuration_file

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -115,7 +115,7 @@ class LeoMenu:
     def capitalizeMinibufferMenuName(self, s: str, removeHyphens: bool) -> str:
         result = []
         for i, ch in enumerate(s):
-            prev =     s[i - 1] if i > 0 else ''
+            prev = s[i - 1] if i > 0 else ''
             prevprev = s[i - 2] if i > 1 else ''
             if (
                 i == 0 or

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -30,13 +30,16 @@ class LeoMenu:
     def finishCreate(self) -> None:
         self.define_enable_dict()
     #@+node:ekr.20120124042346.12937: *4* LeoMenu.define_enable_table
-    #@@nobeautify
-
     def define_enable_dict(self) -> None:
 
         c = self.c
         if not c.commandsDict:
-            return # This is not an error: it happens during init.
+            return  # This is not an error: it happens during init.
+
+        #@+<< define self.enable_dict >>
+        #@+node:ekr.20250506093659.1: *5* << define self.enable_dict >>
+        #@@nobeautify
+
         self.enable_dict = d = {
 
             # File menu...
@@ -98,11 +101,12 @@ class LeoMenu:
             # too slow...
                 # 'mark-changed-items':   c.canMarkChangedHeadlines,
         }
+        #@-<< define self.enable_dict >>
 
-        for i in range(1,9):
-            d [f"expand-to-level-{i}"] = lambda: c.p.hasChildren()
+        for i in range(1, 9):
+            d[f"expand-to-level-{i}"] = lambda: c.p.hasChildren()
 
-        if 0: # Initial testing.
+        if 0:  # Initial testing.
             commandKeys = list(c.commandsDict.keys())
             for key in sorted(d.keys()):
                 if key not in commandKeys:

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -203,7 +203,7 @@ class LeoMenu:
                 if table:
                     self.createMenuEntries(parentMenu, table)
                 if not self.handleSpecialMenus(name, parentName,
-                    alt_name=val2,  #848.
+                    alt_name=val2,  # 848.
                     table=table,
                 ):
                     # Create submenu of parent menu.

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -782,7 +782,7 @@ class RstCommands:
             return f"{p.h}\n{ch * n}"
         #
         # The user is responsible for top-level overlining.
-        u = self.underline_characters  #  '''#=+*^~"'`-:><_'''
+        u = self.underline_characters  # '''#=+*^~"'`-:><_'''
         level = max(0, p.level() - self.root.level())
         level = min(level + 1, len(u) - 1)  # Reserve the first character for explicit titles.
         ch = u[level]

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -955,7 +955,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         self.pending_lws = ''
         self.pending_ws = ''
         entire_line = self.input_token.line.lstrip().startswith('#')
-
         if entire_line:
             # The comment includes all ws.
             # #1496: No further munging needed.
@@ -965,6 +964,17 @@ class TokenBasedOrange:  # Orange is the new Black.
             if m := self.comment_pat.match(val):
                 i = len(m.group(1))
                 val = val[:i] + '# ' + val[i + 1 :]
+            else:
+                j = val.find('#')
+                assert j > -1
+                lws = val[:j]
+                if lws.isspace():
+                    # 4346. Trim lws so it is a multiple of four.
+                    n = len(lws)
+                    excess = n % 4
+                    if excess != 0:
+                        lws = val[: max(0, n - excess)]
+                    val = lws + '# ' + val[j + 1 :].strip()
         else:
             # Exactly two spaces before trailing comments.
             val = '  ' + val.rstrip()
@@ -1412,7 +1422,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         Change *neither* prev_output_kind *nor* pending_lws.
         """
         prev_kind = self.prev_output_kind
-        ### g.trace(prev_kind)
         if prev_kind == 'op-no-blanks':
             # A demand that no blank follows this op.
             self.pending_ws = ''

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -817,6 +817,8 @@ class TokenBasedOrange:  # Orange is the new Black.
             print(self.internal_error_message(repr(e)))
         return contents
     #@+node:ekr.20240105145241.6: *5* tbo.beautify_file (entry) (stats & diffs)
+    nobeautify_pat = re.compile(r'^#\s*@@nobeautify\s*$', re.MULTILINE)
+
     def beautify_file(self, filename: str) -> bool:  # pragma: no cover
         """
         TokenBasedOrange: Beautify the the given external file.
@@ -832,11 +834,12 @@ class TokenBasedOrange:  # Orange is the new Black.
                 f"write: {int(self.write)} "
                 f"{g.shortFileName(filename)}"
             )
-        return False  ### TEMP.
         self.filename = filename
         contents, tokens = self.init_tokens_from_file(filename)
         if not (contents and tokens):
             return False  # Not an error.
+        if self.nobeautify_pat.find(contents):
+            return False  # Honor @nobeautify directive within the file.
         if not isinstance(tokens[0], InputToken):
             self.oops(f"Not an InputToken: {tokens[0]!r}")
 

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -838,7 +838,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         if not (contents and tokens):
             return False  # Not an error.
         if self.nobeautify_sentinel_pat.search(contents):
-            return False  # Honor @nobeautify directive within the file.
+            return False  # Honor @nobeautify sentinel within the file.
         if not isinstance(tokens[0], InputToken):
             self.oops(f"Not an InputToken: {tokens[0]!r}")
 

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1371,7 +1371,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         # Careful: continued strings may contain '\r'
         val = self.regularize_newlines(self.input_token.value)
         if val.startswith(('"""', "'''")):
-            # Strip trailing ws in docstrings.
+            # #4346: Strip trailing ws in docstrings.
             while ' \n' in val:
                 val = val.replace(' \n', '\n')
         self.gen_token('string', val)

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1406,7 +1406,7 @@ class TokenBasedOrange:  # Orange is the new Black.
     #@+node:ekr.20240105145241.27: *5* tbo.gen_blank
     def gen_blank(self) -> None:
         """
-        Queue a *request* a blank.
+        Queue a *request* for a blank.
         Change *neither* prev_output_kind *nor* pending_lws.
         """
 

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -773,7 +773,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         self.verbatim = False  # True: don't beautify.
 
         # Ivars describing the present input token...
-        ### self.index = 0  # The index within the tokens array of the token being scanned.
+        self.index = 0  # The index within the tokens array of the token being scanned.
         self.lws = ''  # Leading whitespace. Required!
         #@-<< tbo.beautify: init ivars >>
 
@@ -1054,7 +1054,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         """
 
         # #4349: Remove trailing ws.
-        ### g.printObj(self.input_tokens)
         while self.input_tokens:
             last_token = self.input_tokens[-1]
             if last_token.kind == 'ws':

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1370,6 +1370,10 @@ class TokenBasedOrange:  # Orange is the new Black.
         """
         # Careful: continued strings may contain '\r'
         val = self.regularize_newlines(self.input_token.value)
+        if val.startswith(('"""', "'''")):
+            # Strip trailing ws in docstrings.
+            while ' \n' in val:
+                val = val.replace(' \n', '\n')
         self.gen_token('string', val)
         self.gen_blank()
     #@+node:ekr.20240105145241.22: *5* tbo.do_verbatim
@@ -1402,7 +1406,6 @@ class TokenBasedOrange:  # Orange is the new Black.
 
         Put the whitespace only if if ends with backslash-newline.
         """
-        ### g.trace(self.input_token)  ###
         val = self.input_token.value
         last_token = self.input_tokens[self.index - 1]
 
@@ -1413,8 +1416,7 @@ class TokenBasedOrange:  # Orange is the new Black.
             self.pending_lws = ''
             self.pending_ws = val
         else:
-            ### self.pending_ws = val
-            self.pending_ws = ' ' if val else ''  ###
+            self.pending_ws = ' ' if val else ''  # #4346.
     #@+node:ekr.20240105145241.27: *5* tbo.gen_blank
     def gen_blank(self) -> None:
         """
@@ -1446,7 +1448,6 @@ class TokenBasedOrange:  # Orange is the new Black.
     def gen_token(self, kind: str, value: str) -> None:
         """Add an output token to the code list."""
 
-        ### g.trace(repr(self.pending_lws), repr(self.pending_ws))
         if self.pending_lws:
             self.output_list.append(self.pending_lws)
         elif self.pending_ws:

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -773,7 +773,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         self.verbatim = False  # True: don't beautify.
 
         # Ivars describing the present input token...
-        self.index = 0  # The index within the tokens array of the token being scanned.
+        ### self.index = 0  # The index within the tokens array of the token being scanned.
         self.lws = ''  # Leading whitespace. Required!
         #@-<< tbo.beautify: init ivars >>
 
@@ -1042,7 +1042,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         self.gen_blank()
         self.gen_token('word-op', s)
         self.gen_blank()
-    #@+node:ekr.20240105145241.17: *5* tbo.do_newline, do_nl & generators
+    #@+node:ekr.20240105145241.17: *5* tbo.do_newline & do_nl
     #@+node:ekr.20240418043826.1: *6* tbo.do_newline
     def do_newline(self) -> None:
         """
@@ -1052,6 +1052,15 @@ class TokenBasedOrange:  # Orange is the new Black.
 
         NEWLINE tokens end *logical* lines of Python code.
         """
+
+        # #4349: Remove trailing ws.
+        ### g.printObj(self.input_tokens)
+        while self.input_tokens:
+            last_token = self.input_tokens[-1]
+            if last_token.kind == 'ws':
+                self.input_tokens.pop()
+            else:
+                break
 
         self.output_list.append('\n')
         self.pending_lws = ''  # Set only by 'dedent', 'indent' or 'ws' tokens.
@@ -1068,7 +1077,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         NL tokens end *physical* lines. They appear when when a logical line of
         code spans multiple physical lines.
         """
-        return self.do_newline()
+        self.do_newline()
     #@+node:ekr.20240105145241.18: *5* tbo.do_number
     def do_number(self) -> None:
         """Handle a number token."""

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -964,17 +964,17 @@ class TokenBasedOrange:  # Orange is the new Black.
             if m := self.comment_pat.match(val):
                 i = len(m.group(1))
                 val = val[:i] + '# ' + val[i + 1 :]
-            else:
-                j = val.find('#')
-                assert j > -1
-                lws = val[:j]
-                if lws.isspace():
-                    # 4346. Trim lws so it is a multiple of four.
-                    n = len(lws)
-                    excess = n % 4
-                    if excess != 0:
-                        lws = val[: max(0, n - excess)]
-                    val = lws + '# ' + val[j + 1 :].strip()
+            # else:
+                # j = val.find('#')
+                # assert j > -1
+                # lws = val[:j]
+                # if lws.isspace():
+                    # # 4346. Trim lws so it is a multiple of four.
+                    # n = len(lws)
+                    # excess = n % 4
+                    # if excess != 0:
+                        # lws = val[: max(0, n - excess)]
+                    # val = lws + '# ' + val[j + 1 :].strip()
         else:
             # Exactly two spaces before trailing comments.
             val = '  ' + val.rstrip()

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1392,6 +1392,7 @@ class TokenBasedOrange:  # Orange is the new Black.
 
         Put the whitespace only if if ends with backslash-newline.
         """
+        ### g.trace(self.input_token)  ###
         val = self.input_token.value
         last_token = self.input_tokens[self.index - 1]
 
@@ -1402,15 +1403,16 @@ class TokenBasedOrange:  # Orange is the new Black.
             self.pending_lws = ''
             self.pending_ws = val
         else:
-            self.pending_ws = val
+            ### self.pending_ws = val
+            self.pending_ws = ' ' if val else ''  ###
     #@+node:ekr.20240105145241.27: *5* tbo.gen_blank
     def gen_blank(self) -> None:
         """
         Queue a *request* for a blank.
         Change *neither* prev_output_kind *nor* pending_lws.
         """
-
         prev_kind = self.prev_output_kind
+        ### g.trace(prev_kind)
         if prev_kind == 'op-no-blanks':
             # A demand that no blank follows this op.
             self.pending_ws = ''
@@ -1435,6 +1437,7 @@ class TokenBasedOrange:  # Orange is the new Black.
     def gen_token(self, kind: str, value: str) -> None:
         """Add an output token to the code list."""
 
+        ### g.trace(repr(self.pending_lws), repr(self.pending_ws))
         if self.pending_lws:
             self.output_list.append(self.pending_lws)
         elif self.pending_ws:

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -964,17 +964,6 @@ class TokenBasedOrange:  # Orange is the new Black.
             if m := self.comment_pat.match(val):
                 i = len(m.group(1))
                 val = val[:i] + '# ' + val[i + 1 :]
-            # else:
-                # j = val.find('#')
-                # assert j > -1
-                # lws = val[:j]
-                # if lws.isspace():
-                    # # 4346. Trim lws so it is a multiple of four.
-                    # n = len(lws)
-                    # excess = n % 4
-                    # if excess != 0:
-                        # lws = val[: max(0, n - excess)]
-                    # val = lws + '# ' + val[j + 1 :].strip()
         else:
             # Exactly two spaces before trailing comments.
             val = '  ' + val.rstrip()

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1322,13 +1322,20 @@ class TokenBasedOrange:  # Orange is the new Black.
         if val == ')':
             self.paren_level -= 1
             self.in_arg_list = max(0, self.in_arg_list - 1)
+            if self.prev_output_kind != 'line-indent':
+                self.pending_ws = ''
         elif val == ']':
             self.square_brackets_stack.pop()
+            if self.prev_output_kind != 'line-indent':
+                self.pending_ws = ''
         else:
             self.curly_brackets_level -= 1
-
-        if self.prev_output_kind != 'line-indent':
-            self.pending_ws = ''
+            # A hack: put a space before a comma.
+            last = self.output_list[-1]
+            if last == ',':
+                self.pending_ws = ' '
+            elif self.prev_output_kind != 'line-indent':
+                self.pending_ws = ''
         self.gen_token('rt', val)
     #@+node:ekr.20240105145241.38: *6* tbo.gen_star_op
     def gen_star_op(self) -> None:

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1611,7 +1611,7 @@ class TokenBasedOrange:  # Orange is the new Black.
                     elif token.value == ':':
                         self.set_context(i, 'annotation')
                 prev = token
-    #@+node:ekr.20250507041900.1: *6* tbo.finish_paren (new)
+    #@+node:ekr.20250507041900.1: *6* tbo.finish_paren
     def finish_paren(self, end: int, state: Optional[ScanState]) -> None:
         """Set context for '=' tokens when scanning from '(' to ')'."""
 

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -832,6 +832,7 @@ class TokenBasedOrange:  # Orange is the new Black.
                 f"write: {int(self.write)} "
                 f"{g.shortFileName(filename)}"
             )
+        return False  ### TEMP.
         self.filename = filename
         contents, tokens = self.init_tokens_from_file(filename)
         if not (contents and tokens):

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -969,7 +969,9 @@ class TokenBasedOrange:  # Orange is the new Black.
                 val = val[:i] + '# ' + val[i + 1 :]
         else:
             # Exactly two spaces before trailing comments.
-            val = '  ' + val.rstrip()
+            i = val.find('#')
+            assert i >= 0, repr(val)
+            val = val[:i].rstrip() + '  # ' + val[i + 1 :].lstrip()
         self.gen_token('comment', val)
     #@+node:ekr.20240111051726.1: *5* tbo.do_dedent
     def do_dedent(self) -> None:

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -611,7 +611,7 @@ class TokenBasedOrange:  # Orange is the new Black.
 
         # Regular expressions.
         'at_others_pat', 'beautify_pat', 'comment_pat', 'end_doc_pat',
-        'nobeautify_pat', 'node_pat', 'start_doc_pat',
+        'nobeautify_pat', 'nobeautify_sentinel_pat', 'node_pat', 'start_doc_pat',
     ]
     #@-<< TokenBasedOrange: __slots__ >>
     #@+<< TokenBasedOrange: python-related constants >>
@@ -668,6 +668,7 @@ class TokenBasedOrange:  # Orange is the new Black.
             r'#\s*pragma:\s*beautify\b|#\s*@@beautify|#\s*@\+node|#\s*@[+-]others|#\s*@[+-]<<')
         self.comment_pat = re.compile(r'^(\s*)#[^@!# \n]')
         self.nobeautify_pat = re.compile(r'\s*#\s*pragma:\s*no\s*beautify\b|#\s*@@nobeautify')
+        self.nobeautify_sentinel_pat = re.compile(r'^#\s*@@nobeautify\s*$', re.MULTILINE)
 
         # Patterns from FastAtRead class, specialized for python delims.
         self.node_pat = re.compile(r'^(\s*)#@\+node:([^:]+): \*(\d+)?(\*?) (.*)$')  # @node
@@ -817,8 +818,6 @@ class TokenBasedOrange:  # Orange is the new Black.
             print(self.internal_error_message(repr(e)))
         return contents
     #@+node:ekr.20240105145241.6: *5* tbo.beautify_file (entry) (stats & diffs)
-    nobeautify_pat = re.compile(r'^#\s*@@nobeautify\s*$', re.MULTILINE)
-
     def beautify_file(self, filename: str) -> bool:  # pragma: no cover
         """
         TokenBasedOrange: Beautify the the given external file.
@@ -838,7 +837,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         contents, tokens = self.init_tokens_from_file(filename)
         if not (contents and tokens):
             return False  # Not an error.
-        if self.nobeautify_pat.find(contents):
+        if self.nobeautify_sentinel_pat.search(contents):
             return False  # Honor @nobeautify directive within the file.
         if not isinstance(tokens[0], InputToken):
             self.oops(f"Not an InputToken: {tokens[0]!r}")

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -153,7 +153,7 @@ class VimCommands:
         '}': None,
         '[': None,
         ']': None,
-        ':': None, # Not a motion.
+        ':': None,  # Not a motion.
         ',': None,
         '$': self.vim_dollar,
         '>': None,
@@ -163,7 +163,7 @@ class VimCommands:
         '(': None,
         ')': None,
         '%': None,
-        '.': None, # Not a motion.
+        '.': None,  # Not a motion.
         '+': None,
         '?': self.vim_question,
         '"': None,
@@ -173,7 +173,7 @@ class VimCommands:
         '/': self.vim_slash,
         '_': None,
         # Digits.
-        '0': self.vim_0, # Only 0 starts a motion.
+        '0': self.vim_0,  # Only 0 starts a motion.
         # Uppercase letters.
         'A': None,  # vim doesn't enter insert mode.
         'B': None,
@@ -198,24 +198,24 @@ class VimCommands:
         'V': None,
         'W': None,
         'X': None,
-        'Y': self.vim_Y, # Yank Leo outline.
+        'Y': self.vim_Y,  # Yank Leo outline.
         'Z': None,
         # Lowercase letters...
-        'a': None,      # vim doesn't enter insert mode.
+        'a': None,  # vim doesn't enter insert mode.
         'b': self.vim_b,
         # 'c': self.vim_c,
-        'd': None,      # Not valid.
+        'd': None,  # Not valid.
         'e': self.vim_e,
         'f': self.vim_f,
         'g': self.vim_g,
         'h': self.vim_h,
-        'i': None,      # vim doesn't enter insert mode.
+        'i': None,  # vim doesn't enter insert mode.
         'j': self.vim_j,
         'k': self.vim_k,
         'l': self.vim_l,
         # 'm': self.vim_m,
         # 'n': self.vim_n,
-        'o': None,      # vim doesn't enter insert mode.
+        'o': None,  # vim doesn't enter insert mode.
         # 'p': self.vim_p,
         # 'q': self.vim_q,
         # 'r': self.vim_r,

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -497,7 +497,7 @@ class QuickSearchController:
             if hitBase:
                 # If I hit the base then revert to all positions
                 # this is basically the "main" chapter
-                hitBase = False  #reset
+                hitBase = False  # reset
                 hNodes = c.all_positions()
                 bNodes = c.all_positions()
             else:
@@ -513,7 +513,7 @@ class QuickSearchController:
             hm = self.find_h(hpat, list(hNodes), flags)  # Returns a list of positions.
             bm = self.find_b(bpat, list(bNodes), flags)  # Returns a list of positions.
             bm_keys = [match[0].key() for match in bm]
-            numOfHm = len(hm)  #do this before trim to get accurate count
+            numOfHm = len(hm)  # do this before trim to get accurate count
             hm = [match for match in hm if match[0].key() not in bm_keys]
             if self.showParents:
                 # Was: parents = OrderedDefaultDict(list)
@@ -754,7 +754,7 @@ class QuickSearchController:
                 it = {"type": "headline", "label": p.h}
                 if self.addItem(it, (p, None)):
                     return lineMatchHits
-                if m is not None:  #p might not have body matches
+                if m is not None:  # p might not have body matches
                     ms = self.matchlines(p.b, m)
                     for match_list, pos in ms:
                         lineMatchHits += 1
@@ -1324,7 +1324,7 @@ class LeoServer:
             commanders = g.app.commanders()
             for commander in commanders:
                 if str(id(commander)) == str(commanderId):
-                    self.c = commander  #  Found commander by id!
+                    self.c = commander  # Found commander by id!
                     self.c.selectPosition(self.c.p)
                     self._check_outline(self.c)
                     result = {"total": total, "filename": self.c.fileName()}
@@ -4725,7 +4725,7 @@ class LeoServer:
                 commanders = g.app.commanders()
                 for commander in commanders:
                     if str(id(commander)) == str(commanderId):
-                        c = commander  #  Found commander by id!
+                        c = commander  # Found commander by id!
                         break
         # Still not found?
         if not c:  # pragma: no cover

--- a/leo/external/codewise.py
+++ b/leo/external/codewise.py
@@ -333,7 +333,7 @@ def shortFileName(fileName, n=None):
         return ''
     if n is None or n < 1:
         return os.path.basename(fileName)
-    return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
+    return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
 #@+node:ekr.20110310093050.14268: *5* trace (codewise)
 # Convert all args to strings.
 

--- a/leo/external/codewise.py
+++ b/leo/external/codewise.py
@@ -333,7 +333,7 @@ def shortFileName(fileName, n=None):
         return ''
     if n is None or n < 1:
         return os.path.basename(fileName)
-    return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
+    return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
 #@+node:ekr.20110310093050.14268: *5* trace (codewise)
 # Convert all args to strings.
 

--- a/leo/external/codewise.py
+++ b/leo/external/codewise.py
@@ -333,7 +333,7 @@ def shortFileName(fileName, n=None):
         return ''
     if n is None or n < 1:
         return os.path.basename(fileName)
-    return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
+    return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
 #@+node:ekr.20110310093050.14268: *5* trace (codewise)
 # Convert all args to strings.
 
@@ -607,7 +607,7 @@ class CodeWise:
             # we are rescanning a file with old entries - nuke old entries
             c = self.cursor()
             c.execute("delete from function where file = (?)", (idd,))
-            #self.dbconn.commit()
+            # self.dbconn.commit()
             self.fileids_scanned.add(idd)
         return idd
     #@+node:ekr.20110310091639.14266: *3* feed_function

--- a/leo/external/edb.py
+++ b/leo/external/edb.py
@@ -836,8 +836,8 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     if hasattr(func, '__func__'):
                         func = func.__func__
                     code = func.__code__
-                    #use co_name to identify the bkpt (function names
-                    #could be aliased, but co_name is invariant)
+                    # use co_name to identify the bkpt (function names
+                    # could be aliased, but co_name is invariant)
                     funcname = code.co_name
                     lineno = code.co_firstlineno
                     filename = code.co_filename

--- a/leo/external/lproto.py
+++ b/leo/external/lproto.py
@@ -153,7 +153,7 @@ class LProtoServer:
         lsock.connect(lsock,
             QtCore.SIGNAL('readyRead()'),
             readyread_cb)
-        #self.connect(self.qsock, SIGNAL('connectionClosed()'), self.handleClosed)
+        # self.connect(self.qsock, SIGNAL('connectionClosed()'), self.handleClosed)
     #@+node:ekr.20111012091630.9385: *3* readyread
     def readyread(self):
         pass

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -1120,7 +1120,7 @@ class LeoGlobals:
         if n is None or n < 1:
             return os.path.basename(fileName)
         else:
-            return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
+            return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
     #@+node:ekr.20160317054700.93: *3* g.splitLines
     def splitLines(self, s):
         '''Split s into lines, preserving trailing newlines.'''

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -1120,7 +1120,7 @@ class LeoGlobals:
         if n is None or n < 1:
             return os.path.basename(fileName)
         else:
-            return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
+            return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
     #@+node:ekr.20160317054700.93: *3* g.splitLines
     def splitLines(self, s):
         '''Split s into lines, preserving trailing newlines.'''
@@ -1271,7 +1271,7 @@ class Pattern:
         g.trace('unmatched %s in %s' % (delim, s), g.callers(4))
         return len(s) + 1
     #@+node:ekr.20160317054700.104: *3* pattern.match (trace-matches)
-    def match(self, s, trace=False):
+    def match(self, s, trace = False):
         '''
         Perform the match on the entire string if possible.
         Return (found, new s)
@@ -2028,7 +2028,7 @@ class StubFormatter(AstFormatter):
         caller = g.callers(2).split(',')[1].strip()  # The direct caller of match_all.
         patterns = self.patterns_dict.get(name, []) + self.regex_patterns
         for pattern in patterns:
-            found, s = pattern.match(s, trace=False)
+            found, s = pattern.match(s, trace = False)
             if found:
                 if trace:
                     aList = d.get(name, [])

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -1120,7 +1120,7 @@ class LeoGlobals:
         if n is None or n < 1:
             return os.path.basename(fileName)
         else:
-            return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
+            return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
     #@+node:ekr.20160317054700.93: *3* g.splitLines
     def splitLines(self, s):
         '''Split s into lines, preserving trailing newlines.'''
@@ -1271,7 +1271,7 @@ class Pattern:
         g.trace('unmatched %s in %s' % (delim, s), g.callers(4))
         return len(s) + 1
     #@+node:ekr.20160317054700.104: *3* pattern.match (trace-matches)
-    def match(self, s, trace = False):
+    def match(self, s, trace=False):
         '''
         Perform the match on the entire string if possible.
         Return (found, new s)
@@ -2028,7 +2028,7 @@ class StubFormatter(AstFormatter):
         caller = g.callers(2).split(',')[1].strip()  # The direct caller of match_all.
         patterns = self.patterns_dict.get(name, []) + self.regex_patterns
         for pattern in patterns:
-            found, s = pattern.match(s, trace = False)
+            found, s = pattern.match(s, trace=False)
             if found:
                 if trace:
                     aList = d.get(name, [])

--- a/leo/external/npyscreen/__init__.py
+++ b/leo/external/npyscreen/__init__.py
@@ -178,4 +178,6 @@ except Exception:
     pass
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
+
 #@-leo

--- a/leo/external/npyscreen/apNPSApplication.py
+++ b/leo/external/npyscreen/apNPSApplication.py
@@ -48,4 +48,5 @@ class NPSApp:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/apNPSApplicationAdvanced.py
+++ b/leo/external/npyscreen/apNPSApplicationAdvanced.py
@@ -21,4 +21,5 @@ class NPSAppAdvanced(apNPSApplicationManaged.NPSAppManaged):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/apNPSApplicationEvents.py
+++ b/leo/external/npyscreen/apNPSApplicationEvents.py
@@ -96,4 +96,5 @@ class StandardApp(NPSAppManaged, EventHandler):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/apNPSApplicationManaged.py
+++ b/leo/external/npyscreen/apNPSApplicationManaged.py
@@ -215,4 +215,5 @@ class NPSAppManaged(apNPSApplication.NPSApp):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/apOptions.py
+++ b/leo/external/npyscreen/apOptions.py
@@ -390,4 +390,5 @@ class OptionDate(Option):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/eveventhandler.py
+++ b/leo/external/npyscreen/eveventhandler.py
@@ -79,4 +79,5 @@ class EventHandler:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmActionForm.py
+++ b/leo/external/npyscreen/fmActionForm.py
@@ -136,4 +136,5 @@ class ActionFormExpanded(ActionForm):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmActionFormV2.py
+++ b/leo/external/npyscreen/fmActionFormV2.py
@@ -140,4 +140,5 @@ class ActionFormMinimal(ActionFormV2):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmFileSelector.py
+++ b/leo/external/npyscreen/fmFileSelector.py
@@ -285,4 +285,5 @@ def selectFile(starting_value=None, *args, **keywords):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmForm.py
+++ b/leo/external/npyscreen/fmForm.py
@@ -570,4 +570,5 @@ def blank_terminal():
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmFormMultiPage.py
+++ b/leo/external/npyscreen/fmFormMultiPage.py
@@ -263,4 +263,5 @@ class FormMultiPageActionWithMenus(FormMultiPageAction, wgNMenuDisplay.HasMenus)
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmFormMutt.py
+++ b/leo/external/npyscreen/fmFormMutt.py
@@ -102,4 +102,5 @@ class FormMuttWithMenus(FormMutt, fmFormWithMenus.FormBaseNewWithMenus):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmFormMuttActive.py
+++ b/leo/external/npyscreen/fmFormMuttActive.py
@@ -274,4 +274,5 @@ class FormMuttActiveTraditionalWithMenus(FormMuttActiveTraditional,
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmFormWithMenus.py
+++ b/leo/external/npyscreen/fmFormWithMenus.py
@@ -117,4 +117,5 @@ class SplitFormWithMenus(fmForm.SplitForm, FormWithMenus):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fmPopup.py
+++ b/leo/external/npyscreen/fmPopup.py
@@ -51,4 +51,5 @@ class ActionPopupWide(fmActionFormV2.ActionFormV2):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/fm_form_edit_loop.py
+++ b/leo/external/npyscreen/fm_form_edit_loop.py
@@ -143,4 +143,5 @@ class FormDefaultEditLoop:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/globals.py
+++ b/leo/external/npyscreen/globals.py
@@ -9,4 +9,5 @@ DISABLE_RESIZE_SYSTEM = False
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/muMenu.py
+++ b/leo/external/npyscreen/muMenu.py
@@ -83,4 +83,5 @@ class Menu:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/muNewMenu.py
+++ b/leo/external/npyscreen/muNewMenu.py
@@ -102,4 +102,5 @@ class MenuItem:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npysGlobalOptions.py
+++ b/leo/external/npyscreen/npysGlobalOptions.py
@@ -7,4 +7,5 @@ ASCII_ONLY = False  # See the safe_string function in wgwidget.  At the moment t
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npysNPSFilteredData.py
+++ b/leo/external/npyscreen/npysNPSFilteredData.py
@@ -55,4 +55,5 @@ class NPSFilteredDataList(NPSFilteredDataBase):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npysThemeManagers.py
+++ b/leo/external/npyscreen/npysThemeManagers.py
@@ -155,4 +155,5 @@ class ThemeManager:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npysThemes.py
+++ b/leo/external/npyscreen/npysThemes.py
@@ -172,4 +172,5 @@ class TransparentThemeLightText(TransparentThemeDarkText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npysTree.py
+++ b/leo/external/npyscreen/npysTree.py
@@ -230,4 +230,5 @@ class TreeData:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npyspmfuncs.py
+++ b/leo/external/npyscreen/npyspmfuncs.py
@@ -45,4 +45,5 @@ show_cursor = showcursor
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/npyssafewrapper.py
+++ b/leo/external/npyscreen/npyssafewrapper.py
@@ -116,4 +116,5 @@ def wrapper_no_fork(call_function, reset=False):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/proto_fm_screen_area.py
+++ b/leo/external/npyscreen/proto_fm_screen_area.py
@@ -183,4 +183,5 @@ class ScreenArea:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/stdfmemail.py
+++ b/leo/external/npyscreen/stdfmemail.py
@@ -276,4 +276,5 @@ class EmailViewFm(npyscreen.SplitFormWithMenus):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/utilNotify.py
+++ b/leo/external/npyscreen/utilNotify.py
@@ -116,4 +116,5 @@ def notify_yes_no(message, title="Message", form_color='STANDOUT', wrap=True, ed
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/util_viewhelp.py
+++ b/leo/external/npyscreen/util_viewhelp.py
@@ -28,4 +28,5 @@ def view_help(message, title="Message", form_color="STANDOUT", scroll_exit=False
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgFormControlCheckbox.py
+++ b/leo/external/npyscreen/wgFormControlCheckbox.py
@@ -72,4 +72,5 @@ class FormControlCheckbox(wgcheckbox.Checkbox):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgNMenuDisplay.py
+++ b/leo/external/npyscreen/wgNMenuDisplay.py
@@ -271,4 +271,5 @@ class HasMenus:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgannotatetextbox.py
+++ b/leo/external/npyscreen/wgannotatetextbox.py
@@ -118,4 +118,5 @@ class AnnotateTextboxBaseRight(AnnotateTextboxBase):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgautocomplete.py
+++ b/leo/external/npyscreen/wgautocomplete.py
@@ -135,4 +135,5 @@ class TitleFilename(titlefield.TitleText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgboxwidget.py
+++ b/leo/external/npyscreen/wgboxwidget.py
@@ -246,4 +246,5 @@ class BoxTitle(BoxBasic):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgbutton.py
+++ b/leo/external/npyscreen/wgbutton.py
@@ -124,4 +124,5 @@ class MiniButtonPress(MiniButton):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgcheckbox.py
+++ b/leo/external/npyscreen/wgcheckbox.py
@@ -232,4 +232,5 @@ class RoundCheckBoxMultiline(CheckBoxMultiline):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgcombobox.py
+++ b/leo/external/npyscreen/wgcombobox.py
@@ -117,4 +117,5 @@ class TitleCombo(titlefield.TitleText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgdatecombo.py
+++ b/leo/external/npyscreen/wgdatecombo.py
@@ -107,4 +107,5 @@ class TitleDateCombo(titlefield.TitleText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgeditmultiline.py
+++ b/leo/external/npyscreen/wgeditmultiline.py
@@ -414,4 +414,5 @@ class DocWrapper(textwrap.TextWrapper):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgfilenamecombo.py
+++ b/leo/external/npyscreen/wgfilenamecombo.py
@@ -60,4 +60,5 @@ class TitleFilenameCombo(wgcombobox.TitleCombo):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wggrid.py
+++ b/leo/external/npyscreen/wggrid.py
@@ -361,4 +361,5 @@ class SimpleGrid(widget.Widget):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wggridcoltitles.py
+++ b/leo/external/npyscreen/wggridcoltitles.py
@@ -54,4 +54,5 @@ class GridColTitles(grid.SimpleGrid):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmonthbox.py
+++ b/leo/external/npyscreen/wgmonthbox.py
@@ -297,4 +297,5 @@ class MonthBox(DateEntryBase):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmultiline.py
+++ b/leo/external/npyscreen/wgmultiline.py
@@ -958,4 +958,5 @@ class TitleBufferPager(TitleMultiLine):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmultilineeditable.py
+++ b/leo/external/npyscreen/wgmultilineeditable.py
@@ -143,4 +143,5 @@ class MultiLineEditableBoxed(wgboxwidget.BoxTitle):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmultilinetree.py
+++ b/leo/external/npyscreen/wgmultilinetree.py
@@ -486,4 +486,5 @@ class MLTreeAnnotatedAction(MLTree, multiline.MultiLineAction):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmultilinetreeselectable.py
+++ b/leo/external/npyscreen/wgmultilinetreeselectable.py
@@ -137,4 +137,5 @@ class MLTreeMultiSelectAnnotated(MLTreeMultiSelect):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmultiselect.py
+++ b/leo/external/npyscreen/wgmultiselect.py
@@ -131,4 +131,5 @@ class TitleMultiSelectFixed(multiline.TitleMultiLine):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgmultiselecttree.py
+++ b/leo/external/npyscreen/wgmultiselecttree.py
@@ -58,4 +58,5 @@ class MultiSelectTree(multilinetree.SelectOneTree):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgpassword.py
+++ b/leo/external/npyscreen/wgpassword.py
@@ -34,4 +34,5 @@ class TitlePassword(titlefield.TitleText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgselectone.py
+++ b/leo/external/npyscreen/wgselectone.py
@@ -70,4 +70,5 @@ class TitleSelectOne(multiline.TitleMultiLine):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgslider.py
+++ b/leo/external/npyscreen/wgslider.py
@@ -192,4 +192,5 @@ class TitleSliderPercent(TitleSlider):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgtextbox.py
+++ b/leo/external/npyscreen/wgtextbox.py
@@ -586,4 +586,5 @@ class FixedText(TextfieldBase):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgtextbox_controlchrs.py
+++ b/leo/external/npyscreen/wgtextbox_controlchrs.py
@@ -40,4 +40,5 @@ class TextfieldCtrlChars(textbox.Textfield):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgtextboxunicode.py
+++ b/leo/external/npyscreen/wgtextboxunicode.py
@@ -42,4 +42,5 @@ class TextfieldUnicode(wgtextbox.Textfield):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgtexttokens.py
+++ b/leo/external/npyscreen/wgtexttokens.py
@@ -209,4 +209,5 @@ class TitleTextTokens(wgtitlefield.TitleText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgtitlefield.py
+++ b/leo/external/npyscreen/wgtitlefield.py
@@ -206,4 +206,5 @@ class TitleFixedText(TitleText):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgwidget.py
+++ b/leo/external/npyscreen/wgwidget.py
@@ -926,4 +926,5 @@ class DummyWidget(Widget):
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/npyscreen/wgwidget_proto.py
+++ b/leo/external/npyscreen/wgwidget_proto.py
@@ -83,4 +83,5 @@ class _LinePrinter:
 #@-others
 #@@language python
 #@@tabwidth -4
+#@@nobeautify
 #@-leo

--- a/leo/external/py2cs.py
+++ b/leo/external/py2cs.py
@@ -1190,7 +1190,7 @@ class LeoGlobals:
     def shortFileName(self, fileName, n=None):
         if n is None or n < 1:
             return os.path.basename(fileName)
-        return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
+        return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
     #@+node:ekr.20160316091132.91: *3* g.splitLines
     def splitLines(self, s):
         '''Split s into lines, preserving trailing newlines.'''

--- a/leo/external/py2cs.py
+++ b/leo/external/py2cs.py
@@ -1190,7 +1190,7 @@ class LeoGlobals:
     def shortFileName(self, fileName, n=None):
         if n is None or n < 1:
             return os.path.basename(fileName)
-        return '/'.join(fileName.replace('\\', '/').split('/')[-n :])
+        return '/'.join(fileName.replace('\\', '/').split('/')[-n:])
     #@+node:ekr.20160316091132.91: *3* g.splitLines
     def splitLines(self, s):
         '''Split s into lines, preserving trailing newlines.'''

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -302,7 +302,7 @@ def cweb_keyword(colorer, s, i):
     seq = s[i : i + 2]
     if seq in ('@<', '@.'):
         return 0
-    return  colorer.match_keywords(s, i)
+    return colorer.match_keywords(s, i)
 #@+node:ekr.20250302073158.1: *3* function: cweb_backslash
 def cweb_backslash(colorer, s, i):
     """Handle TeX control sequences."""
@@ -326,7 +326,7 @@ def cweb_at_sign(colorer, s, i):
 
     seq = s[i : i + 3]
     if i == 0 or not s[:i].strip():
-        in_doc_part = seq.startswith(('@', '@ ', '@**',  '@*'))  # Anything else ends the doc part.
+        in_doc_part = seq.startswith(('@', '@ ', '@**', '@*'))  # Anything else ends the doc part.
 
     if seq in ('@<', '@.'):
         # Color sections.

--- a/leo/modes/jupytext.py
+++ b/leo/modes/jupytext.py
@@ -19,7 +19,7 @@ def jupytext_comment(colorer: Any, s: str, i: int) -> int:
     """
     Switch to md or python coloring if s is a %% comment, provided that
     c.p.b contains @language jupytext.
-    
+
     New in Leo 6.8.3.
     """
     trace = 'coloring' in g.app.debug and not g.unitTesting

--- a/leo/modes/md.py
+++ b/leo/modes/md.py
@@ -182,7 +182,7 @@ def md_jupytext_comment(colorer, s, i):
     """
     Switch to python coloring if s is '# %%', provided that c.p.b contains
     @language jupytext.
-    
+
     New in Leo 6.8.3.
     """
     trace = 'coloring' in g.app.debug and not g.unitTesting

--- a/leo/modes/nim.py
+++ b/leo/modes/nim.py
@@ -665,7 +665,7 @@ word_pattern = re.compile(r'\b(\w+)')
 def nim_unusual_single_quote(colorer, s, i):
     """
     Handle unusual single quotes, including custom_numeric_literals.
-    
+
     Color all such single quotes as a keyword1.
     """
 

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -319,7 +319,7 @@ def python_comment(colorer, s, i):
     """
     Switch to md coloring if s is '# %% [markdown]', provided that c.p.b
     contains @language jupytext.
-    
+
     New in Leo 6.8.3.
     """
     trace = 'coloring' in g.app.debug and not g.unitTesting

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -116,10 +116,10 @@ def doFileAction(filename, c):
                 break
         if not done:
             g.warning("no file action matches " + filename)
-            return False  #TL - Inform onIconDoubleClick that no action was taken
-        return True  #TL - Inform onIconDoubleClick that action was taken
+            return False  # TL - Inform onIconDoubleClick that no action was taken
+        return True  # TL - Inform onIconDoubleClick that action was taken
     g.warning("no FileActions node")
-    return False  #TL - Inform onIconDoubleClick that no action was taken
+    return False  # TL - Inform onIconDoubleClick that no action was taken
 #@+node:ekr.20040915105758.16: ** applyFileAction
 def applyFileAction(p, filename, c):
 

--- a/leo/plugins/active_path.py
+++ b/leo/plugins/active_path.py
@@ -455,7 +455,7 @@ def openDir(c, parent, d):
             or (excdirs and entry in dirs)
             or (excfiles and entry in files)
         ):
-            toRemove.add(p.h)  #must not strip '/', so nodes can be removed
+            toRemove.add(p.h)  # must not strip '/', so nodes can be removed
         else:
             oldlist.add(entry)
 

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -161,7 +161,7 @@ class backlinkController:
     def deleteLink(self, on, to, type_):
         """delete a link from 'on' to 'to' of type 'type_'"""
 
-        vid = on.gnx  #X unknownAttributes['_bklnk']['id']
+        vid = on.gnx  # X unknownAttributes['_bklnk']['id']
         links = on.unknownAttributes['_bklnk']['links']
 
         for n, link in enumerate(links):

--- a/leo/plugins/contextmenu.py
+++ b/leo/plugins/contextmenu.py
@@ -313,7 +313,7 @@ def openwith_rclick(c: Cmdr, p: Position, menu: Wrapper) -> None:
                 return pth
             return pth[len(prefix) :]
 
-        path = c.getPath(p)  + '/'
+        path = c.getPath(p) + '/'
         filetypes = [
             ("All files", "*"),
             ("Python files", "*.py"),

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -247,7 +247,7 @@ class TextFrame(leoFrame.LeoFrame):
         stroke = c.k.shortcutFromSetting(char)
         g.trace('char', repr(char), 'stroke', repr(stroke))
         e = leoTypingEvent(c, w, char, stroke)
-        k.masterKeyHandler(event=e)  ## ,stroke=key)
+        k.masterKeyHandler(event=e)  # # ,stroke=key)
     #@+node:ekr.20150107090324.30: *3* update
     def update(self):
         pass

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -247,7 +247,7 @@ class TextFrame(leoFrame.LeoFrame):
         stroke = c.k.shortcutFromSetting(char)
         g.trace('char', repr(char), 'stroke', repr(stroke))
         e = leoTypingEvent(c, w, char, stroke)
-        k.masterKeyHandler(event=e)  # # ,stroke=key)
+        k.masterKeyHandler(event=e)
     #@+node:ekr.20150107090324.30: *3* update
     def update(self):
         pass

--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 import leo.core.leoGlobals as g
 assert g
 from leo.core.leoQt import Qt, QtCore, QtWidgets, QtGui
-from leo.core.leoQt import ItemFlag, ItemDataRole, StandardPixmap  #2347
+from leo.core.leoQt import ItemFlag, ItemDataRole, StandardPixmap  # 2347
 
 try:
     from cStringIO import StringIO

--- a/leo/plugins/examples/chinese_menu.py
+++ b/leo/plugins/examples/chinese_menu.py
@@ -103,7 +103,7 @@ def onMenu(tag, keywords):
                 ("Reformat Paragraph", "重新格式化段落"),
                 ("Indent", "增加缩进"),
                 ("Unindent", "减少缩进"),
-                ("Match Brackets", "括号匹配"),  #  <({["), #EKR
+                ("Match Brackets", "括号匹配"),  # <({["), #EKR
             ("Edit Headline...", "编辑标题..."),
                 ("Edit Headline", "编辑标题"),
                 ("End Edit Headline", "结束编辑标题"),

--- a/leo/plugins/examples/french_fm.py
+++ b/leo/plugins/examples/french_fm.py
@@ -80,7 +80,7 @@ def onMenu(tag, keywords):
                 ("Reformat Paragraph", "Reformater &Paragraphe"),
                 ("Indent", "&Indenter"),
                 ("Unindent", "Dé&sindenter"),
-                ("Match Brackets", "&Vérifier Parité des Signes"),  #  <({["), #EKR
+                ("Match Brackets", "&Vérifier Parité des Signes"),  # <({["), #EKR
             ("Edit Headline...", "Éditer &Entête..."),
                 ("Edit Headline", "&Modifier l'Entête"),
                 ("End Edit Headline", "Modification &Terminée"),

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -194,7 +194,7 @@ class FreeLayoutController:
     def get_main_splitter(self, w: Wrapper = None) -> Optional[Wrapper]:
         """
         Return the main splitter.
-        
+
         We tacitly assume that this splitter contains the body pane.
         """
         top = self.get_top_splitter()

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -122,7 +122,7 @@ class Rust_Importer(Importer):
         def skip_r() -> None:
             """
             Skip over a raw string literal or add a single character 'r'.
-          
+
             Raw string literals start with: 'r', 0 <= n < 256 '#' chars, and '"'.
             Raw string literals end with: '"' followed by n '#' chars.
             """

--- a/leo/plugins/mime.py
+++ b/leo/plugins/mime.py
@@ -80,7 +80,7 @@ def init():
 #@+node:dan.20090203174248.31: ** open_mimetype
 def open_mimetype(tag, keywords, val=None):
     """Simulate double-clicking on the filename in a file manager.
-    
+
     Order of preference is:
     1) @string mime_open_cmd setting
     2) _mime_open_cmd, defined per sys.platform detection
@@ -100,7 +100,7 @@ def open_mimetype(tag, keywords, val=None):
 
     # honor @path
     fname = p.h[6:]
-    path =  c.getPath(p) or ''
+    path = c.getPath(p) or ''
     fpath = g.finalize_join(path, fname)
 
     # stop here if the file doesn't exist

--- a/leo/plugins/mod_leo2ascd.py
+++ b/leo/plugins/mod_leo2ascd.py
@@ -108,7 +108,7 @@ def SectionUnderline(h, level, v):
         g.es("Section level is more than maximum Section Levels: %d\n  %s" % (
             asciiDocSectionLevels, v.headString()))
         level = asciiDocSectionLevels - 1
-    str = Conf.current["headingUnderlines"][level]  # '
+    str = Conf.current["headingUnderlines"][level]
     return str * max(len(h), 1)
 #@+node:ekr.20101110094152.5843: *3* WriteAll
 def WriteAll(c):

--- a/leo/plugins/mod_leo2ascd.py
+++ b/leo/plugins/mod_leo2ascd.py
@@ -108,7 +108,7 @@ def SectionUnderline(h, level, v):
         g.es("Section level is more than maximum Section Levels: %d\n  %s" % (
             asciiDocSectionLevels, v.headString()))
         level = asciiDocSectionLevels - 1
-    str = Conf.current["headingUnderlines"][level]  #'
+    str = Conf.current["headingUnderlines"][level]  # '
     return str * max(len(h), 1)
 #@+node:ekr.20101110094152.5843: *3* WriteAll
 def WriteAll(c):

--- a/leo/plugins/nodeActions.py
+++ b/leo/plugins/nodeActions.py
@@ -269,7 +269,7 @@ def doNodeAction(pClicked, c):
     if pNA:
         # Found "nodeActions" node
         foundPattern = False
-        passEventExternal = False  #No pass to next plugin after pattern matched
+        passEventExternal = False  # No pass to next plugin after pattern matched
         # Check entire subtree under the "nodeActions" node for pattern
         for pScript in pNA.subtree():
 
@@ -281,7 +281,7 @@ def doNodeAction(pClicked, c):
             if pClicked == pScript:
                 continue
 
-            pattern = pScript.h.strip()  #Pattern node's header
+            pattern = pScript.h.strip()  # Pattern node's header
             if messageLevel >= 4:
                 g.blue("nA: Checking pattern '" + pattern)
 
@@ -294,7 +294,7 @@ def doNodeAction(pClicked, c):
             # What directives exist?
             useRegEx = re.search("X", directives) is not None
             passEventInternal = re.search("V", directives) is not None
-            if not passEventExternal:  #don't disable once enabled.
+            if not passEventExternal:  # don't disable once enabled.
                 passEventExternal = re.search(">", directives) is not None
             # Remove the directives from the end of the pattern (if they exist)
             pattern = re.sub(r" \[.*]$", "", pattern, 1)
@@ -307,10 +307,10 @@ def doNodeAction(pClicked, c):
             # if pattern begins with "@files" and clicked node is an @file type
             # node then replace "@files" in pattern with clicked node's @file type
             patternBeginsWithAtFiles = re.search("^@files ", pattern)
-            clickedAtFileTypeNode = False  #assume @file type node not clicked
+            clickedAtFileTypeNode = False  # assume @file type node not clicked
             if patternBeginsWithAtFiles:
                 if pClicked.isAnyAtFileNode():
-                    clickedAtFileTypeNode = True  #Tell "write @file type nodes" code
+                    clickedAtFileTypeNode = True  # Tell "write @file type nodes" code
                     # Replace "@files" in pattern with clicked node's @file type
                     pattern = re.sub("^@files", hClicked.split(' ')[0], pattern)
                     if messageLevel >= 4:
@@ -352,22 +352,22 @@ def doNodeAction(pClicked, c):
             # no match to any pattern, always pass event to next plugin
             if messageLevel >= 1:
                 g.blue("nA: No patterns matched to " "" + hClicked + '"')
-            return False  #TL - Inform onIconDoubleClick that no action was taken
+            return False  # TL - Inform onIconDoubleClick that no action was taken
         if passEventExternal:
             # last matched pattern has directive to pass event to next plugin
             if messageLevel >= 2:
                 g.blue("nA: Event passed to next plugin")
-            return False  #TL - Inform onIconDoubleClick to pass double-click event
+            return False  # TL - Inform onIconDoubleClick to pass double-click event
         #
         # last matched pattern did not have directive to pass event to plugin
         if messageLevel >= 2:
             g.blue("nA: Event not passed to next plugin")
-        return True  #TL - Inform onIconDoubleClick to not pass double-click
+        return True  # TL - Inform onIconDoubleClick to not pass double-click
     #
     # nodeActions plugin enabled without a 'nodeActions' node
     if messageLevel >= 4:
         g.blue("nA: The nodeActions node does not exist")
-    return False  #TL - Inform onIconDoubleClick that no action was taken
+    return False  # TL - Inform onIconDoubleClick that no action was taken
 #@+node:TL.20080507213950.10: ** applyNodeAction
 def applyNodeAction(pScript, pClicked, c):
 

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -490,7 +490,7 @@ class LeoQtEventFilter(QtCore.QObject):
             ])
         update_events = (
             (e.Type.UpdateLater, 'update-later'),  # 78
-            (e.Type.UpdateRequest, 'update'),  #     77
+            (e.Type.UpdateRequest, 'update'),  # 77
         )
         option_table = (
             (traceActivate, activate_events),

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -186,7 +186,7 @@ class DynamicWindow(QtWidgets.QMainWindow):
     def create_layout(self) -> tuple[QWidget, QWidget]:
         """
         Create the layout given by @string qt_layout_name.
-        
+
         Return the tuple (main_splitter, Optional[secondary_splitter])
         """
         c = self.leo_c
@@ -1024,9 +1024,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
     def createVRPanes(self) -> list[QtWidgets.QFrame]:
         """
         Create the VR and/or the VR3 panes if either plugin is enabled.
-        
+
         Return a list containing the panes.
-        
+
         The caller is responsible for placing the panes in the properly place.
         """
         panes: list[QtWidgets.QFrame] = []
@@ -1106,9 +1106,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
     ) -> None:
         """
         Set the orientations of the splitters in the Leo main window.
-        
+
         Only the legacy layout should use this method!
-        
+
         """
         # c = self.leo_c
         vert = orientation and orientation.lower().startswith('v')

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1539,7 +1539,7 @@ class LeoQtGui(leoGui.LeoGui):
     def find_parent_splitter(self, widget: QWidget) -> Optional[Tuple[QSplitter, QWidget]]:
         """
         Find the nearest parent QSplitter widget for the given widget.
-        
+
         Return (splitter, child) where:
         - splitter is the QSplitter containing the widget.
         - child is the *direct* child of the splitter that contains the widget.

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -188,7 +188,7 @@ def render_focused(event: LeoKeyEvent) -> None:
         ├───────────┤     │     │
         │ log       │     │     │
         └───────────┴─────┴─────┘
-        
+
     Note: The expand/contract-main-splitter commands have no effect when using this layout.
     """
     c = event.get('c')
@@ -220,7 +220,7 @@ def restoreDefaultLayout(event: LeoKeyEvent) -> None:
 def swapLogPanel(event: LeoKeyEvent) -> None:
     """
     Move the Log frame between main and secondary splitters.
-    
+
     **Do not use this layout as the initial layout.**
     """
     c = event.get('c')

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -485,7 +485,7 @@ class LeoLineTextWidget(QtWidgets.QFrame):
         """
         Update the line numbers for all events on the text edit and the viewport.
         This is easier than connecting all necessary signals.
-        
+
         Return True if the event filter was installed correctly.
         """
         if obj in (self.edit, self.edit.viewport()):
@@ -503,7 +503,7 @@ if QtWidgets:
         def __init__(self, parent: QWidget, c: Cmdr, wrapper: BaseTextAPI) -> None:
             """
             ctor for LeoQTextBrowser class.
-            
+
             wrapper is a LeoQtBody or LeoQtLog.
             """
             for attr in ('leo_c', 'leo_wrapper',):

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -187,7 +187,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # mypy complains that there is a mismatch with the base redraw method.
     redraw = full_redraw  # type:ignore
-    redraw_now = full_redraw  #type:ignore
+    redraw_now = full_redraw  # type:ignore
     #@+node:vitalije.20200329160945.1: *5* tree declutter code
     #@+node:tbrown.20150807090639.1: *6* qtree.declutter_node & helpers
     def declutter_node(self, c: Cmdr, v: VNode, item: QTreeWidgetItem) -> QIcon:
@@ -1182,7 +1182,7 @@ class LeoQtTree(leoFrame.LeoTree):
         # e.setCursorPosition(ins) # Does not work.
         e.setFocus()
         wrapper = self.connectEditorWidget(e, item)  # Hook up the widget.
-        if vc and c.vim_mode:  #  and selectAll
+        if vc and c.vim_mode:  # and selectAll
             # For now, *always* enter insert mode.
             if vc.is_text_wrapper(wrapper):
                 vc.begin_insert_mode(w=wrapper)

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -897,7 +897,7 @@ class quickMoveButton:
                     p.moveToLastChildOf(p2)
                 elif self.which in ('next sibling', 'prev sibling'):
                     if not p2.parent():
-                        raise NotImplementedError("Not implemented for top-level nodes")  #FIXME
+                        raise NotImplementedError("Not implemented for top-level nodes")  # FIXME
                     if self.which == 'next sibling':
                         p.moveToNthChildOf(p2.parent(), p2._childIndex)
                     elif self.which == 'prev sibling':

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -70,11 +70,11 @@ This plugin defines the following commands that can be bound to keys:
 - find-quick-test-failures:
   Lists nodes in c.db.get('unittest/cur/fail')
 
-- find-quick-timeline:   
+- find-quick-timeline:
   Lists all nodes in reversed gnx order, basically newest to
   oldest, creation wise, not modification wise.
 
-- find-quick-changed:  
+- find-quick-changed:
   Lists all nodes that are changed (aka "dirty") since last save.
   Handy when you want to see why a file's marked as changed.
 

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -461,7 +461,7 @@ class QuickSearchController:
                 it.setFont(f)
                 if self.addItem(it, (p[0], None)):
                     return lineMatchHits
-                if p[1] is not None:  #p might not have body matches
+                if p[1] is not None:  # p might not have body matches
                     ms = matchlines(p[0].b, p[1])
                     for ml, pos in ms:
                         lineMatchHits += 1
@@ -594,7 +594,7 @@ class QuickSearchController:
             if hitBase:
                 # If I hit the base then revert to all positions
                 # this is basically the "main" chapter
-                hitBase = False  #reset
+                hitBase = False  # reset
                 hNodes = self.c.all_positions()
                 bNodes = self.c.all_positions()
             else:
@@ -609,7 +609,7 @@ class QuickSearchController:
             hm = self.find_h(hpat, hNodes, flags)
             bm = self.find_b(bpat, bNodes, flags)
             bm_keys = [match[0].key() for match in bm]
-            numOfHm = len(hm)  #do this before trim to get accurate count
+            numOfHm = len(hm)  # do this before trim to get accurate count
             hm = [match for match in hm if match[0].key() not in bm_keys]
             if self.widgetUI.showParents.isChecked():
                 parents: dict[str, Match_List] = {}
@@ -743,7 +743,7 @@ class QuickSearchController:
             tgt()
         elif len(tgt) == 2:
             p, pos = tgt
-            if hasattr(p, 'v'):  #p might be "Root"
+            if hasattr(p, 'v'):  # p might be "Root"
                 if not c.positionExists(p):
                     g.es("Node moved or deleted.\nMaybe re-do search.",
                         color='red')

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -1247,7 +1247,7 @@ class ScreenShotController:
            :glob:
 
            slide-*
-        ''' % (title)  #,sc.slide_base_name)
+        ''' % (title)  # ,sc.slide_base_name)
         # Indices and tables
         # ==================
         # * :ref:`genindex`

--- a/leo/plugins/stickynotes_plus.py
+++ b/leo/plugins/stickynotes_plus.py
@@ -308,7 +308,7 @@ class notetextedit(QTextEdit):
     def make_heading(self, heading):
         # not finished
         cursor = self.textCursor()
-        cursor.select(QTextCursor.BlockUnderCursor)  #QTextCursor.LineUnderCursor
+        cursor.select(QTextCursor.BlockUnderCursor)  # QTextCursor.LineUnderCursor
 
         char_format = QTextCharFormat()
         font = QFont()
@@ -480,7 +480,7 @@ class notetextedit(QTextEdit):
         pos = event.pos()
         anch = self.anchorAt(pos)
         self.viewport().setCursor(Qt.PointingHandCursor if anch else Qt.IBeamCursor)
-        QTextEdit.mouseMoveEvent(self, event)  #? recursion
+        QTextEdit.mouseMoveEvent(self, event)  # ? recursion
 
     #@+node:ekr.20100103100944.5417: *3* mouseReleaseEvent
     def mouseReleaseEvent(self, event):
@@ -488,7 +488,7 @@ class notetextedit(QTextEdit):
         pos = event.pos()
         url = self.anchorAt(pos)
         if url:
-            if not url.startswith('http://'):  #linux seems to need this
+            if not url.startswith('http://'):  # linux seems to need this
                 url = 'http://{0}'.format(url)
             webbrowser.open(url, new=2, autoraise=True)
         else:
@@ -650,7 +650,7 @@ def stickynoteplus_f(event):
     c = event['c']
     p = c.p
     v = p.v
-    def get_markdown():  #focusin():
+    def get_markdown():  # focusin():
         print("focus in")
         if v is c.p.v:
             nf.setHtml(markdown.markdown(v.b))
@@ -658,7 +658,7 @@ def stickynoteplus_f(event):
             nf.dirty = False
 
 
-    def save():  #focusout():
+    def save():  # focusout():
         print("focus out")
         if not nf.dirty:
             return

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1170,7 +1170,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def update_movie(self, s: str, keywords: Any) -> None:
         """
         Show an @movie in the VR pane.
-        
+
         The first line of `s` should be the path to the movie.
         """
         ok, path = self.get_fn(s, '@movie')
@@ -1210,7 +1210,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def update_pandoc(self, s: str, keywords: Any) -> None:
         """
         Display an @pandoc node in the VR pane.
-        
+
         This code has been disabled.
         """
         # global pandoc_exec
@@ -1471,7 +1471,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def update_svg(self, s: str, keywords: Any) -> None:
         """
         Show an svg image in the VR pane.
-        
+
         `s` may be a path to the image or the image itself.
         """
         if 0:  # Use webengine. Works, but scaling is too big.
@@ -1659,7 +1659,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
     def get_fn(self, s: str, tag: str) -> tuple[bool, str]:
         """
         Return an absolute path using s or c.p.h.
-        
+
         Resolve relative paths using the outline's directory.
         """
         c = self.c

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1365,10 +1365,10 @@ def is_theme_dark(c):
 #@+node:tom.20241005134508.1: ** tinker with colors()
 def tinker_with_colors(c, kind: str = REST):
     """Use Editor's fore- and back-ground colors.
-    
+
     ARGUMENT
     html -- The HTML to be re-colored.  Must be a string, not a byte array.
-    
+
     Note that this will not change any other colors. So some of the output
     colors may not be as well coordinated as before the fg/bg colors
     were changed.
@@ -1697,7 +1697,7 @@ def getVr3(event):
 @g.command('vr3')
 def viewrendered(event):
     """Create VR3 in this commander if not already created.
-    
+
     The VR3 instance will be created as a child of the widget cache splitter
     of the Dynamic Window that represents the Entire window of this outline.
 
@@ -2188,7 +2188,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:TomP.20200329223820.1: *3* vr3.ctor & helpers
     def __init__(self, c, parent=None):
         """Ctor for ViewRenderedController class.
-        
+
         ARGUMENTS
         c -- the controller for this outline
         parent -- the widget that will contain this VR3 widget.
@@ -3941,7 +3941,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:tom.20250103185205.1: *4* vr3.update_pdf
     def update_pdf(self, s, keywords):
         """Display PDF file.
-        
+
         The path to the PDF file must be either in the headline after
         the leading "@pdf " or the first line in the body. The
         path must use "/" separators and may not start with "file:".
@@ -3968,9 +3968,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:tom.20250104125231.1: *5* v3.get_file_path
     def get_file_path(self, kind=None):
         """Return an absolute file path from a node.
-        
+
         ~, .., and symbolic links resolved.
-        
+
         The file path may be absolute or relative to the path
         applicable to the selected node. If the headline starts
         with a kind, such as "@pdf", and contains a path to an
@@ -3981,7 +3981,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
         ARGUMENTS
         s -- a single line of text that may contain a path to a file.
         kind -- A headline prefix starting with "@", such as "@pdf".
-        
+
         RETURNS
         A fully resolved absolute path or None.
         """
@@ -4000,12 +4000,12 @@ class ViewRenderedController3(QtWidgets.QWidget):
     #@+node:tom.20250104130838.1: *5* v3.get_file_from_string
     def get_file_from_string(self, s):
         """Return the path to an existing file based on s.
-        
+
         s is a string whose first line may contain a path to
         a file. If it does, return the fully resolved
         path to an existing file, else an empty string. The path
         may be absolute or relative to the node's effective path.
-        
+
         For an unsaved outline, assume that relative paths are
         relative to the .leo directory.
         """

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3646,7 +3646,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             ok = True
             path = fn
             is_url = True
-        else:  #file URL
+        else:  # file URL
             ok, path = self.get_fn(fn, '@image')
 
         if not ok:
@@ -4065,7 +4065,7 @@ class ViewRenderedController3(QtWidgets.QWidget):
             c.executeScript(
                 event=None,
                 args=None, p=None,
-                script=c.p.b,  #None,
+                script=c.p.b,  # None,
                 useSelectedText=False,
                 define_g=True,
                 define_name='__main__',

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -33,6 +33,7 @@ python = 'py' if isWindows else 'python'
 for command in [
     f'{python} -c "import leo.core.leoTokens" {args} leo/commands',
     f'{python} -c "import leo.core.leoTokens" {args} leo/core',
+    f'{python} -c "import leo.core.leoTokens" {args} leo/external',
     f'{python} -c "import leo.core.leoTokens" {args} leo/plugins',
     f'{python} -c "import leo.core.leoTokens" {args} leo/scripts',
     f'{python} -c "import leo.core.leoTokens" {args} leo/modes',

--- a/leo/scripts/build_leo.py
+++ b/leo/scripts/build_leo.py
@@ -4,7 +4,7 @@
 
 """
 build_leo.py: Build Leo as follows:
-    
+
 - Delete all files in the `leo-editor/leo/dist` directory.
 - Run `python -m build > build_log.txt`.
 

--- a/leo/scripts/flake8_leo.py
+++ b/leo/scripts/flake8_leo.py
@@ -27,7 +27,7 @@ args = ' '.join(sys.argv[1:]) + leo_editor_dir
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
-command = fr'{python} -m flake8 {args} --config={leo_editor_dir}{os.sep}setup.cfg'
+command = fr'{python} -m flake8 {args} --show-source --config={leo_editor_dir}{os.sep}setup.cfg'
 subprocess.Popen(command, shell=True).communicate()
 
 #@-leo

--- a/leo/scripts/full_test_leo.py
+++ b/leo/scripts/full_test_leo.py
@@ -2,7 +2,7 @@
 #@+node:ekr.20240323051724.1: * @file ../scripts/full_test_leo.py
 """
 full_test_leo.py: Run all these tests scripts in this order:
-    
+
 - beautify_leo.py.
 - run_test_leo.py.
 - flake8_leo.py.

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -20,7 +20,7 @@ class TestColorizer(LeoUnitTest):
     def color(self, language_name, text):
         """
         Run the test by colorizing a node with the given text.
-        
+
         Colorize using the jEdit and pygments colorizers.
         """
         c = self.c

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -154,11 +154,11 @@ class TestCommands(LeoUnitTest):
         # It will return True if it changed the text.
         val = c.doCommandByName('convert-blanks')
         assert val is True, f"expected: True got: {val}"
-        
+
         # Call it again, it should return False.
         val = c.doCommandByName('convert-blanks')
         assert val is False, f"expected: False got: {val}"
-        
+
     #@+node:felix.20250414224344.1: *3* TestCommands.test_c_doCommandByName_return_result_from_leo_script
     def test_c_doCommandByName_return_result_from_leo_script(self):
         c, p = self.c, self.c.p

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -873,6 +873,17 @@ class TestTokenBasedOrange(BaseTest):
                 g.printObj(expected, tag='Expected (Black)')
                 g.printObj(results, tag='Results')
             self.assertEqual(expected, results)
+    #@+node:ekr.20250505153051.1: *3* TestTBO.test_spaces_after_keyword
+    def test_spaces_after_keyword(self):
+
+        contents = """return  ''\n"""
+        expected = """return ''\n"""
+        contents, tokens = self.make_data(contents)
+        results = self.beautify(contents, tokens)
+        if results != expected:  # pragma: no cover
+            g.printObj(results, tag='Results')
+            g.printObj(expected, tag='Expected')
+        assert results == expected
     #@+node:ekr.20240105153425.76: *3* TestTBO.test_star_star_operator
     def test_star_star_operator(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -553,10 +553,10 @@ class TestTokenBasedOrange(BaseTest):
         # All entries are expected values...
         black_table = (
             # leoserver.py: line 1575.
-            """s = s[len('@nocolor') :]\n""",
+            ### """s = s[len('@nocolor') :]\n""",
             # leoGlobals.py.
-            """g.pr(f"{self.calledDict.get(key,0):d}", key)""",  # line 1805
-            """tracing_tags [id(self)] = tag""",  # line 1913.
+            ### """g.pr(f"{self.calledDict.get(key,0):d}", key)""",  # line 1805
+            ### """tracing_tags [id(self)] = tag""",  # line 1913.
             # make_stub_files.py.
             """def match(self, s, trace=False):\n    pass""",
         )
@@ -567,11 +567,14 @@ class TestTokenBasedOrange(BaseTest):
             results = self.beautify(contents, tokens, filename=description)
             if results != expected:  # pragma: no cover
                 print('')
-                print(
-                    f"TestTokenBasedOrange.{tag}: FAIL\n"
-                    f"  contents: {contents.rstrip()}\n"
-                    f"     black: {expected.rstrip()}\n"
-                    f"    orange: {results.rstrip() if results else 'None'}")
+                # print(
+                    # f"TestTokenBasedOrange.{tag}: FAIL\n"
+                    # f"  contents: {contents.rstrip()}\n"
+                    # f"     black: {expected.rstrip()}\n"
+                    # f"    orange: {results.rstrip() if results else 'None'}")
+                g.printObj(tokens, tag='Tokens')
+                g.printObj(expected, tag='Expected')
+                g.printObj(results, tag='Results')
             self.assertEqual(results, expected, msg=description)
     #@+node:ekr.20240105153425.65: *3* TestTBO.test_leo_sentinels
     def test_leo_sentinels_1(self):

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -553,10 +553,10 @@ class TestTokenBasedOrange(BaseTest):
         # All entries are expected values...
         black_table = (
             # leoserver.py: line 1575.
-            ### """s = s[len('@nocolor') :]\n""",
+            """s = s[len('@nocolor') :]\n""",
             # leoGlobals.py.
-            ### """g.pr(f"{self.calledDict.get(key,0):d}", key)""",  # line 1805
-            ### """tracing_tags [id(self)] = tag""",  # line 1913.
+            """g.pr(f"{self.calledDict.get(key,0):d}", key)""",  # line 1805
+            """tracing_tags [id(self)] = tag""",  # line 1913.
             # make_stub_files.py.
             """def match(self, s, trace=False):\n    pass""",
         )
@@ -567,12 +567,7 @@ class TestTokenBasedOrange(BaseTest):
             results = self.beautify(contents, tokens, filename=description)
             if results != expected:  # pragma: no cover
                 print('')
-                # print(
-                    # f"TestTokenBasedOrange.{tag}: FAIL\n"
-                    # f"  contents: {contents.rstrip()}\n"
-                    # f"     black: {expected.rstrip()}\n"
-                    # f"    orange: {results.rstrip() if results else 'None'}")
-                g.printObj(tokens, tag='Tokens')
+                # g.printObj(tokens, tag='Tokens')
                 g.printObj(expected, tag='Expected')
                 g.printObj(results, tag='Results')
             self.assertEqual(results, expected, msg=description)

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -439,26 +439,6 @@ class TestTokenBasedOrange(BaseTest):
                 g.printObj(results, tag='Results')
                 g.printObj(expected, tag='Expected')
         assert not fails, fails
-    #@+node:ekr.20250505151026.1: *3* TestTBO.test_badly_indented_comment
-    def test_badly_indented_comment(self):
-
-        contents = """
-    if 1:
-          # Indentation not a multiple of four.
-        pass
-    """
-        expected = textwrap.dedent("""\
-    if 1:
-        # Indentation not a multiple of four.
-        pass
-    """)
-        contents, tokens = self.make_data(contents)
-        results = self.beautify(contents, tokens)
-        if results != expected:  # pragma: no cover
-            g.printObj(tokens, tag='Tokens')
-            g.printObj(results, tag='Results')
-            g.printObj(expected, tag='Expected')
-        assert results == expected
     #@+node:ekr.20240105153425.54: *3* TestTBO.test_comment_space_after_delim
     def test_comment_space_after_delim(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -903,7 +903,7 @@ class TestTokenBasedOrange(BaseTest):
     This line contains trailing ws  
     """
     '''
-        expected = textwrap.dedent('''
+        expected = textwrap.dedent('''\
     """
     This line contains trailing ws
     """

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -993,6 +993,18 @@ class TestTokenBasedOrange(BaseTest):
         expected = contents
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected, msg=contents)
+    #@+node:ekr.20250505231955.1: *3* TestTBO.test_ws_in_blank_line
+    def test_ws_in_blank_line(self):
+
+        contents = 'line 1\n   \nline 2\n'
+        expected = 'line 1\n\nline 2\n'
+        contents, tokens = self.make_data(contents)
+        results = self.beautify(contents, tokens)
+        if results != expected:  # pragma: no cover
+            g.printObj(tokens, tag='Tokens')
+            g.printObj(results, tag='Results')
+            g.printObj(expected, tag='Expected')
+        assert results == expected
     #@+node:ekr.20240105153425.81: *3* TestTBO.verbatim2
     def test_verbatim2(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -521,6 +521,42 @@ class TestTokenBasedOrange(BaseTest):
         expected = contents.rstrip() + '\n'
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected)
+    #@+node:ekr.20250506092303.1: *3* TestTBO.test_flake8_errors
+    def test_flake8_errors(self):
+
+
+        tag = 'test_flake8_errors'
+
+        # All entries are expected values...
+        table = (
+            # Errors due to @nobeautify directives leoMenu.py.
+            # """for i in range(1,9):\n    pass""",
+            # """a = range(1, 9)\n""",
+            # """d ["key"] = None\n""",
+
+            # leoserver.py: line 1575.
+            """s = s[len('@nocolor') :]\n""",
+
+            # leoGlobals.py: line 1913.
+            """tracing_tags [id(self)] = tag""",
+        )
+        for i, contents in enumerate(table):
+            description = f"{tag} part {i}"
+            contents, tokens = self.make_data(contents, description=description)
+            expected = self.blacken(contents)
+            results = self.beautify(contents, tokens, filename=description)
+            if 0:  # pragma: no cover
+                g.printObj(tokens, tag=description)
+                g.printObj(expected, tag='Expected')
+                g.printObj(results, tag='Results')
+            if results != expected:  # pragma: no cover
+                print('')
+                print(
+                    f"TestTokenBasedOrange.{tag}: FAIL\n"
+                    f"  contents: {contents.rstrip()}\n"
+                    f"     black: {expected.rstrip()}\n"
+                    f"    orange: {results.rstrip() if results else 'None'}")
+            self.assertEqual(results, expected, msg=description)
     #@+node:ekr.20240105153425.65: *3* TestTBO.test_leo_sentinels
     def test_leo_sentinels_1(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -898,16 +898,13 @@ class TestTokenBasedOrange(BaseTest):
     #@+node:ekr.20250505152406.1: *3* TestTBO.test_trailing_ws_in_docstring
     def test_trailing_ws_in_docstring(self):
 
-        contents = '''
-    """
-    This line contains trailing ws  
-    """
-    '''
         expected = textwrap.dedent('''\
     """
     This line contains trailing ws
     """
     ''')
+        # Create the trailing ws by hand so flake8 doesn't complain!
+        contents = expected.replace('ws', 'ws  ')
         assert contents != expected
         contents, tokens = self.make_data(contents)
         results = self.beautify(contents, tokens)

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -881,6 +881,7 @@ class TestTokenBasedOrange(BaseTest):
         contents, tokens = self.make_data(contents)
         results = self.beautify(contents, tokens)
         if results != expected:  # pragma: no cover
+            g.printObj(tokens, tag='Tokens')
             g.printObj(results, tag='Results')
             g.printObj(expected, tag='Expected')
         assert results == expected

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -557,6 +557,8 @@ class TestTokenBasedOrange(BaseTest):
             # leoGlobals.py.
             """g.pr(f"{self.calledDict.get(key,0):d}", key)""",  # line 1805
             """tracing_tags [id(self)] = tag""",  # line 1913.
+            # make_stub_files.py.
+            """def match(self, s, trace=False):\n    pass""",
         )
         for i, contents in enumerate(black_table):
             description = f"{tag} (black) part {i}"

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -439,6 +439,25 @@ class TestTokenBasedOrange(BaseTest):
                 g.printObj(results, tag='Results')
                 g.printObj(expected, tag='Expected')
         assert not fails, fails
+    #@+node:ekr.20250505151026.1: *3* TestTBO.test_badly_indented_comment (new)
+    def test_badly_indented_comment(self):
+
+        contents = """
+    if 1:
+          # Indentation not a multiple of four.
+        pass
+    """
+        expected = textwrap.dedent("""
+    if 1:
+        # Indentation not a multiple of four.
+        pass
+    """)
+        contents, tokens = self.make_data(contents)
+        results = self.beautify(contents, tokens)
+        if results != expected:  # pragma: no cover
+            g.printObj(results, tag='Results')
+            g.printObj(expected, tag='Expected')
+        assert results == expected
     #@+node:ekr.20240105153425.54: *3* TestTBO.test_comment_space_after_delim
     def test_comment_space_after_delim(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -882,6 +882,26 @@ class TestTokenBasedOrange(BaseTest):
         expected = contents
         results = self.beautify(contents, tokens)
         self.assertEqual(results, expected)
+    #@+node:ekr.20250505152406.1: *3* TestTBO.test_trailing_ws_in_docstring
+    def test_trailing_ws_in_docstring(self):
+
+        contents = '''
+    """
+    This line contains trailing ws  
+    """
+    '''
+        expected = textwrap.dedent('''
+    """
+    This line contains trailing ws
+    """
+    ''')
+        assert contents != expected
+        contents, tokens = self.make_data(contents)
+        results = self.beautify(contents, tokens)
+        if results != expected:  # pragma: no cover
+            g.printObj(results, tag='Results')
+            g.printObj(expected, tag='Expected')
+        assert results == expected
     #@+node:ekr.20240109070553.1: *3* TestTBO.test_unary_ops
     def test_unary_ops(self):
 

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -439,7 +439,7 @@ class TestTokenBasedOrange(BaseTest):
                 g.printObj(results, tag='Results')
                 g.printObj(expected, tag='Expected')
         assert not fails, fails
-    #@+node:ekr.20250505151026.1: *3* TestTBO.test_badly_indented_comment (new)
+    #@+node:ekr.20250505151026.1: *3* TestTBO.test_badly_indented_comment
     def test_badly_indented_comment(self):
 
         contents = """
@@ -447,7 +447,7 @@ class TestTokenBasedOrange(BaseTest):
           # Indentation not a multiple of four.
         pass
     """
-        expected = textwrap.dedent("""
+        expected = textwrap.dedent("""\
     if 1:
         # Indentation not a multiple of four.
         pass
@@ -455,6 +455,7 @@ class TestTokenBasedOrange(BaseTest):
         contents, tokens = self.make_data(contents)
         results = self.beautify(contents, tokens)
         if results != expected:  # pragma: no cover
+            g.printObj(tokens, tag='Tokens')
             g.printObj(results, tag='Results')
             g.printObj(expected, tag='Expected')
         assert results == expected
@@ -911,6 +912,7 @@ class TestTokenBasedOrange(BaseTest):
         contents, tokens = self.make_data(contents)
         results = self.beautify(contents, tokens)
         if results != expected:  # pragma: no cover
+            g.printObj(tokens, tag='Tokens')
             g.printObj(results, tag='Results')
             g.printObj(expected, tag='Expected')
         assert results == expected

--- a/leo/unittests/core/test_leoTokens.py
+++ b/leo/unittests/core/test_leoTokens.py
@@ -524,31 +524,45 @@ class TestTokenBasedOrange(BaseTest):
     #@+node:ekr.20250506092303.1: *3* TestTBO.test_flake8_errors
     def test_flake8_errors(self):
 
-
         tag = 'test_flake8_errors'
 
-        # All entries are expected values...
-        table = (
-            # Errors due to @nobeautify directives leoMenu.py.
-            # """for i in range(1,9):\n    pass""",
-            # """a = range(1, 9)\n""",
-            # """d ["key"] = None\n""",
-
-            # leoserver.py: line 1575.
-            """s = s[len('@nocolor') :]\n""",
-
-            # leoGlobals.py: line 1913.
-            """tracing_tags [id(self)] = tag""",
+        # Part 1: tests w/o black.
+        non_black_table = (
+            # leoAbbrevCommands.py: line 160.
+            """c.abbrev_subst_env = {'c': c, 'g': g, '_values': {}, }\n""",
         )
-        for i, contents in enumerate(table):
-            description = f"{tag} part {i}"
+        for i, contents in enumerate(non_black_table):
+            description = f"{tag} (w/o black) part {i}"
             contents, tokens = self.make_data(contents, description=description)
-            expected = self.blacken(contents)
+            expected = contents
             results = self.beautify(contents, tokens, filename=description)
             if 0:  # pragma: no cover
                 g.printObj(tokens, tag=description)
                 g.printObj(expected, tag='Expected')
                 g.printObj(results, tag='Results')
+            if results != expected:  # pragma: no cover
+                print('')
+                print(
+                    f"TestTokenBasedOrange.{tag}: FAIL\n"
+                    f"  contents: {contents.rstrip()}\n"
+                    f"     black: {expected.rstrip()}\n"
+                    f"    orange: {results.rstrip() if results else 'None'}")
+            self.assertEqual(results, expected, msg=description)
+
+
+        # All entries are expected values...
+        black_table = (
+            # leoserver.py: line 1575.
+            """s = s[len('@nocolor') :]\n""",
+            # leoGlobals.py.
+            """g.pr(f"{self.calledDict.get(key,0):d}", key)""",  # line 1805
+            """tracing_tags [id(self)] = tag""",  # line 1913.
+        )
+        for i, contents in enumerate(black_table):
+            description = f"{tag} (black) part {i}"
+            contents, tokens = self.make_data(contents, description=description)
+            expected = self.blacken(contents)
+            results = self.beautify(contents, tokens, filename=description)
             if results != expected:  # pragma: no cover
                 print('')
                 print(

--- a/leo/unittests/misc_tests/test_modes.py
+++ b/leo/unittests/misc_tests/test_modes.py
@@ -162,7 +162,7 @@ class TestModes(LeoUnitTest):
             r"'\xff'",  # Must begin with [0-7]
             r"'\u{7fhi}'",  # Invalid hex digits.
         )
-        for s  in error_table:
+        for s in error_table:
             kind, seq = rust_char(colorer, s, i=0)
             assert kind == 'literal4', kind
             assert seq == "'", repr(seq)

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3083,10 +3083,10 @@ class TestPython(BaseTestImporter):
         #        Designed to test find_end_of_block.
         s = '''
             class TracerCore:
-                
+
                 def start(self):
                     """Start this tracer."""
-                    
+
                 def stop(self):
                     """Stop this tracer."""
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,30 +66,40 @@ extend-ignore =
     
     # continuation line unaligned for hanging indent.
     E131
+    
+    # whitespace before ':'
+    # To do?
+    E203
 
     # whitespace before '['
-    # E211
+    E211
     
     # multiple spaces before operator
-    # E221
+    # Conflicts with extra spacing in @nobeautify nodes.
+    E221
     
     # multiple spaces after operator
-    # E222
+    # Conflicts with extra spacing in @nobeautify nodes.
+    E222
     
     # missing whitespace around operator
-    # E225
+    # To do?
+    E225
     
     # missing whitespace after ','
-    # E231
+    # To do?
+    E231
     
     # unexpected spaces around keyword / parameter equals
     E251
     
     # at least two spaces before inline comment
-    # E261
+    # To do?
+    E261
     
     # missing whitespace around parameter equals.
-    # E252
+    # To do?
+    E252
     
     # inline comment should start with '# '
     E262
@@ -101,10 +111,12 @@ extend-ignore =
     E266
     
     # multiple spaces before keyword
-    # E272
-    
+    # To do?
+    E272
+
     # missing whitespace after keyword.
-    # E275
+    # To do?
+    E275
     
     # trailing whitespace
     # E293
@@ -128,7 +140,7 @@ extend-ignore =
     E306
 
     # Line too long.
-    # E501
+    E501
     
     # global `whatever` is unused: name is never assigned in scope.
     # F824

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,8 +92,7 @@ extend-ignore =
     E251
 
     # at least two spaces before inline comment
-    # To do?
-    E261
+    # E261
 
     # missing whitespace around parameter equals.
     # To do?

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,28 +68,28 @@ extend-ignore =
     E131
 
     # whitespace before '['
-    E211
+    # E211
     
     # multiple spaces before operator
-    E221
+    # E221
     
     # multiple spaces after operator
-    E222
+    # E222
     
     # missing whitespace around operator
-    E225
+    # E225
     
     # missing whitespace after ','
-    E231
+    # E231
     
     # unexpected spaces around keyword / parameter equals
     E251
     
     # at least two spaces before inline comment
-    E261
+    # E261
     
     # missing whitespace around parameter equals.
-    E252
+    # E252
     
     # inline comment should start with '# '
     E262
@@ -101,10 +101,10 @@ extend-ignore =
     E266
     
     # multiple spaces before keyword
-    E272
+    # E272
     
     # missing whitespace after keyword.
-    E275
+    # E275
     
     # trailing whitespace
     # E293
@@ -116,7 +116,7 @@ extend-ignore =
     E302
     
     # whitespace before ':'
-    E203
+    # E203
     
     # too many blank lines (2)
     E303
@@ -128,7 +128,7 @@ extend-ignore =
     E306
 
     # Line too long.
-    E501
+    # E501
     
     # global `whatever` is unused: name is never assigned in scope.
     # F824

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,11 +68,11 @@ extend-ignore =
     E131
 
     # whitespace before ':'
-    # To do?
+    # Conflict between black and flake8?
     E203
 
     # whitespace before '['
-    E211
+    # E211
 
     # multiple spaces before operator
     # Conflicts with extra spacing in @nobeautify nodes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -107,11 +107,11 @@ extend-ignore =
     E266
 
     # multiple spaces before keyword
-    # To do?
+    # Interferes with @nobeautify
     E272
 
     # missing whitespace after keyword.
-    # To do?
+    # Interferes with @nobeautify. Also warns about assert(whatever)
     E275
 
     # trailing whitespace

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ extend-ignore =
     E131
 
     # whitespace before ':'
-    # Conflict between black and flake8?
+    # Conflict between black and flake8.
     E203
 
     # whitespace before '['
@@ -86,8 +86,7 @@ extend-ignore =
     # E225
 
     # missing whitespace after ','
-    # To do?
-    E231
+    # E231
 
     # unexpected spaces around keyword / parameter equals
     E251

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,8 +83,7 @@ extend-ignore =
     E222
 
     # missing whitespace around operator
-    # To do?
-    E225
+    # E225
 
     # missing whitespace after ','
     # To do?

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ extend-ignore =
     
     # Don't complain on every save. Let reindent handle this later.
     # blank line contains whitespace
-    W293
+    # W293
 
     # Harmless...
     

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,8 +95,7 @@ extend-ignore =
     # E261
 
     # missing whitespace around parameter equals.
-    # To do?
-    E252
+    # E252
 
     # inline comment should start with '# '
     E262

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,6 +105,9 @@ extend-ignore =
     
     # missing whitespace after keyword.
     E275
+    
+    # trailing whitespace
+    # E293
 
     # expected 1 blank line, found 0.
     E301
@@ -128,4 +131,4 @@ extend-ignore =
     E501
     
     # global `whatever` is unused: name is never assigned in scope.
-    F824
+    # F824

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,86 +30,86 @@ extend-ignore =
     # Don't check B020. It conflicts with Leo idioms like `for p in p.children():
     # Found for loop that reassigns the iterable it is iterating with each iterable value.
     B020
-    
+
     # Don't complain on every save. Let reindent handle this later.
     # blank line contains whitespace
     # W293
 
     # Harmless...
-    
+
     # expected an indented block (comment)
     E115
 
     # unexpected indentation (comment)
     E116
-    
+
     # over-indented (comment)
     E117
-    
+
     # continuation line over-indented for visual indent
     E127
-    
+
     # continuation line missing indentation or outdented.
     E122
-    
+
     # closing bracket does not match visual indentation.
     E124
-    
+
     # continuation line with same indent as next logical line
     E125
-    
+
     # continuation line under-indented for visual indent.
     E128
-    
+
     # visually indented line with same indent as next logical line
     E129
-    
+
     # continuation line unaligned for hanging indent.
     E131
-    
+
     # whitespace before ':'
     # To do?
     E203
 
     # whitespace before '['
     E211
-    
+
     # multiple spaces before operator
     # Conflicts with extra spacing in @nobeautify nodes.
     E221
-    
+
     # multiple spaces after operator
     # Conflicts with extra spacing in @nobeautify nodes.
     E222
-    
+
     # missing whitespace around operator
     # To do?
     E225
-    
+
     # missing whitespace after ','
     # To do?
     E231
-    
+
     # unexpected spaces around keyword / parameter equals
     E251
-    
+
     # at least two spaces before inline comment
     # To do?
     E261
-    
+
     # missing whitespace around parameter equals.
     # To do?
     E252
-    
+
     # inline comment should start with '# '
     E262
-    
+
     # block comment should start with '# '.
     E265
-    
+
     # too many leading '#' for block comment
     E266
-    
+
     # multiple spaces before keyword
     # To do?
     E272
@@ -117,30 +117,30 @@ extend-ignore =
     # missing whitespace after keyword.
     # To do?
     E275
-    
+
     # trailing whitespace
     # E293
 
     # expected 1 blank line, found 0.
     E301
-    
+
     # expected 2 blank lines, found 1.
     E302
-    
+
     # whitespace before ':'
     # E203
-    
+
     # too many blank lines (2)
     E303
-    
+
     # expected 2 blank lines after class or function definition, found 0.
     E305
-    
+
     # expected 1 blank line before a nested definition, found 0.
     E306
 
     # Line too long.
     E501
-    
+
     # global `whatever` is unused: name is never assigned in scope.
     # F824


### PR DESCRIPTION
See #4346. flake8 found these bugs.

**Notes**

- flake8 error E114 will warns about indented comments that are not multiples of four.
  The beautifier will *not* attempt fix this rare case; there is no way to determine what the author intended.
- Various *valid* flake8 errors arose from `@nobeautify` code.
  The valid complaints have been fixed. The others have been suppressed in various ways.

**Tasks**

- [x] `setup.cfg`: Enable various flake8 suppressions. They were previously marked with `# To do?".
- [x] Ensure exactly one blank between tokens. This fixes quirps in several files!
- [x] The beautifier now remove trailing ws. This cleans up many files!
- [x] Improve the formatting of comments, including a special case for `###` comments.
   This improvement affects many files, including npyscreen files.
- [x] Add `@nobeautify` directives to all npyscreen `@file` nodes.
- [x] Don't beautify any file containing the corresponding `#@@nobeautify` sentinels.
- [x] Fix a beautifier bug: retain space between ',' and '}'. Thank you @tbpassin!
- [x] Add various unit tests.
- [x] `beautify_all_leo.py`: beautify all files in `leo/external` (but all npyscreen files have `@nobeautify` directives).
- [x] Beautify all files.
- [x] Retest `--gui=console` option.