### PR TITLE
PR for #4385: Improve @clean!

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -357,9 +357,13 @@ def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
     This command is not undoable.
     """
     c, p = self, self.p
+    at = c.atFileCommands
+
     if not p.isAnyAtFileNode():
         g.warning(f"not an @<file> node: {p.h!r}")
         return
+
+    at.changed_roots = []  # #4385.
     full_path = c.fullPath(p)
     if os.path.isdir(full_path):
         g.warning(f"not a file: {full_path!r}")
@@ -390,6 +394,17 @@ def refreshFromDisk(self: Self, event: LeoKeyEvent = None) -> None:
     else:
         g.es_print(f"refresh-from-disk: Unknown @<file> node: {p.h!r}")
         return
+
+    if at.changed_roots:  # #4385.
+        update_p = at.clone_all_changed_vnodes()
+        if update_p:
+            # Select update_p.  See fc.setPositionsFromVnodes.
+            c.db['current_position'] = ','.join([
+                str(z) for z in update_p.archivedPosition()
+            ])
+            update_p.expand()
+        at.changed_roots = []
+
     if p.v.gnx != old_gnx and not g.unitTesting:
         g.es_print(f"refresh-from-disk changed the gnx for `{p.h}`")
         g.es_print(f"from `{old_gnx}` to: `{p.v.gnx}`")

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -240,8 +240,7 @@ def importAnyFile(self: Self, event: LeoKeyEvent = None) -> None:
             ic.importFilesCommand(
                 files=[fn],
                 parent=parent,
-                # Experimental: attempt to use permissive section ref logic.
-                treeType='@auto',  # was '@clean'
+                treeType='@auto',  # Use permissive section ref logic.
             )
             c.redraw()
     c.raise_error_dialogs(kind='read')

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -47,7 +47,6 @@ class AtFile:
         'startSentinelComment', 'endSentinelComment',
         #@verbatim
         # @shadow and @clean files.
-        # 'all_changed_vnodes', 'changed_vnodes',
         'changed_roots', 'changed_vnodes_dict', 'bodies_dict', 'private_s', 'public_s',
         # Writing.
         'indent', 'sentinels',
@@ -582,7 +581,7 @@ class AtFile:
             at.initReadIvars(p, fileName)
             p.v.b = ''  # Required for @auto API checks.
             p.v._deleteAllChildren()
-            p = ic.createOutline(parent=p.copy())
+            p = ic.createOutline(parent=p.copy(), treeType='@auto')
             # Do *not* call c.selectPosition(p) here.
             # That would improperly expand nodes.
         except Exception:
@@ -839,7 +838,7 @@ class AtFile:
         while p.hasChildren():
             p.firstChild().doDelete()
         # Import the outline, exactly as @auto does.
-        ic.createOutline(parent=p.copy())
+        ic.createOutline(parent=p.copy(), treeType='@auto')
         if ic.errors:
             g.error('errors inhibited read @shadow', fn)
         if ic.errors or not g.os_path_exists(fn):

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -870,11 +870,8 @@ class AtFile:
         ic.treeType = '@file'  # Required.
         _junk, ext = g.os_path_splitext(fileName)
         func = ic.dispatch(ext.lower(), root)
-        if func:
-            if False and not g.unitTesting:
-                print('\n')
-                g.trace(fileName)
-            # func(c, root, new_body_s)
+        if False and func:  ### Not ready yet.
+            func(c, root, new_body_s)
     #@+node:ekr.20041005105605.116: *4* at.Reading utils...
     #@+node:ekr.20041005105605.119: *5* at.createImportedNode
     def createImportedNode(self, root: Position, headline: str) -> Position:  # pragma: no cover

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -591,7 +591,7 @@ class AtFile:
         at, c, x = self, self.c, self.c.shadowController
 
         if new_contents:
-            fileName = 'root.h'  # For error messages only.
+            fileName = root.h  # Required.
         else:
             fileName = c.fullPath(root)
             if not g.os_path_exists(fileName):
@@ -869,9 +869,13 @@ class AtFile:
         # Run importer.
         ic.treeType = '@file'  # Required.
         _junk, ext = g.os_path_splitext(fileName)
-        func = ic.dispatch(ext.lower(), root)
-        if False and func:  ### Not ready yet.
-            func(c, root, new_body_s)
+        for p in root.self_and_subtree():
+            if p.v == v:
+                func = ic.dispatch(ext.lower(), root)
+                if func:
+                    func(c, p, new_body_s)
+                return
+        g.trace('Not found:', v)  # Should never happen.
     #@+node:ekr.20041005105605.116: *4* at.Reading utils...
     #@+node:ekr.20041005105605.119: *5* at.createImportedNode
     def createImportedNode(self, root: Position, headline: str) -> Position:  # pragma: no cover

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -917,10 +917,7 @@ class AtFile:
         root: Position,
         vnode_list: list[VNode],
     ) -> None:
-        """
-        Analyze all changed vnodes in a *single* file,
-        splitting or moving them as necessary.
-        """
+        """#4385: Analyze all changed vnodes in a *single* file."""
         at = self
         assert vnode_list, root.h
         changed_root_vnodes = [z.v for z in at.changed_roots]
@@ -929,10 +926,7 @@ class AtFile:
             at.do_changed_vnode(fileName, root, v)
     #@+node:ekr.20250711061442.1: *5* at.do_changed_vnode
     def do_changed_vnode(self, fileName: str, root: Position, v: VNode) -> None:
-        """
-        Propagate the changes from the public file (without_sentinels)
-        to the private file (with_sentinels)
-        """
+        """#4385: Run the importer on a changed VNode."""
         c = self.c
         ic = c.importCommands
         new_body_s = v.b

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -901,6 +901,7 @@ class AtFile:
         """
         #4385: Clean up nodes created by at.do_changed_vnode.
         """
+        g.trace(root.h)  ###
         for p in root.subtree():
             # Clear extraneous `@others` nodes.
             if p.b.strip() == '@others':

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -827,19 +827,23 @@ class AtFile:
     ) -> bool:  # pragma: no cover
         """A convenience wrapper for FastAtRead.read_into_root()"""
         return FastAtRead(c, gnx2vnode).read_into_root(contents, path, root)
-    #@+node:ekr.20250709051341.1: *4* at.post_process_at_clean_vnodes
+    #@+node:ekr.20250709051341.1: *4* at.post_process_at_clean_vnodes (to do)
     def post_process_at_clean_vnodes(self) -> None:
-        """Analyze all changed vnodes, splitting or moving them as necessary."""
+        """
+        Analyze all changed vnodes in a *single* file,
+        splitting or moving them as necessary.
+        """
         at, c = self, self.c
         if not at.changed_vnodes:
             return
-        if not g.unitTesting:  ### Temporary.
+        if False and not g.unitTesting:  ### Temporary.
             g.trace(c.p.h)
             g.printObj(at.changed_vnodes, tag='changed_vodes')
             print('at.bodies_dict...')
             for key in at.bodies_dict:
                 print(f"key: {key}")
                 g.printObj(at.bodies_dict.get(key))
+
     #@+node:ekr.20041005105605.116: *4* at.Reading utils...
     #@+node:ekr.20041005105605.119: *5* at.createImportedNode
     def createImportedNode(self, root: Position, headline: str) -> Position:  # pragma: no cover

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -916,11 +916,14 @@ class AtFile:
         ic = c.importCommands
         new_body_s = v.b
 
+        ### This can't have any effect!
+        ### ic.treeType = '@file'
+
         # Find a position for v.
         for p in root.self_and_subtree():
             if p.v == v:
-                ic.treeType = '@file'  # Required.
                 _junk, ext = g.os_path_splitext(fileName)
+                # Get the `do_import` function for the proper importer module.
                 func = ic.dispatch(ext.lower(), root)
                 if func:
                     func(c, p, new_body_s)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -640,7 +640,6 @@ class AtFile:
         if new_private_lines == old_private_lines:
             return True
         if not g.unitTesting:
-            print('')
             g.es_print("updating:", root.h)
         root.clearVisitedInTree()
         gnx2vnode = at.fileCommands.gnxDict
@@ -867,15 +866,15 @@ class AtFile:
             for tag, ai, aj, bi, bj in sm.get_opcodes():
                 print(f"{tag:8} a: {ai:3} {aj:3} b: {bi:3} {bj}")
 
-        if not g.unitTesting:  # Run importer.
-            ic.treeType = '@file'  # Required.
-            _junk, ext = g.os_path_splitext(fileName)
-            func = ic.dispatch(ext.lower(), root)
-            if func:
-                if not g.unitTesting:
-                    print('\n')
-                    g.trace(fileName)
-                # func(c, root, new_body_s)
+        # Run importer.
+        ic.treeType = '@file'  # Required.
+        _junk, ext = g.os_path_splitext(fileName)
+        func = ic.dispatch(ext.lower(), root)
+        if func:
+            if False and not g.unitTesting:
+                print('\n')
+                g.trace(fileName)
+            # func(c, root, new_body_s)
     #@+node:ekr.20041005105605.116: *4* at.Reading utils...
     #@+node:ekr.20041005105605.119: *5* at.createImportedNode
     def createImportedNode(self, root: Position, headline: str) -> Position:  # pragma: no cover

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -98,7 +98,6 @@ class AtFile:
         self.cancelFlag = False
         self.yesToAll = False
         # Reading.
-        ### self.changed_vnodes_dict: dict[VNode, list[VNode]] = {}
         self.changed_roots: list[Position] = []
         self.bodies_dict: dict[VNode, str] = {}
         self.importRootSeen = False
@@ -410,7 +409,6 @@ class AtFile:
         """Scan positions, looking for @<file> nodes to read."""
         at, c = self, self.c
         at.changed_roots = []
-        ### at.changed_vnodes_dict = {}
         old_changed = c.changed
         t1 = time.time()
         c.init_error_dialogs()
@@ -424,7 +422,6 @@ class AtFile:
             g.es(f"read {len(files)} files in {t2 - t1:2.2f} seconds")
 
         # Carefully set c.changed.
-        ### c.changed = old_changed or bool(at.changed_vnodes_dict)
         c.changed = old_changed or bool(at.changed_roots)
         update_p = at.clone_all_changed_vnodes()
         if update_p:
@@ -435,7 +432,6 @@ class AtFile:
             update_p.expand()
 
         at.changed_roots = []
-        ### at.changed_vnodes_dict = {}
 
         # Last.
         c.raise_error_dialogs()
@@ -501,7 +497,6 @@ class AtFile:
         """Read all @<file> nodes in root's tree."""
         at, c = self, self.c
         at.changed_roots = []
-        ### at.changed_vnodes_dict = {}
         old_changed = c.changed
         t1 = time.time()
         c.init_error_dialogs()
@@ -518,7 +513,6 @@ class AtFile:
                 g.es("no @<file> nodes in the selected tree")
 
         # Carefully set c.changed.
-        ### c.changed = old_changed or bool(at.changed_vnodes_dict)
         c.changed = old_changed or bool(at.changed_roots)
         update_p = at.clone_all_changed_vnodes()
         if update_p:
@@ -529,7 +523,6 @@ class AtFile:
             update_p.expand()
 
         at.changed_roots = []
