### PR TITLE
PR: Support @leo nodes

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -302,6 +302,18 @@ class AtFile:
         root_v = leoNodes.VNode(context=c)
         root = leoNodes.Position(root_v)
         FastAtRead(c, gnx2vnode={}).read_into_root(s, fn, root)
+    #@+node:ekr.20250724123631.1: *5* at.openAtLeoNode
+    @cmd('open-at-leo-file')
+    def writeAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+        c, p = self.c, self.c.p
+        if not p.isAtLeoNode():
+            g.red('Please select an @leo node')
+            return
+        path = c.fullPath(p)
+        if g.os_path_exists(path):
+            g.openWithFileName(path, old_c=c)  # type:ignore
+        else:
+            g.red(f"file not found: {path}")
     #@+node:ekr.20041005105605.19: *5* at.openFileForReading & helper
     def openFileForReading(self, fromString: str = None) -> tuple[Optional[str], Optional[str]]:
         """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1437,7 +1437,7 @@ class AtFile:
         at.root = root
         if p.isAtLeoNode() or p.isAtIgnoreNode():  # pragma: no cover
             # Should have been handled in findFilesToWrite.
-            g.trace(f"Can not happen: {p.h} is an @ignore node")
+            g.trace(f"Can not happen: unexpected node: {p.h}")
             return
         try:
             at.writePathChanged(p)

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1374,7 +1374,7 @@ class AtFile:
         files: list[Position] = []
         while p and p != after:
             if p.isAtLeoNode():
-                pass
+                p.moveToNodeAfterTree()
             elif p.isAtIgnoreNode() and not p.isAtAsisFileNode():
                 # Honor @ignore in *body* text, but *not* in @asis nodes.
                 if p.isAnyAtFileNode():

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -307,6 +307,7 @@ class AtFile:
     def openAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         """
         Open the outline given by the @leo node at c.p.
+        If the outline has already been loaded, switch to its tab.
 
         Scripts should use c.makeLinkLeoFiles helper to make @leo files.
         """

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1373,7 +1373,9 @@ class AtFile:
         seen = set()
         files: list[Position] = []
         while p and p != after:
-            if p.isAtIgnoreNode() and not p.isAtAsisFileNode():
+            if p.isAtLeoNode():
+                pass
+            elif p.isAtIgnoreNode() and not p.isAtAsisFileNode():
                 # Honor @ignore in *body* text, but *not* in @asis nodes.
                 if p.isAnyAtFileNode():
                     c.ignored_at_file_nodes.append(p.h)
@@ -1433,7 +1435,7 @@ class AtFile:
         """
         at = self
         at.root = root
-        if p.isAtIgnoreNode():  # pragma: no cover
+        if p.isAtLeoNode() or p.isAtIgnoreNode():  # pragma: no cover
             # Should have been handled in findFilesToWrite.
             g.trace(f"Can not happen: {p.h} is an @ignore node")
             return

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -305,6 +305,11 @@ class AtFile:
     #@+node:ekr.20250724123631.1: *5* at.openAtLeoFile
     @cmd('open-at-leo-file')
     def openAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+        """
+        Open the outline given by the @leo node at c.p.
+
+        Scripts should use c.makeLinkLeoFiles helper to make @leo files.
+        """
         c, p = self.c, self.c.p
         if not p.isAtLeoNode():
             g.red('Please select an @leo node')

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -302,9 +302,9 @@ class AtFile:
         root_v = leoNodes.VNode(context=c)
         root = leoNodes.Position(root_v)
         FastAtRead(c, gnx2vnode={}).read_into_root(s, fn, root)
-    #@+node:ekr.20250724123631.1: *5* at.openAtLeoNode
+    #@+node:ekr.20250724123631.1: *5* at.openAtLeoFile
     @cmd('open-at-leo-file')
