### PR TITLE
PR: Add # fmt: skip pragmas to restore legacy formatting

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -91,8 +91,8 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         c = self.c
         table = (
             ('global-abbreviations', 'global'),
-            ('abbreviations', 'local'),
-        )
+            ('abbreviations',       'local'),
+        )  # fmt: skip
         for source, tag in table:
             aList = c.config.getData(source, strip_data=False) or []
             abbrev, result = [], []

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -351,7 +351,6 @@ class CheckNodes:
     ok_head_prefixes: list[str]
     suppressions: list[str]
 
-    ### Possible bug fix???
     def __init__(self, c: Cmdr) -> None:
         """ctor for CheckNodes class."""
         self.c = c

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -483,7 +483,13 @@ def save(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
             return
 
         # Prompt for fileName.
-        new_file_name = g.app.gui.runSaveFileDialog(c, title="Save", filetypes=[("Leo files", "*.leo *.leojs *.db")])
+        new_file_name = g.app.gui.runSaveFileDialog(
+            c,
+            title="Save",
+            filetypes=[
+                ("Leo files", "*.leo *.leojs *.db"),
+            ],
+        )
         if new_file_name:
             final_file_name = set_name_and_title(c, new_file_name)
             do_save(c, final_file_name)
@@ -640,7 +646,9 @@ def save_as_leojs(self: Self, event: LeoKeyEvent = None) -> None:
     fileName = g.app.gui.runSaveFileDialog(
         c,
         title="Save As JSON (.leojs)",
-        filetypes=[("Leo JSON files", "*.leojs")],
+        filetypes=[
+            ("Leo JSON files", "*.leojs"),
+        ],
     )
     if not fileName:
         return
@@ -663,7 +671,9 @@ def save_as_db(self: Self, event: LeoKeyEvent = None) -> None:
     fileName = g.app.gui.runSaveFileDialog(
         c,
         title="Save As DB",
-        filetypes=[("Leo files", "*.db")],
+        filetypes=[
+            ("Leo files", "*.db"),
+        ],
     )
     if not fileName:
         return
@@ -687,7 +697,9 @@ def save_as_xml(self: Self, event: LeoKeyEvent = None) -> None:
     fileName = g.app.gui.runSaveFileDialog(
         c,
         title="Save As XML",
-        filetypes=[("Leo files", "*.leo")],
+        filetypes=[
+            ("Leo files", "*.leo"),
+        ],
     )
     if not fileName:
         return
@@ -726,7 +738,10 @@ def save_node_as_xml_outline(self: Self, event: LeoKeyEvent = None) -> None:
 def exportHeadlines(self: Self, event: LeoKeyEvent = None) -> None:
     """Export headlines for c.p and its subtree to an external file."""
     c = self
-    filetypes = [("Text files", "*.txt"), ("All files", "*")]
+    filetypes = [
+        ("Text files", "*.txt"),
+        ("All files", "*"),
+    ]
     fileName = g.app.gui.runSaveFileDialog(c, title="Export Headlines", filetypes=filetypes)
     c.bringToFront()
     if fileName:
@@ -743,7 +758,10 @@ def flattenOutline(self: Self, event: LeoKeyEvent = None) -> None:
     The outline is represented in MORE format.
     """
     c = self
-    filetypes = [("Text files", "*.txt"), ("All files", "*")]
+    filetypes = [
+        ("Text files", "*.txt"),
+        ("All files", "*"),
+    ]
     fileName = g.app.gui.runSaveFileDialog(c, title="Flatten Selected Outline", filetypes=filetypes)
     c.bringToFront()
     if fileName:
@@ -788,7 +806,11 @@ def outlineToCWEB(self: Self, event: LeoKeyEvent = None) -> None:
     The outline is represented in CWEB format.
     """
     c = self
-    filetypes = [("CWEB files", "*.w"), ("Text files", "*.txt"), ("All files", "*")]
+    filetypes = [
+        ("CWEB files", "*.w"),
+        ("Text files", "*.txt"),
+        ("All files", "*"),
+    ]
     fileName = g.app.gui.runSaveFileDialog(c, title="Outline To CWEB", filetypes=filetypes)
     c.bringToFront()
     if fileName:
@@ -805,7 +827,11 @@ def outlineToNoweb(self: Self, event: LeoKeyEvent = None) -> None:
     The outline is represented in noweb format.
     """
     c = self
-    filetypes = [("Noweb files", "*.nw"), ("Text files", "*.txt"), ("All files", "*")]
+    filetypes = [
+        ("Noweb files", "*.nw"),
+        ("Text files", "*.txt"),
+        ("All files", "*"),
+    ]
     fileName = g.app.gui.runSaveFileDialog(c, title="Outline To Noweb", filetypes=filetypes)
     c.bringToFront()
     if fileName:
@@ -846,7 +872,10 @@ def weave(self: Self, event: LeoKeyEvent = None) -> None:
     fileName = g.app.gui.runSaveFileDialog(
         c,
         title="Weave",
-        filetypes=[("Text files", "*.txt"), ("All files", "*")],
+        filetypes=[
+            ("Text files", "*.txt"),
+            ("All files", "*"),
+        ],
     )
     c.bringToFront()
     if fileName:

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -31,8 +31,10 @@ def about(self: Self, event: LeoKeyEvent = None) -> None:
     # Doing so would add unwanted leading tabs.
     version = g.app.signon + '\n\n'
     theCopyright = (
-        "Copyright 1999-%s by Edward K. Ream\n" + "All Rights Reserved\n" + "Leo is distributed under the MIT License"
-    ) % datetime.date.today().year
+        "Copyright 1999-%s by Edward K. Ream\n"
+        "All Rights Reserved\n"
+        "Leo is distributed under the MIT License"
+    ) % datetime.date.today().year  # fmt: skip
     url = "https://leo-editor.github.io/leo-editor/"
     email = "edreamleo@gmail.com"
     g.app.gui.runAboutLeoDialog(c, version, theCopyright, url, email)

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -31,9 +31,9 @@ def about(self: Self, event: LeoKeyEvent = None) -> None:
     # Doing so would add unwanted leading tabs.
     version = g.app.signon + '\n\n'
     theCopyright = (
-        "Copyright 1999-%s by Edward K. Ream\n"
-        "All Rights Reserved\n"
-        "Leo is distributed under the MIT License"
+        'Copyright 1999-%s by Edward K. Ream\n'
+        'All Rights Reserved\n'
+        'Leo is distributed under the MIT License'
     ) % datetime.date.today().year  # fmt: skip
     url = "https://leo-editor.github.io/leo-editor/"
     email = "edreamleo@gmail.com"

--- a/leo/commands/commanderHelpCommands.py
+++ b/leo/commands/commanderHelpCommands.py
@@ -285,7 +285,11 @@ def createMyLeoSettings(c: Cmdr) -> Optional[Cmdr]:
     nd.h = '@keys'
     nd = nd.insertAsNthChild(0)
     nd.h = '@shortcuts'
-    nd.b = "# You can define keyboard shortcuts here of the form:\n#\n#    some-command Shift-F5\n"
+    nd.b = (
+        '# You can define keyboard shortcuts here of the form:\n'
+        '#\n'
+        '#    some-command Shift-F5\n'
+    )  # fmt: skip
     c2.setChanged()
     c2.redraw()
     return c2

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1033,7 +1033,10 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.backward = backward
         self.extend = extend or self.extendMode  # Bug fix: 2010/01/19
         self.insert = self.w.getInsertPoint()
-        s = f"{'Backward find' if backward else 'Find'} character{' & extend' if extend else ''}: "
+        s = (
+            f"{'Backward find' if backward else 'Find'} "
+            f"character{' & extend' if extend else ''}: "
+        )  # fmt: skip
         k.setLabelBlue(s)
         # Get the arg without touching the focus.
         k.getArg(event, handler=self.findCharacter1, oneCharacter=True, useMinibuffer=False)
@@ -1610,7 +1613,10 @@ class EditCommandsClass(BaseEditCommandsClass):
         i = w.getInsertPoint()
         row, col = g.convertPythonIndexToRowCol(s, i)
         percent = int((i * 100) / len(s))
-        k.setLabelGrey('char: %s row: %d col: %d pos: %d (%d%% of %d)' % (repr(s[i]), row, col, i, percent, len(s)))
+        k.setLabelGrey(
+            'char: %s row: %d col: %d pos: %d (%d%% of %d)'
+            % (repr(s[i]), row, col, i, percent, len(s))
+        )  # fmt: skip
 
     # @+node:ekr.20150514063305.248: *4* ec.viewLossage
     @cmd('view-lossage')
@@ -2368,11 +2374,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         language = c.getLanguage(p)
         i, j = oldSel
         s = w.getAllText()
-        if ch in (
-            '(',
-            '[',
-            '{',
-        ):
+        if ch in ('([{'):
             automatch = language not in ('plain',)
             if automatch:
                 ch = ch + {'(': ')', '[': ']', '{': '}'}.get(ch)
@@ -3928,7 +3930,13 @@ class EditCommandsClass(BaseEditCommandsClass):
             i, junk = g.getLine(s, sel_1)
             junk, j = g.getLine(s, sel_2)
             txt = s[i:j]
-            columns = [w.get(toInt(f"{z}.{sint2}"), toInt(f"{z}.{sint4}")) for z in range(sint1, sint3 + 1)]
+            columns = [
+                w.get(
+                    toInt(f"{z}.{sint2}"),
+                    toInt(f"{z}.{sint4}"),
+                )
+                for z in range(sint1, sint3 + 1)
+            ]
             aList = g.splitLines(txt)
             zlist = list(zip(columns, aList))
             zlist.sort()

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -861,7 +861,10 @@ class GitDiffController:
         # Go back at most 5 revs...
         n1, n2 = 1, 0
         while n1 <= 5:
-            ok = self.diff_revs(rev1=f"HEAD@{{{n1}}}", rev2=f"HEAD@{{{n2}}}")
+            ok = self.diff_revs(
+                rev1=f"HEAD@{{{n1}}}",
+                rev2=f"HEAD@{{{n2}}}",
+            )
             if ok:
                 return
             n1, n2 = n1 + 1, n2 + 1

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -545,7 +545,10 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         fn = g.app.gui.runOpenFileDialog(
             c,
             title='Open Text File',
-            filetypes=[("Text", "*.txt"), ("All files", "*")],
+            filetypes=[
+                ("Text", "*.txt"),
+                ("All files", "*"),
+            ],
         )
         return fn
 
@@ -636,7 +639,10 @@ class EditFileCommandsClass(BaseEditCommandsClass):
         fileName = g.app.gui.runSaveFileDialog(
             c,
             title='save-file',
-            filetypes=[("Text", "*.txt"), ("All files", "*")],
+            filetypes=[
+                ("Text", "*.txt"),
+                ("All files", "*"),
+            ],
         )
         if fileName:
             try:

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -1600,7 +1600,11 @@ class GitDiffController:
     ) -> None:
         """Create an outline-oriented diff from the *hidden* outlines c1 and c2."""
         added, deleted, changed = self.compute_dicts(c1, c2)
-        table = ((added, 'Added'), (deleted, 'Deleted'), (changed, 'Changed'))
+        table = (
+            (added,   'Added'),
+            (deleted, 'Deleted'),
+            (changed, 'Changed'),
+        )  # fmt: skip
         for d, kind in table:
             self.create_compare_node(c1, c2, d, kind, rev1, rev2)
 

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -257,9 +257,7 @@ class GoToCommands:
                     offset = 0
                     gnx, h = self.get_script_node_info(s, delim2)
                 elif s2.startswith('@+others') or s2.startswith('@+<<'):
-                    stack.append(
-                        (gnx, h, offset),
-                    )
+                    stack.append((gnx, h, offset))
                     # @verbatim
                     # @others is visible in the outline, but *not* in the file.
                     offset += 1
@@ -311,9 +309,7 @@ class GoToCommands:
                     offset = 0
                     gnx, h = self.get_script_node_info(s, delim2)
                 elif s2.startswith('@+others') or s2.startswith('@+<<'):
-                    stack.append(
-                        (gnx, h, offset),
-                    )
+                    stack.append((gnx, h, offset))
                     offset += 1
                 elif s2.startswith('@-others') or s2.startswith('@-<<'):
                     gnx, h, offset = stack.pop()

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -139,8 +139,7 @@ class LeoApp:
         self.failFast = False  # True: Use the failfast option in unit tests.
         self.gui: LeoGui = None  # The gui class.
         self.guiArgName: str = None  # The gui name given in --gui option.
-        # True: load files as theme files (ignore myLeoSettings.leo).
-        self.isTheme = False
+        self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
         self.loaded_session = False  # Set by startup logic to True if no files specified on the command line.
         self.silentMode = False  # True: no signon.
@@ -1507,7 +1506,10 @@ class LeoApp:
             aList = sorted(set(g.app.already_open_files))
             g.app.already_open_files = []
             g.app.gui.dismiss_splash_screen()
-            message = 'The following files may already be open\nin another copy of Leo:\n\n' + '\n'.join(aList)
+            message = (
+                'The following files may already be open\nin another copy of Leo:\n\n'
+                '\n'.join(aList)
+            )  # fmt: skip
             g.app.gui.runAskOkDialog(c, title='Already Open Files', message=message, text="Ok")
 
     # @+node:ekr.20171127111141.1: *3* app.Import utils
@@ -3123,7 +3125,7 @@ class LoadManager:
             return True
         message = (
             f"Leo requires Python {g.minimum_python_version} or higher"
-            "You may download Python from http://python.org/download/"
+            'You may download Python from http://python.org/download/'
         )
         try:
             if not g.isValidPython:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -1021,14 +1021,9 @@ class AstDumper:  # pragma: no cover
     # @+node:ekr.20141012064706.18393: *4* dumper.get_fields
     def get_fields(self, node: Node) -> Generator:
         return (
-            (a, b)
-            for a, b in ast.iter_fields(node)
-            if a
-            not in [
-                'ctx',
-            ]
-            and b not in (None, [])
-        )
+            (a, b) for a, b in ast.iter_fields(node)
+            if a not in ['ctx',] and b not in (None, [])
+        )  # fmt: skip
 
     # @-others
 

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3346,7 +3346,11 @@ class AtFile:
                     c.redraw()
                     return False
         if message is None:
-            message = f"{g.splitLongFileName(fileName)}\n{g.tr('already exists.')}\n{g.tr('Overwrite this file?')}"
+            message = (
+                f"{g.splitLongFileName(fileName)}\n"
+                f"{g.tr('already exists.')}\n"
+                f"{g.tr('Overwrite this file?')}"
+            )  # fmt: skip
         result = g.app.gui.runAskYesNoCancelDialog(
             c,
             title='Overwrite existing file?',

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -3996,7 +3996,10 @@ class FastAtRead:
                     g.trace('Ignore bad @verbatim sentinel', repr(line))
                 else:
                     # A useful trace.
-                    g.trace(f"{g.shortFileName(self.path)}: warning: inserting unexpected line: {line.rstrip()!r}")
+                    g.trace(
+                        f"{g.shortFileName(self.path)}: "
+                        f"warning: inserting unexpected line: {line.rstrip()!r}"
+                    )  # fmt: skip
                     # #2213: *Do* insert the line, with a warning.
                     body.append(line)
             # @-<< handle remaining @ lines >>

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -302,9 +302,7 @@ class BaseColorizer:
             i_size = self.zoom_dict.get(key)
         else:
             s_size: str = size or default_size
-            if s_size.endswith(
-                ('pt', 'px'),
-            ):
+            if s_size.endswith(('pt', 'px')):
                 s_size = s_size[:-2]
             try:
                 i_size = int(s_size)
@@ -1091,11 +1089,7 @@ class JEditColorizer(BaseColorizer):
                 ('\t', self.match_trailing_ws, True),
             ]
         # Replace the bound method by an unbound method.
-        for (
-            ch,
-            rule,
-            atFront,
-        ) in table:
+        for ch, rule, atFront in table:
             rule = rule.__func__
             theList = theDict.get(ch, [])
             if rule not in theList:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -1917,7 +1917,10 @@ class Commands:
             if paths:
                 break
         if len(paths) > 1:
-            message = f"Multiple @path directives in {p.h!r}\nUsing the first path: @path {paths[0]}"
+            message = (
+                f"Multiple @path directives in {p.h!r}\n"
+                f"Using the first path: @path {paths[0]}"
+            )  # fmt: skip
             g.print_unique_message(message)
         return paths[0] if paths else None
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -2139,10 +2139,7 @@ class Commands:
                     n = parent.children.index(immediate)
                 else:
                     break
-                stack.insert(
-                    0,
-                    (immediate, n),
-                )
+                stack.insert(0, (immediate, n))
                 immediate = parent
             else:
                 v, n = stack.pop()
@@ -2165,10 +2162,7 @@ class Commands:
                 n = parent.children.index(v)
             else:
                 return None
-            stack.insert(
-                0,
-                (v, n),
-            )
+            stack.insert(0, (v, n))
             v = parent
         # v.parents includes the hidden root node.
         if not stack:
@@ -2521,11 +2515,19 @@ class Commands:
         next = p.next()
         if back:
             if not g._assert(p == back.next()):
-                g.trace(f"p!=p.back().next()\n     back: {back}\nback.next: {back.next()}")
+                g.trace(
+                    f"p!=p.back().next()\n"
+                    f"     back: {back}\n"
+                    f"back.next: {back.next()}"
+                )  # fmt: skip
                 return False
         if next:
             if not g._assert(p == next.back()):
-                g.trace(f"p!=p.next().back\n     next: {next}\nnext.back: {next.back()}")
+                g.trace(
+                    f"p!=p.next().back\n"
+                    f"     next: {next}\n"
+                    f"next.back: {next.back()}"
+                )  # fmt: skip
                 return False
         return True
 

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -634,10 +634,10 @@ class CompareLeoOutlines:
         """Create an outline-oriented diff from the outlines c1 and c2."""
         added, deleted, changed = self.compute_dicts(c1, c2)
         table = (
-            (added, 'Added'),
+            (added,   'Added'),
             (deleted, 'Deleted'),
             (changed, 'Changed'),
-        )
+        )  # fmt: skip
         for d, kind in table:
             self.create_compare_node(c1, c2, d, kind)
 

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -633,7 +633,11 @@ class CompareLeoOutlines:
     def make_diff_outlines(self, c1: Cmdr, c2: Cmdr) -> None:
         """Create an outline-oriented diff from the outlines c1 and c2."""
         added, deleted, changed = self.compute_dicts(c1, c2)
-        table = ((added, 'Added'), (deleted, 'Deleted'), (changed, 'Changed'))
+        table = (
+            (added, 'Added'),
+            (deleted, 'Deleted'),
+            (changed, 'Changed'),
+        )
         for d, kind in table:
             self.create_compare_node(c1, c2, d, kind)
 

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -1431,15 +1431,12 @@ class GlobalConfigManager:
         return (
             type1 is None
             or type2 is None
-            or type1.startswith('string')
-            and type2 not in shortcuts
-            or type1 == 'language'
-            and type2 == 'string'
-            or type1 == 'int'
-            and type2 == 'size'
+            or type1.startswith('string') and type2 not in shortcuts
+            or type1 == 'language' and type2 == 'string'
+            or type1 == 'int' and type2 == 'size'
             or (type1 in shortcuts and type2 in shortcuts)
             or type1 == type2
-        )
+        )  # fmt: skip
 
     # @+node:ekr.20060608224112: *4* gcm.getAbbrevDict
     def getAbbrevDict(self) -> dict[str, Value]:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -677,7 +677,10 @@ class ExternalFilesController:
             return
         path_name = g.splitLongFileName(path)
         kind = '@asis' if p.h.startswith('@asis') else '@nosent'
-        message = f"{path_name} has changed outside Leo.\n\nAn {kind} node created this file.\n\n"
+        message = (
+            f"{path_name} has changed outside Leo.\n\n"
+            f"An {kind} node created this file.\n\n"
+        )  # fmt: skip
         if kind == '@nosent':
             message += '@nosent nodes cannot be updated from disk.\n'
         elif kind == '@asis':

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1740,8 +1740,11 @@ class FileCommands:
             result = {
                 'leoHeader': {'fileFormat': 2},
                 'vnodes': [self.leojs_vnode(sp, gnxSet)],
-                'tnodes': {p.v.gnx: p.v._bodyString for p in sp.self_and_subtree() if p.v._bodyString},
-            }
+                'tnodes': {
+                    p.v.gnx: p.v._bodyString
+                    for p in sp.self_and_subtree()
+                    if p.v._bodyString},
+            }  # fmt: skip
 
         else:  # write everything from the top node 'c.rootPosition()'
             # build uas dict
@@ -1758,9 +1761,16 @@ class FileCommands:
             # result for whole outline
             result = {
                 'leoHeader': {'fileFormat': 2},
-                'vnodes': [self.leojs_vnode(p, gnxSet) for p in c.rootPosition().self_and_siblings()],
-                'tnodes': {v.gnx: v._bodyString for v in c.all_unique_nodes() if (v._bodyString and v.isWriteBit())},
-            }
+                'vnodes': [
+                    self.leojs_vnode(p, gnxSet)
+                    for p in c.rootPosition().self_and_siblings()
+                ],
+                'tnodes': {
+                    v.gnx: v._bodyString
+                    for v in c.all_unique_nodes()
+                    if (v._bodyString and v.isWriteBit())
+                },
+            }  # fmt: skip
         self.leojs_globals()  # Call only to set db like non-json save file.
         # uas could be empty. Only add it if needed
         if uas:
@@ -2244,7 +2254,11 @@ class FileCommands:
     def putXMLLine(self) -> None:
         """Put the **properly encoded** <?xml> element."""
         # Use self.leo_file_encoding encoding.
-        self.put(f"{g.app.prolog_prefix_string}\"{self.leo_file_encoding}\"{g.app.prolog_postfix_string}\n")
+        self.put(
+            f"{g.app.prolog_prefix_string}"
+            f'"{self.leo_file_encoding}"'
+            f"{g.app.prolog_postfix_string}\n"
+        )  # fmt: skip
 
     # @-others
 

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -1203,7 +1203,11 @@ class LeoFind:
         n = self._change_all_helper(settings)
         # #947, #880 and #722: Set ancestor @<file> nodes by brute force.
         for p in c.all_positions():  # pragma: no cover
-            if p.anyAtFileNodeName() and not p.v.isDirty() and any(p2.v.isDirty() for p2 in p.subtree()):
+            if (
+                p.anyAtFileNodeName()
+                and not p.v.isDirty()
+                and any(p2.v.isDirty() for p2 in p.subtree())
+            ):  # fmt: skip
                 p.setDirty()
         c.redraw()
         return n

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -3262,14 +3262,14 @@ class LeoFind:
         # Too similar to another method...
         status = []
         table = (
-            ('whole_word', 'Word'),
-            ('ignore_case', 'Ignore Case'),
-            ('pattern_match', 'Regex'),
+            ('whole_word',      'Word'),
+            ('ignore_case',     'Ignore Case'),
+            ('pattern_match',   'Regex'),
             ('suboutline_only', '[Outline Only]'),
-            ('node_only', '[Node Only]'),
+            ('node_only',       '[Node Only]'),
             ('search_headline', 'Head'),
-            ('search_body', 'Body'),
-        )
+            ('search_body',     'Body'),
+        )  # fmt: skip
         for ivar, val in table:
             if getattr(self, ivar):
                 status.append(val)
@@ -3339,21 +3339,21 @@ class LeoFind:
         c = self.c
         ftm = c.findCommands.ftm
         table = (
-            ('Word', ftm.check_box_whole_word),
+            ('Word',    ftm.check_box_whole_word),
             ('Ig-case', ftm.check_box_ignore_case),
-            ('regeXp', ftm.check_box_regexp),
-            ('Body', ftm.check_box_search_body),
-            ('Head', ftm.check_box_search_headline),
+            ('regeXp',  ftm.check_box_regexp),
+            ('Body',    ftm.check_box_search_body),
+            ('Head',    ftm.check_box_search_headline),
             # ('wrap-Around', ftm.check_box_wrap_around),
             ('mark-Changes', ftm.check_box_mark_changes),
             ('mark-Finds', ftm.check_box_mark_finds),
-        )
+        )  # fmt: skip
         result = [option for option, ivar in table if ivar.isChecked()]
         table2 = (
             ('Suboutline', ftm.radio_button_suboutline_only),
-            ('Node', ftm.radio_button_node_only),
-            ('File', ftm.radio_button_file_only),
-        )
+            ('Node',       ftm.radio_button_node_only),
+            ('File',       ftm.radio_button_file_only),
+        )  # fmt: skip
         for option, ivar in table2:
             if ivar.isChecked():
                 result.append(f"[{option}]")

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1840,12 +1840,12 @@ class TkIDDialog(EmergencyDialog):
     """A class that creates an tkinter dialog to get the Leo ID."""
 
     message = (
-        "leoID.txt not found\n\n"
-        "Please enter an id that identifies you uniquely.\n"
-        "Your git/cvs/bzr login name is a good choice.\n\n"
-        "Leo uses this id to uniquely identify nodes.\n\n"
-        "Your id should contain only letters and numbers\n"
-        "and must be at least 3 characters in length."
+        'leoID.txt not found\n\n'
+        'Please enter an id that identifies you uniquely.\n'
+        'Your git/cvs/bzr login name is a good choice.\n\n'
+        'Leo uses this id to uniquely identify nodes.\n\n'
+        'Your id should contain only letters and numbers\n'
+        'and must be at least 3 characters in length.'
     )
 
     title = 'Enter Leo id'
@@ -2199,7 +2199,11 @@ def assert_is(obj: object, list_or_class: Any, warn: bool = True) -> bool:
     if warn:
         ok = isinstance(obj, list_or_class)
         if not ok:
-            g.es_print(f"can not happen. {obj!r}: expected {list_or_class}, got: {obj.__class__.__name__}")
+            g.es_print(
+                f"can not happen. {obj!r}: "
+                f"expected {list_or_class}, "
+                f"got: {obj.__class__.__name__}"
+            )  # fmt: skip
             g.es_print(g.callers())
         return ok
     ok = isinstance(obj, list_or_class)
@@ -5644,7 +5648,10 @@ def toUnicode(s: object, encoding: str = None, reportErrors: bool = False) -> st
     tag = 'g.toUnicode'
     if not isinstance(s, bytes):
         if reportErrors and not isinstance(s, (NullObject, TracingNullObject)):
-            message = f"{tag}: unexpected argument of type {s.__class__.__name__}\nCallers: {g.callers}"
+            message = (
+                f"{tag}: unexpected argument of type {s.__class__.__name__}\n"
+                f"Callers: {g.callers}"
+            )  # fmt: skip
             g.es_print_unique_message(message)
         return ''
     if not encoding:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -713,7 +713,11 @@ class GeneralSetting:
     def __repr__(self) -> str:
         # Better for g.printObj.
         val = str(self.val).replace('\n', ' ')
-        return f"GS: path: {g.shortFileName(self.path or '')} source: {self.source or ''} kind: {self.kind} val: {val}"
+        return (
+            f"GS: path: {g.shortFileName(self.path or '')} "
+            f"source: {self.source or ''} "
+            f"kind: {self.kind} val: {val}"
+        )  # fmt: skip
 
     dump = __repr__
     __str__ = __repr__
@@ -1980,7 +1984,11 @@ class Tracer:
         if event == 'return':
             if self.stack:
                 name = self.stack.pop()
-                if self.trace and self.verbose and (self.limit == 0 or len(self.stack) < self.limit):
+                if (
+                    self.trace
+                    and self.verbose
+                    and (self.limit == 0 or len(self.stack) < self.limit)
+                ):  # fmt: skip
                     g.trace(f"{pad}ret ", name)
             else:
                 g.trace('return underflow')
@@ -2446,7 +2454,11 @@ def checkUnchangedIvars(
     for key in d:
         if key not in exceptions:
             if getattr(obj, key) != d.get(key):
-                g.trace(f"changed ivar: {key} old: {repr(d.get(key))} new: {repr(getattr(obj, key))}")
+                g.trace(
+                    f"changed ivar: {key} "
+                    f"old: {repr(d.get(key))} "
+                    f"new: {repr(getattr(obj, key))}"
+                )  # fmt: skip
                 ok = False
     return ok
 
@@ -6239,7 +6251,10 @@ def isUniqueClass(obj: object, list_or_class: Any, *, n: int = 2) -> None:
         if isinstance(obj, list_or_class):
             return
     except Exception as e:
-        print(f"\ng.isUniqueClass: {g.callers()}\nBad arg 2: {list_or_class!r}\n{e!r}\n")
+        print(
+            f"\ng.isUniqueClass: {g.callers()}\n"
+            f"Bad arg 2: {list_or_class!r}\n{e!r}\n"
+        )  # fmt: skip
         return
     key = g.callers(n)
     value_s = obj.__class__.__name__
@@ -8109,7 +8124,10 @@ def handleUrl(url: str, c: Cmdr = None, p: Position = None) -> Optional[str]:
     urll = url.lower()
     if urll.startswith('@url'):
         url = url[4:].lstrip()
-    if urll.startswith(('#', 'unl://', 'unl:gnx:')) or urll.startswith('file://') and '-->' in urll:
+    if (
+        urll.startswith(('#', 'unl://', 'unl:gnx:'))
+        or urll.startswith('file://') and '-->' in urll
+    ):  # fmt: skip
         return g.handleUnl(url, c)
     try:
         g.handleUrlHelper(url, c, p)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -496,7 +496,13 @@ class BindingInfo:
     def dump(self) -> str:
         result = [f"BindingInfo kind: {self.kind}"]
         # Print all existing ivars.
-        table = ('pane', 'commandName', 'func', 'stroke')  # 'nextMode',
+        table = (
+            'pane',
+            'commandName',
+            'func',
+            'stroke',
+            # 'nextMode',
+        )
         for ivar in table:
             if hasattr(self, ivar):
                 val = getattr(self, ivar)
@@ -5585,10 +5591,10 @@ def stripBOM(s_bytes: bytes) -> tuple[str, bytes]:
         # Important: test longer bom's first.
         (4, 'utf-32', codecs.BOM_UTF32_BE),
         (4, 'utf-32', codecs.BOM_UTF32_LE),
-        (3, 'utf-8', codecs.BOM_UTF8),
+        (3, 'utf-8',  codecs.BOM_UTF8),
         (2, 'utf-16', codecs.BOM_UTF16_BE),
         (2, 'utf-16', codecs.BOM_UTF16_LE),
-    )
+    )  # fmt: skip
     if s_bytes:
         for n, e, bom in table:
             assert len(bom) == n

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -728,23 +728,23 @@ class StringFindTabManager:
         c, find = self.c, self.c.findCommands
         # Find/change text boxes.
         table1 = (
-            ('find_findbox', 'find_text', '<find pattern here>'),
+            ('find_findbox',    'find_text',   '<find pattern here>'),
             ('find_replacebox', 'change_text', ''),
-        )
+        )  # fmt: skip
         for widget_ivar, setting_name, default in table1:
             w = getattr(self, widget_ivar)
             s = c.config.getString(setting_name) or default
             w.insert(s)
         # Check boxes.
         table2 = (
-            ('ignore_case', 'check_box_ignore_case'),
-            ('mark_changes', 'check_box_mark_changes'),
-            ('mark_finds', 'check_box_mark_finds'),
-            ('pattern_match', 'check_box_regexp'),
-            ('search_body', 'check_box_search_body'),
+            ('ignore_case',     'check_box_ignore_case'),
+            ('mark_changes',    'check_box_mark_changes'),
+            ('mark_finds',      'check_box_mark_finds'),
+            ('pattern_match',   'check_box_regexp'),
+            ('search_body',     'check_box_search_body'),
             ('search_headline', 'check_box_search_headline'),
-            ('whole_word', 'check_box_whole_word'),
-        )
+            ('whole_word',      'check_box_whole_word'),
+        )  # fmt: skip
         for setting_name, widget_ivar in table2:
             w = getattr(self, widget_ivar)
             val = c.config.getBool(setting_name, default=False)
@@ -753,11 +753,11 @@ class StringFindTabManager:
                 w.toggle()
         # Radio buttons
         table3 = (
-            ('file_only', 'file_only', 'radio_button_file_only'),  # #2684.
-            ('node_only', 'node_only', 'radio_button_node_only'),
-            ('entire_outline', None, 'radio_button_entire_outline'),
+            ('file_only',      'file_only',        'radio_button_file_only'),  # #2684.
+            ('node_only',      'node_only',        'radio_button_node_only'),
+            ('entire_outline',  None,              'radio_button_entire_outline'),
             ('suboutline_only', 'suboutline_only', 'radio_button_suboutline_only'),
-        )
+        )  # fmt: skip
         for setting_name, ivar, widget_ivar in table3:
             w = getattr(self, widget_ivar)
             val = c.config.getBool(setting_name, default=False)
@@ -781,9 +781,9 @@ class StringFindTabManager:
         if not find:
             return
         table = (
-            ('search_body', self.check_box_search_body),
+            ('search_body',     self.check_box_search_body),
             ('search_headline', self.check_box_search_headline),
-        )
+        )  # fmt: skip
         for setting_name, w in table:
             val = c.config.getBool(setting_name, default=False)
             if val != w.isChecked():

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2170,9 +2170,7 @@ class TabImporter:
                 grand_parent = stack[-1][1] if stack else root
                 parent = grand_parent.insertAsLastChild()  # lws == level
                 parent.h = h
-                stack.append(
-                    (level, parent),
-                )
+                stack.append((level, parent))
             elif not parent.h:
                 parent.h = h
         elif lws > level:
@@ -2180,9 +2178,7 @@ class TabImporter:
             level = lws
             parent = parent.insertAsLastChild()
             parent.h = h
-            stack.append(
-                (level, parent),
-            )
+            stack.append((level, parent))
         else:
             # Find the previous parent.
             while stack:
@@ -2192,9 +2188,7 @@ class TabImporter:
                     parent = grand_parent.insertAsLastChild()  # lws < level
                     parent.h = h
                     level = lws
-                    stack.append(
-                        (level, parent),
-                    )
+                    stack.append((level, parent))
                     break
             else:
                 level = 0

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -1235,10 +1235,7 @@ class FileNameChooser:
             # Re-init all ivars.
             self.log = c.frame.log or NullLog(frame=c.frame, parentFrame=None)
             self.callback = callback
-            self.filterExt = filterExt or [
-                '.pyc',
-                '.bin',
-            ]
+            self.filterExt = filterExt or ['.pyc', '.bin']
             self.prompt = prompt
             self.tabName = tabName
             join = g.finalize_join
@@ -1654,11 +1651,7 @@ class GetArg:
         """Return True if ga.get_arg should return."""
         k = self.k
         return (
-            char
-            in (
-                '\n',
-                'Return',
-            )
+            char in ('\n', 'Return')
             or k.oneCharacterArg
             or stroke
             and stroke in k.getArgEscapes
@@ -3909,14 +3902,11 @@ class KeyHandlerClass:
         state = k.unboundKeyAction
         w_name = c.widget_name(w)
         pane_matches = (
-            name
-            and w_name.startswith(name)
-            or key in ('command', 'insert', 'overwrite')
-            and state == key
-            or key in ('text', 'all')
-            and g.isTextWrapper(w)
+            name and w_name.startswith(name)
+            or key in ('command', 'insert', 'overwrite') and state == key
+            or key in ('text', 'all') and g.isTextWrapper(w)
             or key in ('button', 'all')
-        )
+        )  # fmt: skip
         if not pane_matches:
             return None
         #

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -127,7 +127,12 @@ class LeoMenu:
         for i, ch in enumerate(s):
             prev = s[i - 1] if i > 0 else ''
             prevprev = s[i - 2] if i > 1 else ''
-            if i == 0 or i == 1 and prev == '&' or prev == '-' or prev == '&' and prevprev == '-':
+            if (
+                i == 0
+                or i == 1 and prev == '&'
+                or prev == '-'
+                or prev == '&' and prevprev == '-'
+            ):  # fmt: skip
                 result.append(ch.capitalize())
             elif removeHyphens and ch == '-':
                 result.append(' ')

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2209,8 +2209,9 @@ class VNode:
     # @+node:ekr.20031218072017.3345: *4* v.__repr__ & v.__str__
     def __repr__(self) -> str:  # pragma: no cover
         return (
-            '<VNode: hidden root>' if self.gnx == 'hidden-root-vnode-gnx' else f"<VNode {self.gnx} {self.headString()}>"
-        )
+            '<VNode: hidden root>' if self.gnx == 'hidden-root-vnode-gnx'
+            else f"<VNode {self.gnx} {self.headString()}>"
+        )  # fmt: skip
 
     __str__ = __repr__
 
@@ -2293,10 +2294,7 @@ class VNode:
         return self.findAtFileName(names)
 
     def atNoSentinelsFileNodeName(self) -> str:
-        names = (
-            "@nosent",
-            "@file-nosent",
-        )
+        names = ("@nosent", "@file-nosent")
         return self.findAtFileName(names)
 
     def atRstFileNodeName(self) -> str:
@@ -2308,17 +2306,11 @@ class VNode:
         return self.findAtFileName(names)
 
     def atSilentFileNodeName(self) -> str:
-        names = (
-            "@asis",
-            "@file-asis",
-        )
+        names = ("@asis", "@file-asis")
         return self.findAtFileName(names)
 
     def atThinFileNodeName(self) -> str:
-        names = (
-            "@thin",
-            "@file-thin",
-        )
+        names = ("@thin", "@file-thin")
         return self.findAtFileName(names)
 
     # New names, less confusing

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1211,16 +1211,12 @@ class Position:
                 if p2 == p3:
                     # 2011/02/25: compare full positions, not just vnodes.
                     # A match with the to-be-moved node.
-                    stack.append(
-                        (v, childIndex - 1),
-                    )
+                    stack.append((v, childIndex - 1))
                     changed = True
                     break  # terminate only the inner loop.
                 p3.moveToBack()
             else:
-                stack.append(
-                    (v, childIndex),
-                )
+                stack.append((v, childIndex))
             i += 1
         if changed:
             p.stack = stack
@@ -1253,9 +1249,7 @@ class Position:
         p = self
         parent_v = parent.v
         p.stack = parent.stack[:]
-        p.stack.append(
-            (parent_v, parent._childIndex),
-        )
+        p.stack.append((parent_v, parent._childIndex))
         p._childIndex = n
         child = p.v
         child._addLink(n, parent_v)
@@ -1266,9 +1260,7 @@ class Position:
         p = self
         parent_v = parent.v
         p.stack = parent.stack[:]
-        p.stack.append(
-            (parent_v, parent._childIndex),
-        )
+        p.stack.append((parent_v, parent._childIndex))
         p._childIndex = n
         child = p.v
         child._addCopiedLink(n, parent_v)
@@ -1391,9 +1383,7 @@ class Position:
         """Move a position to it's first child's position."""
         p = self
         if p.v and p.v.children:
-            p.stack.append(
-                (p.v, p._childIndex),
-            )
+            p.stack.append((p.v, p._childIndex))
             p.v = p.v.children[0]
             p._childIndex = 0
         else:
@@ -1405,9 +1395,7 @@ class Position:
         """Move a position to it's last child's position."""
         p = self
         if p.v and p.v.children:
-            p.stack.append(
-                (p.v, p._childIndex),
-            )
+            p.stack.append((p.v, p._childIndex))
             n = len(p.v.children)
             p.v = p.v.children[n - 1]
             p._childIndex = n - 1
@@ -1456,9 +1444,7 @@ class Position:
     def moveToNthChild(self, n: int) -> Position:
         p = self
         if p.v and len(p.v.children) > n:
-            p.stack.append(
-                (p.v, p._childIndex),
-            )
+            p.stack.append((p.v, p._childIndex))
             p.v = p.v.children[n]
             p._childIndex = n
         else:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -58,8 +58,10 @@ class NodeIndices:
         v2 = fc.gnxDict.get(gnx)
         if v2 and v2 != v:
             g.internalError(  # pragma: no cover
-                f"getNewIndex: gnx clash {gnx}\n          v: {v}\n         v2: {v2}"
-            )
+                f"getNewIndex: gnx clash {gnx}\n"
+                f"          v: {v}\n"
+                f"         v2: {v2}"
+            )  # fmt: skip
 
     # @+node:ekr.20150302061758.14: *3* ni.compute_last_index
     def compute_last_index(self, c: Cmdr) -> None:

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -502,7 +502,11 @@ class PersistenceDataController:
 
     # @+node:ekr.20140712105644.16745: *5* pd.is_foreign_file
     def is_foreign_file(self, p: Position) -> bool:
-        return self.is_at_auto_node(p) or g.match_word(p.h, 0, '@org-mode') or g.match_word(p.h, 0, '@vim-outline')
+        return (
+            self.is_at_auto_node(p)
+            or g.match_word(p.h, 0, '@org-mode')
+            or g.match_word(p.h, 0, '@vim-outline')
+        )  # fmt: skip
 
     # @+node:ekr.20140713135856.17745: *4* pd.Pickling
     # @+node:ekr.20140713062552.17737: *5* pd.pickle

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -432,9 +432,7 @@ class LeoPluginsController:
             tags = modules_d.get(module)
             for tag in tags:
                 n = max(n, len(tag))
-                data.append(
-                    (tag, module),
-                )
+                data.append((tag, module))
         lines = sorted(list(set(["%*s %s\n" % (-n, s1, s2) for (s1, s2) in data])))
         g.es_print('', ''.join(lines), tabName=tabName)
 

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -408,7 +408,10 @@ class RstCommands:
         i = s.find('<title></title>')
         if i == -1:
             return s
-        m = re.search(r'<h1>([^<]*)</h1>', s) or re.search(r'<h1><[^>]+>([^<]*)</a></h1>', s)
+        m = (
+            re.search(r'<h1>([^<]*)</h1>', s) or
+            re.search(r'<h1><[^>]+>([^<]*)</a></h1>', s)
+        )  # fmt: skip
         if m:
             s = s.replace('<title></title>', f"<title>{m.group(1)}</title>")
         return s

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -395,7 +395,10 @@ class Undoer:
         if g.unitTesting:
             assert command.lower() != 'typing', g.callers()
         elif command.lower() == 'typing':  # pragma: no cover
-            g.trace('Error: undoType should not be "Typing"\nCall u.doTyping instead')
+            g.trace(
+                'Error: undoType should not be "Typing"\n'
+                'Call u.doTyping instead'
+            )  # fmt: skip
         u.updateAfterTyping(p, w)
 
     # @+node:ekr.20050315134017.4: *5* u.afterChangeGroup
@@ -1323,7 +1326,10 @@ class Undoer:
                 if g.unitTesting:
                     assert p.b == all, (w, g.callers())
                 elif p.b != all:
-                    g.trace(f"\np.b != w.getAllText() p: {p.h} \nw: {w!r} \n{g.callers()}\n")
+                    g.trace(
+                        f"\np.b != w.getAllText() p: {p.h} \n"
+                        f"w: {w!r} \n{g.callers()}\n"
+                    )  # fmt: skip
             p.v.insertSpot = ins = w.getInsertPoint()
             # From u.doTyping.
             newSel = w.getSelectionRange()

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -673,7 +673,9 @@ class QuickSearchController:
     # @+node:felix.20220225003906.13: *4* QSC.qsc_find_changed
     def qsc_find_changed(self) -> None:
         c = self.c
-        changed: list[tuple[Position, Match_Iter]] = [(p.copy(), None) for p in c.all_unique_positions() if p.isDirty()]
+        changed: list[tuple[Position, Match_Iter]] = [
+            (p.copy(), None) for p in c.all_unique_positions() if p.isDirty()
+        ]  # fmt: skip
         self.clear()
         self.addHeadlineMatches(changed)
 
@@ -1847,7 +1849,13 @@ class LeoServer:
         try:
             scon: QuickSearchController = c.patched_quicksearch_controller
             result: dict[str, Any] = {}
-            navlist = [{"key": k, "h": scon.its[k][0]["label"], "t": scon.its[k][0]["type"]} for k in scon.its.keys()]
+            navlist = [
+                {
+                    "key": k,
+                    "h": scon.its[k][0]["label"],
+                    "t": scon.its[k][0]["type"],
+                } for k in scon.its.keys()
+            ]  # fmt: skip
             result["navList"] = navlist
             result["messages"] = scon.lw
             result["navText"] = scon.navText
@@ -4835,9 +4843,11 @@ class LeoServer:
         except Exception:
             if self.log_flag or traces:
                 print(
-                    f"{tag}: Bad ap: {ap!r}\n{tag}: v {v!r} childIndex: {childIndex!r}\n{tag}: stack: {stack!r}",
+                    f"{tag}: Bad ap: {ap!r}\n"
+                    f"{tag}: v {v!r} childIndex: {childIndex!r}\n"
+                    f"{tag}: stack: {stack!r}",
                     flush=True,
-                )
+                )  # fmt: skip
             return None  # Return None on any error so caller can react.
         return p
 

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -1947,9 +1947,9 @@ class LeoServer:
 
             # Find/change text boxes.
             table = (
-                ('find_findbox', 'find_text', ''),
+                ('find_findbox',    'find_text',   ''),
                 ('find_replacebox', 'change_text', ''),
-            )
+            )  # fmt: skip
             for widget_ivar, setting_name, default in table:
                 w = getattr(ftm, widget_ivar)
                 s = searchSettings.get(setting_name) or default
@@ -1957,14 +1957,14 @@ class LeoServer:
                 w.insert(s)
             # Check boxes.
             table2 = (
-                ('ignore_case', 'check_box_ignore_case'),
-                ('mark_changes', 'check_box_mark_changes'),
-                ('mark_finds', 'check_box_mark_finds'),
-                ('pattern_match', 'check_box_regexp'),
-                ('search_body', 'check_box_search_body'),
+                ('ignore_case',     'check_box_ignore_case'),
+                ('mark_changes',    'check_box_mark_changes'),
+                ('mark_finds',      'check_box_mark_finds'),
+                ('pattern_match',   'check_box_regexp'),
+                ('search_body',     'check_box_search_body'),
                 ('search_headline', 'check_box_search_headline'),
-                ('whole_word', 'check_box_whole_word'),
-            )
+                ('whole_word',      'check_box_whole_word'),
+            )  # fmt: skip
             for setting_name, widget_ivar in table2:
                 w = getattr(ftm, widget_ivar)
                 val = searchSettings.get(setting_name)
@@ -1973,11 +1973,11 @@ class LeoServer:
                     w.toggle()
             # Radio buttons
             table3 = (
-                ('node_only', 'node_only', 'radio_button_node_only'),
-                ('file_only', 'file_only', 'radio_button_file_only'),
-                ('entire_outline', None, 'radio_button_entire_outline'),
+                ('node_only',       'node_only',       'radio_button_node_only'),
+                ('file_only',       'file_only',       'radio_button_file_only'),
+                ('entire_outline',  None,              'radio_button_entire_outline'),
                 ('suboutline_only', 'suboutline_only', 'radio_button_suboutline_only'),
-            )
+            )  # fmt: skip
             for setting_name, ivar, widget_ivar in table3:
                 w = getattr(ftm, widget_ivar)
                 val = searchSettings.get(setting_name, False)

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -435,7 +435,10 @@ class ServerExternalFilesController(ExternalFilesController):
             return
         path_name = g.shortFileName(path)
         kind = '@asis' if p.h.startswith('@asis') else '@nosent'
-        message = f"{path_name} has changed outside Leo.\n\nAn {kind} node created this file.\n\n"
+        message = (
+            f"{path_name} has changed outside Leo.\n\n"
+            f"An {kind} node created this file.\n\n"
+        )  # fmt: skip
         if kind == '@nosent':
             message += '@nosent nodes cannot be updated from disk.\n'
         elif kind == '@asis':

--- a/leo/modes/forth.py
+++ b/leo/modes/forth.py
@@ -197,14 +197,14 @@ class extendForth:
         c = self.c
         assert c
         table = (
-            (self.definingwords, "forth-defwords"),
-            (self.brackets, "forth-delimiter-pairs"),
-            (self.keywords, "forth-words"),
-            (self.stringwords, "forth-string-word-pairs"),
-            (self.boldwords, "forth-bold-words"),
+            (self.definingwords,   "forth-defwords"),
+            (self.brackets,        "forth-delimiter-pairs"),
+            (self.keywords,        "forth-words"),
+            (self.stringwords,     "forth-string-word-pairs"),
+            (self.boldwords,       "forth-bold-words"),
             (self.bolditalicwords, "forth-bold-italic-words"),
-            (self.italicwords, "forth-italic-words"),
-        )
+            (self.italicwords,     "forth-italic-words"),
+        )  # fmt: skip
         # Add entries from @data nodes (if they exist) to the corresponding lists.
         for ivarList, setting in table:
             extras = []
@@ -221,9 +221,9 @@ class extendForth:
                     ivarList.extend(extras)
         # Create brackets1/2 and stringwords1/2 lists.
         table2 = (
-            ("brackets", "@data forth-delimiter-pairs"),
+            ("brackets",    "@data forth-delimiter-pairs"),
             ("stringwords", "@data forth-string-word-pairs"),
-        )
+        )  # fmt: skip
         for ivar, setting in table2:
             self.splitList(ivar, setting)
 
@@ -293,13 +293,13 @@ class extendForth:
         # global forth_main_keywords_dict
         # global forth_keyword_rule
         table = (
-            (self.keywords, 'keyword1'),
-            # (self.definingwords,    'keyword2'), # Done in createDefiningWordRules.
-            (self.boldwords, 'keyword3'),
+            (self.keywords,        'keyword1'),
+            # (self.definingwords, 'keyword2'), # Done in createDefiningWordRules.
+            (self.boldwords,       'keyword3'),
             (self.bolditalicwords, 'keyword4'),
-            (self.italicwords, 'keyword5'),
-            (self.stringwords, 'string'),
-        )
+            (self.italicwords,     'keyword5'),
+            (self.stringwords,     'string'),
+        )  # fmt: skip
         d = forth_main_keywords_dict
         for keywordList, kind in table:
             for z in keywordList:

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -1015,24 +1015,24 @@ class StringFindTabManager:
         find = c.findCommands
         # Find/change text boxes.
         table = (
-            ('find_findbox', 'find_text', '<find pattern here>'),
+            ('find_findbox',    'find_text',   '<find pattern here>'),
             ('find_replacebox', 'change_text', ''),
-        )
+        )  # fmt: skip
         for ivar, setting_name, default in table:
             s = c.config.getString(setting_name) or default
             w = getattr(self, ivar)
             w.insert(s)
         # Check boxes.
         table1 = (
-            ('ignore_case', self.check_box_ignore_case),
-            ('mark_changes', self.check_box_mark_changes),
-            ('mark_finds', self.check_box_mark_finds),
-            ('pattern_match', self.check_box_regexp),
-            ('search_body', self.check_box_search_body),
+            ('ignore_case',     self.check_box_ignore_case),
+            ('mark_changes',    self.check_box_mark_changes),
+            ('mark_finds',      self.check_box_mark_finds),
+            ('pattern_match',   self.check_box_regexp),
+            ('search_body',     self.check_box_search_body),
             ('search_headline', self.check_box_search_headline),
-            ('whole_word', self.check_box_whole_word),
+            ('whole_word',      self.check_box_whole_word),
             # ('wrap', self.check_box_wrap_around),
-        )
+        )  # fmt: skip
         for setting_name, w in table1:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
@@ -1048,11 +1048,11 @@ class StringFindTabManager:
 
         # Radio buttons
         table2 = (
-            ('entire_outline', None, self.radio_button_entire_outline),
-            ('file_only', 'file_only', self.radio_button_file_only),
-            ('node_only', 'node_only', self.radio_button_node_only),
+            ('entire_outline',  None,              self.radio_button_entire_outline),
+            ('file_only',       'file_only',       self.radio_button_file_only),
+            ('node_only',       'node_only',       self.radio_button_node_only),
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
-        )
+        )  # fmt: skip
         for setting_name, ivar, w in table2:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
@@ -1599,7 +1599,9 @@ class LeoCursesGui(leoGui.LeoGui):
     # @+node:ekr.20171126191726.1: *6* CGui.monkeyPatch
     def monkeyPatch(self, c: Cmdr) -> None:
         """Monkey patch commands"""
-        table = (('start-search', self.startSearch),)
+        table = (
+            ('start-search', self.startSearch),
+        )  # fmt: skip
         for commandName, func in table:
             g.global_commands_dict[commandName] = func
             c.k.overrideCommand(commandName, func)
@@ -2230,7 +2232,9 @@ class LeoCursesGui(leoGui.LeoGui):
         c.inFindCommand = True  # A new flag.
         fc.minibuffer_mode = True
         if 0:  # Allow hard settings, for tests.
-            table = (('pattern_match', ftm.check_box_regexp, True),)
+            table = (
+                ('pattern_match', ftm.check_box_regexp, True),
+            )  # fmt: skip
             for setting_name, w, val in table:
                 assert hasattr(fc, setting_name), setting_name
                 setattr(fc, setting_name, val)
@@ -2353,13 +2357,13 @@ class CoreFrame(leoFrame.LeoFrame):
             ('box', 'mark &Finds'),
             ('box', 'mark &Changes'),
             # Right colunn.
-            ('rb', '&Entire outline'),
-            ('rb', '&Suboutline only'),
-            ('rb', '&Node only'),
-            ('rb', 'fi&Le only'),  # #2684.
+            ('rb',  '&Entire outline'),
+            ('rb',  '&Suboutline only'),
+            ('rb',  '&Node only'),
+            ('rb',  'fi&Le only'),  # #2684.
             ('box', 'search &Headline'),
             ('box', 'search &Body'),
-        )
+        )  # fmt: skip
         for kind, label in table:
             name = mungeName(kind, label)
             func = d.get(kind)
@@ -3926,15 +3930,15 @@ class LeoMLTree(npyscreen.MLTree):
         """Return a list of reasons why we must redraw."""
         trace = False and not g.unitTesting
         table = (
-            ('cache', not self._safe_to_display_cache or self.never_cache),
-            ('value', self._last_value is not self.value),
-            ('values', self.values != self._last_values),
-            ('start', self.start_display_at != self._last_start_display_at),
-            ('clear', not clear),
-            ('cursor', self._last_cursor_line != self.cursor_line),
-            ('filter', self._last_filter != self._filter),
+            ('cache',   not self._safe_to_display_cache or self.never_cache),
+            ('value',   self._last_value is not self.value),
+            ('values',  self.values != self._last_values),
+            ('start',   self.start_display_at != self._last_start_display_at),
+            ('clear',   not clear),
+            ('cursor',  self._last_cursor_line != self.cursor_line),
+            ('filter',  self._last_filter != self._filter),
             ('editing', not self.editing),
-        )
+        )  # fmt: skip
         reasons = (reason for (reason, cond) in table if cond)
         if trace:
             g.trace('line: %2s %-20s %s' % (self.cursor_line, ','.join(reasons), self.values[self.cursor_line].content))

--- a/leo/plugins/import_cisco_config.py
+++ b/leo/plugins/import_cisco_config.py
@@ -52,7 +52,10 @@ def create_import_cisco_menu(tag, keywords):
     def importCiscoConfigCallback(event=None, c=c):
         importCiscoConfig(c)
 
-    table = (("-", None, None), ("Import C&isco Configuration", "Shift+Ctrl+I", importCiscoConfigCallback))
+    table = (
+        ("-", None, None),
+        ("Import C&isco Configuration", "Shift+Ctrl+I", importCiscoConfigCallback),
+    )  # fmt: skip
     c.frame.menu.createMenuEntries(importMenu, table)
 
 

--- a/leo/plugins/import_cisco_config.py
+++ b/leo/plugins/import_cisco_config.py
@@ -55,7 +55,7 @@ def create_import_cisco_menu(tag, keywords):
     table = (
         ("-", None, None),
         ("Import C&isco Configuration", "Shift+Ctrl+I", importCiscoConfigCallback),
-    )  # fmt: skip
+    )
     c.frame.menu.createMenuEntries(importMenu, table)
 
 

--- a/leo/plugins/macros.py
+++ b/leo/plugins/macros.py
@@ -156,7 +156,9 @@ class ParamClass:
     def addMenu(self):
         """Add a submenu in the outline menu."""
         c = self.c
-        table = (("Parameterize Section Reference", None, self.parameterize),)
+        table = (
+            ("Parameterize Section Reference", None, self.parameterize),
+        )  # fmt: skip
         c.frame.menu.createMenuItemsFromTable("Outline", table)
 
     # @-others

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -1043,7 +1043,10 @@ if asynchat:
             every message.
 
             """
-            message = "%s - - [%s] %s\n" % (self.address_string(), self.log_date_time_string(), format % args)
+            message = (
+                "%s - - [%s] %s\n"
+                % (self.address_string(), self.log_date_time_string(), format % args)
+            )  # fmt: skip
             g.es(message)
 
         # @+node:EKR.20040517080250.17: *3* collect_incoming_data

--- a/leo/plugins/mod_read_dir_outline.py
+++ b/leo/plugins/mod_read_dir_outline.py
@@ -49,9 +49,9 @@ def onCreate(tag, keywords):
     else:
         mess1 = "Read a Directory..."
     table = (
-        ("-", None, None),
+        ("-",   None,               None),
         (mess1, "Shift+Ctrl+Alt+D", cc.readDir),
-    )
+    )  # fmt: skip
     c.frame.menu.createMenuEntries(menu, table)
 
 