-        ### at.changed_vnodes_dict = {}
 
         # Last.
         c.raise_error_dialogs()
@@ -683,7 +676,6 @@ class AtFile:
         # #4385: Handle the changed nodes.
         if vnode_list:
             at.changed_roots.append(root)
-            ### at.changed_vnodes_dict[root.v] = vnode_list
             at.post_process_at_clean_vnodes(fileName, root, vnode_list)
             at.delete_empty_changed_organizers(root, vnode_list)
 
@@ -881,18 +873,6 @@ class AtFile:
                 if p.isDirty():
                     clone = p.clone()
                     clone.moveToLastChildOf(parent)
-            ### Doesn't work well.
-                # vnode_list = at.changed_vnodes_dict.get(root.v, [])
-                # for v in vnode_list:
-                    # # Find the corresponding position.
-                    # for p in root.self_and_subtree():
-                        # if p.v == v:
-                            # clone = p.clone()
-                            # clone.moveToLastChildOf(parent)
-                            # root.setDirty()
-                            # break
-                    # else:
-                        # g.trace('Not found', v.h)  # Should never happen.
 
         # Defensive programming.
         if c.checkOutline() > 0:
@@ -913,7 +893,7 @@ class AtFile:
         at, c = self, self.c
         while True:
             for p in root.subtree():
-                # Handle a node containing only @others.
+                # Handle a changed node containing only @others.
                 if (
                     p.b.strip() == '@others'
                     and p.b != at.bodies_dict.get(p.v)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -921,7 +921,7 @@ class AtFile:
             if p.v == v:
                 _junk, ext = g.os_path_splitext(fileName)
                 # Get the `do_import` function for the proper importer module.
-                func = ic.dispatch(ext.lower(), root, treeType='@clean')
+                func = ic.dispatch(ext.lower(), root)
                 if func:
                     func(c, p, new_body_s)
                 break
@@ -1437,7 +1437,7 @@ class AtFile:
         at, c = self, self.c
         # Dispatch the proper writer.
         junk, ext = g.os_path_splitext(fileName)
-        writer = at.dispatch(ext, root, treeType='@auto')
+        writer = at.dispatch(ext, root)
         if writer:
             at.outputList = []
             writer(root)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -99,8 +99,8 @@ class AtFile:
         self.cancelFlag = False
         self.yesToAll = False
         # Reading.
-        self.changed_roots: list[Position] = []
-        self.bodies_dict: dict[VNode, str] = {}
+        self.changed_roots: list[Position] = []  # Global.
+        self.bodies_dict: dict[VNode, str] = {}  # Local to at.readOneAtCleanNode.
         self.importRootSeen = False
         self.readVersion = ''
         self.read_i = 0

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -440,13 +440,11 @@ class AtFile:
         """
         Make clones of all changed VNodes.
 
-        Called from at.readAll and at.readAllSelected.
+        Called from at.readAll, at.readAllSelected and c.refreshFromDisk.
         """
-        ### What about refresh from disk???
         at, c, u = self, self.c, self.c.undoer
         if g.unitTesting:
             return None
-        g.trace(len(at.changed_roots), g.callers(2))  ###
         if not at.changed_roots:
             return None
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -899,9 +899,8 @@ class AtFile:
         vnode_list: list[VNode]
     ) -> None:
         """
-        #4385: Clean up nodes created by at.do_changed_vnode.
+        #4385: Clean up nodes created by at.do_changed_vnode or the importer.
         """
-        g.trace(root.h)  ###
         for p in root.subtree():
             # Clear extraneous `@others` nodes.
             if p.b.strip() == '@others':

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -712,19 +712,19 @@ class AtFile:
         FastAtRead(c, gnx2vnode).read_into_root(contents, fileName, root)
         g.doHook('after-reading-external-file', c=c, p=root)
 
-        # #4385: Compute the list of changed vnodes.
-        vnode_list: list[VNode] = []
+        # #4385: Call do_changed_vnodes for all changed vnodes.
+        changed = False
         for p in root.self_and_subtree():
-            if at.bodies_dict.get(p.v) != p.b:
-                vnode_list.append(p.v)
+            v = p.v
+            if at.bodies_dict.get(v) != p.b:
+                changed = True
                 p.v.setDirty()
                 root.v.setDirty()
-
-        # #4385: Handle the changed nodes.
-        if vnode_list:
-            at.changed_roots.append(root.copy())
-            for v in vnode_list:
                 at.do_changed_vnode(fileName, root, v)
+
+        # #4385: Do final optimizations.
+        if changed:
+            at.changed_roots.append(root.copy())
             at.delete_empty_changed_organizers(root)
             at.move_leading_blank_lines(root)
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -727,7 +727,8 @@ class AtFile:
         # #4385: Handle the changed nodes.
         if vnode_list:
             at.changed_roots.append(root.copy())
-            at.post_process_at_clean_vnodes(fileName, root, vnode_list)
+            for v in vnode_list:
+                at.do_changed_vnode(fileName, root, v)
             at.delete_empty_changed_organizers(root)
             at.move_leading_blank_lines(root)
 
@@ -799,19 +800,6 @@ class AtFile:
                         back.b += lines.pop(0)
                     p.b = ''.join(lines)
                     back.v.setDirty()  # Include back in the update list.
-    #@+node:ekr.20250709051341.1: *6* at.post_process_at_clean_vnodes
-    def post_process_at_clean_vnodes(self,
-        fileName: str,
-        root: Position,
-        vnode_list: list[VNode],
-    ) -> None:
-        """#4385: Analyze all changed vnodes in a *single* file."""
-        at = self
-        assert vnode_list, root.h
-        changed_root_vnodes = [z.v for z in at.changed_roots]
-        assert root.v in changed_root_vnodes, root.v
-        for v in vnode_list:
-            at.do_changed_vnode(fileName, root, v)
     #@+node:ekr.20150204165040.8: *6* at.read_at_clean_lines
     def read_at_clean_lines(self, fn: str) -> list[str]:  # pragma: no cover
         """Return all lines of the @clean/@nosent file at fn."""

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -640,6 +640,7 @@ class AtFile:
         if new_private_lines == old_private_lines:
             return True
         if not g.unitTesting:
+            print('')
             g.es_print("updating:", root.h)
         root.clearVisitedInTree()
         gnx2vnode = at.fileCommands.gnxDict
@@ -849,17 +850,16 @@ class AtFile:
         Propagate the changes from the public file (without_sentinels)
         to the private file (with_sentinels)
         """
-        trace = True and not g.unitTesting  ###
         at, c = self, self.c
+        ic = c.importCommands
         x = c.shadowController
+        old_body_s = at.bodies_dict.get(v)
+        new_body_s = v.b
 
-        # Part 1: compute diffs.
-        old_body = g.splitLines(at.bodies_dict.get(v))
-        new_body = g.splitLines(v.b)
-        a = x.preprocess(old_body)
-        b = x.preprocess(new_body)
-        sm = difflib.SequenceMatcher(None, a, b)
-        if trace:
+        if 0:  # Part 1: dump diffs.
+            a = x.preprocess(g.splitLines(old_body_s))
+            b = x.preprocess(g.splitLines(new_body_s))
+            sm = difflib.SequenceMatcher(None, a, b)
             print('')
             g.trace('v:', v.h)
             g.printObj(a, tag='a')
@@ -867,7 +867,15 @@ class AtFile:
             for tag, ai, aj, bi, bj in sm.get_opcodes():
                 print(f"{tag:8} a: {ai:3} {aj:3} b: {bi:3} {bj}")
 
-        # Part 2: Run importer.  ### To do.
+        if not g.unitTesting:  # Run importer.
+            ic.treeType = '@file'  # Required.
+            _junk, ext = g.os_path_splitext(fileName)
+            func = ic.dispatch(ext.lower(), root)
+            if func:
+                if not g.unitTesting:
+                    print('\n')
+                    g.trace(fileName)
+                # func(c, root, new_body_s)
     #@+node:ekr.20041005105605.116: *4* at.Reading utils...
     #@+node:ekr.20041005105605.119: *5* at.createImportedNode
     def createImportedNode(self, root: Position, headline: str) -> Position:  # pragma: no cover

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -469,10 +469,8 @@ class AtFile:
                 clone = p.clone()
                 clone.moveToLastChildOf(parent)
                 # Insert the diff into the parent's body.
-                a = g.splitLines(at.bodies_dict.get(p.v, ''))
+                a = g.splitLines(at.bodies_dict.get(v, ''))
                 b = g.splitLines(p.b)
-                ### g.printObj(a, tag=f"OLD {id(v)} {v.h}")
-                ### g.printObj(b, tag=f"NEW {id(v)} {v.h}")
                 parent_body.append(f"{p.h}\n")
                 parent_body.extend(difflib.unified_diff(a, b))
                 parent_body.append('\n')

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -787,7 +787,7 @@ class AtFile:
         """
         Move leading blank lines (only in dirty nodes!) to the preceding node.
         """
-        for p in root.subtree():
+        for p in root.subtree():  # back must exist below.
             if p.v.isDirty():
                 lines = g.splitLines(p.b)
                 if lines and lines[0].isspace():

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -858,14 +858,12 @@ class AtFile:
         new_body = g.splitLines(v.b)
         a = x.preprocess(old_body)
         b = x.preprocess(new_body)
+        sm = difflib.SequenceMatcher(None, a, b)
         if trace:
             print('')
             g.trace('v:', v.h)
             g.printObj(a, tag='a')
             g.printObj(b, tag='b')
-
-        sm = difflib.SequenceMatcher(None, a, b)
-        if trace:
             for tag, ai, aj, bi, bj in sm.get_opcodes():
                 print(f"{tag:8} a: {ai:3} {aj:3} b: {bi:3} {bj}")
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -720,10 +720,10 @@ class AtFile:
             if at.bodies_dict.get(v) != p.b:
                 changed_vnodes.append(v)
                 v.setDirty()
-                root.v.setDirty()
 
         # Handle all changed vnodes.
         if changed_vnodes:
+            root.v.setDirty()
             at.changed_roots.append(root.copy())
             for v in changed_vnodes:
                 at.do_changed_vnode(fileName, root, v)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -715,11 +715,7 @@ class AtFile:
         # #4385: Compute the list of changed vnodes.
         vnode_list: list[VNode] = []
         for p in root.self_and_subtree():
-            if p.v not in at.bodies_dict:
-                vnode_list.append(p.v)
-                p.v.setDirty()
-                root.v.setDirty()
-            elif at.bodies_dict.get(p.v) != p.b:
+            if at.bodies_dict.get(p.v) != p.b:
                 vnode_list.append(p.v)
                 p.v.setDirty()
                 root.v.setDirty()

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2991,7 +2991,10 @@ class AtFile:
         ok = g.writeFile(contents, encoding, fileName)
         if ok:
             c.setFileTimeStamp(fileName)
-            if not g.unitTesting:
+            if (
+                not g.unitTesting
+                and c.config.getBool('report-changed-files', default=True)
+            ):
                 g.es(f"{timestamp}wrote: {sfn}")  # pragma: no cover
         else:  # pragma: no cover
             g.error('error writing', sfn)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -862,15 +862,21 @@ class AtFile:
         # Clone nodes as children of the found node.
         undoData = u.beforeInsertNode(c.p)
         for v in at.all_changed_vnodes:
-            v.cloneAsNthChild(update_v, len(update_v.children))
-            update_v.children.append(v)
-            v.parents.append(update_v)
+            g.trace('clone?', v.isCloned(), v.h, len(v.b), 'v.parents', v.parents)
+            clone = v.cloneAsNthChild(update_v, len(update_v.children))
+            g.trace('clone.parents', clone.parents)
+            # if not v.parents:
+                # clone.parents.append(update_v)  ### Experimental.
+            g.trace(id(v) == id(clone))
+            # clone.h = v.h
+            # clone.b = v.b
+            # update_v.children.append(clone)
 
-        # Sort the clones in place, without undo.
+        # Defensive programming.
         if c.checkOutline() > 0:
             return None
 
-        g.trace(g.callers(8))
+        # Sort the clones in place, without undo.
         update_p.v.children.sort(key=lambda v: v.h.lower())
         u.afterInsertNode(update_p, 'Clone Updated Nodes', undoData)
         return update_p

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -5,7 +5,6 @@
 #@+node:ekr.20041005105605.2: ** << leoAtFile imports & annotations >>
 from __future__ import annotations
 from collections.abc import Callable
-import difflib
 import io
 import os
 import re
@@ -843,7 +842,7 @@ class AtFile:
             at.do_changed_vnode(fileName, root, v)
 
 
-    #@+node:ekr.20250711061442.1: *4* at.do_changed_vnode (to do)
+    #@+node:ekr.20250711061442.1: *4* at.do_changed_vnode
     def do_changed_vnode(self, fileName: str, root: Position, v: VNode) -> None:
         """
         Propagate the changes from the public file (without_sentinels)
