### PR TITLE
PR fixes #4419: improve python importer

### DIFF
--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -1078,6 +1078,8 @@ class TokenBasedOrange:  # Orange is the new Black.
             print(f"Found tab character in {self.filename}")
             print(self.consider_message)
         elif (len(self.input_token.value) % self.tab_width) != 0:  # pragma: no cover
+            # g.trace('len(input_token.value):', len(self.input_token.value),
+            # 'tab_width:', self.tab_width)
             print(f"Indentation error in {self.filename}")
             print(self.consider_message)
 

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -312,6 +312,9 @@ class Importer:
         # Add all outer blocks to the to-do list.
         todo_list = self.find_blocks(0, len(self.lines))
 
+        # Leo 6.8.7: pre-process the blocks.
+        self.preprocess_blocks(todo_list)
+
         # Link the blocks to the outer block.
         for block in todo_list:
             block.parent_v = parent.v
@@ -605,6 +608,20 @@ class Importer:
                   adjusts headlines of *all* imported nodes.
         """
 
+    #@+node:ekr.20250810142621.1: *4* i.preprocess_blocks
+    def preprocess_blocks(self, blocks: list[Block]) -> None:
+        """Move blank lines from the start one block to the end of the previous block."""
+        for i, block in enumerate(blocks):
+            try:
+                block2 = blocks[i + 1]
+            except IndexError:
+                break
+            for i in range(block2.start, block2.end):
+                s = block2.lines[i]
+                if s.strip():
+                    break
+                block.end += 1
+                block2.start += 1
     #@+node:ekr.20230529075138.38: *4* i.preprocess_lines
     def preprocess_lines(self, lines: list[str]) -> list[str]:
         """

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -42,13 +42,11 @@ class Block:
     #@+node:ekr.20230921061842.1: *3* Block.__repr__
     def __repr__(self) -> str:
         kind_name_s = f"{self.kind} {self.name}"
-        parent_v_s = self.parent_v.h if self.parent_v else '<no parent_v>'
-        v_s = self.v.h if self.v else '<no v>'
-        return (
-            f"Block: kind/name: {kind_name_s!r:20} "
-            f"{self.start:2} {self.start_body:2} {self.end:2} "
-            f"parent_v: {parent_v_s!r} v: {v_s!r}"
-        )
+        lines = self.lines[self.start : self.end]
+        result = [f"Block {self.start}:{self.end} {kind_name_s!r}\n"]
+        for i, s in enumerate(lines):
+           result.append(f"  {i:3} {s!r}\n")
+        return ''.join(result)
 
     __str__ = __repr__
     #@+node:ekr.20230921061937.1: *3* Block.dump_lines
@@ -312,9 +310,6 @@ class Importer:
         # Add all outer blocks to the to-do list.
         todo_list = self.find_blocks(0, len(self.lines))
 
-        # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
-        self.preprocess_blocks(todo_list)
-
         # Link the blocks to the outer block.
         for block in todo_list:
             block.parent_v = parent.v
@@ -346,6 +341,14 @@ class Importer:
                 block.child_blocks.append(inner_block)
                 inner_block.parent_v = child_v
                 todo_list.append(inner_block)
+
+        # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
+        self.preprocess_blocks(result_blocks)
+
+        if 0:  ### Temp.
+            g.trace(f"Blocks for {parent.h}...")
+            for block in result_blocks:
+                print(block)
 
         # Post pass: generate all bodies
         self.generate_all_bodies(parent, outer_block, result_blocks)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -45,7 +45,7 @@ class Block:
         lines = self.lines[self.start : self.end]
         result = [f"Block {self.start}:{self.end} {kind_name_s!r}\n"]
         for i, s in enumerate(lines):
-           result.append(f"  {i:3} {s!r}\n")
+            result.append(f"  {i:3} {s!r}\n")
         return ''.join(result)
 
     __str__ = __repr__

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -345,7 +345,7 @@ class Importer:
         # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
         self.preprocess_blocks(result_blocks)
 
-        if 0:  ### Temp.
+        if 1:  ### Temp.
             g.trace(f"Blocks for {parent.h}...")
             for block in result_blocks:
                 print(block)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -287,7 +287,7 @@ class Importer:
                     if level == 0:
                         return i
         return i2
