### PR TITLE
PR 2 for #4491: rewrite beautify-python-code-on-write using ruff format

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2589,7 +2589,7 @@ class AtFile:
         if self.checkPythonCodeOnWrite:  # First
             ok = self.checkPythonSyntax(root, contents)
         if ok and self.beautifyOnWrite:  # Second.
-            ok = self.runTokenBasedBeautifier(root, fileName)
+            ok = self.runRuffFormat(root, fileName)
         if ok and self.runPyFlakesOnWrite:  # Creates clickable links.
             ok = self.runPyflakes(root)
         if ok and self.runFlake8OnWrite:  # Does *not* create clickable links.
@@ -2640,9 +2640,9 @@ class AtFile:
             else:
                 g.es_print(f"{j + 1:5}: {line}")
 
-    # @+node:ekr.20240926044644.1: *6* at.runTokenBasedBeautifier
-    def runTokenBasedBeautifier(self, root: Position, filename: str) -> bool:
-        """Run Leo's token-based beautifier on the selected position."""
+    # @+node:ekr.20240926044644.1: *6* at.runTokenBasedBeautifier (revise)
+    def runRuffFormat(self, root: Position, filename: str) -> bool:
+        """Run ruff format on the selected position."""
         c = self.c
         p = c.p
         if not os.path.exists(filename):
@@ -2650,10 +2650,11 @@ class AtFile:
         old_p = p.copy()
         try:
             old_sys_argv = sys.argv[:]
-            sys.argv = ['tbo']  # A hack: don't run leo.core.leoTokens.main.
-            from leo.core.leoTokens import beautify_file
-
-            changed = beautify_file(filename)
+            # sys.argv = ['tbo']  # A hack: don't run leo.core.leoTokens.main.
+            # from leo.core.leoTokens import beautify_file
+            # changed = beautify_file(filename)
+            g.trace('@bool beautify-python-code-on-write not ready yet')
+            changed = False  ### To do.
             if changed:
                 g.es(f"beautified: {g.shortFileName(filename)}")
                 # Suppress the reload prompt.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -10,6 +10,7 @@ import difflib
 import io
 import os
 import re
+import subprocess
 import sys
 import tabnanny
 import time
@@ -2640,7 +2641,7 @@ class AtFile:
             else:
                 g.es_print(f"{j + 1:5}: {line}")
 
-    # @+node:ekr.20240926044644.1: *6* at.runTokenBasedBeautifier (revise)
+    # @+node:ekr.20240926044644.1: *6* at.runRuffFormat
     def runRuffFormat(self, root: Position, filename: str) -> bool:
         """Run ruff format on the selected position."""
         c = self.c
@@ -2648,13 +2649,19 @@ class AtFile:
         if not os.path.exists(filename):
             return False
         old_p = p.copy()
+        old_contents = g.readFile(filename)
         try:
-            old_sys_argv = sys.argv[:]
-            # sys.argv = ['tbo']  # A hack: don't run leo.core.leoTokens.main.
-            # from leo.core.leoTokens import beautify_file
-            # changed = beautify_file(filename)
-            g.trace('@bool beautify-python-code-on-write not ready yet')
-            changed = False  ### To do.
+            # Define components of a single command.
+            args = (
+                f"--config {g.app.leoEditorDir}{os.sep}pyproject.toml",
+                '--config line-length=120',
+                '--silent',
+            )
+            isWindows = sys.platform.startswith('win')
+            python = 'py' if isWindows else 'python'
+            command = f"{python} -m ruff format {' '.join(args)} {filename}"
+            subprocess.Popen(command, shell=True).communicate()  # Wait for results.
+            changed = old_contents != g.readFile(filename)
             if changed:
                 g.es(f"beautified: {g.shortFileName(filename)}")
                 # Suppress the reload prompt.
@@ -2667,7 +2674,6 @@ class AtFile:
             g.es_exception()
             return False
         finally:
-            sys.argv = old_sys_argv
             # #4159: This may not restore the outline as it was,
             # but it's much better than doing nothing.
             c.selectPosition(old_p)


### PR DESCRIPTION
See #4491. *Note*: This PR should have no effect on LeoJS or LeoInteg.

- [x] Use `ruff format` when `@bool beautify-python-code-on-write = True`

Note that Leo's dependencies already include ruff.