### PR TITLE
PR2: Reformat cmd decorators by removing 'magic' comma.

### DIFF
--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -89,13 +89,7 @@ def body_cmd(name: str) -> Callable:
 
 def frame_cmd(name: str) -> Callable:
     """Command decorator for the LeoFrame class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'frame',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'frame'])
 
 
 # @-<< leoFrame command decorators >>

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -914,13 +914,7 @@ def method_name(f: Callable) -> str:
 # @+node:ekr.20210228141208.1: **  decorators (curses2)
 def frame_cmd(name: str) -> Callable:
     """Command decorator for the LeoFrame class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'frame',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'frame'])
 
 
 def log_cmd(name: str) -> Callable:

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -90,13 +90,7 @@ def body_cmd(name: str) -> Callable:
 
 def frame_cmd(name: str) -> Callable:
     """Command decorator for the LeoQtFrame class."""
-    return g.new_cmd_decorator(
-        name,
-        [
-            'c',
-            'frame',
-        ],
-    )
+    return g.new_cmd_decorator(name, ['c', 'frame'])
 
 
 def log_cmd(name: str) -> Callable:


### PR DESCRIPTION
A follow up to PR #4514.