### PR TITLE
PR: beautify scripts

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1249,9 +1249,7 @@ class Commands:
         if beautify_flag and not script and not g.unitTesting:
             from leo.core.leoTokens import TokenBasedOrange
             tbo = TokenBasedOrange()
-            for p2 in script_p.self_and_subtree():
-                tbo.beautify_script_node(p2)
-            c.redraw(script_p)
+            tbo.beautify_script_tree(script_p)
 
         # Compute the script if necessary.
         if not script:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -628,6 +628,14 @@ class Commands:
                     repr(self.fixedWindowPosition))
         else:
             c.windowPosition = 500, 700, 50, 50  # width,height,left,top.
+    #@+node:ekr.20250508044308.1: *3* @cmd beautify-tree
+    @cmd('beautify-tree')
+    def beautify_tree_command(self, event: LeoKeyEvent = None) -> None:
+        """Undoably beautify c.p."""
+        c = self
+        from leo.core.leoTokens import TokenBasedOrange
+        tbo = TokenBasedOrange()
+        tbo.beautify_script_tree(c.p)
     #@+node:ekr.20210530065748.1: *3* @cmd c.execute-general-script
     @cmd('execute-general-script')
     def execute_general_script_command(self, event: LeoKeyEvent = None) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -631,7 +631,7 @@ class Commands:
     #@+node:ekr.20250508044308.1: *3* @cmd beautify-tree
     @cmd('beautify-tree')
     def beautify_tree_command(self, event: LeoKeyEvent = None) -> None:
-        """Undoably beautify c.p."""
+        """Undoably beautify c.p and its subtree."""
         c = self
         from leo.core.leoTokens import TokenBasedOrange
         tbo = TokenBasedOrange()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1230,7 +1230,7 @@ class Commands:
                 g.es_print(message, color='blue')
                 return None
         if runPyflakes:
-            run_pyflakes = c.config.getBool('run-pyflakes-on-write', default=False)
+            run_pyflakes = language == 'python' and c.config.getBool('run-pyflakes-on-write', default=False)
         else:
             run_pyflakes = False
         if not script:
@@ -1240,11 +1240,14 @@ class Commands:
         script_p = p or c.p  # Only for error reporting below.
 
         # #4350: Optionally beautify the script.
-        beautify = c.config.getBool('beautify-python-code-on-write', default=False)
+        beautify = language == 'python' and c.config.getBool('beautify-python-code-on-write', default=False)
         if beautify and not g.unitTesting:
             from leo.core.leoTokens import TokenBasedOrange
             tbo = TokenBasedOrange()
-            script = tbo.beautify_script(script)
+            script2 = tbo.beautify_script(script)
+            if script2 != script:
+                tbo.propagate_script_changes(script, script2, script_p)
+                script = script2
 
         # #532: Optionally check all scripts with pyflakes.
         if run_pyflakes and not g.unitTesting:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1238,7 +1238,15 @@ class Commands:
                 useSelectedText = False
             script = g.getScript(c, p, useSelectedText=useSelectedText)
         script_p = p or c.p  # Only for error reporting below.
