### PR TITLE
PR fixes #4416: The _mod_time uA should not pollute descendentVnodeUnknownAttributes

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -697,7 +697,7 @@ class AtFile:
         # #4385: Do nothing if the file has not changed.
         try:
             old_mod_time = root.v.u['_mod_time']  # #4385
-            # g.trace(f"{old_mod_time:20} {root.h}")
+            g.trace(f"{old_mod_time:20} {root.h}")
         except Exception:
             old_mod_time = None
         new_mod_time = g.os_path_getmtime(fileName)
@@ -1672,14 +1672,12 @@ class AtFile:
                 at.addToOrphanList(root)
             else:
                 contents = ''.join(at.outputList)
-
-                # #4385: at.replaceFile always writes @clean roots,
-                #        even if the file hasn't changed.
-                #        This forces the `_mod_time` uA to change.
                 at.replaceFile(contents, at.encoding, fileName, root)
 
                 # #4385: This is the *only* place that sets the `_mod_time` uA.
                 root.v.u['_mod_time'] = g.os_path_getmtime(fileName)
+                g.trace(f"{root.v.u.get('_mod_time')} {root.h}")
+
         except Exception:
             at.writeException(fileName, root)
     #@+node:ekr.20090225080846.5: *6* at.writeOneAtEditNode
@@ -2964,20 +2962,20 @@ class AtFile:
         if not old_contents:
             old_contents = ''
 
-        if not root.isAtCleanNode():  # #4394: Always write @clean nodes!
-            # Compare the old and new contents.
-            unchanged = (
-                contents == old_contents
-                or (not at.explicitLineEnding and at.compareIgnoringLineEndings(old_contents, contents))
-                or ignoreBlankLines and at.compareIgnoringBlankLines(old_contents, contents))
-            if unchanged:
-                at.unchangedFiles += 1
-                if not g.unitTesting and c.config.getBool(
-                    'report-unchanged-files', default=True):
-                    g.es(f"{timestamp}unchanged: {sfn}")  # pragma: no cover
-                # Check unchanged files.
-                at.checkPythonCode(contents, fileName, root)
-                return False  # No change to original file.
+        unchanged = (
+            contents == old_contents
+            or (not at.explicitLineEnding and at.compareIgnoringLineEndings(old_contents, contents))
+            or ignoreBlankLines and at.compareIgnoringBlankLines(old_contents, contents))
+
+        if unchanged:
+            at.unchangedFiles += 1
+            if not g.unitTesting and c.config.getBool(
+                'report-unchanged-files', default=True):
+                g.es(f"{timestamp}unchanged: {sfn}")  # pragma: no cover
+
+            # Check *unchanged* files.
+            at.checkPythonCode(contents, fileName, root)
+            return False  # No change to original file.
 
         # Warn if we are only adjusting the line endings.
         if at.explicitLineEnding:  # pragma: no cover
@@ -3001,6 +2999,7 @@ class AtFile:
             g.error('error writing', sfn)
             g.es('not written:', sfn)
             at.addToOrphanList(root)
+
         # Check *after* writing the file.
         at.checkPythonCode(contents, fileName, root)
         return ok

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -697,6 +697,7 @@ class AtFile:
         # #4385: Do nothing if the file has not changed.
         try:
             old_mod_time = root.v.u['_mod_time']  # #4385
+            # g.trace(f"{old_mod_time:20} {root.h}")
         except Exception:
             old_mod_time = None
         new_mod_time = g.os_path_getmtime(fileName)

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -315,8 +315,6 @@ class FastRead:
                 if key != 'tx':
                     s: Optional[str] = self.resolveUa(key, val)
                     if s:
-                        if False and key == '_mod_time':
-                            g.trace(key, val, s)  ###
                         gnx2ua[gnx][key] = s
         return gnx2body, gnx2ua
     #@+node:ekr.20180602062323.9: *4* fast.scanVnodes
@@ -1863,28 +1861,12 @@ class FileCommands:
         aList2: list[tuple[VNode, dict]] = self.createUaList(vnode_list)
         d: dict[str, dict] = {}
         for v, d2 in aList2:
-            # New in Leo 6.8.7: Don't pollute the descendentVnodeUnknownAttributes.
-            #### Should be done in createUaList.
-            if '_mod_time' in d2:
-                del d2['_mod_time']  ### Experimental
-                ### g.printObj(d2, tag=p.h)  ###
-                if not d2:  ### Experimental.
-                    continue
             aList3 = [str(z) for z in pDict.get(v)]
             key = '.'.join(aList3)
             d[key] = d2
         if not d:
             return ''
         # Pickle and hexlify d.