-    def writeAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
+    def openAtLeoFile(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover
         c, p = self.c, self.c.p
         if not p.isAtLeoNode():
             g.red('Please select an @leo node')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3598,7 +3598,7 @@ class Commands:
     def makeLinkLeoFiles(self,
         *,
         extensions: list[str],  # List of file extensions for generated @<file> nodes.
-        kind: str,  # One of @auto, @clean, @file, etc.
+        kind: str,  # Any @<file> type. @clean is recommended.
         top_directory: str,
         sub_directories: list[str] = None,
         sub_outline_name: str = None,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3598,8 +3598,8 @@ class Commands:
     def makeLinkLeoFiles(self,
         *,
         extensions: list[str],  # List of file extensions for generated @<file> nodes.
-        kind: str,  # Any @<file> type. @clean is recommended.
         top_directory: str,
+        kind: str = '@clean',  # Any @<file> type. @clean is recommended.
         sub_directories: list[str] = None,
         sub_outline_name: str = None,
         top_outline_name: str = 'leo_links.leo',

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3602,7 +3602,6 @@ class Commands:
         kind: str = '@clean',  # Any @<file> type. @clean is recommended.
         report_changed_at_clean_nodes: bool = True,  # Recommended.
         sub_directories: list[str] = None,
-        sub_outline_name: str = None,
         top_outline_name: str = None,
     ) -> None:
         #@+<< c.makeLinkLeoFiles: docstring >>
@@ -3688,9 +3687,9 @@ class Commands:
                     ])
                 #@-<< find files in sub_directory >>
                 if files:
+                    sub_outline_name = f"{g.shortFileName(sub_directory)}_links.leo"
                     #@+<< add link to the sub outline to top_links >>
                     #@+node:ekr.20250725163807.1: *5* << add link to the sub outline to top_links >>
-                    sub_outline_name = f"{g.shortFileName(sub_directory)}_links.leo"
                     abs_path = f"{sub_directory}{os.sep}{sub_outline_name}"
                     rel_link = os.path.relpath(abs_path, start=top_directory)
                     top_links.append(rel_link.replace('\\', '/'))

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3660,21 +3660,26 @@ class Commands:
                     f"{sub_directory}{os.sep}**{os.sep}*{ext}",
                     recursive=True,
                 )
-                if new_files:
-                    ### To do: handle non-direct directories.
-                    outline_name = f"{g.shortFileName(sub_directory)}_links.leo"
-                    top_links.append(outline_name)
+
+                # _create_link_files converts these full paths to relative paths.
                 files.extend([
                     z for z in new_files
                     if os.path.isfile(z) and z not in files
                 ])
+
+            # Create one link to the sub-directory.
+            if files:
+                outline_name = f"{g.shortFileName(sub_directory)}_links.leo"
+                abs_path = f"{sub_directory}{os.sep}{outline_name}"
+                relative_link = os.path.relpath(abs_path, start=top_directory)
+                top_links.append(relative_link.replace('\\', '/'))
 
             self._create_link_file(
                 directory=sub_directory,
                 extensions=extensions,
                 files=files,
                 kind=kind,
-                ### To do: handle non-direct directories.
+                ### To do: generalize ../
                 links=[f"../{top_outline_name}"],  # Add one link to the parent.
                 outline_name=f"{g.shortFileName(sub_directory)}_links.leo",
             )
@@ -3697,6 +3702,11 @@ class Commands:
         links: list[str],
         outline_name: str,
     ) -> None:
+        """
+        The caller is responsible for making links relative to the top-level directory.
+
+        This method creates @<file> nodes whose paths are relative to *this* directory.
+        """
         # pylint: disable=no-member
         c = self
         assert os.path.exists(directory), directory

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3671,16 +3671,20 @@ class Commands:
             if files:
                 outline_name = f"{g.shortFileName(sub_directory)}_links.leo"
                 abs_path = f"{sub_directory}{os.sep}{outline_name}"
-                relative_link = os.path.relpath(abs_path, start=top_directory)
-                top_links.append(relative_link.replace('\\', '/'))
+                rel_link = os.path.relpath(abs_path, start=top_directory)
+                top_links.append(rel_link.replace('\\', '/'))
 
+            # Compute the relative back link for the sub-outline.
+            abs_back_link = f"{top_directory}{os.sep}{top_outline_name}"
+            rel_back_link = os.path.relpath(abs_back_link, start=sub_directory)
+
+            # Generate the sub-outline
             self._create_link_file(
                 directory=sub_directory,
                 extensions=extensions,
                 files=files,
                 kind=kind,
-                ### To do: generalize ../
-                links=[f"../{top_outline_name}"],  # Add one link to the parent.
+                links=[rel_back_link.replace('\\', '/')],  # Add one link to the parent.
                 outline_name=f"{g.shortFileName(sub_directory)}_links.leo",
             )
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3647,7 +3647,13 @@ class Commands:
                 if os.path.isdir(os.path.join(top_directory, z))
             ]
 
