### PR TITLE
PR 2 for goto-global-line

### DIFF
--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -55,6 +55,9 @@ class GoToCommands:
             return self.find_script_line(n, p)
         # Step 0: goto-global-line works only for @file and @clean nodes.
         if not any((root.isAtCleanNode(), root.isAtCleanNode())):
+            # Support the special case used by g.findGnx.
+            if p and n == 0:
+                return p, 0
             # #4355: Print a warning once.
             g.es_print_unique_message('goto-global-line works only for @file and @clean')
             return None, -1

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -54,11 +54,11 @@ class GoToCommands:
         if not root:
             return self.find_script_line(n, p)
         # Step 0: goto-global-line works only for @file, @edit, @clean, and 'single' @asis nodes.
-        invalid = (
+        valid = (
             root.isAtCleanNode() or root.isAtEditNode() or root.isAtFileNode()
-            or (root.isAtAsisFileNode() and len(root.v.children) > 0)
+            or (root.isAtAsisFileNode() and len(root.v.children) == 0)
         )
-        if invalid:
+        if not valid:
             # Support the special case used by g.findGnx.
             if p and n == 0:
                 return p, 0

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -60,7 +60,9 @@ class GoToCommands:
                 return p, 0
             # #4355: Print a warning once.
             if not g.unitTesting:
-                g.es_print_unique_message('goto-global-line works only for @file and @clean')
+                g.es_print_unique_message(
+                    'goto-global-line works only for @file, @clean, @edit and single @asis nodes'
+                )
             return None, -1
         # Step 1: Get the lines of external files *with* sentinels,
         #         even if the actual external file actually contains no sentinels.

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -53,8 +53,12 @@ class GoToCommands:
         root, fileName = self.find_root(p)
         if not root:
             return self.find_script_line(n, p)
-        # Step 0: goto-global-line works only for @file and @clean nodes.
-        if not any((root.isAtCleanNode(), root.isAtFileNode())):
+        # Step 0: goto-global-line works only for @file, @edit, @clean, and 'single' @asis nodes.
+        invalid = (
+            root.isAtCleanNode() or root.isAtEditNode() or root.isAtFileNode()
+            or (root.isAtAsisFileNode() and len(root.v.children) > 0)
+        )
+        if invalid:
             # Support the special case used by g.findGnx.
             if p and n == 0:
                 return p, 0

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -54,7 +54,7 @@ class GoToCommands:
         if not root:
             return self.find_script_line(n, p)
         # Step 0: goto-global-line works only for @file and @clean nodes.
-        if not any((root.isAtCleanNode(), root.isAtCleanNode())):
+        if not any((root.isAtCleanNode(), root.isAtFileNode())):
             # Support the special case used by g.findGnx.
             if p and n == 0:
                 return p, 0

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -104,10 +104,9 @@ class TestGotoCommands(LeoUnitTest):
             for i, clean_line in enumerate(clean_contents):
                 p, offset = x.find_file_line(i)
                 assert offset is not None, repr(p)
-                if offset == -1:  # PR #4360.
-                    continue
-                assert offset >= 0, (offset, repr(p))
+                assert offset > 0, (offset, repr(p))
                 line = g.splitLines(p.b)[offset - 1]
+
                 # g.trace(f"{i:>2} {offset} {p.h:20} {line!r}")
                 if p.h.startswith('@clean'):
                     if offset == 1:
@@ -135,10 +134,8 @@ class TestGotoCommands(LeoUnitTest):
 
                 # Test goto-global-line.
                 goto_p, goto_offset = x.find_file_line(global_i)
-                if not goto_p:
-                    continue
                 assert p.h == goto_p.h, (p, goto_p)
-                assert goto_offset >= 0, repr(p)
+                assert goto_offset == 1, repr(p)
 
                 # Update global_i.
                 if p == root:

--- a/leo/unittests/commands/test_gotoCommands.py
+++ b/leo/unittests/commands/test_gotoCommands.py
@@ -104,9 +104,10 @@ class TestGotoCommands(LeoUnitTest):
             for i, clean_line in enumerate(clean_contents):
                 p, offset = x.find_file_line(i)
                 assert offset is not None, repr(p)
-                assert offset > 0, (offset, repr(p))
+                if offset == -1:  # PR #4360.
+                    continue
+                assert offset >= 0, (offset, repr(p))
                 line = g.splitLines(p.b)[offset - 1]
-
                 # g.trace(f"{i:>2} {offset} {p.h:20} {line!r}")
                 if p.h.startswith('@clean'):
                     if offset == 1:
@@ -134,8 +135,10 @@ class TestGotoCommands(LeoUnitTest):
 
                 # Test goto-global-line.
                 goto_p, goto_offset = x.find_file_line(global_i)
+                if not goto_p:
+                    continue
                 assert p.h == goto_p.h, (p, goto_p)
-                assert goto_offset == 1, repr(p)
+                assert goto_offset >= 0, repr(p)
 
                 # Update global_i.
                 if p == root:


### PR DESCRIPTION
See #4355 and PR #4359.

Last-minute testing of PR #4359 revealed a special case that should be valid for all kinds of `@<file>` nodes.

- [x] Add another special case to goto.find_file_line_helper.