### PR TITLE
PR for #4356: relative imports

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -248,7 +248,7 @@ def import_txt_file(c: Cmdr, fn: str) -> None:
     g.setGlobalOpenDir(fn)
     undoData = u.beforeInsertNode(c.p)
     p = c.p.insertAfter()
-    p.h = f"@edit {fn}"
+    p.h = f"@edit {c.relativeDirectory(fn)}"
     s, e = g.readFileIntoString(fn, kind='@edit')
     p.b = s
     u.afterInsertNode(p, 'Import', undoData)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2729,6 +2729,12 @@ class Commands:
         c = self
         path = c.getPath(p)
         return g.finalize_join(path, p.anyAtFileNodeName())
+    #@+node:ekr.20250616161500.1: *4* c.relativeDirectory
+    def relativeDirectory(self, path: str) -> str:
+        """Return the path relative this outline, or the full, absolute path."""
+        c = self
+        baseDir = os.path.dirname(c.fileName())
+        return g.relativeDirectory(baseDir, path)
     #@+node:ekr.20171123135625.39: *4* c.getTime
     def getTime(self, body: bool = True) -> str:
         c = self

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2731,7 +2731,7 @@ class Commands:
         return g.finalize_join(path, p.anyAtFileNodeName())
     #@+node:ekr.20250616161500.1: *4* c.relativeDirectory
     def relativeDirectory(self, path: str) -> str:
-        """Return the path relative this outline, or the full, absolute path."""
+        """Return the path relative to this outline, or the full, absolute path."""
         c = self
         baseDir = os.path.dirname(c.fileName())
         return g.relativeDirectory(baseDir, path)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3310,7 +3310,12 @@ def readlineForceUnixNewline(f: IO, fileName: Optional[str] = None) -> str:
     return s
 #@+node:ekr.20250615134309.1: *3* g.relativeDirectory
 def relativeDirectory(baseDir: str, path: str) -> str:
-    """Return the path relative to the base directory, or the full, absolute path."""
+    """
+    Return the path relative to the base directory.
+    Return path if baseDir is not an ancestor of path."""
+    if not baseDir:
+        # Likely an unsaved outline.
+        return path
     if g.isWindows:
         baseDir = baseDir.lower()
         path = path.lower()
@@ -3319,8 +3324,10 @@ def relativeDirectory(baseDir: str, path: str) -> str:
         if rel_path:
             return rel_path
     except ValueError:
-        pass  # Windows throws ValueError if the drives are different.
-    return os.path.abspath(os.path.normpath(path))
+        # Windows throws ValueError if the drives are different.
+        if not g.unitTesting:
+            g.es_print(f"{baseDir} and {path} are on different drives")
+    return path
 #@+node:ekr.20031218072017.3124: *3* g.sanitize_filename
 def sanitize_filename(s: str) -> str:
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3319,11 +3319,8 @@ def relativeDirectory(baseDir: str, path: str) -> str:
         if rel_path:
             return rel_path
     except ValueError:
-        pass
+        pass  # Windows throws ValueError if the drives are different.
     return os.path.abspath(os.path.normpath(path))
-        
-    
-   
 #@+node:ekr.20031218072017.3124: *3* g.sanitize_filename
 def sanitize_filename(s: str) -> str:
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3308,6 +3308,22 @@ def readlineForceUnixNewline(f: IO, fileName: Optional[str] = None) -> str:
     if len(s) >= 2 and s[-2] == "\r" and s[-1] == "\n":
         s = s[0:-2] + "\n"
     return s
+#@+node:ekr.20250615134309.1: *3* g.relativeDirectory
+def relativeDirectory(baseDir: str, path: str) -> str:
+    """Return the path relative to the base directory, or the full, absolute path."""
+    if g.isWindows:
+        baseDir = baseDir.lower()
+        path = path.lower()
+    try:
+        rel_path = os.path.relpath(path, start=baseDir)
+        if rel_path:
+            return rel_path
+    except ValueError:
+        pass
+    return os.path.abspath(os.path.normpath(path))
+        
+    
+   
 #@+node:ekr.20031218072017.3124: *3* g.sanitize_filename
 def sanitize_filename(s: str) -> str:
     """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -3311,11 +3311,25 @@ def readlineForceUnixNewline(f: IO, fileName: Optional[str] = None) -> str:
 #@+node:ekr.20250615134309.1: *3* g.relativeDirectory
 def relativeDirectory(baseDir: str, path: str) -> str:
     """
-    Return the path relative to the base directory.
-    Return path if baseDir is not an ancestor of path."""
+    'path' should be an absolute path.
+    Return 'path' relative to the base directory.
+    Return 'path' if 'baseDir' is not an ancestor of 'path'.
+    """
+
+    def oops(message: str) -> None:
+        if not g.unitTesting:
+            g.es_print(f"g.relativeDirectory: {message}")
+
+    if not path:
+        oops(f"{path!r} should be an absolute path")
+        return path
+
     if not baseDir:
         # Likely an unsaved outline.
+        if not g.unitTesting:
+            g.es_print_unique_message('Save this outline to use relative import paths')
         return path