-    #@+node:ekr.20230529075138.14: *4* i.gen_block (iterative)
+    #@+node:ekr.20230529075138.14: *4* i.gen_block (iterative) (trace)
     def gen_block(self, parent: Position) -> None:
         """
         Importer.gen_block.
@@ -345,7 +345,7 @@ class Importer:
         # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
         self.preprocess_blocks(result_blocks)
 
-        if 1:  ### Temp.
+        if 0:  ### Temp.
             g.trace(f"Blocks for {parent.h}...")
             for block in result_blocks:
                 print(block)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -312,7 +312,7 @@ class Importer:
         # Add all outer blocks to the to-do list.
         todo_list = self.find_blocks(0, len(self.lines))
 
-        # Leo 6.8.7: pre-process the blocks.
+        # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
         self.preprocess_blocks(todo_list)
 
         # Link the blocks to the outer block.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -55,7 +55,7 @@ class Block:
     def dump_lines(self, tag: str = None) -> None:
         if not tag:
             tag = repr(self)
-        g.printObj(self.lines[self.start:self.end], tag=tag)
+        g.printObj(self.lines[self.start : self.end], tag=tag)
     #@+node:ekr.20230921061932.1: *3* Block.long_repr
     def long_repr(self) -> str:
         """A longer form of Block.__repr__"""
@@ -63,7 +63,7 @@ class Block:
         for child_block in self.child_blocks:
             child_blocks.append(f"{child_block.kind}:{child_block.name}")
         child_blocks_s = '\n'.join(child_blocks) if child_blocks else '<no children>'
-        lines_s = g.objToString(self.lines[self.start:self.end], tag='lines')
+        lines_s = g.objToString(self.lines[self.start : self.end], tag='lines')
         return f"\n{self!r} child_blocks: {child_blocks_s}\n{lines_s}"
     #@-others
 
@@ -400,7 +400,7 @@ class Importer:
             children_start, children_end = find_all_child_lines(block)
 
             # Add the head lines to block.v.
-            head_lines = self.lines[block.start:children_start]
+            head_lines = self.lines[block.start : children_start]
             block.v.b = self.compute_body(head_lines)
 
             # Add an @others directive if necessary.
@@ -409,7 +409,7 @@ class Importer:
                 block.v.b = block.v.b + f"{block_common_lws}@others\n"
 
             # Add the tail lines to block.v
-            tail_lines = self.lines[children_end:block.end]
+            tail_lines = self.lines[children_end : block.end]
             tail_s = self.compute_body(tail_lines)
             if tail_s.strip():
                 block.v.b = block.v.b.rstrip() + '\n' + tail_s
@@ -423,9 +423,9 @@ class Importer:
             """
             n = len(self.lines)
             for block in blocks:
-                lines = self.lines[block.start:block.end]
+                lines = self.lines[block.start : block.end]
                 lines2 = self.remove_common_lws(common_lws, lines)
-                self.lines[block.start:block.end] = lines2
+                self.lines[block.start : block.end] = lines2
             assert n == len(self.lines)
         #@-others
 
@@ -473,7 +473,7 @@ class Importer:
             if block.child_blocks:
                 handle_block_with_children(block, block_common_lws)
             else:
-                block.v.b = self.compute_body(self.lines[block.start:block.end])
+                block.v.b = self.compute_body(self.lines[block.start : block.end])
 
             # Add all child blocks to the to-do list.
             todo_list.extend(block.child_blocks)
@@ -661,7 +661,7 @@ class Importer:
         lws_list: list[int] = []
         for block in blocks:
             assert self.lines == block.lines
-            lines = self.lines[block.start:block.end]
+            lines = self.lines[block.start : block.end]
             for line in lines:
                 stripped_line = line.lstrip()
                 if stripped_line:  # Skip empty lines
@@ -725,7 +725,7 @@ class Importer:
     def trace_block(self, block: Block) -> None:
         """For debugging: trace one block."""
         tag = f"  {block.kind:>10} {block.name:<20} {block.start} {block.start_body} {block.end}"
-        g.printObj(block.lines[block.start:block.end], tag=tag)
+        g.printObj(block.lines[block.start : block.end], tag=tag)
     #@-others
 #@-others
 #@@language python

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -352,7 +352,7 @@ class Importer:
 
         # Post pass: generate all bodies
         self.generate_all_bodies(parent, outer_block, result_blocks)