--- a/leo/plugins/open_shell.py
+++ b/leo/plugins/open_shell.py
@@ -65,9 +65,14 @@ class pluginController:
     def load_menu(self):
         c = self.c
         if sys.platform == "win32":
-            table = (("&Open Console Window", None, self.launchCmd), ("Open &Explorer", None, self.launchExplorer))
+            table = (
+                ("&Open Console Window", None, self.launchCmd),
+                ("Open &Explorer",       None, self.launchExplorer),
+            )  # fmt: skip
         else:
-            table = (("Open &xterm", None, self.launchxTerm),)
+            table = (
+                ("Open &xterm", None, self.launchxTerm),
+            )  # fmt: skip
         c.frame.menu.createNewMenu("E&xtensions", "top")
         c.frame.menu.createMenuItemsFromTable("Extensions", table)
 

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -378,13 +378,13 @@ class LeoQtEventFilter(QtCore.QObject):
         """Return the text version of the modifiers of the key event."""
         modifiers = event.modifiers()
         mod_table = (
-            (KeyboardModifier.AltModifier, 'Alt'),
+            (KeyboardModifier.AltModifier,     'Alt'),
             (KeyboardModifier.ControlModifier, 'Control'),
-            (KeyboardModifier.MetaModifier, 'Meta'),
-            (KeyboardModifier.ShiftModifier, 'Shift'),
+            (KeyboardModifier.MetaModifier,    'Meta'),
+            (KeyboardModifier.ShiftModifier,   'Shift'),
             # #1448: Replacing this by 'Key' would make separate keypad bindings impossible.
-            (KeyboardModifier.KeypadModifier, 'KeyPad'),
-        )
+            (KeyboardModifier.KeypadModifier,  'KeyPad'),
+        )  # fmt: skip
         # pylint: disable=superfluous-parens.
         mods = [b for a, b in mod_table if (modifiers & a)]
         return mods