-        # #532: check all scripts with pyflakes.
+
+        # #4350: Optionally beautify the script.
+        beautify = c.config.getBool('beautify-python-code-on-write', default=False)
+        if beautify and not g.unitTesting:
+            from leo.core.leoTokens import TokenBasedOrange
+            tbo = TokenBasedOrange()
+            script = tbo.beautify_script(script)
+
+        # #532: Optionally check all scripts with pyflakes.
         if run_pyflakes and not g.unitTesting:
             from leo.commands import checkerCommands as cc
             prefix = ('c,g,p,script_gnx=None,None,None,None;'

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -915,13 +915,13 @@ class TokenBasedOrange:  # Orange is the new Black.
             return False
         results_s: str = self.beautify(contents_s, self.filename, tokens)
 
-        # Part 2: Undo replacements.
+        # Part 3: Undo replacements.
         body_lines: list[str] = g.splitLines(p.b)
         results: list[str] = g.splitLines(results_s)
         for i in indices:
             results[i] = body_lines[i]
 
-        # Update the body if necessary.
+        # Part 4: Update the body if necessary.
         new_body = ''.join(results)
         changed = p.b.rstrip() != new_body.rstrip()
         if changed:

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -889,6 +889,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         at_others_pat = re.compile(r'(\s*)\@others(.*)')
         section_ref_pat = re.compile(r'(\s*)\<\<(.+)\>\>(.*)')
         nobeautify_pat = re.compile(r'(\s*)\@nobeautify(.*)')
+        trailing_ws_pat = re.compile(r'(.*)#(.*)')
 
         # Part 1: Replace @others and section references with 'pass'
         #         This hack is valid!
@@ -915,11 +916,14 @@ class TokenBasedOrange:  # Orange is the new Black.
             return False
         results_s: str = self.beautify(contents_s, self.filename, tokens)
 
-        # Part 3: Undo replacements.
+        # Part 3: Undo replacements, regularize comments and clean trailing ws.
         body_lines: list[str] = g.splitLines(p.b)
         results: list[str] = g.splitLines(results_s)
         for i in indices:
-            results[i] = body_lines[i].rstrip() + '\n'  # Clean trailing ws.
+            old_line = body_lines[i]
+            if m := trailing_ws_pat.match(old_line):
+                old_line = f"{m.group(1).rstrip()}  #{m.group(2)}"
+            results[i] = old_line.rstrip() + '\n'
 
         # Part 4: Update the body if necessary.
         new_body = ''.join(results)

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -879,7 +879,8 @@ class TokenBasedOrange:  # Orange is the new Black.
         if n_changed:
             u.afterChangeGroup(root, undoType)
             c.redraw(root)
-            g.es_print(f"Beautified {n_changed} node{g.plural(n_changed)}")
+            if not g.unitTesting:
+                g.es_print(f"Beautified {n_changed} node{g.plural(n_changed)}")
     #@+node:ekr.20250508030747.1: *6* tbo.beautify_script_node
     def beautify_script_node(self, p: Position) -> bool:
         """Beautify a single node"""
@@ -890,6 +891,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         nobeautify_pat = re.compile(r'(\s*)\@nobeautify(.*)')
 
         # Part 1: Replace @others and section references with 'pass'
+        #         This hack is valid!
         indices: list[int] = []  # Indices of replaced lines.
         contents: list[str] = []  # Contents after replacements.
         for i, s in enumerate(g.splitLines(p.b)):
@@ -923,8 +925,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         new_body = ''.join(results)
         changed = p.b.rstrip() != new_body.rstrip()
         if changed:
-            # g.printObj(p.b, tag=f"Old body: {p.h}")
-            # g.printObj(new_body, tag=f"New body: {p.h}")
             p.b = new_body
         return changed
     #@+node:ekr.20240105145241.8: *5* tbo.init_tokens_from_file

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -860,7 +860,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         if self.write:  # --write.
             self.write_file(filename, results)
         return True
-    #@+node:ekr.20250507130940.1: *5* tbo.beautify_script (entry) NEW
+    #@+node:ekr.20250507130940.1: *5* tbo.beautify_script (entry)
     def beautify_script(self, contents: str) -> str:
         if not contents:
             return ''
@@ -1786,7 +1786,7 @@ class TokenBasedOrange:  # Orange is the new Black.
     #@-others
 #@-others
 
-if __name__ == '__main__':  ### or 'leoTokens' in __name__:
+if __name__ == '__main__':
     main()  # pragma: no cover
 
 #@@language python

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -860,6 +860,21 @@ class TokenBasedOrange:  # Orange is the new Black.
         if self.write:  # --write.
             self.write_file(filename, results)
         return True
+    #@+node:ekr.20250507130940.1: *5* tbo.beautify_script (entry) NEW
+    def beautify_script(self, contents: str) -> str:
+        if not contents:
+            return ''
+        if self.nobeautify_sentinel_pat.search(contents):
+            return contents  # Honor @nobeautify sentinel within the file.
+        g.printObj(contents, tag='beautify_script: Contents')
+        self.indent_level = 0
+        self.filename = 'execute-script'
+        tokens = Tokenizer().make_input_tokens(contents)
+        if not tokens:
+            return contents  # Not an error.
+        results = self.beautify(contents, self.filename, tokens)
+        g.printObj(results, tag='beautify_script: Results')
+        return results
     #@+node:ekr.20240105145241.8: *5* tbo.init_tokens_from_file
     def init_tokens_from_file(self, filename: str) -> tuple[
         str, list[InputToken]
@@ -1771,7 +1786,7 @@ class TokenBasedOrange:  # Orange is the new Black.
     #@-others
 #@-others
 
-if __name__ == '__main__' or 'leoTokens' in __name__:
+if __name__ == '__main__':  ### or 'leoTokens' in __name__:
     main()  # pragma: no cover
 
 #@@language python

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -867,13 +867,19 @@ class TokenBasedOrange:  # Orange is the new Black.
     def beautify_script_tree(self, root: Position) -> None:
         """Undoably beautify root's entire tree."""
         c = root.v.context
-        changed = False
+        u, undoType = c.undoer, 'beautify-script'
+        u.beforeChangeGroup(c.p, undoType)
+        n_changed = 0
         for p in root.self_and_subtree():
-            changed2 = self.beautify_script_node(p)
-            if changed2:
-                changed = True
-        if changed:
+            bunch = u.beforeChangeNodeContents(p)
+            changed = self.beautify_script_node(p)
+            if changed:
+                n_changed += 1
+                u.afterChangeNodeContents(p, undoType, bunch)
+        if n_changed:
+            u.afterChangeGroup(root, undoType)
             c.redraw(root)
+            g.es_print(f"Beautified {n_changed} node{g.plural(n_changed)}")
     #@+node:ekr.20250508030747.1: *6* tbo.beautify_script_node
     def beautify_script_node(self, p: Position) -> bool:
         """Beautify a single node"""

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -919,7 +919,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         body_lines: list[str] = g.splitLines(p.b)
         results: list[str] = g.splitLines(results_s)
         for i in indices:
-            results[i] = body_lines[i]
+            results[i] = body_lines[i].rstrip() + '\n'  # Clean trailing ws.
 
         # Part 4: Update the body if necessary.
         new_body = ''.join(results)

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -872,8 +872,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         section_ref_pat = re.compile(r'(\s*)\<\<(.+)\>\>(.*)')
         nobeautify_pat = re.compile(r'(\s*)\@nobeautify(.*)')
 
-        # g.printObj(p.b, tag=f"Body: {p.h}")
-
         # Part 1: Replace @others and section references with 'pass'
         indices: list[int] = []  # Indices of replaced lines.
         contents: list[str] = []  # Contents after replacements.
@@ -889,19 +887,14 @@ class TokenBasedOrange:  # Orange is the new Black.
             else:
                 contents.append(s)
 
-        # g.printObj(contents, tag=f"Contents: {p.h}")
-        # g.printObj(indices, tag=f"Indices: {p.h}")
-
         # Part 2: Beautify.
         self.indent_level = 0
         self.filename = 'beautify-script'
         contents_s = ''.join(contents)
         tokens = Tokenizer().make_input_tokens(contents_s)
         if not tokens:
-            return  # Not an error.
+            return
         results_s: str = self.beautify(contents_s, self.filename, tokens)
-
-        # g.printObj(results_s, tag=f"Raw results: {p.h}")
 
         # Part 2: Undo replacements.
         body_lines: list[str] = g.splitLines(p.b)
@@ -909,10 +902,11 @@ class TokenBasedOrange:  # Orange is the new Black.
         for i in indices:
             results[i] = body_lines[i]
 
+        # Update the body if necessary.
         new_body = ''.join(results)
-        if p.b != new_body:
-            # g.printObj(results, tag=f"Results: {p.h}")
-            print(f"Beautify: {p.h}")
+        if p.b.rstrip() != new_body.rstrip():
+            g.printObj(p.b, tag=f"Old body: {p.h}")
+            g.printObj(results, tag=f"New body: {p.h}")
             p.b = new_body
     #@+node:ekr.20240105145241.8: *5* tbo.init_tokens_from_file
     def init_tokens_from_file(self, filename: str) -> tuple[

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -863,7 +863,7 @@ class TokenBasedOrange:  # Orange is the new Black.
         if self.write:  # --write.
             self.write_file(filename, results)
         return True
-    #@+node:ekr.20250508041634.1: *5* tbo.beautify_script (entry) and helper
+    #@+node:ekr.20250508041634.1: *5* tbo.beautify_script_tree (entry) and helper
     def beautify_script_tree(self, root: Position) -> None:
         """Undoably beautify root's entire tree."""
         c = root.v.context

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -886,7 +886,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         """Beautify a single node"""
 
         # Patterns for lines that must be replaced.
-        at_others_pat = re.compile(r'(\s*)\@others(.*)')
         section_ref_pat = re.compile(r'(\s*)\<\<(.+)\>\>(.*)')
         nobeautify_pat = re.compile(r'(\s*)\@nobeautify(.*)')
         trailing_ws_pat = re.compile(r'(.*)#(.*)')
@@ -897,9 +896,6 @@ class TokenBasedOrange:  # Orange is the new Black.
         contents: list[str] = []  # Contents after replacements.
         for i, s in enumerate(g.splitLines(p.b)):
             if m := section_ref_pat.match(s):
-                contents.append(f"{m.group(1)}pass\n")
-                indices.append(i)
-            elif m := at_others_pat.match(s):
                 contents.append(f"{m.group(1)}pass\n")
                 indices.append(i)
             elif m := nobeautify_pat.match(s):

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -30,16 +30,17 @@ args = '--all --beautified --write --report'
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
+# Use -m so that __name__ == '__main__'.
 for command in [
-    f'{python} -c "import leo.core.leoTokens" {args} leo/commands',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/core',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/external',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/plugins',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/scripts',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/modes',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/unittests/commands',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/unittests/plugins',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/unittests/misc_tests',
+    f'{python} -m "leo.core.leoTokens" {args} leo/commands',
+    f'{python} -m "leo.core.leoTokens" {args} leo/core',
+    f'{python} -m "leo.core.leoTokens" {args} leo/external',
+    f'{python} -m "leo.core.leoTokens" {args} leo/plugins',
+    f'{python} -m "leo.core.leoTokens" {args} leo/scripts',
+    f'{python} -m "leo.core.leoTokens" {args} leo/modes',
+    f'{python} -m "leo.core.leoTokens" {args} leo/unittests/commands',
+    f'{python} -m "leo.core.leoTokens" {args} leo/unittests/plugins',
+    f'{python} -m "leo.core.leoTokens" {args} leo/unittests/misc_tests',
 ]:
     subprocess.Popen(command, shell=True).communicate()
 #@-leo

--- a/leo/scripts/beautify_leo.py
+++ b/leo/scripts/beautify_leo.py
@@ -30,15 +30,16 @@ args = '--beautified --write'
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
+# Use -m so that __name__ == '__main__'.
 for command in [
-    f'{python} -c "import leo.core.leoTokens" {args} leo/commands',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/core',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/scripts',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/plugins',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/modes',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/unittests/commands',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/unittests/plugins',
-    f'{python} -c "import leo.core.leoTokens" {args} leo/unittests/misc_tests',
+    f'{python} -m "leo.core.leoTokens" {args} leo/commands',
+    f'{python} -m "leo.core.leoTokens" {args} leo/core',
+    f'{python} -m "leo.core.leoTokens" {args} leo/scripts',
+    f'{python} -m "leo.core.leoTokens" {args} leo/plugins',
+    f'{python} -m "leo.core.leoTokens" {args} leo/modes',
+    f'{python} -m "leo.core.leoTokens" {args} leo/unittests/commands',
+    f'{python} -m "leo.core.leoTokens" {args} leo/unittests/plugins',
+    f'{python} -m "leo.core.leoTokens" {args} leo/unittests/misc_tests',
 ]:
     subprocess.Popen(command, shell=True).communicate()
 #@-leo


### PR DESCRIPTION
See #4350.

- [x] `leoTokens.py`: call `main` function only if `__name__ == '__main__'`.
- [x] Use `python -m leo.core.leoTokens` in beautifier scripts.  Required.
- [x] Add `tbo.beautify_script_tree` and its helper, `tbo.beautify_script_node`.
- [x] Add `beautify-tree` command.

**Aha: `tbo.beautify_script_node` is sound**

A hack: `tbo.beautify_script_node` translates section refs to `pass` statements.
The hacks exists because section references might have names that Python's tokenizer won't accept.

This hack is sound because section references must appear on a line of their own:
```python
if <<a test >>:   syntax error!
   whatever
if (  # Valid
    << a test >>
):
    whatever
```
As a result, the inserted `pass` statement should yield valid tokens. But  Leo's beautifier uses only tokens, so all should be well.

**Notes**

- Automatic beautification of scripts is undoable. So is the `beautify-tree` command.
- Unit tests of this code would be tricky. I'll add a unit test only if bugs are reported later.