@@ -851,20 +850,7 @@ class AtFile:
         """
         at, c = self, self.c
         ic = c.importCommands
-        x = c.shadowController
-        old_body_s = at.bodies_dict.get(v)
         new_body_s = v.b
-
-        if 0:  # Part 1: dump diffs.
-            a = x.preprocess(g.splitLines(old_body_s))
-            b = x.preprocess(g.splitLines(new_body_s))
-            sm = difflib.SequenceMatcher(None, a, b)
-            print('')
-            g.trace('v:', v.h)
-            g.printObj(a, tag='a')
-            g.printObj(b, tag='b')
-            for tag, ai, aj, bi, bj in sm.get_opcodes():
-                print(f"{tag:8} a: {ai:3} {aj:3} b: {bi:3} {bj}")
 
         # Run importer.
         ic.treeType = '@file'  # Required.
@@ -874,8 +860,13 @@ class AtFile:
                 func = ic.dispatch(ext.lower(), root)
                 if func:
                     func(c, p, new_body_s)
-                return
-        g.trace('Not found:', v)  # Should never happen.
+                break
+        else:
+            g.trace('Not found:', v)  # Should never happen.
+
+        # Always set the dirty bit.
+        v.setDirty()
+        at.any_changed_vnodes = True
     #@+node:ekr.20041005105605.116: *4* at.Reading utils...
     #@+node:ekr.20041005105605.119: *5* at.createImportedNode
     def createImportedNode(self, root: Position, headline: str) -> Position:  # pragma: no cover

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -871,13 +871,15 @@ class AtFile:
         # Clone nodes as children of the found node.
         undoData = u.beforeInsertNode(c.p)
         for root in at.changed_roots:
+            parent = update_p.insertAsLastChild()
+            parent.h = f"Updated from: {g.shortFileName(c.fullPath(root))}"
             vnode_list = at.changed_vnodes_dict.get(root.v, [])
             for v in vnode_list:
                 # Find the corresponding position.
                 for p in root.self_and_subtree():
                     if p.v == v:
                         clone = p.clone()
-                        clone.moveToLastChildOf(update_p)
+                        clone.moveToLastChildOf(parent)
                         root.setDirty()
                         break
                 else:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -99,8 +99,6 @@ class AtFile:
         self.cancelFlag = False
         self.yesToAll = False
         # Reading.
-        ### self.all_changed_vnodes: list[VNode] = []
-        ###self.changed_vnodes: list[VNode] = []
         self.changed_vnodes_dict: dict[VNode, list[VNode]] = {}
         self.changed_roots: list[Position] = []
         self.bodies_dict: dict[VNode, str] = {}
@@ -412,7 +410,6 @@ class AtFile:
     def readAll(self, root: Position) -> None:
         """Scan positions, looking for @<file> nodes to read."""
         at, c = self, self.c
-        ### at.all_changed_vnodes = []
         at.changed_roots = []
         at.changed_vnodes_dict = {}
         old_changed = c.changed
@@ -428,7 +425,6 @@ class AtFile:
             g.es(f"read {len(files)} files in {t2 - t1:2.2f} seconds")
 
         # Carefully set c.changed.
-        ### c.changed = old_changed or bool(at.all_changed_vnodes)
         c.changed = old_changed or bool(at.changed_vnodes_dict)
         update_p = at.clone_all_changed_vnodes()
         if update_p:
@@ -438,7 +434,6 @@ class AtFile:
             ])
             update_p.expand()
 
-        ### at.all_changed_vnodes = []
         at.changed_roots = []
         at.changed_vnodes_dict = {}
 
@@ -505,7 +500,6 @@ class AtFile:
     def readAllSelected(self, root: Position) -> None:  # pragma: no cover
         """Read all @<file> nodes in root's tree."""
         at, c = self, self.c
-        ### at.all_changed_vnodes = []
         at.changed_roots = []
         at.changed_vnodes_dict = {}
         old_changed = c.changed
@@ -524,7 +518,6 @@ class AtFile:
                 g.es("no @<file> nodes in the selected tree")
 
         # Carefully set c.changed.
-        ### c.changed = old_changed or bool(at.all_changed_vnodes)
         c.changed = old_changed or bool(at.changed_vnodes_dict)
         update_p = at.clone_all_changed_vnodes()
         if update_p:
@@ -534,7 +527,6 @@ class AtFile:
             ])
             update_p.expand()
 
-        ### at.all_changed_vnodes = []
         at.changed_roots = []
         at.changed_vnodes_dict = {}
 
@@ -640,7 +632,6 @@ class AtFile:
         # #4385: Init the per-file data.
         at.initReadIvars(root, fileName)
         at.bodies_dict = {}
-        ### at.changed_vnodes = []
 
         # Don't update if the outline and file are in synch.
         if old_mod_time and old_mod_time >= new_mod_time:
@@ -680,12 +671,10 @@ class AtFile:
 
         for p in root.self_and_subtree():
             if p.v not in at.bodies_dict:
-                ### at.changed_vnodes.append(p.v)
                 vnode_list.append(p.v)
                 p.v.setDirty()
                 root.v.setDirty()
             elif at.bodies_dict.get(p.v) != p.b:
-                ### at.changed_vnodes.append(p.v)
                 vnode_list.append(p.v)
                 p.v.setDirty()
                 root.v.setDirty()
@@ -695,8 +684,6 @@ class AtFile:
             at.changed_roots.append(root)
             at.changed_vnodes_dict[root.v] = vnode_list
             at.post_process_at_clean_vnodes(fileName, root)
-
-        ### if at.changed_vnodes:
 
         return True  # Errors not detected.
     #@+node:ekr.20150204165040.7: *6* at.dump_lines

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -728,15 +728,12 @@ class AtFile:
         if vnode_list:
             at.changed_roots.append(root.copy())
             at.post_process_at_clean_vnodes(fileName, root, vnode_list)
-            at.delete_empty_changed_organizers(root, vnode_list)
-            at.move_leading_blank_lines(root, vnode_list)
+            at.delete_empty_changed_organizers(root)
+            at.move_leading_blank_lines(root)
 
         return True  # Errors not detected.
     #@+node:ekr.20250712215845.1: *6* at.delete_empty_changed_organizers
-    def delete_empty_changed_organizers(self,
-        root: Position,
-        vnode_list: list[VNode]
-    ) -> None:
+    def delete_empty_changed_organizers(self, root: Position) -> None:
         """
         #4385: Clean up nodes created by at.do_changed_vnode.
         """
@@ -789,7 +786,7 @@ class AtFile:
         for s in lines:
             print(s.rstrip())
     #@+node:ekr.20250714115142.1: *6* at.move_leading_blank_lines
-    def move_leading_blank_lines(self, root: Position, vnode_list: list[VNode]) -> None:
+    def move_leading_blank_lines(self, root: Position) -> None:
         """
         Move leading blank lines (only in dirty nodes!) to the preceding node.
         """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -650,8 +650,12 @@ class AtFile:
         for p in root.self_and_subtree():
             if p.v not in at.bodies_dict:
                 at.changed_vnodes.append(p.v)
+                p.v.setDirty()
+                root.v.setDirty()
             elif at.bodies_dict.get(p.v) != p.b:
                 at.changed_vnodes.append(p.v)
+                p.v.setDirty()
+                root.v.setDirty()
 
         # #4385: Handle the changed nodes.
         if at.changed_vnodes:

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -426,8 +426,12 @@ class AtFile:
         c.changed = old_changed or bool(at.all_changed_vnodes)
         update_p = at.clone_all_changed_vnodes()
         if update_p:
-            g.trace('old:', c.p.h, 'new:', update_p.h)  ###
-            c.selectPosition(update_p)
+            # Select update_p.  See fc.setPositionsFromVnodes.
+            c.db['current_position'] = ','.join([
+                str(z) for z in update_p.archivedPosition()
+            ])
+            update_p.expand()
+
         at.all_changed_vnodes = []
 
         # Last.
@@ -513,7 +517,12 @@ class AtFile:
         c.changed = old_changed or bool(at.all_changed_vnodes)
         update_p = at.clone_all_changed_vnodes()
         if update_p:
-            c.selectPosition(update_p)
+            # Select update_p.  See fc.setPositionsFromVnodes.
+            c.db['current_position'] = ','.join([
+                str(z) for z in update_p.archivedPosition()
+            ])
+            update_p.expand()
+
         at.all_changed_vnodes = []
 
         # Last.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -916,15 +916,12 @@ class AtFile:
         ic = c.importCommands
         new_body_s = v.b
 
-        ### This can't have any effect!
-        ### ic.treeType = '@file'
-
         # Find a position for v.
         for p in root.self_and_subtree():
             if p.v == v:
                 _junk, ext = g.os_path_splitext(fileName)
                 # Get the `do_import` function for the proper importer module.
-                func = ic.dispatch(ext.lower(), root)
+                func = ic.dispatch(ext.lower(), root, treeType='@clean')
                 if func:
                     func(c, p, new_body_s)
                 break
@@ -1440,7 +1437,7 @@ class AtFile:
         at, c = self, self.c
         # Dispatch the proper writer.
         junk, ext = g.os_path_splitext(fileName)
