### PR TITLE
PR: Fix or suppress all new mypy complaints

### DIFF
--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -11,10 +11,10 @@ from leo.commands.baseCommands import BaseEditCommandsClass
 
 if TYPE_CHECKING:  # pragma: no cover
     try:
-        from typing import Self
+        from typing import Self  # Python 3.11 introduced the Self annotation.
     except Exception:
         from typing import Any
-        Self = Any
+        Self = Any  # type:ignore
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -857,7 +857,7 @@ class AstDumper:  # pragma: no cover
                 else:
                     assert isinstance(z, (ast.FormattedValue, ast.Constant))
                     if isinstance(z, ast.Constant):
-                        results.append(z.value)
+                        results.append(z.value)  # type:ignore
                         strings += 1
                     else:
                         results.append(z.__class__.__name__)

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -42,9 +42,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position, VNode
     from leo.core.leoGlobals import GeneralSetting
     try:
-        from typing import Self
+        from typing import Self  # Introduced in Python 3.11
     except Exception:
-        Self = Any
+        Self = Any  # type:ignore
     KWargs = Any
     Lexer = Callable
     QWidget = QtWidgets.QWidget

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2272,7 +2272,7 @@ class KeyHandlerClass:
                 tag = bi.kind
                 pane = bi.pane
                 if stroke and not pane.endswith('-mode'):
-                    k.bindKey(pane, stroke, command, commandName, tag=tag)
+                    k.bindKey(pane, stroke, command, commandName, tag=tag)  # type:ignore
     #@+node:ekr.20061031131434.103: *4* k.makeMasterGuiBinding
     def makeMasterGuiBinding(self, stroke: Stroke, w: Wrapper = None) -> None:
         """Make a master gui binding for stroke in pane w, or in all the standard widgets."""

--- a/leo/external/leosax.py
+++ b/leo/external/leosax.py
@@ -120,7 +120,7 @@ class LeoReader(ContentHandler):
         """Set ivars"""
         super().__init__(*args, **kwargs)
         self.root: Any = LeoNode()
-        self.root.h = 'ROOT'
+        self.root.h = 'ROOT'  # type:ignore
         # changes type from [] to str, done by endElement() for other vnodes
 
         self.cur: Any = self.root

--- a/leo/plugins/attrib_edit.py
+++ b/leo/plugins/attrib_edit.py
@@ -482,7 +482,7 @@ class editWatcher:
         if not self._widget:
             self._widget = w = QtWidgets.QLineEdit(str(self.value))
             w.textChanged.connect(self.updateValue)
-            self._widget.focusOutEvent = self.lostFocus
+            self._widget.focusOutEvent = self.lostFocus  # type:ignore
             # see lostFocus()
         return self._widget
 

--- a/leo/plugins/plugins_menu.py
+++ b/leo/plugins/plugins_menu.py
@@ -160,7 +160,7 @@ def add_menu_from_settings(c: Cmdr) -> None:
         if kind.startswith('@menu'):
             name = kind[len('@menu') :].strip().strip('&')
             if name.lower() == 'plugins':
-                table = []
+                table: list[Any] = []
                 for kind2, val21, val22 in val:
                     if kind2 == '@item':
                         # Similar to createMenuFromConfigList.

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2772,7 +2772,7 @@ class LeoQtMenu(leoMenu.LeoMenu):
         menu = self.getMenu('openwith')
         if not menu:
             menu = self.new_menu(parent, tearoff=False, label=label)
-            menu.insert_cascade(parent, index, label, menu, underline=amp_index)
+            menu.insert_cascade(parent, index, label, menu, underline=amp_index)  # type:ignore
         return menu
     #@+node:ekr.20110605121601.18358: *5* LeoQtMenu.disable/enableMenu (not used)
     def disableMenu(self, menu: QMenu, name: str) -> None:

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -630,7 +630,7 @@ class LayoutCacheWidget(QWidget):
         # In building the SPLITTER dict we replace the placeholder
         # by VR3_OBJ_NAME if it exists, otherwise VR_OBJ_NAME.
         SPLITTERS: dict[str, str] = dict()
-        for k, v in layout['SPLITTERS'].items():
+        for k, v in layout['SPLITTERS'].items():  # type:ignore
             if k == VRX_PLACEHOLDER_NAME:
                 k = VR3_OBJ_NAME if has_vr3 else VR_OBJ_NAME
             SPLITTERS[k] = v