+        g.es_print(
+            f"Scanning {len(sub_directories)} directories. "
+            'This may take awhile'
+        )
+
         # The main loop.
+        all_files: list[str] = []
         top_links: list[str] = []
         for sub_directory in sub_directories:
             sub_directory = os.path.join(top_directory, sub_directory)
@@ -3673,6 +3679,7 @@ class Commands:
                 abs_path = f"{sub_directory}{os.sep}{outline_name}"
                 rel_link = os.path.relpath(abs_path, start=top_directory)
                 top_links.append(rel_link.replace('\\', '/'))
+                all_files.append(outline_name)
 
             # Compute the relative back link for the sub-outline.
             abs_back_link = f"{top_directory}{os.sep}{top_outline_name}"
@@ -3689,6 +3696,7 @@ class Commands:
             )
 
         # Create the top-level links file.
+        all_files.append(top_outline_name)
         self._create_link_file(
             directory=top_directory,
             extensions=extensions,
@@ -3697,6 +3705,9 @@ class Commands:
             links=top_links,
             outline_name=top_outline_name,
         )
+        all_files = sorted(list(set(all_files)))
+        if not g.unitTesting:
+            g.es_print(f"Done! Created {len(all_files)} outline files")
     #@+node:ekr.20250717132857.1: *5* c._create_link_file
     def _create_link_file(self,
         directory: str,
@@ -3722,7 +3733,7 @@ class Commands:
         assert settings_p
         c.selectPosition(settings_p)
         c.copyOutline()
-        c2 = g.app.newCommander(fileName=outline_name)
+        c2 = g.app.newCommander(fileName=outline_name, gui=g.app.nullGui)
         c2.pasteOutline()
         c2.rootPosition().doDelete()
         c2.selectPosition(c2.rootPosition())
@@ -3740,7 +3751,7 @@ class Commands:
 
         outline_path = os.path.join(directory, outline_name)
         c2.clearChanged()
-        c2.saveTo(fileName=outline_path)
+        c2.saveTo(fileName=outline_path, silent=True)
         c2.redraw()
         # c2.close()
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3688,8 +3688,13 @@ class Commands:
                     all_files.append(outline_name)
 
                 # Compute the relative back link for the sub-outline.
-                abs_back_link = f"{top_directory}{os.sep}{top_outline_name}"
-                rel_back_link = os.path.relpath(abs_back_link, start=sub_directory)
+                if use_back_links:
+                    # Add one link to the parent.
+                    abs_back_link = f"{top_directory}{os.sep}{top_outline_name}"
+                    rel_back_link = os.path.relpath(abs_back_link, start=sub_directory)
+                    links = [rel_back_link.replace('\\', '/')]
+                else:
+                    links = []
 
                 # Generate the sub-outline
                 self._create_link_file(
@@ -3697,9 +3702,8 @@ class Commands:
                     extensions=extensions,
                     files=files,
                     kind=kind,
-                    links=[rel_back_link.replace('\\', '/')],  # Add one link to the parent.
+                    links=links,
                     outline_name=f"{g.shortFileName(sub_directory)}_links.leo",
-                    use_back_links=use_back_links,
                 )
 
             # Create the top-level links file.
@@ -3711,7 +3715,6 @@ class Commands:
                 kind='@leo',
                 links=top_links,
                 outline_name=top_outline_name,
-                use_back_links=use_back_links,
             )
             all_files = sorted(list(set(all_files)))
             if not g.unitTesting:
@@ -3729,7 +3732,6 @@ class Commands:
         kind: str,
         links: list[str],
         outline_name: str,
-        use_back_links: bool,
     ) -> None:
         """
         The caller is responsible for making links relative to the top-level directory.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3809,6 +3809,14 @@ class Commands:
         Note: gui eventually defaults to g.app.gui.
         """
         c = self