-        writer = at.dispatch(ext, root)
+        writer = at.dispatch(ext, root, treeType='@auto')
         if writer:
             at.outputList = []
             writer(root)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -899,7 +899,7 @@ class AtFile:
         vnode_list: list[VNode]
     ) -> None:
         """
-        #4385: Clean up nodes created by the at.do_changed_vnode.
+        #4385: Clean up nodes created by at.do_changed_vnode.
         """
         for p in root.subtree():
             # Clear extraneous `@others` nodes.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -923,14 +923,9 @@ class AtFile:
         Propagate the changes from the public file (without_sentinels)
         to the private file (with_sentinels)
         """
-        at, c = self, self.c
-        ### c = self.c
+        c = self.c
         ic = c.importCommands
         new_body_s = v.b
-
-        # Remember the old nodes.
-        old_nodes = [z.v for z in root.self_and_subtree()]
-        ### g.printObj(old_nodes, tag='Before')
 
         # Find a position for v.
         for p in root.self_and_subtree():
@@ -943,18 +938,6 @@ class AtFile:
                 break
         else:
             g.trace('Not found:', v)  # Should never happen.
-
-        # Add any inserted nodes to the changed_vnodes_dict.
-        new_nodes = [z.v for z in root.self_and_subtree()]
-        ### g.printObj(new_nodes, tag='After')
-        for v2 in new_nodes:
-            if v2 not in old_nodes:
-                vnode_list = at.changed_vnodes_dict[root.v]
-                if v2 not in vnode_list:
-                    ### print('ADD', v2.h)
-                    v2.setDirty()
-                    vnode_list.append(v2)
-                    at.changed_vnodes_dict[root.v] = vnode_list
 
         # Always set the dirty bit.
         v.setDirty()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3468,7 +3468,7 @@ class Commands:
         path = os.path.expandvars(path)
         return path
     #@+node:ekr.20171124101444.1: *3* c.File
-    #@+node:ekr.20200305104646.1: *4* c.archivedPositionToPosition (new)
+    #@+node:ekr.20200305104646.1: *4* c.archivedPositionToPosition
     def archivedPositionToPosition(self, s: str) -> Position:
         """Convert an archived position (a string) to a position."""
         c = self

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4739,6 +4739,7 @@ class Commands:
         #@-<< docstring >>
         c = self
 
+        # Same test as RecursiveImportController.run.
         if kind not in ('@auto', '@clean', '@edit', '@file', '@nosent'):
             g.es_print(f"Invalid kind: {kind!r}")
             return

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4708,7 +4708,7 @@ class Commands:
         *,  # All arguments are kwargs.
         dir_: str = None,  # A directory or file name.
         ignore_pattern: re.Pattern = None,  # Ignore files matching this regex pattern.
-        kind: str = None,
+        kind: str = '@file',
         recursive: bool = True,
         safe_at_file: bool = True,
         theTypes: list[str] = None,
@@ -4738,6 +4738,10 @@ class Commands:
         """
         #@-<< docstring >>
         c = self
+
+        if kind not in ('@auto', '@clean', '@edit', '@file', '@nosent'):
+            g.es_print(f"Invalid kind: {kind!r}")
+            return
 
         # Import all files in dir_ after c.p.
         try:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -195,10 +195,17 @@ class ExternalFilesController:
             if state in ('yes', 'no'):
                 state = self.ask(c, path, p=p)
             if state in ('yes', 'yes-all'):
-                old_c = c.p
+                old_p = c.p
                 c.selectPosition(p)  # Required.
                 c.refreshFromDisk()
-                c.redraw(old_c)  # #3695: Don't change c.p!
+                # #4385: Careful: refresh-from-disk may change positions.
+                select_p = (
+                    old_p if c.positionExists(old_p)
+                    else p if c.positionExists(p)
+                    else c.p
+                )
+                c.redraw(select_p)  # #3695: Don't change c.p!
+
     #@+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:
         """Check c's .leo file for external changes."""

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1679,10 +1679,8 @@ class RecursiveImportController:
             verbose=self.verbose,  # Leo 6.6.
         )
 
-        p = parent.lastChild()
-        p.h = self.kind + p.h[5:]  # Honor the requested kind.
-
         # #4385: set mod time for @clean files.
+        p = parent.lastChild()
         if self.kind == '@clean':
             p.v.u['_mod_time'] = g.os_path_getmtime(path)
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1677,7 +1677,7 @@ class RecursiveImportController:
             files=[path],
             parent=parent,
             shortFn=True,
-            treeType='@file',  ### ???
+            treeType=self.kind,  # Leo 6.8.6.
             verbose=self.verbose,  # Leo 6.6.
         )
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -582,7 +582,7 @@ class LeoImportCommands:
         # Each importer file defines `do_import` at the top level with this signature:
         # def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
 
-        func = self.dispatch(ext, p, treeType=treeType)  # The do_import callback.
+        func = self.dispatch(ext, p)  # The do_import callback.
 
         # Call the scanning function.
         if g.unitTesting:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -276,7 +276,7 @@ class LeoImportCommands:
             # All nodes should start with '@', even if the doc part is empty.
             result += nl + "@ " if self.webType == "cweb" else nl + "@" + nl
         return i, result
-    #@+node:ekr.20031218072017.3297: *4* ic.convertVnodeToWeb
+    #@+node:ekr.20031218072017.3297: *4* ic.positionToWeb
     def positionToWeb(self, p: Position) -> str:
         """
         This code converts a VNode to noweb text as follows:
@@ -427,13 +427,6 @@ class LeoImportCommands:
         except IOError:
             g.warning("can not open", fileName)
             return
-        self.treeType = "@file"
-        # Set self.treeType to @root if p or an ancestor is an @root node.
-        for p in current.parents():
-            flag, junk = g.is_special(p.b, "@root")
-            if flag:
-                self.treeType = "@root"
-                break
         for p in current.self_and_subtree(copy=False):
             s = self.positionToWeb(p)
             if s:
@@ -747,14 +740,14 @@ class LeoImportCommands:
         files: list[str] = None,
         parent: Position = None,
         shortFn: bool = False,
-        treeType: str = None,
+        treeType: str = '@file',
         verbose: bool = True,  # Legacy value.
     ) -> None:
         # Not a command.  It must *not* have an event arg.
         c, u = self.c, self.c.undoer
         if not c or not c.p or not files:
             return
-        self.treeType = treeType or '@file'
+        self.treeType = treeType
         self.verbose = verbose
         if not parent:
             g.trace('===== no parent', g.callers())
@@ -1124,9 +1117,14 @@ class LeoImportCommands:
             g.es_print('can not run parse-body: node has children:', p.h)
             return
         language = c.getLanguage(p)
-        self.treeType = '@file'
         ext = '.' + d.get(language)
+
+        ### This can no effect on the parser!
+        ### self.treeType = '@file'
+
+        # The parser is the `do_import` function for each importer class.
         parser = g.app.classDispatchDict.get(ext)
+
         # Fix bug 151: parse-body creates "None declarations"
         if p.isAnyAtFileNode():
             fn = p.anyAtFileNodeName()
@@ -1677,7 +1675,7 @@ class RecursiveImportController:
             files=[path],
             parent=parent,
             shortFn=True,
-            treeType='@file',  # '@auto','@clean','@nosent' cause problems.
+            treeType='@file',  ### # ? '@auto','@clean','@nosent' cause problems.
             verbose=self.verbose,  # Leo 6.6.
         )
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -552,7 +552,12 @@ class LeoImportCommands:
             g.print_exception()
     #@+node:ekr.20031218072017.3209: *3* ic.Import
     #@+node:ekr.20031218072017.3210: *4* ic.createOutline & helpers
-    def createOutline(self, parent: Position, ext: str = None, s: str = None) -> Position:
+    def createOutline(self,
+        parent: Position,
+        ext: str = None,
+        s: str = None,
+        treeType: str = '@file',
+    ) -> Position:
         """
         Create an outline by importing a file, reading the file with the
         given encoding if string s is None.
@@ -577,7 +582,8 @@ class LeoImportCommands:
         # Each importer file defines `do_import` at the top level with this signature:
         # def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
 
-        func = self.dispatch(ext, p)  # The do_import callback.
+        func = self.dispatch(ext, p, treeType=treeType)  # The do_import callback.
+
         # Call the scanning function.
         if g.unitTesting:
             assert func or ext in ('.txt', '.w', '.xxx'), (repr(func), ext, p.h)
@@ -585,7 +591,7 @@ class LeoImportCommands:
             s = g.toUnicode(s, encoding=self.encoding)
             s = s.replace('\r', '')
             # func is a factory that instantiates the importer class.
-            func(c, p, s)
+            func(c, p, s, treeType=treeType)
         else:
             # Just copy the file to the parent node.
             s = g.toUnicode(s, encoding=self.encoding)
@@ -594,8 +600,7 @@ class LeoImportCommands:
         if g.unitTesting:
             return p
 
-        # #488894: unsettling dialog when saving Leo file
-        # #889175: Remember the full fileName.
+        # Remember the full fileName.
         c.atFileCommands.rememberReadPath(fileName, p)
         p.contract()
         w = c.frame.body.wrapper
@@ -1118,9 +1123,6 @@ class LeoImportCommands:
             return
         language = c.getLanguage(p)
         ext = '.' + d.get(language)
-
-        ### This can no effect on the parser!
-        ### self.treeType = '@file'
 
         # The parser is the `do_import` function for each importer class.
         parser = g.app.classDispatchDict.get(ext)
@@ -1675,7 +1677,7 @@ class RecursiveImportController:
             files=[path],
             parent=parent,
             shortFn=True,
-            treeType='@file',  ### # ? '@auto','@clean','@nosent' cause problems.
+            treeType='@file',  ### ???
             verbose=self.verbose,  # Leo 6.6.
         )
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -312,7 +312,7 @@ class LeoImportCommands:
                     docSeen = True
                     result += docstart
                 i, result = self.convertCodePartToWeb(s, i, p, result)
-            elif self.treeType == "@file" or startInCode:
+            elif startInCode:
                 if not docSeen:
                     docSeen = True
                     result += docstart

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -575,7 +575,7 @@ class LeoImportCommands:
             return None
 
         # Each importer file defines `do_import` at the top level with this signature:
-        # def do_import(c: Cmdr, parent: Position, s: str) -> None:
+        # def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
 
         func = self.dispatch(ext, p)  # The do_import callback.
         # Call the scanning function.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1605,7 +1605,7 @@ class RecursiveImportController:
         """Ctor for RecursiveImportController class."""
         self.c = c
         self.ignore_pattern = ignore_pattern or re.compile(r'\.git|node_modules')
