### PR TITLE
PR for #4496: slow ruff format

### DIFF
--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2589,7 +2589,7 @@ class AtFile:
         if self.checkPythonCodeOnWrite:  # First
             ok = self.checkPythonSyntax(root, contents)
         if ok and self.beautifyOnWrite:  # Second.
-            ok = self.runRuffFormat(root, fileName)
+            ok = self.runRuffFormat(contents, root, fileName)
         if ok and self.runPyFlakesOnWrite:  # Creates clickable links.
             ok = self.runPyflakes(root)
         if ok and self.runFlake8OnWrite:  # Does *not* create clickable links.
@@ -2641,22 +2641,37 @@ class AtFile:
                 g.es_print(f"{j + 1:5}: {line}")
 
     # @+node:ekr.20240926044644.1: *6* at.runRuffFormat
-    def runRuffFormat(self, root: Position, filename: str) -> bool:
-        """Run ruff format on the selected position."""
+    def runRuffFormat(self, contents: str, root: Position, filename: str) -> bool:
+        """
+        Run ruff format on the selected position.
+        Return True if all went well.
+        """
         c = self.c
         p = c.p
+        efc = g.app.externalFilesController
         if not os.path.exists(filename):
             return False
         old_p = p.copy()
-        ok = c.beautify_with_ruff(root, filename)
-        if not ok:
-            return False
+        results = c.beautify_with_ruff(contents, root, filename)
 
-        # *Always* reload the file, suppressing the reload prompt.
-        # g.es(f"beautified: {g.shortFileName(filename)}")
-
-        efc = g.app.externalFilesController
+        # Always suppress the reload prompt.
         efc.set_time(filename)
+
+        # Do nothing else if there has been no change.
+        if contents == results:
+            return True
+
+        if 0:  # Debugging only.
+            diff = difflib.unified_diff(
+                g.splitLines(contents),
+                g.splitLines(results),
+                fromfile='Old',
+                tofile='New',
+            )
+            g.printObj(list(diff), tag='Diff')
+
+        # Reload the file, suppressing the reload prompt.
+        g.es(f"beautified: {g.shortFileName(filename)}", color='blue')
         c.refreshFromDisk(root)
 
         # #4159: This may not restore the outline as it was,

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5333,15 +5333,14 @@ class Commands:
         args.append(f"--config {toml_s}")
 
         # Calculate the ruff command.
-        isWindows = sys.platform.startswith('win')
-        python = 'py' if isWindows else 'python'
+        python = 'py' if g.isWindows else 'python'
         command = f"{python} -m ruff format {' '.join(args)} {filename}"
 
         # Run the command.
         try:
             subprocess.Popen(command, shell=True).communicate()  # Wait for results.
             results = g.readFile(filename)
-            if sys.platform.startswith('win'):
+            if g.isWindows:
                 results = results.replace('\r', '')
             return results
         except Exception:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -5310,10 +5310,10 @@ class Commands:
 
     # @+node:ekr.20171124084149.1: *3* c.Scripting/beautifier utils
     # @+node:ekr.20260110090421.1: *4* c.beautify_with_ruff
-    def beautify_with_ruff(self, root: Position, filename: str) -> bool:
+    def beautify_with_ruff(self, contents: str, root: Position, filename: str) -> str:
         """
         Use ruff format to format a temp file.
-        Return True if there were no exceptions.
+        Return the beautified contents.
         """
         c = self
 
@@ -5340,10 +5340,13 @@ class Commands:
         # Run the command.
         try:
             subprocess.Popen(command, shell=True).communicate()  # Wait for results.
-            return True
+            results = g.readFile(filename)
+            if sys.platform.startswith('win'):
+                results = results.replace('\r', '')
+            return results
         except Exception:
             g.es_exception()
-            return False
+            return contents
 
     # @+node:ekr.20260110083713.1: *4* c.beautify_script_tree
     def beautify_script_tree(self, root: Position) -> None:
@@ -5359,10 +5362,7 @@ class Commands:
         ok = g.writeFile(old_contents, 'utf-8', path)
         if not ok:
             return
-        c.beautify_with_ruff(root, path)
-        results = g.readFile(path)
-        if sys.platform.startswith('win'):
-            results = results.replace('\r', '')
+        results = c.beautify_with_ruff(old_contents, root, path)
         if old_contents == results:
             return
 


### PR DESCRIPTION
See #4496.

Aha! On Windows we must strip `\r` from the results of `ruff format`. That was the root of the performance bug.

- [x] Add `contents` arg to `at.runRuffFormat` and `c.beautify_with_ruff`.
- [x]  `c.beautify_with_ruff` returns the (possibly beautified) contents, stripped of `\r' characters.
- [x] `at.runRuffFormat` does nothing (except call `efc.set_time`) if the file hasn't changed.