### PR TITLE
PR: Investigate re-importing changed @clean nodes

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -755,8 +755,75 @@ class AtFile:
             c.setChanged(force=True)
             root.v.setDirty()
             at.changed_roots.append(root.copy())
+            if 1:  ### Experimental, dangerous
+                for v in changed_vnodes:
+                    at.do_changed_vnode(fileName, root, v)
+            if 0:  ### Not yet.
+                at.delete_empty_changed_organizers(root)
+                at.move_leading_blank_lines(root)
 
         return True  # No errors.
+    #@+node:ekr.20250804185731.1: *6* at.delete_empty_changed_organizers
+    def delete_empty_changed_organizers(self, root: Position) -> None:
+        """
+        #4385: Clean up nodes created by at.do_changed_vnode.
+        """
+        at, c = self, self.c
+        while True:
+            for p in root.subtree():
+                # Handle a changed node containing only @others.
+                if (
+                    p.b.strip() == '@others'
+                    and p.b != at.bodies_dict.get(p.v)
+                    and p.hasChildren()
+                ):
+                    # We expect only one child here.
+                    for child in p.children():
+                        child.v.setDirty()
+                    p.promote()
+                    next = p.next()
+                    # Transfer the old value to preserve diffs.
+                    at.bodies_dict[next.v] = at.bodies_dict.get(p.v)
+                    c.selectPosition(next)
+                    p.doDelete()
+                    break  # Rescan: root.subtree is no longer valid.
+            else:
+                break
+    #@+node:ekr.20250804185839.1: *6* at.do_changed_vnode
+    def do_changed_vnode(self, fileName: str, root: Position, v: VNode) -> None:
+        """#4385: Run the importer on a changed VNode."""
+        c = self.c
+        ic = c.importCommands
+        new_body_s = v.b
+
+        # Find a position for v.
+        for p in root.self_and_subtree():
+            if p.v == v:
+                _junk, ext = g.os_path_splitext(fileName)
+                # Get the `do_import` function for the proper importer module.
+                func = ic.dispatch(ext.lower(), root)
+                if func:
+                    func(c, p, new_body_s, treeType='@clean')
+                break
+        else:
+            g.trace('Not found:', v)  # Should never happen.
+
+        # Always set the dirty bit.
+        v.setDirty()
+    #@+node:ekr.20250804185742.1: *6* at.move_leading_blank_lines
+    def move_leading_blank_lines(self, root: Position) -> None:
+        """
+        Move leading blank lines (only in dirty nodes!) to the preceding node.
+        """
+        for p in root.subtree():  # back must exist below.
+            if p.v.isDirty():
+                lines = g.splitLines(p.b)
+                if lines and lines[0].isspace():
+                    back = p.threadBack()
+                    while lines and lines[0].isspace():
+                        back.b += lines.pop(0)
+                    p.b = ''.join(lines)
+                    back.v.setDirty()  # Include back in the update list.
     #@+node:ekr.20150204165040.8: *6* at.read_at_clean_lines
     def read_at_clean_lines(self, fn: str) -> list[str]:  # pragma: no cover
         """Return all lines of the @clean/@nosent file at fn."""


### PR DESCRIPTION
This PR tries to understand why `at.do_changed_vnode` failed so spectacularly for html files.

- [x] Restore dangerous code. Highly experimental

A few experiments with html files show that `at.do_changed_vnode` definitely *should not* ever be called for html files. The problem is that html importer will likely destroy the existing outline structure.

That statement *might* also be true for other file types.

In short, I think it's best never to "improve" changed nodes! So I am closing this PR!