-        self.kind = kind  # in ('@auto', '@clean', '@edit', '@file', '@nosent')
+        self.kind = kind  # ric.run checks the kind.
         self.n_files: int = 0
         self.recursive = recursive
         self.root: Position = None

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -569,7 +569,7 @@ class LeoImportCommands:
         """
         c = self.c
         p = parent.copy()
-        self.treeType = '@file'  # Fix #352.
+        self.treeType = treeType
         fileName = c.fullPath(parent)
         if g.is_binary_external_file(fileName):
             return self.import_binary_file(fileName, parent)
@@ -579,19 +579,17 @@ class LeoImportCommands:
         if s is None:
             return None
 
-        # Each importer file defines `do_import` at the top level with this signature:
-        # def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
-
-        func = self.dispatch(ext, p)  # The do_import callback.
-
-        # Call the scanning function.
+        # Each importer file defines `do_import` at the top level.
+        func = self.dispatch(ext, p)
         if g.unitTesting:
             assert func or ext in ('.txt', '.w', '.xxx'), (repr(func), ext, p.h)
+
+        # Call the scanning function.
         if func and not c.config.getBool('suppress-import-parsing', default=False):
             s = g.toUnicode(s, encoding=self.encoding)
             s = s.replace('\r', '')
             # func is a factory that instantiates the importer class.
-            func(c, p, s, treeType=treeType)
+            func(c, p, s, treeType=self.treeType)
         else:
             # Just copy the file to the parent node.
             s = g.toUnicode(s, encoding=self.encoding)
@@ -767,7 +765,7 @@ class LeoImportCommands:
                 fn = c.relativeDirectory(fn)
                 p.h = f"{treeType} {fn}"
                 u.afterInsertNode(p, 'Import', undoData)
-                p = self.createOutline(parent=p)
+                p = self.createOutline(parent=p, treeType=self.treeType)
                 if p:  # createOutline may fail.
                     p.contract()
                     p.setDirty()

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -165,7 +165,7 @@ class LeoImportCommands:
     #@+node:ekr.20031218072017.3290: *4* ic.convertCodePartToWeb & helpers
     def convertCodePartToWeb(self, s: str, i: int, p: Position, result: str) -> tuple[int, str]:
         """
-        # Headlines not containing a section reference are ignored in noweb
+        Headlines not containing a section reference are ignored in noweb
         and generate index index in cweb.
         """
         ic = self

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -44,7 +44,8 @@ if TYPE_CHECKING:  # pragma: no cover
 class ShadowController:
 
     __slots__ = (
-        'a', 'b', 'c', 'changed_vnodes',
+        'a', 'b', 'c',
+        ### 'changed_vnodes',
         'delim1', 'delim2', 'dispatch_dict',
         'encoding', 'errors', 'gnxDict',
         'marker', 'node_pat', 'old_sent_lines', 'results',

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -45,7 +45,6 @@ class ShadowController:
 
     __slots__ = (
         'a', 'b', 'c',
-        ### 'changed_vnodes',
         'delim1', 'delim2', 'dispatch_dict',
         'encoding', 'errors', 'gnxDict',
         'marker', 'node_pat', 'old_sent_lines', 'results',

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1466,8 +1466,7 @@ class LeoServer:
                 ic.importFilesCommand(
                     files=[fn],
                     parent=parent,
-                    treeType='@auto',  # was '@clean'
-                    # Experimental: attempt to use permissive section ref logic.
+                    treeType='@auto',  # Use permissive section ref logic.
                 )
         return self._make_response()  # Just send empty as 'ok'
     #@+node:felix.20220808210033.1: *4* server.export commands

--- a/leo/plugins/examples/chinese_menu.py
+++ b/leo/plugins/examples/chinese_menu.py
@@ -65,7 +65,7 @@ def onMenu(tag, keywords):
             ("Import...", "导入..."),
                 ("Import Derived File", "导入生成的文件"),
                 ("Import To @file", "导入到 @file"),
-                ("Import To @root", "导入到 @root"),
+                # ("Import To @root", "导入到 @root"),
                 ("Import CWEB Files", "导入 CWEB 文件"),
                 ("Import noweb Files", "导入 noweb 文件"),
                 ("Import Flattened Outline", "导入平坦 (Flattened) 大纲文件 (MORE 格式)"),

--- a/leo/plugins/examples/french_fm.py
+++ b/leo/plugins/examples/french_fm.py
@@ -46,7 +46,7 @@ def onMenu(tag, keywords):
                 ("Untangle", "&Sélection"),
             ("Import...", "&Importer..."),
                 ("Import To @file", "Dans Structure @&file"),
-                ("Import To @root", "Dans Structure @&root"),
+                # ("Import To @root", "Dans Structure @&root"),
                 ("Import CWEB Files", "Fichier &CWEB"),
                 ("Import noweb Files", "Fichier &Noweb"),
                 ("Import Flattened Outline", "Fichier &MORE"),

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -605,30 +605,7 @@ class Importer:
         """
 
         #@+others  # Define helper functions.
-        #@+node:ekr.20250712053348.1: *5* i.function: delete_empty_changed_organizers
-        def delete_empty_changed_organizers(parent: Position) -> None:
-            """
-            #4385: Clean up nodes created by the at.do_changed_node.
-            """
-
-            # Handle all possible nodes.
-            while parent and not parent.isAnyAtFileNode():
-                parent = parent.parent()
-
-            for p in parent.subtree():
-                # Clear extraneous `@others` nodes.
-                if p.b.strip() == '@others':
-                    p.b = ''
-
-                # Delete a duplicate *child*, not the parent.
-                if not p.b and p.numberOfChildren() == 1 and p.firstChild().h == p.h:
-                    child = p.firstChild()
-                    p.b = child.b
-                    child.doDelete()
         #@-others
-
-        # This cleanup is useful for all languages.
-        delete_empty_changed_organizers(self.root)
     #@+node:ekr.20230529075138.38: *4* i.preprocess_lines
     def preprocess_lines(self, lines: list[str]) -> list[str]:
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -393,7 +393,7 @@ class Importer:
                 end = max(end, child_block.end)
             return start, end
         #@+node:ekr.20230924154050.1: *6* function: handle_block_with_children
-        def handle_block_with_children(block: Block, block_common_lws: str, parent: Position) -> None:
+        def handle_block_with_children(block: Block, block_common_lws: str) -> None:
             """A block with children."""
 
             # Find all lines that will be covered by @others.
@@ -471,7 +471,7 @@ class Importer:
                 # Do *not* change parent.h!
                 block.v.h = self.compute_headline(block)
             if block.child_blocks:
-                handle_block_with_children(block, block_common_lws, parent)
+                handle_block_with_children(block, block_common_lws)
             else:
                 block.v.b = self.compute_body(self.lines[block.start:block.end])
 

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -155,6 +155,9 @@ class Importer:
         If not, the caller can insert the desired blank lines.
         """
         s = ''.join(lines)
+        if self.treeType in ('@auto', '@auto'):
+            return s
+        # Legacy:
         return s.lstrip('\n').rstrip() + '\n' if s.strip() else ''
     #@+node:ekr.20230529075138.13: *4* i.compute_headline
     def compute_headline(self, block: Block) -> str:

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -492,9 +492,6 @@ class Importer:
         # A hook for language-specific processing.
         self.postprocess(parent, result_blocks)
 
-        # Leo 6.8.6:
-        at.delete_empty_changed_organizers(parent, vnode_list=None)
-
         # Note: i.gen_lines appends @language and @tabwidth directives to parent.b.
     #@+node:ekr.20230529075138.15: *4* i.gen_lines (top level)
     def gen_lines(self, lines: list[str], parent: Position) -> None:

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -156,16 +156,8 @@ class Importer:
         """
         s = ''.join(lines)
         if self.treeType in ('@auto', '@clean'):
-            result = s
-        else:  # Legacy:
-            result = s.lstrip('\n').rstrip() + '\n' if s.strip() else ''
-        if False and not g.unitTesting:  ###
-            if result == s:
-                g.trace('No change', parent.h)
-            else:
-                g.printObj(s, tag=f"s: {parent.h}")
-            g.printObj(result, tag=f"result: {parent.h}")
-        return result
+            return s
+        return s.lstrip('\n').rstrip() + '\n' if s.strip() else ''
     #@+node:ekr.20230529075138.13: *4* i.compute_headline
     def compute_headline(self, block: Block) -> str:
         """
@@ -501,7 +493,7 @@ class Importer:
         self.postprocess(parent, result_blocks)
 
         # Leo 6.8.6:
-        at.delete_empty_changed_organizers(parent, vnode_list=None)  ### Experimental.
+        at.delete_empty_changed_organizers(parent, vnode_list=None)
 
         # Note: i.gen_lines appends @language and @tabwidth directives to parent.b.
     #@+node:ekr.20230529075138.15: *4* i.gen_lines (top level)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -524,13 +524,19 @@ class Importer:
         if self.root.isAnyAtFileNode():  # #4385.
             parent.b += f"@language {self.language}\n@tabwidth {self.tab_width}\n"
     #@+node:ekr.20230529075138.37: *4* i.import_from_string (driver)
-    def import_from_string(self, parent: Position, s: str) -> None:
+    def import_from_string(self,
+        parent: Position,
+        s: str,
+        treeType: str = '@file',
+    ) -> None:
         """
         Importer.import_from_string.
 
         parent: An @<file> node containing the absolute path to the to-be-imported file.
 
         s: The contents of the file.
+
+        treeType: the desired @<file> node.
 
         The top-level code for almost all importers.
 

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -551,7 +551,10 @@ class Importer:
         # Fix #449: Cloned @auto nodes duplicates section references.
         if parent.isCloned() and parent.hasChildren():  # pragma: no cover (missing test)
             return
+
+        # Bind ivars.
         self.root = root = parent.copy()
+        self.treeType = treeType
 
         # Check for intermixed blanks and tabs.
         self.tab_width = c.getTabWidth(p=root)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -521,7 +521,8 @@ class Importer:
                 raise
 
         # Add trailing lines.
-        parent.b += f"@language {self.language}\n@tabwidth {self.tab_width}\n"
+        if g.unitTesting or self.root.isAnyAtFileNode():  # #4385.
+            parent.b += f"@language {self.language}\n@tabwidth {self.tab_width}\n"
 
     #@+node:ekr.20230529075138.37: *4* i.import_from_string (driver)
     def import_from_string(self, parent: Position, s: str) -> None:

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -521,9 +521,8 @@ class Importer:
                 raise
 
         # Add trailing lines.
-        if g.unitTesting or self.root.isAnyAtFileNode():  # #4385.
+        if self.root.isAnyAtFileNode():  # #4385.
             parent.b += f"@language {self.language}\n@tabwidth {self.tab_width}\n"
-
     #@+node:ekr.20230529075138.37: *4* i.import_from_string (driver)
     def import_from_string(self, parent: Position, s: str) -> None:
         """
@@ -586,6 +585,32 @@ class Importer:
         **Note**: The RecursiveImportController class contains a postpass that
                   adjusts headlines of *all* imported nodes.
         """
+
+        #@+others  # Define helper functions.
+        #@+node:ekr.20250712053348.1: *5* i.function: delete_empty_changed_organizers
+        def delete_empty_changed_organizers(parent: Position) -> None:
+            """
+            #4385: Clean up nodes created by the at.do_changed_node.
+            """
+
+            # Handle all possible nodes.
+            while parent and not parent.isAnyAtFileNode():
+                parent = parent.parent()
+
+            for p in parent.subtree():
+                # Clear extraneous `@others` nodes.
+                if p.b.strip() == '@others':
+                    p.b = ''
+
+                # Delete a duplicate *child*, not the parent.
+                if not p.b and p.numberOfChildren() == 1 and p.firstChild().h == p.h:
+                    child = p.firstChild()
+                    p.b = child.b
+                    child.doDelete()
+        #@-others
+
+        # This cleanup is useful for all languages.
+        delete_empty_changed_organizers(self.root)
     #@+node:ekr.20230529075138.38: *4* i.preprocess_lines
     def preprocess_lines(self, lines: list[str]) -> list[str]:
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -110,6 +110,7 @@ class Importer:
         self.root: Position = None
         delims = g.set_delims_from_language(self.language)
         self.single_comment, self.block1, self.block2 = delims
