### PR TITLE
Fixes #4427 : Set mod_time UA in @clean vnodes that were read from leo startup and left unmodified.

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -696,13 +696,12 @@ class AtFile:
 
         # #4385: Do nothing if the file has not changed.
         try:
-            old_mod_time = root.v.u['_mod_time']  # #4385
-            g.trace(f"{old_mod_time:20} {root.h}")
+            old_mod_time = root.v.u['_mod_time']  # #4385 The file's *last-seen* mod time.
         except Exception:
             old_mod_time = None
-        new_mod_time = g.os_path_getmtime(fileName)
+        new_mod_time = g.os_path_getmtime(fileName)  # The file's *present* mod time.
 
-        # Don't update if the outline and file are in synch.
+        # Make sure it's newer: Don't update if the outline and file are in synch.
         if old_mod_time and old_mod_time >= new_mod_time:
             return
 
@@ -713,6 +712,10 @@ class AtFile:
         # #4385: *Clear* the mod time until we write the file.
         if '_mod_time' in root.v.u:
             del root.v.u['_mod_time']
+
+        # Until the @clean's content is modified and written: set to file's *present* mod time.
+        # This and writeOneAtCleanNode are the *only* two places that sets the `_mod_time` uA.
+        root.v.u['_mod_time'] = new_mod_time  # #4427
 
         # #4385: Remember all old bodies.
         for p in root.self_and_subtree():
@@ -1671,10 +1674,8 @@ class AtFile:
             else:
                 contents = ''.join(at.outputList)
                 at.replaceFile(contents, at.encoding, fileName, root)
-
-                # #4385: This is the *only* place that sets the `_mod_time` uA.
+                # #4385: This and readOneAtCleanNode are the *only* two places that sets the `_mod_time` uA.
                 root.v.u['_mod_time'] = g.os_path_getmtime(fileName)
-                g.trace(f"{root.v.u.get('_mod_time')} {root.h}")
 
         except Exception:
             at.writeException(fileName, root)


### PR DESCRIPTION
vnode's UA is now set to new_mod_time for a proper default upon reading, until possible further modifications.

Fixes #4427