### PR TITLE
PR for #4373: Crash in u.undoGroup

### DIFF
--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -1529,8 +1529,8 @@ class Undoer:
         c, u = self.c, self
         # Remember these values.
         newSel = u.newSel
-        p = u.p.copy()  # Exists now, but may not exist later.
-        newP = u.newP.copy()  # May not exist now, but must exist later.
+        p = u.p.copy()  # u.p must exist now.
+        newP = u.newP.copy() if u.newP else c.p.copy()  # #4373: u.newP might not exist now.
         if g.unitTesting:
             assert c.positionExists(p), repr(p)
         u.groupCount += 1
@@ -1899,8 +1899,8 @@ class Undoer:
         c, u = self.c, self
         # Remember these values.
         oldSel = u.oldSel
-        p = u.p.copy()  # May not exist now, but must exist later.
-        newP = u.newP.copy()  # Must exist now, but may not exist later.
+        p = u.p.copy() if u.p else c.p.copy()  # #4373: u.p might not exist now.
+        newP = u.newP.copy()  # u.newP must exist now.
         if g.unitTesting:
             assert c.positionExists(newP), repr(newP)
         u.groupCount += 1

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -372,6 +372,36 @@ class TestUndo(LeoUnitTest):
         c.undoer.undo()
         c.undoer.redo()
         self.assertEqual(original.b, original_s)
+    #@+node:ekr.20250625044932.1: *3* TestUndo.test_undo_group_after_move
+    def test_undo_group_after_move(self):
+        # Test a group of moves.
+        c, p, u = self.c, self.c.p, self.c.undoer
+        undoType = 'test-undo-group-after-move'
+        p1 = p.insertAfter()
+        p1.h = 'p1'
+        p2 = p1.insertAfter()
+        p2.h = 'p2'
+        p3 = p2.insertAfter()
+        p3.h = 'p3'
+        p4 = p3.insertAfter()
+        p4.h = 'p4'
+        u.clearUndoState()
+        # Do moves that invalidate nodes.
+        c.selectPosition(p2)
+        u.beforeChangeGroup(c.p, undoType)
+        c.moveOutlineRight()  # Invalidates p2, p3, p4
+        # Re-establish p3 and p4.
+        p3 = p1.next()
+        assert p3.h == 'p3', p3.h
+        p4 = p3.next()
+        assert p4.h == 'p4', p4.h
+        c.selectPosition(p3)
+        c.moveOutlineDown()
+        u.afterChangeGroup(c.p, undoType)
+        # Undo and redo thrice.
+        for i in range(3):
+            u.undo()
+            u.redo()
     #@-others
 #@-others
 #@-leo


### PR DESCRIPTION
See #4373. This PR probably affects LeoJS.

- [x] Add defaults if args do not exist. The old code did not respect the comments!
- [x] Add a unit test.
