### PR TITLE
Change getPath's default to homeDir for unsaved Leo files.

### DIFF
--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1761,7 +1761,7 @@ class Commands:
                 paths.append(path)
 
         # Add absbase and reverse the list.
-        absbase = g.os_path_dirname(c.fileName()) if c.fileName() else os.getcwd()
+        absbase = g.os_path_dirname(c.fileName()) if c.fileName() else g.app.homeDir
         paths.append(absbase)
         paths.reverse()
 


### PR DESCRIPTION
Fixes #4368