### PR TITLE
PR for #4411: rewrite parse-body

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1365,6 +1365,7 @@ def createMoveMarkedNode(c: Cmdr) -> Position:
     return p
 #@+node:ekr.20031218072017.2923: *3* c_oc.markChangedHeadlines
 @g.commander_command('mark-changed-items')
+@g.commander_command('mark-changed-nodes')
 def markChangedHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
     """Mark all nodes that have been changed."""
     c, current, u = self, self.p, self.undoer

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -682,7 +682,10 @@ class AtFile:
     #@+node:ekr.20150204165040.5: *5* at.readOneAtCleanNode & helpers
     def readOneAtCleanNode(self, root: Position, *, new_contents: str = None) -> bool:
         """Update the @clean/@nosent node at root."""
-        at, c, x = self, self.c, self.c.shadowController
+        at, c = self, self.c
+        ic = c.importCommands
+        x = c.shadowController
+        ic = c.importCommands
 
         if new_contents:
             fileName = root.h  # Required.
@@ -755,6 +758,10 @@ class AtFile:
             c.setChanged(force=True)
             root.v.setDirty()
             at.changed_roots.append(root.copy())
+            # Attempt to split nodes if a node splitter exists.
+            if vnode_splitter := ic.get_vnode_splitter(root):
+                for v in changed_vnodes:
+                    vnode_splitter(v)
 
         return True  # No errors.
     #@+node:ekr.20150204165040.8: *6* at.read_at_clean_lines

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -680,12 +680,9 @@ class AtFile:
             g.doHook('after-reading-external-file', c=c, p=p)
         return p  # For #451: return p.
     #@+node:ekr.20150204165040.5: *5* at.readOneAtCleanNode & helpers
-    def readOneAtCleanNode(self, root: Position, *, new_contents: str = None) -> bool:
+    def readOneAtCleanNode(self, root: Position, *, new_contents: str = None) -> None:
         """Update the @clean/@nosent node at root."""
-        at, c = self, self.c
-        ic = c.importCommands
-        x = c.shadowController
-        ic = c.importCommands
+        at, c, x = self, self.c, self.c.shadowController
 
         if new_contents:
             fileName = root.h  # Required.
@@ -693,7 +690,7 @@ class AtFile:
             fileName = c.fullPath(root)
             if not g.os_path_exists(fileName):
                 g.es_print(f"not found: {fileName}", color='red', nodeLink=root.get_UNL())
-                return False
+                return
             # Suppresses file-changed dialog.
             at.rememberReadPath(fileName, root)
 
@@ -706,7 +703,7 @@ class AtFile:
 
         # Don't update if the outline and file are in synch.
         if old_mod_time and old_mod_time >= new_mod_time:
-            return True
+            return
 
         # #4385: Init the per-file data.
         at.initReadIvars(root, fileName)
@@ -734,9 +731,9 @@ class AtFile:
         else:
             new_private_lines = []
             root.b = ''.join(new_public_lines)
-            return True
+            return
         if new_private_lines == old_private_lines:
-            return True
+            return
         if not g.unitTesting:
             g.es_print("updating:", root.h)
         root.clearVisitedInTree()
@@ -758,12 +755,6 @@ class AtFile:
             c.setChanged(force=True)
             root.v.setDirty()
             at.changed_roots.append(root.copy())
-            # Attempt to split nodes if a node splitter exists.
-            if vnode_splitter := ic.get_vnode_splitter(root):
-                for v in changed_vnodes:
-                    vnode_splitter(v)
-
-        return True  # No errors.
     #@+node:ekr.20150204165040.8: *6* at.read_at_clean_lines
     def read_at_clean_lines(self, fn: str) -> list[str]:  # pragma: no cover
         """Return all lines of the @clean/@nosent file at fn."""

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -38,7 +38,7 @@ StringIO = io.StringIO
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoNodes import Position, VNode
+    from leo.core.leoNodes import Position
     Value = Any
 #@-<< leoImport annotations >>
 #@+others
@@ -1147,24 +1147,23 @@ class LeoImportCommands:
         except Exception:
             g.es_exception()
             p.b = s