+
+        t1 = time.process_time()
+
+        # Using the Qt gui will likely overwhelm Leo!
+        if gui is None:
+            gui = g.app.nullGui
+
+        # The main loop.
         calls = 0  # The number of calls to g.openWithFileName.
         result: list[Commands] = []
         scanned: list[str] = []  # List of paths already scanned.
@@ -3843,7 +3851,10 @@ class Commands:
             fileName = todo.pop()
             scan(fileName)
 
-        if not g.unitTesting:  ### Temp.
+        if not g.unitTesting:
+            t2 = time.process_time()
+            kind = 'hidden ' if gui == g.app.nullGui else ''
+            g.es_print(f"Done! Opened {len(result)} {kind}outlines in {t2 - t1:3.2} sec")
             g.trace('calls', calls, c.shortFileName())
             g.printObj(scanned, tag='Scanned')
             g.printObj(result, tag='Result')

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3649,7 +3649,7 @@ class Commands:
 
         # The main loop.
         top_links: list[str] = []
-        for sub_directory in sub_directories[:3]:  ###
+        for sub_directory in sub_directories:
             sub_directory = os.path.join(top_directory, sub_directory)
             assert os.path.exists(sub_directory), repr(sub_directory)
             files = []

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3839,7 +3839,7 @@ class Commands:
             g.es_print('Scan', fileName)
             for p in c.all_unique_positions():
                 if p.isAtLeoNode():
-                    fileName = p.atLeoFileName()
+                    fileName = p.atLeoNodeName()
                     if fileName not in todo and fileName not in scanned:
                         c2 = g.openWithFileName(fileName, gui=gui)
                         calls += 1

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3613,14 +3613,17 @@ class Commands:
 
         Scripts calling this method need only specify the value of the following kwargs:
 
-        - extensions:      List of file extensions for generated @<file> nodes.
-        - kind:            One of @auto, @clean, @file, etc.
-        - sub_directories: An optional list of sub-directories in which to create sub-outlines.
-                           Relative paths are relative to the top-level directory.
-                           If the list is empty, it defaults to all direct directories of
-                           the top-level directory.
-        - top_directory:   The full, absolute, path to the top-level directory.
-        - top_file_name:   The name of the top-level link outline.
+        - extensions:       List of file extensions for generated @<file> nodes.
+        - kind:             One of @auto, @clean, @file, etc.
+        - report_changed_at_clean_nodes:
+                            The value to use for @bool report-changed-at-clean-nodes
+                            in all generated outlines.
+        - sub_directories:  An optional list of sub-directories in which to create sub-outlines.
+                            Relative paths are relative to the top-level directory.
+                            If the list is empty, it defaults to all direct directories of
+                            the top-level directory.
+        - top_directory:    The full, absolute, path to the top-level directory.
+        - top_outline_name: The name of the top-level link outline.
         """
         #@-<< c.makeLinkLeoFiles: docstring >>
         c = self

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3668,10 +3668,10 @@ class Commands:
             for sub_directory in sub_directories:
                 sub_directory = os.path.join(top_directory, sub_directory)
                 assert os.path.exists(sub_directory), repr(sub_directory)
+                files = []
                 #@+<< find files in sub_directory >>
                 #@+node:ekr.20250725163431.1: *5* << find files in sub_directory >>
                 # Set files to the list of full, absolute, files in subdirectory.
-                files = []
                 for ext in extensions:
                     if not ext.startswith('.'):
                         ext = '.' + ext
@@ -3688,7 +3688,7 @@ class Commands:
                 #@-<< find files in sub_directory >>
                 if files:
                     #@+<< add link to the sub outline to top_links >>
-                    #@+node:ekr.20250725163807.1: *5* << add link to the sub outline to top_links>>
+                    #@+node:ekr.20250725163807.1: *5* << add link to the sub outline to top_links >>
                     sub_outline_name = f"{g.shortFileName(sub_directory)}_links.leo"
                     abs_path = f"{sub_directory}{os.sep}{sub_outline_name}"
                     rel_link = os.path.relpath(abs_path, start=top_directory)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3627,7 +3627,6 @@ class Commands:
         c = self
         #@+<< return if initial checks fail >>
         #@+node:ekr.20250725152511.1: *5* << return if initial checks fail >>
-        # Check the top directory.
         if (
             not top_directory
             or not os.path.isdir(top_directory)
@@ -3636,10 +3635,6 @@ class Commands:
         ):
             g.es_print(f"Not an absolute directory: {top_directory!r}")
             return
-
-        # Make sure all extensions begin with '.':
-        if isinstance(extensions, str):
-            extensions = [extensions]
         if not isinstance(extensions, (list, tuple)):
             g.es_print(f"Invalid list of extensions: {extensions!r}")
             return

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3600,6 +3600,7 @@ class Commands:
         extensions: list[str],  # List of file extensions for generated @<file> nodes.
         top_directory: str,
         kind: str = '@clean',  # Any @<file> type. @clean is recommended.
+        report_changed_at_clean_nodes: bool = True,  # Recommended.
         sub_directories: list[str] = None,
         sub_outline_name: str = None,
         top_outline_name: str = 'leo_links.leo',
@@ -3710,6 +3711,7 @@ class Commands:
                         kind=kind,
                         links=back_link,
                         outline_name=f"{g.shortFileName(sub_directory)}_links.leo",
+                        report_changed_at_clean_nodes=report_changed_at_clean_nodes,
                     )
                     #@-<< create the sub outline >>
                     all_files.append(sub_outline_name)
@@ -3722,6 +3724,7 @@ class Commands:
                 kind='@leo',
                 links=top_links,
                 outline_name=top_outline_name,
+                report_changed_at_clean_nodes=report_changed_at_clean_nodes,
             )
             #@-<< create the top-level outline >>
             all_files = sorted(list(set(all_files)))
@@ -3740,6 +3743,7 @@ class Commands:
         kind: str,
         links: list[str],
         outline_name: str,
+        report_changed_at_clean_nodes: bool,
     ) -> None:
         """
         The caller is responsible for making links relative to the top-level directory.