@@ -516,15 +516,15 @@ class LeoQtEventFilter(QtCore.QObject):
         )
         option_table = (
             (traceActivate, activate_events),
-            (traceFocus, focus_events),
-            (traceHide, hide_events),
-            (traceHover, hover_events),
-            (traceKey, key_events),
-            (traceLayout, layout_events),
-            (traceMouse, mouse_events),
-            (tracePaint, paint_events),
-            (traceUpdate, update_events),
-        )
+            (traceFocus,    focus_events),
+            (traceHide,     hide_events),
+            (traceHover,    hover_events),
+            (traceKey,      key_events),
+            (traceLayout,   layout_events),
+            (traceMouse,    mouse_events),
+            (tracePaint,    paint_events),
+            (traceUpdate,   update_events),
+        )  # fmt: skip
         for option, table in option_table:
             if option:
                 show.extend(table)

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -252,13 +252,13 @@ class DynamicWindow(QtWidgets.QMainWindow):
         vLayout2 = self.createVLayout(spellFrame, 'spellVLayout')
         grid = self.createGrid(None, 'spellGrid', spacing=2)
         table = (
-            ('Add', 'Add', 2, 1),
-            ('Find', 'Find', 2, 0),
-            ('Change', 'Change', 3, 0),
-            ('FindChange', 'Change,Find', 3, 1),
-            ('Ignore', 'Ignore', 4, 0),
-            ('Hide', 'Hide', 4, 1),
-        )
+            ('Add',         'Add',         2, 1),
+            ('Find',        'Find',        2, 0),
+            ('Change',      'Change',      3, 0),
+            ('FindChange',  'Change,Find', 3, 1),
+            ('Ignore',      'Ignore',      4, 0),
+            ('Hide',        'Hide',        4, 1),
+        )  # fmt: skip
         for ivar, label, row, col in table:
             name = f"spell_{label}_button"
             button = self.createButton(spellFrame, name, label)