-        if not g.unitTesting:  ###
-            if 1:
-                g.printObj(d, tag=f"{g.my_name()} {p.h}")
-            if 1:  ###
-                for key in d:
-                    d2 = d.get(key)
-                    if '_mod_time' in d2:
-                        g.printObj(d2, tag=f"{g.my_name()} {p.h}")
-                        break
         return self.pickle(v=p.v, val=d, tag='descendentVnodeUnknownAttributes')
     #@+node:ekr.20080805085257.1: *6* fc.createUaList
     def createUaList(self, vnode_list: list[VNode]) -> list[tuple[VNode, dict]]:
@@ -1897,6 +1879,9 @@ class FileCommands:
             if isinstance(v.unknownAttributes, dict):
                 # Create a new dict containing only entries that can be pickled.
                 d = dict(v.unknownAttributes)  # Copy the dict.
+                # New in Leo 6.8.7: Remove '_mod_time' from the uA.
+                if '_mod_time' in d:
+                    del d['_mod_time']
                 for key in d:
                     # Just see if val can be pickled.  Suppress any error.
                     ok = self.pickle(v=v, val=d.get(key), tag=None)
@@ -2107,8 +2092,6 @@ class FileCommands:
             # #526: do this for @auto nodes.
             # #3990: do this for @edit nodes.
             attrs.append(self.putDescendentVnodeUas(p))
-        if False and attrs:  ###
-            g.printObj(attrs, tag=f"{g.my_name()} {p.h}")  ###
         return ''.join(attrs)
     #@+node:ekr.20031218072017.1579: *5* fc.put_v_elements & helper
     def put_v_elements(self, p: Position = None) -> None:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -363,7 +363,7 @@ class FastRead:
                     v._headString = 'PLACE HOLDER'
                     #@-<< Make a new vnode, linked to the parent >>
                     #@+<< handle all other v attributes >>
-                    #@+node:ekr.20180605075113.1: *6* << handle all other v attributes >>
+                    #@+node:ekr.20180605075113.1: *6* << handle all other v attributes >> (fast.scanVnodes)
                     # FastRead.nativeVnodeAttributes defines the native attributes of <v> elements.
                     d = e.attrib
                     s = d.get('descendentTnodeUnknownAttributes')
@@ -376,7 +376,7 @@ class FastRead:
                         aDict = fc.getDescendentUnknownAttributes(s, v=v)
                         if aDict:
                             fc.descendentVnodeUaDictList.append((v, aDict),)
-                    #
+
                     # Handle vnode uA's
                     uaDict = gnx2ua[gnx]  # A defaultdict(dict)
                     for key, val in d.items():

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -85,14 +85,18 @@ class BadLeoFile(Exception):
 #@+node:ekr.20180602062323.1: ** class FastRead
 class FastRead:
 
+    #@+<< FastRead: define nativeVnodeAttributes >>
+    #@+node:ekr.20250806185821.1: *3* << FastRead: define nativeVnodeAttributes >>
     # Used to exclude attributes from being unpickeld as UAs with resolveUa.
     nativeVnodeAttributes = (
+        '_mod_time',  # Leo 6.8.7.
         'a',
         'descendentTnodeUnknownAttributes',
         'descendentVnodeUnknownAttributes',
         'expanded', 'marks', 't',
         'tnodeList',  # Removed in Leo 4.7.
     )
+    #@-<< FastRead: define nativeVnodeAttributes >>
 
     def __init__(self, c: Cmdr, gnx2vnode: dict[str, VNode]) -> None:
         self.c = c

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -87,7 +87,6 @@ class FastRead:
 
     #@+<< FastRead: define nativeVnodeAttributes >>
     #@+node:ekr.20250806185821.1: *3* << FastRead: define nativeVnodeAttributes >>