-    #@+node:ekr.20230920165923.1: *5* i.generate_all_bodies
+    #@+node:ekr.20230920165923.1: *5* i.generate_all_bodies (to be deleted?)
     def generate_all_bodies(self, parent: Position, outer_block: Block, result_blocks: list[Block]) -> None:
         """Carefully generate bodies from the given blocks."""
         c = self.c

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -287,7 +287,7 @@ class Importer:
                     if level == 0:
                         return i
         return i2
-    #@+node:ekr.20230529075138.14: *4* i.gen_block (iterative) (trace) (to be rewritten??)
+    #@+node:ekr.20230529075138.14: *4* i.gen_block (iterative) (trace) (to be deleted??)
     def gen_block(self, parent: Position) -> None:
         """
         Importer.gen_block.

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -28,15 +28,15 @@ class Block:
     def __init__(self,
         kind: str, name: str, start: int, start_body: int, end: int, lines: list[str],
     ) -> None:
-        self.child_blocks: list[Block] = []
+        self.child_blocks: list[Block] = []  ### To be deleted???
         self.end = end
         self.kind = kind
         self.lines = lines
         self.name = name
-        self.parent_v: VNode = None
+        self.parent_v: VNode = None  ### To be deleted???
         self.start = start
         self.start_body = start_body
-        self.v: VNode = None
+        self.v: VNode = None  ### To be deleted???
 
     #@+others
     #@+node:ekr.20230921061842.1: *3* Block.__repr__
@@ -287,7 +287,7 @@ class Importer:
                     if level == 0:
                         return i
         return i2
-    #@+node:ekr.20230529075138.14: *4* i.gen_block (iterative) (trace)
+    #@+node:ekr.20230529075138.14: *4* i.gen_block (iterative) (trace) (to be rewritten??)
     def gen_block(self, parent: Position) -> None:
         """
         Importer.gen_block.

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -21,6 +21,9 @@ class Python_Importer(Importer):
     language = 'python'
     string_list = ['"""', "'''", '"', "'"]  # longest first.
 
+    #@+<< Python_i: patterns >>
+    #@+node:ekr.20250811175614.1: *3* << Python_i: patterns >>
+
     # The default patterns. Overridden in the Cython_Importer class.
     # Group 1 matches the name of the class/def.
     async_def_pat = re.compile(r'\s*async\s+def\s+(\w+)\s*\(')
@@ -32,6 +35,7 @@ class Python_Importer(Importer):
         ('async def', async_def_pat),
         ('def', def_pat),
     )
+    #@-<< Python_i: patterns >>
 
     #@+others
     #@+node:ekr.20230830051934.1: *3* python_i.delete_comments_and_strings
@@ -105,7 +109,112 @@ class Python_Importer(Importer):
         assert len(result) == len(lines)  # A crucial invariant.
         assert textwrap.dedent(''.join(result)) == ''.join(result)  # A crucial check.
         return result
