### PR TITLE
PR for #4404: Fix data loss in @clean updates

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -743,7 +743,6 @@ class AtFile:
         g.doHook('after-reading-external-file', c=c, p=root)
 
         # Calculate all changed vnodes.
-        # Do not call at.do_changed_vnodes in this loop!
         changed_vnodes: list[VNode] = []
         for p in root.self_and_subtree():
             v = p.v
@@ -757,7 +756,7 @@ class AtFile:
             root.v.setDirty()
             at.changed_roots.append(root.copy())
 
-        return True  # Errors not detected.
+        return True  # No errors.
     #@+node:ekr.20150204165040.8: *6* at.read_at_clean_lines
     def read_at_clean_lines(self, fn: str) -> list[str]:  # pragma: no cover
         """Return all lines of the @clean/@nosent file at fn."""

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2859,6 +2859,83 @@ def test_g_scanAtWrapDirectives_wrap_without_nowrap_(self):
     aList = g.get_directives_dict_list(c.p)
     s = g.scanAtWrapDirectives(aList)
     assert s is None, repr(s)
+#@+node:ekr.20250803082508.1: *3* deleted via PR #4405
+#@+node:ekr.20250803082521.1: *3* From at.readOneAtCleanNode
+    if changed_vnodes:
+        c.setChanged(force=True)
+        root.v.setDirty()
+        at.changed_roots.append(root.copy())
+        for v in changed_vnodes:
+            at.do_changed_vnode(fileName, root, v)
+        at.delete_empty_changed_organizers(root)
+        at.move_leading_blank_lines(root)
+#@+node:ekr.20250711061442.1: *4* at.do_changed_vnode
+def do_changed_vnode(self, fileName: str, root: Position, v: VNode) -> None:
+    """#4385: Run the importer on a changed VNode."""
+    c = self.c
+    ic = c.importCommands
+    new_body_s = v.b
+
+    # Find a position for v.
+    for p in root.self_and_subtree():
+        if p.v == v:
+            _junk, ext = g.os_path_splitext(fileName)
+            # Get the `do_import` function for the proper importer module.
+            func = ic.dispatch(ext.lower(), root)
+            if func:
+                func(c, p, new_body_s, treeType='@clean')
+            break
+    else:
+        g.trace('Not found:', v)  # Should never happen.
+
+    # Always set the dirty bit.
+    v.setDirty()
+#@+node:ekr.20150204165040.7: *4* at.dump
+def dump(self, lines: list[str], tag: str) -> None:  # pragma: no cover
+    """Dump all lines."""
+    print(f"***** {tag} lines...\n")
+    for s in lines:
+        print(s.rstrip())
+#@+node:ekr.20250712215845.1: *4* at.delete_empty_changed_organizers
+def delete_empty_changed_organizers(self, root: Position) -> None:
+    """
+    #4385: Clean up nodes created by at.do_changed_vnode.
+    """
+    at, c = self, self.c
+    while True:
+        for p in root.subtree():
+            # Handle a changed node containing only @others.
+            if (
+                p.b.strip() == '@others'
+                and p.b != at.bodies_dict.get(p.v)
+                and p.hasChildren()
+            ):
+                # We expect only one child here.
+                for child in p.children():
+                    child.v.setDirty()
+                p.promote()
+                next = p.next()
+                # Transfer the old value to preserve diffs.
+                at.bodies_dict[next.v] = at.bodies_dict.get(p.v)
+                c.selectPosition(next)
+                p.doDelete()
+                break  # Rescan: root.subtree is no longer valid.
+        else:
+            break
+#@+node:ekr.20250714115142.1: *4* at.move_leading_blank_lines
+def move_leading_blank_lines(self, root: Position) -> None:
+    """
+    Move leading blank lines (only in dirty nodes!) to the preceding node.
+    """
+    for p in root.subtree():  # back must exist below.
+        if p.v.isDirty():
+            lines = g.splitLines(p.b)
+            if lines and lines[0].isspace():
+                back = p.threadBack()
+                while lines and lines[0].isspace():
+                    back.b += lines.pop(0)
+                p.b = ''.join(lines)
+                back.v.setDirty()  # Include back in the update list.
 #@-all
 #@@nosearch
 #@-leo

--- a/leo/doc/leoAttic.txt
+++ b/leo/doc/leoAttic.txt
@@ -2860,7 +2860,7 @@ def test_g_scanAtWrapDirectives_wrap_without_nowrap_(self):
     s = g.scanAtWrapDirectives(aList)
     assert s is None, repr(s)
 #@+node:ekr.20250803082508.1: *3* deleted via PR #4405
-#@+node:ekr.20250803082521.1: *3* From at.readOneAtCleanNode
+#@+node:ekr.20250803082521.1: *4* From at.readOneAtCleanNode
     if changed_vnodes:
         c.setChanged(force=True)
         root.v.setDirty()
@@ -2869,7 +2869,7 @@ def test_g_scanAtWrapDirectives_wrap_without_nowrap_(self):
             at.do_changed_vnode(fileName, root, v)
         at.delete_empty_changed_organizers(root)
         at.move_leading_blank_lines(root)
-#@+node:ekr.20250711061442.1: *4* at.do_changed_vnode
+#@+node:ekr.20250711061442.1: *5* at.do_changed_vnode
 def do_changed_vnode(self, fileName: str, root: Position, v: VNode) -> None:
     """#4385: Run the importer on a changed VNode."""
     c = self.c
@@ -2890,13 +2890,13 @@ def do_changed_vnode(self, fileName: str, root: Position, v: VNode) -> None:
 
     # Always set the dirty bit.
     v.setDirty()
-#@+node:ekr.20150204165040.7: *4* at.dump
+#@+node:ekr.20150204165040.7: *5* at.dump
 def dump(self, lines: list[str], tag: str) -> None:  # pragma: no cover
     """Dump all lines."""
     print(f"***** {tag} lines...\n")
     for s in lines:
         print(s.rstrip())
-#@+node:ekr.20250712215845.1: *4* at.delete_empty_changed_organizers
+#@+node:ekr.20250712215845.1: *5* at.delete_empty_changed_organizers
 def delete_empty_changed_organizers(self, root: Position) -> None:
     """
     #4385: Clean up nodes created by at.do_changed_vnode.
@@ -2922,7 +2922,7 @@ def delete_empty_changed_organizers(self, root: Position) -> None:
                 break  # Rescan: root.subtree is no longer valid.
         else:
             break
-#@+node:ekr.20250714115142.1: *4* at.move_leading_blank_lines
+#@+node:ekr.20250714115142.1: *5* at.move_leading_blank_lines
 def move_leading_blank_lines(self, root: Position) -> None:
     """
     Move leading blank lines (only in dirty nodes!) to the preceding node.


### PR DESCRIPTION
See #4404. This PR will form the entire content of Leo 6.8.6.1.

- [x] Remove all code that post-processes `@clean trees`. The code is now in the attic.

I could try to make the importers work, but that seems too risky. I have no plans to resurrect the code.