@@ -448,13 +448,13 @@ class DynamicWindow(QtWidgets.QMainWindow):
 
         # Create Buttons in column 2 (Leo 4.11.1.)
         table = (
-            (0, 2, 'find-next'),  # 'findButton',
-            (1, 2, 'find-prev'),  # 'findPreviousButton',
-            (2, 2, 'find-all'),  # 'findAllButton',
-            (3, 2, 'replace'),  # 'changeButton',
+            (0, 2, 'find-next'),          # 'findButton',
+            (1, 2, 'find-prev'),          # 'findPreviousButton',
+            (2, 2, 'find-all'),           # 'findAllButton',
+            (3, 2, 'replace'),            # 'changeButton',
             (4, 2, 'replace-then-find'),  # 'changeThenFindButton',
-            (5, 2, 'replace-all'),  # 'changeAllButton',
-        )
+            (5, 2, 'replace-all'),        # 'changeAllButton',
+        )  # fmt: skip
         for row2, col, cmd_name in table:
             stroke = k.getStrokeForCommandName(cmd_name)
             if stroke:
@@ -1296,9 +1296,9 @@ class FindTabManager:
         find = c.findCommands
         # Find/change text boxes.
         table1 = (
-            ('find_findbox', 'find_text', '<find pattern here>'),
+            ('find_findbox',    'find_text',   '<find pattern here>'),
             ('find_replacebox', 'change_text', ''),
-        )
+        )  # fmt: skip
         for ivar, setting_name, default in table1:
             s = c.config.getString(setting_name) or default
             w = getattr(self, ivar)