-    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks (culprit)
+    #@+node:ekr.20250811180656.1: *3* python_i.gen_block (NEW, Experimental)
+    def gen_block(self, root: Position) -> None:
+        """
+        Python_Importer.gen_block.
+
+        Create all blocks and their parent nodes.
+
+        Note:  i.gen_lines adds the @language and @tabwidth directives.
+        """
+        parent_stack: list[Position] = []
+        prev_block = None
+        prev_indent = 0  # The indentation of the present block.
+        result_blocks: list[Block] = []
+
+        def lws_n(s: str) -> int:
+            """Return the length of the leading whitespace for s."""
+            return len(s) - len(s.lstrip())
+
+        def match(s: str) -> tuple[str, re.Match]:
+            for kind, pattern in self.block_patterns:
+                if m := pattern.match(s):
+                    return kind, m
+            return None, None
+
+        for i, s in enumerate(self.guide_lines):
+            kind, m = match(s)
+            if m:
+                # cython may include trailing whitespace.
+                name = m.group(1).strip()
+                indent = lws_n(s)
+
+                # Looks like a new block, but don't create an inner def.
+                if (
+                    'def' in kind
+                    and prev_block
+                    and 'def' in prev_block.kind
+                    and indent > prev_indent
+                ):
+                    g.trace('Skip', name)
+                    continue
+
+                # End the previous block.
+                if prev_block:
+                    prev_block.end = i
+
+                # Calculate and create the parent.
+                if not parent:
+                    parent = root
+                elif indent < prev_indent:
+                    g.trace('Unindent')
+                    parent = root
+                    prev_parent = None
+                elif indent == prev_indent:
+                    g.trace('Same indent')
+                    parent = prev_parent or root
+                else:
+                    g.trace('Indent!')
+                    parent = prev_parent.insertAsLastChild()
+                    parent.h = '???'
+                g.trace(bool(prev_parent), prev_indent, indent, name)
+
+                # Create the new node as the last child of the parent.
+                node = parent.insertAsLastChild()
+                node.h = name
+                # Start a new block.
+                block = Block(kind,
+                    lines=self.lines,  ### Necessary???
+                    name=name,
+                    start=i,
+                    start_body=self.find_start_of_body(i),
+                    end=None,
+                    # parent_v = parent.v,
+                )
+                result_blocks.append(block)
+
+                # Adjust the status.
+                prev_block = block
+                prev_parent = parent
+                prev_indent = indent
+
+        if prev_block:
+            prev_block.end = len(self.lines)
+
+        # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
+        self.preprocess_blocks(result_blocks)
+
+        if 0:  ### Temp.
+            g.trace(f"Blocks for {parent.h}...")
+            for block in result_blocks:
+                print(block)
+
+        # Post pass: generate all bodies
+        ### self.generate_all_bodies(parent, outer_block, result_blocks)
+
+        if 1:
+            g.trace('Nodes...')
+        for p in root.self_and_subtree():
+            level_s = '.' * p.level()
+            print(f"{level_s} {p.h}")
+
+        # A hook for language-specific processing.
+        ### self.postprocess(parent, result_blocks)
+
+        # Note: i.gen_lines appends @language and @tabwidth directives to parent.b.
+
+    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks (culprit) (to be deleted?)
     def find_blocks(self, i1: int, i2: int) -> list[Block]:
         """
         Python_Importer.find_blocks: override Importer.find_blocks.
@@ -134,10 +243,6 @@ class Python_Importer(Importer):
                 if m := pattern.match(s):
                     # cython may include trailing whitespace.
                     name = m.group(1).strip()
-                    if trace:
-                        print('')
-                        g.trace(name, m)
-                        print('')
                     end = self.find_end_of_block(i, i2)
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
 
@@ -159,7 +264,7 @@ class Python_Importer(Importer):
         if trace:
             g.printObj(results, tag=f"{i1}:{i2}")
         return results
-    #@+node:ekr.20230514140918.4: *3* python_i.find_end_of_block
+    #@+node:ekr.20230514140918.4: *3* python_i.find_end_of_block (to be deleted?)
     def find_end_of_block(self, i: int, i2: int) -> int:
         """
         i is the index of the class/def line (within the *guide* lines).
@@ -225,6 +330,10 @@ class Python_Importer(Importer):
                 i += 1
         # g.printObj(self.guide_lines[i0:i2], tag=f"find_end_of_block: {i0}:{i2}")
         return i2
+    #@+node:ekr.20250811185435.1: *3* python_i.find_start_of_body (to do)
+    def find_start_of_body(self, i: int) -> int:
+        """Find the first line after the class/def line."""
+        return i + 1  ### Temp.
     #@+node:ekr.20230825095926.1: *3* python_i.postprocess & helpers
     def postprocess(self, parent: Position, result_blocks: list[Block]) -> None:
         """

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -116,7 +116,7 @@ class Python_Importer(Importer):
         **Important**: An @others directive will refer to the returned blocks,
                        so there must be *no gaps* between blocks!
         """
-        trace = True  ### # Only while debugging.
+        trace = False  # Only while debugging.
 
         i, prev_i, results = i1, i1, []
 