@@ -3751,8 +3755,13 @@ class Commands:
 
         # Create an @settings tree containing one @history-list node.
         c2 = g.app.newCommander(fileName=outline_name, gui=g.app.nullGui)
+
+        # Create the @settings tree.
         root = c2.rootPosition()
         root.h = '@settings'
+        report_p = root.insertAsLastChild()
+        report_s = 'True' if report_changed_at_clean_nodes else 'False'
+        report_p.h = f"@bool report-changed-at-clean-nodes = {report_s}"
         history_p = root.insertAsLastChild()
         history_p.h = '@data history-list'
         history_p.b = 'open-at-leo-file\n'
@@ -3769,6 +3778,7 @@ class Commands:
             p = c2.lastTopLevel().insertAfter()
             p.h = f"{kind} {relative_path}"
 
+        # Create the file!
         outline_path = os.path.join(directory, outline_name)
         c2.clearChanged()
         c2.saveTo(fileName=outline_path, silent=True)

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3754,7 +3754,6 @@ class Commands:
         This method creates @<file> nodes whose paths are relative to *this* directory.
         """
         # pylint: disable=no-member
-        c = self
         assert os.path.exists(directory), directory
 
         # Create an @settings tree containing one @history-list node.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3603,7 +3603,7 @@ class Commands:
         report_changed_at_clean_nodes: bool = True,  # Recommended.
         sub_directories: list[str] = None,
         sub_outline_name: str = None,
-        top_outline_name: str = 'leo_links.leo',
+        top_outline_name: str = None,
     ) -> None:
         #@+<< c.makeLinkLeoFiles: docstring >>
         #@+node:ekr.20250717132150.1: *5* << c.makeLinkLeoFiles: docstring >>
@@ -3639,6 +3639,8 @@ class Commands:
             g.es_print(f"Invalid list of extensions: {extensions!r}")
             return
         #@-<< return if initial checks fail >>
+        if not top_outline_name:
+            top_outline_name = f"{os.path.basename(top_directory)}_links.leo"
         #@+<< calculate the list of subdirectories >>
         #@+node:ekr.20250725152709.1: *5* << calculate the list of subdirectories >>
         # Default to all direct sub-directories of the top directory.

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3775,7 +3775,7 @@ class Commands:
 
         # Create the file!
         outline_path = os.path.join(directory, outline_name)
-        c2.clearChanged()
+        c2.clearChanged()  # Essential!
         c2.saveTo(fileName=outline_path, silent=True)
         c2.redraw()
         c2.close()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3827,7 +3827,6 @@ class Commands:
             gui = g.app.nullGui
 
         # The main loop.
-        calls = 0  # The number of calls to g.openWithFileName.
         result: list[Commands] = []
         scanned: list[str] = []  # List of paths already scanned.
         todo: list[str] = []
@@ -3837,7 +3836,6 @@ class Commands:
             Add all paths not already seen to the todo list.
             Add all newly-opened commanders to the result list.
             """