@@ -646,7 +646,7 @@ class LayoutCacheWidget(QWidget):
                 self.created_splitter_dict[name] = splitter
 
         SPLITTER_DICT: Dict[str, QSplitter] = OrderedDict()
-        for name in ORIENTATIONS:
+        for name in ORIENTATIONS:  # type:ignore
             splitter = self.find_splitter_by_name(name)
             if splitter is not None and SPLITTER_DICT.get(name, None) is None:
                 SPLITTER_DICT[name] = splitter
@@ -700,7 +700,7 @@ class LayoutCacheWidget(QWidget):
         # {'main_splitter':Orientation.Horizontal...}
 
         for splitter_name, splitter in SPLITTER_DICT.items():
-            orientation = ORIENTATIONS[splitter_name]
+            orientation = ORIENTATIONS[splitter_name]  # type:ignore
             splitter.setOrientation(orientation)
         #@-<< set default orientations >>
         #@+<< move widgets to targets >>

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -598,7 +598,7 @@ class todoController:
                 if prog != '':
                     prog = int(prog or 0)
                     use = prog // 10 * 10
-                    use = 'prg%03d.png' % use
+                    use = 'prg%03d.png' % use  # type:ignore
                     com.appendImageDictToList(icons, g.os_path_join('cleo', use),
                         2, on='vnode', cleoIcon='1', where=self.prog_location)
             elif which == 'duedate':

--- a/leo/plugins/word_export.py
+++ b/leo/plugins/word_export.py
@@ -89,7 +89,7 @@ def writeNodeAndTree(c, word, header_style, level,
         child = vnode.nthChild(i)
         h = child.h
         h = g.toEncodedString(h, encoding, reportErrors=True)
-        doPara(word, "%s %s" % (thishead, h), "%s %d" % (header_style, min(level, maxlevel)))
+        doPara(word, "%s %s" % (thishead, h), "%s %d" % (header_style, min(level, maxlevel)))  # type:ignore
         writeNodeAndTree(c, word, header_style, level + 1, maxlevel, usesections, thishead, child)
 #@+node:EKR.20040517075715.19: ** word-export-export
 @g.command('word-export-export')


### PR DESCRIPTION
See also #4401 (prepare for Python 3.14).

The following mypy complaints appear in Leo 6.8.6 with mypy version 1.17.0.

```
mypy_leo.py
leo\plugins\qt_layout.py:633: error: Item "object" of "object | Any" has no attribute "items"  [union-attr]
leo\plugins\qt_layout.py:649: error: Item "object" of "object | Any" has no attribute "__iter__" (not iterable)  [union-attr]
leo\plugins\qt_layout.py:703: error: Value of type "object | Any" is not indexable  [index]
leo\core\leoColorizer.py:47: error: Incompatible types in assignment (expression has type "type[Any]", variable has type "<typing special form>")  [assignment]
leo\core\leoAst.py:860: error: Argument 1 to "append" of "list" has incompatible type "str | bytes | int | float | complex | EllipsisType"; expected "str"  [arg-type]
leo\commands\killBufferCommands.py:17: error: Incompatible types in assignment (expression has type "type[Any]", variable has type "<typing special form>")  [assignment]
leo\core\leoKeys.py:2275: error: Argument 2 to "bindKey" of "KeyHandlerClass" has incompatible type "KeyStroke"; expected "str"  [arg-type]
leo\plugins\qt_frame.py:2775: error: Argument 1 to "insert_cascade" of "LeoQtMenu" has incompatible type "QWidget"; expected "LeoQtFrame"  [arg-type]
leo\external\leosax.py:123: error: Incompatible types in assignment (expression has type "str", variable has type "list[Any]")  [assignment]
leo\plugins\word_export.py:92: error: If x = b'abc' then "%s" % x produces "b'abc'", not "abc". If this is desired behavior use "%r" % x. Otherwise, decode the bytes  [str-bytes-safe]
leo\plugins\todo.py:601: error: Incompatible types in assignment (expression has type "str", variable has type "int")  [assignment]
leo\plugins\plugins_menu.py:172: error: Argument 1 to "append" of "list" has incompatible type "str"; expected "tuple[Any, str]"  [arg-type]
leo\plugins\attrib_edit.py:485: error: Cannot assign to a method  [method-assign]
Found 13 errors in 11 files (checked 258 source files)
```