@@ -231,7 +231,7 @@ class Python_Importer(Importer):
         Python_Importer.postprocess.
         """
 
-        return  ###
+        ### return  ###
 
         #@+others  # Define helper functions.
         #@+node:ekr.20230830113521.1: *4* python_i.function: adjust_at_others
@@ -243,13 +243,20 @@ class Python_Importer(Importer):
                 if p.h.startswith('class') and p.hasChildren():
                     child = p.firstChild()
                     lines = g.splitLines(p.b)
-                    for i, line in enumerate(lines):
-                        if line.strip().startswith('@others'):  ### and child.b.startswith('\n'):
-                            g.trace(p.h)  ###
-                            p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
-                            ### p.b = ''.join(lines[:i]) + '\n\n' + ''.join(lines[i:])
-                            ### child.b = child.b[1:]
-                            break
+                    if 1:  # Original.
+                        for i, line in enumerate(lines):
+                            if line.strip().startswith('@others') and child.b.startswith('\n'):
+                                p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
+                                child.b = child.b[1:]
+                                break
+                    else:  # Experimental.
+                        for i, line in enumerate(lines):
+                            if line.strip().startswith('@others'):
+                                g.trace(p.h)  ###
+                                p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
+                                ### p.b = ''.join(lines[:i]) + '\n\n' + ''.join(lines[i:])
+                                ### child.b = child.b[1:]
+                                break
         #@+node:ekr.20230825100219.1: *4* python_i.function: adjust_headlines
         def adjust_headlines(parent: Position) -> None:
             """
@@ -296,11 +303,11 @@ class Python_Importer(Importer):
                 i += 1
             return None
 
-        #@+node:ekr.20230825164234.1: *4* python_i.function: move_class_docstring
+        #@+node:ekr.20230825164234.1: *4* python_i.function: move_class_docstring (trace)
         def move_class_docstring(docstring: str, child_p: Position, class_p: Position) -> None:
             """Move the docstring from child_p to class_p."""
 
-            g.trace(child_p.h, '==>', class_p.h)  ###
+            ### g.trace(child_p.h, '==>', class_p.h)  ###
 
             # Remove the docstring from child_p.b.
             child_p.b = child_p.b.replace(docstring, '')
@@ -334,14 +341,14 @@ class Python_Importer(Importer):
                         docstring = find_docstring(child1)
                         if docstring:
                             move_class_docstring(docstring, child1, p)
-        #@+node:ekr.20230930181855.1: *4* python_i.function: move_module_preamble
+        #@+node:ekr.20230930181855.1: *4* python_i.function: move_module_preamble (trace)
         def move_module_preamble(lines: list[str], parent: Position, result_blocks: list[Block]) -> None:
             """Move the preamble lines from the parent's first child to the start of parent.b."""
             child1 = parent.firstChild()
             if not child1:
                 return
 
-            g.trace(parent.h)  ###
+            ### g.trace(parent.h)  ###
 
             # Compute the preamble.
             preamble_start = max(0, result_blocks[1].start_body - 1)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -105,7 +105,7 @@ class Python_Importer(Importer):
         assert len(result) == len(lines)  # A crucial invariant.
         assert textwrap.dedent(''.join(result)) == ''.join(result)  # A crucial check.
         return result
-    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks
+    #@+node:ekr.20230514140918.1: *3* python_i.find_blocks (culprit)
     def find_blocks(self, i1: int, i2: int) -> list[Block]:
         """
         Python_Importer.find_blocks: override Importer.find_blocks.
@@ -116,7 +116,7 @@ class Python_Importer(Importer):
         **Important**: An @others directive will refer to the returned blocks,
                        so there must be *no gaps* between blocks!
         """
-        trace = False  # Only while debugging.
+        trace = True  ### # Only while debugging.
 
         i, prev_i, results = i1, i1, []
 
@@ -156,6 +156,8 @@ class Python_Importer(Importer):
                         i = prev_i = end
                     break
             assert i > progress, g.callers()
+        if trace:
+            g.printObj(results, tag=f"{i1}:{i2}")
         return results
     #@+node:ekr.20230514140918.4: *3* python_i.find_end_of_block
     def find_end_of_block(self, i: int, i2: int) -> int:
@@ -229,6 +231,8 @@ class Python_Importer(Importer):
         Python_Importer.postprocess.
         """
 
+        return  ###
+
         #@+others  # Define helper functions.
         #@+node:ekr.20230830113521.1: *4* python_i.function: adjust_at_others
         def adjust_at_others(parent: Position) -> None:
@@ -240,9 +244,11 @@ class Python_Importer(Importer):
                     child = p.firstChild()
                     lines = g.splitLines(p.b)
                     for i, line in enumerate(lines):
-                        if line.strip().startswith('@others') and child.b.startswith('\n'):
+                        if line.strip().startswith('@others'):  ### and child.b.startswith('\n'):
+                            g.trace(p.h)  ###
                             p.b = ''.join(lines[:i]) + '\n' + ''.join(lines[i:])
-                            child.b = child.b[1:]
+                            ### p.b = ''.join(lines[:i]) + '\n\n' + ''.join(lines[i:])
+                            ### child.b = child.b[1:]
                             break
         #@+node:ekr.20230825100219.1: *4* python_i.function: adjust_headlines
         def adjust_headlines(parent: Position) -> None:
@@ -294,6 +300,8 @@ class Python_Importer(Importer):
         def move_class_docstring(docstring: str, child_p: Position, class_p: Position) -> None:
             """Move the docstring from child_p to class_p."""
 
+            g.trace(child_p.h, '==>', class_p.h)  ###
+
             # Remove the docstring from child_p.b.
             child_p.b = child_p.b.replace(docstring, '')
             child_p.b = child_p.b.lstrip('\n')
@@ -332,6 +340,8 @@ class Python_Importer(Importer):
             child1 = parent.firstChild()
             if not child1:
                 return
+
+            g.trace(parent.h)  ###
 
             # Compute the preamble.
             preamble_start = max(0, result_blocks[1].start_body - 1)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -118,10 +118,22 @@ class Python_Importer(Importer):
 
         Note:  i.gen_lines adds the @language and @tabwidth directives.
         """
-        parent_stack: list[Position] = []
+        parents: list[Position] = [root]
+        parent_blocks: list[Block] = []
         prev_block = None
-        prev_indent = 0  # The indentation of the present block.
+        prev_indent = 0
         result_blocks: list[Block] = []
+
+        def end_block(block):  ### prev_indent, level,
+            indent = lws_n(block.lines[block.start])
+            parent = parents[-1]
+            parent_s = '<root>' if parent == root else parent.h
+            g.trace(f"{block.name}, indent: {indent}, parent: {parent_s}\n{block}")
+            if block.kind == 'class':
+                new_parent = parent.insertAsLastChild()
+                new_parent.h = block.name
+                parents.append(new_parent)
+                parent_blocks.append(block)
 
         def lws_n(s: str) -> int:
             """Return the length of the leading whitespace for s."""
@@ -140,39 +152,20 @@ class Python_Importer(Importer):
                 name = m.group(1).strip()
                 indent = lws_n(s)
 
-                # Looks like a new block, but don't create an inner def.
+                # Don't create an inner blocks (of any kind) within defs.
                 if (
-                    'def' in kind
-                    and prev_block
+                    prev_block
                     and 'def' in prev_block.kind
                     and indent > prev_indent
                 ):
-                    g.trace('Skip', name)
+                    ### g.trace('***Skip', indent, prev_indent, prev_block.kind, name)
                     continue
 
                 # End the previous block.
                 if prev_block:
                     prev_block.end = i
+                    end_block(prev_block)  ### prev_indent, indent,
 
-                # Calculate and create the parent.
-                if not parent:
-                    parent = root
-                elif indent < prev_indent:
-                    g.trace('Unindent')
-                    parent = root
-                    prev_parent = None
-                elif indent == prev_indent:
-                    g.trace('Same indent')
-                    parent = prev_parent or root
-                else:
-                    g.trace('Indent!')
-                    parent = prev_parent.insertAsLastChild()
-                    parent.h = '???'
-                g.trace(bool(prev_parent), prev_indent, indent, name)
-
-                # Create the new node as the last child of the parent.
-                node = parent.insertAsLastChild()
-                node.h = name
                 # Start a new block.
                 block = Block(kind,
                     lines=self.lines,  ### Necessary???
@@ -186,28 +179,29 @@ class Python_Importer(Importer):
 
                 # Adjust the status.
                 prev_block = block
-                prev_parent = parent
                 prev_indent = indent
 
         if prev_block:
+            g.printObj(self.lines[-3:], tag='last block')
             prev_block.end = len(self.lines)
+            end_block(prev_block)
 
         # Leo 6.8.7: Move lines from the start of blocks to the end of previous blocks.
         self.preprocess_blocks(result_blocks)
 
         if 0:  ### Temp.
-            g.trace(f"Blocks for {parent.h}...")
+            g.trace(f"Blocks for {root.h}...")
             for block in result_blocks:
                 print(block)
 
         # Post pass: generate all bodies
         ### self.generate_all_bodies(parent, outer_block, result_blocks)
 
-        if 1:
+        if 0:  ### Temp
             g.trace('Nodes...')
-        for p in root.self_and_subtree():
-            level_s = '.' * p.level()
-            print(f"{level_s} {p.h}")
+            for p in root.self_and_subtree():
+                level_s = '.' * p.level()
+                print(f"{level_s} {p.h}")
 
         # A hook for language-specific processing.
         ### self.postprocess(parent, result_blocks)

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -178,7 +178,7 @@ class Python_Importer(Importer):
                     lines=self.lines,  ### Necessary???
                     name=name,
                     start=i,
-                    start_body=self.find_start_of_body(i),
+                    start_body=self.find_start_of_body(i, kind),
                     end=None,
                     # parent_v = parent.v,
                 )
