### PR TITLE
PR: Reformat cmd decorators by removing 'magic' commas

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -24,13 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the abbrevCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'abbrevCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'abbrevCommands'])
 
 
 # @+others

--- a/leo/commands/bufferCommands.py
+++ b/leo/commands/bufferCommands.py
@@ -19,13 +19,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the BufferCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'bufferCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'bufferCommands'])
 
 
 # @+others

--- a/leo/commands/controlCommands.py
+++ b/leo/commands/controlCommands.py
@@ -21,13 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the ControlCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'controlCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'controlCommands'])
 
 
 # @+others

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -24,13 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the ConvertCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'convertCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'convertCommands'])
 
 
 # @+<< class To_Python >>

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -20,13 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the DebugCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'debugCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'debugCommands'])
 
 
 class DebugCommandsClass(BaseEditCommandsClass):

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -25,13 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the EditCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'editCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'editCommands'])
 
 
 # @+others

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -23,13 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the EditFileCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'editFileCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'editFileCommands'])
 
 
 # @+others

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -21,13 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the helpCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'helpCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'helpCommands'])
 
 
 # @+others

--- a/leo/commands/killBufferCommands.py
+++ b/leo/commands/killBufferCommands.py
@@ -26,13 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the KillBufferCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'killBufferCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'killBufferCommands'])
 
 
 # @+others

--- a/leo/commands/rectangleCommands.py
+++ b/leo/commands/rectangleCommands.py
@@ -18,13 +18,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the RectangleCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'rectangleCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'rectangleCommands'])
 
 
 # @+others

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -29,13 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the SpellCommandsClass class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'spellCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'spellCommands'])
 
 
 # @+others

--- a/leo/core/leoChapters.py
+++ b/leo/core/leoChapters.py
@@ -23,13 +23,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20150509030349.1: ** cc.cmd (decorator)
 def cmd(name: str) -> Callable:
     """Command decorator for the ChapterController class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'chapterController',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'chapterController'])
 
 
 # @+node:ekr.20070317085437: ** class ChapterController

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -80,12 +80,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the Commands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c'])
 
 
 # @+others

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -45,13 +45,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20150509194827.1: ** cmd (decorator)
 def cmd(name: str) -> Callable:
     """Command decorator for the FileCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'fileCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'fileCommands'])
 
 
 # @+node:ekr.20210316035506.1: **  commands (leoFileCommands.py)

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -85,13 +85,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the findCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'findCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'findCommands'])
 
 
 # @+others

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -167,13 +167,7 @@ def ac_cmd(name: str) -> Callable:
 # @+node:ekr.20150509035028.1: ** cmd (decorator)
 def cmd(name: str) -> Callable:
     """Command decorator for the leoKeys class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'k',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'k'])
 
 
 # @+node:ekr.20061031131434.4: ** class AutoCompleterClass

--- a/leo/core/leoPrinting.py
+++ b/leo/core/leoPrinting.py
@@ -29,13 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the PrintingController class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'printingController',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'printingController'])
 
 
 # @+others

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -51,13 +51,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the RstCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'rstCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'rstCommands'])
 
 
 # @+others

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -62,13 +62,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the Undoer class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'undoer',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'undoer'])
 
 
 # @+others

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -42,13 +42,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 def cmd(name: str) -> Callable:
     """Command decorator for the VimCommands class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'vimCommands',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'vimCommands'])
 
 
 # @+others


### PR DESCRIPTION
This PR reduces diffs in the summary PR, PR #4487.