-            nonlocal calls
             if fileName in scanned:
                 return
             scanned.append(fileName)
@@ -3847,7 +3845,6 @@ class Commands:
                     fileName = p.atLeoNodeName()
                     if fileName not in todo and fileName not in scanned:
                         c2 = g.openWithFileName(fileName, gui=gui)
-                        calls += 1
                         todo.append(fileName)
                         assert c2 not in result
                         result.append(c2)
@@ -3864,7 +3861,6 @@ class Commands:
             t2 = time.process_time()
             kind = 'hidden ' if gui == g.app.nullGui else ''
             g.es_print(f"Done! Opened {len(result)} {kind}outlines in {t2 - t1:3.2} sec")
-            g.trace('calls', calls, c.shortFileName())
             g.printObj(scanned, tag='Scanned')
             g.printObj(result, tag='Result')
         return result

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3655,10 +3655,10 @@ class Commands:
         )
 
         # The main loop.
+        old_p = c.p
         try:
             t1 = time.process_time()
             c.enableRedrawFlag = False
-            old_p = c.p
             all_files: list[str] = []
             top_links: list[str] = []
             for sub_directory in sub_directories:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3756,18 +3756,15 @@ class Commands:
         # pylint: disable=no-member
         c = self
         assert os.path.exists(directory), directory
-        # g.trace(f"{directory}{os.sep}{outline_name}")
 
-        # Create the outline and copy the settings.
-        h = '@settings'
-        settings_p = g.findNodeAnywhere(c, h)
-        assert settings_p
-        c.selectPosition(settings_p)
-        c.copyOutline()
+        # Create an @settings tree containing one @history-list node.
         c2 = g.app.newCommander(fileName=outline_name, gui=g.app.nullGui)
-        c2.pasteOutline()
-        c2.rootPosition().doDelete()
-        c2.selectPosition(c2.rootPosition())
+        root = c2.rootPosition()
+        root.h = '@settings'
+        history_p = root.insertAsLastChild()
+        history_p.h = '@data history-list'
+        history_p.b = 'open-at-leo-file\n'
+        c2.selectPosition(root)
 
         # Create @leo nodes.
         for link in links:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3622,6 +3622,33 @@ class Commands:
                 p.moveToNodeAfterTree()
             else:
                 p.moveToThreadNext()