@@ -331,9 +331,11 @@ class Python_Importer(Importer):
         # g.printObj(self.guide_lines[i0:i2], tag=f"find_end_of_block: {i0}:{i2}")
         return i2
     #@+node:ekr.20250811185435.1: *3* python_i.find_start_of_body (to do)
-    def find_start_of_body(self, i: int) -> int:
+    def find_start_of_body(self, i: int, kind: str) -> int:
         """Find the first line after the class/def line."""
-        return i + 1  ### Temp.
+        if 'def' in kind:
+            return None
+        return i + 1  ### To do: find the end of the class def.
     #@+node:ekr.20230825095926.1: *3* python_i.postprocess & helpers
     def postprocess(self, parent: Position, result_blocks: list[Block]) -> None:
         """

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -36,6 +36,8 @@ for command in [
     f'{python} -m "leo.core.leoTokens" {args} leo/core',
     f'{python} -m "leo.core.leoTokens" {args} leo/external',
     f'{python} -m "leo.core.leoTokens" {args} leo/plugins',
+    f'{python} -m "leo.core.leoTokens" {args} leo/plugins/importers',
+    f'{python} -m "leo.core.leoTokens" {args} leo/plugins/writers',
     f'{python} -m "leo.core.leoTokens" {args} leo/scripts',
     f'{python} -m "leo.core.leoTokens" {args} leo/modes',
     f'{python} -m "leo.core.leoTokens" {args} leo/unittests/commands',

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -106,7 +106,12 @@ class BaseTestImporter(LeoUnitTest):
         p = self.run_test(s)
         self.check_round_trip(p, expected_s or s)
     #@+node:ekr.20230526124600.1: *3* BaseTestImporter.new_run_test
-    def new_run_test(self, s: str, expected_results: tuple, *, trace: bool = False) -> None:
+    def new_run_test(self, s: str, expected_results: tuple,
+        *,
+        check: bool = True,
+        retain_trailing_ws=False,
+        trace: bool = False,
+    ) -> None:
         """
         Run a unit test of an import scanner,
         i.e., create a tree from string s at location p.
@@ -124,12 +129,18 @@ class BaseTestImporter(LeoUnitTest):
         parent.h = f"{kind} {self.short_id}"
 
         # createOutline calls Importer.gen_lines and Importer.check.
-        test_s = textwrap.dedent(s).strip() + '\n'
+
+        if retain_trailing_ws:  # A hack for testing.
+            test_s = textwrap.dedent(s).lstrip()
+        else:
+            test_s = textwrap.dedent(s).strip() + '\n'
+        ### g.printObj(test_s)
 
         c.importCommands.createOutline(parent.copy(), ext, test_s)
 
         # Dump the actual results on failure and raise AssertionError.
