### PR TITLE
PR fixes #4443, part 2

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -3898,14 +3898,16 @@ class EditCommandsClass(BaseEditCommandsClass):
         c, u, undoType = self.c, self.c.undoer, 'clear-all-uas'
         # #1276.
         changed = False
-        u.beforeChangeGroup(c.p, undoType)
+        first_p = c.p
         for p in c.all_unique_positions():
             if p.v.u:
+                if not changed:  # #4443
+                    u.beforeChangeGroup(first_p, undoType)
+                    changed = True
                 bunch = u.beforeChangeUA(p)
                 p.v.u = {}
                 p.setDirty()
                 u.afterChangeUA(p, undoType, bunch)
-                changed = True
         if changed:
             c.setChanged()
             u.afterChangeGroup(c.p, undoType)

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -1130,9 +1130,6 @@ class LeoImportCommands:
             g.es_print(f"No importer class for @language {language}")
             return
         importer = importer_class(c)
-
-        # Handle undo.
-        u.beforeChangeGroup(p, undoType)
         try:
             old_p = p.copy()
             c.selectPosition(p)
@@ -1172,6 +1169,8 @@ class LeoImportCommands:
 
         # The main loop.
         changed = len(blocks) > 1
+        if changed:
+            u.beforeChangeGroup(p, undoType)
         self.preprocess_blocks(blocks)
         while len(blocks) > 1:
             # Change the node.

--- a/leo/core/leoTokens.py
+++ b/leo/core/leoTokens.py
@@ -867,12 +867,14 @@ class TokenBasedOrange:  # Orange is the new Black.
         """Undoably beautify root's entire tree."""
         c = root.v.context
         u, undoType = c.undoer, 'beautify-script'
-        u.beforeChangeGroup(c.p, undoType)
+        first_p = c.p
         n_changed = 0
         for p in root.self_and_subtree():
             bunch = u.beforeChangeNodeContents(p)
             changed = self.beautify_script_node(p)
             if changed:
+                if n_changed == 0:  # #4443.
+                    u.beforeChangeGroup(first_p, undoType)
                 n_changed += 1
                 u.afterChangeNodeContents(p, undoType, bunch)
         if n_changed:


### PR DESCRIPTION
See #4443.

**The constraints**

- Leo must never call `u.afterUndoGroup` unless it has first called `u.beforeChangeGroup`.
- Conversely, Leo must never call `u.beforeUndoGroup` unless will later call `u.afterChangeGroup`.

**What I did**

- [x] Fix the same bug in three different commands.
- [x] Review all calls to `u.afterChangeGroup` to ensure the above constraints are satisfied.