+    #@+node:ekr.20250717080554.1: *4* c.openAllLinkedFiles
+    def openAllLinkedFiles(self, gui: LeoGui = None) -> list[Commands]:
+        """
+        Open the transitive closure of all outlines reachable from any @leo
+        node in this outline.
+
+        Return the list of newly-opened commanders.
+        """
+        result: list[Commands] = []
+
+        return result
+
+    #@+node:ekr.20031218072017.2081: *4* c.openRecentFile
+    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = None) -> None:
+        """
+        c.openRecentFile: This is not a command!
+
+        This method is a helper called only from the recentFilesCallback in
+        rf.createRecentFilesMenuItems.
+        """
+        c = self
+        if g.doHook("recentfiles1", c=c, p=c.p, v=c.p, fileName=fn):
+            return
+        c2 = g.openWithFileName(fn, old_c=c)
+        if c2:
+            g.app.makeAllBindings()
+            g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
     #@+node:ekr.20031218072017.2823: *4* c.openWith
     def openWith(self, event: LeoKeyEvent = None, d: dict[str, Position] = None) -> None:
         """
@@ -3662,21 +3689,6 @@ class Commands:
             else:
                 g.internalError(f"no gnx for vnode: {v}")
         c.fileCommands.gnxDict = d
-    #@+node:ekr.20031218072017.2081: *4* c.openRecentFile
-    def openRecentFile(self, event: LeoKeyEvent = None, fn: str = None) -> None:
-        """
-        c.openRecentFile: This is not a command!
-
-        This method is a helper called only from the recentFilesCallback in
-        rf.createRecentFilesMenuItems.
-        """
-        c = self
-        if g.doHook("recentfiles1", c=c, p=c.p, v=c.p, fileName=fn):
-            return
-        c2 = g.openWithFileName(fn, old_c=c)
-        if c2:
-            g.app.makeAllBindings()
-            g.doHook("recentfiles2", c=c2, p=c2.p, v=c2.p, fileName=fn)
     #@+node:ekr.20180508111544.1: *3* c.Git
     #@+node:ekr.20180510104805.1: *4* c.diff_file
     def diff_file(self, fn: str, rev1: str = 'HEAD', rev2: str = '') -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3639,6 +3639,13 @@ class Commands:
             g.es_print(f"Invalid list of extensions: {extensions!r}")
             return
         #@-<< return if initial checks fail >>
+        #@+<< make sure that all extensions start with '.' >>
+        #@+node:ekr.20250729064219.1: *5* << make sure that all extensions start with '.' >>
+        extensions = [
+            (z if z.startswith('.') else f".{z}")
+            for z in extensions
+        ]
+        #@-<< make sure that all extensions start with '.' >>
         if not top_outline_name:
             top_outline_name = f"{os.path.basename(top_directory)}_links.leo"
         #@+<< calculate the list of subdirectories >>
@@ -3669,8 +3676,6 @@ class Commands:
                 #@+node:ekr.20250725163431.1: *5* << find files in sub_directory >>
                 # Set files to the list of full, absolute, files in subdirectory.
                 for ext in extensions:
-                    if not ext.startswith('.'):
-                        ext = '.' + ext
                     new_files = glob.glob(
                         f"{sub_directory}{os.sep}**{os.sep}*{ext}",
                         recursive=True,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3829,10 +3829,9 @@ class Commands:
             """
             nonlocal calls
             if fileName in scanned:
-                g.trace('Skip', fileName)  ###
                 return
             scanned.append(fileName)
-            g.trace('Scan', fileName)  ###
+            g.es_print('Scan', fileName)
             for p in c.all_unique_positions():
                 if p.isAtLeoNode():
                     fileName = p.atLeoFileName()

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3603,8 +3603,6 @@ class Commands:
         sub_directories: list[str] = None,
         sub_outline_name: str = None,
         top_outline_name: str = 'leo_links.leo',
-        use_back_links: bool = False,
-
     ) -> None:
         #@+<< c.makeLinkLeoFiles: docstring >>
         #@+node:ekr.20250717132150.1: *5* << c.makeLinkLeoFiles: docstring >>
@@ -3698,14 +3696,9 @@ class Commands:
                     #@+<< compute the sub outline's back link >>
                     #@+node:ekr.20250725165018.1: *5* << compute the sub outline's back link >>
                     # Compute the relative back link for the sub-outline.
-                    if use_back_links:
-                        # Add one link to the parent.
-                        abs_back_link = f"{top_directory}{os.sep}{top_outline_name}"
-                        rel_back_link = os.path.relpath(abs_back_link, start=sub_directory)
-                        back_link = [rel_back_link.replace('\\', '/')]
-                    else:
-                        back_link = []
-
+                    abs_back_link = f"{top_directory}{os.sep}{top_outline_name}"
+                    rel_back_link = os.path.relpath(abs_back_link, start=sub_directory)
+                    back_link = [rel_back_link.replace('\\', '/')]
                     #@-<< compute the sub outline's back link >>
                     #@+<< create the sub outline >>
                     #@+node:ekr.20250725152555.1: *5* << create the sub outline >>

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3798,7 +3798,7 @@ class Commands:
                 p.moveToNodeAfterTree()
             else:
                 p.moveToThreadNext()