@@ -1309,15 +1309,15 @@ class FindTabManager:
                 w.setSelection(0, len(s))
         # Check boxes.
         table2 = (
-            ('ignore_case', self.check_box_ignore_case),
-            ('mark_changes', self.check_box_mark_changes),
-            ('mark_finds', self.check_box_mark_finds),
-            ('pattern_match', self.check_box_regexp),
-            ('search_body', self.check_box_search_body),
+            ('ignore_case',     self.check_box_ignore_case),
+            ('mark_changes',    self.check_box_mark_changes),
+            ('mark_finds',      self.check_box_mark_finds),
+            ('pattern_match',   self.check_box_regexp),
+            ('search_body',     self.check_box_search_body),
             ('search_headline', self.check_box_search_headline),
-            ('whole_word', self.check_box_whole_word),
-            # ('wrap', self.check_box_wrap_around),
-        )
+            ('whole_word',      self.check_box_whole_word),
+            # ('wrap',          self.check_box_wrap_around),
+        )  # fmt: skip
         for setting_name, w in table2:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
@@ -1340,11 +1340,11 @@ class FindTabManager:
             w.stateChanged.connect(check_box_callback)
         # Radio buttons
         table3 = (
-            ('node_only', 'node_only', self.radio_button_node_only),
-            ('entire_outline', None, self.radio_button_entire_outline),
+            ('node_only',       'node_only',       self.radio_button_node_only),
+            ('entire_outline',  None,              self.radio_button_entire_outline),
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
-            ('file_only', 'file_only', self.radio_button_file_only),
-        )
+            ('file_only',       'file_only',       self.radio_button_file_only),
+        )  # fmt: skip
         for setting_name, ivar, w in table3:
             val = c.config.getBool(setting_name, default=False)
             # The setting name is also the name of the LeoFind ivar.
@@ -1381,14 +1381,14 @@ class FindTabManager:
         find.change_text = change_text
         # Check boxes...
         table1 = (
-            ('ignore_case', self.check_box_ignore_case),
-            ('mark_changes', self.check_box_mark_changes),
-            ('mark_finds', self.check_box_mark_finds),
-            ('pattern_match', self.check_box_regexp),
-            ('search_body', self.check_box_search_body),
+            ('ignore_case',     self.check_box_ignore_case),
+            ('mark_changes',    self.check_box_mark_changes),
+            ('mark_finds',      self.check_box_mark_finds),
+            ('pattern_match',   self.check_box_regexp),
+            ('search_body',     self.check_box_search_body),
             ('search_headline', self.check_box_search_headline),
-            ('whole_word', self.check_box_whole_word),
-        )
+            ('whole_word',      self.check_box_whole_word),
+        )  # fmt: skip
         for setting_name, w in table1:
             val = d.get(setting_name, False)
             # The setting name is also the name of the LeoFind ivar.
@@ -1397,11 +1397,11 @@ class FindTabManager:
             w.setChecked(val)
         # Radio buttons...
         table2 = (
-            ('node_only', 'node_only', self.radio_button_node_only),
-            ('entire_outline', None, self.radio_button_entire_outline),
+            ('node_only',       'node_only',       self.radio_button_node_only),
+            ('entire_outline',  None,              self.radio_button_entire_outline),
             ('suboutline_only', 'suboutline_only', self.radio_button_suboutline_only),
-            ('file_only', 'file_only', self.radio_button_file_only),
-        )
+            ('file_only',       'file_only',       self.radio_button_file_only),
+        )  # fmt: skip
         for setting_name, ivar, w in table2:
             val = d.get(setting_name, False)
             # The setting name is also the name of the LeoFind ivar.
@@ -1423,9 +1423,9 @@ class FindTabManager:
         if not find:
             return
         table = (
-            ('search_body', self.check_box_search_body),
+            ('search_body',     self.check_box_search_body),
             ('search_headline', self.check_box_search_headline),
-        )
+        )  # fmt: skip
         for setting_name, w in table:
             val = c.config.getBool(setting_name, default=False)
             if val != w.isChecked():
@@ -2430,12 +2430,12 @@ class LeoQtLog(leoFrame.LeoLog):
         weight: int = font.weight()
         weight_s: str = ''
         table2 = (
-            (Weight.Light, 'light'),  # #2330.
-            (Weight.Normal, 'normal'),
+            (Weight.Light,    'light'),  # #2330.
+            (Weight.Normal,   'normal'),
             (Weight.DemiBold, 'demibold'),
-            (Weight.Bold, 'bold'),
-            (Weight.Black, 'black'),
-        )
+            (Weight.Bold,     'bold'),
+            (Weight.Black,    'black'),
+        )  # fmt: skip
         for val2, name2 in table2:
             if weight == val2:
                 weight_s = name2

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -2183,11 +2183,11 @@ class StyleSheetManager:
         open_path = self.find_icon_path('tree-image-open')
         # Make all substitutions in the stylesheet.
         table = (
-            (open_path, re.compile(r'\bimage:\s*@tree-image-open', re.IGNORECASE)),
+            (open_path,  re.compile(r'\bimage:\s*@tree-image-open', re.IGNORECASE)),
             (close_path, re.compile(r'\bimage:\s*@tree-image-closed', re.IGNORECASE)),
             # (open_path,  re.compile(r'\bimage:\s*at-tree-image-open', re.IGNORECASE)),
             # (close_path, re.compile(r'\bimage:\s*at-tree-image-closed', re.IGNORECASE)),
-        )
+        )  # fmt: skip
         for path, pattern in table:
             for mo in pattern.finditer(sheet):
                 old = mo.group(0)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -1011,11 +1011,11 @@ if QtWidgets:
         def leo_dumpButton(self, event: LeoKeyEvent, tag: str) -> str:
             button = event.button()
             table = (
-                (MouseButton.NoButton, 'no button'),
-                (MouseButton.LeftButton, 'left-button'),
-                (MouseButton.RightButton, 'right-button'),
+                (MouseButton.NoButton,     'no button'),
+                (MouseButton.LeftButton,   'left-button'),
+                (MouseButton.RightButton,  'right-button'),
                 (MouseButton.MiddleButton, 'middle-button'),
-            )
+            )  # fmt: skip
             for val, s in table:
                 if button == val:
                     kind = s

--- a/leo/unittests/commands/test_checkerCommands.py
+++ b/leo/unittests/commands/test_checkerCommands.py
@@ -42,12 +42,12 @@ class TestChecker(LeoUnitTest):
                     pass
                 def eggs():
                     pass
-            """,  # Too many defs.
-            "   ",  # Empty body.
-            "\ntest\n",  # Leading blank line.
+            """,                    # Too many defs.
+            "   ",                  # Empty body.
+            "\ntest\n",             # Leading blank line.
             "\n\nclass MyClass\n",  # Trailing class line.
-            "\n\ndef spam():",  # Trailing def line.
-        )
+            "\n\ndef spam():",      # Trailing def line.
+        )  # fmt: skip
         p = c.rootPosition()
         for s in table:
             p.b = s

--- a/leo/unittests/commands/test_editCommands.py
+++ b/leo/unittests/commands/test_editCommands.py
@@ -4163,16 +4163,16 @@ class TestEditCommands(LeoUnitTest):
 
         # New in Leo 4.10: whitespace (blank,tab,newline) *is* significant in definitions.
         table = (
-            ('ut1', 'ut1=aa', 'aa'),
-            # ('ut2','ut2 =bb','bb'),
-            ('ut3', 'ut3=cc=dd', 'cc=dd'),
-            ('ut4', 'ut4= ee', ' ee'),
-            ('ut5', 'ut5= ff = gg', ' ff = gg'),
-            ('ut6', 'ut6= hh==ii', ' hh==ii'),
-            ('ut7', 'ut7=j=k', 'j=k'),
-            ('ut8', 'ut8=l==m', 'l==m'),
-            ('@ut1', '@ut1=@a', '@a'),
-        )
+            ('ut1',  'ut1=aa',       'aa'),
+            # ('ut2','ut2 =bb',      'bb'),
+            ('ut3',  'ut3=cc=dd',    'cc=dd'),
+            ('ut4',  'ut4= ee',      ' ee'),
+            ('ut5',  'ut5= ff = gg', ' ff = gg'),
+            ('ut6',  'ut6= hh==ii',  ' hh==ii'),
+            ('ut7',  'ut7=j=k',      'j=k'),
+            ('ut8',  'ut8=l==m',     'l==m'),
+            ('@ut1', '@ut1=@a',      '@a'),
+        )  # fmt: skip
         for name, s, expected in table:
             for s2, kind in ((s, '(no nl)'), (s + '\n', '(nl)')):
                 f(s2, tag='unit-test')
@@ -4189,8 +4189,8 @@ class TestEditCommands(LeoUnitTest):
         table = (
             ('cap', 'Targetword'),
             ('low', 'targetword'),
-            ('up', 'TARGETWORD'),
-        )
+            ('up',  'TARGETWORD'),
+        )  # fmt: skip
         for which, result in table:
             w.setInsertPoint(5)  # Must be inside the target.
             c.editCommands.capitalizeHelper(event=None, which=which, undoType='X')

--- a/leo/unittests/commands/test_spellCommands.py
+++ b/leo/unittests/commands/test_spellCommands.py
@@ -65,20 +65,20 @@ class TestSpellCommands(LeoUnitTest):
 
         table = (
             # Should not be checked.
-            ('abc9: https://test1', 'abc'),
+            ('abc9: https://test1',             'abc'),
             # Should be checked.
-            ("Leo's: https://test2", 'Leo'),
-            ("we'lll", "we'll"),
-            (r'\begin', 'begin'),
-            ('beginx', 'begin'),
-            (r'\beginx', 'begin'),
-            (r'\bibliographystyle{acm}', 'bibliographystyle'),
+            ("Leo's: https://test2",            'Leo'),
+            ("we'lll",                          "we'll"),
+            (r'\begin',                         'begin'),
+            ('beginx',                          'begin'),
+            (r'\beginx',                        'begin'),
+            (r'\bibliographystyle{acm}',        'bibliographystyle'),
             # Tests of munging.
             ('_Insert_indexterm__140664580.txt', 'Insert_indexterm'),
-            ('sel_1', 'sel'),
-            ('selll_1', 'sell'),
-            ('a_b_c', 'a_b_c'),
-        )
+            ('sel_1',                           'sel'),
+            ('selll_1',                         'sell'),
+            ('a_b_c',                           'a_b_c'),
+        )  # fmt: skip
         for line, expected in table:
             p.b = line + '\n'
             result = handler.find()

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -834,11 +834,11 @@ class TestTOG(BaseTest):
 
         # All examples are from PEP750: https://peps.python.org/pep-0750/
         table = (
-            'template1: Template = t"Hello {name}"',  # Plain.
-            'template2 = t"Hello {name!r}"',  # Conversion.
-            'template3 = t"Value: {value:.2f}"',  # Format.
+            'template1: Template = t"Hello {name}"',        # Plain.
+            'template2 = t"Hello {name!r}"',                # Conversion.
+            'template3 = t"Value: {value:.2f}"',            # Format.
             'template4 = t"Value: {value:.{precision}f}"',  # Format.
-        )
+        )  # fmt: skip
         debug_list = [
             # 'contents',
             # 'sync',  # Trace tog.token.
@@ -1692,11 +1692,11 @@ class TestFstringify(BaseTest):
     def test_munge_spec(self):
         # !head:tail or :tail
         table = (
-            ('+1s', '', '+1'),
-            ('-2s', '', '>2'),
-            ('3s', '', '3'),
-            ('4r', 'r', '4'),
-        )
+            ('+1s', '',  '+1'),
+            ('-2s', '',  '>2'),
+            ('3s',  '',  '3'),
+            ('4r',  'r', '4'),
+        )  # fmt: skip
         for spec, e_head, e_tail in table:
             head, tail = Fstringify().munge_spec(spec)
             assert (head, tail) == (e_head, e_tail), (
@@ -1733,12 +1733,21 @@ class TestFstringify(BaseTest):
     def test_single_quotes(self):
         table = (
             # Case 0.
-            ("""print('%r "default"' % style_name)""", """print(f'{style_name!r} "default"')\n"""),
+            (
+                """print('%r "default"' % style_name)""",
+                """print(f'{style_name!r} "default"')\n""",
+            ),
             # Case 1.
-            ("""print('%r' % "val")""", """print(f'{"val"!r}')\n"""),
+            (
+                """print('%r' % "val")""",
+                """print(f'{"val"!r}')\n""",
+            ),
             # Case 2.
-            ("""print("%r" % "val")""", """print(f'{"val"!r}')\n"""),
-        )
+            (
+                """print("%r" % "val")""",
+                """print(f'{"val"!r}')\n""",
+            ),
+        )  # fmt: skip
         for i, data in enumerate(table):
             contents, expected = data
             description = f"test_single_quotes: {i}"

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -158,15 +158,15 @@ class TestAtFile(LeoUnitTest):
             (at.othersDirective, '@others'),
             (at.othersDirective, '@others\n'),
             (at.othersDirective, '    @others'),