+        self.treeType: str = None  # Set by i.import_from_string.
         self.tab_width = 0  # Must be set later.
     #@+node:ekr.20230529075640.1: *3* i: Generic methods: may be overridden
     #@+node:ekr.20230529075138.36: *4* i.check_blanks_and_tabs

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -159,7 +159,7 @@ class Importer:
             result = s
         else:  # Legacy:
             result = s.lstrip('\n').rstrip() + '\n' if s.strip() else ''
-        if not g.unitTesting:
+        if not g.unitTesting:  ###
             if result == s:
                 g.trace('No change', parent.h)
             else:

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -147,7 +147,7 @@ class Importer:
                 g.es(message)
         return ok
     #@+node:ekr.20230925112827.1: *4* i.compute_body
-    def compute_body(self, lines: list[str], parent: Position) -> str:
+    def compute_body(self, lines: list[str]) -> str:
         """
         Return the regularized body text from the given list of lines.
 
@@ -401,7 +401,7 @@ class Importer:
 
             # Add the head lines to block.v.
             head_lines = self.lines[block.start:children_start]
-            block.v.b = self.compute_body(head_lines, parent)
+            block.v.b = self.compute_body(head_lines)
 
             # Add an @others directive if necessary.
             if block.v not in at_others_dict:
@@ -410,7 +410,7 @@ class Importer:
 
             # Add the tail lines to block.v
             tail_lines = self.lines[children_end:block.end]
-            tail_s = self.compute_body(tail_lines, parent)
+            tail_s = self.compute_body(tail_lines)
             if tail_s.strip():
                 block.v.b = block.v.b.rstrip() + '\n' + tail_s
 
@@ -433,7 +433,7 @@ class Importer:
         if not outer_block.child_blocks:
             # Put everything in parent.b.
             # Do *not* change parent.h!
-            parent.b = self.compute_body(outer_block.lines, parent)
+            parent.b = self.compute_body(outer_block.lines)
             return
 
         outer_block.v = parent.v
@@ -473,7 +473,7 @@ class Importer:
             if block.child_blocks:
                 handle_block_with_children(block, block_common_lws, parent)
             else:
-                block.v.b = self.compute_body(self.lines[block.start:block.end], parent)
+                block.v.b = self.compute_body(self.lines[block.start:block.end])
 
             # Add all child blocks to the to-do list.
             todo_list.extend(block.child_blocks)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -552,6 +552,11 @@ class Importer:
         if parent.isCloned() and parent.hasChildren():  # pragma: no cover (missing test)
             return
 
+        # Check treeType.
+        if treeType not in ('@auto', '@clean', '@edit', '@file', '@nosent'):
+            g.es_print(f"Invalid treeType: {treeType!r}")
+            return
+
         # Bind ivars.
         self.root = root = parent.copy()
         self.treeType = treeType

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -159,12 +159,12 @@ class Importer:
             result = s
         else:  # Legacy:
             result = s.lstrip('\n').rstrip() + '\n' if s.strip() else ''
-        if not g.unitTesting:  ###
+        if False and not g.unitTesting:  ###
             if result == s:
                 g.trace('No change', parent.h)
             else:
                 g.printObj(s, tag=f"s: {parent.h}")
-                g.printObj(result, tag=f"result: {parent.h}")
+            g.printObj(result, tag=f"result: {parent.h}")
         return result
     #@+node:ekr.20230529075138.13: *4* i.compute_headline
     def compute_headline(self, block: Block) -> str:

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -90,9 +90,9 @@ class C_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for c."""
-    C_Importer(c).import_from_string(parent, s)
+    C_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.c', '.cc', '.c++', '.cpp', '.cxx', '.h', '.h++',],

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -24,7 +24,7 @@ class Coffeescript_Importer(Python_Importer):
 
 def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for coffeescript."""
-    Coffeescript_Importer(c).import_from_string(parent, s)
+    Coffeescript_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.coffee',],

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -22,7 +22,7 @@ class Coffeescript_Importer(Python_Importer):
     )
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for coffeescript."""
     Coffeescript_Importer(c).import_from_string(parent, s)
 

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -24,7 +24,7 @@ class Coffeescript_Importer(Python_Importer):
 
 def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for coffeescript."""
-    Coffeescript_Importer(c).import_from_string(parent, s, treeType=treeType)  ###
+    Coffeescript_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.coffee',],

--- a/leo/plugins/importers/coffeescript.py
+++ b/leo/plugins/importers/coffeescript.py
@@ -24,7 +24,7 @@ class Coffeescript_Importer(Python_Importer):
 
 def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for coffeescript."""
-    Coffeescript_Importer(c).import_from_string(parent, s, treeType=treeType)
+    Coffeescript_Importer(c).import_from_string(parent, s, treeType=treeType)  ###
 
 importer_dict = {
     'extensions': ['.coffee',],

--- a/leo/plugins/importers/csharp.py
+++ b/leo/plugins/importers/csharp.py
@@ -17,9 +17,9 @@ class Csharp_Importer(C_Importer):
     language = 'csharp'
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for csharp."""
-    Csharp_Importer(c).import_from_string(parent, s)
+    Csharp_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.cs', '.c#'],

--- a/leo/plugins/importers/cython.py
+++ b/leo/plugins/importers/cython.py
@@ -35,9 +35,9 @@ class Cython_Importer(Python_Importer):
     )
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for cython."""
-    Cython_Importer(c).import_from_string(parent, s)
+    Cython_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.pyx',],

--- a/leo/plugins/importers/dart.py
+++ b/leo/plugins/importers/dart.py
@@ -22,9 +22,9 @@ class Dart_Importer(Importer):
     )
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for dart."""
-    Dart_Importer(c).import_from_string(parent, s)
+    Dart_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.dart'],

--- a/leo/plugins/importers/elisp.py
+++ b/leo/plugins/importers/elisp.py
@@ -53,9 +53,9 @@ class Elisp_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for elisp."""
-    Elisp_Importer(c).import_from_string(parent, s)
+    Elisp_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.el', '.clj', '.cljs', '.cljc'],

--- a/leo/plugins/importers/html.py
+++ b/leo/plugins/importers/html.py
@@ -20,9 +20,9 @@ class Html_Importer(Xml_Importer):
         super().__init__(c, tags_setting='import_html_tags')
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for html."""
-    Html_Importer(c).import_from_string(parent, s)
+    Html_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.html', '.htm',],

--- a/leo/plugins/importers/ini.py
+++ b/leo/plugins/importers/ini.py
@@ -38,9 +38,9 @@ class Ini_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for .ini files."""
-    Ini_Importer(c).import_from_string(parent, s)
+    Ini_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.ini',],

--- a/leo/plugins/importers/java.py
+++ b/leo/plugins/importers/java.py
@@ -24,9 +24,9 @@ class Java_Importer(Importer):
     )
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for java."""
-    Java_Importer(c).import_from_string(parent, s)
+    Java_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.java'],

--- a/leo/plugins/importers/javascript.py
+++ b/leo/plugins/importers/javascript.py
@@ -108,9 +108,9 @@ class JS_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for javascript."""
-    JS_Importer(c).import_from_string(parent, s)
+    JS_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.js',],

--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -154,9 +154,9 @@ class Rst_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for reStructureText."""
-    Rst_Importer(c).import_from_string(parent, s)
+    Rst_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     '@auto': ['@auto-rst',],  # Fix #392: @auto-rst file.txt: -rst ignored on read

--- a/leo/plugins/importers/lua.py
+++ b/leo/plugins/importers/lua.py
@@ -55,9 +55,9 @@ class Lua_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for lua."""
-    Lua_Importer(c).import_from_string(parent, s)
+    Lua_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.lua',],

--- a/leo/plugins/importers/markdown.py
+++ b/leo/plugins/importers/markdown.py
@@ -130,9 +130,9 @@ class Markdown_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for markdown."""
-    Markdown_Importer(c).import_from_string(parent, s)
+    Markdown_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     '@auto': ['@auto-md', '@auto-markdown',],

--- a/leo/plugins/importers/org.py
+++ b/leo/plugins/importers/org.py
@@ -64,9 +64,9 @@ class Org_Importer(Importer):
 
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for .org files."""
-    Org_Importer(c).import_from_string(parent, s)
+    Org_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     '@auto': ['@auto-org', '@auto-org-mode',],

--- a/leo/plugins/importers/otl.py
+++ b/leo/plugins/importers/otl.py
@@ -88,9 +88,9 @@ class Otl_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for .otl files."""
-    Otl_Importer(c).import_from_string(parent, s)
+    Otl_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     '@auto': ['@auto-otl', '@auto-vim-outline',],

--- a/leo/plugins/importers/pascal.py
+++ b/leo/plugins/importers/pascal.py
@@ -45,9 +45,9 @@ class Pascal_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for pascal."""
-    Pascal_Importer(c).import_from_string(parent, s)
+    Pascal_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.pas'],

--- a/leo/plugins/importers/perl.py
+++ b/leo/plugins/importers/perl.py
@@ -46,9 +46,9 @@ class Perl_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for perl."""
-    Perl_Importer(c).import_from_string(parent, s)
+    Perl_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.pl',],

--- a/leo/plugins/importers/php.py
+++ b/leo/plugins/importers/php.py
@@ -17,9 +17,9 @@ class Php_Importer(Importer):
     language = 'php'
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for php."""
-    Php_Importer(c).import_from_string(parent, s)
+    Php_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.php'],

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -286,12 +286,12 @@ class Python_Importer(Importer):
                 # Clear extraneous `@others` nodes.
                 if p.b.strip() == '@others':
                     p.b = ''
-                # Promote duplicate nodes.
-                if not p.b and p.numberOfChildren() > 0 and p.firstChild().h == p.h:
-                    while p.hasChildren():
-                        child = p.firstChild()
-                        child.moveAfter(p)
-                        p.doDelete()
+
+                # Delete a duplicate *child*, not the parent.
+                if not p.b and p.numberOfChildren() == 1 and p.firstChild().h == p.h:
+                    child = p.firstChild()
+                    p.b = child.b
+                    child.doDelete()
         #@+node:ekr.20230825164231.1: *4* function: find_docstring
         def find_docstring(p: Position) -> Optional[str]:
             """Creating a regex that returns a docstring is too tricky."""

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -280,11 +280,11 @@ class Python_Importer(Importer):
             if g.unitTesting:  # Don't interfere with unit tests.
                 return
 
+            # Handle all possible nodes.
             while parent and not parent.isAnyAtFileNode():
                 parent = parent.parent()
 
             for p in parent.subtree():
-                # g.printObj(p.b, tag=f"{g.my_name()} body: {p.h}")
                 if p.b.strip() == '@others':
                     p.b = ''
                     at.any_changed_vnodes = True

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -270,26 +270,6 @@ class Python_Importer(Importer):
                     if not found:
                         # Replace 'def ' by 'function'
                         child.h = f"function: {child.h[4:].strip()}"
