### PR TITLE
Fixes #4426: Set the external files controller's timestamp for external files when opening a leo file instead of leaving the efc's _time_d untouched.

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -432,8 +432,14 @@ class AtFile:
         t1 = time.time()
         c.init_error_dialogs()
         files = at.findFilesToRead(root, all=True)
+        efc = g.app.externalFilesController
         for p in files:
             at.readFileAtPosition(p)
+            # An @<file> was read: In case this was a tab opened earlier, for which efc had entries,
+            # we need to update the external files controller's timestamp for those external files
+            # instead of leaving the _time_d empty, which would have defaulted to set_time's default.
+            if efc:
+                efc.set_time(c.fullPath(p))  # #4426 Same effect as leaving efc's _time_d empty.
         for p in files:
             p.v.clearDirty()
         if not g.unitTesting and files:  # pragma: no cover

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -556,12 +556,12 @@ class ExternalFilesController:
                 pass
     #@+node:ekr.20150407204201.1: *4* efc.get_mtime
     def get_mtime(self, path: str) -> float:
-        """Return the modification time for the path."""
+        """Return the modification time of a file for the given path."""
         return g.os_path_getmtime(g.os_path_realpath(path))
     #@+node:ekr.20150405122428.1: *4* efc.get_time
     def get_time(self, path: str) -> float:
         """
-        return timestamp for path
+        return timestamp stored for the given path
 
         see set_time() for notes
         """

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6189,7 +6189,7 @@ def os_path_exists(path: str) -> bool:
     return os.path.exists(path) if path else False
 #@+node:ekr.20031218072017.2150: *3* g.os_path_getmtime
 def os_path_getmtime(path: str) -> float:
-    """Return the modification time of path."""
+    """Return the modification time of a file for a given path."""
     if not path:
         return 0
     try:


### PR DESCRIPTION
(same effect as leaving untouched if was not already opened because efc's "has_changed" defaults to set_time's own default if _time_d entry is unset.)
Fixes #4426