-            (at.miscDirective, '@tabwidth -4'),
-            (at.miscDirective, '@tabwidth -4\n'),
-            (at.miscDirective, '@encoding'),
-            (at.noDirective, '@encoding.setter'),
-            (at.noDirective, '@encoding("abc")'),
-            (at.noDirective, 'encoding = "abc"'),
-            (at.noDirective, '@directive'),  # A crucial new test.
-            (at.noDirective, '@raw'),  # 2021/11/04.
-        )
+            (at.miscDirective,   '@tabwidth -4'),
+            (at.miscDirective,   '@tabwidth -4\n'),
+            (at.miscDirective,   '@encoding'),
+            (at.noDirective,     '@encoding.setter'),
+            (at.noDirective,     '@encoding("abc")'),
+            (at.noDirective,     'encoding = "abc"'),
+            (at.noDirective,     '@directive'),  # A crucial new test.
+            (at.noDirective,     '@raw'),  # 2021/11/04.
+        )  # fmt: skip
         for expected, s in table:
             result = at.directiveKind4(s, 0)
             self.assertEqual(expected, result, msg=repr(s))
@@ -178,13 +178,13 @@ class TestAtFile(LeoUnitTest):
         at.initWriteIvars(p)
         ref = g.angleBrackets(' abc ')
         table = (
-            (True, f"{ref}\n"),
-            (True, f"{ref}"),
-            (True, f"  {ref}  \n"),
+            (True,  f"{ref}\n"),
+            (True,  f"{ref}"),
+            (True,  f"  {ref}  \n"),
             (False, f"if {ref}:\n"),
             (False, f"{ref} # comment\n"),
             (False, f"# {ref}\n"),
-        )
+        )  # fmt: skip
         for valid, s in table:
             name, n1, n2 = at.findSectionName(s, 0, p)
             self.assertEqual(valid, bool(name), msg=repr(s))
@@ -195,14 +195,14 @@ class TestAtFile(LeoUnitTest):
         table = (
             # start, end, new_df, isThin, encoding
             # pre 4.2 formats...
-            ('#', '', False, True, 'utf-8', '#@+leo-thin-encoding=utf-8.'),
-            ('#', '', False, False, 'utf-8', '#@+leo-encoding=utf-8.'),
+            ('#', '',    False, True,  'utf-8',  '#@+leo-thin-encoding=utf-8.'),
+            ('#', '',    False, False, 'utf-8',  '#@+leo-encoding=utf-8.'),
             # 4.2 formats...
-            ('#', '', True, True, 'utf-8', '#@+leo-ver=4-thin-encoding=utf-8,.'),
-            ('/*', '*/', True, True, 'utf-8', r'\*@+leo-ver=5-thin-encoding=utf-8,.*/'),
-            ('#', '', True, True, 'utf-8', '#@+leo-ver=5-thin'),
-            ('#', '', True, True, 'utf-16', '#@+leo-ver=5-thin-encoding=utf-16,.'),
-        )
+            ('#', '',    True,  True,  'utf-8',  '#@+leo-ver=4-thin-encoding=utf-8,.'),
+            ('/*', '*/', True,  True,  'utf-8',  r'\*@+leo-ver=5-thin-encoding=utf-8,.*/'),
+            ('#', '',    True,  True,  'utf-8',  '#@+leo-ver=5-thin'),
+            ('#', '',    True,  True,  'utf-16', '#@+leo-ver=5-thin-encoding=utf-16,.'),
+        )  # fmt: skip
         try:
             for start, end, new_df, isThin, encoding, s in table:
                 valid, new_df2, start2, end2, isThin2 = at.parseLeoSentinel(s)

--- a/leo/unittests/core/test_leoColorizer.py
+++ b/leo/unittests/core/test_leoColorizer.py
@@ -80,9 +80,9 @@ class TestColorizer(LeoUnitTest):
         grand = child.insertAsLastChild()
         language_table = (
             ('python', '@language rest\n@language python\n', ''),
-            ('rest', '@language rest', ''),
+            ('rest',   '@language rest', ''),
             ('python', '@language rest\n@language python\n', ''),
-        )
+        )  # fmt: skip
         for i, data in enumerate(language_table):
             language, child_s, grand_s = data
             child.b = child_s

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -224,11 +224,11 @@ class TestCommands(LeoUnitTest):
         seps = ('\\', '/') if g.isWindows else ('/',)
         for sep in seps:
             table = (
-                (f"~{sep}a.py", f"{home}{sep}a.py"),
+                (f"~{sep}a.py",              f"{home}{sep}a.py"),
                 (f"~{sep}x{sep}..{sep}b.py", f"{home}{sep}x{sep}..{sep}b.py"),
-                (f"$LEO_BASE{sep}b.py", f"{abs_base}{sep}b.py"),
-                ('c.py', 'c.py'),
-            )
+                (f"$LEO_BASE{sep}b.py",      f"{abs_base}{sep}b.py"),
+                ('c.py',                     'c.py'),
+            )  # fmt: skip
             for s, expected in table:
                 got = c.expand_path_expression(s)
                 self.assertEqual(got, expected, msg=s)
@@ -279,12 +279,12 @@ class TestCommands(LeoUnitTest):
         c = self.c
         p = c.p
         table = (
-            ('nl', '\n'),
-            ('lf', '\n'),
-            ('cr', '\r'),
-            ('crlf', '\r\n'),
+            ('nl',       '\n'),
+            ('lf',       '\n'),
+            ('cr',       '\r'),
+            ('crlf',     '\r\n'),
             ('platform', '\r\n' if g.isWindows else '\n'),
-        )
+        )  # fmt: skip
         for kind, expected_ending in table:
             directive = f"@lineending {kind}\n"
             p.b = directive

--- a/leo/unittests/core/test_leoCompare.py
+++ b/leo/unittests/core/test_leoCompare.py
@@ -41,11 +41,11 @@ class TestCompare(LeoUnitTest):
 
         # Populate the nodes.
         table = (
-            (node1, 'node 1', '# Node 1.\n'),
-            (node2, 'node 1a', '# Node 1.\n'),  # Headlines differ.
+            (node1,  'node 1',  '# Node 1.\n'),
+            (node2,  'node 1a', '# Node 1.\n'),    # Headlines differ.
             (child1, 'child 1', '# Child 1.\n'),
             (child2, 'child 1', '# Child 1a.\n'),  # Bodies differ.
-        )
+        )  # fmt: skip
         for p, h, b in table:
             p.h = h
             p.b = b

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -739,20 +739,20 @@ class TestFind(LeoUnitTest):
                 )
 
         plain_table = (
-            # pattern   s           i,  j   expected, expected_i, expected_j
+            # pattern   s  i,  j   expected, expected_i, expected_j
             ('a', 'abaca', 0, -1, 'a', 4, 5),
             ('A', 'Abcde', 0, -1, 'A', 0, 1),
-        )
+        )  # fmt: skip
         nocase_table = (
-            # pattern   s           i,  j   expected, expected_i, expected_j
-            ('a', 'abaAca', 0, -1, 'a', 5, 6),
-            ('A', 'Abcdca', 0, -1, 'a', 5, 6),
-        )
+            # pattern   s    i,  j   expected, expected_i, expected_j
+            ('a', 'abaAca',  0, -1, 'a', 5, 6),
+            ('A', 'Abcdca',  0, -1, 'a', 5, 6),
+        )  # fmt: skip
         word_table = (
-            # pattern   s           i,  j   expected, expected_i, expected_j
-            ('a', 'abaAca', 0, -1, '', -1, -1),
+            # pattern   s    i,  j   expected, expected_i, expected_j
+            ('a', 'abaAca',  0, -1, '', -1, -1),
             ('A', 'AA A AB', 0, -1, 'A', 3, 4),
-        )
+        )  # fmt: skip
         test(plain_table, 'plain_table', nocase=False, word=False)
         test(nocase_table, 'nocase_table', nocase=True, word=False)
         test(word_table, 'word_table', nocase=False, word=True)
@@ -785,20 +785,20 @@ class TestFind(LeoUnitTest):
                 )
 
         plain_table = (
-            # pattern   s           i,  j   expected, expected_i, expected_j
-            ('a', 'baca', 0, -1, 'a', 1, 2),
+            # pattern s    i,  j   expected, expected_i, expected_j
+            ('a', 'baca',  0, -1, 'a', 1, 2),
             ('A', 'bAcde', 0, -1, 'A', 1, 2),
-        )
+        )  # fmt: skip
         nocase_table = (
-            # pattern   s           i,  j   expected, expected_i, expected_j
+            # pattern s     i,  j   expected, expected_i, expected_j
             ('a', 'abaAca', 0, -1, 'a', 0, 1),
             ('A', 'abcdca', 0, -1, 'a', 0, 1),
-        )
+        )  # fmt: skip
         word_table = (
-            # pattern   s           i,  j   expected, expected_i, expected_j
-            ('a', 'abaAca', 0, -1, '', -1, -1),
+            # pattern s      i,  j   expected, expected_i, expected_j
+            ('a', 'abaAca',  0, -1,  '', -1, -1),
             ('A', 'AA A AAB', 0, -1, 'A', 3, 4),
-        )
+        )  # fmt: skip
         test(plain_table, 'plain_table', nocase=False, word=False)
         test(nocase_table, 'nocase_table', nocase=True, word=False)
         test(word_table, 'word_table', nocase=False, word=True)
@@ -824,20 +824,20 @@ class TestFind(LeoUnitTest):
 
         plain_table = (
             # pattern   s       expected
-            (r'.', 'A', 'A'),
-            (r'A', 'xAy', 'A'),
-        )
+            (r'.',      'A',    'A'),
+            (r'A',      'xAy',  'A'),
+        )  # fmt: skip
         nocase_table = (
             # pattern   s       expected
-            (r'.', 'A', 'A'),
-            (r'.', 'a', 'a'),
-            (r'A', 'xay', 'a'),
-            (r'a', 'xAy', 'A'),
-        )
+            (r'.',      'A',    'A'),
+            (r'.',      'a',    'a'),
+            (r'A',      'xay',  'a'),
+            (r'a',      'xAy',  'A'),
+        )  # fmt: skip
         back_table = (
             # pattern   s           expected
-            (r'a.b', 'a1b a2b', 'a2b'),
-        )
+            (r'a.b',    'a1b a2b', 'a2b'),
+        )  # fmt: skip
         test(plain_table, 'plain_table', back=False, nocase=False)
         test(nocase_table, 'nocase_table', back=False, nocase=True)
         test(back_table, 'back_table', back=True, nocase=False)
@@ -865,11 +865,11 @@ class TestFind(LeoUnitTest):
         c = self.c
         fc = c.findCommands
         plain_table = (
-            # s         find    change  count   result
-            ('aA', 'a', 'C', 1, 'CA'),
-            ('Aa', 'A', 'C', 1, 'Ca'),
-            ('Aba', 'b', 'C', 1, 'ACa'),
-        )
+            # s     find    change  count   result
+            ('aA',  'a',    'C',    1,      'CA'),
+            ('Aa',  'A',    'C',    1,      'Ca'),
+            ('Aba', 'b',    'C',    1,      'ACa'),
+        )  # fmt: skip
         for s, find, change, count, result in plain_table:
             fc.ignore_case = False
             fc.find_text = find
@@ -884,9 +884,9 @@ class TestFind(LeoUnitTest):
         fc = c.findCommands
         plain_table = (
             # s         find    change  count   result
-            ('aA', 'a', 'C', 2, 'CC'),
-            ('AbBa', 'b', 'C', 2, 'ACCa'),
-        )
+            ('aA',      'a',    'C',    2,      'CC'),
+            ('AbBa',    'b',    'C',    2,      'ACCa'),
+        )  # fmt: skip
         for s, find, change, count, result in plain_table:
             fc.ignore_case = True
             fc.find_text = find
@@ -900,12 +900,12 @@ class TestFind(LeoUnitTest):
         c = self.c
         fc = c.findCommands
         regex_table = (
-            # s                 find        change  count   result
-            ('a ba aa a ab a', r'\b\w+\b', 'C', 6, 'C C C C C C'),
-            ('a AA aa aab ab a', r'\baa\b', 'C', 1, 'a AA C aab ab a'),
+            # s                  find        change  count   result
+            ('a ba aa a ab a',   r'\b\w+\b', 'C',    6,      'C C C C C C'),
+            ('a AA aa aab ab a', r'\baa\b',  'C',    1,      'a AA C aab ab a'),
             # Multi-line
-            ('aaa AA\naa aab', r'\baa\b', 'C', 1, 'aaa AA\nC aab'),
-        )
+            ('aaa AA\naa aab',   r'\baa\b',  'C',    1,      'aaa AA\nC aab'),
+        )  # fmt: skip
         for s, find, change, count, result in regex_table:
             fc.ignore_case = False
             fc.find_text = find
