### PR TITLE
PR for #4495: The efc should not change c.p by default

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -418,11 +418,13 @@ def refreshFromDisk(
         c.selectPosition(update_p)
     else:
         update_p = p  # #4495: Do *not* change the position!
-    if not silent:
+
+    # #4495: Report the updated file.
+    if not silent and not g.unitTesting:
         g.es_print(f"update: {update_p.h}", color='blue')
-    at.changed_roots = []
 
     # Create the 'Recovered Nodes' tree.
+    at.changed_roots = []
     c.fileCommands.handleNodeConflicts()
     c.setChanged()
     c.redraw()

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -377,6 +377,7 @@ def refreshFromDisk(
     p: Position = None,  # For compatibility with existing scripts.
     *,
     event: LeoKeyEvent = None,  # Required for all commands.
+    silent: bool = True,
 ) -> None:
     """
     Refresh an @<file> node from disk.
@@ -416,8 +417,9 @@ def refreshFromDisk(
         update_p.expand()
         c.selectPosition(update_p)
     else:
-        c.selectPosition(p)
-
+        update_p = p  # #4495: Do *not* change the position!
+    if not silent:
+        g.es_print(f"update: {update_p.h}", color='blue')
     at.changed_roots = []
 
     # Create the 'Recovered Nodes' tree.

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -206,7 +206,7 @@ class ExternalFilesController:
             if state in ('yes', 'no'):
                 state = self.ask(c, path, p=p)
             if state in ('yes', 'yes-all'):
-                c.refreshFromDisk(p)
+                c.refreshFromDisk(p, silent=False)
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:


### PR DESCRIPTION
See #4495.

- [x] Add silent flag to `c.refreshFromDisk` with default `True'.
- [x] Only `efc.idle_check_commander` calls `c.refreshFromDisk` with `silent=False`.
- [x] `c.refreshFromDisk` changes `c.p` only if `@bool report-changed-at-clean-nodes` is True.