+
     if g.isWindows:
         baseDir = baseDir.lower()
         path = path.lower()
@@ -3325,8 +3339,7 @@ def relativeDirectory(baseDir: str, path: str) -> str:
             return rel_path
     except ValueError:
         # Windows throws ValueError if the drives are different.
-        if not g.unitTesting:
-            g.es_print(f"{baseDir} and {path} are on different drives")
+        oops(f"{baseDir} and {path} are on different drives")
     return path
 #@+node:ekr.20031218072017.3124: *3* g.sanitize_filename
 def sanitize_filename(s: str) -> str:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -839,14 +839,14 @@ class LeoImportCommands:
             p.setDirty()
             c.setChanged()
         c.redraw(current)
-    #@+node:ekr.20031218072017.3225: *5* createOutlineFromWeb
+    #@+node:ekr.20031218072017.3225: *5* ic.createOutlineFromWeb
     def createOutlineFromWeb(self, path: str, parent: Position) -> Position:
         c = self.c
         u = c.undoer
         junk, fileName = g.os_path_split(path)
         undoData = u.beforeInsertNode(parent)
         # Create the top-level headline.
-        p = parent.insertAsLastChild()
+        p = parent.insertAfter()
         p.initHeadString(fileName)
         if self.webType == "cweb":
             self.setBodyString(p, "@ignore\n@language cweb")
@@ -854,7 +854,7 @@ class LeoImportCommands:
         self.scanWebFile(path, p)
         u.afterInsertNode(p, 'Import', undoData)
         return p
-    #@+node:ekr.20031218072017.3227: *5* findFunctionDef
+    #@+node:ekr.20031218072017.3227: *5* ic.findFunctionDef
     def findFunctionDef(self, s: str, i: int) -> Optional[str]:
         # Look at the next non-blank line for a function name.
         i = g.skip_ws_and_nl(s, i)
@@ -872,7 +872,7 @@ class LeoImportCommands:
             else:
                 i += 1
         return None
-    #@+node:ekr.20031218072017.3228: *5* scanBodyForHeadline
+    #@+node:ekr.20031218072017.3228: *5* ic.scanBodyForHeadline
     #@+at This method returns the proper headline text.
     # 1. If s contains a section def, return the section ref.
     # 2. cweb only: if s contains @c, return the function name following the @c.
@@ -933,7 +933,7 @@ class LeoImportCommands:
                 i = g.skip_line(s, i)
             #@-<< scan noweb body for headline >>
         return "@"  # default.
-    #@+node:ekr.20031218072017.3231: *5* scanWebFile (handles limbo)
+    #@+node:ekr.20031218072017.3231: *5* ic.scanWebFile (handles limbo)
     def scanWebFile(self, fileName: str, parent: Position) -> None:
         theType = self.webType
         lb = "@<" if theType == "cweb" else "<<"
@@ -1057,8 +1057,8 @@ class LeoImportCommands:
             self.createHeadline(parent, body, headline)
             #@-<< Create a node for the next module >>
             assert i > outer_progress
-    #@+node:ekr.20031218072017.3236: *5* Symbol table
-    #@+node:ekr.20031218072017.3237: *6* cstCanonicalize
+    #@+node:ekr.20031218072017.3236: *5* ic: Symbol table
+    #@+node:ekr.20031218072017.3237: *6* ic.cstCanonicalize
     # We canonicalize strings before looking them up,
     # but strings are entered in the form they are first encountered.
 
@@ -1068,13 +1068,13 @@ class LeoImportCommands:
         s = s.replace("\t", " ").replace("\r", "")
         s = s.replace("\n", " ").replace("  ", " ")
         return s.strip()
-    #@+node:ekr.20031218072017.3238: *6* cstDump
+    #@+node:ekr.20031218072017.3238: *6* ic.cstDump
     def cstDump(self) -> str:
         s = "Web Symbol Table...\n\n"
         for name in sorted(self.web_st):
             s += name + "\n"
         return s
-    #@+node:ekr.20031218072017.3239: *6* cstEnter
+    #@+node:ekr.20031218072017.3239: *6* ic.cstEnter
     # We only enter the section name into the symbol table if the ... convention is not used.
 
     def cstEnter(self, s: str) -> None:
@@ -1089,7 +1089,7 @@ class LeoImportCommands:
             if name.lower() == lower:
                 return
         self.web_st.append(upper)
-    #@+node:ekr.20031218072017.3240: *6* cstLookup
+    #@+node:ekr.20031218072017.3240: *6* ic.cstLookup
     # This method returns a string if the indicated string is a prefix of an entry in the web_st.
 
     def cstLookup(self, target: str) -> str:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -769,6 +769,7 @@ class LeoImportCommands:
                 # Leo 5.6: Handle undo here, not in createOutline.
                 undoData = u.beforeInsertNode(parent)
                 p = parent.insertAsLastChild()
+                fn = c.relativeDirectory(fn)
                 p.h = f"{treeType} {fn}"
                 u.afterInsertNode(p, 'Import', undoData)
                 p = self.createOutline(parent=p)