@@ -920,9 +920,9 @@ class TestFind(LeoUnitTest):
         fc = c.findCommands
         word_table = (
             # s                 find    change  count   result
-            ('a ba aa a ab a', 'a', 'C', 3, 'C ba aa C ab C'),
-            ('a ba aa a ab a', 'aa', 'C', 1, 'a ba C a ab a'),
-        )
+            ('a ba aa a ab a',  'a',    'C',    3,      'C ba aa C ab C'),
+            ('a ba aa a ab a',  'aa',   'C',    1,      'a ba C a ab a'),
+        )  # fmt: skip
         for s, find, change, count, result in word_table:
             fc.ignore_case = False
             fc.find_text = find
@@ -937,9 +937,9 @@ class TestFind(LeoUnitTest):
         fc = c.findCommands
         word_table = (
             # s                 find    change  count   result
-            ('a ba aa A ab a', 'a', 'C', 3, 'C ba aa C ab C'),
-            ('a ba aa AA ab a', 'aa', 'C', 2, 'a ba C C ab a'),
-        )
+            ('a ba aa A ab a',  'a',    'C',    3,      'C ba aa C ab C'),
+            ('a ba aa AA ab a', 'aa',   'C',    2,      'a ba C C ab a'),
+        )  # fmt: skip
         for s, find, change, count, result in word_table:
             fc.ignore_case = True
             fc.find_text = find
@@ -954,27 +954,27 @@ class TestFind(LeoUnitTest):
         x = leoFind.LeoFind(c)
         table = (
             # Replace \n, \t, and \f by newline, tab, and form-feed.
-            ('\\f', '\f'),
-            ('\\n', '\n'),
-            ('\\t', '\t'),
-            ('a\\n', 'a\n'),
-            ('\\\n', '\\\n'),  # Backslash-newline!
-            ('a\\tc', 'a\tc'),
+            ('\\f',      '\f'),
+            ('\\n',      '\n'),
+            ('\\t',      '\t'),
+            ('a\\n',     'a\n'),
+            ('\\\n',     '\\\n'),  # Backslash-newline!
+            ('a\\tc',    'a\tc'),
             ('a\\t\\fc', 'a\t\fc'),
-            ('a\\nc', 'a\nc'),
+            ('a\\nc',    'a\nc'),
             # Allow escaped backslash: #4284.
-            ('\\', '\\'),
-            ('\\\\', '\\\\'),
-            ('\\\\n', '\\\\n'),
-            ('\\\\t', '\\\\t'),
+            ('\\',      '\\'),
+            ('\\\\',    '\\\\'),
+            ('\\\\n',   '\\\\n'),
+            ('\\\\t',   '\\\\t'),
             ('b\\\\nd', 'b\\\\nd'),
             # Make no other replacements.
-            (r'a\bc', r'a\bc'),
-            (r'a\\bc', r'a\\bc'),
-            (r'a \ b', r'a \ b'),
-            (r'a \\ b', r'a \\ b'),
+            (r'a\bc',    r'a\bc'),
+            (r'a\\bc',   r'a\\bc'),
+            (r'a \ b',   r'a \ b'),
+            (r'a \\ b',  r'a \\ b'),
             (r'a \\\ b', r'a \\\ b'),
-        )
+        )  # fmt: skip
         for s, expected in table:
             got = x.replace_back_slashes(s)
             self.assertEqual(expected, got, msg=s)

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -309,11 +309,11 @@ class TestGlobals(LeoUnitTest):
     def test_g_comment_delims_from_extension(self):
         # New in Leo 4.6, set_delims_from_language returns '' instead of None.
         table = (
-            ('.c', ('//', '/*', '*/')),
-            ('.html', ('', '<!--', '-->')),
-            ('.py', ('#', '', '')),
+            ('.c',       ('//', '/*', '*/')),
+            ('.html',    ('', '<!--', '-->')),
+            ('.py',      ('#', '', '')),
             ('.Globals', ('', '', '')),
-        )
+        )  # fmt: skip
         for ext, expected in table:
             result = g.comment_delims_from_extension(ext)
             self.assertEqual(result, expected, msg=repr(ext))
@@ -323,32 +323,32 @@ class TestGlobals(LeoUnitTest):
         s1 = 'abc\n\np\nxy'
         table1 = (
             (-1, (0, 0)),  # One too small.
-            (0, (0, 0)),
-            (1, (0, 1)),
-            (2, (0, 2)),
-            (3, (0, 3)),  # The newline ends a row.
-            (4, (1, 0)),
-            (5, (2, 0)),
-            (6, (2, 1)),
-            (7, (3, 0)),
-            (8, (3, 1)),
-            (9, (3, 2)),  # One too many.
+            (0,  (0, 0)),
+            (1,  (0, 1)),
+            (2,  (0, 2)),
+            (3,  (0, 3)),  # The newline ends a row.
+            (4,  (1, 0)),
+            (5,  (2, 0)),
+            (6,  (2, 1)),
+            (7,  (3, 0)),
+            (8,  (3, 1)),
+            (9,  (3, 2)),  # One too many.
             (10, (3, 2)),  # Two too many.
-        )
+        )  # fmt: skip
         s2 = 'abc\n\np\nxy\n'
         table2 = (
-            (9, (3, 2)),
+            (9,  (3, 2)),
             (10, (4, 0)),  # One too many.
             (11, (4, 0)),  # Two too many.
-        )
+        )  # fmt: skip
         s3 = 'ab'  # Test special case.  This was the cause of off-by-one problems.
         table3 = (
             (-1, (0, 0)),  # One too small.
-            (0, (0, 0)),
-            (1, (0, 1)),
-            (2, (0, 2)),  # One too many.
-            (3, (0, 2)),  # Two too many.
-        )
+            (0,  (0, 0)),
+            (1,  (0, 1)),
+            (2,  (0, 2)),  # One too many.
+            (3,  (0, 2)),  # Two too many.
+        )  # fmt: skip
         for n, s, table in ((1, s1, table1), (2, s2, table2), (3, s3, table3)):
             for i, result in table:
                 row, col = g.convertPythonIndexToRowCol(s, i)
@@ -373,9 +373,9 @@ class TestGlobals(LeoUnitTest):
             (9, (3, 2)),  # One too large.
         )
         table2 = (
-            (9, (3, 2)),
+            (9,  (3, 2)),
             (10, (4, 0)),  # One two many.
-        )
+        )  # fmt: skip
         for s, table in ((s1, table1), (s2, table2)):
             for i, data in table:
                 row, col = data
@@ -416,8 +416,8 @@ class TestGlobals(LeoUnitTest):
         table = (
             ('abc a bc x', 'bc', 0, 6),
             ('abc a bc x', 'bc', 1, 6),
-            ('abc a x', 'bc', 0, -1),
-        )
+            ('abc a x',    'bc', 0, -1),
+        )  # fmt: skip
         for s, word, i, expected in table:
             actual = g.find_word(s, word, i)
             self.assertEqual(actual, expected)
@@ -532,15 +532,15 @@ class TestGlobals(LeoUnitTest):
     # @+node:ekr.20210905203541.24: *4* TestGlobals.test_g_isDirective
     def test_g_isDirective(self):
         table = (
-            (True, '@language python\n'),
-            (True, '@tabwidth -4 #test\n'),
-            (True, '@others\n'),
-            (True, '    @others\n'),
-            (True, '@encoding\n'),
+            (True,  '@language python\n'),
+            (True,  '@tabwidth -4 #test\n'),
+            (True,  '@others\n'),
+            (True,  '    @others\n'),
+            (True,  '@encoding\n'),
             (False, '@encoding.setter\n'),
             (False, '@encoding("abc")\n'),
             (False, 'encoding = "abc"\n'),
-        )
+        )  # fmt: skip
         for expected, s in table:
             result = g.isDirective(s)
             self.assertEqual(expected, bool(result), msg=s)
@@ -548,28 +548,28 @@ class TestGlobals(LeoUnitTest):
     # @+node:ekr.20210905203541.25: *4* TestGlobals.test_g_match_word
     def test_g_match_word(self):
         table = (
-            (True, 0, 'a', 'a'),
+            (True,  0, 'a', 'a'),
             (False, 0, 'a', 'b'),
-            (True, 0, 'a', 'a b'),
+            (True,  0, 'a', 'a b'),
             (False, 1, 'a', 'aa b'),  # Tests bug fixed 2017/06/01.
             (False, 1, 'a', '_a b'),
             (False, 0, 'a', 'aw b'),
             (False, 0, 'a', 'a_'),
-            (True, 2, 'a', 'b a c'),
+            (True,  2, 'a', 'b a c'),
             (False, 0, 'a', 'b a c'),
             # Tests of #3588.
-            (True, 4, '.lws', 'self.lws = 0'),
-            (True, 4, '.lws', 'self.lws=0'),
+            (True,  4, '.lws', 'self.lws = 0'),
+            (True,  4, '.lws', 'self.lws=0'),
             (False, 4, '.lws', 'self.lws2a=0'),
             (False, 4, '.lws', 'self.lws0=0'),
-            (True, 2, '.lws', '  .lws  #comment'),
+            (True,  2, '.lws', '  .lws  #comment'),
             (False, 2, '.lws', '  .lws2  #comment'),
-            (True, 0, '###', '### comment'),
-            (True, 0, '###', '###comment'),
-            (True, 2, '###', '  ###comment'),
-            (True, 2, '###', '  ###.'),
-            (True, 1, '###', 'a###.'),
-        )
+            (True,  0, '###',  '### comment'),
+            (True,  0, '###',  '###comment'),
+            (True,  2, '###',  '  ###comment'),
+            (True,  2, '###',  '  ###.'),
+            (True,  1, '###',  'a###.'),
+        )  # fmt: skip
         for ignore_case in (True, False):
             for expected, i, word, line in table:
                 if ignore_case:
@@ -624,17 +624,17 @@ class TestGlobals(LeoUnitTest):
 
         # @-<< define class TestClass >>
         table = (
-            (s, 'String1'),
-            ('This is a test', "String2"),
-            ({'a': 1, 'b': 2}, 'Dict'),
-            (['one', 'two', 'three'], 'List'),
-            (('x', 'y'), 'Tuple'),
-            (g.printObj, 'Function'),
-            (TestClass, "Class"),
-            (TestClass(), "Instance"),
-            (TestClass.test_function, 'unbound method'),
+            (s,                         'String1'),
+            ('This is a test',          "String2"),
+            ({'a': 1, 'b': 2},          'Dict'),
+            (['one', 'two', 'three'],   'List'),
+            (('x', 'y'),                'Tuple'),
+            (g.printObj,                'Function'),
+            (TestClass,                 "Class"),
+            (TestClass(),               "Instance"),
+            (TestClass.test_function,   'unbound method'),
             (TestClass().test_function, 'bound method'),
-        )
+        )  # fmt: skip
         for data, tag in table:
             result = g.objToString(data, tag=tag)
             self.assertTrue(tag in result, msg=data)
@@ -742,20 +742,20 @@ class TestGlobals(LeoUnitTest):
         if g.isWindows:
             table = (
                 # g.relativeDirectory lowers all results.
-                ('c:\\Users\\ekr', 'c:\\Users\\ekr\\test1.py', 'test1.py'),
+                ('c:\\Users\\ekr', 'c:\\Users\\ekr\\test1.py',   'test1.py'),
                 ('c:\\Users\\ekr', 'c:\\Users\\user2\\test2.py', '..\\user2\\test2.py'),
-                ('c:\\Users\\ekr', 'd:\\Users\\ekr\\test3.py', 'd:\\users\\ekr\\test3.py'),
+                ('c:\\Users\\ekr', 'd:\\Users\\ekr\\test3.py',   'd:\\users\\ekr\\test3.py'),
                 # Unsaved outlines.
-                ('', 'c:\\Users\\ekr\\test4.py', 'c:\\Users\\ekr\\test4.py'),
-            )
+                ('',                'c:\\Users\\ekr\\test4.py',  'c:\\Users\\ekr\\test4.py'),
+            )  # fmt: skip
         else:  # Linux/MacOS tests.
             table = (
-                ('/home', '/home/test1.py', 'test1.py'),
+                ('/home',         '/home/test1.py',         'test1.py'),
                 ('/home/folder1', '/home/folder1/test2.py', 'test2.py'),
                 ('/home/folder1', '/home/folder2/test3.py', '../folder2/test3.py'),
                 # Unsaved outlines.
-                ('', '/home/test4.py', '/home/test4.py'),
-            )
+                ('',              '/home/test4.py',         '/home/test4.py'),
+            )  # fmt: skip
         for base, fn, expected in table:
             actual = g.relativeDirectory(base, fn)
             self.assertEqual(actual, expected)
@@ -784,10 +784,10 @@ class TestGlobals(LeoUnitTest):
     def test_g_removeTrailing(self):
         s = 'aa bc \n \n\t\n'
         table = (
-            ('\t\n ', 'aa bc'),
+            ('\t\n ',    'aa bc'),
             ('abc\t\n ', ''),
-            ('c\t\n ', 'aa b'),
-        )
+            ('c\t\n ',   'aa b'),
+        )  # fmt: skip
         for arg, val in table:
             result = g.removeTrailing(s, arg)
             self.assertEqual(result, val)
@@ -795,14 +795,14 @@ class TestGlobals(LeoUnitTest):
     # @+node:ekr.20210905203541.32: *4* TestGlobals.test_g_sanitize_filename
     def test_g_sanitize_filename(self):
         table = (
-            ('A25&()', 'A'),  # Non-alpha characters.
-            ('B\tc', 'B c'),  # Tabs.
-            ('"AB"', "'AB'"),  # Double quotes.
-            ('\\/:|<>*:.', '_'),  # Special characters.
+            ('A25&()', 'A'),         # Non-alpha characters.
+            ('B\tc', 'B c'),         # Tabs.
+            ('"AB"', "'AB'"),        # Double quotes.
+            ('\\/:|<>*:.', '_'),     # Special characters.
             ('_____________', '_'),  # Combining underscores.
             ('A' * 200, 'A' * 128),  # Maximum length.
-            ('abc.', 'abc_'),  # Trailing dots.
-        )
+            ('abc.', 'abc_'),        # Trailing dots.
+        )  # fmt: skip
         for s, expected in table:
             got = g.sanitize_filename(s)
             self.assertEqual(got, expected, msg=repr(s))
@@ -810,10 +810,10 @@ class TestGlobals(LeoUnitTest):
     # @+node:ekr.20210905203541.48: *4* TestGlobals.test_g_set_delims_from_language
     def test_g_set_delims_from_language(self):
         table = (
-            ('c', ('//', '/*', '*/')),
+            ('c',      ('//', '/*', '*/')),
             ('python', ('#', '', '')),
             ('xxxyyy', ('', '', '')),
-        )
+        )  # fmt: skip
         for language, expected in table:
             result = g.set_delims_from_language(language)
             self.assertEqual(result, expected, msg=language)