-        #@+node:ekr.20250711094940.1: *4* python_i.function: delete_empty_changed_organizers
-        def delete_empty_changed_organizers(parent: Position) -> None:
-            """
-            #4385: Clean up nodes created by the at.do_changed_node.
-            """
-
-            # Handle all possible nodes.
-            while parent and not parent.isAnyAtFileNode():
-                parent = parent.parent()
-
-            for p in parent.subtree():
-                # Clear extraneous `@others` nodes.
-                if p.b.strip() == '@others':
-                    p.b = ''
-
-                # Delete a duplicate *child*, not the parent.
-                if not p.b and p.numberOfChildren() == 1 and p.firstChild().h == p.h:
-                    child = p.firstChild()
-                    p.b = child.b
-                    child.doDelete()
         #@+node:ekr.20230825164231.1: *4* python_i.function: find_docstring
         def find_docstring(p: Position) -> Optional[str]:
             """Creating a regex that returns a docstring is too tricky."""
@@ -369,7 +349,6 @@ class Python_Importer(Importer):
         move_module_preamble(self.lines, parent, result_blocks)
         move_class_docstrings(parent)
         adjust_at_others(parent)
-        delete_empty_changed_organizers(parent)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -230,7 +230,7 @@ class Python_Importer(Importer):
         """
 
         #@+others  # Define helper functions.
-        #@+node:ekr.20230830113521.1: *4* function: adjust_at_others
+        #@+node:ekr.20230830113521.1: *4* python_i.function: adjust_at_others
         def adjust_at_others(parent: Position) -> None:
             """
             Add a blank line before @others, and remove the leading blank line in the first child.
@@ -244,7 +244,7 @@ class Python_Importer(Importer):
                             p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
                             child.b = child.b[1:]
                             break
-        #@+node:ekr.20230825100219.1: *4* function: adjust_headlines
+        #@+node:ekr.20230825100219.1: *4* python_i.function: adjust_headlines
         def adjust_headlines(parent: Position) -> None:
             """
             python_i.adjust_headlines.
@@ -253,7 +253,7 @@ class Python_Importer(Importer):
 
             Add class names for all methods.
 
-            Change 'def' to 'function:' for all non-methods.
+            Change 'def' to 'python_i.function:' for all non-methods.
             """
             for child in parent.subtree():
                 found = False
@@ -270,7 +270,7 @@ class Python_Importer(Importer):
                     if not found:
                         # Replace 'def ' by 'function'
                         child.h = f"function: {child.h[4:].strip()}"
-        #@+node:ekr.20250711094940.1: *4* function: delete_empty_changed_organizers
+        #@+node:ekr.20250711094940.1: *4* python_i.function: delete_empty_changed_organizers
         def delete_empty_changed_organizers(parent: Position) -> None:
             """
             #4385: Clean up nodes created by the at.do_changed_node.
@@ -292,7 +292,7 @@ class Python_Importer(Importer):
                     child = p.firstChild()
                     p.b = child.b
                     child.doDelete()
-        #@+node:ekr.20230825164231.1: *4* function: find_docstring
+        #@+node:ekr.20230825164231.1: *4* python_i.function: find_docstring
         def find_docstring(p: Position) -> Optional[str]:
             """Creating a regex that returns a docstring is too tricky."""
             delims = ('"""', "'''")
@@ -312,7 +312,7 @@ class Python_Importer(Importer):
                 i += 1
             return None
 
-        #@+node:ekr.20230825164234.1: *4* function: move_class_docstring
+        #@+node:ekr.20230825164234.1: *4* python_i.function: move_class_docstring
         def move_class_docstring(docstring: str, child_p: Position, class_p: Position) -> None:
             """Move the docstring from child_p to class_p."""
 
@@ -336,7 +336,7 @@ class Python_Importer(Importer):
             # This isn't perfect in some situations.
             docstring_list = [f"{' '*4}{z}" for z in g.splitLines(docstring)]
             class_p.b = ''.join(class_lines[:n] + docstring_list + class_lines[n:])
-        #@+node:ekr.20230825111112.1: *4* function: move_class_docstrings
+        #@+node:ekr.20230825111112.1: *4* python_i.function: move_class_docstrings
         def move_class_docstrings(parent: Position) -> None:
             """
             Move class docstrings from the class node's first child to the class node.
@@ -348,7 +348,7 @@ class Python_Importer(Importer):
                         docstring = find_docstring(child1)
                         if docstring:
                             move_class_docstring(docstring, child1, p)
-        #@+node:ekr.20230930181855.1: *4* function: move_module_preamble
+        #@+node:ekr.20230930181855.1: *4* python_i.function: move_module_preamble
         def move_module_preamble(lines: list[str], parent: Position, result_blocks: list[Block]) -> None:
             """Move the preamble lines from the parent's first child to the start of parent.b."""
             child1 = parent.firstChild()

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -275,8 +275,6 @@ class Python_Importer(Importer):
             """
             #4385: Clean up nodes created by the at.do_changed_node.
             """
-            if g.unitTesting:  # Don't interfere with unit tests.
-                return
 
             # Handle all possible nodes.
             while parent and not parent.isAnyAtFileNode():
@@ -353,9 +351,6 @@ class Python_Importer(Importer):
             """Move the preamble lines from the parent's first child to the start of parent.b."""
             child1 = parent.firstChild()
             if not child1:
-                return
-
-            if not g.unitTesting and not parent.isAnyAtFileNode():  # #4385.
                 return
 
             # Compute the preamble.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -275,8 +275,6 @@ class Python_Importer(Importer):
             """
             #4385: Clean up nodes created by the at.do_changed_node.
             """
-            c = self.c
-            at = c.atFileCommands
             if g.unitTesting:  # Don't interfere with unit tests.
                 return
 
@@ -285,18 +283,15 @@ class Python_Importer(Importer):
                 parent = parent.parent()
 
             for p in parent.subtree():
+                # Clear extraneous `@others` nodes.
                 if p.b.strip() == '@others':
                     p.b = ''
-                    at.any_changed_vnodes = True
-                    p.setDirty()
-                    parent.setDirty()
-                child = p.firstChild()
-                if not p.b and p.numberOfChildren() == 1 and child.h == p.h:
-                    child.moveAfter(p)
-                    child.setDirty()
-                    p.doDelete()
-                    parent.setDirty()
-                    at.any_changed_vnodes = True
+                # Promote duplicate nodes.
+                if not p.b and p.numberOfChildren() > 0 and p.firstChild().h == p.h:
+                    while p.hasChildren():
+                        child = p.firstChild()
+                        child.moveAfter(p)
+                        p.doDelete()
         #@+node:ekr.20230825164231.1: *4* function: find_docstring
         def find_docstring(p: Position) -> Optional[str]:
             """Creating a regex that returns a docstring is too tricky."""

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -373,9 +373,9 @@ class Python_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for python."""
-    Python_Importer(c).import_from_string(parent, s)
+    Python_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.py', '.pyw', '.pyi', '.codon'],  # mypy uses .pyi extension.

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -391,7 +391,7 @@ class Rust_Importer(Importer):
             return
 
         #@+others  # Define helper functions.
-        #@+node:ekr.20231031162249.1: *4* function: convert_docstring
+        #@+node:ekr.20231031162249.1: *4* rust_i.function: convert_docstring
         def convert_docstring(p: Position) -> None:
             """Convert the leading comments of p.b to a docstring."""
             if not p.b.strip():
@@ -420,7 +420,7 @@ class Rust_Importer(Importer):
                     results.append('\n')
             results.append('@c\n')
             p.b = ''.join(results) + ''.join(tail)
-        #@+node:ekr.20231031162142.1: *4* function: move_module_preamble
+        #@+node:ekr.20231031162142.1: *4* rust_i.function: move_module_preamble
         def move_module_preamble(lines: list[str], parent: Position, result_blocks: list[Block]) -> None:
             """
             Move the preamble lines from the parent's first child to the start of parent.b.
@@ -456,12 +456,36 @@ class Rust_Importer(Importer):
             parent.b = preamble_s + parent.b
             child1.b = child1.b.replace(preamble_s, '')
             child1.b = child1.b.lstrip('\n')
+        #@+node:ekr.20250712051537.1: *4* rust_i.function: delete_empty_changed_organizers
+        def delete_empty_changed_organizers(parent: Position) -> None:
+            """
+            #4385: Clean up nodes created by the at.do_changed_node.
+            """
+            if g.unitTesting:  # Don't interfere with unit tests.
+                return
+
+            # Handle all possible nodes.
+            while parent and not parent.isAnyAtFileNode():
+                parent = parent.parent()
+
+            for p in parent.subtree():
+                g.trace(p.level(), p.h)
+                # Clear extraneous `@others` nodes.
+                if p.b.strip() == '@others':
+                    p.b = ''
+
+                # Delete a duplicate *child*, not the parent.
+                if not p.b and p.numberOfChildren() == 1 and p.firstChild().h == p.h:
+                    child = p.firstChild()
+                    p.b = child.b
+                    child.doDelete()
         #@-others
 
         move_module_preamble(self.lines, parent, result_blocks)
         if 0:
             for p in parent.self_and_subtree():
                 convert_docstring(p)
+        delete_empty_changed_organizers(parent)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -391,7 +391,7 @@ class Rust_Importer(Importer):
             return
 
         #@+others  # Define helper functions.
-        #@+node:ekr.20231031162249.1: *4* rust_i.function: convert_docstring
+        #@+node:ekr.20231031162249.1: *4* rust_i.function: convert_docstring (not used)
         def convert_docstring(p: Position) -> None:
             """Convert the leading comments of p.b to a docstring."""
             if not p.b.strip():
@@ -452,10 +452,18 @@ class Rust_Importer(Importer):
             preamble_s = ''.join(real_preamble_lines)
             if not preamble_s.strip():
                 return
-            # Adjust the bodies.
+
+            # First, adjust the bodies.
             parent.b = preamble_s + parent.b
             child1.b = child1.b.replace(preamble_s, '')
-            child1.b = child1.b.lstrip('\n')
+
+            # Next, move leading lines to the parent, before the @others line.
+            while child1.b.startswith('\n'):
+                if '@others' in parent.b:
+                    parent.b = parent.b.replace('@others', '\n@others')
+                else:
+                    parent.b += '\n'
+                child1.b = child1.b[1:]
         #@-others
 
         move_module_preamble(self.lines, parent, result_blocks)

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -456,33 +456,12 @@ class Rust_Importer(Importer):
             parent.b = preamble_s + parent.b
             child1.b = child1.b.replace(preamble_s, '')
             child1.b = child1.b.lstrip('\n')
-        #@+node:ekr.20250712051537.1: *4* rust_i.function: delete_empty_changed_organizers
-        def delete_empty_changed_organizers(parent: Position) -> None:
-            """
-            #4385: Clean up nodes created by the at.do_changed_node.
-            """
-
-            # Handle all possible nodes.
-            while parent and not parent.isAnyAtFileNode():
-                parent = parent.parent()
-
-            for p in parent.subtree():
-                # Clear extraneous `@others` nodes.
-                if p.b.strip() == '@others':
-                    p.b = ''
-
-                # Delete a duplicate *child*, not the parent.
-                if not p.b and p.numberOfChildren() == 1 and p.firstChild().h == p.h:
-                    child = p.firstChild()
-                    p.b = child.b
-                    child.doDelete()
         #@-others
 
         move_module_preamble(self.lines, parent, result_blocks)
         if 0:
             for p in parent.self_and_subtree():
                 convert_docstring(p)