-        self.check_outline(parent, expected_results, trace=trace)
+        if check:
+            self.check_outline(parent, expected_results, trace=trace)
     #@+node:ekr.20211127042843.1: *3* BaseTestImporter.run_test
     def run_test(self, s: str) -> Position:
         """
@@ -3081,7 +3092,6 @@ class TestPython(BaseTestImporter):
 
         # A reference unit test to test experimental test.
         # This test should most edge cases of the Python importer.
-        trace = True
         s = '''
             class MyClass:
                 """MyClass: docstring"""
@@ -3092,7 +3102,9 @@ class TestPython(BaseTestImporter):
                 def f2(
                     self, arg1
                 ):
-                   pass
+                   a = 1
+                   def inner_def():
+                       pass
 
             # About main
             def main():
@@ -3100,15 +3112,18 @@ class TestPython(BaseTestImporter):
 
             if __name__ == '__main__':
                 main()
+
             '''
 
         expected_results = (
             (0, '',  # Ignore the first headline.
-                   '@others\n'
-                   "if __name__ == '__main__':\n"
-                    '    main()\n'
-                   '@language python\n'
-                   '@tabwidth -4\n'
+                '@others\n'
+                '\n'
+                "if __name__ == '__main__':\n"
+                '    main()\n'
+                '\n'
+                '@language python\n'
+                '@tabwidth -4\n'
             ),
             (1, 'class MyClass',
                     'class MyClass:\n'
@@ -3123,16 +3138,20 @@ class TestPython(BaseTestImporter):
                     'def f2(\n'
                     '   self, arg1\n'
                     '):\n'
-                    '    pass\n'
+                    '    a = 1\n'
+                    '    def inner_def():\n'
+                    '        pass\n'
                     '\n'
             ),
             (1, 'function: main',
                     '# About main\n'
                     'def main():\n'
                     '    pass\n'
+                    '\n'
             ),
         )
-        self.new_run_test(s, expected_results, trace=trace)
+        self.new_run_test(s, expected_results,
+            check=False, retain_trailing_ws=True, trace=True)
     #@+node:ekr.20240219045037.1: *3* TestPython.test_almost_empty_defs
     def test_almost_empty_defs(self):
 

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3076,6 +3076,63 @@ class TestPython(BaseTestImporter):
     ext = '.py'
 
     #@+others
+    #@+node:ekr.20250812130557.1: *3* TestPython.test_python_reference_test
+    def test_python_reference_test(self):
+
+        # A reference unit test to test experimental test.
+        # This test should most edge cases of the Python importer.
+        trace = True
+        s = '''
+            class MyClass:
+                """MyClass: docstring"""
+
+                def f1():
+                    pass
+
+                def f2(
+                    self, arg1
+                ):
+                   pass
+
+            # About main
+            def main():
+                pass
+
+            if __name__ == '__main__':
+                main()
+            '''
+
+        expected_results = (
+            (0, '',  # Ignore the first headline.
+                   '@others\n'
+                   "if __name__ == '__main__':\n"
+                    '    main()\n'
+                   '@language python\n'
+                   '@tabwidth -4\n'
+            ),
+            (1, 'class MyClass',
+                    'class MyClass:\n'
+                    '    ATothers\n'.replace('AT', '@')
+            ),
+            (2, 'MyClass.f1',
+                    'def f1(self):\n'
+                    '    pass\n'
+                    '\n'
+            ),
+            (2, 'MyClass.f2',
+                    'def f2(\n'
+                    '   self, arg1\n'
+                    '):\n'
+                    '    pass\n'
+                    '\n'
+            ),
+            (1, 'function: main',
+                    '# About main\n'
+                    'def main():\n'
+                    '    pass\n'
+            ),
+        )
+        self.new_run_test(s, expected_results, trace=trace)
     #@+node:ekr.20240219045037.1: *3* TestPython.test_almost_empty_defs
     def test_almost_empty_defs(self):
 

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -3091,7 +3091,7 @@ class TestPython(BaseTestImporter):
     def test_python_reference_test(self):
 
         # A reference unit test to test experimental test.
-        # This test should most edge cases of the Python importer.
+        # This test should contain all edge cases of the Python importer.
         s = '''
             class MyClass:
                 """MyClass: docstring"""


### PR DESCRIPTION
See #4419.

- [x] Create `i.preprocess_blocks`.  Call it from `i.gen_block`.
    - Five importers override `i.gen_block`. None of them need to call  `i.preprocess_blocks`.
    - Hurray! All unit tests pass with this change!
- [ ] Fix round tripping!

**Related changes**

These changes ensure that round-tripping works when Leo automatically beautifies written files.

- [x] Update `scripts/beautify_all_leo.py`.
- [x] Beautify `importers/base_importer.py`.