### PR TITLE
PR for #4355: Print warning unless root is an @file or @clean node

### DIFF
--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -53,6 +53,11 @@ class GoToCommands:
         root, fileName = self.find_root(p)
         if not root:
             return self.find_script_line(n, p)
+        # Step 0: goto-global-line works only for @file and @clean nodes.
+        if not any((root.isAtCleanNode(), root.isAtCleanNode())):
+            # #4355: Print a warning once.
+            g.es_print_unique_message('goto-global-line works only for @file and @clean')
+            return None, -1
         # Step 1: Get the lines of external files *with* sentinels,
         #         even if the actual external file actually contains no sentinels.
         sentinels = root.isAtFileNode()


### PR DESCRIPTION
See #4355.

An edge case: The code warns on the deprecated `@thin` spelling. Probably LeoJS doesn't support `@thin`, so this edge case is especially minor.