-        delete_empty_changed_organizers(parent)
     #@-others
 #@-others
 

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -460,6 +460,7 @@ class Rust_Importer(Importer):
             # Next, move leading lines to the parent, before the @others line.
             while child1.b.startswith('\n'):
                 if '@others' in parent.b:
+                    # Assume the importer created the @others.
                     parent.b = parent.b.replace('@others', '\n@others')
                 else:
                     parent.b += '\n'

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -461,15 +461,12 @@ class Rust_Importer(Importer):
             """
             #4385: Clean up nodes created by the at.do_changed_node.
             """
-            if g.unitTesting:  # Don't interfere with unit tests.
-                return
 
             # Handle all possible nodes.
             while parent and not parent.isAnyAtFileNode():
                 parent = parent.parent()
 
             for p in parent.subtree():
-                g.trace(p.level(), p.h)
                 # Clear extraneous `@others` nodes.
                 if p.b.strip() == '@others':
                     p.b = ''

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -486,9 +486,9 @@ class Rust_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for rust."""
-    Rust_Importer(c).import_from_string(parent, s)
+    Rust_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.rs',],

--- a/leo/plugins/importers/scheme.py
+++ b/leo/plugins/importers/scheme.py
@@ -27,9 +27,9 @@ class Scheme_Importer(Elisp_Importer):
     )
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for scheme."""
-    Scheme_Importer(c).import_from_string(parent, s)
+    Scheme_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.scm',],

--- a/leo/plugins/importers/tcl.py
+++ b/leo/plugins/importers/tcl.py
@@ -24,9 +24,9 @@ class Tcl_Importer(Importer):
     )
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for tcl."""
-    Tcl_Importer(c).import_from_string(parent, s)
+    Tcl_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.tcl'],

--- a/leo/plugins/importers/treepad.py
+++ b/leo/plugins/importers/treepad.py
@@ -93,9 +93,9 @@ class Treepad_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for treepad."""
-    Treepad_Importer(c).import_from_string(parent, s)
+    Treepad_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.hjt',],

--- a/leo/plugins/importers/typescript.py
+++ b/leo/plugins/importers/typescript.py
@@ -54,9 +54,9 @@ class TS_Importer(JS_Importer):
     #@-<< define function patterns >>
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for typescript."""
-    TS_Importer(c).import_from_string(parent, s)
+    TS_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.ts',],

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -138,9 +138,9 @@ class Xml_Importer(Importer):
     #@-others
 #@-others
 
-def do_import(c: Cmdr, parent: Position, s: str) -> None:
+def do_import(c: Cmdr, parent: Position, s: str, treeType: str = '@file') -> None:
     """The importer callback for xml."""
-    Xml_Importer(c).import_from_string(parent, s)
+    Xml_Importer(c).import_from_string(parent, s, treeType=treeType)
 
 importer_dict = {
     'extensions': ['.xml',],

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -68,8 +68,9 @@ class TestLeoImport(BaseTestImporter):
                 '\n'
                 '@others\n'
                 'return new_func\n'
-                '@language python\n'
-                '@tabwidth -4\n'
+                # #4385. This is an improvement!
+                # '@language python\n'
+                # '@tabwidth -4\n'
             ),
             (1, 'function: macro',
                 'def macro(func):\n'

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1106,7 +1106,8 @@ class TestAtShadow(LeoUnitTest):
         # Run the test.
         self.readOneAtCleanNode(test_p, new_contents)
         assert test_p.b == new_contents
-        assert test_p.v in at.changed_vnodes
+        ### assert test_p.v in at.changed_vnodes
+        assert test_p.v in at.changed_vnodes_dict.get(test_p.v)
         assert p.v.isDirty(), p
         assert test_p.isDirty(), test_p
     #@-others

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1105,6 +1105,8 @@ class TestAtShadow(LeoUnitTest):
         self.readOneAtCleanNode(test_p, new_contents)
         assert test_p.b == new_contents
         assert test_p.v in at.changed_vnodes
+        assert p.v.isDirty()
+        assert test_p.isDirty()
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1083,22 +1083,24 @@ class TestAtShadow(LeoUnitTest):
 
         # Create the test node.
         test_p = p.insertAsLastChild()
-        test_p.h = 'test'
+        test_p.h = 'test.py'
         test_p.b = self.prep(
             """
-                node 1 line 1
-                node 1 line 2
-                node 2 line 1
-                node 2 line 2
+                def spam():
+                    pass
+
+                def eggs():
+                    pass
             """)
 
         # Define the new contents.
         new_contents = self.prep(
             """
-                node 1 line 1
-                node 1 line 1 changed
-                node 2 line 1
-                node 2 line 2
+                def spam():
+                    pass
+
+                def eggs():
+                    pass  # Changed.
             """)
 
         # Run the test.

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1107,8 +1107,8 @@ class TestAtShadow(LeoUnitTest):
         self.readOneAtCleanNode(test_p, new_contents)
         assert test_p.b == new_contents
         assert test_p.v in at.changed_vnodes
-        assert p.v.isDirty()
-        assert test_p.isDirty()
+        assert p.v.isDirty(), p
+        assert test_p.isDirty(), test_p
     #@-others
 #@-others
 #@-leo

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1079,7 +1079,6 @@ class TestAtShadow(LeoUnitTest):
     def test_changed_vnodes(self):
         c = self.c
         p = c.p
-        at = c.atFileCommands
 
         # Create the test node.
         test_p = p.insertAsLastChild()
@@ -1106,7 +1105,6 @@ class TestAtShadow(LeoUnitTest):
         # Run the test.
         self.readOneAtCleanNode(test_p, new_contents)
         assert test_p.b == new_contents
-        assert test_p.v in at.changed_vnodes_dict.get(test_p.v)
         assert p.v.isDirty(), p
         assert test_p.isDirty(), test_p
     #@-others

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1106,7 +1106,6 @@ class TestAtShadow(LeoUnitTest):
         # Run the test.
         self.readOneAtCleanNode(test_p, new_contents)
         assert test_p.b == new_contents
-        ### assert test_p.v in at.changed_vnodes
         assert test_p.v in at.changed_vnodes_dict.get(test_p.v)
         assert p.v.isDirty(), p
         assert test_p.isDirty(), test_p


### PR DESCRIPTION
This PR covers *all* phases of #4385.

This PR is the biggest improvement in `@clean` since it debuted 10 years ago in April, 2015:
we can now use `@clean` nodes on huge repos!

This PR removes bugs and hangnails we've been living with since day one:

- Leo will detect changes to external `@clean` files whether or not Leo is running.
- Leo leaves whitespace unchanged when importing to `@clean` or `@auto`. Why has nobody complained???
- When importing or updating `@clean` trees, Leo will move leading blank lines to the start of the previous node.
    These moves happen *only in newly-updated nodes*, so you can "undo" these moves if you like.
    However, in my experience moving leading blank lines to the previous node is almost always best.

**A spectacular new feature: the update review tree**

- Whenever Leo detects updated nodes in `@clean` trees, Leo will create a new top-level node called
`Updated @clean/@auto nodes`.
  Let's call this node and its descendents the **update report tree**.
- This top-level node contains **update organizer nodes**  for each file that contains updated nodes.
  The name of these nodes has the form: `Updated from: whatever.py`
- Leo creates clones of each updated node as children of these organizer nodes.
- Leo puts the diffs of all the updated nodes from each file in the appropriate update organizer node.

The update review tree completes the `@clean world`. It ranks with Leo's killer `git-diff` and `cff` commands!
You can retain, change or delete any part of the update report tree as you like:
- Deleting any part of this tree has no effect on any external file.
- As with the `cff` and `git-diff` commands, changing cloned nodes *will* change the corresponding external file.

<details><summary><b>Phase 1: A huge optimization: Don't read unchanged `@`clean files</b></summary>
<br>

- This PR makes *no* significant changes to the `@clean` (Mulder-Ream) update algorithm.
  The only changes to `leoShadow.py involve annotations and removing an unused method.
- Leo keeps track of when it last wrote each external file as follows:
  - [x] `at.readOneAtCleanNode` and `at.writeOneAtCleanNode` always write the `_mod_time` uA.
  - [x] Importers set the mod time for `@clean` nodes *only*. The mod time of other kinds of nodes will never be used.
  - [x] The `RecursiveImportController` script marks outlines as dirty, so that mod times will (usually!) be written.

</details>

<details><summary><b>Phase 2: Create summary clones of updated `@`clean files</b></summary>
<br>

- [x] `at.readOneAtCleanNode` inits and updates the global `x.bodies_dict` dict.
- [x] Add `at.do_changed_vnode`. It calls the proper importer.
- [x] Add the `delete_empty_changed_organizers` function to `python_i.post_process`.
  This function handles imperfections when importing parts of Python files.
- [x] Add tests of rust files.
- [x] Group cloned updates by file.

</details>

<details><summary><b>Phase 3: Final improvements and bug fixes</b></summary>
<br>

- [x] Add the `treeType` kwarg to all `do_import` functions and `i.import_from_string` in an upward compatible way.
    To do this, I had to ignore and remove evil incorrect comments about the `treeType` arguments!
- [x] Don't touch whitespace when importing to `@clean` or `@auto`.
    - Retain whitespace in `rust_i.function: move_module_preamble`.
    - Retain whitespace (in `@clean` and `@auto` trees) in `i.compute_body`.
- [x] Fix several bugs in the import logic, especially the Rust importer.
    The rust importer now passes the **acid test**:
    Leo round-trips all imported files in the [Rust compiler repo](https://github.com/rust-lang/rust/tree/master/compiler) without changes!
- [x] Call `at.readOneAtCleanNode` from the external files controller.
- [x] Add diffs to update organizer nodes!

</details>

<details><summary><b>Code Cleanups and Testing</b></summary>
<br>

- [x] Add `__slots__` to the `ShadowController` class.
- [x] Remove vestigial code related to `@root` trees.
- [x] Change `TestShadow` to `TestAtShadow` in headlines.
- [x] Add unit tests for the new code that detects changed nodes.
- [x] Add  `TestAtShadow.readOneAtCleanNode`.
     This is a much more straightforward approach to unit tests.

</details>

<details><summary><b>Fix Bugs</b></summary>
<br>

The following bugs had to be fixed as part of this PR:

- [x] *Only* `at.WriteAll` sets the `at.canCancelFlag`, `at.cancelFlag`, and `at.yesToAll` ivars.
    This bug was directly relevant to the `@clean` import and write logic.
- [x] `at.shouldPromptForDangerousWrite` no longer complains about unread `@clean` trees.
- [x] Fix crasher in `g.objToString`: The `VNode` keys in `at.bodies_dict` are not sortable!
- [x] Fix crasher in `efc.idle_check_commander`: The old `c.p` position may no longer exist!

</details>

**Latest statistics**

The following statistics are for `rust_c.leo` containing all the sources for the Rust compiler:

```
Import:
imported 38912 nodes in 1980 files in 90.11 seconds

Load:
read 2019 files in 0.68 seconds
read outline in 3.80 seconds
```