-    # Used to exclude attributes from being unpickeld as UAs with resolveUa.
     nativeVnodeAttributes = (
         '_mod_time',  # Leo 6.8.7.
         'a',

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -315,6 +315,8 @@ class FastRead:
                 if key != 'tx':
                     s: Optional[str] = self.resolveUa(key, val)
                     if s:
+                        if False and key == '_mod_time':
+                            g.trace(key, val, s)  ###
                         gnx2ua[gnx][key] = s
         return gnx2body, gnx2ua
     #@+node:ekr.20180602062323.9: *4* fast.scanVnodes
@@ -1861,12 +1863,28 @@ class FileCommands:
         aList2: list[tuple[VNode, dict]] = self.createUaList(vnode_list)
         d: dict[str, dict] = {}
         for v, d2 in aList2:
+            # New in Leo 6.8.7: Don't pollute the descendentVnodeUnknownAttributes.
+            #### Should be done in createUaList.
+            if '_mod_time' in d2:
+                del d2['_mod_time']  ### Experimental
+                ### g.printObj(d2, tag=p.h)  ###
+                if not d2:  ### Experimental.
+                    continue
             aList3 = [str(z) for z in pDict.get(v)]
             key = '.'.join(aList3)
             d[key] = d2
         if not d:
             return ''
         # Pickle and hexlify d.
+        if not g.unitTesting:  ###
+            if 1:
+                g.printObj(d, tag=f"{g.my_name()} {p.h}")
+            if 1:  ###
+                for key in d:
+                    d2 = d.get(key)
+                    if '_mod_time' in d2:
+                        g.printObj(d2, tag=f"{g.my_name()} {p.h}")
+                        break
         return self.pickle(v=p.v, val=d, tag='descendentVnodeUnknownAttributes')
     #@+node:ekr.20080805085257.1: *6* fc.createUaList
     def createUaList(self, vnode_list: list[VNode]) -> list[tuple[VNode, dict]]:
@@ -2089,6 +2107,8 @@ class FileCommands:
             # #526: do this for @auto nodes.
             # #3990: do this for @edit nodes.
             attrs.append(self.putDescendentVnodeUas(p))
+        if False and attrs:  ###
+            g.printObj(attrs, tag=f"{g.my_name()} {p.h}")  ###
         return ''.join(attrs)
     #@+node:ekr.20031218072017.1579: *5* fc.put_v_elements & helper
     def put_v_elements(self, p: Position = None) -> None:

--- a/leo/plugins/qt_commands.py
+++ b/leo/plugins/qt_commands.py
@@ -118,7 +118,7 @@ def showColorNames(event: LeoKeyEvent) -> None:
         g.es('created color picker in icon area')
 #@+node:ekr.20170324142416.1: ** qt: show-color-wheel
 @g.command('show-color-wheel')
-def showColorWheel(self: Any, event: LeoKeyEvent=None) -> None:
+def showColorWheel(self: Any, event: LeoKeyEvent = None) -> None:
     """Show a Qt color dialog."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QColorDialog()
@@ -145,7 +145,7 @@ def showColorWheel(self: Any, event: LeoKeyEvent=None) -> None:
         QtWidgets.QApplication.clipboard().setText(text)
 #@+node:ekr.20170324143944.3: ** qt: show-fonts
 @g.command('show-fonts')
-def showFonts(self: Any, event: LeoKeyEvent=None) -> None:
+def showFonts(self: Any, event: LeoKeyEvent = None) -> None:
     """Open a tab in the log pane showing a font picker."""
     c, p = self.c, self.c.p
     picker = QtWidgets.QFontDialog()
@@ -186,7 +186,7 @@ def showFonts(self: Any, event: LeoKeyEvent=None) -> None:
         c.undoer.afterChangeNodeContents(p, 'change-font', udata)
 #@+node:ekr.20140918124632.17893: ** qt: show-style-sheet
 @g.command('show-style-sheet')
-def print_style_sheet(event: LeoKeyEvent=None) -> None:
+def print_style_sheet(event: LeoKeyEvent = None) -> None:
     """show-style-sheet command."""
     c: Cmdr = event.get('c')
     if c:


### PR DESCRIPTION
See #4416.

- [x] Add '_mod_time' to `FastRead.nativeVnodeAttributes`.
- [x] `fc.createUaList`: Remove `_mod_time` from uAs.
- [x] Oops: Make changes to `qt_commands.py` from another PR.
- [x] Verify that `FastRead.scanTnodes` gets the `_mod_time` attribute from `<t>` elements.
- [x] Ensure that Leo writes a `_mod_time` attribute when writing an *unchanged* `@clean` node.

**Related changes**

- [x] Improve reporting in `at.replaceFile`.

**Notes**

- For compatibility, `FastRead.resolveUa` must remain as it is.

