### PR TITLE
PR for #4377: binding legends

### DIFF
--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1922,7 +1922,7 @@ class LoadManager:
             g.es(f"{kind:>10}:", os.path.normpath(theDir), color='blue')
     #@+node:ekr.20120215062153.10740: *3* LM.Settings
     #@+node:ekr.20120130101219.10182: *4* LM.computeBindingLetter
-    def computeBindingLetter(self, c: Cmdr, path: str, scope: str) -> str:
+    def computeBindingLetter(self, c: Cmdr, path: str) -> str:
         lm = self
         if not path:
             return 'D'
@@ -1939,7 +1939,7 @@ class LoadManager:
             return 'T'
         tag = 'register-command:'
         if path.startswith(tag):
-            return self.computeBindingLetter(c, path=path[len(tag) :], scope=scope)
+            return self.computeBindingLetter(c, path=path[len(tag) :])
         if path.endswith('-mode'):
             return '@'
         return 'D'

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -1922,7 +1922,7 @@ class LoadManager:
             g.es(f"{kind:>10}:", os.path.normpath(theDir), color='blue')
     #@+node:ekr.20120215062153.10740: *3* LM.Settings
     #@+node:ekr.20120130101219.10182: *4* LM.computeBindingLetter
-    def computeBindingLetter(self, c: Cmdr, path: str) -> str:
+    def computeBindingLetter(self, c: Cmdr, path: str, scope: str) -> str:
         lm = self
         if not path:
             return 'D'
@@ -1939,7 +1939,7 @@ class LoadManager:
             return 'T'
         tag = 'register-command:'
         if path.startswith(tag):
-            return self.computeBindingLetter(c, path=path[len(tag) :])
+            return self.computeBindingLetter(c, path=path[len(tag) :], scope=scope)
         if path.endswith('-mode'):
             return '@'
         return 'D'

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1107,7 +1107,7 @@ class ActiveSettingsOutline:
                     val = c.config.settingsDict.get(key)
                     if isinstance(val, g.GeneralSetting):
                         # Use self.c, not self.commander.
-                        letter = lm.computeBindingLetter(self.c, val.path, scope=None)
+                        letter = lm.computeBindingLetter(self.c, val.path)
                         p.h = f"[{letter}] INACTIVE: {p.h}"
                         p.h = f"UNUSED: {p.h}"
                     self.add(p)
@@ -1237,7 +1237,7 @@ class GlobalConfigManager:
         for key in sorted(list(d.keys())):
             gs = d.get(key)  # gs is a GeneralSetting or None
             if gs and gs.kind:
-                letter = lm.computeBindingLetter(c, gs.path, scope=None)
+                letter = lm.computeBindingLetter(c, gs.path)
                 val = gs.val
                 if gs.kind == 'data':
                     # #748: Remove comments

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1097,7 +1097,7 @@ class ActiveSettingsOutline:
                 continue
             if m.group(2) and m.group(1) in valid_list:
                 #@+<< handle a real setting >>
-                #@+node:ekr.20190905091614.11: *4* << handle a real setting >>
+                #@+node:ekr.20190905091614.11: *4* << handle a real setting >> (aso)
                 key = g.app.config.munge(m.group(2).strip())
                 val = d.get(key)
                 if isinstance(val, g.GeneralSetting):
@@ -1107,7 +1107,7 @@ class ActiveSettingsOutline:
                     val = c.config.settingsDict.get(key)
                     if isinstance(val, g.GeneralSetting):
                         # Use self.c, not self.commander.
-                        letter = lm.computeBindingLetter(self.c, val.path)
+                        letter = lm.computeBindingLetter(self.c, val.path, scope=None)
                         p.h = f"[{letter}] INACTIVE: {p.h}"
                         p.h = f"UNUSED: {p.h}"
                     self.add(p)
@@ -1237,7 +1237,7 @@ class GlobalConfigManager:
         for key in sorted(list(d.keys())):
             gs = d.get(key)  # gs is a GeneralSetting or None
             if gs and gs.kind:
-                letter = lm.computeBindingLetter(c, gs.path)
+                letter = lm.computeBindingLetter(c, gs.path, scope=None)
                 val = gs.val
                 if gs.kind == 'data':
                     # #748: Remove comments

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -410,6 +410,8 @@ class BindingInfo:
 
     This includes other information besides just the KeyStroke.
     """
+    __slots__ = ['commandName', 'func', 'kind', 'nextMode', 'pane', 'stroke']
+
     # Important: The startup code uses this class,
     # so it is convenient to define it in leoGlobals.py.
     #@+others

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2498,6 +2498,7 @@ class KeyHandlerClass:
     [D] default binding
     [F] loaded .leo File
     [M] myLeoSettings.leo
+    [T] Theme file
     [@] @mode, @button, @command
 
     '''
@@ -2557,7 +2558,7 @@ class KeyHandlerClass:
             commandName = bi.commandName
             kind = bi.kind
             key = key.replace('+Key', '')
-            letter = lm.computeBindingLetter(c, kind, scope)
+            letter = lm.computeBindingLetter(c, kind)
             pane = f"{scope if scope else 'all':>7}: "
             left = pane + key  # pane and shortcut fields
             n = max(n, len(left))

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -211,7 +211,7 @@ class BaseLeoPlugin:
     """
     #@-<<docstring>>
     #@+others
-    #@+node:ekr.20100908125007.6012: *3* __init__ (BaseLeoPlugin)
+    #@+node:ekr.20100908125007.6012: *3* BaseLeoPlugin.__init__
     def __init__(self, tag: str, keywords: Keywords) -> None:
         """
         Ctor for the BaseLeoPlugin class.
@@ -219,7 +219,7 @@ class BaseLeoPlugin:
         # mypy can't infer the type of keywords['c'].
         self.c: Cmdr = keywords['c']  # type:ignore
         self.commandNames: list[str] = []
-    #@+node:ekr.20100908125007.6013: *3* setCommand
+    #@+node:ekr.20100908125007.6013: *3* BaseLeoPlugin.setCommand
     def setCommand(
         self,
         commandName: str,
@@ -236,9 +236,8 @@ class BaseLeoPlugin:
         self.shortcut = shortcut
         self.handler = handler
         # #4087: k.registerCommand no longer supports the 'shortcut' kwarg.
-        self.c.k.registerCommand(commandName, handler,
-            pane=pane, verbose=verbose)
-    #@+node:ekr.20100908125007.6014: *3* setMenuItem
+        self.c.k.registerCommand(commandName, handler, pane=pane, verbose=verbose)
+    #@+node:ekr.20100908125007.6014: *3* BaseLeoPlugin.setMenuItem
     def setMenuItem(self, menu: Wrapper, commandName: str = None, handler: Callable = None) -> None:
         """Create a menu item in 'menu' using text 'commandName' calling handler 'handler'
         if commandName and handler are none, use the most recently defined values
@@ -254,7 +253,7 @@ class BaseLeoPlugin:
             handler = self.handler
         table = ((commandName, None, handler),)
         self.c.frame.menu.createMenuItemsFromTable(menu, table)
-    #@+node:ekr.20100908125007.6015: *3* setButton
+    #@+node:ekr.20100908125007.6015: *3* BaseLeoPlugin.setButton
     def setButton(self, buttonText: str = None, commandName: str = None, color: str = None) -> None:
         """Associate an existing command with a 'button'
         """

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -1079,6 +1079,7 @@ class ScriptingController:
         trace = False and not g.unitTesting
         shortcut = self.getShortcut(h) or ''
         commandName = self.cleanButtonText(h)
+        fileName = source_c.fileName() if source_c else None
         if trace and not g.isascii(commandName):
             g.trace(commandName)
         # Register the original function.
@@ -1088,6 +1089,7 @@ class ScriptingController:
             func=func,
             pane=pane,
             shortcut=shortcut,
+            fileName=fileName,
         )
 
         # 2013/11/13 Jake Peck:
@@ -1112,6 +1114,7 @@ class ScriptingController:
                     k.registerCommand(
                         allowBinding=True,
                         commandName=commandName2,
+                        fileName=fileName,
                         func=registerAllCommandsCallback,
                         pane=pane,
                         shortcut=shortcut,


### PR DESCRIPTION
See #4377.

- [x] Add optional `fileName` kwarg to `k.registerCommand` and `k.registerCommandShortcut`.
  Also, require kwargs in both methods. These are minor **breaking changes**.
- [x] `sc.registerAllCommandsCallback` calls `k.registerCommand` with proper `fileName` kwarg.
- [x] Add `__slots__` to `g.BindingInfo` class.

**Discussion**

`k.registerCommandShortcut` uses the `fileName` data to more accurately assign legends.