-    #@+node:ekr.20250805134824.1: *3* ic.get_vnode_splitter & splitters
-    def get_vnode_splitter(self, root: Position) -> Optional[Callable]:
+    #@+node:ekr.20250805134824.1: *3* ic.get_node_splitter & splitters
+    def get_node_splitter(self, root: Position) -> Optional[Callable]:
         """Return the vnode splitter for the file's language."""
         c = self.c
         language = c.getLanguage(root)
         d = {
-            'python': self.split_python_vnode,
-            'rust': self.split_rust_vnode,
+            'python': self.split_python_node,
+            'rust': self.split_rust_node,
         }
         return d.get(language, None)
-
-    #@+node:ekr.20250805135410.1: *4* ic.split_python_vnode
-    def split_python_vnode(self, v: VNode) -> None:
+    #@+node:ekr.20250805135410.1: *4* ic.split_python_node
+    def split_python_node(self, p: Position) -> None:
         """Split the given vnode if it contains multiple python functions or methods."""
         from leo.plugins.importers.python import Python_Importer
         c = self.c
         importer = Python_Importer(c)
-        importer.lines = lines = g.splitLines(v.b)
+        importer.lines = lines = g.splitLines(p.b)
         importer.guide_lines = importer.delete_comments_and_strings(lines)
         ### g.printObj(importer.guide_lines, tag='Guide lines')
         blocks = importer.find_blocks(0, len(lines))
@@ -1174,23 +1173,23 @@ class LeoImportCommands:
             ### if s.startswith('def'):
             return s
 
-        g.printObj(blocks, tag=v.h)  ###
+        g.printObj(blocks, tag=p.h)  ###
         while len(blocks) > 1:
             block = blocks.pop(0)
             head = lines[block.start:block.end]
             g.printObj(head, tag=block.name)  ###
-            v.b = ''.join(head)
+            p.b = ''.join(head)
             tail = lines[block.end:]
             g.printObj(tail, tag="tail")  ###
-            v2 = v.insertAfter()
-            v2.h = clean_headline(tail[0])  ### To do.
-            v2.b = ''.join(tail)
-            v = v2
+            p2 = p.insertAfter()
+            p2.h = clean_headline(tail[0])  ### To do.
+            p2.b = ''.join(tail)
+            p = p2
         c.checkOutline()
-    #@+node:ekr.20250805135428.1: *4* ic.split_rust_vnode
-    def split_rust_vnode(self, v: VNode) -> None:
+    #@+node:ekr.20250805135428.1: *4* ic.split_rust_node (to do)
+    def split_rust_vnode(self, p: Position) -> None:
         """Split the given vnode if it contains multiple rust functions."""
-        g.trace(v)
+        g.trace(p)
         from leo.plugins.importers.rust import Rust_Importer as importer
         assert importer  ###
     #@+node:ekr.20031218072017.3305: *3* ic.Utilities

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1125,6 +1125,7 @@ class LeoImportCommands:
             g.es_print('can not run parse-body: node has children:', p.h)
             return
         language = c.getLanguage(p)
