### PR TITLE
fix TypeError when attempting to run show-fonts command

### DIFF
--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -145,7 +145,7 @@ def showColorWheel(self: Any, event: LeoKeyEvent) -> None:
         QtWidgets.QApplication.clipboard().setText(text)
 #@+node:ekr.20170324143944.3: ** qt: show-fonts
 @g.command('show-fonts')
-def showFonts(self: Any, event: LeoKeyEvent) -> None:
+def showFonts(self: Any, event: LeoKeyEvent=None) -> None:
     """Open a tab in the log pane showing a font picker."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QFontDialog()


### PR DESCRIPTION
without this fix, the command 'show-fonts' (from Menu or minibuffer) gives an error when using Qt:

```
Traceback (most recent call last):
  File "/home/jkn/leo-editor/leo/core/leoKeys.py", line 2475, in callAltXFunction
    func(event)
TypeError: showFonts() missing 1 required positional argument: 'event'
```