-    #@+node:ekr.20250717080554.1: *4* c.openAllLinkedFiles
+    #@+node:ekr.20250717080554.1: *4* c.openAllLinkedFiles (transitive closure)
     def openAllLinkedFiles(self, gui: LeoGui = None) -> list[Commands]:
         """
         Open the transitive closure of all outlines reachable from any @leo

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2130,9 +2130,12 @@ class VNode:
     #@+node:ekr.20031218072017.3350: *4* v.anyAtFileNodeName
     def anyAtFileNodeName(self) -> str:
         """Return the file name following an @file node or an empty string."""
+        v = self
         return (
-            self.findAtFileName(g.app.atAutoNames) or
-            self.findAtFileName(g.app.atFileNames))
+            v.findAtFileName(g.app.atAutoNames)
+            or v.findAtFileName(g.app.atFileNames)
+            or v.atLeoNodeName()
+        )
     #@+node:ekr.20031218072017.3348: *4* v.at...FileNodeName
     # These return the filename following @xxx, in v.headString.
     # Return the the empty string if v is not an @xxx node.
@@ -2200,7 +2203,7 @@ class VNode:
     #@+node:ekr.20040326031436: *4* v.isAnyAtFileNode
     def isAnyAtFileNode(self) -> bool:
         """Return True if v is any kind of @file or related node."""
-        return bool(self.anyAtFileNodeName())
+        return bool(self.anyAtFileNodeName() or self.atLeoNodeName())
     #@+node:ekr.20040325073709: *4* v.isAt...FileNode
     def isAtAutoNode(self) -> bool:
         return bool(self.atAutoNodeName())

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1028,6 +1028,9 @@ class Position:
     def atFileNodeName(self) -> str:
         return self.v.atFileNodeName()
 
+    def atLeoNodeName(self) -> str:
+        return self.v.atLeoNodeName()
+
     def atNoSentinelsFileNodeName(self) -> str:
         return self.v.atNoSentinelsFileNodeName()
 
@@ -1070,6 +1073,9 @@ class Position:
 
     def isAtIgnoreNode(self) -> bool:
         return self.v.isAtIgnoreNode()
+
+    def isAtLeoNode(self) -> bool:
+        return self.v.isAtLeoNode()
 
     def isAtNoSentinelsFileNode(self) -> bool:
         return self.v.isAtNoSentinelsFileNode()
@@ -2158,6 +2164,10 @@ class VNode:
         names = ("@jupytext",)
         return self.findAtFileName(names)
 
+    def atLeoNodeName(self) -> str:
+        names = ("@leo")
+        return self.findAtFileName(names)
+
     def atNoSentinelsFileNodeName(self) -> str:
         names = ("@nosent", "@file-nosent",)
         return self.findAtFileName(names)
@@ -2212,6 +2222,9 @@ class VNode:
 
     def isAtRstFileNode(self) -> bool:
         return bool(self.atRstFileNodeName())
+
+    def isAtLeoNode(self) -> bool:
+        return bool(self.atLeoNodeName())
 
     def isAtNoSentinelsFileNode(self) -> bool:
         return bool(self.atNoSentinelsFileNodeName())

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2165,7 +2165,7 @@ class VNode:
         return self.findAtFileName(names)
 
     def atLeoNodeName(self) -> str:
-        names = ("@leo")
+        names = ("@leo",)
         return self.findAtFileName(names)
 
     def atNoSentinelsFileNodeName(self) -> str:


### PR DESCRIPTION
#4396 has been closed. This PR is more straightforward:

- [x] Add the infrastructure to recognize `@leo` nodes:
    - [x] Add `p/v.atLeoNodeName` and `p/v.isAtLeoNode`.
    - [x] Generalize `v.anyAtFileNodeName` and `v.isAnyAtFileNode`.
- [x] Add `c.openAllLinkedFiles`, a transitive closure algorithm following `@leo` links.
    This method open  all `.leo` files reachable via `@leo` nodes in c's outline.
    Use the null gui by default. Opening dozens of tabs is too much for Qt.
- [x] Add `open-at-leo-node` command.
- [x] Add `c.makeLinkLeoFiles`, a helper for scripts that make sub-outlines.

Here is the script I use to create dozens of sub-outlines in my local clone of Rust's compiler.
```python
c.makeLinkLeoFiles(
    extensions=['.rs'],
    top_directory=r'C:\Repos\ekr-fork-rust\compiler',
)
```