@@ -821,13 +821,13 @@ class TestGlobals(LeoUnitTest):
     # @+node:ekr.20210905203541.49: *4* TestGlobals.test_g_set_delims_from_string
     def test_g_set_delims_from_string(self):
         table = (
-            ('c', '@comment // /* */', ('//', '/*', '*/')),
-            ('c', '// /* */', ('//', '/*', '*/')),
-            ('python', '@comment #', ('#', '', '')),
-            ('python', '#', ('#', '', '')),
-            ('xxxyyy', '@comment a b c', ('a', 'b', 'c')),
-            ('xxxyyy', 'a b c', ('a', 'b', 'c')),
-        )
+            ('c',      '@comment // /* */', ('//', '/*', '*/')),
+            ('c',      '// /* */',          ('//', '/*', '*/')),
+            ('python', '@comment #',        ('#', '', '')),
+            ('python', '#',                 ('#', '', '')),
+            ('xxxyyy', '@comment a b c',    ('a', 'b', 'c')),
+            ('xxxyyy', 'a b c',             ('a', 'b', 'c')),
+        )  # fmt: skip
         for language, s, expected in table:
             result = g.set_delims_from_string(s)
             self.assertEqual(result, expected, msg=language)
@@ -916,20 +916,22 @@ class TestGlobals(LeoUnitTest):
 
     # @+node:ekr.20210905203541.54: *4* TestGlobals.test_g_splitLongFileName
     def test_g_splitLongFileName(self):
-        table = (r'abcd/xy\pdqabc/aaa.py',)
+        table = (
+            r'abcd/xy\pdqabc/aaa.py',
+        )  # fmt: skip
         for s in table:
             g.splitLongFileName(s, limit=3)
 
     # @+node:ekr.20210905203541.55: *4* TestGlobals.test_g_stripPathCruft
     def test_g_stripPathCruft(self):
         table = (
-            (None, None),  # Retain empty paths for warnings.
-            ('', ''),
+            (None,          None),  # Retain empty paths for warnings.
+            ('',            ''),
             (g.app.loadDir, g.app.loadDir),
-            ('<abc>', 'abc'),
-            ('"abc"', 'abc'),
-            ("'abc'", 'abc'),
-        )
+            ('<abc>',       'abc'),
+            ('"abc"',       'abc'),
+            ("'abc'",       'abc'),
+        )  # fmt: skip
         for path, expected in table:
             result = g.stripPathCruft(path)
             self.assertEqual(result, expected)
@@ -1010,10 +1012,10 @@ class TestGlobals(LeoUnitTest):
     def test_g_getUNLFilePart(self):
         table = (
             ('unl:' + 'gnx://a.leo#whatever', 'a.leo'),
-            ('unl:' + '//b.leo#whatever', 'b.leo'),
-            ('file:' + '//c.leo#whatever', 'c.leo'),
-            ('//d.leo#whatever', 'd.leo'),
-        )
+            ('unl:' + '//b.leo#whatever',     'b.leo'),
+            ('file:' + '//c.leo#whatever',    'c.leo'),
+            ('//d.leo#whatever',              'd.leo'),
+        )  # fmt: skip
         for unl, expected in table:
             self.assertEqual(expected, g.getUNLFilePart(unl), msg=unl)
 

--- a/leo/unittests/core/test_leoKeys.py
+++ b/leo/unittests/core/test_leoKeys.py
@@ -95,9 +95,9 @@ class TestKeys(LeoUnitTest):
         c = self.c
         table = (
             (50, 'c.'),
-            (3, 'p.ins'),
+            (3,  'p.ins'),
             (17, 'g.print'),
-        )
+        )  # fmt: skip
         ac = c.k.autoCompleter
         ac.w = c.frame.body.wrapper
         for expected, prefix in table:
@@ -196,24 +196,24 @@ class TestKeys(LeoUnitTest):
         bg = getColor('body_text_background_color') or 'white'
         fg = getColor('body_text_foreground_color') or 'black'
         table = (
-            ('command_mode_bg_color', getColor('command_mode_bg_color') or bg),
-            ('command_mode_fg_color', getColor('command_mode_fg_color') or fg),
-            ('enable_alt_ctrl_bindings', getBool('enable_alt_ctrl_bindings')),
-            ('enable_autocompleter', getBool('enable_autocompleter_initially')),
-            ('enable_calltips', getBool('enable_calltips_initially')),
-            ('ignore_unbound_non_ascii_keys', getBool('ignore_unbound_non_ascii_keys')),
-            ('insert_mode_bg_color', getColor('insert_mode_bg_color') or bg),
-            ('insert_mode_fg_color', getColor('insert_mode_fg_color') or fg),
-            ('minibuffer_background_color', getColor('minibuffer_background_color') or 'lightblue'),
-            ('minibuffer_error_color', getColor('minibuffer_error_color') or 'red'),
-            ('minibuffer_warning_color', getColor('minibuffer_warning_color') or 'lightgrey'),
-            ('overwrite_mode_bg_color', getColor('overwrite_mode_bg_color') or bg),
-            ('overwrite_mode_fg_color', getColor('overwrite_mode_fg_color') or fg),
-            # ('swap_mac_keys',                 getBool('swap_mac_keys')),
-            ('unselected_body_bg_color', getColor('unselected_body_bg_color') or bg),
-            ('unselected_body_fg_color', getColor('unselected_body_fg_color') or bg),
+            ('command_mode_bg_color',          getColor('command_mode_bg_color') or bg),
+            ('command_mode_fg_color',          getColor('command_mode_fg_color') or fg),
+            ('enable_alt_ctrl_bindings',       getBool('enable_alt_ctrl_bindings')),
+            ('enable_autocompleter',           getBool('enable_autocompleter_initially')),
+            ('enable_calltips',                getBool('enable_calltips_initially')),
+            ('ignore_unbound_non_ascii_keys',  getBool('ignore_unbound_non_ascii_keys')),
+            ('insert_mode_bg_color',           getColor('insert_mode_bg_color') or bg),
+            ('insert_mode_fg_color',           getColor('insert_mode_fg_color') or fg),
+            ('minibuffer_background_color',    getColor('minibuffer_background_color') or 'lightblue'),
+            ('minibuffer_error_color',         getColor('minibuffer_error_color') or 'red'),
+            ('minibuffer_warning_color',       getColor('minibuffer_warning_color') or 'lightgrey'),
+            ('overwrite_mode_bg_color',        getColor('overwrite_mode_bg_color') or bg),
+            ('overwrite_mode_fg_color',        getColor('overwrite_mode_fg_color') or fg),
+            # ('swap_mac_keys',                getBool('swap_mac_keys')),
+            ('unselected_body_bg_color',       getColor('unselected_body_bg_color') or bg),
+            ('unselected_body_fg_color',       getColor('unselected_body_fg_color') or bg),
             ('warn_about_redefined_shortcuts', getBool('warn_about_redefined_shortcuts')),
-        )
+        )  # fmt: skip
         for ivar, setting in table:
             self.assertTrue(hasattr(k, ivar), msg=ivar)
             val = getattr(k, ivar)

--- a/leo/unittests/core/test_leoNodes.py
+++ b/leo/unittests/core/test_leoNodes.py
@@ -187,16 +187,16 @@ class TestNodes(LeoUnitTest):
         c, p = self.c, self.c.p
         root = p.next()
         table = (
-            ('all_positions', c.all_positions),
+            ('all_positions',        c.all_positions),
             ('all_unique_positions', c.all_unique_positions),
-            ('children', root.children),
-            ('self_and_siblings', root.self_and_siblings),
-            ('self_and_parents', root.firstChild().self_and_parents),
-            ('self_and_subtree', root.self_and_subtree),
-            ('following_siblings', root.following_siblings),
-            ('parents', root.firstChild().firstChild().parents),
-            ('unique_subtree', root.unique_subtree),
-        )
+            ('children',             root.children),
+            ('self_and_siblings',    root.self_and_siblings),
+            ('self_and_parents',     root.firstChild().self_and_parents),
+            ('self_and_subtree',     root.self_and_subtree),
+            ('following_siblings',   root.following_siblings),
+            ('parents',              root.firstChild().firstChild().parents),
+            ('unique_subtree',       root.unique_subtree),
+        )  # fmt: skip
         for kind, generator in table:
             aList = []
             for p in generator():
@@ -1035,9 +1035,9 @@ class TestNodes(LeoUnitTest):
         p = self.c.p
         table = (
             ('@auto-rst rst-file', 'rst-file', 'rst-file'),
-            ('@auto x', 'x', ''),
-            ('xyz', '', ''),
-        )
+            ('@auto x',             'x',        ''),
+            ('xyz',                 '',         ''),
+        )  # fmt: skip
         for s, expected1, expected2 in table:
             result1 = p.v.atAutoNodeName(h=s)
             result2 = p.v.atAutoRstNodeName(h=s)

--- a/leo/unittests/core/test_leoPersistence.py
+++ b/leo/unittests/core/test_leoPersistence.py
@@ -89,7 +89,7 @@ class TestPersistence(LeoUnitTest):
             ('', parent),  # Important special case.
             ('node1-->child11', child11),
             ('node1-->child12', child12),
-            ('node2', node2),
+            ('node2',            node2),
             ('node2-->child21', child21),
             ('node2-->child22', child22),
             # Partial matches.
@@ -98,10 +98,10 @@ class TestPersistence(LeoUnitTest):
             # ('xxx-->child21',node3_child1_child21),
             # This is ambiguous.
             # No matches.
-            ('nodex', None),
+            ('nodex',          None),
             ('node1-->childx', None),
             ('node3-->childx', None),
-        )
+        )  # fmt: skip
         for unl, expected in table:
             result = pd.find_position_for_relative_unl(parent, unl)
             self.assertEqual(result, expected, msg=unl)

--- a/leo/unittests/core/test_leoVim.py
+++ b/leo/unittests/core/test_leoVim.py
@@ -40,7 +40,11 @@ class TestVim(LeoUnitTest):
             abc
             xyz
         """)
-        table = (('a', 'a'), ('a', 'b'), ('a', '\nx'))
+        table = (
+            ('a', 'a'),
+            ('a', 'b'),
+            ('a', '\nx'),
+        )
         for (
             a,
             b,

--- a/leo/unittests/misc_tests/test_modes.py
+++ b/leo/unittests/misc_tests/test_modes.py
@@ -144,13 +144,13 @@ class TestModes(LeoUnitTest):
 
         # Lifetimes.
         lifetime_table = (
-            ("'a", "'a"),
-            ("'a>", "'a"),
-            ("'a ", "'a"),
-            ("'static", "'static"),
+            ("'a",        "'a"),
+            ("'a>",       "'a"),
+            ("'a ",       "'a"),
+            ("'static",   "'static"),
             ("'static\n", "'static"),
-            ("'static ", "'static"),
-        )
+            ("'static ",  "'static"),
+        )  # fmt: skip
         for s, expected_seq in lifetime_table:
             kind, seq = rust_char(colorer, s, i=0)
             assert kind == 'literal1', kind
@@ -158,13 +158,13 @@ class TestModes(LeoUnitTest):
 
         # Errors.
         error_table = (
-            "'xx",  # Bad lifetime.
+            "'xx",                          # Bad lifetime.
             "'BSBSy'".replace('BS', '\\'),  # Too long.
-            "'BSy'".replace('BS', '\\'),  # Invalid escape: \y
-            r"'\u{ffff}'",  # Must begin with [0-7]
-            r"'\xff'",  # Must begin with [0-7]
-            r"'\u{7fhi}'",  # Invalid hex digits.
-        )
+            "'BSy'".replace('BS', '\\'),    # Invalid escape: \y
+            r"'\u{ffff}'",                  # Must begin with [0-7]
+            r"'\xff'",                      # Must begin with [0-7]
+            r"'\u{7fhi}'",                  # Invalid hex digits.
+        )  # fmt: skip
         for s in error_table:
             kind, seq = rust_char(colorer, s, i=0)
             assert kind == 'literal4', kind

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -142,14 +142,20 @@ class TestQtGui(LeoUnitTest):
         # Run the tests.
         table = (
             # python.
-            (True, 'File "test_file.py", line 5'),
+            (
+                True,
+                'File "test_file.py", line 5',
+            ),
             # pylint.
             (
                 True,
                 r'leo\unittest\test_file.py:1326:8: W0101: Unreachable code (unreachable)',
             ),
             # pyflakes.
-            (True, r"test_file.py:51:13 'leo.core.leoQt5.*' imported but unused"),
+            (
+                True,
+                r"test_file.py:51:13 'leo.core.leoQt5.*' imported but unused",
+            ),
             # mypy...
             (
                 True,
@@ -159,10 +165,19 @@ class TestQtGui(LeoUnitTest):
                 True,
                 r'leo\core\test_file.py:116: note: Use "-> None" if function does not return a value',
             ),
-            (False, 'Found 1 error in 1 file (checked 1 source file)'),
-            (False, 'mypy: done'),
+            (
+                False,
+                'Found 1 error in 1 file (checked 1 source file)',
+            ),
+            (
+                False,
+                'mypy: done',
+            ),
             # Random output.
-            (False, 'Hello world\n'),
+            (
+                False,
+                'Hello world\n',
+            ),
         )
         for expected, s in table:
             s = s.replace('\\', os.sep).rstrip() + '\n'

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -2103,10 +2103,10 @@ class TestMarkdown(BaseTestImporter):
         x = markdown.Markdown_Importer(c)
         assert x.md_pattern_table
         table = (
-            (1, 'name', '# name\n'),
+            (1, 'name',   '# name\n'),
             (2, 'a test', '## a test\n'),
             (3, 'a test', '### a test\n'),
-        )
+        )  # fmt: skip
         for data in table:
             level, name, line = data
             level2, name2 = x.is_hash(line)

--- a/leo/unittests/plugins/test_plugins.py
+++ b/leo/unittests/plugins/test_plugins.py
@@ -135,11 +135,11 @@ class TestPlugins(LeoUnitTest):
     def test_regularizeName(self):
         pc = LeoPluginsController()
         table = (
-            ('x', 'x'),
-            ('foo.bar', 'foo.bar'),
-            ('x.py', 'leo.plugins.x'),
+            ('x',             'x'),
+            ('foo.bar',       'foo.bar'),
+            ('x.py',          'leo.plugins.x'),
             ('leo.plugins.x', 'leo.plugins.x'),
-        )
+        )  # fmt: skip
         for fn, expected in table:
             result = pc.regularizeName(fn)
             self.assertEqual(result, expected, msg=fn)


### PR DESCRIPTION
**Goals**

- Restore formatting of many tables, making them more readable.
- Restore formatting of complex messages, emphasizing line breaks.
- Reduce the diffs in PR #4487.
- Change as little as possible.

**Note**:

- Beautifying on write instantly showed me the results of changes!
- This PR's diffs should consist only of:
   - changed whitespace and newlines,
   - added magic commas,
   - Added `# fmt: skip` directives.

**Tasks**

- [x] Reformat tables found by the `table.*? = \(` regex search.
- [x] Regularize `filetypes` args using magic commas. This may increase the diffs, but it's worth doing.
- [x] Fix problems found in the `leo/core` and `leo/commands/` directories.
- [x] Fix problems in Qt plugins.