@@ -1675,6 +1676,7 @@ class RecursiveImportController:
         self.n_files += 1
         if self.kind == '@edit':
             p = parent.insertAsLastChild()
+            path = c.relativeDirectory(path)
             p.v.h = '@edit ' + path.replace('\\', '/')
             s, e = g.readFileIntoString(path, kind=self.kind)
             p.v.b = s

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -703,6 +703,9 @@ class TestGlobals(LeoUnitTest):
             ('c:\\Users\\ekr', 'c:\\Users\\ekr\\test4.py', 'test4.py'),
             ('c:\\Users\\ekr', 'c:\\Users\\user2\\test5.py', '..\\user2\\test5.py'),
             ('c:\\Users\\ekr', 'd:\\Users\\ekr\\test6.py', 'd:\\users\\ekr\\test6.py'),
+            # Unsaved outlines.
+            ('', '/home/test7.py', '/home/test7.py'),
+            ('', 'c:\\Users\\ekr\\test8.py', 'c:\\Users\\ekr\\test8.py'),
         )
         for base, fn, expected in table:
             actual = g.relativeDirectory(base, fn)

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -691,6 +691,22 @@ class TestGlobals(LeoUnitTest):
         if 0:
             print(path12, g.os.path.abspath(path12))
             print(path13, g.os.path.abspath(path13))
+    #@+node:ekr.20250616080611.1: *4* TestGlobals.test_g_relativeDirectory
+    def test_g_relativeDirectory(self):
+
+        table = (
+            # Linux tests.
+            ('/home', '/home/test1.py', 'test1.py'),
+            ('/home/folder1', '/home/folder1/test2.py', 'test2.py'),
+            ('/home/folder1', '/home/folder2/test3.py', '..\\folder2\\test3.py'),
+            # Windows tests: g.relativeDirectory lowers all results.
+            ('c:\\Users\\ekr', 'c:\\Users\\ekr\\test4.py', 'test4.py'),
+            ('c:\\Users\\ekr', 'c:\\Users\\user2\\test5.py', '..\\user2\\test5.py'),
+            ('c:\\Users\\ekr', 'd:\\Users\\ekr\\test6.py', 'd:\\users\\ekr\\test6.py'),
+        )
+        for base, fn, expected in table:
+            actual = g.relativeDirectory(base, fn)
+            self.assertEqual(actual, expected)
     #@+node:ekr.20210905203541.28: *4* TestGlobals.test_g_removeBlankLines
     def test_g_removeBlankLines(self):
         for s, expected in (
@@ -699,23 +715,6 @@ class TestGlobals(LeoUnitTest):
             (' \t \n\n  \n c\n\t\n', ' c\n'),
         ):
             result = g.removeBlankLines(s)
-            self.assertEqual(result, expected, msg=repr(s))
-    #@+node:ekr.20250113053113.1: *4* TestGlobals.test_g_splitLinesAtNewline
-    def test_g_splitLinesAtNewline(self):
-        for s, expected in (
-            (None, []),
-            ('', []),
-            (' ', [' ']),
-            ('\t', ['\t']),
-            (' a', [' a']),
-            ('\t b', ['\t b']),
-            ('a\nb', ['a\n', 'b']),
-            ('a\nb\n', ['a\n', 'b\n']),
-            ('\n  \n\nb\n', ['\n', '  \n', '\n', 'b\n']),
-            ('\fa\n', ['\fa\n']),
-            ('c\fd', ['c\fd']),
-        ):
-            result = g.splitLinesAtNewline(s)
             self.assertEqual(result, expected, msg=repr(s))
     #@+node:ekr.20210905203541.30: *4* TestGlobals.test_g_removeLeadingBlankLines
     def test_g_removeLeadingBlankLines(self):
@@ -831,6 +830,23 @@ class TestGlobals(LeoUnitTest):
             for i, result in table:
                 j = g.skip_to_start_of_line(s, i)
                 self.assertEqual(j, result, msg=i)
+    #@+node:ekr.20250113053113.1: *4* TestGlobals.test_g_splitLinesAtNewline
+    def test_g_splitLinesAtNewline(self):
+        for s, expected in (
+            (None, []),
+            ('', []),
+            (' ', [' ']),
+            ('\t', ['\t']),
+            (' a', [' a']),
+            ('\t b', ['\t b']),
+            ('a\nb', ['a\n', 'b']),
+            ('a\nb\n', ['a\n', 'b\n']),
+            ('\n  \n\nb\n', ['\n', '  \n', '\n', 'b\n']),
+            ('\fa\n', ['\fa\n']),
+            ('c\fd', ['c\fd']),
+        ):
+            result = g.splitLinesAtNewline(s)
+            self.assertEqual(result, expected, msg=repr(s))
     #@+node:ekr.20210905203541.54: *4* TestGlobals.test_g_splitLongFileName
     def test_g_splitLongFileName(self):
         table = (


### PR DESCRIPTION
See #4356.

- [x] Add `g.relativeDirectory` and corresponding unit test.
- [x] Add `c.relativeDirectory`.
- [x] Call `c.relativeDirectory` from the import logic.
- [x] Test `c.relativeDirectory` by hand. Creating an actual unit test would be tricky.