+        # This dict should *never* include 'html' and 'xml' importers.
         d = {
             'c': C_Importer(c),
             'javascript': JS_Importer(c),

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -30,6 +30,7 @@ except ImportError:
 # Leo imports...
 from leo.core import leoGlobals as g
 from leo.plugins.importers.python import Python_Importer
+from leo.plugins.importers.rust import Rust_Importer
 
 # Abbreviation.
 StringIO = io.StringIO
@@ -1202,57 +1203,28 @@ class LeoImportCommands:
 
         # Delegate all the work.
         return self.parse_body_helper(p, importer=importer, compute_headline=compute_headline)
-
-
-        # c = self.c
-        # u, undoType = c.undoer, 'parse-body'
-        # importer = Python_Importer(c)
-        # importer.lines = lines = g.splitLines(p.b)
-        # importer.guide_lines = importer.delete_comments_and_strings(lines)
-        # blocks = importer.find_blocks(0, len(lines))
-
-        # def_pat = re.compile(r'^def\s+(\w+)')
-
-        # def compute_headline(lines: list[str]) -> str:
-            # """Compute the headlline for the given lines."""
-            # for s in lines:
-                # s = s.strip()
-                # if s.startswith('class'):
-                    # return s.replace(':', '')
-                # if s.startswith('def'):
-                    # if m := def_pat.match(s):
-                        # return f"def {m.group(1)}"
-                    # return s.replace(':', '')
-            # return 'Unknown!'
-
-        # # The main loop.
-        # changed = len(blocks) > 1
-        # self.preprocess_blocks(blocks)
-        # while len(blocks) > 1:
-            # # Change the node.
-            # bunch = u.beforeChangeBody(p)
-            # block = blocks.pop(0)
-            # # g.printObj(block.lines[block.start:block.end], tag=block.name)
-            # head = lines[block.start:block.end]
-            # tail = lines[block.end:]
-            # p.b = ''.join(head)
-            # u.afterChangeBody(p, undoType, bunch)
-            # # Insert another node.
-            # bunch = u.beforeInsertNode(p)
-            # p2 = p.insertAfter()
-            # p2.h = compute_headline(tail)  ### To do.
-            # p2.b = ''.join(tail)
-            # u.afterInsertNode(p2, undoType, bunch)
-            # # Continue splitting p2.
-            # p = p2
-        # return changed
     #@+node:ekr.20250807084630.1: *5* function: compute_headline
-    #@+node:ekr.20250805135428.1: *4* ic.parse_rust_node (to do)
-    def parse_rust_node(self, p: Position) -> None:
-        """Split the given vnode if it contains multiple rust functions."""
-        g.trace(p)
-        from leo.plugins.importers.rust import Rust_Importer as importer
-        assert importer  ###
+    #@+node:ekr.20250805135428.1: *4* ic.parse_rust_node
+    def parse_rust_node(self, p: Position) -> bool:
+        """
+        Parse p.b int rust functions and classes.
+
+        Return True if there have been any changes.
+        """
+        c = self.c
+        importer = Rust_Importer(c)
+
+        def compute_headline(lines: list[str]) -> str:
+            """Compute the headlline for the given lines."""
+            for s in lines:
+                s = s.strip()
+                for (kind, pattern) in importer.block_patterns:
+                    if m := pattern.match(s):
+                        return m.group(0)
+            return 'Unknown!'
+
+        # Delegate all the work.
+        return self.parse_body_helper(p, importer=importer, compute_headline=compute_headline)
     #@+node:ekr.20250807084702.1: *4* ic.preprocess_blocks
     def preprocess_blocks(self, blocks: list[Block]) -> None:
         """Move blank lines from the start one block to the end of the previous block."""

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -33,6 +33,7 @@ from leo.plugins.importers.c import C_Importer
 from leo.plugins.importers.javascript import JS_Importer
 from leo.plugins.importers.python import Python_Importer
 from leo.plugins.importers.rust import Rust_Importer
+from leo.plugins.importers.typescript import TS_Importer
 
 # Abbreviation.
 StringIO = io.StringIO
@@ -1120,8 +1121,6 @@ class LeoImportCommands:
         """
         c = self.c
         u, undoType = c.undoer, 'parse-body'
-        if not p:
-            return
         if p.hasChildren():
             g.es_print('can not run parse-body: node has children:', p.h)
             return
@@ -1131,6 +1130,7 @@ class LeoImportCommands:
             'javascript': JS_Importer(c),
             'python': Python_Importer(c),
             'rust': Rust_Importer(c),
+            'typescript': TS_Importer(c),
         }
         if importer := d.get(language):
             u.beforeChangeGroup(p, undoType)
@@ -1165,8 +1165,15 @@ class LeoImportCommands:
                 for (kind, pattern) in importer.block_patterns:
                     if m := pattern.match(s):
                         s = m.group(0)
-                        if s.endswith('('):
-                            s = s[:-1]
+                        # Truncate at the first '(' or '{'.
+                        i1 = s.find('(')
+                        i2 = s.find('{')
+                        if i1 > -1 or i2 > -1:
+                            i = (
+                                min(i1, i2) if i1 > -1 and i2 > -1
+                                else max(i1, i2)
+                            )
+                            s = s[:i]
                         return s
             return p.h
 

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1187,7 +1187,7 @@ class LeoImportCommands:
             p = p2
         c.checkOutline()
     #@+node:ekr.20250805135428.1: *4* ic.split_rust_node (to do)
-    def split_rust_vnode(self, p: Position) -> None:
+    def split_rust_node(self, p: Position) -> None:
         """Split the given vnode if it contains multiple rust functions."""
         g.trace(p)
         from leo.plugins.importers.rust import Rust_Importer as importer

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1150,7 +1150,7 @@ class LeoImportCommands:
         else:
             g.es_print(f"can not run parse-body on {language} nodes")
     #@+node:ekr.20250807161513.1: *4* ic.compute_imported_headline
-    def compute_imported_headline(self, importer: Any, lines: list[str]) -> str:
+    def compute_imported_headline(self, importer: Any, lines: list[str], p: Position) -> str:
         """Compute the headline for the given imported lines."""
         for s in lines:
             s = s.strip()
@@ -1158,16 +1158,12 @@ class LeoImportCommands:
                 if m := pattern.match(s):
                     s = m.group(0)
                     # Truncate at the first '(' or '{'.
-                    i1 = s.find('(')
-                    i2 = s.find('{')
-                    if i1 > -1 or i2 > -1:
-                        i = (
-                            min(i1, i2) if i1 > -1 and i2 > -1
-                            else max(i1, i2)
-                        )
+                    i1, i2 = s.find('('), s.find('{')
+                    i = min(i1, i2) if i1 > -1 and i2 > -1 else max(i1, i2)
+                    if i > -1:
                         s = s[:i]
                     return s
-        return None
+        return p.h
     #@+node:ekr.20250807093257.1: *4* ic.parse_body_helper
     def parse_body_helper(self, p: Position, *, importer: Any) -> bool:
         """The common code for the parse-body command."""
@@ -1187,12 +1183,12 @@ class LeoImportCommands:
             head = lines[block.start:block.end]
             tail = lines[block.end:]
             p.b = ''.join(head)
-            p.h = self.compute_imported_headline(importer, head) or p.h
+            p.h = self.compute_imported_headline(importer, head, p)
             u.afterChangeBody(p, undoType, bunch)
             # Insert another node.
             bunch = u.beforeInsertNode(p)
             p2 = p.insertAfter()
-            p2.h = self.compute_imported_headline(importer, tail) or p.h
+            p2.h = self.compute_imported_headline(importer, tail, p)
             p2.b = ''.join(tail)
             u.afterInsertNode(p2, undoType, bunch)
             # Continue splitting p2.

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -38,7 +38,7 @@ StringIO = io.StringIO
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
-    from leo.core.leoNodes import Position
+    from leo.core.leoNodes import Position, VNode
     Value = Any
 #@-<< leoImport annotations >>
 #@+others
@@ -1147,6 +1147,29 @@ class LeoImportCommands:
         except Exception:
             g.es_exception()
             p.b = s
+    #@+node:ekr.20250805134824.1: *3* ic.get_vnode_splitter & splitters
+    def get_vnode_splitter(self, root: Position) -> Optional[Callable]:
+        """Return the vnode splitter for the file's language."""
+        c = self.c
+        language = c.getLanguage(root)
+        d = {
+            'python': self.split_python_vnode,
+            'rust': self.split_rust_vnode,
+        }
+        return d.get(language, None)
+
+    #@+node:ekr.20250805135410.1: *4* ic.split_python_vnode
+    def split_python_vnode(self, v: VNode) -> None:
+        """Split the given vnode if it contains multiple python functions or methods."""
+        g.trace(v)
+        from leo.plugins.importers.python import Python_Importer as importer
+        assert importer  ###
+    #@+node:ekr.20250805135428.1: *4* ic.split_rust_vnode
+    def split_rust_vnode(self, v: VNode) -> None:
+        """Split the given vnode if it contains multiple rust functions."""
+        g.trace(v)
+        from leo.plugins.importers.rust import Rust_Importer as importer
+        assert importer  ###
     #@+node:ekr.20031218072017.3305: *3* ic.Utilities
     #@+node:ekr.20090122201952.4: *4* ic.appendStringToBody & setBodyString (leoImport)
     def appendStringToBody(self, p: Position, s: str) -> None:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1161,9 +1161,32 @@ class LeoImportCommands:
     #@+node:ekr.20250805135410.1: *4* ic.split_python_vnode
     def split_python_vnode(self, v: VNode) -> None:
         """Split the given vnode if it contains multiple python functions or methods."""
-        g.trace(v)
-        from leo.plugins.importers.python import Python_Importer as importer
-        assert importer  ###
+        from leo.plugins.importers.python import Python_Importer
+        c = self.c
+        importer = Python_Importer(c)
+        importer.lines = lines = g.splitLines(v.b)
+        importer.guide_lines = importer.delete_comments_and_strings(lines)
+        ### g.printObj(importer.guide_lines, tag='Guide lines')
+        blocks = importer.find_blocks(0, len(lines))
+
+        def clean_headline(s: str) -> str:
+            """Adjust functions to match python importer."""
+            ### if s.startswith('def'):
+            return s
+
+        g.printObj(blocks, tag=v.h)  ###
+        while len(blocks) > 1:
+            block = blocks.pop(0)
+            head = lines[block.start:block.end]
+            g.printObj(head, tag=block.name)  ###
+            v.b = ''.join(head)
+            tail = lines[block.end:]
+            g.printObj(tail, tag="tail")  ###
+            v2 = v.insertAfter()
+            v2.h = clean_headline(tail[0])  ### To do.
+            v2.b = ''.join(tail)
+            v = v2
+        c.checkOutline()
     #@+node:ekr.20250805135428.1: *4* ic.split_rust_vnode
     def split_rust_vnode(self, v: VNode) -> None:
         """Split the given vnode if it contains multiple rust functions."""

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2620,6 +2620,16 @@ class VNode:
         v._linkAsNthChild(parent_v, n)
         return v
 
+    def insertAfter(self) -> VNode:  ###
+        v = self
+        c = v.context
+        v2 = VNode(c)
+        for parent in v.parents:
+            for i, child in enumerate(parent.children):
+                if child == v:
+                    v2._linkAsNthChild(parent, i + 1)
+        return v2
+
     def insertAsFirstChild(self) -> VNode:
         v = self
         return v.insertAsNthChild(0)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2620,16 +2620,6 @@ class VNode:
         v._linkAsNthChild(parent_v, n)
         return v
 
-    def insertAfter(self) -> VNode:  ###
-        v = self
-        c = v.context
-        v2 = VNode(c)
-        for parent in v.parents:
-            for i, child in enumerate(parent.children):
-                if child == v:
-                    v2._linkAsNthChild(parent, i + 1)
-        return v2
-
     def insertAsFirstChild(self) -> VNode:
         v = self
         return v.insertAsNthChild(0)

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -395,6 +395,8 @@ class Undoer:
             if not u.changeGroupWarning:
                 u.changeGroupWarning = True
                 g.trace("Position mismatch", g.callers())
+                print('p:', p)
+                print('c.p', c.p)
         if u.redoing or u.undoing:
             return  # pragma: no cover
         if not u.beads:  # pragma: no cover
@@ -723,6 +725,8 @@ class Undoer:
             if not u.changeGroupWarning:
                 u.changeGroupWarning = True
                 g.trace("Position mismatch", g.callers())
+                print('p:', p)
+                print('c.p', c.p)
         bunch = u.createCommonBunch(p)
         # Set types.
         bunch.kind = 'beforeGroup'

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -677,22 +677,6 @@ class Undoer:
         bunch.newParent_v = p._parentVnode()
         bunch.newP = p.copy()
         u.pushBead(bunch)
-    #@+node:ekr.20230713151537.1: *5* u.afterParseBody
-    def afterParseBody(self, p: Position, command: str, bunch: g.Bunch) -> None:
-        """
-        Create an undo node using d created by u.beforeParseBody
-        """
-        c = self.c
-        u, w = self, c.frame.body.wrapper
-        if u.redoing or u.undoing:
-            return  # pragma: no cover
-        # Set the type & helpers.
-        bunch.kind = 'parse-body'
-        bunch.undoType = command
-        bunch.undoHelper = u.undoParseBody
-        bunch.redoHelper = u.redoParseBody
-        u.pushBead(bunch)
-        u.updateAfterTyping(p, w)
     #@+node:ekr.20080425060424.12: *5* u.afterPromote
     def afterPromote(self, p: Position, children: list[VNode]) -> None:
         """Create an undo node for demote operations."""
@@ -858,12 +842,6 @@ class Undoer:
         bunch = u.createCommonBunch(p)
         bunch.oldN = p.childIndex()
         bunch.oldParent_v = p._parentVnode()
-        return bunch
-    #@+node:ekr.20230713145834.1: *5* u.beforeParseBody
-    def beforeParseBody(self, p: Position) -> g.Bunch:
-        u = self
-        bunch = u.createCommonBunch(p)
-        bunch.oldBody = p.b
         return bunch
     #@+node:ekr.20080425060424.3: *5* u.beforeSort
     def beforeSort(self,

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -19,7 +19,7 @@ class C_Importer(Importer):
     language = 'c'
     string_list = ['"']  # Not single quotes.
 
-    block_patterns = (
+    block_patterns: tuple = (
         ('class', re.compile(r'.*?\bclass\s+(\w+)\s*\{')),
         ('func', re.compile(r'.*?\b(\w+)\s*\(.*?\)\s*(const)?\s*{')),
         ('namespace', re.compile(r'.*?\bnamespace\s+(\w+)?\s*\{')),

--- a/leo/plugins/importers/dart.py
+++ b/leo/plugins/importers/dart.py
@@ -17,7 +17,7 @@ class Dart_Importer(Importer):
 
     language = 'dart'
 
-    block_patterns = (
+    block_patterns: tuple = (
         ('function', re.compile(r'^\s*([\w\s]+)\s*\(.*?\)\s*\{')),
     )
 #@-others

--- a/leo/plugins/importers/html.py
+++ b/leo/plugins/importers/html.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class Html_Importer(Xml_Importer):
 
     language = 'html'
+    block_patterns: tuple = tuple()
 
     def __init__(self, c: Cmdr) -> None:
         """Html_Importer.__init__"""

--- a/leo/plugins/importers/ini.py
+++ b/leo/plugins/importers/ini.py
@@ -17,7 +17,9 @@ class Ini_Importer(Importer):
     language = 'ini'
 
     section_pat = re.compile(r'^\s*(\[.*\])')
-    block_patterns = (('section', section_pat),)
+    block_patterns: tuple = (
+        ('section', section_pat),
+    )
 
     #@+others
     #@+node:ekr.20230516142345.1: *3* ini_i.find_end_of_block

--- a/leo/plugins/importers/java.py
+++ b/leo/plugins/importers/java.py
@@ -17,7 +17,7 @@ class Java_Importer(Importer):
 
     language = 'java'
 
-    block_patterns = (
+    block_patterns: tuple = (
         ('class', re.compile(r'.*?\bclass\s+(\w+)')),
         ('func', re.compile(r'.*?\b(\w+)\s*\(.*?\)\s*{')),
         ('interface', re.compile(r'.*?\binterface\s+(\w*)\s*{')),

--- a/leo/plugins/importers/pascal.py
+++ b/leo/plugins/importers/pascal.py
@@ -17,7 +17,7 @@ class Pascal_Importer(Importer):
 
     language = 'pascal'
 
-    block_patterns = (
+    block_patterns: tuple = (
         ('constructor', re.compile(r'^\s*\bconstructor\s+([\w_\.]+)')),
         ('destructor', re.compile(r'^\s*\bdestructor\s+([\w_\.]+)')),
         ('function', re.compile(r'^\s*\bfunction\s+([\w_\.]+)')),

--- a/leo/plugins/importers/perl.py
+++ b/leo/plugins/importers/perl.py
@@ -17,7 +17,7 @@ class Perl_Importer(Importer):
 
     language = 'perl'
 
-    block_patterns = (
+    block_patterns: tuple = (
         ('sub', re.compile(r'\s*sub\s+(\w+)')),
     )
 

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -22,7 +22,7 @@ class Rust_Importer(Importer):
     #@+<< define rust block patterns >>
     #@+node:ekr.20231111065650.1: *3* << define rust block patterns >>
 
-    block_patterns = (
+    block_patterns: tuple = (
 
         # Patterns that *do* require '{' on the same line...
 

--- a/leo/plugins/importers/typescript.py
+++ b/leo/plugins/importers/typescript.py
@@ -51,6 +51,7 @@ class TS_Importer(JS_Importer):
         # (1,  re.compile(r'(\w+)\s*\(.*\).*{')),
             # name (...) {
     )
+    block_patterns = function_patterns
     #@-<< define function patterns >>
 #@-others
 

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -20,7 +20,7 @@ class Xml_Importer(Importer):
     minimum_block_size = 2  # Helps handle one-line elements.
 
     # xml_i.add_tags defines all patterns.
-    block_patterns: tuple = None
+    block_patterns: tuple = tuple()
     end_patterns: tuple = None
     start_patterns: tuple = None
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -99,6 +99,57 @@ class TestLeoImport(BaseTestImporter):
         # Test redo
         u.redo()
         self.check_outline(target, expected_results)
+    #@+node:ekr.20250807095221.1: *3* TestLeoImport.test_rust_importer_parse_body
+    def test_rust_importer_parse_body(self):
+
+        c = self.c
+        u = c.undoer
+        x = c.importCommands
+        target = c.p.insertAfter()
+        c.selectPosition(target)
+        target.h = 'target'
+
+        body_1 = self.prep(
+        '''
+            @language rust
+
+            fn spam() {
+                println!("spam");
+            }
+
+            fn eggs() {
+                println!("eggs");
+            }
+        ''')
+        target.b = body_1
+        x.parse_body(target)
+
+        expected_results = (
+            (0, 'fn spam',
+                '@language rust\n'
+                '\n'
+                'fn spam() {\n'
+                '    println!("spam");\n'
+                '}\n'
+                '\n'
+            ),
+            (0, 'fn eggs',
+                'fn eggs() {\n'
+                '    println!("eggs");\n'
+                '}\n'
+                '\n'
+            ),
+        )
+        # Don't call run_test.
+        self.check_outline(target, expected_results)
+
+        # Test undo
+        u.undo()
+        self.assertEqual(target.b, body_1, msg='undo test')
+        self.assertFalse(target.hasChildren(), msg='undo test')
+        # Test redo
+        u.redo()
+        self.check_outline(target, expected_results)
     #@+node:ekr.20230715004610.1: *3* TestLeoImport.slow_test_ric_run
     def slow_test_ric_run(self):
         c = self.c

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -76,10 +76,12 @@ class TestLeoImport(BaseTestImporter):
                 'def spam():\n'
                 '    """A docstring"""\n'
                 "    print('a string')\n"
+                '\n'
             ),
             (0, 'def eggs',
                 'def eggs():\n'
                 '    pass\n'
+                '\n'
             ),
             (0, 'class NewClass',
                 'class NewClass\n'

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -48,34 +48,43 @@ class TestLeoImport(BaseTestImporter):
         u = c.undoer
         x = c.importCommands
         target = c.p.insertAfter()
+        c.selectPosition(target)
         target.h = 'target'
 
         body_1 = self.prep(
-        """
+        '''
             import os
 
-            def macro(func):
-                def new_func(*args, **kwds):
-                    raise RuntimeError('blah blah blah')
-            return new_func
-        """)
+            def spam():
+                """A docstring"""
+                print('a string')
+
+            def eggs():
+                pass
+
+            class NewClass:
+                def f1(self):
+                    pass
+        ''')
         target.b = body_1
         x.parse_body(target)
 
         expected_results = (
-            (0, '',  # Ignore the top-level headline.
+            (0, 'def spam',
                 'import os\n'
                 '\n'
-                '@others\n'
-                'return new_func\n'
-                # #4385. This is an improvement!
-                # '@language python\n'
-                # '@tabwidth -4\n'
+                'def spam():\n'
+                '    """A docstring"""\n'
+                "    print('a string')\n"
             ),
-            (1, 'function: macro',
-                'def macro(func):\n'
-                '    def new_func(*args, **kwds):\n'
-                "        raise RuntimeError('blah blah blah')\n"
+            (0, 'def eggs',
+                'def eggs():\n'
+                '    pass\n'
+            ),
+            (0, 'class NewClass',
+                'class NewClass\n'
+                '    def f1(self):\n'
+                '        pass\n'
             ),
         )
         # Don't call run_test.


### PR DESCRIPTION
See #4411.

- [x] Add `g.app.importerClassesDict` and `g.app.importerModulesDict`.
- [x] Rewrite the `parse-body` command. It is now defined for all importers (languages) except `xml` and `html`.
- [x] Rewrite corresponding unit tests.
- [x] Test all supported importers by hand, especially undo/redo.

**Related changes**

- [x] `at.readOneAtCleanNode` returns `None`. This will be the *only* change to `leoAtFile.py`!
- [x] Add `mark-changed-nodes` command as an alias of the existing `mark-changed-items` command.
- [x] Delete `u.beforeParseBody` and `u.afterParseBody`. Replace them with existing undoer helpers.
- [x] Improve "Position mismatch" messages in `u.beforeUndoGroup` and `u.afterUndoGroup`.
- [x] Ensure that all importers define `x.block_patterns` as a tuple.  