### PR TITLE
PR2: beautify all of Leo's files with line-length = 100

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -511,7 +511,9 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         return False
 
     # @+node:ekr.20161121112837.1: *4* abbrev.match_prefix
-    def match_prefix(self, ch: str, i: int, j: int, prefix: str, s: str) -> tuple[int, str, str, str]:
+    def match_prefix(
+        self, ch: str, i: int, j: int, prefix: str, s: str
+    ) -> tuple[int, str, str, str]:
         """A match helper."""
         i = j - len(prefix)
         word = g.checkUnicode(prefix) + g.checkUnicode(ch)

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -196,7 +196,9 @@ def find_missing_docstrings(event: LeoKeyEvent) -> None:
         # By Виталије Милошевић.
         # It may be useful to skip __init__ methods because their docstring
         # is usually docstring of the class
-        return line.startswith(('def ', 'class ')) and not line.partition(' ')[2].startswith('__init__')
+        return line.startswith(('def ', 'class ')) and not line.partition(' ')[2].startswith(
+            '__init__'
+        )
 
     # @+node:ekr.20190615182754.1: *4* function: is_root
     def is_root(p: Position) -> bool:
@@ -425,7 +427,9 @@ class CheckNodes:
             and not any(p.h.startswith(z)
             for z in self.ok_head_prefixes)
         )  # fmt: skip
-        trailing_class_or_def = len(stripped_lines) > 1 and stripped_lines[-1].startswith(('class ', 'def '))
+        trailing_class_or_def = len(stripped_lines) > 1 and stripped_lines[-1].startswith(
+            ('class ', 'def ')
+        )
         return any((too_many_defs, leading_blank_line, empty_body, trailing_class_or_def))
 
     # @-others

--- a/leo/commands/checkerCommands.py
+++ b/leo/commands/checkerCommands.py
@@ -196,9 +196,10 @@ def find_missing_docstrings(event: LeoKeyEvent) -> None:
         # By Виталије Милошевић.
         # It may be useful to skip __init__ methods because their docstring
         # is usually docstring of the class
-        return line.startswith(('def ', 'class ')) and not line.partition(' ')[2].startswith(
-            '__init__'
-        )
+        return (
+            line.startswith(('def ', 'class '))
+            and not line.partition(' ')[2].startswith('__init__')
+        )  # fmt: skip
 
     # @+node:ekr.20190615182754.1: *4* function: is_root
     def is_root(p: Position) -> bool:
@@ -427,9 +428,10 @@ class CheckNodes:
             and not any(p.h.startswith(z)
             for z in self.ok_head_prefixes)
         )  # fmt: skip
-        trailing_class_or_def = len(stripped_lines) > 1 and stripped_lines[-1].startswith(
-            ('class ', 'def ')
-        )
+        trailing_class_or_def = (
+            len(stripped_lines) > 1
+            and stripped_lines[-1].startswith(('class ', 'def '))
+        )  # fmt: skip
         return any((too_many_defs, leading_blank_line, empty_body, trailing_class_or_def))
 
     # @-others

--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -1101,7 +1101,9 @@ def startsParagraph(s: str) -> bool:
 
 # @+node:ekr.20201124191844.1: ** c_ec.reformatSelection
 @g.commander_command('reformat-selection')
-def reformatSelection(self: Self, event: LeoKeyEvent = None, undoType: str = 'Reformat Selection') -> None:
+def reformatSelection(
+    self: Self, event: LeoKeyEvent = None, undoType: str = 'Reformat Selection'
+) -> None:
     """
     Reformat the selected text, as in reformat-paragraph, but without
     expanding the selection past the selected lines.
@@ -1209,7 +1211,9 @@ def toggleAngleBrackets(self: Self, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20171123135625.49: ** c_ec.unformatParagraph & helper
 @g.commander_command('unformat-paragraph')
-def unformatParagraph(self: Self, event: LeoKeyEvent = None, undoType: str = 'Unformat Paragraph') -> None:
+def unformatParagraph(
+    self: Self, event: LeoKeyEvent = None, undoType: str = 'Unformat Paragraph'
+) -> None:
     """
     Unformat a text paragraph. Removes all extra whitespace in a paragraph.
 

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -571,7 +571,9 @@ def saveAs(self: Self, event: LeoKeyEvent = None, fileName: str = None) -> None:
 @g.commander_command('save-to')
 @g.commander_command('file-save-to')
 @g.commander_command('save-file-to')
-def saveTo(self: Self, event: LeoKeyEvent = None, fileName: str = None, silent: bool = False) -> None:
+def saveTo(
+    self: Self, event: LeoKeyEvent = None, fileName: str = None, silent: bool = False
+) -> None:
     """
     Save a copy of the Leo outline to a file, prompting for a new file name.
     Leave the file name of the Leo outline unchanged.

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -1296,7 +1296,9 @@ def insertHeadlineHelper(
     elif as_last_child:
         p = current.insertAsLastChild()
     elif (
-        as_child or (current.hasChildren() and current.isExpanded()) or (c.hoistStack and current == c.hoistStack[-1].p)
+        as_child
+        or (current.hasChildren() and current.isExpanded())
+        or (c.hoistStack and current == c.hoistStack[-1].p)
     ):
         # Make sure the new node is visible when hoisting.
         if c.config.getBool('insert-new-nodes-at-end'):
@@ -1959,7 +1961,9 @@ def reverseSortSiblings(self: Cmdr, event: LeoKeyEvent = None, key: str = None) 
 
 # @+node:ekr.20050415134809: *3* c_oc.sortChildren
 @g.commander_command('sort-children')
-def sortChildren(self: Cmdr, event: LeoKeyEvent = None, key: Callable = None, reverse: bool = False) -> None:
+def sortChildren(
+    self: Cmdr, event: LeoKeyEvent = None, key: Callable = None, reverse: bool = False
+) -> None:
     """Sort the children of a node."""
     # This method no longer supports the 'cmp' keyword arg.
     c, p = self, self.p

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -658,7 +658,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # #2606: End the pattern at the *first* "):" so arguments don't end prematurely.
         #        Alas, now we can't convert defs that already have return values.
-        def_pat = re.compile(r'^([ \t]*)def[ \t]+(\w+)\s*\((.*?)\):(.*?)\n', re.MULTILINE + re.DOTALL)
+        def_pat = re.compile(
+            r'^([ \t]*)def[ \t]+(\w+)\s*\((.*?)\):(.*?)\n', re.MULTILINE + re.DOTALL
+        )
 
         return_dict: dict[str, str] = {
             '__init__': 'None',
@@ -1365,7 +1367,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 self.config_fn = None
                 self.enable_unit_tests = False
                 self.files: list[str] = []  # May also be set in the config file.
-                self.output_directory = self.finalize(c.config.getString('stub-output-directory') or '.')
+                self.output_directory = self.finalize(
+                    c.config.getString('stub-output-directory') or '.'
+                )
                 self.output_fn: str = None
                 self.overwrite = c.config.getBool('stub-overwrite', default=False)
                 self.trace_matches = c.config.getBool('stub-trace-matches', default=False)
@@ -2195,7 +2199,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             return ''.join(lines).replace(self.kill_semicolons_flag, '\n')
 
         # @+node:ekr.20231119103026.32: *8* py2rust.do_assignment
-        assignment_pat = re.compile(r'^([ \t]*)(.*?)\s+=\s+(.*)$')  # Require whitespace around the '='
+        assignment_pat = re.compile(
+            r'^([ \t]*)(.*?)\s+=\s+(.*)$'
+        )  # Require whitespace around the '='
 
         def do_assignment(self, lines: list[str]) -> None:
             """Add let to all non-tuple assignments."""
@@ -2256,7 +2262,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # @+node:ekr.20231119103026.34: *8* py2rust.do_ternary
         ternary_pat1 = re.compile(r'^([ \t]*)(.*?)\s*=\s*(.*?) if (.*?) else (.*);$')  # assignment
-        ternary_pat2 = re.compile(r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$')  # return statement
+        ternary_pat2 = re.compile(
+            r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$'
+        )  # return statement
 
         def do_ternary(self, lines: list[str]) -> None:
             i = 0
@@ -2976,7 +2984,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             self.move_docstrings(lines)
             self.do_f_strings(lines)
             self.do_ternary(lines)
-            self.do_assignment(lines)  # Do this last, so it doesn't add 'const' to inserted comments.
+            self.do_assignment(
+                lines
+            )  # Do this last, so it doesn't add 'const' to inserted comments.
             s = (
                 ''.join(lines)
                 .replace('@language python', '@language typescript')
@@ -2985,7 +2995,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             return re.sub(r'\bNone\b', 'null', s)
 
         # @+node:ekr.20211021061023.1: *8* py2ts.do_assignment
-        assignment_pat = re.compile(r'^([ \t]*)(.*?)\s+=\s+(.*)$')  # Require whitespace around the '='
+        assignment_pat = re.compile(
+            r'^([ \t]*)(.*?)\s+=\s+(.*)$'
+        )  # Require whitespace around the '='
 
         def do_assignment(self, lines: list[str]) -> None:
             """Add const to all non-tuple assignments."""
@@ -3057,7 +3069,9 @@ class ConvertCommandsClass(BaseEditCommandsClass):
 
         # @+node:ekr.20211021051033.1: *8* py2ts.do_ternary
         ternary_pat1 = re.compile(r'^([ \t]*)(.*?)\s*=\s*(.*?) if (.*?) else (.*);$')  # assignment
-        ternary_pat2 = re.compile(r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$')  # return statement
+        ternary_pat2 = re.compile(
+            r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$'
+        )  # return statement
 
         def do_ternary(self, lines: list[str]) -> None:
             i = 0

--- a/leo/commands/convertCommands.py
+++ b/leo/commands/convertCommands.py
@@ -2199,9 +2199,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             return ''.join(lines).replace(self.kill_semicolons_flag, '\n')
 
         # @+node:ekr.20231119103026.32: *8* py2rust.do_assignment
-        assignment_pat = re.compile(
-            r'^([ \t]*)(.*?)\s+=\s+(.*)$'
-        )  # Require whitespace around the '='
+        # Require whitespace around the '='
+        assignment_pat = re.compile(r'^([ \t]*)(.*?)\s+=\s+(.*)$')
 
         def do_assignment(self, lines: list[str]) -> None:
             """Add let to all non-tuple assignments."""
@@ -2261,10 +2260,10 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 assert i > progress
 
         # @+node:ekr.20231119103026.34: *8* py2rust.do_ternary
-        ternary_pat1 = re.compile(r'^([ \t]*)(.*?)\s*=\s*(.*?) if (.*?) else (.*);$')  # assignment
-        ternary_pat2 = re.compile(
-            r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$'
-        )  # return statement
+        # assignment
+        ternary_pat1 = re.compile(r'^([ \t]*)(.*?)\s*=\s*(.*?) if (.*?) else (.*);$')
+        # return statement
+        ternary_pat2 = re.compile(r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$')
 
         def do_ternary(self, lines: list[str]) -> None:
             i = 0
@@ -2984,9 +2983,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             self.move_docstrings(lines)
             self.do_f_strings(lines)
             self.do_ternary(lines)
-            self.do_assignment(
-                lines
-            )  # Do this last, so it doesn't add 'const' to inserted comments.
+            # Do this last, so it doesn't add 'const' to inserted comments.
+            self.do_assignment(lines)
             s = (
                 ''.join(lines)
                 .replace('@language python', '@language typescript')
@@ -2995,9 +2993,8 @@ class ConvertCommandsClass(BaseEditCommandsClass):
             return re.sub(r'\bNone\b', 'null', s)
 
         # @+node:ekr.20211021061023.1: *8* py2ts.do_assignment
-        assignment_pat = re.compile(
-            r'^([ \t]*)(.*?)\s+=\s+(.*)$'
-        )  # Require whitespace around the '='
+        # Require whitespace around the '='
+        assignment_pat = re.compile(r'^([ \t]*)(.*?)\s+=\s+(.*)$')
 
         def do_assignment(self, lines: list[str]) -> None:
             """Add const to all non-tuple assignments."""
@@ -3068,10 +3065,10 @@ class ConvertCommandsClass(BaseEditCommandsClass):
                 assert i > progress
 
         # @+node:ekr.20211021051033.1: *8* py2ts.do_ternary
-        ternary_pat1 = re.compile(r'^([ \t]*)(.*?)\s*=\s*(.*?) if (.*?) else (.*);$')  # assignment
-        ternary_pat2 = re.compile(
-            r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$'
-        )  # return statement
+        # assignment
+        ternary_pat1 = re.compile(r'^([ \t]*)(.*?)\s*=\s*(.*?) if (.*?) else (.*);$')
+        # return statement
+        ternary_pat2 = re.compile(r'^([ \t]*)return\s+(.*?) if (.*?) else (.*);$')
 
         def do_ternary(self, lines: list[str]) -> None:
             i = 0

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -71,10 +71,10 @@ class DebugCommandsClass(BaseEditCommandsClass):
         debuggers = (
             # #1431: only expand path expression in @string debugger-path.
             debugger_path or '@string debugger-path',
-            g.os_path_join(
-                pythonDir, 'Lib', 'site-packages', 'winpdb.py'
-            ),  # winpdb 1.1.2 or newer.
-            g.os_path_join(pythonDir, 'scripts', '_winpdb.py'),  # Older version.
+            # winpdb 1.1.2 or newer.
+            g.os_path_join(pythonDir, 'Lib', 'site-packages', 'winpdb.py'),
+            # Older version.
+            g.os_path_join(pythonDir, 'scripts', '_winpdb.py'),
         )
         for debugger in debuggers:
             if debugger:

--- a/leo/commands/debugCommands.py
+++ b/leo/commands/debugCommands.py
@@ -71,7 +71,9 @@ class DebugCommandsClass(BaseEditCommandsClass):
         debuggers = (
             # #1431: only expand path expression in @string debugger-path.
             debugger_path or '@string debugger-path',
-            g.os_path_join(pythonDir, 'Lib', 'site-packages', 'winpdb.py'),  # winpdb 1.1.2 or newer.
+            g.os_path_join(
+                pythonDir, 'Lib', 'site-packages', 'winpdb.py'
+            ),  # winpdb 1.1.2 or newer.
             g.os_path_join(pythonDir, 'scripts', '_winpdb.py'),  # Older version.
         )
         for debugger in debuggers:

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -2325,9 +2325,10 @@ class EditCommandsClass(BaseEditCommandsClass):
         else:
             w.insert(i, ch)
             w.setInsertPoint(i + 1)
-            if c.autoindent_in_nocolor or (
-                c.frame.body.colorizer.useSyntaxColoring(p) and undoType != "Change"
-            ):
+            if (
+                c.autoindent_in_nocolor
+                or c.frame.body.colorizer.useSyntaxColoring(p) and undoType != "Change"
+            ):  # fmt: skip
                 # No auto-indent if in @nocolor mode or after a Change command.
                 self.updateAutoIndent(p, w)
         w.seeInsertPoint()

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -517,7 +517,9 @@ class EditCommandsClass(BaseEditCommandsClass):
             start_text = w.getAllText()[: w.getInsertPoint()]
             if start_text:
                 # make non-path characters whitespace
-                start_text = ''.join(i if i not in '\'"`()[]{}<>!|*,@#$&' else ' ' for i in start_text)
+                start_text = ''.join(
+                    i if i not in '\'"`()[]{}<>!|*,@#$&' else ' ' for i in start_text
+                )
                 if start_text[-1].isspace():  # use node path if nothing typed
                     start_text = ''
                 else:
@@ -1491,7 +1493,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         c.setChanged()
 
     # @+node:ekr.20150514063305.241: *4* ec.insertIconFromFile
-    def insertIconFromFile(self, path: str, p: Position = None, pos: int = None, **kargs: KWargs) -> None:
+    def insertIconFromFile(
+        self, path: str, p: Position = None, pos: int = None, **kargs: KWargs
+    ) -> None:
         c = self.c
         if not p:
             p = c.p
@@ -2277,7 +2281,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         w.flashCharacter(i, bg, fg, flashes, delay)
 
     # @+node:ekr.20150514063305.272: *5* ec.flashMatchingBracketsHelper
-    def flashMatchingBracketsHelper(self, c: Cmdr, ch: str, i: int, p: Position, w: Wrapper) -> None:
+    def flashMatchingBracketsHelper(
+        self, c: Cmdr, ch: str, i: int, p: Position, w: Wrapper
+    ) -> None:
         """Flash matching brackets at char ch at position i at widget w."""
         d = {}
         # pylint: disable=consider-using-enumerate
@@ -2319,7 +2325,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         else:
             w.insert(i, ch)
             w.setInsertPoint(i + 1)
-            if c.autoindent_in_nocolor or (c.frame.body.colorizer.useSyntaxColoring(p) and undoType != "Change"):
+            if c.autoindent_in_nocolor or (
+                c.frame.body.colorizer.useSyntaxColoring(p) and undoType != "Change"
+            ):
                 # No auto-indent if in @nocolor mode or after a Change command.
                 self.updateAutoIndent(p, w)
         w.seeInsertPoint()
@@ -2363,7 +2371,9 @@ class EditCommandsClass(BaseEditCommandsClass):
             w.seeInsertPoint()  # 2011/10/02: Fix cursor-movement bug.
 
     # @+node:ekr.20150514063305.276: *5* ec.updateAutomatchBracket
-    def updateAutomatchBracket(self, p: Position, w: Wrapper, ch: str, oldSel: tuple[int, int]) -> None:
+    def updateAutomatchBracket(
+        self, p: Position, w: Wrapper, ch: str, oldSel: tuple[int, int]
+    ) -> None:
         c = self.c
         language = c.getLanguage(p)
         i, j = oldSel
@@ -3021,7 +3031,9 @@ class EditCommandsClass(BaseEditCommandsClass):
 
     # @+node:ekr.20150514063305.302: *4* ec.extend-to-word
     @cmd('extend-to-word')
-    def extendToWord(self, event: LeoKeyEvent, select: bool = True, w: Wrapper = None) -> tuple[int, int]:
+    def extendToWord(
+        self, event: LeoKeyEvent, select: bool = True, w: Wrapper = None
+    ) -> tuple[int, int]:
         """Compute the word at the cursor. Select it if select arg is True."""
         if not w:
             w = self.editWidget(event)
@@ -3174,7 +3186,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         self.movePageHelper(event, kind='forward', extend=True)
 
     # @+node:ekr.20150514063305.307: *5* ec.movePageHelper
-    def movePageHelper(self, event: LeoKeyEvent, kind: str, extend: bool) -> None:  # kind in back/forward.
+    def movePageHelper(
+        self, event: LeoKeyEvent, kind: str, extend: bool
+    ) -> None:  # kind in back/forward.
         """Move the cursor up/down one page, possibly extending the selection."""
         w = self.editWidget(event)
         if not w:
@@ -3958,7 +3972,9 @@ class EditCommandsClass(BaseEditCommandsClass):
         return self.sortLines(event, ignoreCase=True)
 
     @cmd('sort-lines')
-    def sortLines(self, event: LeoKeyEvent, ignoreCase: bool = False, reverse: bool = False) -> None:
+    def sortLines(
+        self, event: LeoKeyEvent, ignoreCase: bool = False, reverse: bool = False
+    ) -> None:
         """Sort the selected lines."""
         w = self.editWidget(event)
         if not self._chckSel(event):

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -927,9 +927,8 @@ class GitDiffController:
         i: int,  # The index into contents_list and revs_list
         path: str,
         contents_list: list[list[str]],  # Lines for each contents.
-        node_patterns: list[
-            tuple[str, re.Pattern]
-        ],  # Patterns matching @+node sentinels for each gnx.
+        # Patterns matching @+node sentinels for each gnx.
+        node_patterns: list[tuple[str, re.Pattern]],
         revs_list: list[str],
     ) -> Optional[g.Bunch]:
         """

--- a/leo/commands/editFileCommands.py
+++ b/leo/commands/editFileCommands.py
@@ -292,7 +292,9 @@ class EditFileCommandsClass(BaseEditCommandsClass):
                 ("Leo files", "*.leo *.leojs *.db"),
                 ("All files", "*"),
             ]
-            fileName = g.app.gui.runOpenFileDialog(c, title="Compare Leo Files", filetypes=filetypes)
+            fileName = g.app.gui.runOpenFileDialog(
+                c, title="Compare Leo Files", filetypes=filetypes
+            )
             if not fileName:
                 return
             # Read the file into the hidden commander.
@@ -925,7 +927,9 @@ class GitDiffController:
         i: int,  # The index into contents_list and revs_list
         path: str,
         contents_list: list[list[str]],  # Lines for each contents.
-        node_patterns: list[tuple[str, re.Pattern]],  # Patterns matching @+node sentinels for each gnx.
+        node_patterns: list[
+            tuple[str, re.Pattern]
+        ],  # Patterns matching @+node sentinels for each gnx.
         revs_list: list[str],
     ) -> Optional[g.Bunch]:
         """
@@ -1251,7 +1255,9 @@ class GitDiffController:
         s2 = self.get_file_from_rev(rev2, fn)
         lines1 = g.splitLines(s1)
         lines2 = g.splitLines(s2)
-        diff_list = list(difflib.unified_diff(lines1, lines2, rev1 or 'uncommitted', rev2 or 'uncommitted'))
+        diff_list = list(
+            difflib.unified_diff(lines1, lines2, rev1 or 'uncommitted', rev2 or 'uncommitted')
+        )
         child = self.create_file_node(diff_list, fn)
         kind = 'Added' if not s1 else 'Deleted' if not s2 else 'Changed'
         child.h = f"{kind}: {fn}"
@@ -1593,7 +1599,9 @@ class GitDiffController:
         old_public_lines, junk = x.separate_sentinels(old_private_lines, marker)
         if old_public_lines:
             # Fix #1136: The old lines might not exist.
-            new_private_lines = x.propagate_changed_lines(new_public_lines, old_private_lines, marker, p=hidden_root)
+            new_private_lines = x.propagate_changed_lines(
+                new_public_lines, old_private_lines, marker, p=hidden_root
+            )
             at.fast_read_into_root(
                 c=hidden_c,
                 contents=''.join(new_private_lines),

--- a/leo/commands/gotoCommands.py
+++ b/leo/commands/gotoCommands.py
@@ -69,7 +69,9 @@ class GoToCommands:
                 return p, 0
             # #4355: Print a warning once.
             if not g.unitTesting:
-                g.es_print_unique_message('goto-global-line works only for @file, @clean, @edit and single @asis nodes')
+                g.es_print_unique_message(
+                    'goto-global-line works only for @file, @clean, @edit and single @asis nodes'
+                )
             return None, -1
         # Step 1: Get the lines of external files *with* sentinels,
         #         even if the actual external file actually contains no sentinels.
@@ -180,7 +182,9 @@ class GoToCommands:
         return None, -1
 
     # @+node:ekr.20181003080042.1: *3* goto.node_offset_to_file_line
-    def node_offset_to_file_line(self, target_offset: int, target_p: Position, root: Position) -> int:
+    def node_offset_to_file_line(
+        self, target_offset: int, target_p: Position, root: Position
+    ) -> int:
         """
         Given a zero-based target_offset within target_p.b, return the line
         number of the corresponding line within root's file.
@@ -222,7 +226,9 @@ class GoToCommands:
         return None
 
     # @+node:ekr.20150624085605.1: *3* goto.scan_nonsentinel_lines
-    def scan_nonsentinel_lines(self, lines: list[str], n: int, root: Position) -> tuple[str, str, int]:
+    def scan_nonsentinel_lines(
+        self, lines: list[str], n: int, root: Position
+    ) -> tuple[str, str, int]:
         """
         Scan a list of lines containing sentinels, looking for the node and
         offset within the node of the n'th (one-based) line.

--- a/leo/commands/helpCommands.py
+++ b/leo/commands/helpCommands.py
@@ -399,7 +399,9 @@ class HelpCommandsClass(BaseEditCommandsClass):
                     s = title + textwrap.dedent(s)
                 else:
                     # Fixes bug 618570:
-                    s = title + ''.join([line.lstrip() if line.strip() else '\n' for line in g.splitLines(s)])
+                    s = title + ''.join(
+                        [line.lstrip() if line.strip() else '\n' for line in g.splitLines(s)]
+                    )
             else:
                 # @+<< set s to about help-for-command >>
                 # @+node:ekr.20150514063305.384: *5* << set s to about help-for-command >>

--- a/leo/commands/spellCommands.py
+++ b/leo/commands/spellCommands.py
@@ -810,7 +810,11 @@ class SpellTabHandler:
                         alts2 = sc.process_word(alt_word)
                         if alts2:
                             # Add the top three *new* suggestions to the top of alts.
-                            new_alts = [alts2[i] for i in range(3) if i < len(alts2) and alts2[i] not in alts]
+                            new_alts = [
+                                alts2[i]
+                                for i in range(3)
+                                if i < len(alts2) and alts2[i] not in alts
+                            ]
                             for z in reversed(new_alts):
                                 alts.insert(0, z)
                         else:

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -11899,7 +11899,7 @@ rest_comments_literal1_font_weight = normal
 If not given, Leo's beautifier uses Leo's pyproject.toml file.
 </t>
 <t tx="ekr.20260111055136.1"># If given, this setting overrides any value in pyproject.toml or ruff.toml
-# Leo uses 120 for its own files.</t>
+# Leo uses pyproject.toml to give line length.</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -141,9 +141,8 @@ class LeoApp:
         self.guiArgName: str = None  # The gui name given in --gui option.
         self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
-        self.loaded_session = (
-            False  # Set by startup logic to True if no files specified on the command line.
-        )
+        # Set by startup logic to True if no files specified on the command line.
+        self.loaded_session = False
         self.silentMode = False  # True: no signon.
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -141,7 +141,9 @@ class LeoApp:
         self.guiArgName: str = None  # The gui name given in --gui option.
         self.isTheme = False  # True: load files as theme files (ignore myLeoSettings.leo).
         self.listen_to_log_flag = False  # True: execute listen-to-log command.
-        self.loaded_session = False  # Set by startup logic to True if no files specified on the command line.
+        self.loaded_session = (
+            False  # Set by startup logic to True if no files specified on the command line.
+        )
         self.silentMode = False  # True: no signon.
         self.start_fullscreen = False  # For qt_frame plugin.
         self.start_maximized = False  # For qt_frame plugin.
@@ -158,7 +160,9 @@ class LeoApp:
         self.disable_redraw = False  # True: disable all redraws.
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
-        self.log_listener: Optional[Popen] = None  # The external process created by the 'listen-for-log' command.
+        self.log_listener: Optional[Popen] = (
+            None  # The external process created by the 'listen-for-log' command.
+        )
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.
         self.statsDict: dict[str, Value] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.
@@ -180,7 +184,9 @@ class LeoApp:
         self.leoEditorDir: str = None  # The leo-editor directory.
         self.loadDir: str = None  # The leo/core directory.
         self.machineDir: str = None  # The machine-specific directory.
-        self.theme_directory: str = None  # The directory from which the theme file was loaded, if any.
+        self.theme_directory: str = (
+            None  # The directory from which the theme file was loaded, if any.
+        )
         # @-<< LeoApp: global directories >>
         # @+<< LeoApp: global data >>
         # @+node:ekr.20161028035956.1: *5* << LeoApp: global data >>
@@ -200,9 +206,13 @@ class LeoApp:
         # @+<< LeoApp: global controller/manager objects >>
         # @+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
         # Singleton applications objects...
-        self.backgroundProcessManager: BackgroundProcessManager = None  # A BackgroundProcessManager.
+        self.backgroundProcessManager: BackgroundProcessManager = (
+            None  # A BackgroundProcessManager.
+        )
         self.config: GlobalConfigManager = None  # g.app.config.
-        self.db: Union[dict, SqlitePickleShare] = None  # A global db, managed by g.app.global_cacher.
+        self.db: Union[dict, SqlitePickleShare] = (
+            None  # A global db, managed by g.app.global_cacher.
+        )
         self.externalFilesController: ExternalFilesController = None
         self.global_cacher: Union[dict, GlobalCacher] = None
         self.idleTimeManager: IdleTimeManager = None
@@ -242,7 +252,9 @@ class LeoApp:
         # @-<< LeoApp: global importer/reader/writer data >>
         # @+<< LeoApp: global status vars >>
         # @+node:ekr.20161028040054.1: *5* << LeoApp: global status vars >>
-        self.already_open_files: list[str] = []  # A list of file names that *might* be open in another copy of Leo.
+        self.already_open_files: list[
+            str
+        ] = []  # A list of file names that *might* be open in another copy of Leo.
         self.dragging = False  # True: dragging.
         self.inBridge = False  # True: running from leoBridge module.
         self.inScript = False  # True: executing a script.
@@ -262,7 +274,9 @@ class LeoApp:
         self.log: LeoFrame = None  # The LeoFrame containing the present log.
         self.logInited = False  # False: all log message go to logWaiting list.
         self.logIsLocked = False  # True: no changes to log are allowed.
-        self.logWaiting: list[tuple] = []  # List of tuples (s, color, newline) waiting to go to a log.
+        self.logWaiting: list[
+            tuple
+        ] = []  # List of tuples (s, color, newline) waiting to go to a log.
         self.printWaiting: list[str] = []  # Queue of messages to be sent to the printer.
         self.signon = ''
         self.signon1 = ''
@@ -284,9 +298,13 @@ class LeoApp:
         # @-<< LeoApp: plugins and event handlers >>
         # @+<< LeoApp: scripting ivars >>
         # @+node:ekr.20161028040303.1: *5* << LeoApp: scripting ivars >>
-        self.scriptDict: dict[str, Value] = {}  # For use by scripts. Cleared before running each script.
+        self.scriptDict: dict[
+            str, Value
+        ] = {}  # For use by scripts. Cleared before running each script.
         self.scriptResult: Value = None  # For use by leoPymacs.
-        self.permanentScriptDict: dict[str, Value] = {}  # For use by scripts. Never cleared automatically.
+        self.permanentScriptDict: dict[
+            str, Value
+        ] = {}  # For use by scripts. Never cleared automatically.
         # @-<< LeoApp: scripting ivars >>
         # Define all global data.
         self.init_at_auto_names()
@@ -2019,7 +2037,9 @@ class LoadManager:
                 val = settings_d2.get(key)
                 if val:
                     fn = g.shortFileName(val.path)
-                    g.es_print(f"--trace-setting: in {fn:20}: @{val.kind} {g.app.trace_setting}={val.val}")
+                    g.es_print(
+                        f"--trace-setting: in {fn:20}: @{val.kind} {g.app.trace_setting}={val.val}"
+                    )
             settings_d = settings_d.copy()
             settings_d.update(settings_d2)
         if shortcuts_d2:
@@ -2034,7 +2054,9 @@ class LoadManager:
         return settings_d, bindings_d
 
     # @+node:ekr.20120214165710.10726: *4* LM.createSettingsDicts
-    def createSettingsDicts(self, c: Cmdr, localFlag: bool) -> Optional[tuple[g.SettingsDict, g.SettingsDict]]:
+    def createSettingsDicts(
+        self, c: Cmdr, localFlag: bool
+    ) -> Optional[tuple[g.SettingsDict, g.SettingsDict]]:
         from leo.core import leoConfig
 
         if c:
@@ -2111,7 +2133,9 @@ class LoadManager:
                 g.es_print(f"--trace-binding: {c.shortFileName()} sets {binding} to None")
             elif localFlag and binding in c.commandsDict:
                 d = c.k.computeInverseBindingDict()
-                g.trace(f"--trace-binding: {c.shortFileName():20} binds {binding} to {d.get(binding) or []}")
+                g.trace(
+                    f"--trace-binding: {c.shortFileName():20} binds {binding} to {d.get(binding) or []}"
+                )
             else:
                 stroke = g.KeyStroke(binding)
                 bi_list = inverted_new_d.get(stroke)
@@ -2124,7 +2148,9 @@ class LoadManager:
                             pane = f" in {bi.pane} panes"
                         else:
                             pane = ''
-                        g.es_print(f"--trace-binding: {fn:20} binds {stroke2} to {bi.commandName:>20}{pane}")
+                        g.es_print(
+                            f"--trace-binding: {fn:20} binds {stroke2} to {bi.commandName:>20}{pane}"
+                        )
                     print('')
             # @-<< trace the binding >>
         # Check for duplicate shortcuts only in the new file.
@@ -2250,7 +2276,9 @@ class LoadManager:
         for c in commanders:
             # Merge the settings dicts from c's outline into
             # *new copies of* settings_d and bindings_d.
-            settings_d, bindings_d = lm.computeLocalSettings(c, settings_d, bindings_d, localFlag=False)
+            settings_d, bindings_d = lm.computeLocalSettings(
+                c, settings_d, bindings_d, localFlag=False
+            )
         # Adjust the name.
         bindings_d.setName('lm.globalBindingsDict')
         lm.globalSettingsDict = settings_d
@@ -2614,7 +2642,9 @@ class LoadManager:
         # Allow plugins to be defined in ~/.leo/plugins.
         for pattern in (
             g.finalize_join(g.app.homeDir, '.leo', 'plugins'),  # ~/.leo/plugins.
-            g.finalize_join(g.app.loadDir, '..', 'plugins', 'writers', '*.py'),  # leo/plugins/writers
+            g.finalize_join(
+                g.app.loadDir, '..', 'plugins', 'writers', '*.py'
+            ),  # leo/plugins/writers
         ):
             for filename in g.glob_glob(pattern):
                 sfn = g.shortFileName(filename)
@@ -3285,7 +3315,9 @@ class LoadManager:
             c.redraw()
         elif c.looksLikeDerivedFile(fn):
             # 2011/10/10: Create an @file node.
-            p = c.importCommands.importDerivedFiles(parent=c.rootPosition(), paths=[fn], command=None)  # Not undoable.
+            p = c.importCommands.importDerivedFiles(
+                parent=c.rootPosition(), paths=[fn], command=None
+            )  # Not undoable.
             if not p:
                 return None
             if p.hasBack():
@@ -3412,7 +3444,9 @@ class LoadManager:
 
         if c.looksLikeDerivedFile(fn):
             # Create an @file node.
-            p = c.importCommands.importDerivedFiles(parent=c.rootPosition(), paths=[fn], command=None)  # Not undoable.
+            p = c.importCommands.importDerivedFiles(
+                parent=c.rootPosition(), paths=[fn], command=None
+            )  # Not undoable.
             if not p:
                 return
             if p.hasBack():
@@ -3636,7 +3670,9 @@ class RecentFilesManager:
             if name.strip() == "":
                 continue  # happens with empty list/new file
 
-            def recentFilesCallback(event: LeoKeyEvent = None, c: Cmdr = c, name: str = name) -> None:
+            def recentFilesCallback(
+                event: LeoKeyEvent = None, c: Cmdr = c, name: str = name
+            ) -> None:
                 c.openRecentFile(fn=name)
 
             if groupedEntries:
@@ -3866,7 +3902,11 @@ class RecentFilesManager:
                     ok = rf.writeRecentFilesFileHelper(fileName)
                     if ok:
                         written = True
-                    if not rf.recentFileMessageWritten and not g.unitTesting and not g.app.silentMode:  # #459:
+                    if (
+                        not rf.recentFileMessageWritten
+                        and not g.unitTesting
+                        and not g.app.silentMode
+                    ):  # #459:
                         if ok:
                             g.es_print(f"wrote recent file: {fileName}")
                         else:

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -159,9 +159,8 @@ class LeoApp:
         self.disable_redraw = False  # True: disable all redraws.
         self.disableSave = False  # May be set by plugins.
         self.idle_timers: list[IdleTime] = []  # A list of IdleTime instances, so they persist.
-        self.log_listener: Optional[Popen] = (
-            None  # The external process created by the 'listen-for-log' command.
-        )
+        # The external process created by the 'listen-for-log' command.
+        self.log_listener: Optional[Popen] = None
         self.positions = 0  # The number of positions generated.
         self.scanErrors = 0  # The number of errors seen by g.scanError.
         self.statsDict: dict[str, Value] = {}  # dict used by g.stat, g.clear_stats, g.print_stats.
@@ -183,9 +182,8 @@ class LeoApp:
         self.leoEditorDir: str = None  # The leo-editor directory.
         self.loadDir: str = None  # The leo/core directory.
         self.machineDir: str = None  # The machine-specific directory.
-        self.theme_directory: str = (
-            None  # The directory from which the theme file was loaded, if any.
-        )
+        # The directory from which the theme file was loaded, if any.
+        self.theme_directory: str = None
         # @-<< LeoApp: global directories >>
         # @+<< LeoApp: global data >>
         # @+node:ekr.20161028035956.1: *5* << LeoApp: global data >>

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -203,13 +203,12 @@ class LeoApp:
         # @+<< LeoApp: global controller/manager objects >>
         # @+node:ekr.20161028040028.1: *5* << LeoApp: global controller/manager objects >>
         # Singleton applications objects...
-        self.backgroundProcessManager: BackgroundProcessManager = (
-            None  # A BackgroundProcessManager.
-        )
+
+        # A BackgroundProcessManager.
+        self.backgroundProcessManager: BackgroundProcessManager = None
         self.config: GlobalConfigManager = None  # g.app.config.
-        self.db: Union[dict, SqlitePickleShare] = (
-            None  # A global db, managed by g.app.global_cacher.
-        )
+        # A global db, managed by g.app.global_cacher.
+        self.db: Union[dict, SqlitePickleShare] = None
         self.externalFilesController: ExternalFilesController = None
         self.global_cacher: Union[dict, GlobalCacher] = None
         self.idleTimeManager: IdleTimeManager = None
@@ -249,9 +248,8 @@ class LeoApp:
         # @-<< LeoApp: global importer/reader/writer data >>
         # @+<< LeoApp: global status vars >>
         # @+node:ekr.20161028040054.1: *5* << LeoApp: global status vars >>
-        self.already_open_files: list[
-            str
-        ] = []  # A list of file names that *might* be open in another copy of Leo.
+        # A list of file names that *might* be open in another copy of Leo.
+        self.already_open_files: list[str] = []
         self.dragging = False  # True: dragging.
         self.inBridge = False  # True: running from leoBridge module.
         self.inScript = False  # True: executing a script.
@@ -268,13 +266,16 @@ class LeoApp:
         # @-<< LeoApp: global status vars >>
         # @+<< LeoApp: the global log >>
         # @+node:ekr.20161028040141.1: *5* << LeoApp: the global log >>
-        self.log: LeoFrame = None  # The LeoFrame containing the present log.
-        self.logInited = False  # False: all log message go to logWaiting list.
-        self.logIsLocked = False  # True: no changes to log are allowed.
-        self.logWaiting: list[
-            tuple
-        ] = []  # List of tuples (s, color, newline) waiting to go to a log.
-        self.printWaiting: list[str] = []  # Queue of messages to be sent to the printer.
+        # The LeoFrame containing the present log.
+        self.log: LeoFrame = None
+        # False: all log message go to logWaiting list.
+        self.logInited = False
+        # True: no changes to log are allowed.
+        self.logIsLocked = False
+        # List of tuples (s, color, newline) waiting to go to a log.
+        self.logWaiting: list[tuple] = []
+        # Queue of messages to be sent to the printer.
+        self.printWaiting: list[str] = []
         self.signon = ''
         self.signon1 = ''
         self.signon2 = ''
@@ -2638,10 +2639,10 @@ class LoadManager:
 
         # Allow plugins to be defined in ~/.leo/plugins.
         for pattern in (
-            g.finalize_join(g.app.homeDir, '.leo', 'plugins'),  # ~/.leo/plugins.
-            g.finalize_join(
-                g.app.loadDir, '..', 'plugins', 'writers', '*.py'
-            ),  # leo/plugins/writers
+            # ~/.leo/plugins.
+            g.finalize_join(g.app.homeDir, '.leo', 'plugins'),
+            # leo/plugins/writers
+            g.finalize_join(g.app.loadDir, '..', 'plugins', 'writers', '*.py'),
         ):
             for filename in g.glob_glob(pattern):
                 sfn = g.shortFileName(filename)
@@ -3311,10 +3312,10 @@ class LoadManager:
             c.selectPosition(p)
             c.redraw()
         elif c.looksLikeDerivedFile(fn):
-            # 2011/10/10: Create an @file node.
+            # Create an @file node. Not undoable!
             p = c.importCommands.importDerivedFiles(
                 parent=c.rootPosition(), paths=[fn], command=None
-            )  # Not undoable.
+            )
             if not p:
                 return None
             if p.hasBack():
@@ -3440,10 +3441,10 @@ class LoadManager:
             return  # Should not happen.
 
         if c.looksLikeDerivedFile(fn):
-            # Create an @file node.
+            # Create an @file node. Not undoable!
             p = c.importCommands.importDerivedFiles(
                 parent=c.rootPosition(), paths=[fn], command=None
-            )  # Not undoable.
+            )
             if not p:
                 return
             if p.hasBack():

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -745,9 +745,10 @@ if 1:  # pragma: no cover
     # @+node:ekr.20200120110005.1: *4* function: is_statement_node
     def is_statement_node(node: Node) -> bool:
         """Return True if node is a top-level statement."""
-        return is_long_statement(node) or isinstance(
-            node, (ast.Break, ast.Continue, ast.Pass, ast.Try)
-        )
+        return (
+            is_long_statement(node)
+            or isinstance(node, (ast.Break, ast.Continue, ast.Pass, ast.Try))
+        )  # fmt: skip
 
     # @+node:ekr.20191231082137.1: *4* function: nearest_common_ancestor
     def nearest_common_ancestor(node1: Node, node2: Node) -> Optional[Node]:

--- a/leo/core/leoAst.py
+++ b/leo/core/leoAst.py
@@ -745,7 +745,9 @@ if 1:  # pragma: no cover
     # @+node:ekr.20200120110005.1: *4* function: is_statement_node
     def is_statement_node(node: Node) -> bool:
         """Return True if node is a top-level statement."""
-        return is_long_statement(node) or isinstance(node, (ast.Break, ast.Continue, ast.Pass, ast.Try))
+        return is_long_statement(node) or isinstance(
+            node, (ast.Break, ast.Continue, ast.Pass, ast.Try)
+        )
 
     # @+node:ekr.20191231082137.1: *4* function: nearest_common_ancestor
     def nearest_common_ancestor(node1: Node, node2: Node) -> Optional[Node]:
@@ -1005,7 +1007,9 @@ class AstDumper:  # pragma: no cover
         if isinstance(node, ast.AST):
             fields = [(a, self.dump_ast(b, level + 1)) for a, b in self.get_fields(node)]
             if self.include_attributes and node._attributes:
-                fields.extend([(a, self.dump_ast(getattr(node, a), level + 1)) for a in node._attributes])
+                fields.extend(
+                    [(a, self.dump_ast(getattr(node, a), level + 1)) for a in node._attributes]
+                )
             if self.annotate_fields:
                 aList = ['%s=%s' % (a, b) for a, b in fields]
             else:
@@ -1055,7 +1059,11 @@ class Fstringify:
         # Main pass.
         string_node = ast.Str if g.python_version_tuple < (3, 12, 0) else ast.Constant  # pylint: disable=no-member
         for node in ast.walk(tree):
-            if isinstance(node, ast.BinOp) and op_name(node.op) == '%' and isinstance(node.left, string_node):
+            if (
+                isinstance(node, ast.BinOp)
+                and op_name(node.op) == '%'
+                and isinstance(node.left, string_node)
+            ):
                 self.make_fstring(node)
         results = tokens_to_string(self.tokens)
         return results
@@ -1382,7 +1390,9 @@ class Fstringify:
         return [tokens]
 
     # @+node:ekr.20191226155316.1: *4* fs.substitute_values
-    def substitute_values(self, lt_s: str, specs: list[re.Match], values: list[list[Token]]) -> list[Token]:
+    def substitute_values(
+        self, lt_s: str, specs: list[re.Match], values: list[list[Token]]
+    ) -> list[Token]:
         """
         Replace specifiers with values in lt_s string.
 
@@ -1933,7 +1943,9 @@ class TokenOrderGenerator:
         self.token('endmarker', '')
 
     # @+node:ekr.20191229071733.1: *4* tog.init_from_file
-    def init_from_file(self, filename: str) -> tuple[str, str, list[Token], Node]:  # pragma: no cover
+    def init_from_file(
+        self, filename: str
+    ) -> tuple[str, str, list[Token], Node]:  # pragma: no cover
         """
         Create the tokens and ast tree for the given file.
         Create links between tokens and the parse tree.
@@ -1950,7 +1962,9 @@ class TokenOrderGenerator:
         return contents, encoding, tokens, tree
 
     # @+node:ekr.20191229071746.1: *4* tog.init_from_string
-    def init_from_string(self, contents: str, filename: str) -> tuple[list[Token], Node]:  # pragma: no cover
+    def init_from_string(
+        self, contents: str, filename: str
+    ) -> tuple[list[Token], Node]:  # pragma: no cover
         """
         Tokenize, parse and create links in the contents string.
 
@@ -3520,7 +3534,9 @@ def scan_ast_args() -> tuple[object, dict[str, object], list[str]]:
     description = textwrap.dedent("""\
         Execute fstringify or beautify commands contained in leoAst.py.
     """)
-    parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=description, formatter_class=argparse.RawTextHelpFormatter
+    )
     parser.add_argument('PATHS', nargs='*', help='directory or list of files')
     group = parser.add_mutually_exclusive_group(required=False)  # Don't require any args.
     add = group.add_argument

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2423,8 +2423,9 @@ class AtFile:
         else:  # pragma: no cover
             # Do give this error even if unit testing.
             at.writeError(
-                f"undefined section: {g.truncate(name, 60)}\n  referenced from: {g.truncate(p.h, 60)}"
-            )
+                f"undefined section: {g.truncate(name, 60)}\n"
+                f"  referenced from: {g.truncate(p.h, 60)}"
+            )  # fmt: skip
 
     # @+node:ekr.20041005105605.180: *5* writing doc lines...
     # @+node:ekr.20041005105605.181: *6* at.putBlankDocLine

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -232,7 +232,9 @@ class AtFile:
 
         # Set other ivars.
         at.sentinels = True
-        at.force_newlines_in_at_nosent_bodies = c.config.getBool('force-newlines-in-at-nosent-bodies')
+        at.force_newlines_in_at_nosent_bodies = c.config.getBool(
+            'force-newlines-in-at-nosent-bodies'
+        )
         # For at.putBody only.
 
         at.encoding = c.getEncoding(root)
@@ -764,12 +766,16 @@ class AtFile:
             at.bodies_dict[p.v] = p.b
 
         # Calculate data.
-        new_public_lines = g.splitLines(new_contents) if new_contents else at.read_at_clean_lines(fileName)
+        new_public_lines = (
+            g.splitLines(new_contents) if new_contents else at.read_at_clean_lines(fileName)
+        )
         old_private_lines = self.write_at_clean_sentinels(root)
         marker = x.markerFromFileLines(old_private_lines, fileName)
         old_public_lines, junk = x.separate_sentinels(old_private_lines, marker)
         if old_public_lines:
-            new_private_lines = x.propagate_changed_lines(new_public_lines, old_private_lines, marker, p=root)
+            new_private_lines = x.propagate_changed_lines(
+                new_public_lines, old_private_lines, marker, p=root
+            )
         else:
             new_private_lines = []
             root.b = ''.join(new_public_lines)
@@ -889,9 +895,13 @@ class AtFile:
         new_public_lines = g.splitLines(contents)
         old_private_lines = self.write_at_clean_sentinels(root)
         old_public_lines, junk = x.separate_sentinels(old_private_lines, marker)
-        new_private_lines = x.propagate_changed_lines(new_public_lines, old_private_lines, marker, p=root)
+        new_private_lines = x.propagate_changed_lines(
+            new_public_lines, old_private_lines, marker, p=root
+        )
         if old_public_lines:  # Don't even *think* about removing this test.
-            new_private_lines = x.propagate_changed_lines(new_public_lines, old_private_lines, marker, p=root)
+            new_private_lines = x.propagate_changed_lines(
+                new_public_lines, old_private_lines, marker, p=root
+            )
         else:
             # This is not an error, it is
             # the first time the @jupytext has been read.
@@ -1398,7 +1408,9 @@ class AtFile:
         g.es('unless you can save the file successfully.', color='red')
 
     # @+node:ekr.20190108112519.1: *6* at.reportEndOfWrite
-    def reportEndOfWrite(self, files: list[Position], all: bool, dirty: bool) -> None:  # pragma: no cover
+    def reportEndOfWrite(
+        self, files: list[Position], all: bool, dirty: bool
+    ) -> None:  # pragma: no cover
         at = self
         if g.unitTesting:
             return
@@ -1774,7 +1786,9 @@ class AtFile:
                 # The hook must print an error message.
                 return False
 
-            contents = ''.join([s for s in g.splitLines(p.b) if at.directiveKind4(s, 0) == at.noDirective])
+            contents = ''.join(
+                [s for s in g.splitLines(p.b) if at.directiveKind4(s, 0) == at.noDirective]
+            )
             at.replaceFile(contents, at.encoding, fileName, root)
             c.raise_error_dialogs(kind='write')
             return True
@@ -1839,7 +1853,9 @@ class AtFile:
 
             # Write a minimal Jupyter file if the @jupytext tree is empty.
             if not root.b.strip() and not root.hasChildren():
-                prefix_list = c.config.getData('jupyter-prefix', strip_comments=False, strip_data=False)
+                prefix_list = c.config.getData(
+                    'jupyter-prefix', strip_comments=False, strip_data=False
+                )
                 if prefix_list:
                     prefix = ''.join(prefix_list)
                     root.b = prefix.strip() + '\n\n'
@@ -2049,7 +2065,9 @@ class AtFile:
             if not fileName:
                 at.addToOrphanList(root)
                 return ''
-            contents = ''.join([s for s in g.splitLines(root.b) if at.directiveKind4(s, 0) == at.noDirective])
+            contents = ''.join(
+                [s for s in g.splitLines(root.b) if at.directiveKind4(s, 0) == at.noDirective]
+            )
             return contents
         except Exception:
             at.writeException(fileName, root)
@@ -2194,7 +2212,9 @@ class AtFile:
                 status.at_comment_seen = True
             elif g.match_word(s, i, '@delims'):
                 status.at_delims_seen = True
-            if status.at_comment_seen and status.at_delims_seen and not status.at_warning_given:  # pragma: no cover
+            if (
+                status.at_comment_seen and status.at_delims_seen and not status.at_warning_given
+            ):  # pragma: no cover
                 status.at_warning_given = True
                 at.error(f"@comment and @delims in node {p.h}")
             at.putDirective(s, i, p)
@@ -2402,7 +2422,9 @@ class AtFile:
             at.putCodeLine(s, i)
         else:  # pragma: no cover
             # Do give this error even if unit testing.
-            at.writeError(f"undefined section: {g.truncate(name, 60)}\n  referenced from: {g.truncate(p.h, 60)}")
+            at.writeError(
+                f"undefined section: {g.truncate(name, 60)}\n  referenced from: {g.truncate(p.h, 60)}"
+            )
 
     # @+node:ekr.20041005105605.180: *5* writing doc lines...
     # @+node:ekr.20041005105605.181: *6* at.putBlankDocLine
@@ -2578,7 +2600,9 @@ class AtFile:
         c.orphan_at_file_nodes.append(root.h)
 
     # @+node:ekr.20090514111518.5661: *5* at.checkPythonCode & helpers
-    def checkPythonCode(self, contents: str, fileName: str, root: Position) -> None:  # pragma: no cover
+    def checkPythonCode(
+        self, contents: str, fileName: str, root: Position
+    ) -> None:  # pragma: no cover
         """Perform python-related checks on root."""
         if not g.app.log:
             return  # We are auto-saving.
@@ -3332,7 +3356,9 @@ class AtFile:
         p.v.tempAttributes['read-path'] = d
 
     # @+node:ekr.20090712050729.6017: *4* at.promptForDangerousWrite
-    def promptForDangerousWrite(self, fileName: str, message: str = None) -> bool:  # pragma: no cover
+    def promptForDangerousWrite(
+        self, fileName: str, message: str = None
+    ) -> bool:  # pragma: no cover
         """Raise a dialog asking the user whether to overwrite an existing file."""
         at, c, root = self, self.c, self.root
         if at.cancelFlag:
@@ -3950,7 +3976,9 @@ class FastAtRead:
                     # Carefully update the section reference pattern!
                     section_delim1 = d1 = re.escape(m.group(1))
                     section_delim2 = d2 = re.escape(m.group(2) or '')
-                    self.ref_pat = re.compile(rf'^(\s*){comment_delim1}@(\+|-){d1}(.*){d2}\s*{comment_delim2}$')
+                    self.ref_pat = re.compile(
+                        rf'^(\s*){comment_delim1}@(\+|-){d1}(.*){d2}\s*{comment_delim2}$'
+                    )
                 body.append(f"@section-delims {m.group(1)} {m.group(2)}\n")
                 continue
             # @-<< handle @section-delims >>

--- a/leo/core/leoBeautify.py
+++ b/leo/core/leoBeautify.py
@@ -81,7 +81,9 @@ def blacken_files_diff(event: LeoKeyEvent) -> None:
         path = c.fullPath(root)
         if path and os.path.exists(path):
             g.es_print(f"{tag}: {path}")
-            g.execute_shell_commands(f'&"{python}" -m black --skip-string-normalization --diff "{path}"')
+            g.execute_shell_commands(
+                f'&"{python}" -m black --skip-string-normalization --diff "{path}"'
+            )
         else:
             print(f"{tag}: file not found:{path}")
             g.es(f"{tag}: file not found:\n{path}")
@@ -269,7 +271,9 @@ class CPrettyPrinter:
         c.bodyWantsFocus()
 
     # @+node:ekr.20110917174948.6911: *3* cpp.indent & helpers
-    def indent(self, p: Position, toList: bool = False, giveWarnings: bool = True) -> Union[str, list[str]]:
+    def indent(
+        self, p: Position, toList: bool = False, giveWarnings: bool = True
+    ) -> Union[str, list[str]]:
         """Beautify a node with @language C in effect."""
         if not should_beautify(p):
             return [] if toList else ''  # #2271

--- a/leo/core/leoBridge.py
+++ b/leo/core/leoBridge.py
@@ -81,7 +81,9 @@ def controller(
     """Create an singleton instance of a bridge controller."""
     global gBridgeController
     if not gBridgeController:
-        gBridgeController = BridgeController(gui, loadPlugins, readSettings, silent, tracePlugins, useCaches, verbose)
+        gBridgeController = BridgeController(
+            gui, loadPlugins, readSettings, silent, tracePlugins, useCaches, verbose
+        )
     return gBridgeController
 
 

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -905,7 +905,9 @@ class BaseColorizer:
 
     # @+node:ekr.20170127142001.8: *5* BaseColorizer.findColorDirectives
     # Order is important: put longest matches first.
-    color_directives_pat = re.compile(r'(^@color|^@killcolor|^@nocolor-node|^@nocolor)', re.MULTILINE)
+    color_directives_pat = re.compile(
+        r'(^@color|^@killcolor|^@nocolor-node|^@nocolor)', re.MULTILINE
+    )
 
     def findColorDirectives(self, p: Position) -> dict[str, str]:
         """Return a dict with each color directive in p.b, without the leading '@'."""
@@ -963,7 +965,9 @@ class JEditColorizer(BaseColorizer):
         self.nested = False  # True: allow nested comments, etc.
         self.nested_level = 0  # Nesting level if self.nested is True.
         self.nextState = 1  # Don't use 0.
-        self.restartDict: dict[int, Callable] = {}  # Keys are state numbers, values are restart functions.
+        self.restartDict: dict[
+            int, Callable
+        ] = {}  # Keys are state numbers, values are restart functions.
         self.stateDict: dict[int, str] = {}  # Keys are state numbers, values state names.
         self.stateNameDict: dict[str, int] = {}  # Keys are state names, values are state numbers.
 
@@ -1028,7 +1032,9 @@ class JEditColorizer(BaseColorizer):
             self.section_delim2 = '>>'
 
     # @+node:ekr.20110605121601.18576: *4* jedit.addImportedRules
-    def addImportedRules(self, mode: JEditModeDescriptor, rulesDict: dict[str, RuleSet], rulesetName: str) -> None:
+    def addImportedRules(
+        self, mode: JEditModeDescriptor, rulesDict: dict[str, RuleSet], rulesetName: str
+    ) -> None:
         """Append any imported rules at the end of the rulesets specified in mode.importDict"""
         if self.importedRulesets.get(rulesetName):
             return
@@ -2242,7 +2248,11 @@ class JEditColorizer(BaseColorizer):
             return 0
         if at_word_start and i > 0 and s[i - 1] in self.word_chars:
             return 0  # 7/5/2008
-        if at_word_start and i + len(pattern) + 1 < len(s) and s[i + len(pattern)] in self.word_chars:
+        if (
+            at_word_start
+            and i + len(pattern) + 1 < len(s)
+            and s[i + len(pattern)] in self.word_chars
+        ):
             return 0
         if g.match(s, i, pattern):
             j = i + len(pattern)
@@ -3102,7 +3112,9 @@ if QtGui:
         # This is c.frame.body.colorizer.highlighter
         # @+others
         # @+node:ekr.20110605121601.18566: *3* leo_h.ctor (sets style)
-        def __init__(self, c: Cmdr, colorizer: BaseColorizer, document: QtGui.QTextDocument) -> None:
+        def __init__(
+            self, c: Cmdr, colorizer: BaseColorizer, document: QtGui.QTextDocument
+        ) -> None:
             """ctor for LeoHighlighter class."""
             self.c = c
             self.colorizer = colorizer
@@ -3384,7 +3396,9 @@ class PygmentsColorizer(BaseColorizer):
 
     # @+node:ekr.20190319151826.78: *3* pyg_c.mainLoop & helpers
     format_dict: dict[str, str] = {}  # Keys are repr(Token), values are formats.
-    lexers_dict: dict[str, Lexer] = {}  # Keys are language names, values are instantiated, patched lexers.
+    lexers_dict: dict[
+        str, Lexer
+    ] = {}  # Keys are language names, values are instantiated, patched lexers.
     state_s_dict: dict[str, int] = {}  # Keys are strings, values are ints.
     state_n_dict: dict[int, str] = {}  # # Keys are ints, values are strings.
     state_index = 1  # Index of state number to be allocated.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -965,11 +965,12 @@ class JEditColorizer(BaseColorizer):
         self.nested = False  # True: allow nested comments, etc.
         self.nested_level = 0  # Nesting level if self.nested is True.
         self.nextState = 1  # Don't use 0.
-        self.restartDict: dict[
-            int, Callable
-        ] = {}  # Keys are state numbers, values are restart functions.
-        self.stateDict: dict[int, str] = {}  # Keys are state numbers, values state names.
-        self.stateNameDict: dict[str, int] = {}  # Keys are state names, values are state numbers.
+        # Keys are state numbers, values are restart functions.
+        self.restartDict: dict[int, Callable] = {}
+        # Keys are state numbers, values state names.
+        self.stateDict: dict[int, str] = {}
+        # Keys are state names, values are state numbers.
+        self.stateNameDict: dict[str, int] = {}
 
         # #2276: Set by init_section_delims.
         self.section_delim1 = '<<'

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -228,7 +228,9 @@ class Commands:
         """Init ivars used while executing a command."""
         self.commandsDict: dict[str, Callable] = {}  # Keys are command names, values are functions.
         self.disableCommandsMessage = ''  # The presence of this message disables all commands.
-        self.hookFunction: Optional[Callable] = None  # One of three places that g.doHook looks for hook functions.
+        self.hookFunction: Optional[Callable] = (
+            None  # One of three places that g.doHook looks for hook functions.
+        )
         self.ignoreChangedPaths = False  # True: disable path changed message in at.WriteAllHelper.
         self.inCommand = False  # Interlocks to prevent premature closing of a window.
         self.outlineToNowebDefaultFileName: str = "noweb.nw"  # For Outline To Noweb dialog.
@@ -254,7 +256,9 @@ class Commands:
         self.expansionNode = None  # The last node we expanded or contracted.
         self.nodeConflictList: list[Position] = []  # List of nodes with conflicting read-time data.
         self.nodeConflictFileName: Optional[str] = None  # The fileName for c.nodeConflictList.
-        self.user_dict: dict[str, Value] = {}  # Non-persistent dictionary for free use by scripts and plugins.
+        self.user_dict: dict[
+            str, Value
+        ] = {}  # Non-persistent dictionary for free use by scripts and plugins.
 
     # @+node:ekr.20120217070122.10467: *5* c.initEventIvars
     def initEventIvars(self) -> None:
@@ -279,9 +283,13 @@ class Commands:
         self.ignored_at_file_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
         self.import_error_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
         self.last_dir: str = None  # The last used directory.
-        self.mFileName: str = fileName or ''  # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
+        self.mFileName: str = (
+            fileName or ''
+        )  # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
         self.mRelativeFileName = relativeFileName or ''
-        self.orphan_at_file_nodes: list[Position] = []  # List of orphaned nodes for c.raise_error_dialogs.
+        self.orphan_at_file_nodes: list[
+            Position
+        ] = []  # List of orphaned nodes for c.raise_error_dialogs.
 
     # @+node:ekr.20120217070122.10470: *5* c.initObjects
     def initObjects(self, gui: LeoGui) -> None:
@@ -652,7 +660,9 @@ class Commands:
         c.fixedWindowPositionData = getData('fixedWindowPosition')
         c.focus_border_color = getColor('focus-border-color') or 'red'
         c.focus_border_command_state_color = getColor('focus-border-command-state-color') or 'blue'
-        c.focus_border_overwrite_state_color = getColor('focus-border-overwrite-state-color') or 'green'
+        c.focus_border_overwrite_state_color = (
+            getColor('focus-border-overwrite-state-color') or 'green'
+        )
         c.focus_border_width = getInt('focus-border-width') or 1  # pixels
         c.forceExecuteEntireBody = getBool('force-execute-entire-body', default=False)
         c.make_node_conflicts_node = getBool('make-node-conflicts-node', default=True)
@@ -1156,14 +1166,18 @@ class Commands:
                         'Cannot find a terminal to launch the external file',
                         color='red',
                     )
-                    g.es(f'   You can specify a terminal in an "@data {MAP_SETTING_NODE}" setting node')
+                    g.es(
+                        f'   You can specify a terminal in an "@data {MAP_SETTING_NODE}" setting node'
+                    )
                     g.es('  ', SETTINGS_HELP)
                     return
 
                 shell_name = getShell()
                 execute_arg = getTermExecuteCmd(term)
                 if (not processor) and checkShebang(fullpath):
-                    cmd_ = f"""{term} {execute_arg}"{shell_name} -c 'cd {direc}; {fullpath} ;read'" """
+                    cmd_ = (
+                        f"""{term} {execute_arg}"{shell_name} -c 'cd {direc}; {fullpath} ;read'" """
+                    )
                 elif processor:
                     cmd_ = f"""{term} {execute_arg}"{shell_name} -c 'cd {direc};{processor} {fullpath} ;read'" """
                 else:
@@ -1370,7 +1384,9 @@ class Commands:
                         namespace = namespace or {}
                         namespace.update(script_gnx=script_p.gnx)
                     # We *always* execute the script with p = c.p.
-                    callResult = c.executeScriptHelper(args, define_g, define_name, namespace, script)
+                    callResult = c.executeScriptHelper(
+                        args, define_g, define_name, namespace, script
+                    )
                 except KeyboardInterrupt:
                     g.es('interrupted')
                 except Exception:
@@ -2641,7 +2657,9 @@ class Commands:
 
         # For unit testing.
         strict = 'test:strict' in g.app.debug
-        verbose = any(z in g.app.debug for z in ('test:verbose', 'gnx', 'shutdown', 'startup', 'verbose'))
+        verbose = any(
+            z in g.app.debug for z in ('test:verbose', 'gnx', 'shutdown', 'startup', 'verbose')
+        )
         error_list, messages, n = find_errors()
         if n == 0:
             return 0
@@ -2743,7 +2761,9 @@ class Commands:
             g.es_exception()
             if dump:
                 # Write the invalid ouitline to the corresponding leo.txt file.
-                filename = os.path.normpath(os.path.expanduser(f"~/.leo/BAD-{c.shortFileName()}.txt"))
+                filename = os.path.normpath(
+                    os.path.expanduser(f"~/.leo/BAD-{c.shortFileName()}.txt")
+                )
                 try:
                     with open(filename, 'bw') as f:
                         for s in g.splitLines(translated_contents):
@@ -2776,7 +2796,9 @@ class Commands:
                     g.enl()
                 # @-<< print dots >>
             if c.getLanguage(p) == "python":
-                if not g.scanForAtSettings(p) and (not ignoreAtIgnore or not g.scanForAtIgnore(c, p)):
+                if not g.scanForAtSettings(p) and (
+                    not ignoreAtIgnore or not g.scanForAtIgnore(c, p)
+                ):
                     try:
                         c.checkPythonNode(p)
                     except (SyntaxError, tokenize.TokenError, tabnanny.NannyNag):
@@ -3856,7 +3878,11 @@ class Commands:
         # @+node:ekr.20250725152709.1: *5* << calculate the list of subdirectories >>
         # Default to all direct sub-directories of the top directory.
         if not sub_directories:
-            sub_directories = [z for z in os.listdir(top_directory) if os.path.isdir(os.path.join(top_directory, z))]
+            sub_directories = [
+                z
+                for z in os.listdir(top_directory)
+                if os.path.isdir(os.path.join(top_directory, z))
+            ]
         # @-<< calculate the list of subdirectories >>
         g.es_print(f"Scanning {len(sub_directories)} directories.\nThis may take awhile.")
         # The main loop.
@@ -4230,7 +4256,9 @@ class Commands:
                 g.es_print(import_message2)
                 if use_dialogs:
                     import_dialog_message = f"{import_message1}\n{import_message2}"
-                    g.app.gui.runAskOkDialog(c, message=import_dialog_message, title='Import errors')
+                    g.app.gui.runAskOkDialog(
+                        c, message=import_dialog_message, title='Import errors'
+                    )
         if c.ignored_at_file_nodes:
             files = '\n'.join(sorted(set(c.ignored_at_file_nodes)))  # type:ignore
             if files not in self.warnings_dict:
@@ -5488,7 +5516,9 @@ class Commands:
         u.beforeChangeGroup(u_node, undoType)
         changed_node = False
         for idx, head in enumerate(heads):
-            if parent is None and idx == 0:  # if parent = None, create top level node for first head
+            if (
+                parent is None and idx == 0
+            ):  # if parent = None, create top level node for first head
                 if not forcecreate:
                     for pos in self.all_positions():
                         if pos.h == head:
@@ -5568,7 +5598,11 @@ class Commands:
         for z in aList:
             try:
                 op, p, n = z
-                ok = op in ('insert', 'delete') and isinstance(p, leoNodes.position) and isinstance(n, int)
+                ok = (
+                    op in ('insert', 'delete')
+                    and isinstance(p, leoNodes.position)
+                    and isinstance(n, int)
+                )
                 if ok:
                     aList2 = d.get(p.v, [])
                     data = n, op
@@ -5694,7 +5728,8 @@ class Commands:
         c.configurables.sort(key=lambda obj: obj.__class__.__name__.lower())
         for obj in c.configurables:
             func = (
-                getattr(obj, 'reloadSettings', None) or getattr(obj, 'reload_settings', None)  # An official alias.
+                getattr(obj, 'reloadSettings', None)
+                or getattr(obj, 'reload_settings', None)  # An official alias.
             )
             if func:
                 try:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -255,9 +255,8 @@ class Commands:
         self.expansionNode = None  # The last node we expanded or contracted.
         self.nodeConflictList: list[Position] = []  # List of nodes with conflicting read-time data.
         self.nodeConflictFileName: Optional[str] = None  # The fileName for c.nodeConflictList.
-        self.user_dict: dict[
-            str, Value
-        ] = {}  # Non-persistent dictionary for free use by scripts and plugins.
+        # Non-persistent dictionary for free use by scripts and plugins.
+        self.user_dict: dict[str, Value] = {}
 
     # @+node:ekr.20120217070122.10467: *5* c.initEventIvars
     def initEventIvars(self) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -228,9 +228,8 @@ class Commands:
         """Init ivars used while executing a command."""
         self.commandsDict: dict[str, Callable] = {}  # Keys are command names, values are functions.
         self.disableCommandsMessage = ''  # The presence of this message disables all commands.
-        self.hookFunction: Optional[Callable] = (
-            None  # One of three places that g.doHook looks for hook functions.
-        )
+        # One of three places that g.doHook looks for hook functions.
+        self.hookFunction: Optional[Callable] = None
         self.ignoreChangedPaths = False  # True: disable path changed message in at.WriteAllHelper.
         self.inCommand = False  # Interlocks to prevent premature closing of a window.
         self.outlineToNowebDefaultFileName: str = "noweb.nw"  # For Outline To Noweb dialog.
@@ -283,13 +282,11 @@ class Commands:
         self.ignored_at_file_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
         self.import_error_nodes: list[Position] = []  # List of nodes for c.raise_error_dialogs.
         self.last_dir: str = None  # The last used directory.
-        self.mFileName: str = (
-            fileName or ''
-        )  # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
+        # Do _not_ use os_path_norm: it converts an empty path to '.' (!!)
+        self.mFileName: str = fileName or ''
         self.mRelativeFileName = relativeFileName or ''
-        self.orphan_at_file_nodes: list[
-            Position
-        ] = []  # List of orphaned nodes for c.raise_error_dialogs.
+        # List of orphaned nodes for c.raise_error_dialogs.
+        self.orphan_at_file_nodes: list[Position] = []
 
     # @+node:ekr.20120217070122.10470: *5* c.initObjects
     def initObjects(self, gui: LeoGui) -> None:
@@ -5516,9 +5513,8 @@ class Commands:
         u.beforeChangeGroup(u_node, undoType)
         changed_node = False
         for idx, head in enumerate(heads):
-            if (
-                parent is None and idx == 0
-            ):  # if parent = None, create top level node for first head
+            # if parent = None, create top level node for first head
+            if parent is None and idx == 0:
                 if not forcecreate:
                     for pos in self.all_positions():
                         if pos.h == head:
@@ -5727,10 +5723,8 @@ class Commands:
         c.configurables = list(set(c.configurables))
         c.configurables.sort(key=lambda obj: obj.__class__.__name__.lower())
         for obj in c.configurables:
-            func = (
-                getattr(obj, 'reloadSettings', None)
-                or getattr(obj, 'reload_settings', None)  # An official alias.
-            )
+            # An official alias.
+            func = getattr(obj, 'reloadSettings', None) or getattr(obj, 'reload_settings', None)
             if func:
                 try:
                     func()  # pylint: disable=not-callable

--- a/leo/core/leoCompare.py
+++ b/leo/core/leoCompare.py
@@ -266,14 +266,22 @@ class BaseLeoCompare:
                 if self.ignoreBlankLines and s1.isspace():
                     s1 = None
                     continue
-                if self.ignoreSentinelLines and sentinelComment1 and self.isSentinel(s1, sentinelComment1):
+                if (
+                    self.ignoreSentinelLines
+                    and sentinelComment1
+                    and self.isSentinel(s1, sentinelComment1)
+                ):
                     s1 = None
                     continue
             if s2:
                 if self.ignoreBlankLines and s2.isspace():
                     s2 = None
                     continue
-                if self.ignoreSentinelLines and sentinelComment2 and self.isSentinel(s2, sentinelComment2):
+                if (
+                    self.ignoreSentinelLines
+                    and sentinelComment2
+                    and self.isSentinel(s2, sentinelComment2)
+                ):
                     s2 = None
                     continue
             # @-<< ignore blank lines and/or sentinels >>
@@ -552,7 +560,9 @@ class CompareLeoOutlines:
         return added, deleted, changed
 
     # @+node:ekr.20180211170333.6: *4* loc.create_compare_node
-    def create_compare_node(self, c1: Cmdr, c2: Cmdr, d: dict[str, tuple[VNode, VNode]], kind: str) -> None:
+    def create_compare_node(
+        self, c1: Cmdr, c2: Cmdr, d: dict[str, tuple[VNode, VNode]], kind: str
+    ) -> None:
         """Create nodes describing the changes."""
         if not d:
             return

--- a/leo/core/leoConfig.py
+++ b/leo/core/leoConfig.py
@@ -558,7 +558,11 @@ class ParserBaseClass:
                 if g.match_word(h, 0, tag):
                     itemName = h[len(tag) :].strip()
                     if itemName:
-                        lines = [z for z in g.splitLines(p.b) if z.strip() and not z.strip().startswith('#')]
+                        lines = [
+                            z
+                            for z in g.splitLines(p.b)
+                            if z.strip() and not z.strip().startswith('#')
+                        ]
                         # Only the first body line is significant.
                         # This allows following comment lines.
                         body = lines[0].strip() if lines else ''
@@ -678,7 +682,9 @@ class ParserBaseClass:
             self.valueError(p, kind, name, val)
 
     # @+node:ekr.20041120105609: *4* pbc.doShortcuts
-    def doShortcuts(self, p: Position, kind: str, junk_name: str, junk_val: Value, s: str = None) -> None:
+    def doShortcuts(
+        self, p: Position, kind: str, junk_name: str, junk_val: Value, s: str = None
+    ) -> None:
         """Handle an @shortcut or @shortcuts node."""
         c, d = self.c, self.shortcutsDict
         if s is None:
@@ -941,7 +947,9 @@ class ParserBaseClass:
     def traverse(self) -> tuple[Value, Value]:
         """Traverse the entire settings tree."""
         c = self.c
-        self.settingsDict: dict[str, list[g.GeneralSetting]] = g.SettingsDict(f"settingsDict for {c.shortFileName()}")
+        self.settingsDict: dict[str, list[g.GeneralSetting]] = g.SettingsDict(
+            f"settingsDict for {c.shortFileName()}"
+        )
         self.shortcutsDict = g.SettingsDict(f"shortcutsDict for {c.shortFileName()}")
         # This must be called after the outline has been inited.
         p = c.config.settingsRoot()
@@ -1316,7 +1324,11 @@ class GlobalConfigManager:
                 val = gs.val
                 if gs.kind == 'data':
                     # #748: Remove comments
-                    aList = [' ' * 8 + z.rstrip() for z in val if z.strip() and not z.strip().startswith('#')]
+                    aList = [
+                        ' ' * 8 + z.rstrip()
+                        for z in val
+                        if z.strip() and not z.strip().startswith('#')
+                    ]
                     if not aList:
                         val = '[]'
                     elif limit == 0 or len(aList) < limit:
@@ -1614,8 +1626,12 @@ class LocalConfigManager:
         if previousSettings:
             self.settingsDict = previousSettings.settingsDict
             self.shortcutsDict = previousSettings.shortcutsDict
-            assert isinstance(self.settingsDict, g.SettingsDict), self.settingsDict.__class__.__name__
-            assert isinstance(self.shortcutsDict, g.SettingsDict), self.shortcutsDict.__class__.__name__
+            assert isinstance(self.settingsDict, g.SettingsDict), (
+                self.settingsDict.__class__.__name__
+            )
+            assert isinstance(self.shortcutsDict, g.SettingsDict), (
+                self.shortcutsDict.__class__.__name__
+            )
         else:
             self.settingsDict = d1 = lm.globalSettingsDict
             self.shortcutsDict = d2 = lm.globalBindingsDict

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1724,8 +1724,12 @@ class FileCommands:
             for p in sp.self_and_subtree():
                 if hasattr(p.v, 'unknownAttributes') and len(p.v.unknownAttributes.keys()):
                     try:
-                        json.dumps(p.v.unknownAttributes, skipkeys=True, cls=SetJSONEncoder)  # If this test passes ok
-                        uas[p.v.gnx] = p.v.unknownAttributes  # Valid UA's as-is. UA's are NOT encoded.
+                        json.dumps(
+                            p.v.unknownAttributes, skipkeys=True, cls=SetJSONEncoder
+                        )  # If this test passes ok
+                        uas[p.v.gnx] = (
+                            p.v.unknownAttributes
+                        )  # Valid UA's as-is. UA's are NOT encoded.
                     except TypeError:
                         g.trace(f"Can not serialize uA for {p.h}", g.callers(6))
                         g.printObj(p.v.unknownAttributes)
@@ -1787,7 +1791,9 @@ class FileCommands:
             g.trace('set window_position:', c.db['window_position'], c.shortFileName())
 
     # @+node:ekr.20210316085413.2: *6* fc.leojs_vnodes
-    def leojs_vnode(self, p: Position, gnxSet: set[Value], isIgnore: bool = False) -> dict[str, Value]:
+    def leojs_vnode(
+        self, p: Position, gnxSet: set[Value], isIgnore: bool = False
+    ) -> dict[str, Value]:
         """Return a jsonized vnode."""
         # c = self.c
         fc = self
@@ -1901,7 +1907,9 @@ class FileCommands:
     def writeZipFile(self, s: str) -> None:
         """Write string s as a .zip file."""
         # The name of the file in the archive.
-        contentsName = g.toEncodedString(g.shortFileName(self.mFileName), self.leo_file_encoding, reportErrors=True)
+        contentsName = g.toEncodedString(
+            g.shortFileName(self.mFileName), self.leo_file_encoding, reportErrors=True
+        )
         # The name of the archive itself.
         fileName = g.toEncodedString(self.mFileName, self.leo_file_encoding, reportErrors=True)
         # Write the archive.

--- a/leo/core/leoFind.py
+++ b/leo/core/leoFind.py
@@ -640,7 +640,9 @@ class LeoFind:
     do_find_var = do_find_def
 
     # @+node:ekr.20240526125901.1: *6* find._load_quicksearch_entries
-    def _load_quicksearch_entries(self, word: str, matches: list[tuple[int, Position, str]]) -> None:
+    def _load_quicksearch_entries(
+        self, word: str, matches: list[tuple[int, Position, str]]
+    ) -> None:
         """Put all matches in the Nav pane."""
         c = self.c
         x = c.quicksearch_controller
@@ -974,7 +976,9 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.16916: *4* find.find-tab-open
     @cmd('find-tab-open')
-    def open_find_tab(self, event: LeoKeyEvent = None, show: bool = True) -> None:  # pragma: no cover (cmd)
+    def open_find_tab(
+        self, event: LeoKeyEvent = None, show: bool = True
+    ) -> None:  # pragma: no cover (cmd)
         """Open the Find tab in the log pane."""
         c = self.c
         if c.config.getBool('use-find-dialog', default=True):
@@ -1007,7 +1011,9 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.17019: *4* find.set-find-*
     @cmd('set-find-everywhere')
-    def set_find_scope_every_where(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (cmd)
+    def set_find_scope_every_where(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (cmd)
         """Set the 'Entire Outline' radio button in the Find tab."""
         self.set_find_scope('entire-outline')
 
@@ -1143,7 +1149,9 @@ class LeoFind:
     # @+node:ekr.20131117164142.16994: *4* find.change-all & helper
     @cmd('change-all')
     @cmd('replace-all')
-    def interactive_change_all(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def interactive_change_all(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         """Replace all instances of the search string with the replacement string."""
         self.ftm.clear_focus()
         self.ftm.set_entry_focus()
@@ -1156,7 +1164,9 @@ class LeoFind:
             escape_handler=self.interactive_replace_all1,
         )
 
-    def interactive_replace_all1(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_replace_all1(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         k = self.k
         find_pattern = k.arg
         self._sString = k.arg
@@ -1167,7 +1177,9 @@ class LeoFind:
         self.add_change_string_to_label()
         k.getNextArg(self.interactive_replace_all2)
 
-    def interactive_replace_all2(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_replace_all2(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
 
         # Update settings data.
@@ -1406,9 +1418,13 @@ class LeoFind:
             return
         if not preloaded:
             self.preload_find_pattern(w)
-        self.start_state_machine(event, prefix='Clone Find All: ', handler=self.interactive_clone_find_all1)
+        self.start_state_machine(
+            event, prefix='Clone Find All: ', handler=self.interactive_clone_find_all1
+        )
 
-    def interactive_clone_find_all1(self, event: LeoKeyEvent) -> int:  # pragma: no cover (interactive)
+    def interactive_clone_find_all1(
+        self, event: LeoKeyEvent
+    ) -> int:  # pragma: no cover (interactive)
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
         # Settings...
         pattern = k.arg
@@ -1466,7 +1482,9 @@ class LeoFind:
             return
         if not preloaded:
             self.preload_find_pattern(w)
-        self.start_state_machine(event, prefix='Clone Find All Flattened: ', handler=self.interactive_cff1)
+        self.start_state_machine(
+            event, prefix='Clone Find All Flattened: ', handler=self.interactive_cff1
+        )
 
     def interactive_cff1(self, event: LeoKeyEvent) -> int:  # pragma: no cover (interactive)
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
@@ -1506,7 +1524,9 @@ class LeoFind:
     @cmd('clone-find-tag')
     @cmd('find-clone-tag')
     @cmd('cft')
-    def interactive_clone_find_tag(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def interactive_clone_find_tag(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         """
         clone-find-tag (aka find-clone-tag and cft).
 
@@ -1525,7 +1545,9 @@ class LeoFind:
                 handler=self.interactive_clone_find_tag1,
             )
 
-    def interactive_clone_find_tag1(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_clone_find_tag1(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         c, k = self.c, self.k
         # Settings...
         self.find_text = tag = k.arg
@@ -1587,7 +1609,9 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.16998: *4* find.find-all & helper
     @cmd('find-all')
-    def interactive_find_all(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def interactive_find_all(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         """
         Create a summary node containing descriptions of all matches of the
         search string.
@@ -1603,7 +1627,9 @@ class LeoFind:
             escape_handler=self.find_all_escape_handler,
         )
 
-    def interactive_find_all1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def interactive_find_all1(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         k = self.k
         # Settings.
         find_pattern = k.arg
@@ -1629,7 +1655,9 @@ class LeoFind:
         self.add_change_string_to_label()
         k.getNextArg(self.find_all_escape_handler2)
 
-    def find_all_escape_handler2(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def find_all_escape_handler2(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         c, k, w = self.c, self.k, self.c.frame.body.wrapper
         find_pattern = self._sString
         change_pattern = k.arg
@@ -1881,7 +1909,9 @@ class LeoFind:
 
     # @+node:ekr.20250206055338.1: *4* find.find-source-for-command & helpers
     @cmd('find-source-for-command')
-    def find_source_for_command(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def find_source_for_command(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         """
         Create a summary node containing descriptions of all matches of the
         search string.
@@ -1894,7 +1924,9 @@ class LeoFind:
         self.findTextList = self.find_all_commands()
         self.start_state_machine(event, 'Command Name: ', handler=self.find_source_for_command1)
 
-    def find_source_for_command1(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def find_source_for_command1(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         k = self.k
         # Settings.
         find_pattern = k.arg
@@ -1998,7 +2030,9 @@ class LeoFind:
     # @+node:ekr.20131117164142.17003: *4* find.re-search
     @cmd('re-search')
     @cmd('re-search-forward')
-    def interactive_re_search_forward(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_re_search_forward(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         """Same as start-find, with regex."""
         # Set flag for show_find_options.
         self.pattern_match = True
@@ -2015,7 +2049,9 @@ class LeoFind:
 
     # @+node:ekr.20210112044303.1: *4* find.re-search-backward
     @cmd('re-search-backward')
-    def interactive_re_search_backward(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_re_search_backward(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         """Same as start-find, but with regex and in reverse."""
         # Set flags for show_find_options.
         self.reverse = True
@@ -2034,7 +2070,9 @@ class LeoFind:
 
     # @+node:ekr.20131117164142.17004: *4* find.search_backward
     @cmd('search-backward')
-    def interactive_search_backward(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_search_backward(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         """Same as start-find, but in reverse."""
         # Set flag for show_find_options.
         self.reverse = True
@@ -2192,14 +2230,20 @@ class LeoFind:
 
     # @+node:ekr.20160920164418.2: *4* find.tag-children & helper
     @cmd('tag-children')
-    def interactive_tag_children(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def interactive_tag_children(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         """Prompt for a tag and add it to all children of c.p."""
         w = self.c.frame.body.wrapper
         if not w:
             return
-        self.start_state_machine(event, prefix='Tag Children: ', handler=self.interactive_tag_children1)
+        self.start_state_machine(
+            event, prefix='Tag Children: ', handler=self.interactive_tag_children1
+        )
 
-    def interactive_tag_children1(self, event: LeoKeyEvent) -> None:  # pragma: no cover (interactive)
+    def interactive_tag_children1(
+        self, event: LeoKeyEvent
+    ) -> None:  # pragma: no cover (interactive)
         c, k, p = self.c, self.k, self.c.p
         # Settings...
         tag = k.arg
@@ -2227,7 +2271,9 @@ class LeoFind:
 
     # @+node:ekr.20230124043210.1: *4* find.tag-node & helper
     @cmd('tag-node')
-    def interactive_tag_node(self, event: LeoKeyEvent = None) -> None:  # pragma: no cover (interactive)
+    def interactive_tag_node(
+        self, event: LeoKeyEvent = None
+    ) -> None:  # pragma: no cover (interactive)
         """Prompt for a tag and add it to c.p."""
         w = self.c.frame.body.wrapper
         if not w:
@@ -2297,7 +2343,9 @@ class LeoFind:
 
     # @+node:ekr.20210112192427.1: *3* LeoFind.Commands: helpers
     # @+node:ekr.20210110073117.9: *4* find._cf_helper & helpers
-    def _cf_helper(self, settings: Settings, flatten: bool) -> int:  # Caller has  checked the settings.
+    def _cf_helper(
+        self, settings: Settings, flatten: bool
+    ) -> int:  # Caller has  checked the settings.
         """
         The common part of the clone-find commands.
 
@@ -2964,7 +3012,9 @@ class LeoFind:
         - Backspacing to an empty search pattern
           completely undoes the effect of the search.
         """
-        self.start_incremental(event, 'isearch-forward', forward=True, ignoreCase=False, regexp=False)
+        self.start_incremental(
+            event, 'isearch-forward', forward=True, ignoreCase=False, regexp=False
+        )
 
     # @+node:ekr.20131117164142.16942: *5* find.isearch_backward
     @cmd('isearch-backward')
@@ -2979,7 +3029,9 @@ class LeoFind:
         - Backspacing to an empty search pattern
           completely undoes the effect of the search.
         """
-        self.start_incremental(event, 'isearch-backward', forward=False, ignoreCase=False, regexp=False)
+        self.start_incremental(
+            event, 'isearch-backward', forward=False, ignoreCase=False, regexp=False
+        )
 
     # @+node:ekr.20131117164142.16943: *5* find.isearch_forward_regexp
     @cmd('isearch-forward-regexp')
@@ -2994,7 +3046,9 @@ class LeoFind:
         - Backspacing to an empty search pattern
           completely undoes the effect of the search.
         """
-        self.start_incremental(event, 'isearch-forward-regexp', forward=True, ignoreCase=False, regexp=True)
+        self.start_incremental(
+            event, 'isearch-forward-regexp', forward=True, ignoreCase=False, regexp=True
+        )
 
     # @+node:ekr.20131117164142.16944: *5* find.isearch_backward_regexp
     @cmd('isearch-backward-regexp')
@@ -3170,7 +3224,9 @@ class LeoFind:
         return [key for pane, key in aList]
 
     # @+node:ekr.20131117164142.16953: *5* find.push & pop
-    def push(self, p: Position, i: int, j: int, in_headline: bool) -> None:  # pragma: no cover (cmd)
+    def push(
+        self, p: Position, i: int, j: int, in_headline: bool
+    ) -> None:  # pragma: no cover (cmd)
         data = p.copy(), i, j, in_headline
         self.stack.append(data)
 
@@ -3283,7 +3339,9 @@ class LeoFind:
         """Initialize searches in vim mode."""
         c = self.c
         if c.vim_mode and c.vimCommands:
-            c.vimCommands.update_dot_before_search(find_pattern=pattern, change_pattern=None)  # A flag.
+            c.vimCommands.update_dot_before_search(
+                find_pattern=pattern, change_pattern=None
+            )  # A flag.
 
     # @+node:ekr.20150629072547.1: *4* find.preload_find_pattern
     def preload_find_pattern(self, w: Wrapper) -> None:  # pragma: no cover (cmd)

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -756,7 +756,9 @@ class LeoLog:
         self.frameDict: dict[str, Widget] = {}  # Keys are page names. Values are Frames
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
-        self.textDict: dict[str, Widget] = {}  # Keys are page names. Values are logCtrl's (text widgets).
+        self.textDict: dict[
+            str, Widget
+        ] = {}  # Keys are page names. Values are logCtrl's (text widgets).
         self.wrapper: TextAPI = None  # For cursesGui2.py.
 
     # @+node:ekr.20070302094848.1: *3* LeoLog.clearTab
@@ -1264,7 +1266,9 @@ class LeoTree:
         """Select the new node, part 1."""
         c = self.c
         call_event_handlers = p != old_p
-        if call_event_handlers and g.doHook("select1", c=c, new_p=p, old_p=old_p, new_v=p, old_v=old_p):
+        if call_event_handlers and g.doHook(
+            "select1", c=c, new_p=p, old_p=old_p, new_v=p, old_v=old_p
+        ):
             if 'select' in g.app.debug:
                 g.trace('select1 override')
             return
@@ -1805,7 +1809,9 @@ class NullTree(LeoTree):
         super().__init__(frame)
         assert self.frame
         self.c = frame.c
-        self.editWidgetsDict: dict[VNode, Widget] = {}  # Keys are vnodes, values are StringTextWidgets.
+        self.editWidgetsDict: dict[
+            VNode, Widget
+        ] = {}  # Keys are vnodes, values are StringTextWidgets.
         self.font = None
         self.fontName = None
         self.canvas = None

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -756,9 +756,8 @@ class LeoLog:
         self.frameDict: dict[str, Widget] = {}  # Keys are page names. Values are Frames
         self.logNumber = 0  # To create unique name fields for text widgets.
         self.newTabCount = 0  # Number of new tabs created.
-        self.textDict: dict[
-            str, Widget
-        ] = {}  # Keys are page names. Values are logCtrl's (text widgets).
+        # Keys are page names. Values are logCtrl's (text widgets).
+        self.textDict: dict[str, Widget] = {}
         self.wrapper: TextAPI = None  # For cursesGui2.py.
 
     # @+node:ekr.20070302094848.1: *3* LeoLog.clearTab
@@ -1809,9 +1808,8 @@ class NullTree(LeoTree):
         super().__init__(frame)
         assert self.frame
         self.c = frame.c
-        self.editWidgetsDict: dict[
-            VNode, Widget
-        ] = {}  # Keys are vnodes, values are StringTextWidgets.
+        # Keys are vnodes, values are StringTextWidgets.
+        self.editWidgetsDict: dict[VNode, Widget] = {}
         self.font = None
         self.fontName = None
         self.canvas = None

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2438,7 +2438,11 @@ getLineAfter = get_line_after
 def getIvarsDict(obj: object) -> dict[str, Value]:
     """Return a dictionary of ivars:values for non-methods of obj."""
     d: dict[str, Value] = dict(
-        [[key, getattr(obj, key)] for key in dir(obj) if not isinstance(getattr(obj, key), types.MethodType)]
+        [
+            [key, getattr(obj, key)]
+            for key in dir(obj)
+            if not isinstance(getattr(obj, key), types.MethodType)
+        ]
     )
     return d
 
@@ -2976,7 +2980,10 @@ def isDirective(s: str) -> bool:
 # @+node:ekr.20200810074755.1: *3* g.isValidLanguage
 def isValidLanguage(language: str) -> bool:
     """True if the given language may be used as an external file."""
-    return bool(language and (language in g.app.language_delims_dict or language in g.app.delegate_language_dict))
+    return bool(
+        language
+        and (language in g.app.language_delims_dict or language in g.app.delegate_language_dict)
+    )
 
 
 # @+node:ekr.20250403040834.1: *3* --- to be deprecated! Using directives list
@@ -4015,7 +4022,11 @@ def skip_braces(s: str, i: int) -> int:
         elif g.match(s, i, '/*'):
             i = g.skip_block_comment(s, i)
         # 7/29/02: be more careful handling conditional code.
-        elif g.match_word(s, i, "#if") or g.match_word(s, i, "#ifdef") or g.match_word(s, i, "#ifndef"):
+        elif (
+            g.match_word(s, i, "#if")
+            or g.match_word(s, i, "#ifdef")
+            or g.match_word(s, i, "#ifndef")
+        ):
             i, delta = g.skip_pp_if(s, i)
             level += delta
         else:
@@ -4174,7 +4185,9 @@ def skip_pp_directive(s: str, i: int) -> int:
 
 def skip_pp_if(s: str, i: int) -> tuple[int, int]:
     start_line = g.get_line(s, i)  # used for error messages.
-    assert g.match_word(s, i, "#if") or g.match_word(s, i, "#ifdef") or g.match_word(s, i, "#ifndef")
+    assert (
+        g.match_word(s, i, "#if") or g.match_word(s, i, "#ifdef") or g.match_word(s, i, "#ifndef")
+    )
     i = g.skip_line(s, i)
     i, delta1 = g.skip_pp_part(s, i)
     i = g.skip_ws(s, i)
@@ -4200,7 +4213,11 @@ def skip_pp_part(s: str, i: int) -> tuple[int, int]:
     delta = 0
     while i < len(s):
         c = s[i]
-        if g.match_word(s, i, "#if") or g.match_word(s, i, "#ifdef") or g.match_word(s, i, "#ifndef"):
+        if (
+            g.match_word(s, i, "#if")
+            or g.match_word(s, i, "#ifdef")
+            or g.match_word(s, i, "#ifndef")
+        ):
             i, delta1 = g.skip_pp_if(s, i)
             delta += delta1
         elif g.match_word(s, i, "#else") or g.match_word(s, i, "#endif"):
@@ -4713,7 +4730,9 @@ class GitIssueController:
             g.es_print('state must be in (None, "open", "closed")')
 
     # @+node:ekr.20180325024334.1: *5* git.get_all_issues
-    def get_all_issues(self, label_list: list, root: Position, state: str, limit: int = 100) -> None:
+    def get_all_issues(
+        self, label_list: list, root: Position, state: str, limit: int = 100
+    ) -> None:
         """Get all issues for the base url."""
         try:
             import requests
@@ -4814,7 +4833,8 @@ class GitIssueController:
             aList = [
                 z
                 for z in r.json()
-                if z.get('milestone') is not None and self.milestone == z.get('milestone').get('title')
+                if z.get('milestone') is not None
+                and self.milestone == z.get('milestone').get('title')
             ]
         else:
             aList = [z for z in r.json()]
@@ -5395,7 +5415,9 @@ def longestCommonPrefix(s1: str, s2: str) -> str:
     return prefix
 
 
-def itemsMatchingPrefixInList(s: str, aList: list[str], matchEmptyPrefix: bool = False) -> tuple[list, str]:
+def itemsMatchingPrefixInList(
+    s: str, aList: list[str], matchEmptyPrefix: bool = False
+) -> tuple[list, str]:
     """This method returns a sorted list items of aList whose prefix is s.
 
     It also returns the longest common prefix of all the matches.
@@ -7439,7 +7461,9 @@ def findNodeByPath(c: Cmdr, path: str) -> Optional[Position]:
 
 
 # @+node:ekr.20210303123423.1: *4* g.findNodeInChildren
-def findNodeInChildren(c: Cmdr, p: Position, headline: str, exact: bool = True) -> Optional[Position]:
+def findNodeInChildren(
+    c: Cmdr, p: Position, headline: str, exact: bool = True
+) -> Optional[Position]:
     """Search for a node in v's tree matching the given headline."""
     p1 = p.copy()
     h = headline.strip()
@@ -7830,7 +7854,9 @@ def computeFileUrl(fn: str, c: Cmdr = None, p: Position = None) -> str:
 
 
 # @+node:ekr.20190608090856.1: *3* g.es_clickable_link (not used)
-def es_clickable_link(c: Cmdr, p: Position, line_number: int, message: str) -> None:  # pragma: no cover
+def es_clickable_link(
+    c: Cmdr, p: Position, line_number: int, message: str
+) -> None:  # pragma: no cover
     """
     Write a clickable message to the given line number of p.b.
 

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -422,7 +422,9 @@ class NullGui(LeoGui):
         self.script = None
 
     # @+node:ekr.20031218072017.3744: *3* NullGui.dialogs
-    def runAboutLeoDialog(self, c: Cmdr, version: str, theCopyright: str, url: str, email: str) -> str:
+    def runAboutLeoDialog(
+        self, c: Cmdr, version: str, theCopyright: str, url: str, email: str
+    ) -> str:
         return None
 
     def runAskOkDialog(self, c: Cmdr, title: str, message: str = None, text: str = "Ok") -> str:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -519,7 +519,9 @@ class LeoImportCommands:
     # @+node:ekr.20031218072017.3303: *4* ic.removeSentinelLines
     # This does not handle @nonl properly, but that no longer matters.
 
-    def removeSentinelLines(self, s: str, line_delim: str, start_delim: str, unused_end_delim: str) -> str:
+    def removeSentinelLines(
+        self, s: str, line_delim: str, start_delim: str, unused_end_delim: str
+    ) -> str:
         """Properly remove all sentinel lines in s."""
         delim = (line_delim or start_delim or '') + '@'
         verbatim = delim + 'verbatim'
@@ -2373,7 +2375,9 @@ class ToDoTask:
         start_s = self.start_date if self.start_date else ''
         end_s = self.complete_date if self.complete_date else ''
         mark_s = '[X]' if self.completed else '[ ]'
-        result = [f"Task: {mark_s} {self.priority:1} start: {start_s:10} end: {end_s:10} {self.task_s}"]
+        result = [
+            f"Task: {mark_s} {self.priority:1} start: {start_s:10} end: {end_s:10} {self.task_s}"
+        ]
         for ivar in ('contexts', 'projects', 'key_vals'):
             aList = getattr(self, ivar, None)
             if aList:
@@ -2467,7 +2471,9 @@ class ZimImportController:
             name = result[1].decode('utf-8')
             unquote = urllib.parse.unquote
             # mypy: error: "str" has no attribute "decode"; maybe "encode"?  [attr-defined]
-            path = [g.os_path_abspath(g.os_path_join(pathToZim, unquote(result[2]).decode('utf-8')))]  # type:ignore
+            path = [
+                g.os_path_abspath(g.os_path_join(pathToZim, unquote(result[2]).decode('utf-8')))
+            ]  # type:ignore
             results.append((level, name, path))
         return results
 
@@ -2691,7 +2697,9 @@ class LegacyExternalFileImporter:
             ("Legacy external files", "*.py"),
             ("All files", "*"),
         ]
-        paths = g.app.gui.runOpenFilesDialog(c, title="Import Legacy External Files", filetypes=filetypes)
+        paths = g.app.gui.runOpenFilesDialog(
+            c, title="Import Legacy External Files", filetypes=filetypes
+        )
         c.bringToFront()
         if paths:
             g.chdir(paths[0])

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -199,9 +199,8 @@ class AutoCompleterClass:
         self.warnings: dict[str, str] = {}  # Keys are language names.
         # Codewise pre-computes...
         self.codewiseSelfList: list[str] = []  # The (global) completions for "self."
-        self.completionsDict: dict[
-            str, list[str]
-        ] = {}  # Keys are prefixes, values are completion lists.
+        # Keys are prefixes, values are completion lists.
+        self.completionsDict: dict[str, list[str]] = {}
         self.reloadSettings()
 
     def reloadSettings(self) -> None:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -199,7 +199,9 @@ class AutoCompleterClass:
         self.warnings: dict[str, str] = {}  # Keys are language names.
         # Codewise pre-computes...
         self.codewiseSelfList: list[str] = []  # The (global) completions for "self."
-        self.completionsDict: dict[str, list[str]] = {}  # Keys are prefixes, values are completion lists.
+        self.completionsDict: dict[
+            str, list[str]
+        ] = {}  # Keys are prefixes, values are completion lists.
         self.reloadSettings()
 
     def reloadSettings(self) -> None:
@@ -509,9 +511,13 @@ class AutoCompleterClass:
         key, options = self.get_cached_options(prefix)
         if not options:
             options = self.get_completions(prefix)
-        tabList, common_prefix = g.itemsMatchingPrefixInList(prefix, options, matchEmptyPrefix=False)
+        tabList, common_prefix = g.itemsMatchingPrefixInList(
+            prefix, options, matchEmptyPrefix=False
+        )
         if not common_prefix:
-            tabList, common_prefix = g.itemsMatchingPrefixInList(prefix, options, matchEmptyPrefix=True)
+            tabList, common_prefix = g.itemsMatchingPrefixInList(
+                prefix, options, matchEmptyPrefix=True
+            )
         if tabList:
             self.show_completion_list(common_prefix, prefix, tabList)
         return common_prefix, prefix, tabList
@@ -2410,7 +2416,9 @@ class KeyHandlerClass:
             widgets = [w]
         else:
             # New in Leo 4.5: we *must* make the binding in the binding widget.
-            bindingWidget = f.tree and hasattr(f.tree, 'bindingWidget') and f.tree.bindingWidget or None
+            bindingWidget = (
+                f.tree and hasattr(f.tree, 'bindingWidget') and f.tree.bindingWidget or None
+            )
             wrapper = f.body and hasattr(f.body, 'wrapper') and f.body.wrapper or None
             canvas = f.tree and hasattr(f.tree, 'canvas') and f.tree.canvas or None
             widgets = [c.miniBufferWidget, wrapper, canvas, bindingWidget]
@@ -2774,7 +2782,9 @@ class KeyHandlerClass:
 
                 # Compute paths to leoSettings.leo and myLeoSettings.leo.
                 local_fn = c.fileName()
-                settings_path = g.os_path_finalize_join(g.app.loadDir, '..', 'config', 'leoSettings.leo')
+                settings_path = g.os_path_finalize_join(
+                    g.app.loadDir, '..', 'config', 'leoSettings.leo'
+                )
                 user_settings_path = g.app.loadManager.my_settings_path
 
                 # Open two or three files.
@@ -2956,7 +2966,9 @@ class KeyHandlerClass:
                     manylines = True
                 n = min(2, len(binding))
                 if manylines:
-                    doc = textwrap.fill(doc, width=50, initial_indent=' ' * 4, subsequent_indent=' ' * 4)
+                    doc = textwrap.fill(
+                        doc, width=50, initial_indent=' ' * 4, subsequent_indent=' ' * 4
+                    )
                 data.append((binding, cmd, doc))
         lines = ['[%*s] %s%s\n' % (-n, binding, cmd, doc) for binding, cmd, doc in data]
         g.es(''.join(lines), tabName=tabName)
@@ -3694,7 +3706,9 @@ class KeyHandlerClass:
         return False
 
     # @+node:ekr.20180418114300.1: *7* k.handleMinibufferHelper
-    def handleMinibufferHelper(self, event: LeoKeyEvent, pane: str, state: str, stroke: Stroke) -> str:
+    def handleMinibufferHelper(
+        self, event: LeoKeyEvent, pane: str, state: str, stroke: Stroke
+    ) -> str:
         """
         Execute a pane binding in the minibuffer.
         Return 'continue', 'ignore', 'found'
@@ -4362,7 +4376,9 @@ class KeyHandlerClass:
         """
         k = self
         d = k.masterBindingsDict  # Dict[scope, g.BindingInfo]
-        result_d: dict[str, list[tuple[str, Stroke]]] = {}  # Dict[command-name, tuple[pane, stroke]]
+        result_d: dict[
+            str, list[tuple[str, Stroke]]
+        ] = {}  # Dict[command-name, tuple[pane, stroke]]
         for scope in sorted(d):
             d2 = d.get(scope, {})  # Dict[stroke, g.BindingInfo]
             for stroke in d2:
@@ -4495,7 +4511,9 @@ class KeyHandlerClass:
         # k.showStateAndMode()
 
     # @+node:ekr.20061031131434.192: *4* k.showStateAndMode
-    def showStateAndMode(self, w: Wrapper = None, prompt: str = None, setFocus: bool = True) -> None:
+    def showStateAndMode(
+        self, w: Wrapper = None, prompt: str = None, setFocus: bool = True
+    ) -> None:
         """Show the state and mode at the start of the minibuffer."""
         c, k = self.c, self
         state = k.unboundKeyAction

--- a/leo/core/leoMenu.py
+++ b/leo/core/leoMenu.py
@@ -238,7 +238,9 @@ class LeoMenu:
             self.createMenuEntries(parentMenu, table)
 
     # @+node:ekr.20070927172712: *6* LeoMenu.handleSpecialMenus
-    def handleSpecialMenus(self, name: str, parentName: str, alt_name: str = None, table: list = None) -> bool:
+    def handleSpecialMenus(
+        self, name: str, parentName: str, alt_name: str = None, table: list = None
+    ) -> bool:
         """
         Handle a special menu if name is the name of a special menu.
         return True if this method handles the menu.
@@ -473,7 +475,9 @@ class LeoMenu:
                 amp_index = index_label.find("&")
                 index_label = index_label.replace("&", "")
                 index = parent.index(index_label)
-                self.insert_cascade(parent, index=index, label=label, menu=menu, underline=amp_index)
+                self.insert_cascade(
+                    parent, index=index, label=label, menu=menu, underline=amp_index
+                )
             else:
                 self.add_cascade(parent, label=label, menu=menu, underline=amp_index)
             return menu
@@ -691,7 +695,9 @@ class LeoMenu:
     ) -> None:
         pass
 
-    def insert_cascade(self, parent: Widget, index: int, label: str, menu: Menu, underline: int) -> Widget:
+    def insert_cascade(
+        self, parent: Widget, index: int, label: str, menu: Menu, underline: int
+    ) -> Widget:
         pass
 
     def new_menu(self, parent: Widget, tearoff: int = 0, label: str = '') -> Menu:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -337,7 +337,9 @@ class Position:
     def __str__(self) -> str:  # pragma: no cover
         p = self
         if p.v:
-            return f"<pos {id(p)} childIndex: {p._childIndex} lvl: {p.level()} key: {p.key()} {p.h}>"
+            return (
+                f"<pos {id(p)} childIndex: {p._childIndex} lvl: {p.level()} key: {p.key()} {p.h}>"
+            )
         return f"<pos {id(p)} [{len(p.stack)}] None>"
 
     __repr__ = __str__
@@ -1349,7 +1351,9 @@ class Position:
             if g.unitTesting:
                 assert False, 'children[%s] != p.v'  # noqa
         else:
-            g.trace(f"**can not happen: bad child index: {n}, len(children): {len(parent_v.children)}")
+            g.trace(
+                f"**can not happen: bad child index: {n}, len(children): {len(parent_v.children)}"
+            )
             g.trace('parent_v.children...\n', g.listToString(parent_v.children))
             g.trace('parent_v', parent_v, 'child', child)
             g.trace('** callers:', g.callers())
@@ -1825,7 +1829,9 @@ class Position:
             if childIndex < 0:
                 p.invalidOutline(f"missing childIndex: {childIndex!r}")  # pragma: no cover
             elif childIndex >= pv.numberOfChildren():
-                p.invalidOutline("missing children entry for index: {childIndex!r}")  # pragma: no cover
+                p.invalidOutline(
+                    "missing children entry for index: {childIndex!r}"
+                )  # pragma: no cover
         elif childIndex < 0:
             p.invalidOutline("negative childIndex: {childIndex!r}")  # pragma: no cover
         if not p.v and pv:
@@ -2256,7 +2262,11 @@ class VNode:
     def anyAtFileNodeName(self) -> str:
         """Return the file name following an @file node or an empty string."""
         v = self
-        return v.findAtFileName(g.app.atAutoNames) or v.findAtFileName(g.app.atFileNames) or v.atLeoNodeName()
+        return (
+            v.findAtFileName(g.app.atAutoNames)
+            or v.findAtFileName(g.app.atFileNames)
+            or v.atLeoNodeName()
+        )
 
     # @+node:ekr.20031218072017.3348: *4* v.at...FileNodeName
     # These return the filename following @xxx, in v.headString.

--- a/leo/core/leoPersistence.py
+++ b/leo/core/leoPersistence.py
@@ -562,7 +562,9 @@ class PersistenceDataController:
     # @+node:ekr.20140711111623.17896: *5* pd.unl
     def unl(self, p: Position) -> str:
         """Return the unl corresponding to the given position."""
-        return '-->'.join(reversed([self.expected_headline(p2) for p2 in p.self_and_parents(copy=False)]))
+        return '-->'.join(
+            reversed([self.expected_headline(p2) for p2 in p.self_and_parents(copy=False)])
+        )
 
     # @+node:ekr.20140711111623.17885: *5* pd.unl_tail
     def unl_tail(self, unl: str) -> str:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -283,7 +283,9 @@ class BaseLeoPlugin:
         if color is None:
             color = 'grey'
         script = f"c.doCommandByName('{self.commandName}')"
-        g.app.gui.makeScriptButton(self.c, args=None, script=script, buttonText=buttonText, bg=color)
+        g.app.gui.makeScriptButton(
+            self.c, args=None, script=script, buttonText=buttonText, bg=color
+        )
 
     # @-others
 
@@ -512,7 +514,9 @@ class LeoPluginsController:
                 self.loadOnePlugin(plugin.strip(), tag=tag)
 
     # @+node:ekr.20100908125007.6024: *4* plugins.loadOnePlugin & helper functions
-    def loadOnePlugin(self, moduleOrFileName: str, tag: str = 'open0', verbose: bool = False) -> Any:
+    def loadOnePlugin(
+        self, moduleOrFileName: str, tag: str = 'open0', verbose: bool = False
+    ) -> Any:
         """
         Load one plugin from a file name or module.
         Use extensive tracing if --trace-plugins is in effect.

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -73,10 +73,11 @@ class RstCommands:
         self.n_docutils = 0  # Number of docutils files written.
 
         # Http support for HtmlParserClass.  See http_addNodeMarker.
-        self.anchor_map: dict[str, Position] = {}  # Keys are anchors. Values are positions
-        self.http_map: dict[
-            str, Position
-        ] = {}  # Keys are named hyperlink targets.  Value are positions.
+
+        # Keys are anchors. Values are positions
+        self.anchor_map: dict[str, Position] = {}
+        # Keys are named hyperlink targets.  Value are positions.
+        self.http_map: dict[str, Position] = {}
         self.nodeNumber = 0  # Unique node number.
 
         # For writing.

--- a/leo/core/leoRst.py
+++ b/leo/core/leoRst.py
@@ -74,7 +74,9 @@ class RstCommands:
 
         # Http support for HtmlParserClass.  See http_addNodeMarker.
         self.anchor_map: dict[str, Position] = {}  # Keys are anchors. Values are positions
-        self.http_map: dict[str, Position] = {}  # Keys are named hyperlink targets.  Value are positions.
+        self.http_map: dict[
+            str, Position
+        ] = {}  # Keys are named hyperlink targets.  Value are positions.
         self.nodeNumber = 0  # Unique node number.
 
         # For writing.
@@ -118,13 +120,17 @@ class RstCommands:
         self.default_path = getString('rst3-default-path') or ''
         self.generate_rst_header_comment = getBool('rst3-generate-rst-header-comment', default=True)
         self.remove_leo_directives = getBool('rst3-remove-leo-directives', default=False)
-        self.underline_characters = getString('rst3-underline-characters') or self.default_underline_characters
+        self.underline_characters = (
+            getString('rst3-underline-characters') or self.default_underline_characters
+        )
         self.write_intermediate_file = getBool('rst3-write-intermediate-file', default=True)
         self.write_intermediate_extension = getString('rst3-write-intermediate-extension') or '.txt'
 
         # Docutils options.
         self.call_docutils = getBool('rst3-call-docutils', default=True)
-        self.publish_argv_for_missing_stylesheets = getString('rst3-publish-argv-for-missing-stylesheets') or ''
+        self.publish_argv_for_missing_stylesheets = (
+            getString('rst3-publish-argv-for-missing-stylesheets') or ''
+        )
         self.stylesheet_embed = getBool('rst3-stylesheet-embed', default=False)
         self.stylesheet_name = getString('rst3-stylesheet-name') or 'default.css'
         self.stylesheet_path = getString('rst3-stylesheet-path') or ''
@@ -707,7 +713,13 @@ class RstCommands:
                 return p.b
         if self.remove_leo_directives:
             # Only remove a few directives, and only if they start the line.
-            return ''.join([z for z in g.splitLines(p.b) if not z.startswith(('@language ', '@others', '@wrap'))])
+            return ''.join(
+                [
+                    z
+                    for z in g.splitLines(p.b)
+                    if not z.startswith(('@language ', '@others', '@wrap'))
+                ]
+            )
         return p.b
 
     # @+node:ekr.20230205101652.1: *4* rst.filter_h

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -186,7 +186,9 @@ class LeoUnitTest(unittest.TestCase):
         print('')
         for p in c.all_positions():
             head_s = f"{' ' * p.level()}{p.h}"
-            print(f"clone? {int(p.isCloned())} id(v): {id(p.v)} gnx: {p.gnx:30}: {head_s:<10} parents: {p.v.parents}")
+            print(
+                f"clone? {int(p.isCloned())} id(v): {id(p.v)} gnx: {p.gnx:30}: {head_s:<10} parents: {p.v.parents}"
+            )
 
     # @+node:ekr.20220805071838.1: *4* LeoUnitTest.dump_headlines
     def dump_headlines(self, c: Cmdr, tag: str = None) -> None:  # pragma: no cover

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -135,7 +135,9 @@ class VimCommands:
                 for key in d2:
                     f, f2 = d.get(key), d2.get(key)
                     if f2 and f and f != f2:
-                        g.trace(f"conflicting motion key in {tag} dict: {key} {f2.__name__} {f.__name__}")
+                        g.trace(
+                            f"conflicting motion key in {tag} dict: {key} {f2.__name__} {f.__name__}"
+                        )
                     elif f2 and not f:
                         g.trace(f"missing motion key in {tag} dict: {key} {f2.__name__}")
                         # d[key] = f2
@@ -450,7 +452,9 @@ class VimCommands:
         self.handler: Callable = self.do_normal_mode  # Use the handler for normal mode.
         self.in_command = False  # True: we have seen some command characters.
         self.in_motion = False  # True if parsing an *inner* motion, the 2j in d2j.
-        self.motion_func: Callable = None  # The callback handler to execute after executing an inner motion.
+        self.motion_func: Callable = (
+            None  # The callback handler to execute after executing an inner motion.
+        )
         self.motion_i: int = None  # The offset into the text at the start of a motion.
         self.n1 = 1  # The first repeat count.
         self.n = 1  # The second repeat count.
@@ -1988,7 +1992,9 @@ class VimCommands:
                 self.handler()
             if self.return_value not in (True, False):
                 # It looks like no acceptance method has been called.
-                self.oops(f"bad return_value: {repr(self.return_value)} {self.state} {self.next_func}")
+                self.oops(
+                    f"bad return_value: {repr(self.return_value)} {self.state} {self.next_func}"
+                )
                 self.done()  # Sets self.return_value to True.
         except Exception:
             g.es_exception()

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -452,9 +452,8 @@ class VimCommands:
         self.handler: Callable = self.do_normal_mode  # Use the handler for normal mode.
         self.in_command = False  # True: we have seen some command characters.
         self.in_motion = False  # True if parsing an *inner* motion, the 2j in d2j.
-        self.motion_func: Callable = (
-            None  # The callback handler to execute after executing an inner motion.
-        )
+        # The callback handler to execute after executing an inner motion.
+        self.motion_func: Callable = None
         self.motion_i: int = None  # The offset into the text at the start of a motion.
         self.n1 = 1  # The first repeat count.
         self.n = 1  # The second repeat count.

--- a/leo/core/leoclient.py
+++ b/leo/core/leoclient.py
@@ -120,7 +120,9 @@ def _get_action_list():
     # Add all remaining methods to the middle.
     tests = inspect.getmembers(server, inspect.ismethod)
     test_names = sorted([name for (name, value) in tests if not name.startswith('_')])
-    middle: list = [("!" + z, {}) for z in test_names if z not in head_names + tail_names + exclude_names]
+    middle: list = [
+        ("!" + z, {}) for z in test_names if z not in head_names + tail_names + exclude_names
+    ]
     middle_names = [name for (name, package) in middle]  # type:ignore
     all_tests = head + middle + tail  # type:ignore
     if 0:

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -195,7 +195,9 @@ class ServerExternalFilesController(ExternalFilesController):
         g.app.idleTimeManager.add_callback(self.on_idle)
 
         self.waitingForAnswer = False
-        self.lastPNode: Position = None  # last p node that was asked for if not set to "AllYes\AllNo"
+        self.lastPNode: Position = (
+            None  # last p node that was asked for if not set to "AllYes\AllNo"
+        )
         self.lastCommander: Cmdr = None
 
     # @+node:felix.20210626222905.6: *3* sefc.clientResult
@@ -641,13 +643,17 @@ class QuickSearchController:
     def qsc_sort_by_gnx(self) -> None:
         """Return positions by gnx."""
         c = self.c
-        timeline: list[tuple[Position, Match_Iter]] = [(p.copy(), None) for p in c.all_unique_positions()]
+        timeline: list[tuple[Position, Match_Iter]] = [
+            (p.copy(), None) for p in c.all_unique_positions()
+        ]
         timeline.sort(key=lambda x: x[0].gnx, reverse=True)
         self.clear()
         self.addHeadlineMatches(timeline)
 
     # @+node:felix.20220225003906.15: *4* QSC.qsc_background_search
-    def qsc_background_search(self, pat: str) -> tuple[list[tuple[Position, Match_Iter]], list[Position]]:
+    def qsc_background_search(
+        self, pat: str
+    ) -> tuple[list[tuple[Position, Match_Iter]], list[Position]]:
         flags: RegexFlag
         if not pat.startswith('r:'):
             hpat = fnmatch.translate('*' + pat + '*').replace(r"\Z(?ms)", "")
@@ -765,7 +771,9 @@ class QuickSearchController:
 
     # @+node:felix.20220225003906.10: *4* QSC.qsc_get_history
     def qsc_get_history(self) -> None:
-        headlines: list[tuple[Position, Match_Iter]] = [(po[0].copy(), None) for po in self.c.nodeHistory.beadList]
+        headlines: list[tuple[Position, Match_Iter]] = [
+            (po[0].copy(), None) for po in self.c.nodeHistory.beadList
+        ]
         headlines.reverse()
         self.clear()
         self.addHeadlineMatches(headlines)
@@ -878,7 +886,9 @@ class QuickSearchController:
         return aList
 
     # @+node:felix.20220225003906.20: *4* QSC.onSelectItem (from quicksearch.py)
-    def onSelectItem(self, it: Any, it_prev: Any = None) -> None:  # it_prev not used. Hard to annotate.
+    def onSelectItem(
+        self, it: Any, it_prev: Any = None
+    ) -> None:  # it_prev not used. Hard to annotate.
         c = self.c
         tgt = self.its.get(it)
         if not tgt:
@@ -1192,7 +1202,9 @@ class LeoServer:
     # @+node:felix.20210621233316.7: *4* server.button commands
     # These will fail unless the open_file inits c.theScriptingController.
     # @+node:felix.20210621233316.8: *5* _check_button_command
-    def _check_button_command(self, c: Cmdr, tag: str) -> dict:  # pragma: no cover (no scripting controller)
+    def _check_button_command(
+        self, c: Cmdr, tag: str
+    ) -> dict:  # pragma: no cover (no scripting controller)
         """
         Check that a button command is possible.
         Raise ServerError if not. Otherwise, return sc.buttonsDict.
@@ -2041,7 +2053,9 @@ class LeoServer:
             if p.v and p.v.isAnyAtFileNode():
                 # ok, its an @file node so check if its absolute path matches the filePath
                 w_path = c.fullPath(p)
-                if w_path and g.os_path_normcase(g.finalize(w_path)) == g.os_path_normcase(g.finalize(filePath)):
+                if w_path and g.os_path_normcase(g.finalize(w_path)) == g.os_path_normcase(
+                    g.finalize(filePath)
+                ):
                     # Found the node that matches the filePath
                     c.selectPosition(p)  # Select the node in Leo's model
                     # +1 because lineNumber is 0-indexed
@@ -2771,7 +2785,9 @@ class LeoServer:
                     children = [self._get_position_d(topHoistPos, c)]
             else:
                 # this outputs all Root Children
-                children = [self._get_position_d(child, c) for child in self._yieldAllRootChildren(c)]
+                children = [
+                    self._get_position_d(child, c) for child in self._yieldAllRootChildren(c)
+                ]
         return self._make_minimal_response({"children": children})
 
     # @+node:felix.20210621233316.43: *5* server.get_focus
@@ -3000,7 +3016,9 @@ class LeoServer:
         return self._make_response({"string": s})
 
     # @+node:felix.20220815193758.1: *5* server.copy_node_as_json
-    def copy_node_as_json(self, param: Param) -> Response:  # pragma: no cover (too dangerous, for now)
+    def copy_node_as_json(
+        self, param: Param
+    ) -> Response:  # pragma: no cover (too dangerous, for now)
         """
         Copy a node as JSON, don't select it.
         Also supports 'asJSON' parameter to get as JSON
@@ -3493,7 +3511,9 @@ class LeoServer:
         if h == oldH:
             return self._make_response()
         bunch = u.beforeChangeHeadline(p)
-        c.setHeadString(p, h)  # c.setHeadString fixes the headline revert bug of p.initHeadString(h)
+        c.setHeadString(
+            p, h
+        )  # c.setHeadString fixes the headline revert bug of p.initHeadString(h)
         c.setChanged()
         p.setDirty()
         u.afterChangeHeadline(p, 'Change Headline', bunch)
@@ -5238,7 +5258,9 @@ class LeoServer:
             d['hasChildren'] = True
             # includeChildren flag is used by get_structure
             if includeChildren:
-                d['children'] = [self._get_position_d(child, c, includeChildren=True) for child in p.children()]
+                d['children'] = [
+                    self._get_position_d(child, c, includeChildren=True) for child in p.children()
+                ]
 
         if p.isCloned():
             d['cloned'] = True
@@ -5976,7 +5998,9 @@ def main() -> None:  # pragma: no cover (tested in client)
                 except OSError as e:
                     print(e)
                     print("Trying with IPv4 Family", flush=True)
-                    server = await websockets.serve(ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None)
+                    server = await websockets.serve(
+                        ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None
+                    )
                     realtime_server = server
 
                 signon = SERVER_STARTED_TOKEN + f" at {wsHost} on port: {wsPort}.\n"
@@ -6017,7 +6041,9 @@ def main() -> None:  # pragma: no cover (tested in client)
             except OSError as e:
                 print(e)
                 print("Trying with IPv4 Family", flush=True)
-                server = websockets.serve(ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None)
+                server = websockets.serve(
+                    ws_handler, wsHost, wsPort, family=socket.AF_INET, max_size=None
+                )
                 realtime_server = loop.run_until_complete(server)
 
             signon = SERVER_STARTED_TOKEN + f" at {wsHost} on port: {wsPort}.\n"

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -195,9 +195,8 @@ class ServerExternalFilesController(ExternalFilesController):
         g.app.idleTimeManager.add_callback(self.on_idle)
 
         self.waitingForAnswer = False
-        self.lastPNode: Position = (
-            None  # last p node that was asked for if not set to "AllYes\AllNo"
-        )
+        # last p node that was asked for if not set to "AllYes\AllNo"
+        self.lastPNode: Position = None
         self.lastCommander: Cmdr = None
 
     # @+node:felix.20210626222905.6: *3* sefc.clientResult

--- a/leo/core/signal_manager.py
+++ b/leo/core/signal_manager.py
@@ -92,7 +92,9 @@ def disconnect_all(listener: object) -> None:
     for emitter in listener._signal_data.emitters:
         for signal in emitter._signal_data.listeners:
             emitter._signal_data.listeners[signal] = [
-                i for i in emitter._signal_data.listeners[signal] if getattr(i, '__self__', None) != listener
+                i
+                for i in emitter._signal_data.listeners[signal]
+                if getattr(i, '__self__', None) != listener
             ]
 
 

--- a/leo/external/codewise.py
+++ b/leo/external/codewise.py
@@ -648,7 +648,10 @@ class CodeWise:
         for name, idd in self.classcache.items():
             if name in clset:
                 c = self.cursor()
-                c.execute('select name, class, file, searchpattern from function where class = (?)', (idd,))
+                c.execute(
+                    'select name, class, file, searchpattern from function where class = (?)',
+                    (idd,),
+                )
                 for name, klassid, fileid, pat in c:
                     result.append((name, pat))
         return result
@@ -660,7 +663,10 @@ class CodeWise:
             c.execute('select name, class, file, searchpattern from function')
         else:
             prefix = str(prefix)
-            c.execute('select name, class, file, searchpattern from function where name like (?)', (prefix + '%',))
+            c.execute(
+                'select name, class, file, searchpattern from function where name like (?)',
+                (prefix + '%',),
+            )
         return [(name, pat, klassid, fileid) for name, klassid, fileid, pat in c]
 
     # @+node:ekr.20110310091639.14265: *3* file_id
@@ -696,7 +702,8 @@ class CodeWise:
         fid = self.file_id(file_name)
         c = self.cursor()
         c.execute(
-            'insert into function(class, name, searchpattern, file) values (?, ?, ?, ?)', [clid, func_name, aux, fid]
+            'insert into function(class, name, searchpattern, file) values (?, ?, ?, ?)',
+            [clid, func_name, aux, fid],
         )
 
     # @+node:ekr.20110310091639.14267: *3* feed_scintilla
@@ -741,7 +748,10 @@ class CodeWise:
                 idd = 0
             c = self.cursor()
             fid = self.file_id(fil)
-            c.execute('insert into function(class, name, searchpattern, file) values (?, ?, ?, ?)', [idd, m, pat, fid])
+            c.execute(
+                'insert into function(class, name, searchpattern, file) values (?, ?, ?, ?)',
+                [idd, m, pat, fid],
+            )
         self.dbconn.commit()
 
     # @+node:ekr.20110310091639.14269: *3* add_source

--- a/leo/external/concurrent/futures/_base.py
+++ b/leo/external/concurrent/futures/_base.py
@@ -319,7 +319,10 @@ class Future(object):
                         _STATE_TO_DESCRIPTION_MAP[self._state],
                         self._result.__class__.__name__,
                     )
-            return '<Future at %s state=%s>' % (hex(id(self)), _STATE_TO_DESCRIPTION_MAP[self._state])
+            return '<Future at %s state=%s>' % (
+                hex(id(self)),
+                _STATE_TO_DESCRIPTION_MAP[self._state],
+            )
 
     def cancel(self):
         """Cancel the future if possible.
@@ -478,7 +481,9 @@ class Future(object):
                 self._state = RUNNING
                 return True
             else:
-                LOGGER.critical('Future %s in unexpected state: %s', id(self.future), self.future._state)
+                LOGGER.critical(
+                    'Future %s in unexpected state: %s', id(self.future), self.future._state
+                )
                 raise RuntimeError('Future in unexpected state')
 
     def set_result(self, result):

--- a/leo/external/concurrent/futures/_compat.py
+++ b/leo/external/concurrent/futures/_compat.py
@@ -30,12 +30,15 @@ def namedtuple(typename, field_names):
     # Parse and validate the field names.  Validation serves two purposes,
     # generating informative error messages and preventing template injection attacks.
     if isinstance(field_names, basestring):
-        field_names = field_names.replace(',', ' ').split()  # names separated by whitespace and/or commas
+        field_names = field_names.replace(
+            ',', ' '
+        ).split()  # names separated by whitespace and/or commas
     field_names = tuple(map(str, field_names))
     for name in (typename,) + field_names:
         if not all(c.isalnum() or c == '_' for c in name):
             raise ValueError(
-                'Type names and field names can only contain alphanumeric characters and underscores: %r' % name
+                'Type names and field names can only contain alphanumeric characters and underscores: %r'
+                % name
             )
         if _iskeyword(name):
             raise ValueError('Type names and field names cannot be a keyword: %r' % name)
@@ -85,7 +88,12 @@ def namedtuple(typename, field_names):
 
     # Execute the template string in a temporary namespace and
     # support tracing utilities by setting a value for frame.f_globals['__name__']
-    namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename, _property=property, _tuple=tuple)
+    namespace = dict(
+        _itemgetter=_itemgetter,
+        __name__='namedtuple_%s' % typename,
+        _property=property,
+        _tuple=tuple,
+    )
     try:
         exec(template, namespace)
     except SyntaxError:

--- a/leo/external/concurrent/futures/process.py
+++ b/leo/external/concurrent/futures/process.py
@@ -184,14 +184,22 @@ def _add_call_item_to_queue(pending_work_items, work_ids, call_queue):
             work_item = pending_work_items[work_id]
 
             if work_item.future.set_running_or_notify_cancel():
-                call_queue.put(_CallItem(work_id, work_item.fn, work_item.args, work_item.kwargs), block=True)
+                call_queue.put(
+                    _CallItem(work_id, work_item.fn, work_item.args, work_item.kwargs), block=True
+                )
             else:
                 del pending_work_items[work_id]
                 continue
 
 
 def _queue_manangement_worker(
-    executor_reference, processes, pending_work_items, work_ids_queue, call_queue, result_queue, shutdown_process_event
+    executor_reference,
+    processes,
+    pending_work_items,
+    work_ids_queue,
+    call_queue,
+    result_queue,
+    shutdown_process_event,
 ):
     """Manages the communication between this process and the worker processes.
 
@@ -301,7 +309,8 @@ class ProcessPoolExecutor(_base.Executor):
     def _adjust_process_count(self):
         for _ in range(len(self._processes), self._max_workers):
             p = multiprocessing.Process(
-                target=_process_worker, args=(self._call_queue, self._result_queue, self._shutdown_process_event)
+                target=_process_worker,
+                args=(self._call_queue, self._result_queue, self._shutdown_process_event),
             )
             p.start()
             self._processes.add(p)

--- a/leo/external/edb.py
+++ b/leo/external/edb.py
@@ -767,7 +767,11 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.commands_bnum = bnum
         # Save old definitions for the case of a keyboard interrupt.
         if bnum in self.commands:
-            old_command_defs = (self.commands[bnum], self.commands_doprompt[bnum], self.commands_silent[bnum])
+            old_command_defs = (
+                self.commands[bnum],
+                self.commands_doprompt[bnum],
+                self.commands_silent[bnum],
+            )
         else:
             old_command_defs = None
         self.commands[bnum] = []
@@ -866,7 +870,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
                     # last thing to try
                     (ok, filename, ln) = self.lineinfo(arg)
                     if not ok:
-                        self.error('The specified object %r is not a function or was not found along sys.path.' % arg)
+                        self.error(
+                            'The specified object %r is not a function or was not found along sys.path.'
+                            % arg
+                        )
                         return
                     funcname = ok  # ok contains a function name
                     lineno = int(ln)
@@ -1619,7 +1626,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
             self.error('No help for %r' % arg)
         else:
             if sys.flags.optimize >= 2:
-                self.error('No help for %r; please do not run Python with -OO if you need command help' % arg)
+                self.error(
+                    'No help for %r; please do not run Python with -OO if you need command help'
+                    % arg
+                )
                 return
             self.message(command.__doc__.rstrip())
 

--- a/leo/external/lproto.py
+++ b/leo/external/lproto.py
@@ -108,7 +108,9 @@ class LProtoServer:
         self.receiver = None
         self.ses = {}
 
-        self.is_connected = self.srv.connect(self.srv, QtCore.SIGNAL("newConnection()"), self.connected)
+        self.is_connected = self.srv.connect(
+            self.srv, QtCore.SIGNAL("newConnection()"), self.connected
+        )
 
     # @+node:ekr.20111012070545.7255: *3* listen
     def listen(self, name):

--- a/leo/external/make_stub_files.py
+++ b/leo/external/make_stub_files.py
@@ -255,7 +255,9 @@ class AstFormatter:
         asynch_prefix = 'asynch ' if async_flag else ''
         if getattr(node, 'returns', None):  # Python 3.
             returns = self.visit(node.returns)
-            result.append(self.indent('%sdef %s(%s): -> %s\n' % (asynch_prefix, name, args, returns)))
+            result.append(
+                self.indent('%sdef %s(%s): -> %s\n' % (asynch_prefix, name, args, returns))
+            )
         else:
             result.append(self.indent('%sdef %s(%s):\n' % (asynch_prefix, name, args)))
         for z in node.body:
@@ -383,7 +385,10 @@ class AstFormatter:
     # Attribute(expr value, identifier attr, expr_context ctx)
 
     def do_Attribute(self, node):
-        return '%s.%s' % (self.visit(node.value), node.attr)  # Don't visit node.attr: it is always a string.
+        return '%s.%s' % (
+            self.visit(node.value),
+            node.attr,
+        )  # Don't visit node.attr: it is always a string.
 
     # @+node:ekr.20160317055215.21: *4* f.Bytes
     def do_Bytes(self, node):  # Python 3.x only.
@@ -446,7 +451,10 @@ class AstFormatter:
             # result.append(',\n'.join(items))
             # result.append('\n}' if keys else '}')
         else:
-            print('Error: f.Dict: len(keys) != len(values)\nkeys: %s\nvals: %s' % (repr(keys), repr(values)))
+            print(
+                'Error: f.Dict: len(keys) != len(values)\nkeys: %s\nvals: %s'
+                % (repr(keys), repr(values))
+            )
         return ''.join(result)
 
     # @+node:ekr.20160317055215.26: *4* f.Ellipsis
@@ -599,7 +607,11 @@ class AstFormatter:
 
     # @+node:ekr.20160317055215.43: *4* f.ifExp (ternary operator)
     def do_IfExp(self, node):
-        return '%s if %s else %s ' % (self.visit(node.body), self.visit(node.test), self.visit(node.orelse))
+        return '%s if %s else %s ' % (
+            self.visit(node.body),
+            self.visit(node.test),
+            self.visit(node.orelse),
+        )
 
     # @+node:ekr.20160317055215.44: *3* f.Statements
 
@@ -629,7 +641,9 @@ class AstFormatter:
 
     # @+node:ekr.20160317055215.46: *4* f.Assign
     def do_Assign(self, node):
-        return self.indent('%s=%s\n' % ('='.join([self.visit(z) for z in node.targets]), self.visit(node.value)))
+        return self.indent(
+            '%s=%s\n' % ('='.join([self.visit(z) for z in node.targets]), self.visit(node.value))
+        )
 
     # @+node:ekr.20160317055215.47: *4* f.AugAssign
     def do_AugAssign(self, node):
@@ -699,7 +713,8 @@ class AstFormatter:
         result = []
         result.append(
             self.indent(
-                '%sfor %s in %s:\n' % ('asynch ' if async_flag else '', self.visit(node.target), self.visit(node.iter))
+                '%sfor %s in %s:\n'
+                % ('asynch ' if async_flag else '', self.visit(node.target), self.visit(node.iter))
             )
         )
         for z in node.body:
@@ -1101,7 +1116,10 @@ class LeoGlobals:
             code1 = f1.f_code  # The code object
             name = code1.co_name
             if name == '__init__':
-                name = '__init__(%s,line %s)' % (self.shortFileName(code1.co_filename), code1.co_firstlineno)
+                name = '__init__(%s,line %s)' % (
+                    self.shortFileName(code1.co_filename),
+                    code1.co_firstlineno,
+                )
             if files:
                 return '%s:%s' % (self.shortFileName(code1.co_filename), name)
             else:
@@ -1800,14 +1818,32 @@ class StandAloneMakeStubFile:
         add = parser.add_option
         add('-c', '--config', dest='fn', help='full path to configuration file')
         add('-d', '--dir', dest='dir', help='full path to the output directory')
-        add('-o', '--overwrite', action='store_true', default=False, help='overwrite existing stub (.pyi) files')
+        add(
+            '-o',
+            '--overwrite',
+            action='store_true',
+            default=False,
+            help='overwrite existing stub (.pyi) files',
+        )
         add('-t', '--test', action='store_true', default=False, help='run unit tests on startup')
         add('--trace-matches', action='store_true', default=False, help='trace Pattern.matches')
         add('--trace-patterns', action='store_true', default=False, help='trace pattern creation')
         add('--trace-reduce', action='store_true', default=False, help='trace st.reduce_types')
         add('--trace-visitors', action='store_true', default=False, help='trace visitor methods')
-        add('-u', '--update', action='store_true', default=False, help='update stubs in existing stub file')
-        add('-v', '--verbose', action='store_true', default=False, help='verbose output in .pyi file')
+        add(
+            '-u',
+            '--update',
+            action='store_true',
+            default=False,
+            help='update stubs in existing stub file',
+        )
+        add(
+            '-v',
+            '--verbose',
+            action='store_true',
+            default=False,
+            help='verbose output in .pyi file',
+        )
         add('-w', '--warn', action='store_true', default=False, help='warn about unannotated args')
         # Parse the options
         options, args = parser.parse_args()
@@ -2246,7 +2282,10 @@ class StubFormatter(AstFormatter):
     def do_Attribute(self, node):
         '''StubFormatter.do_Attribute.'''
         trace = False
-        s = '%s.%s' % (self.visit(node.value), node.attr)  # Don't visit node.attr: it is always a string.
+        s = '%s.%s' % (
+            self.visit(node.value),
+            node.attr,
+        )  # Don't visit node.attr: it is always a string.
         s2 = self.names_dict.get(s)
         if trace and s2 and s2 not in self.attrs_seen:
             self.attrs_seen.append(s2)
@@ -2283,7 +2322,10 @@ class StubFormatter(AstFormatter):
             result.append(', '.join(items))
             result.append('}')
         else:
-            print('Error: f.Dict: len(keys) != len(values)\nkeys: %s\nvals: %s' % (repr(keys), repr(values)))
+            print(
+                'Error: f.Dict: len(keys) != len(values)\nkeys: %s\nvals: %s'
+                % (repr(keys), repr(values))
+            )
         # return ''.join(result)
         return 'Dict[%s]' % ''.join(result)
 
@@ -2604,7 +2646,9 @@ class StubTraverser(ast.NodeVisitor):
     def output_time_stamp(self):
         '''Put a time-stamp in the output file.'''
         if self.output_file:
-            self.output_file.write('# make_stub_files: %s\n' % time.strftime("%a %d %b %Y at %H:%M:%S"))
+            self.output_file.write(
+                '# make_stub_files: %s\n' % time.strftime("%a %d %b %Y at %H:%M:%S")
+            )
 
     # @+node:ekr.20160317054700.169: *4* st.update & helpers
     def update(self, fn, new_root):
@@ -2912,7 +2956,10 @@ class StubTraverser(ast.NodeVisitor):
         # if self.trace_matches or self.trace_reduce:
         # if not self.class_name_stack:
         # print('def %s\n' % node.name)
-        self.out('def %s(%s) -> %s' % (node.name, self.format_arguments(node.args), self.format_returns(node)))
+        self.out(
+            'def %s(%s) -> %s'
+            % (node.name, self.format_arguments(node.args), self.format_returns(node))
+        )
         self.parent_stub = old_stub
 
     # @+node:ekr.20160317054700.181: *4* st.format_arguments & helper

--- a/leo/external/npyscreen/__init__.py
+++ b/leo/external/npyscreen/__init__.py
@@ -6,7 +6,12 @@ try:  # These may fail with Python 3.13+
     # @+node:ekr.20170428084208.444: ** << declarations >>
     from .globals import DEBUG, DISABLE_RESIZE_SYSTEM
 
-    from .wgwidget import TEST_SETTINGS, ExhaustedTestInput, add_test_input_from_iterable, add_test_input_ch
+    from .wgwidget import (
+        TEST_SETTINGS,
+        ExhaustedTestInput,
+        add_test_input_from_iterable,
+        add_test_input_ch,
+    )
 
     from .npyssafewrapper import wrapper, wrapper_basic
 
@@ -38,7 +43,12 @@ try:  # These may fail with Python 3.13+
     from .fmFormMutt import FormMutt, FormMuttWithMenus
     from .fmFileSelector import FileSelector, selectFile
 
-    from .fmFormMuttActive import ActionControllerSimple, TextCommandBox, FormMuttActive, FormMuttActiveWithMenus
+    from .fmFormMuttActive import (
+        ActionControllerSimple,
+        TextCommandBox,
+        FormMuttActive,
+        FormMuttActiveWithMenus,
+    )
     from .fmFormMuttActive import FormMuttActiveTraditional, FormMuttActiveTraditionalWithMenus
 
     from .fmFormMultiPage import (
@@ -77,10 +87,23 @@ try:  # These may fail with Python 3.13+
         BufferPager,
         TitleBufferPager,
     )
-    from .wgmultiselect import MultiSelect, TitleMultiSelect, MultiSelectFixed, TitleMultiSelectFixed, MultiSelectAction
+    from .wgmultiselect import (
+        MultiSelect,
+        TitleMultiSelect,
+        MultiSelectFixed,
+        TitleMultiSelectFixed,
+        MultiSelectAction,
+    )
     from .wgeditmultiline import MultiLineEdit
     from .wgcombobox import ComboBox, TitleCombo
-    from .wgcheckbox import Checkbox, RoundCheckBox, CheckBoxMultiline, RoundCheckBoxMultiline, CheckBox, CheckboxBare
+    from .wgcheckbox import (
+        Checkbox,
+        RoundCheckBox,
+        CheckBoxMultiline,
+        RoundCheckBoxMultiline,
+        CheckBox,
+        CheckboxBare,
+    )
     from .wgFormControlCheckbox import FormControlCheckbox
     from .wgautocomplete import TitleFilename, Filename, Autocomplete
     from .muMenu import Menu
@@ -95,8 +118,16 @@ try:  # These may fail with Python 3.13+
     # The following are maintained for compatibility with old code only.
 
     from .compatibility_code.oldtreeclasses import MultiLineTree, SelectOneTree
-    from .compatibility_code.oldtreeclasses import MultiLineTreeNew, MultiLineTreeNewAction, TreeLine, TreeLineAnnotated
-    from .compatibility_code.oldtreeclasses import MultiLineTreeNewAnnotatedAction, MultiLineTreeNewAnnotated
+    from .compatibility_code.oldtreeclasses import (
+        MultiLineTreeNew,
+        MultiLineTreeNewAction,
+        TreeLine,
+        TreeLineAnnotated,
+    )
+    from .compatibility_code.oldtreeclasses import (
+        MultiLineTreeNewAnnotatedAction,
+        MultiLineTreeNewAnnotated,
+    )
     from .compatibility_code.npysNPSTree import NPSTreeData
 
     # End compatibility.
@@ -104,7 +135,11 @@ try:  # These may fail with Python 3.13+
     from .wgfilenamecombo import FilenameCombo, TitleFilenameCombo
     from .wgboxwidget import BoxBasic, BoxTitle
     from .wgmultiline import MultiLineActionWithShortcuts
-    from .wgmultilineeditable import MultiLineEditable, MultiLineEditableTitle, MultiLineEditableBoxed
+    from .wgmultilineeditable import (
+        MultiLineEditable,
+        MultiLineEditableTitle,
+        MultiLineEditableBoxed,
+    )
 
     from .wgmonthbox import MonthBox
     from .wggrid import SimpleGrid
@@ -128,7 +163,13 @@ try:  # These may fail with Python 3.13+
 
     # Very experimental. Don't use for anything serious
     from .apOptions import SimpleOptionForm
-    from .apOptions import OptionListDisplay, OptionChanger, OptionList, OptionLimitedChoices, OptionListDisplayLine
+    from .apOptions import (
+        OptionListDisplay,
+        OptionChanger,
+        OptionList,
+        OptionLimitedChoices,
+        OptionListDisplayLine,
+    )
     from .apOptions import (
         OptionFreeText,
         OptionSingleChoice,

--- a/leo/external/npyscreen/apNPSApplicationManaged.py
+++ b/leo/external/npyscreen/apNPSApplicationManaged.py
@@ -129,7 +129,9 @@ class NPSAppManaged(apNPSApplication.NPSApp):
                 self._FORM_VISIT_LIST.pop()  # Remove the current form. if it is at the end of the list
             if self._THISFORM.FORM_NAME == self.NEXT_ACTIVE_FORM:
                 # take no action if it looks as if someone has already set the next form.
-                self.setNextForm(self._FORM_VISIT_LIST.pop())  # Switch to the previous form if one exists
+                self.setNextForm(
+                    self._FORM_VISIT_LIST.pop()
+                )  # Switch to the previous form if one exists
         except IndexError:
             self.setNextForm(backup)
 

--- a/leo/external/npyscreen/compatibility_code/npysNPSTree.py
+++ b/leo/external/npyscreen/compatibility_code/npysNPSTree.py
@@ -190,7 +190,9 @@ class NPSTreeData(object):
                     if sort:
                         if key:
                             # must be reverse because about to use extendleft() below.
-                            nodes_to_yield.extendleft(sorted(child.getChildren(), key=key, reverse=True))
+                            nodes_to_yield.extendleft(
+                                sorted(child.getChildren(), key=key, reverse=True)
+                            )
                         else:
                             nodes_to_yield.extendleft(sorted(child.getChildren(), reverse=True))
                     else:

--- a/leo/external/npyscreen/compatibility_code/oldtreeclasses.py
+++ b/leo/external/npyscreen/compatibility_code/oldtreeclasses.py
@@ -15,7 +15,9 @@ class MultiLineTree(multiline.MultiLine):
         if tree == [] or tree == None:
             self._myFullValues = NPSTree.NPSTreeData()
         elif not isinstance(tree, NPSTree.NPSTreeData):
-            raise TypeError("MultiLineTree widget can only contain a NPSTreeData object in its values attribute")
+            raise TypeError(
+                "MultiLineTree widget can only contain a NPSTreeData object in its values attribute"
+            )
         else:
             self._myFullValues = tree
 
@@ -161,7 +163,9 @@ class MultiLineTreeNew(multiline.MultiLine):
             tree = self.convertToTree(tree)
             self._myFullValues = tree
             if not isinstance(tree, NPSTree.NPSTreeData):
-                raise TypeError("MultiLineTree widget can only contain a NPSTreeData object in its values attribute")
+                raise TypeError(
+                    "MultiLineTree widget can only contain a NPSTreeData object in its values attribute"
+                )
         else:
             self._myFullValues = tree
 

--- a/leo/external/npyscreen/fmActionFormV2.py
+++ b/leo/external/npyscreen/fmActionFormV2.py
@@ -89,7 +89,9 @@ class ActionFormV2(fmForm.FormBaseNew):
         self.editw = len(self._widgets__) - 2
 
     # @+node:ekr.20170428084207.146: *3* _add_button
-    def _add_button(self, button_name, button_type, button_text, button_rely, button_relx, button_function):
+    def _add_button(
+        self, button_name, button_type, button_text, button_rely, button_relx, button_function
+    ):
         tmp_rely, tmp_relx = self.nextrely, self.nextrelx
         this_button = self.add_widget(
             button_type,

--- a/leo/external/npyscreen/fmFileSelector.py
+++ b/leo/external/npyscreen/fmFileSelector.py
@@ -127,7 +127,9 @@ class FileGrid(wggrid.SimpleGrid):
     # @+node:ekr.20170428084207.163: *3* FileGrid.h_select_file
     def h_select_file(self, *args, **keywrods):
         try:
-            select_file = os.path.join(self.parent.value, self.values[self.edit_cell[0]][self.edit_cell[1]])
+            select_file = os.path.join(
+                self.parent.value, self.values[self.edit_cell[0]][self.edit_cell[1]]
+            )
             select_file = os.path.abspath(select_file)
         except (TypeError, IndexError):
             self.edit_cell = [0, 0]
@@ -200,7 +202,9 @@ class FileSelector(fmFormMutt.FormMutt):
             utilNotify.notify_confirm(title="Error", message="Selected filename does not exist.")
             return False
         if self.select_dir and not os.path.isdir(self.value):
-            utilNotify.notify_confirm(title="Error", message="Selected filename is not a directory.")
+            utilNotify.notify_confirm(
+                title="Error", message="Selected filename is not a directory."
+            )
             return False
         self.exit_editing()
         return True

--- a/leo/external/npyscreen/fmForm.py
+++ b/leo/external/npyscreen/fmForm.py
@@ -26,7 +26,9 @@ from .globals import DISABLE_RESIZE_SYSTEM
 
 
 # @+node:ekr.20170428084207.176: ** class _FormBase
-class _FormBase(proto_fm_screen_area.ScreenArea, widget.InputHandler, wgwidget_proto._LinePrinter, EventHandler):
+class _FormBase(
+    proto_fm_screen_area.ScreenArea, widget.InputHandler, wgwidget_proto._LinePrinter, EventHandler
+):
     BLANK_COLUMNS_RIGHT = 2
     BLANK_LINES_BASE = 2
     OK_BUTTON_TEXT = 'OK'
@@ -345,7 +347,10 @@ class _FormBase(proto_fm_screen_area.ScreenArea, widget.InputHandler, wgwidget_p
                 break
         if trace:
             w = self._widgets__[n]
-            g.trace('(_FormBase:%s) FOUND: %s --> %s %s' % (self.__class__.__name__, old_n, n, w.__class__.__name__))
+            g.trace(
+                '(_FormBase:%s) FOUND: %s --> %s %s'
+                % (self.__class__.__name__, old_n, n, w.__class__.__name__)
+            )
         self.display()
 
     # @+node:ekr.20170428084207.201: *3* _FormBase.find_previous_editable
@@ -402,7 +407,13 @@ class _FormBase(proto_fm_screen_area.ScreenArea, widget.InputHandler, wgwidget_p
                 # self.curses_pad.addstr(0,1, ' '+str(_title)+' ')
                 if isinstance(_title, bytes):
                     _title = _title.decode('utf-8', 'replace')
-                self.add_line(0, 1, _title, self.make_attributes_list(_title, curses.A_NORMAL), self.columns - 4)
+                self.add_line(
+                    0,
+                    1,
+                    _title,
+                    self.make_attributes_list(_title, curses.A_NORMAL),
+                    self.columns - 4,
+                )
         except Exception:
             pass
 
@@ -426,12 +437,16 @@ class _FormBase(proto_fm_screen_area.ScreenArea, widget.InputHandler, wgwidget_p
         if self.framed:
             if curses.has_colors() and not GlobalOptions.DISABLE_ALL_COLORS:
                 self.curses_pad.attrset(0)
-                self.curses_pad.bkgdset(' ', curses.A_NORMAL | self.theme_manager.findPair(self, self.color))
+                self.curses_pad.bkgdset(
+                    ' ', curses.A_NORMAL | self.theme_manager.findPair(self, self.color)
+                )
             self.curses_pad.border()
             self.draw_title_and_help()
 
     # @+node:ekr.20170428084207.206: *3* add_widget
-    def add_widget(self, widgetClass, w_id=None, max_height=None, rely=None, relx=None, *args, **keywords):
+    def add_widget(
+        self, widgetClass, w_id=None, max_height=None, rely=None, relx=None, *args, **keywords
+    ):
         """Add a widget to the form.  The form will do its best to decide on placing, unless you override it.
         The form of this function is add_widget(WidgetClass, ....) with any arguments or keywords supplied to
         the widget. The widget will be added to self._widgets__
@@ -535,7 +550,9 @@ class TitleFooterForm(TitleForm):
         MAXY, MAXX = self.curses_pad.getmaxyx()
 
         if self.editing:
-            self.curses_pad.hline(MAXY - 1, 0, curses.ACS_HLINE, MAXX - self.__class__.OK_BUTTON_BR_OFFSET[1] - 1)
+            self.curses_pad.hline(
+                MAXY - 1, 0, curses.ACS_HLINE, MAXX - self.__class__.OK_BUTTON_BR_OFFSET[1] - 1
+            )
         else:
             self.curses_pad.hline(MAXY - 1, 0, curses.ACS_HLINE, MAXX - 1)
 

--- a/leo/external/npyscreen/fmFormMultiPage.py
+++ b/leo/external/npyscreen/fmFormMultiPage.py
@@ -76,7 +76,8 @@ class FormMultiPage(fmForm.FormBaseNew):
                 maxx - len(display_text) - 2,
                 display_text,
                 self.make_attributes_list(
-                    display_text, curses.A_NORMAL | self.theme_manager.findPair(self, self.pages_label_color)
+                    display_text,
+                    curses.A_NORMAL | self.theme_manager.findPair(self, self.pages_label_color),
                 ),
                 maxx - len(display_text) - 2,
             )

--- a/leo/external/npyscreen/fmFormMuttActive.py
+++ b/leo/external/npyscreen/fmFormMuttActive.py
@@ -66,7 +66,9 @@ class ActionControllerSimple:
 class TextCommandBox(wgtextbox.Textfield):
     # @+others
     # @+node:ekr.20170428084207.267: *3* __init__
-    def __init__(self, screen, history=False, history_max=100, set_up_history_keys=False, *args, **keywords):
+    def __init__(
+        self, screen, history=False, history_max=100, set_up_history_keys=False, *args, **keywords
+    ):
         super(TextCommandBox, self).__init__(screen, *args, **keywords)
         self.history = history
         self._history_store = collections.deque(maxlen=history_max)
@@ -164,9 +166,16 @@ class TextCommandBoxTraditional(TextCommandBox):
 
     # @+others
     # @+node:ekr.20170428084207.275: *3* __init__
-    def __init__(self, screen, history=True, history_max=100, set_up_history_keys=True, *args, **keywords):
+    def __init__(
+        self, screen, history=True, history_max=100, set_up_history_keys=True, *args, **keywords
+    ):
         super(TextCommandBoxTraditional, self).__init__(
-            screen, history=history, history_max=history_max, set_up_history_keys=set_up_history_keys, *args, **keywords
+            screen,
+            history=history,
+            history_max=history_max,
+            set_up_history_keys=set_up_history_keys,
+            *args,
+            **keywords,
         )
         self.linked_widget = None
         self.always_pass_to_linked_widget = []
@@ -196,7 +205,10 @@ class TextCommandBoxTraditional(TextCommandBox):
             return rtn
 
         if inputchstr and (self.value == '' or self.value == None):
-            if inputchstr in self.BEGINNING_OF_COMMAND_LINE_CHARS or inputch in self.BEGINNING_OF_COMMAND_LINE_CHARS:
+            if (
+                inputchstr in self.BEGINNING_OF_COMMAND_LINE_CHARS
+                or inputch in self.BEGINNING_OF_COMMAND_LINE_CHARS
+            ):
                 return super(TextCommandBoxTraditional, self).handle_input(inputch)
 
         if self.value:
@@ -269,7 +281,9 @@ class FormMuttActiveTraditional(fmFormMutt.FormMutt):
 
 
 # @+node:ekr.20170428084207.283: ** class FormMuttActiveTraditionalWithMenus
-class FormMuttActiveTraditionalWithMenus(FormMuttActiveTraditional, fmFormWithMenus.FormBaseNewWithMenus):
+class FormMuttActiveTraditionalWithMenus(
+    FormMuttActiveTraditional, fmFormWithMenus.FormBaseNewWithMenus
+):
     # @+others
     # @+node:ekr.20170428084207.284: *3* __init__
     def __init__(self, *args, **keywords):

--- a/leo/external/npyscreen/fmFormWithMenus.py
+++ b/leo/external/npyscreen/fmFormWithMenus.py
@@ -32,7 +32,13 @@ class FormBaseNewWithMenus(fmForm.FormBaseNew, wgNMenuDisplay.HasMenus):
         if isinstance(menu_advert, bytes):
             menu_advert = menu_advert.decode('utf-8', 'replace')
         y, x = self.display_menu_advert_at()
-        self.add_line(y, x, menu_advert, self.make_attributes_list(menu_advert, curses.A_NORMAL), self.columns - x - 1)
+        self.add_line(
+            y,
+            x,
+            menu_advert,
+            self.make_attributes_list(menu_advert, curses.A_NORMAL),
+            self.columns - x - 1,
+        )
 
     # @-others
 
@@ -58,7 +64,13 @@ class FormWithMenus(fmForm.Form, wgNMenuDisplay.HasMenus):
         y, x = self.display_menu_advert_at()
         if isinstance(menu_advert, bytes):
             menu_advert = menu_advert.decode('utf-8', 'replace')
-        self.add_line(y, x, menu_advert, self.make_attributes_list(menu_advert, curses.A_NORMAL), self.columns - x - 1)
+        self.add_line(
+            y,
+            x,
+            menu_advert,
+            self.make_attributes_list(menu_advert, curses.A_NORMAL),
+            self.columns - x - 1,
+        )
 
     # @-others
 
@@ -85,7 +97,13 @@ class ActionFormWithMenus(fmActionForm.ActionForm, wgNMenuDisplay.HasMenus):
 
         if isinstance(menu_advert, bytes):
             menu_advert = menu_advert.decode('utf-8', 'replace')
-        self.add_line(y, x, menu_advert, self.make_attributes_list(menu_advert, curses.A_NORMAL), self.columns - x - 1)
+        self.add_line(
+            y,
+            x,
+            menu_advert,
+            self.make_attributes_list(menu_advert, curses.A_NORMAL),
+            self.columns - x - 1,
+        )
 
     # @-others
 

--- a/leo/external/npyscreen/fmPopup.py
+++ b/leo/external/npyscreen/fmPopup.py
@@ -34,7 +34,9 @@ class MessagePopup(Popup):
         from . import wgmultiline as multiline
 
         super(MessagePopup, self).__init__(*args, **keywords)
-        self.TextWidget = self.add(multiline.Pager, scroll_exit=True, max_height=self.widget_useable_space()[0] - 2)
+        self.TextWidget = self.add(
+            multiline.Pager, scroll_exit=True, max_height=self.widget_useable_space()[0] - 2
+        )
 
     # @-others
 

--- a/leo/external/npyscreen/muNewMenu.py
+++ b/leo/external/npyscreen/muNewMenu.py
@@ -13,7 +13,14 @@ class NewMenu:
 
     # @+others
     # @+node:ekr.20170428084207.335: *3* __init__
-    def __init__(self, name=None, shortcut=None, preDisplayFunction=None, pdfuncArguments=None, pdfuncKeywords=None):
+    def __init__(
+        self,
+        name=None,
+        shortcut=None,
+        preDisplayFunction=None,
+        pdfuncArguments=None,
+        pdfuncKeywords=None,
+    ):
         self.name = name
         self._menuList = []
         self.enabled = True
@@ -65,7 +72,9 @@ class MenuItem:
 
     # @+others
     # @+node:ekr.20170428084207.343: *3* __init__
-    def __init__(self, text='', onSelect=None, shortcut=None, document=None, arguments=None, keywords=None):
+    def __init__(
+        self, text='', onSelect=None, shortcut=None, document=None, arguments=None, keywords=None
+    ):
         self.setText(text)
         self.setOnSelect(onSelect)
         self.setDocumentation(document)

--- a/leo/external/npyscreen/npysGlobalOptions.py
+++ b/leo/external/npyscreen/npysGlobalOptions.py
@@ -3,7 +3,9 @@
 # @+others
 # @+node:ekr.20170428084207.352: ** Declarations
 DISABLE_ALL_COLORS = False
-ASCII_ONLY = False  # See the safe_string function in wgwidget.  At the moment the encoding is not safe
+ASCII_ONLY = (
+    False  # See the safe_string function in wgwidget.  At the moment the encoding is not safe
+)
 # @-others
 # @@language python
 # @@tabwidth -4

--- a/leo/external/npyscreen/npysTree.py
+++ b/leo/external/npyscreen/npysTree.py
@@ -238,7 +238,9 @@ class TreeData:
                     if sort:
                         if key:
                             # must be reverse because about to use extendleft() below.
-                            nodes_to_yield.extendleft(sorted(child.get_children(), key=key, reverse=True))
+                            nodes_to_yield.extendleft(
+                                sorted(child.get_children(), key=key, reverse=True)
+                            )
                         else:
                             nodes_to_yield.extendleft(sorted(child.get_children(), reverse=True))
                     else:

--- a/leo/external/npyscreen/npyssafewrapper.py
+++ b/leo/external/npyscreen/npyssafewrapper.py
@@ -91,7 +91,9 @@ def external_reset():
 def wrapper_no_fork(call_function, reset=False):
     global _NEVER_RUN_INITSCR
     if not _NEVER_RUN_INITSCR:
-        warnings.warn("""Repeated calls of endwin may cause a memory leak. Use wrapper_fork to avoid.""")
+        warnings.warn(
+            """Repeated calls of endwin may cause a memory leak. Use wrapper_fork to avoid."""
+        )
     global _SCREEN
     return_code = None
     if _NEVER_RUN_INITSCR:

--- a/leo/external/npyscreen/proto_fm_screen_area.py
+++ b/leo/external/npyscreen/proto_fm_screen_area.py
@@ -53,7 +53,16 @@ class ScreenArea:
 
     # @+others
     # @+node:ekr.20170428084207.427: *3* ScreenArea.__init__
-    def __init__(self, lines=0, columns=0, minimum_lines=24, minimum_columns=80, show_atx=0, show_aty=0, **keywords):
+    def __init__(
+        self,
+        lines=0,
+        columns=0,
+        minimum_lines=24,
+        minimum_columns=80,
+        show_atx=0,
+        show_aty=0,
+        **keywords,
+    ):
         # Putting a default in here will override the system in _create_screen. For testing?
         if not lines:
             lines = self.__class__.DEFAULT_LINES
@@ -125,7 +134,9 @@ class ScreenArea:
         # let's see how big we could be: create a temp screen
         # and see the size curses makes it.  No good to keep, though
         try:
-            mxy, mxx = struct.unpack('hh', fcntl.ioctl(sys.stderr.fileno(), termios.TIOCGWINSZ, 'xxxx'))
+            mxy, mxx = struct.unpack(
+                'hh', fcntl.ioctl(sys.stderr.fileno(), termios.TIOCGWINSZ, 'xxxx')
+            )
             if (mxy, mxx) == (0, 0):
                 raise ValueError
         except (ValueError, NameError):
@@ -157,12 +168,17 @@ class ScreenArea:
         # Getting strange errors on OS X, with curses sometimes crashing at this point.
         # Suspect screen size not updated in time. This try: seems to solve it with no ill effects.
         try:
-            self.curses_pad.refresh(self.show_from_y, self.show_from_x, self.show_aty, self.show_atx, _my, _mx)
+            self.curses_pad.refresh(
+                self.show_from_y, self.show_from_x, self.show_aty, self.show_atx, _my, _mx
+            )
         except curses.error:
             pass
         self.ALL_SHOWN = (
             # #1525: change 'is' to '==' to avoid deprecation warning.
-            self.show_from_y == 0 and self.show_from_x == 0 and _my >= self.lines and _mx >= self.columns
+            self.show_from_y == 0
+            and self.show_from_x == 0
+            and _my >= self.lines
+            and _mx >= self.columns
         )
 
     # @+node:ekr.20170428084207.433: *3* erase

--- a/leo/external/npyscreen/stdfmemail.py
+++ b/leo/external/npyscreen/stdfmemail.py
@@ -72,7 +72,9 @@ class EmailTree(npyscreen.MultiLineTreeNew):
     # @+node:ekr.20170428084207.443: *3* h_save_message_part
     def h_save_message_part(self, ch):
         self.parent.saveMessagePart()
-        npyscreen.notify_wait("Message part saved to your downloads folder: \n %s" % self.parent.DOWNLOAD_DIR)
+        npyscreen.notify_wait(
+            "Message part saved to your downloads folder: \n %s" % self.parent.DOWNLOAD_DIR
+        )
 
     # @-others
 
@@ -103,7 +105,9 @@ class EmailPager(npyscreen.Pager):
     # @+node:ekr.20170428084207.447: *3* h_save_message_part
     def h_save_message_part(self, ch):
         self.parent.saveMessagePart()
-        npyscreen.notify_wait("Message part saved to your downloads folder: \n %s" % self.parent.DOWNLOAD_DIR)
+        npyscreen.notify_wait(
+            "Message part saved to your downloads folder: \n %s" % self.parent.DOWNLOAD_DIR
+        )
 
     # @-others
 
@@ -164,7 +168,11 @@ class EmailViewFm(npyscreen.SplitFormWithMenus):
         )
         self.nextrely = 1
         self.wSubject = self.add(
-            npyscreen.TitleText, begin_entry_at=10, editable=False, use_two_lines=False, name="Subject:"
+            npyscreen.TitleText,
+            begin_entry_at=10,
+            editable=False,
+            use_two_lines=False,
+            name="Subject:",
         )
         self.wFrom = self.add(
             npyscreen.TitleText,
@@ -212,7 +220,9 @@ class EmailViewFm(npyscreen.SplitFormWithMenus):
     # @+node:ekr.20170428084207.456: *3* when_select_part
     def when_select_part(self, vl):
         self.wEmailBody.hidden = False
-        self.wEmailBody.setValuesWrap(vl[0].getContent().get_payload(decode=True).decode(errors='replace').split("\n"))
+        self.wEmailBody.setValuesWrap(
+            vl[0].getContent().get_payload(decode=True).decode(errors='replace').split("\n")
+        )
         self.wEmailBody.start_display_at = 0
         self.wMessageTree.hidden = True
 
@@ -264,7 +274,11 @@ class EmailViewFm(npyscreen.SplitFormWithMenus):
         attempted_filename = fn
         while os.path.exists(os.path.join(self.DOWNLOAD_DIR, attempted_filename)):
             counter += 1
-            attempted_filename = "%s%s%s" % (os.path.splitext(fn)[0], counter, os.path.splitext(fn)[1])
+            attempted_filename = "%s%s%s" % (
+                os.path.splitext(fn)[0],
+                counter,
+                os.path.splitext(fn)[1],
+            )
         fn = attempted_filename
         fqfn = os.path.join(self.DOWNLOAD_DIR, fn)
         if messagePart.get_content_maintype() == "text":

--- a/leo/external/npyscreen/wgNMenuDisplay.py
+++ b/leo/external/npyscreen/wgNMenuDisplay.py
@@ -86,7 +86,9 @@ class MenuViewerController:
                     _menulines.append(itm)
                     _actionsToTake.append((self._goToSubmenu, itm))
                 else:
-                    raise ValueError("menu %s contains objects I don't know how to handle." % self._menu.name)
+                    raise ValueError(
+                        "menu %s contains objects I don't know how to handle." % self._menu.name
+                    )
 
             self._DisplayArea._menuListWidget.values = _menulines
             self._DisplayArea.display()
@@ -121,7 +123,9 @@ class PreviousMenu(NewMenu.NewMenu):
 class MenuDisplay(MenuViewerController):
     # @+others
     # @+node:ekr.20170428084208.266: *3* __init__
-    def __init__(self, color='CONTROL', lines=15, columns=39, show_atx=5, show_aty=2, *args, **keywords):
+    def __init__(
+        self, color='CONTROL', lines=15, columns=39, show_atx=5, show_aty=2, *args, **keywords
+    ):
         self._DisplayArea = MenuDisplayScreen(
             lines=lines, columns=columns, show_atx=show_atx, show_aty=show_aty, color=color
         )
@@ -183,7 +187,9 @@ class wgMenuListWithSortCuts(multiline.MultiLineActionWithShortcuts):
     # @+others
     # @+node:ekr.20170428084208.273: *3* __init__
     def __init__(self, screen, allow_filtering=False, *args, **keywords):
-        return super(wgMenuListWithSortCuts, self).__init__(screen, allow_filtering=allow_filtering, *args, **keywords)
+        return super(wgMenuListWithSortCuts, self).__init__(
+            screen, allow_filtering=allow_filtering, *args, **keywords
+        )
 
     # def actionHighlighted(self, act_on_this, key_press):
     #    if isinstance(act_on_this, MenuItem):

--- a/leo/external/npyscreen/wgannotatetextbox.py
+++ b/leo/external/npyscreen/wgannotatetextbox.py
@@ -52,7 +52,11 @@ class AnnotateTextboxBase(wgwidget.Widget):
         displayy, displayx = self._display_annotation_at()
         _annotation, _color = self.getAnnotationAndColor()
         self.parent.curses_pad.addnstr(
-            displayy, displayx, _annotation, self.ANNOTATE_WIDTH, self.parent.theme_manager.findPair(self, _color)
+            displayy,
+            displayx,
+            _annotation,
+            self.ANNOTATE_WIDTH,
+            self.parent.theme_manager.findPair(self, _color),
         )
 
     # @+node:ekr.20170428084207.488: *3* annotationNoColor
@@ -113,7 +117,11 @@ class AnnotateTextboxBaseRight(AnnotateTextboxBase):
     # @+node:ekr.20170428084207.492: *3* _init_text_area
     def _init_text_area(self, screen):
         self.text_area = Textfield(
-            screen, rely=self.rely, relx=self.relx, width=self.width - self.ANNOTATE_WIDTH, value=self.name
+            screen,
+            rely=self.rely,
+            relx=self.relx,
+            width=self.width - self.ANNOTATE_WIDTH,
+            value=self.name,
         )
 
     # @+node:ekr.20170428084207.493: *3* _display_annotation_at

--- a/leo/external/npyscreen/wgautocomplete.py
+++ b/leo/external/npyscreen/wgautocomplete.py
@@ -92,14 +92,18 @@ class Filename(Autocomplete):
             else:
                 filelist = flist  # os.listdir(os.path.dirname(self.value))
 
-            filelist = list(map((lambda x: os.path.normpath(os.path.join(self.value, x))), filelist))
+            filelist = list(
+                map((lambda x: os.path.normpath(os.path.join(self.value, x))), filelist)
+            )
             files_only = []
             dirs_only = []
 
             if fname.startswith('.'):
                 filelist = list(filter((lambda x: os.path.basename(x).startswith('.')), filelist))
             else:
-                filelist = list(filter((lambda x: not os.path.basename(x).startswith('.')), filelist))
+                filelist = list(
+                    filter((lambda x: not os.path.basename(x).startswith('.')), filelist)
+                )
 
             for index1 in range(len(filelist)):
                 if os.path.isdir(filelist[index1]) and not filelist[index1].endswith(os.sep):

--- a/leo/external/npyscreen/wgboxwidget.py
+++ b/leo/external/npyscreen/wgboxwidget.py
@@ -76,7 +76,9 @@ class BoxBasic(Widget):
                     self, self.color
                 )  # | curses.A_BOLD
             elif self.editing:
-                name_attributes = name_attributes | self.parent.theme_manager.findPair(self, 'HILIGHT')
+                name_attributes = name_attributes | self.parent.theme_manager.findPair(
+                    self, 'HILIGHT'
+                )
             else:
                 name_attributes = name_attributes  # | curses.A_BOLD
 
@@ -84,7 +86,11 @@ class BoxBasic(Widget):
                 name_attributes = name_attributes | curses.A_BOLD
 
             self.add_line(
-                self.rely, self.relx + 4, name, self.make_attributes_list(name, name_attributes), self.width - 8
+                self.rely,
+                self.relx + 4,
+                name,
+                self.make_attributes_list(name, name_attributes),
+                self.width - 8,
             )
             # end draw title
 
@@ -105,7 +111,11 @@ class BoxBasic(Widget):
                 placing = 4
 
             self.add_line(
-                self.rely + HEIGHT, self.relx + placing, footer_text, footer_attributes, self.width - placing - 2
+                self.rely + HEIGHT,
+                self.relx + placing,
+                footer_text,
+                footer_attributes,
+                self.width - placing - 2,
             )
 
     # @+node:ekr.20170428084207.508: *3* get_footer_attributes
@@ -116,7 +126,9 @@ class BoxBasic(Widget):
                 self, self.color
             )  # | curses.A_BOLD
         elif self.editing:
-            footer_attributes = footer_attributes | self.parent.theme_manager.findPair(self, 'HILIGHT')
+            footer_attributes = footer_attributes | self.parent.theme_manager.findPair(
+                self, 'HILIGHT'
+            )
         else:
             footer_attributes = footer_attributes  # | curses.A_BOLD
 

--- a/leo/external/npyscreen/wgbutton.py
+++ b/leo/external/npyscreen/wgbutton.py
@@ -48,7 +48,9 @@ class MiniButton(checkbox._ToggleControl):
             return False
 
         if self.value and self.do_colors():
-            self.parent.curses_pad.addstr(self.rely, self.relx, '>', self.parent.theme_manager.findPair(self))
+            self.parent.curses_pad.addstr(
+                self.rely, self.relx, '>', self.parent.theme_manager.findPair(self)
+            )
             self.parent.curses_pad.addstr(
                 self.rely, self.relx + self.width - 1, '<', self.parent.theme_manager.findPair(self)
             )
@@ -73,7 +75,9 @@ class MiniButton(checkbox._ToggleControl):
                 else:
                     button_attributes = self.parent.theme_manager.findPair(self, self.color)
             else:
-                button_attributes = self.parent.theme_manager.findPair(self, self.color) | button_state
+                button_attributes = (
+                    self.parent.theme_manager.findPair(self, self.color) | button_state
+                )
         else:
             button_attributes = button_state
 

--- a/leo/external/npyscreen/wgcheckbox.py
+++ b/leo/external/npyscreen/wgcheckbox.py
@@ -87,7 +87,10 @@ class CheckboxBare(_ToggleControl):
 
         if self.do_colors():
             self.parent.curses_pad.addstr(
-                self.rely, self.relx, cb_display, self.parent.theme_manager.findPair(self, 'CONTROL')
+                self.rely,
+                self.relx,
+                cb_display,
+                self.parent.theme_manager.findPair(self, 'CONTROL'),
             )
         else:
             self.parent.curses_pad.addstr(self.rely, self.relx, cb_display)
@@ -135,7 +138,9 @@ class Checkbox(_ToggleControl):
         if l_a_width < 1:
             raise ValueError("Width of checkbox + label must be at least 6")
 
-        self.label_area = Textfield(screen, rely=self.rely, relx=self.relx + 5, width=self.width - 5, value=self.name)
+        self.label_area = Textfield(
+            screen, rely=self.rely, relx=self.relx + 5, width=self.width - 5, value=self.name
+        )
 
     # @+node:ekr.20170428084207.550: *3* CheckBox.update
     def update(self, clear=True):
@@ -154,7 +159,10 @@ class Checkbox(_ToggleControl):
 
         if self.do_colors():
             self.parent.curses_pad.addstr(
-                self.rely, self.relx, cb_display, self.parent.theme_manager.findPair(self, 'CONTROL')
+                self.rely,
+                self.relx,
+                cb_display,
+                self.parent.theme_manager.findPair(self, 'CONTROL'),
             )
         else:
             self.parent.curses_pad.addstr(self.rely, self.relx, cb_display)
@@ -216,7 +224,9 @@ class CheckBoxMultiline(Checkbox):
         self.label_area = []
         for y in range(self.height):
             self.label_area.append(
-                Textfield(screen, rely=self.rely + y, relx=self.relx + 5, width=self.width - 5, value=None)
+                Textfield(
+                    screen, rely=self.rely + y, relx=self.relx + 5, width=self.width - 5, value=None
+                )
             )
 
     # @+node:ekr.20170428084207.558: *3* _update_label_area

--- a/leo/external/npyscreen/wgdatecombo.py
+++ b/leo/external/npyscreen/wgdatecombo.py
@@ -17,7 +17,9 @@ import curses
 class DateCombo(textbox.Textfield, monthbox.DateEntryBase):
     # @+others
     # @+node:ekr.20170428084207.578: *3* __init__
-    def __init__(self, screen, allowPastDate=True, allowTodaysDate=True, allowClear=True, **keywords):
+    def __init__(
+        self, screen, allowPastDate=True, allowTodaysDate=True, allowClear=True, **keywords
+    ):
         super(DateCombo, self).__init__(screen, **keywords)
         self.allow_date_in_past = allowPastDate
         self.allow_todays_date = allowTodaysDate
@@ -58,7 +60,9 @@ class DateCombo(textbox.Textfield, monthbox.DateEntryBase):
                 ),
             )
         else:
-            self.parent.curses_pad.addnstr(self.rely, self.relx, self.display_value(self.value), self.width)
+            self.parent.curses_pad.addnstr(
+                self.rely, self.relx, self.display_value(self.value), self.width
+            )
 
     # @+node:ekr.20170428084207.583: *3* h_change_value
     def h_change_value(self, *arg):

--- a/leo/external/npyscreen/wgeditmultiline.py
+++ b/leo/external/npyscreen/wgeditmultiline.py
@@ -20,7 +20,9 @@ class MultiLineEdit(widget.Widget):
 
     # @+others
     # @+node:ekr.20170428084207.589: *3* MultiLineEdit.__init__
-    def __init__(self, screen, autowrap=True, slow_scroll=True, scroll_exit=True, value=None, **keywords):
+    def __init__(
+        self, screen, autowrap=True, slow_scroll=True, scroll_exit=True, value=None, **keywords
+    ):
         self.value = value or ''
         super(MultiLineEdit, self).__init__(screen, **keywords)
         self.cursor_position = 0
@@ -119,7 +121,9 @@ class MultiLineEdit(widget.Widget):
         for line_counter in range(self.height):
             if line_counter >= len(text_to_display) - self.start_display_at:
                 break
-            line_to_display = text_to_display[self.start_display_at + line_counter][xdisplay_offset:]
+            line_to_display = text_to_display[self.start_display_at + line_counter][
+                xdisplay_offset:
+            ]
             line_to_display = self.safe_string(line_to_display)
             if isinstance(line_to_display, bytes):
                 line_to_display = line_to_display.decode(self.encoding, 'replace')
@@ -294,7 +298,9 @@ class MultiLineEdit(widget.Widget):
                     ch_adding = chr(inp)
                 except TypeError:
                     ch_adding = input
-            self.value = self.value[: self.cursor_position] + ch_adding + self.value[self.cursor_position :]
+            self.value = (
+                self.value[: self.cursor_position] + ch_adding + self.value[self.cursor_position :]
+            )
             self.cursor_position += len(ch_adding)
         else:
             return False
@@ -315,7 +321,9 @@ class MultiLineEdit(widget.Widget):
         """Add printable characters.  However, do NOT add newlines with this function"""
         if not self.editable:
             return False
-        self.value = self.value[: self.cursor_position] + chr(input) + self.value[self.cursor_position :]
+        self.value = (
+            self.value[: self.cursor_position] + chr(input) + self.value[self.cursor_position :]
+        )
         self.cursor_position += len(chr(input))
 
         if self.autowrap:

--- a/leo/external/npyscreen/wggrid.py
+++ b/leo/external/npyscreen/wggrid.py
@@ -81,7 +81,9 @@ class SimpleGrid(widget.Widget):
     def make_contained_widgets(self):
         if self.column_width_requested:
             # don't need a margin for the final column
-            self.columns = (self.width + self.col_margin) // (self.column_width_requested + self.col_margin)
+            self.columns = (self.width + self.col_margin) // (
+                self.column_width_requested + self.col_margin
+            )
         elif self.columns_requested:
             self.columns = self.columns_requested
         else:
@@ -158,7 +160,10 @@ class SimpleGrid(widget.Widget):
         self._cell_widget_show_value(cell, cell_value)
 
         if self.value:
-            if cell.grid_current_value_index in self.value or cell.grid_current_value_index == self.value:
+            if (
+                cell.grid_current_value_index in self.value
+                or cell.grid_current_value_index == self.value
+            ):
                 self._cell_widget_show_value_selected(cell, True)
             else:
                 self._cell_widget_show_value_selected(cell, False)
@@ -287,7 +292,9 @@ class SimpleGrid(widget.Widget):
 
     # @+node:ekr.20170428084208.24: *3* SimpleGrid.h_move_cell_right
     def h_move_cell_right(self, inpt):
-        if self.edit_cell[1] <= len(self.values[self.edit_cell[0]]) - 2:  # Only allow move to end of current line
+        if (
+            self.edit_cell[1] <= len(self.values[self.edit_cell[0]]) - 2
+        ):  # Only allow move to end of current line
             self.edit_cell[1] += 1
 
         if self.edit_cell[1] > self.begin_col_display_at + self.columns - 1:

--- a/leo/external/npyscreen/wggridcoltitles.py
+++ b/leo/external/npyscreen/wggridcoltitles.py
@@ -31,7 +31,11 @@ class GridColTitles(grid.SimpleGrid):
             x_offset = title_cell * (self._column_width + self.col_margin)
             self._my_col_titles.append(
                 self._col_widgets(
-                    self.parent, rely=self.rely, relx=self.relx + x_offset, width=self._column_width, height=1
+                    self.parent,
+                    rely=self.rely,
+                    relx=self.relx + x_offset,
+                    width=self._column_width,
+                    height=1,
                 )
             )
 

--- a/leo/external/npyscreen/wgmonthbox.py
+++ b/leo/external/npyscreen/wgmonthbox.py
@@ -226,7 +226,11 @@ class MonthBox(DateEntryBase):
             title_attribute = curses.A_NORMAL
 
         self.add_line(
-            self.rely, self.relx, _title_line, self.make_attributes_list(_title_line, title_attribute), self.width - 1
+            self.rely,
+            self.relx,
+            _title_line,
+            self.make_attributes_list(_title_line, title_attribute),
+            self.width - 1,
         )
 
         if self.value:
@@ -272,10 +276,13 @@ class MonthBox(DateEntryBase):
                                     print_line,
                                     print_column,
                                     str(thisday),
-                                    curses.A_STANDOUT | self.parent.theme_manager.findPair(self, self.color),
+                                    curses.A_STANDOUT
+                                    | self.parent.theme_manager.findPair(self, self.color),
                                 )
                             else:
-                                self.parent.curses_pad.addstr(print_line, print_column, str(thisday), curses.A_STANDOUT)
+                                self.parent.curses_pad.addstr(
+                                    print_line, print_column, str(thisday), curses.A_STANDOUT
+                                )
                         else:
                             if self.do_colors():
                                 self.parent.curses_pad.addstr(
@@ -285,7 +292,9 @@ class MonthBox(DateEntryBase):
                                     self.parent.theme_manager.findPair(self, self.color),
                                 )
                             else:
-                                self.parent.curses_pad.addstr(print_line, print_column, str(thisday))
+                                self.parent.curses_pad.addstr(
+                                    print_line, print_column, str(thisday)
+                                )
                         print_column += self.__class__.DAY_FIELD_WIDTH
 
                     print_line += 1
@@ -298,7 +307,10 @@ class MonthBox(DateEntryBase):
 
             if self.do_colors():
                 self.parent.curses_pad.addstr(
-                    self.rely + 9, self.relx, key_help, self.parent.theme_manager.findPair(self, 'LABEL')
+                    self.rely + 9,
+                    self.relx,
+                    key_help,
+                    self.parent.theme_manager.findPair(self, 'LABEL'),
                 )
             else:
                 self.parent.curses_pad.addstr(self.rely + 9, self.relx, key_help)

--- a/leo/external/npyscreen/wgmultiline.py
+++ b/leo/external/npyscreen/wgmultiline.py
@@ -278,7 +278,9 @@ class MultiLine(widget.Widget):
                         self.parent.theme_manager.findPair(self, 'CONTROL'),
                     )
                 else:
-                    self.parent.curses_pad.addstr(self.rely + self.height - 1, self.relx, MORE_LABEL)
+                    self.parent.curses_pad.addstr(
+                        self.rely + self.height - 1, self.relx, MORE_LABEL
+                    )
             else:
                 # line.value = MORE_LABEL
                 line.name = MORE_LABEL
@@ -300,7 +302,9 @@ class MultiLine(widget.Widget):
                         MORE_LABEL,
                     )
             if self.editing or self.always_show_cursor:
-                self.set_is_line_cursor(self._my_widgets[(self.cursor_line - self.start_display_at)], True)
+                self.set_is_line_cursor(
+                    self._my_widgets[(self.cursor_line - self.start_display_at)], True
+                )
                 self._my_widgets[(self.cursor_line - self.start_display_at)].update(clear=True)
             else:
                 # There is a bug somewhere that affects the first line.  This cures it.
@@ -313,7 +317,10 @@ class MultiLine(widget.Widget):
         self._last_value = copy.copy(self.value)
         # Prevent the program crashing if the user has changed values and
         # the cursor is now on the bottom line.
-        if self._my_widgets[self.cursor_line - self.start_display_at].task in (MORE_LABEL, "PRINTLINELASTOFSCREEN"):
+        if self._my_widgets[self.cursor_line - self.start_display_at].task in (
+            MORE_LABEL,
+            "PRINTLINELASTOFSCREEN",
+        ):
             if self.slow_scroll:
                 self.start_display_at += 1
             else:
@@ -870,7 +877,10 @@ class Pager(MultiLine):
     # @+node:ekr.20170428084208.136: *3* Pager.h_scroll_line_down
     def h_scroll_line_down(self, input):
         self.start_display_at += 1
-        if self.scroll_exit and self.start_display_at >= len(self.values) - self.start_display_at + 1:
+        if (
+            self.scroll_exit
+            and self.start_display_at >= len(self.values) - self.start_display_at + 1
+        ):
             self.editing = False
             self.how_exited = widget.EXITED_DOWN
 

--- a/leo/external/npyscreen/wgmultilinetree.py
+++ b/leo/external/npyscreen/wgmultilinetree.py
@@ -55,7 +55,9 @@ class TreeLine(textbox.TextfieldBase):
 
     # @+node:ekr.20170428084208.179: *3* TreeLine._print_tree
     def _print_tree(self, real_x):
-        if not hasattr(self._tree_real_value, 'find_depth') and not hasattr(self._tree_real_value, 'findDepth'):
+        if not hasattr(self._tree_real_value, 'find_depth') and not hasattr(
+            self._tree_real_value, 'findDepth'
+        ):
             margin_needed = 0
             return margin_needed
 
@@ -74,7 +76,9 @@ class TreeLine(textbox.TextfieldBase):
                     if (i < _tree_depth_next) and (not self._tree_last_line):
                         # was i+1 < # and not (_tree_depth_next==1):
                         if self.show_v_lines:
-                            self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_VLINE, curses.A_NORMAL)
+                            self.parent.curses_pad.addch(
+                                self.rely, real_x, curses.ACS_VLINE, curses.A_NORMAL
+                            )
                             if self.height > 1:
                                 for h in range(self.height - 1):
                                     self.parent.curses_pad.addch(
@@ -85,7 +89,9 @@ class TreeLine(textbox.TextfieldBase):
 
                     else:
                         if self.show_v_lines:
-                            self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_BTEE, curses.A_NORMAL)
+                            self.parent.curses_pad.addch(
+                                self.rely, real_x, curses.ACS_BTEE, curses.A_NORMAL
+                            )
                         else:
                             self.parent.curses_pad.addch(self.rely, real_x, ' ', curses.A_NORMAL)
                     real_x += 1
@@ -93,19 +99,27 @@ class TreeLine(textbox.TextfieldBase):
                     real_x += 1
 
                 if self._tree_sibling_next or _tree_depth_next > self._tree_depth:
-                    self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_LTEE, curses.A_NORMAL)
+                    self.parent.curses_pad.addch(
+                        self.rely, real_x, curses.ACS_LTEE, curses.A_NORMAL
+                    )
                     if self.height > 1:
                         for h in range(self.height - 1):
-                            self.parent.curses_pad.addch(self.rely + h + 1, real_x, curses.ACS_VLINE, curses.A_NORMAL)
+                            self.parent.curses_pad.addch(
+                                self.rely + h + 1, real_x, curses.ACS_VLINE, curses.A_NORMAL
+                            )
                 else:
-                    self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_LLCORNER, curses.A_NORMAL)
+                    self.parent.curses_pad.addch(
+                        self.rely, real_x, curses.ACS_LLCORNER, curses.A_NORMAL
+                    )
                 real_x += 1
                 self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_HLINE, curses.A_NORMAL)
                 real_x += 1
             else:  # dp >= this_safe_depth_display
                 self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_HLINE, curses.A_NORMAL)
                 real_x += 1
-                self.parent.curses_pad.addstr(self.rely, real_x, "[ %s ]" % (str(dp)), curses.A_NORMAL)
+                self.parent.curses_pad.addstr(
+                    self.rely, real_x, "[ %s ]" % (str(dp)), curses.A_NORMAL
+                )
                 real_x += len(str(dp)) + 4
                 self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_RTEE, curses.A_NORMAL)
                 real_x += 1
@@ -115,7 +129,9 @@ class TreeLine(textbox.TextfieldBase):
                 self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_TTEE, curses.A_NORMAL)
                 if self.height > 1:
                     for h in range(self.height - 1):
-                        self.parent.curses_pad.addch(self.rely + h + 1, real_x, curses.ACS_VLINE, curses.A_NORMAL)
+                        self.parent.curses_pad.addch(
+                            self.rely + h + 1, real_x, curses.ACS_VLINE, curses.A_NORMAL
+                        )
             else:  # not expanded
                 self.parent.curses_pad.addch(self.rely, real_x, curses.ACS_RARROW, curses.A_NORMAL)
 
@@ -160,7 +176,9 @@ class TreeLineAnnotated(TreeLine):
         # Must return the "Margin" needed before the entry begins
         # historical reasons.
         _annotation, _color = self.getAnnotationAndColor()
-        self.parent.curses_pad.addstr(self.rely, real_x, _annotation, self.parent.theme_manager.findPair(self, _color))
+        self.parent.curses_pad.addstr(
+            self.rely, real_x, _annotation, self.parent.theme_manager.findPair(self, _color)
+        )
         return len(_annotation)
 
     # @+node:ekr.20170428084208.185: *3* annotationNoColor
@@ -278,11 +296,17 @@ class MLTree(multiline.MultiLine):
     def _walk_tree(self, root, only_expanded=True, ignore_root=True, sort=None, sort_function=None):
         try:
             return root.walk_tree(
-                only_expanded=only_expanded, ignore_root=ignore_root, sort=sort, sort_function=sort_function
+                only_expanded=only_expanded,
+                ignore_root=ignore_root,
+                sort=sort,
+                sort_function=sort_function,
             )
         except AttributeError:
             return root.walkTree(
-                onlyExpanded=only_expanded, ignoreRoot=ignore_root, sort=sort, sort_function=sort_function
+                onlyExpanded=only_expanded,
+                ignoreRoot=ignore_root,
+                sort=sort,
+                sort_function=sort_function,
             )
 
     # @+node:ekr.20170428084208.199: *3* MLTree._walkMyValues
@@ -359,7 +383,9 @@ class MLTree(multiline.MultiLine):
     # @+node:ekr.20170502150015.1: *3* MLTree.Handlers
     # @+node:ekr.20170428084208.206: *4* MLTree.h_collapse_tree
     def h_collapse_tree(self, ch):
-        if self.values[self.cursor_line].expanded and self._has_children(self.values[self.cursor_line]):
+        if self.values[self.cursor_line].expanded and self._has_children(
+            self.values[self.cursor_line]
+        ):
             self.values[self.cursor_line].expanded = False
         else:
             look_for_depth = self._find_depth(self.values[self.cursor_line]) - 1

--- a/leo/external/npyscreen/wgslider.py
+++ b/leo/external/npyscreen/wgslider.py
@@ -14,7 +14,17 @@ class Slider(widget.Widget):
 
     # @+others
     # @+node:ekr.20170428084208.300: *3* Slider.__init__
-    def __init__(self, screen, value=0, out_of=100, step=1, lowest=0, label=True, block_color=None, **keywords):
+    def __init__(
+        self,
+        screen,
+        value=0,
+        out_of=100,
+        step=1,
+        lowest=0,
+        label=True,
+        block_color=None,
+        **keywords,
+    ):
         self.out_of = out_of
         self.value = value
         self.step = step
@@ -96,23 +106,36 @@ class Slider(widget.Widget):
             xoffset = self.relx
             if self.do_colors():
                 self.parent.curses_pad.addch(
-                    self.rely, n + xoffset, BACKGROUND_CHAR, curses.A_NORMAL | self.parent.theme_manager.findPair(self)
+                    self.rely,
+                    n + xoffset,
+                    BACKGROUND_CHAR,
+                    curses.A_NORMAL | self.parent.theme_manager.findPair(self),
                 )
             else:
-                self.parent.curses_pad.addch(self.rely, n + xoffset, BACKGROUND_CHAR, curses.A_NORMAL)
+                self.parent.curses_pad.addch(
+                    self.rely, n + xoffset, BACKGROUND_CHAR, curses.A_NORMAL
+                )
 
         for n in range(int(blocks_to_fill)):
             if self.do_colors():
                 if self.block_color:
                     self.parent.curses_pad.addch(
-                        self.rely, n + xoffset, BARCHAR, self.parent.theme_manager.findPair(self, self.block_color)
+                        self.rely,
+                        n + xoffset,
+                        BARCHAR,
+                        self.parent.theme_manager.findPair(self, self.block_color),
                     )
                 else:
                     self.parent.curses_pad.addch(
-                        self.rely, n + xoffset, BARCHAR, curses.A_STANDOUT | self.parent.theme_manager.findPair(self)
+                        self.rely,
+                        n + xoffset,
+                        BARCHAR,
+                        curses.A_STANDOUT | self.parent.theme_manager.findPair(self),
                     )
             else:
-                self.parent.curses_pad.addch(self.rely, n + xoffset, BARCHAR, curses.A_STANDOUT)  # curses.ACS_BLOCK)
+                self.parent.curses_pad.addch(
+                    self.rely, n + xoffset, BARCHAR, curses.A_STANDOUT
+                )  # curses.ACS_BLOCK)
 
         self.parent.curses_pad.attroff(curses.A_BOLD)
         self.parent.curses_pad.bkgdset(curses.A_NORMAL)

--- a/leo/external/npyscreen/wgtextbox.py
+++ b/leo/external/npyscreen/wgtextbox.py
@@ -64,7 +64,9 @@ class TextfieldBase(widget.Widget):
         if self.on_last_line:
             self.maximum_string_length = self.width - 2  # Leave room for the cursor
         else:
-            self.maximum_string_length = self.width - 1  # Leave room for the cursor at the end of the string.
+            self.maximum_string_length = (
+                self.width - 1
+            )  # Leave room for the cursor at the end of the string.
 
     # @+node:ekr.20170428084208.323: *3* resize
     def resize(self):
@@ -111,7 +113,9 @@ class TextfieldBase(widget.Widget):
             if isinstance(self.value, bytes):
                 # use a unicode version of self.value to work out where the cursor is.
                 # not always accurate, but better than the bytes
-                value_to_use_for_calculations = self.display_value(self.value).decode(self.encoding, 'replace')
+                value_to_use_for_calculations = self.display_value(self.value).decode(
+                    self.encoding, 'replace'
+                )
             if cursor:
                 if self.cursor_position is False:
                     self.cursor_position = len(value_to_use_for_calculations)
@@ -125,12 +129,17 @@ class TextfieldBase(widget.Widget):
                 if self.cursor_position < self.begin_at:
                     self.begin_at = self.cursor_position
 
-                while self.cursor_position > self.begin_at + self.maximum_string_length - self.left_margin:  # -1:
+                while (
+                    self.cursor_position
+                    > self.begin_at + self.maximum_string_length - self.left_margin
+                ):  # -1:
                     self.begin_at += 1
             else:
                 if self.do_colors():
                     self.parent.curses_pad.bkgdset(
-                        ' ', self.parent.theme_manager.findPair(self, self.highlight_color) | curses.A_STANDOUT
+                        ' ',
+                        self.parent.theme_manager.findPair(self, self.highlight_color)
+                        | curses.A_STANDOUT,
                     )
                 else:
                     self.parent.curses_pad.bkgdset(' ', curses.A_STANDOUT)
@@ -138,7 +147,10 @@ class TextfieldBase(widget.Widget):
         if self.highlight:
             if self.do_colors():
                 if self.invert_highlight_color:
-                    attributes = self.parent.theme_manager.findPair(self, self.highlight_color) | curses.A_STANDOUT
+                    attributes = (
+                        self.parent.theme_manager.findPair(self, self.highlight_color)
+                        | curses.A_STANDOUT
+                    )
                 else:
                     attributes = self.parent.theme_manager.findPair(self, self.highlight_color)
                 self.parent.curses_pad.bkgdset(' ', attributes)
@@ -249,7 +261,9 @@ class TextfieldBase(widget.Widget):
         string_to_print = self.display_value(self.value)
         if not string_to_print:
             return None
-        string_to_print = string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin]
+        string_to_print = string_to_print[
+            self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin
+        ]
 
         if sys.version_info[0] >= 3:
             string_to_print = self.display_value(self.value)[
@@ -260,7 +274,9 @@ class TextfieldBase(widget.Widget):
             dv = self.display_value(self.value)
             if isinstance(dv, bytes):
                 dv = dv.decode(self.encoding, 'replace')
-            string_to_print = dv[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin]
+            string_to_print = dv[
+                self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin
+            ]
         return string_to_print
 
     # @+node:ekr.20170428084208.332: *3* TextfieldBase._print
@@ -268,7 +284,9 @@ class TextfieldBase(widget.Widget):
         string_to_print = self._get_string_to_print()
         if not string_to_print:
             return None
-        string_to_print = string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin]
+        string_to_print = string_to_print[
+            self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin
+        ]
 
         if sys.version_info[0] >= 3:
             string_to_print = self.display_value(self.value)[
@@ -279,13 +297,16 @@ class TextfieldBase(widget.Widget):
             dv = self.display_value(self.value)
             if isinstance(dv, bytes):
                 dv = dv.decode(self.encoding, 'replace')
-            string_to_print = dv[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin]
+            string_to_print = dv[
+                self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin
+            ]
 
         column = 0
         place_in_string = 0
         if self.syntax_highlighting:
             self.update_highlighting(
-                start=self.begin_at, end=self.maximum_string_length + self.begin_at - self.left_margin
+                start=self.begin_at,
+                end=self.maximum_string_length + self.begin_at - self.left_margin,
             )
             while column <= (self.maximum_string_length - self.left_margin):
                 if not string_to_print or place_in_string > len(string_to_print) - 1:
@@ -356,17 +377,27 @@ class TextfieldBase(widget.Widget):
 
         if self.syntax_highlighting:
             self.update_highlighting(
-                start=self.begin_at, end=self.maximum_string_length + self.begin_at - self.left_margin
+                start=self.begin_at,
+                end=self.maximum_string_length + self.begin_at - self.left_margin,
             )
             for i in range(
-                len(string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin])
+                len(
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ]
+                )
             ):
                 try:
                     highlight = self._highlightingdata[self.begin_at + i]
                 except Exception:
                     highlight = curses.A_NORMAL
                 self.parent.curses_pad.addstr(
-                    self.rely, self.relx + i + self.left_margin, string_to_print[self.begin_at + i], highlight
+                    self.rely,
+                    self.relx + i + self.left_margin,
+                    string_to_print[self.begin_at + i],
+                    highlight,
                 )
         elif self.do_colors():
             coltofind = 'DEFAULT'
@@ -376,7 +407,11 @@ class TextfieldBase(widget.Widget):
                 self.parent.curses_pad.addstr(
                     self.rely,
                     self.relx + self.left_margin,
-                    string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin],
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ],
                     self.parent.theme_manager.findPair(self, coltofind) | curses.A_BOLD,
                 )
             elif self.important:
@@ -384,14 +419,22 @@ class TextfieldBase(widget.Widget):
                 self.parent.curses_pad.addstr(
                     self.rely,
                     self.relx + self.left_margin,
-                    string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin],
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ],
                     self.parent.theme_manager.findPair(self, coltofind) | curses.A_BOLD,
                 )
             else:
                 self.parent.curses_pad.addstr(
                     self.rely,
                     self.relx + self.left_margin,
-                    string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin],
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ],
                     self.parent.theme_manager.findPair(self),
                 )
         else:
@@ -399,21 +442,33 @@ class TextfieldBase(widget.Widget):
                 self.parent.curses_pad.addstr(
                     self.rely,
                     self.relx + self.left_margin,
-                    string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin],
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ],
                     curses.A_BOLD,
                 )
             elif self.show_bold:
                 self.parent.curses_pad.addstr(
                     self.rely,
                     self.relx + self.left_margin,
-                    string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin],
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ],
                     curses.A_BOLD,
                 )
             else:
                 self.parent.curses_pad.addstr(
                     self.rely,
                     self.relx + self.left_margin,
-                    string_to_print[self.begin_at : self.maximum_string_length + self.begin_at - self.left_margin],
+                    string_to_print[
+                        self.begin_at : self.maximum_string_length
+                        + self.begin_at
+                        - self.left_margin
+                    ],
                 )
 
     # @+node:ekr.20170428084208.334: *3* update_highlighting
@@ -493,7 +548,9 @@ class Textfield(TextfieldBase):
                     ch_adding = chr(inp)
                 except TypeError:
                     ch_adding = input
-            self.value = self.value[: self.cursor_position] + ch_adding + self.value[self.cursor_position :]
+            self.value = (
+                self.value[: self.cursor_position] + ch_adding + self.value[self.cursor_position :]
+            )
             self.cursor_position += len(ch_adding)
 
             # or avoid it entirely:

--- a/leo/external/npyscreen/wgtexttokens.py
+++ b/leo/external/npyscreen/wgtexttokens.py
@@ -101,7 +101,10 @@ class TextTokens(wgtextbox.Textfield, wgwidget.Widget):
 
         while (
             self.find_cursor_offset_on_screen(self.cursor_position)
-            > self.find_cursor_offset_on_screen(self.begin_at) + self.maximum_string_length - self.left_margin - 1
+            > self.find_cursor_offset_on_screen(self.begin_at)
+            + self.maximum_string_length
+            - self.left_margin
+            - 1
         ):  # -1:
             self.begin_at += 1
 
@@ -140,14 +143,20 @@ class TextTokens(wgtextbox.Textfield, wgwidget.Widget):
     # @+node:ekr.20170428084208.375: *3* TextTokens._print
     def _print(self, text, highlighting):
         self.add_line(
-            self.rely, self.relx + self.left_margin, text, highlighting, self.maximum_string_length - self.left_margin
+            self.rely,
+            self.relx + self.left_margin,
+            text,
+            highlighting,
+            self.maximum_string_length - self.left_margin,
         )
 
     # @+node:ekr.20170428084208.376: *3* TextTokens.print_cursor
     def print_cursor(self):
         # _cur_loc_x = self.cursor_position - self.begin_at + self.relx + self.left_margin
         try:
-            char_under_cur = self.decode_token(self.value[self.cursor_position])  # use the real value
+            char_under_cur = self.decode_token(
+                self.value[self.cursor_position]
+            )  # use the real value
             char_under_cur = self.safe_string(char_under_cur)
         except IndexError:
             char_under_cur = ' '

--- a/leo/external/npyscreen/wgtitlefield.py
+++ b/leo/external/npyscreen/wgtitlefield.py
@@ -64,7 +64,9 @@ class TitleText(widget.Widget):
             if 'max_width' in self._passon.keys():
                 if self._passon['max_width'] > 0:
                     if self._passon['max_width'] < self.text_field_begin_at:
-                        raise ValueError("The maximum width specified is less than the text_field_begin_at value.")
+                        raise ValueError(
+                            "The maximum width specified is less than the text_field_begin_at value."
+                        )
                     else:
                         self._passon['max_width'] -= self.text_field_begin_at + 1
 
@@ -77,10 +79,14 @@ class TitleText(widget.Widget):
         if self.use_two_lines:
             if 'max_height' in self._passon and self._passon['max_height']:
                 if self._passon['max_height'] == 1:
-                    raise ValueError("I don't know how to resolve this: max_height == 1 but widget using 2 lines.")
+                    raise ValueError(
+                        "I don't know how to resolve this: max_height == 1 but widget using 2 lines."
+                    )
                 self._passon['max_height'] -= 1
             if 'height' in self._passon and self._passon['height']:
-                raise ValueError("I don't know how to resolve this: height == 1 but widget using 2 lines.")
+                raise ValueError(
+                    "I don't know how to resolve this: height == 1 but widget using 2 lines."
+                )
                 self._passon['height'] -= 1
 
         self.make_contained_widgets()

--- a/leo/external/npyscreen/wgwidget_proto.py
+++ b/leo/external/npyscreen/wgwidget_proto.py
@@ -31,7 +31,9 @@ class _LinePrinter:
             return ch.encode('utf-8', 'replace')
 
     # @+node:ekr.20170428084208.441: *3* add_line
-    def add_line(self, realy, realx, unicode_string, attributes_list, max_columns, force_ascii=False):
+    def add_line(
+        self, realy, realx, unicode_string, attributes_list, max_columns, force_ascii=False
+    ):
         if isinstance(unicode_string, bytes):
             raise ValueError("This class prints unicode strings only.")
 

--- a/leo/external/py2cs.py
+++ b/leo/external/py2cs.py
@@ -696,7 +696,11 @@ class CoffeeScriptTraverser:
 
     # @+node:ekr.20160316091132.51: *4* cv.ifExp (ternary operator)
     def do_IfExp(self, node):
-        return '%s if %s else %s ' % (self.visit(node.body), self.visit(node.test), self.visit(node.orelse))
+        return '%s if %s else %s ' % (
+            self.visit(node.body),
+            self.visit(node.test),
+            self.visit(node.orelse),
+        )
 
     # @+node:ekr.20160316091132.52: *4* cv.UnaryOp
     def do_UnaryOp(self, node):
@@ -731,7 +735,11 @@ class CoffeeScriptTraverser:
     def do_AnnAssign(self, node):
         head = self.leading_string(node)
         tail = self.trailing_comment(node)
-        s = '%s:%s=%s\n' % (self.visit(node.target), self.visit(node.annotation), self.visit(node.value))
+        s = '%s:%s=%s\n' % (
+            self.visit(node.target),
+            self.visit(node.annotation),
+            self.visit(node.value),
+        )
         return head + self.indent(s) + tail
 
     # @+node:ekr.20160316091132.55: *4* cv.Assert
@@ -816,7 +824,11 @@ class CoffeeScriptTraverser:
     def do_For(self, node, async_flag=False):
         result = self.leading_lines(node)
         tail = self.trailing_comment(node)
-        s = '%sfor %s in %s:' % ('async ' if async_flag else '', self.visit(node.target), self.visit(node.iter))
+        s = '%sfor %s in %s:' % (
+            'async ' if async_flag else '',
+            self.visit(node.target),
+            self.visit(node.iter),
+        )
         result.append(self.indent(s + tail))
         for z in node.body:
             self.level += 1
@@ -1167,7 +1179,10 @@ class LeoGlobals:
             code1 = f1.f_code  # The code object
             name = code1.co_name
             if name == '__init__':
-                name = '__init__(%s,line %s)' % (self.shortFileName(code1.co_filename), code1.co_firstlineno)
+                name = '__init__(%s,line %s)' % (
+                    self.shortFileName(code1.co_filename),
+                    code1.co_firstlineno,
+                )
             if files:
                 return '%s:%s' % (self.shortFileName(code1.co_filename), name)
             return name  # The code name
@@ -1276,7 +1291,10 @@ class LeoGlobals:
             s = s.decode(encoding, 'replace')
             if reportErrors:
                 g.trace(g.callers())
-                print("toUnicode: Error converting %s... from %s encoding to unicode" % (s[:200], encoding))
+                print(
+                    "toUnicode: Error converting %s... from %s encoding to unicode"
+                    % (s[:200], encoding)
+                )
         return s
 
     # @+node:ekr.20160316091132.93: *3* g.trace (py2cs.py)
@@ -1396,7 +1414,13 @@ class MakeCoffeeScriptController:
         add = parser.add_option
         add('-c', '--config', dest='fn', help='full path to configuration file')
         add('-d', '--dir', dest='dir', help='full path to the output directory')
-        add('-o', '--overwrite', action='store_true', default=False, help='overwrite existing .coffee files')
+        add(
+            '-o',
+            '--overwrite',
+            action='store_true',
+            default=False,
+            help='overwrite existing .coffee files',
+        )
         # add('-t', '--test', action='store_true', default=False,
         # help='run unit tests on startup')
         add('-v', '--verbose', action='store_true', default=False, help='verbose output')

--- a/leo/modes/actionscript.py
+++ b/leo/modes/actionscript.py
@@ -798,7 +798,9 @@ def actionscript_rule29(colorer, s, i):
 
 
 def actionscript_rule30(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def actionscript_rule31(colorer, s, i):

--- a/leo/modes/ahk.py
+++ b/leo/modes/ahk.py
@@ -1083,11 +1083,15 @@ def ahk_rule12(colorer, s, i):
 
 
 def ahk_rule13(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def ahk_rule14(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern="::", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern="::", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def ahk_rule15(colorer, s, i):

--- a/leo/modes/antlr.py
+++ b/leo/modes/antlr.py
@@ -92,7 +92,9 @@ keywordsDictDict = {
 
 
 def antlr_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/", delegate="java::javadoc")
+    return colorer.match_span(
+        s, i, kind="comment2", begin="/**", end="*/", delegate="java::javadoc"
+    )
 
 
 def antlr_rule1(colorer, s, i):

--- a/leo/modes/asciidoc.py
+++ b/leo/modes/asciidoc.py
@@ -77,7 +77,9 @@ def asciidoc_rule4(colorer, s, i):
 
 
 def asciidoc_rule5(colorer, s, i):
-    return colorer.match_eol_span_regexp(s, i, kind="markup", regexp="^[=-]{4,}", at_line_start=True)
+    return colorer.match_eol_span_regexp(
+        s, i, kind="markup", regexp="^[=-]{4,}", at_line_start=True
+    )
 
 
 def asciidoc_rule6(colorer, s, i):
@@ -94,7 +96,12 @@ def asciidoc_rule8(colorer, s, i):
 
 def asciidoc_rule9(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="comment2", begin="^\\/\\/\\/\\/+\\s*$", end="\\/\\/\\/\\/\\s*$", at_line_start=True
+        s,
+        i,
+        kind="comment2",
+        begin="^\\/\\/\\/\\/+\\s*$",
+        end="\\/\\/\\/\\/\\s*$",
+        at_line_start=True,
     )
 
 
@@ -103,29 +110,48 @@ def asciidoc_rule10(colorer, s, i):
 
 
 def asciidoc_rule11(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="literal1", begin="^----+\\s*$", end="----\\s*$", at_line_start=True)
+    return colorer.match_span_regexp(
+        s, i, kind="literal1", begin="^----+\\s*$", end="----\\s*$", at_line_start=True
+    )
 
 
 def asciidoc_rule12(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="literal2", begin="^\\+\\+\\+\\++\\s*$", end="\\+\\+\\+\\+\\s*$", at_line_start=True
+        s,
+        i,
+        kind="literal2",
+        begin="^\\+\\+\\+\\++\\s*$",
+        end="\\+\\+\\+\\+\\s*$",
+        at_line_start=True,
     )
 
 
 def asciidoc_rule13(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="literal3", begin="^\\.\\.\\.\\.+\\s*$", end="\\.\\.\\.\\.\\s*$", at_line_start=True
+        s,
+        i,
+        kind="literal3",
+        begin="^\\.\\.\\.\\.+\\s*$",
+        end="\\.\\.\\.\\.\\s*$",
+        at_line_start=True,
     )
 
 
 def asciidoc_rule14(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="literal4", begin="^\\*\\*\\*\\*+\\s*$", end="\\*\\*\\*\\*\\s*$", at_line_start=True
+        s,
+        i,
+        kind="literal4",
+        begin="^\\*\\*\\*\\*+\\s*$",
+        end="\\*\\*\\*\\*\\s*$",
+        at_line_start=True,
     )
 
 
 def asciidoc_rule15(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="comment4", begin="^____+\\s*$", end="____\\s*$", at_line_start=True)
+    return colorer.match_span_regexp(
+        s, i, kind="comment4", begin="^____+\\s*$", end="____\\s*$", at_line_start=True
+    )
 
 
 def asciidoc_rule16(colorer, s, i):
@@ -153,15 +179,21 @@ def asciidoc_rule21(colorer, s, i):
 
 
 def asciidoc_rule22(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])_\\S", end="_")
+    return colorer.match_span_regexp(
+        s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])_\\S", end="_"
+    )
 
 
 def asciidoc_rule23(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])'\\S", end="'")
+    return colorer.match_span_regexp(
+        s, i, kind="comment1", begin="(^|[\\s\\.,\\(\\)\\[\\]])'\\S", end="'"
+    )
 
 
 def asciidoc_rule24(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword1", begin="(^|[\\s\\.,\\(])\\*[^\\*\\s]", end="*")
+    return colorer.match_span_regexp(
+        s, i, kind="keyword1", begin="(^|[\\s\\.,\\(])\\*[^\\*\\s]", end="*"
+    )
 
 
 def asciidoc_rule25(colorer, s, i):
@@ -225,7 +257,9 @@ def asciidoc_rule39(colorer, s, i):
 
 
 def asciidoc_rule40(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="comment4", pattern="::::", at_whitespace_end=True)
+    return colorer.match_mark_previous(
+        s, i, kind="comment4", pattern="::::", at_whitespace_end=True
+    )
 
 
 def asciidoc_rule41(colorer, s, i):
@@ -233,7 +267,9 @@ def asciidoc_rule41(colorer, s, i):
 
 
 def asciidoc_rule42(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="markup", begin="\\s*NOTE:", end=" ", at_line_start=True)
+    return colorer.match_span_regexp(
+        s, i, kind="markup", begin="\\s*NOTE:", end=" ", at_line_start=True
+    )
 
 
 def asciidoc_rule43(colorer, s, i):

--- a/leo/modes/asp.py
+++ b/leo/modes/asp.py
@@ -124,19 +124,27 @@ keywordsDictDict = {
 
 
 def asp_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"VBSCRIPT\"%>", delegate="asp::aspvb")
+    return colorer.match_seq(
+        s, i, kind="markup", seq="<%@LANGUAGE=\"VBSCRIPT\"%>", delegate="asp::aspvb"
+    )
 
 
 def asp_rule1(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"JSCRIPT\"%>", delegate="asp::aspjs")
+    return colorer.match_seq(
+        s, i, kind="markup", seq="<%@LANGUAGE=\"JSCRIPT\"%>", delegate="asp::aspjs"
+    )
 
 
 def asp_rule2(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"JAVASCRIPT\"%>", delegate="asp::aspjs")
+    return colorer.match_seq(
+        s, i, kind="markup", seq="<%@LANGUAGE=\"JAVASCRIPT\"%>", delegate="asp::aspjs"
+    )
 
 
 def asp_rule3(colorer, s, i):
-    return colorer.match_seq(s, i, kind="markup", seq="<%@LANGUAGE=\"PERLSCRIPT\"%>", delegate="asp::asppl")
+    return colorer.match_seq(
+        s, i, kind="markup", seq="<%@LANGUAGE=\"PERLSCRIPT\"%>", delegate="asp::asppl"
+    )
 
 
 def asp_rule4(colorer, s, i):
@@ -189,18 +197,30 @@ def asp_rule8(colorer, s, i):
 
 def asp_rule9(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"jscript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def asp_rule10(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"javascript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def asp_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main"
+    )
 
 
 def asp_rule12(colorer, s, i):
@@ -212,7 +232,9 @@ def asp_rule13(colorer, s, i):
 
 
 def asp_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main"
+    )
 
 
 def asp_rule15(colorer, s, i):
@@ -301,18 +323,30 @@ def asp_rule21(colorer, s, i):
 
 def asp_rule22(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"jscript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def asp_rule23(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"javascript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def asp_rule24(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main"
+    )
 
 
 def asp_rule25(colorer, s, i):
@@ -324,7 +358,9 @@ def asp_rule26(colorer, s, i):
 
 
 def asp_rule27(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main"
+    )
 
 
 def asp_rule28(colorer, s, i):
@@ -365,7 +401,9 @@ rulesDict2 = {
 
 
 def asp_rule31(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<%", end="%>", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<%", end="%>", delegate="javascript::main"
+    )
 
 
 def asp_rule32(colorer, s, i):
@@ -414,18 +452,30 @@ def asp_rule35(colorer, s, i):
 
 def asp_rule36(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"jscript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def asp_rule37(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"javascript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def asp_rule38(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main"
+    )
 
 
 def asp_rule39(colorer, s, i):
@@ -437,7 +487,9 @@ def asp_rule40(colorer, s, i):
 
 
 def asp_rule41(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main"
+    )
 
 
 def asp_rule42(colorer, s, i):
@@ -527,18 +579,30 @@ def asp_rule49(colorer, s, i):
 
 def asp_rule50(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>", delegate="asp::asppl_csjs"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"jscript\">",
+        end="</script>",
+        delegate="asp::asppl_csjs",
     )
 
 
 def asp_rule51(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>", delegate="asp::asppl_csjs"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"javascript\">",
+        end="</script>",
+        delegate="asp::asppl_csjs",
     )
 
 
 def asp_rule52(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>", delegate="asp::asppl_csjs")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<script>", end="</script>", delegate="asp::asppl_csjs"
+    )
 
 
 def asp_rule53(colorer, s, i):
@@ -550,7 +614,9 @@ def asp_rule54(colorer, s, i):
 
 
 def asp_rule55(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main"
+    )
 
 
 def asp_rule56(colorer, s, i):
@@ -605,7 +671,9 @@ rulesDict5 = {
 
 
 def asp_rule60(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<%", end="%>", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<%", end="%>", delegate="javascript::main"
+    )
 
 
 # Rules dict for asp_aspjs_tags ruleset.

--- a/leo/modes/aspect_j.py
+++ b/leo/modes/aspect_j.py
@@ -126,7 +126,9 @@ def aspect_j_rule0(colorer, s, i):
 
 
 def aspect_j_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="java::javadoc")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="java::javadoc"
+    )
 
 
 def aspect_j_rule2(colorer, s, i):
@@ -218,7 +220,9 @@ def aspect_j_rule23(colorer, s, i):
 
 
 def aspect_j_rule24(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def aspect_j_rule25(colorer, s, i):

--- a/leo/modes/assembly_6502.py
+++ b/leo/modes/assembly_6502.py
@@ -154,11 +154,15 @@ def assembly_6502_rule2(colorer, s, i):
 
 
 def assembly_6502_rule3(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=" ", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=" ", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def assembly_6502_rule4(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern="\t", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern="\t", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def assembly_6502_rule5(colorer, s, i):

--- a/leo/modes/assembly_macro32.py
+++ b/leo/modes/assembly_macro32.py
@@ -543,7 +543,9 @@ def assembly_macro32_rule2(colorer, s, i):
 
 
 def assembly_macro32_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="%%", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_following(
+        s, i, kind="label", pattern="%%", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_macro32_rule4(colorer, s, i):
@@ -551,7 +553,9 @@ def assembly_macro32_rule4(colorer, s, i):
 
 
 def assembly_macro32_rule5(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_macro32_rule6(colorer, s, i):

--- a/leo/modes/assembly_mcs51.py
+++ b/leo/modes/assembly_mcs51.py
@@ -207,7 +207,9 @@ def assembly_mcs51_rule2(colorer, s, i):
 
 
 def assembly_mcs51_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="%%", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_following(
+        s, i, kind="label", pattern="%%", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_mcs51_rule4(colorer, s, i):
@@ -215,7 +217,9 @@ def assembly_mcs51_rule4(colorer, s, i):
 
 
 def assembly_mcs51_rule5(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_mcs51_rule6(colorer, s, i):

--- a/leo/modes/assembly_parrot.py
+++ b/leo/modes/assembly_parrot.py
@@ -145,7 +145,9 @@ def assembly_parrot_rule1(colorer, s, i):
 
 
 def assembly_parrot_rule2(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_parrot_rule3(colorer, s, i):

--- a/leo/modes/assembly_x86.py
+++ b/leo/modes/assembly_x86.py
@@ -835,7 +835,9 @@ def assembly_x86_rule2(colorer, s, i):
 
 
 def assembly_x86_rule3(colorer, s, i):
-    return colorer.match_mark_following(s, i, kind="label", pattern="%%", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_following(
+        s, i, kind="label", pattern="%%", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_x86_rule4(colorer, s, i):
@@ -843,7 +845,9 @@ def assembly_x86_rule4(colorer, s, i):
 
 
 def assembly_x86_rule5(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def assembly_x86_rule6(colorer, s, i):

--- a/leo/modes/awk.py
+++ b/leo/modes/awk.py
@@ -183,7 +183,9 @@ def awk_rule19(colorer, s, i):
 
 
 def awk_rule20(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def awk_rule21(colorer, s, i):

--- a/leo/modes/batch.py
+++ b/leo/modes/batch.py
@@ -155,13 +155,25 @@ def batch_rule7(colorer, s, i):
 # @+node:ekr.20221129095311.9: ** batch_rule8
 def batch_rule8(colorer, s, i):
     return colorer.match_eol_span(
-        s, i, kind="comment1", seq="REM", at_line_start=True, at_whitespace_end=True, at_word_start=True
+        s,
+        i,
+        kind="comment1",
+        seq="REM",
+        at_line_start=True,
+        at_whitespace_end=True,
+        at_word_start=True,
     )
 
 
 def batch_rule8a(colorer, s, i):
     return colorer.match_eol_span(
-        s, i, kind="comment1", seq="rem", at_line_start=True, at_whitespace_end=True, at_word_start=True
+        s,
+        i,
+        kind="comment1",
+        seq="rem",
+        at_line_start=True,
+        at_whitespace_end=True,
+        at_word_start=True,
     )
 
 

--- a/leo/modes/bbj.py
+++ b/leo/modes/bbj.py
@@ -364,7 +364,9 @@ def bbj_rule16(colorer, s, i):
 
 
 def bbj_rule17(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def bbj_rule18(colorer, s, i):

--- a/leo/modes/bcel.py
+++ b/leo/modes/bcel.py
@@ -271,7 +271,9 @@ def bcel_rule0(colorer, s, i):
 
 
 def bcel_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="bcel::javadoc")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="bcel::javadoc"
+    )
 
 
 def bcel_rule2(colorer, s, i):
@@ -299,7 +301,9 @@ def bcel_rule7(colorer, s, i):
 
 
 def bcel_rule8(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def bcel_rule9(colorer, s, i):

--- a/leo/modes/bibtex.py
+++ b/leo/modes/bibtex.py
@@ -922,123 +922,183 @@ def bibtex_rule0(colorer, s, i):
 
 
 def bibtex_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@article{", end="}", delegate="bibtex::article")
+    return colorer.match_span(
+        s, i, kind="function", begin="@article{", end="}", delegate="bibtex::article"
+    )
 
 
 def bibtex_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@article(", end=")", delegate="bibtex::article")
+    return colorer.match_span(
+        s, i, kind="function", begin="@article(", end=")", delegate="bibtex::article"
+    )
 
 
 def bibtex_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@book{", end="}", delegate="bibtex::book")
+    return colorer.match_span(
+        s, i, kind="function", begin="@book{", end="}", delegate="bibtex::book"
+    )
 
 
 def bibtex_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@book(", end=")", delegate="bibtex::book")
+    return colorer.match_span(
+        s, i, kind="function", begin="@book(", end=")", delegate="bibtex::book"
+    )
 
 
 def bibtex_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@booklet{", end="}", delegate="bibtex::booklet")
+    return colorer.match_span(
+        s, i, kind="function", begin="@booklet{", end="}", delegate="bibtex::booklet"
+    )
 
 
 def bibtex_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@booklet(", end=")", delegate="bibtex::booklet")
+    return colorer.match_span(
+        s, i, kind="function", begin="@booklet(", end=")", delegate="bibtex::booklet"
+    )
 
 
 def bibtex_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@conference{", end="}", delegate="bibtex::conference")
+    return colorer.match_span(
+        s, i, kind="function", begin="@conference{", end="}", delegate="bibtex::conference"
+    )
 
 
 def bibtex_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@conference(", end=")", delegate="bibtex::conference")
+    return colorer.match_span(
+        s, i, kind="function", begin="@conference(", end=")", delegate="bibtex::conference"
+    )
 
 
 def bibtex_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@inbook{", end="}", delegate="bibtex::inbook")
+    return colorer.match_span(
+        s, i, kind="function", begin="@inbook{", end="}", delegate="bibtex::inbook"
+    )
 
 
 def bibtex_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@inbook(", end=")", delegate="bibtex::inbook")
+    return colorer.match_span(
+        s, i, kind="function", begin="@inbook(", end=")", delegate="bibtex::inbook"
+    )
 
 
 def bibtex_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@incollection{", end="}", delegate="bibtex::incollection")
+    return colorer.match_span(
+        s, i, kind="function", begin="@incollection{", end="}", delegate="bibtex::incollection"
+    )
 
 
 def bibtex_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@incollection(", end=")", delegate="bibtex::incollection")
+    return colorer.match_span(
+        s, i, kind="function", begin="@incollection(", end=")", delegate="bibtex::incollection"
+    )
 
 
 def bibtex_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@inproceedings{", end="}", delegate="bibtex::inproceedings")
+    return colorer.match_span(
+        s, i, kind="function", begin="@inproceedings{", end="}", delegate="bibtex::inproceedings"
+    )
 
 
 def bibtex_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@inproceedings(", end=")", delegate="bibtex::inproceedings")
+    return colorer.match_span(
+        s, i, kind="function", begin="@inproceedings(", end=")", delegate="bibtex::inproceedings"
+    )
 
 
 def bibtex_rule15(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@manual{", end="}", delegate="bibtex::manual")
+    return colorer.match_span(
+        s, i, kind="function", begin="@manual{", end="}", delegate="bibtex::manual"
+    )
 
 
 def bibtex_rule16(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@manual(", end=")", delegate="bibtex::manual")
+    return colorer.match_span(
+        s, i, kind="function", begin="@manual(", end=")", delegate="bibtex::manual"
+    )
 
 
 def bibtex_rule17(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@mastersthesis{", end="}", delegate="bibtex::mastersthesis")
+    return colorer.match_span(
+        s, i, kind="function", begin="@mastersthesis{", end="}", delegate="bibtex::mastersthesis"
+    )
 
 
 def bibtex_rule18(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@mastersthesis(", end=")", delegate="bibtex::mastersthesis")
+    return colorer.match_span(
+        s, i, kind="function", begin="@mastersthesis(", end=")", delegate="bibtex::mastersthesis"
+    )
 
 
 def bibtex_rule19(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@misc{", end="}", delegate="bibtex::misc")
+    return colorer.match_span(
+        s, i, kind="function", begin="@misc{", end="}", delegate="bibtex::misc"
+    )
 
 
 def bibtex_rule20(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@misc(", end=")", delegate="bibtex::misc")
+    return colorer.match_span(
+        s, i, kind="function", begin="@misc(", end=")", delegate="bibtex::misc"
+    )
 
 
 def bibtex_rule21(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@phdthesis{", end="}", delegate="bibtex::phdthesis")
+    return colorer.match_span(
+        s, i, kind="function", begin="@phdthesis{", end="}", delegate="bibtex::phdthesis"
+    )
 
 
 def bibtex_rule22(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@phdthesis(", end=")", delegate="bibtex::phdthesis")
+    return colorer.match_span(
+        s, i, kind="function", begin="@phdthesis(", end=")", delegate="bibtex::phdthesis"
+    )
 
 
 def bibtex_rule23(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@proceedings{", end="}", delegate="bibtex::proceedings")
+    return colorer.match_span(
+        s, i, kind="function", begin="@proceedings{", end="}", delegate="bibtex::proceedings"
+    )
 
 
 def bibtex_rule24(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@proceedings(", end=")", delegate="bibtex::proceedings")
+    return colorer.match_span(
+        s, i, kind="function", begin="@proceedings(", end=")", delegate="bibtex::proceedings"
+    )
 
 
 def bibtex_rule25(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@techreport{", end="}", delegate="bibtex::techreport")
+    return colorer.match_span(
+        s, i, kind="function", begin="@techreport{", end="}", delegate="bibtex::techreport"
+    )
 
 
 def bibtex_rule26(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@techreport(", end=")", delegate="bibtex::techreport")
+    return colorer.match_span(
+        s, i, kind="function", begin="@techreport(", end=")", delegate="bibtex::techreport"
+    )
 
 
 def bibtex_rule27(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@unpublished{", end="}", delegate="bibtex::unpublished")
+    return colorer.match_span(
+        s, i, kind="function", begin="@unpublished{", end="}", delegate="bibtex::unpublished"
+    )
 
 
 def bibtex_rule28(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@unpublished(", end=")", delegate="bibtex::unpublished")
+    return colorer.match_span(
+        s, i, kind="function", begin="@unpublished(", end=")", delegate="bibtex::unpublished"
+    )
 
 
 def bibtex_rule29(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@string{", end="}", delegate="bibtex::string")
+    return colorer.match_span(
+        s, i, kind="function", begin="@string{", end="}", delegate="bibtex::string"
+    )
 
 
 def bibtex_rule30(colorer, s, i):
-    return colorer.match_span(s, i, kind="function", begin="@string(", end=")", delegate="bibtex::string")
+    return colorer.match_span(
+        s, i, kind="function", begin="@string(", end=")", delegate="bibtex::string"
+    )
 
 
 # Rules dict for bibtex_main ruleset.
@@ -1084,11 +1144,15 @@ rulesDict1 = {
 
 
 def bibtex_rule31(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule32(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule33(colorer, s, i):
@@ -1357,11 +1421,15 @@ rulesDict2 = {
 
 
 def bibtex_rule45(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule46(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule47(colorer, s, i):
@@ -1630,11 +1698,15 @@ rulesDict3 = {
 
 
 def bibtex_rule59(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule60(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule61(colorer, s, i):
@@ -1903,11 +1975,15 @@ rulesDict4 = {
 
 
 def bibtex_rule73(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule74(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule75(colorer, s, i):
@@ -2176,11 +2252,15 @@ rulesDict5 = {
 
 
 def bibtex_rule87(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule88(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule89(colorer, s, i):
@@ -2449,11 +2529,15 @@ rulesDict6 = {
 
 
 def bibtex_rule101(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule102(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule103(colorer, s, i):
@@ -2722,11 +2806,15 @@ rulesDict7 = {
 
 
 def bibtex_rule115(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule116(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule117(colorer, s, i):
@@ -2995,11 +3083,15 @@ rulesDict8 = {
 
 
 def bibtex_rule129(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule130(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule131(colorer, s, i):
@@ -3268,11 +3360,15 @@ rulesDict9 = {
 
 
 def bibtex_rule143(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule144(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule145(colorer, s, i):
@@ -3541,11 +3637,15 @@ rulesDict10 = {
 
 
 def bibtex_rule157(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule158(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule159(colorer, s, i):
@@ -3814,11 +3914,15 @@ rulesDict11 = {
 
 
 def bibtex_rule171(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule172(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule173(colorer, s, i):
@@ -4087,11 +4191,15 @@ rulesDict12 = {
 
 
 def bibtex_rule185(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule186(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule187(colorer, s, i):
@@ -4360,11 +4468,15 @@ rulesDict13 = {
 
 
 def bibtex_rule199(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule200(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule201(colorer, s, i):
@@ -4633,11 +4745,15 @@ rulesDict14 = {
 
 
 def bibtex_rule213(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule214(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule215(colorer, s, i):
@@ -4910,11 +5026,15 @@ def bibtex_rule227(colorer, s, i):
 
 
 def bibtex_rule228(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule229(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule230(colorer, s, i):
@@ -4939,11 +5059,15 @@ rulesDict16 = {
 
 
 def bibtex_rule231(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="\\{", end="\\}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal3", begin="\\{", end="\\}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule232(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule233(colorer, s, i):
@@ -4965,11 +5089,15 @@ rulesDict17 = {
 
 
 def bibtex_rule234(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="bibtex::textquoted"
+    )
 
 
 def bibtex_rule235(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="{", end="}", delegate="bibtex::textbraced"
+    )
 
 
 def bibtex_rule236(colorer, s, i):

--- a/leo/modes/c.py
+++ b/leo/modes/c.py
@@ -128,12 +128,16 @@ keywordsDictDict = {
 # @+others
 # @+node:ekr.20250330150257.6: *3* function: c_rule0 /**
 def c_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 # @+node:ekr.20250330150257.7: *3* function: c_rule1 /*!
 def c_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 # @+node:ekr.20250330150257.8: *3* function: c_rule2 /*

--- a/leo/modes/clojure.py
+++ b/leo/modes/clojure.py
@@ -946,11 +946,15 @@ def clojure_rule33(colorer, s, i):
 
 
 def clojure_rule34(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="#\"", end="\"", delegate="clojure::regexps")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="#\"", end="\"", delegate="clojure::regexps"
+    )
 
 
 def clojure_rule35(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="clojure::strings")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="clojure::strings"
+    )
 
 
 def clojure_rule36(colorer, s, i):

--- a/leo/modes/coffeescript.py
+++ b/leo/modes/coffeescript.py
@@ -142,7 +142,12 @@ def coffeescript_rule1(colorer, s, i):
 
 def coffeescript_rule2(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal1", begin="\"\"\"", end="\"\"\"", delegate="coffeescript::doublequoteliteral"
+        s,
+        i,
+        kind="literal1",
+        begin="\"\"\"",
+        end="\"\"\"",
+        delegate="coffeescript::doublequoteliteral",
     )
 
 
@@ -151,7 +156,9 @@ def coffeescript_rule3(colorer, s, i):
 
 
 def coffeescript_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="coffeescript::doublequoteliteral")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="coffeescript::doublequoteliteral"
+    )
 
 
 def coffeescript_rule5(colorer, s, i):
@@ -159,15 +166,21 @@ def coffeescript_rule5(colorer, s, i):
 
 
 def coffeescript_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="`", end="`", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="`", end="`", delegate="javascript::main"
+    )
 
 
 def coffeescript_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="///", end="///", delegate="coffeescript::hereregexp")
+    return colorer.match_span(
+        s, i, kind="markup", begin="///", end="///", delegate="coffeescript::hereregexp"
+    )
 
 
 def coffeescript_rule8(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="markup", begin="/(?![\\s=*])", end="/[igmy]{0,4}", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="markup", begin="/(?![\\s=*])", end="/[igmy]{0,4}", no_line_break=True
+    )
 
 
 def coffeescript_rule9(colorer, s, i):
@@ -573,7 +586,9 @@ rulesDict1 = {
 
 
 def coffeescript_rule37(colorer, s, i):
-    return colorer.match_span(s, i, kind="operator", begin="#{", end="}", delegate="coffeescript::main")
+    return colorer.match_span(
+        s, i, kind="operator", begin="#{", end="}", delegate="coffeescript::main"
+    )
 
 
 # Rules dict for coffeescript_doublequoteliteral ruleset.
@@ -587,7 +602,9 @@ rulesDict2 = {
 
 
 def coffeescript_rule38(colorer, s, i):
-    return colorer.match_span(s, i, kind="operator", begin="#{", end="}", delegate="coffeescript::main")
+    return colorer.match_span(
+        s, i, kind="operator", begin="#{", end="}", delegate="coffeescript::main"
+    )
 
 
 def coffeescript_rule39(colorer, s, i):

--- a/leo/modes/coldfusion.py
+++ b/leo/modes/coldfusion.py
@@ -529,19 +529,27 @@ def coldfusion_rule4(colorer, s, i):
 
 
 def coldfusion_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="<CF", end=">", delegate="coldfusion::cftags")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="<CF", end=">", delegate="coldfusion::cftags"
+    )
 
 
 def coldfusion_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="</CF", end=">", delegate="coldfusion::cftags")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="</CF", end=">", delegate="coldfusion::cftags"
+    )
 
 
 def coldfusion_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript"
+    )
 
 
 def coldfusion_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css"
+    )
 
 
 def coldfusion_rule9(colorer, s, i):
@@ -589,11 +597,15 @@ def coldfusion_rule13(colorer, s, i):
 
 
 def coldfusion_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="<CF", end=">", delegate="coldfusion::cftags")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="<CF", end=">", delegate="coldfusion::cftags"
+    )
 
 
 def coldfusion_rule15(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="</CF", end=">", delegate="coldfusion::cftags")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="</CF", end=">", delegate="coldfusion::cftags"
+    )
 
 
 def coldfusion_rule16(colorer, s, i):

--- a/leo/modes/cplusplus.py
+++ b/leo/modes/cplusplus.py
@@ -117,11 +117,15 @@ keywordsDictDict = {
 
 
 def cplusplus_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 def cplusplus_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 def cplusplus_rule2(colorer, s, i):
@@ -221,7 +225,9 @@ def cplusplus_rule25(colorer, s, i):
 
 
 def cplusplus_rule26(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def cplusplus_rule27(colorer, s, i):

--- a/leo/modes/cweb.py
+++ b/leo/modes/cweb.py
@@ -133,7 +133,9 @@ def cweb_rule0(colorer, s, i):
     global in_doc_part
     if in_doc_part:
         return 0
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 # @+node:ekr.20250123061808.2: *3* function: cweb_rule1 /*!
@@ -141,7 +143,9 @@ def cweb_rule1(colorer, s, i):
     global in_doc_part
     if in_doc_part:
         return 0
-    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 # @+node:ekr.20250123061808.3: *3* function: cweb_rule2 /*

--- a/leo/modes/d.py
+++ b/leo/modes/d.py
@@ -137,11 +137,15 @@ def d_rule0(colorer, s, i):
 
 
 def d_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 def d_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 def d_rule3(colorer, s, i):
@@ -229,7 +233,9 @@ def d_rule23(colorer, s, i):
 
 
 def d_rule24(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def d_rule25(colorer, s, i):

--- a/leo/modes/dart.py
+++ b/leo/modes/dart.py
@@ -172,22 +172,38 @@ def dart_rule7(colorer, s, i):
 
 
 def dart_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"\"\"", end="\"\"\"", delegate="dart::dart_literal1")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"\"\"", end="\"\"\"", delegate="dart::dart_literal1"
+    )
 
 
 def dart_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'''", end="'''", delegate="dart::dart_literal1")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'''", end="'''", delegate="dart::dart_literal1"
+    )
 
 
 def dart_rule10(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal1", begin="\"", end="\"", delegate="dart::dart_literal1", no_line_break=True
+        s,
+        i,
+        kind="literal1",
+        begin="\"",
+        end="\"",
+        delegate="dart::dart_literal1",
+        no_line_break=True,
     )
 
 
 def dart_rule11(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal1", begin="'", end="'", delegate="dart::dart_literal1", no_line_break=True
+        s,
+        i,
+        kind="literal1",
+        begin="'",
+        end="'",
+        delegate="dart::dart_literal1",
+        no_line_break=True,
     )
 
 

--- a/leo/modes/doxygen.py
+++ b/leo/modes/doxygen.py
@@ -319,12 +319,16 @@ def doxygen_rule0(colorer, s, i):
 
 # @+node:ekr.20250110045205.2: *3* function: doxygen_rule1
 def doxygen_rule1(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="keyword1", pattern="=", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="keyword1", pattern="=", at_line_start=True, exclude_match=True
+    )
 
 
 # @+node:ekr.20250110045205.3: *3* function: doxygen_rule2
 def doxygen_rule2(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="keyword1", pattern="+=", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="keyword1", pattern="+=", at_line_start=True, exclude_match=True
+    )
 
 
 # @+node:ekr.20250110045205.4: *3* function: doxygen_rule3
@@ -626,7 +630,9 @@ def doxygen_rule11(colorer, s, i):
 
 # @+node:ekr.20250110045223.6: *3* function: doxygen_rule12
 def doxygen_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True
+    )
 
 
 # @+node:ekr.20250110045223.7: *3* function: doxygen_rule13

--- a/leo/modes/factor.py
+++ b/leo/modes/factor.py
@@ -115,7 +115,9 @@ def factor_rule10(colorer, s, i):
 
 
 def factor_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="(", end=")", delegate="factor::stack_effect")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="(", end=")", delegate="factor::stack_effect"
+    )
 
 
 def factor_rule12(colorer, s, i):

--- a/leo/modes/forth.py
+++ b/leo/modes/forth.py
@@ -260,7 +260,13 @@ class extendForth:
 
         def forth_bracket_rule(colorer, s, i):
             return colorer.match_span(
-                s, i, kind="bracketRange", begin=begin, end=end, at_word_start=True, no_word_break=True
+                s,
+                i,
+                kind="bracketRange",
+                begin=begin,
+                end=end,
+                at_word_start=True,
+                no_word_break=True,
             )
 
         return forth_bracket_rule
@@ -322,7 +328,9 @@ class extendForth:
         begin, end = aList
 
         def forth_string_word_rule(colorer, s, i):
-            return colorer.match_span(s, i, kind="literal1", begin=begin.strip(), end=end.strip(), at_word_start=True)
+            return colorer.match_span(
+                s, i, kind="literal1", begin=begin.strip(), end=end.strip(), at_word_start=True
+            )
 
         return forth_string_word_rule
 

--- a/leo/modes/foxpro.py
+++ b/leo/modes/foxpro.py
@@ -1855,7 +1855,9 @@ def foxpro_rule32(colorer, s, i):
 
 
 def foxpro_rule33(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def foxpro_rule34(colorer, s, i):

--- a/leo/modes/gettext.py
+++ b/leo/modes/gettext.py
@@ -87,7 +87,9 @@ def gettext_rule7(colorer, s, i):
 
 
 def gettext_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="gettext::quoted")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="gettext::quoted"
+    )
 
 
 def gettext_rule9(colorer, s, i):

--- a/leo/modes/groovy.py
+++ b/leo/modes/groovy.py
@@ -207,7 +207,9 @@ def groovy_rule0(colorer, s, i):
 
 
 def groovy_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="groovy::groovydoc")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="groovy::groovydoc"
+    )
 
 
 def groovy_rule2(colorer, s, i):
@@ -215,7 +217,9 @@ def groovy_rule2(colorer, s, i):
 
 
 def groovy_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="groovy::literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="groovy::literal"
+    )
 
 
 def groovy_rule4(colorer, s, i):
@@ -224,7 +228,12 @@ def groovy_rule4(colorer, s, i):
 
 def groovy_rule5(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="literal1", begin="<<<([[:alpha:]_][[:alnum:]_]*)\\s*", end="$1", delegate="groovy::literal"
+        s,
+        i,
+        kind="literal1",
+        begin="<<<([[:alpha:]_][[:alnum:]_]*)\\s*",
+        end="$1",
+        delegate="groovy::literal",
     )
 
 
@@ -581,7 +590,9 @@ def groovy_rule29(colorer, s, i):
 
 
 def groovy_rule30(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True
+    )
 
 
 def groovy_rule31(colorer, s, i):

--- a/leo/modes/haxe.py
+++ b/leo/modes/haxe.py
@@ -125,7 +125,9 @@ def haXe_rule6(colorer, s, i):
 
 
 def haXe_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="~([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*")
+    return colorer.match_seq_regexp(
+        s, i, kind="markup", regexp="~([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*"
+    )
 
 
 def haXe_rule8(colorer, s, i):

--- a/leo/modes/html.py
+++ b/leo/modes/html.py
@@ -63,7 +63,9 @@ def html_rule4(colorer, s, i):
     for m in tag_pat.finditer(s, i):  # Don't create substrings.
         if m.group(0) and m.start() == i:
             tag = m.group(0)
-            return colorer.match_span(s, i, kind="markup", begin=tag, end=">", delegate="html::tags")
+            return colorer.match_span(
+                s, i, kind="markup", begin=tag, end=">", delegate="html::tags"
+            )
 
     # An error.
     return colorer.match_span(s, i, kind="comment", begin="<", end=">")

--- a/leo/modes/inform.py
+++ b/leo/modes/inform.py
@@ -152,7 +152,9 @@ def inform_rule0(colorer, s, i):
 
 
 def inform_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="inform::informinnertext")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="inform::informinnertext"
+    )
 
 
 def inform_rule2(colorer, s, i):

--- a/leo/modes/inno_setup.py
+++ b/leo/modes/inno_setup.py
@@ -348,7 +348,9 @@ keywordsDictDict = {
 
 
 def inno_setup_rule0(colorer, s, i):
-    return colorer.match_seq(s, i, kind="keyword2", seq="[code]", at_line_start=True, delegate="pascal::main")
+    return colorer.match_seq(
+        s, i, kind="keyword2", seq="[code]", at_line_start=True, delegate="pascal::main"
+    )
 
 
 def inno_setup_rule1(colorer, s, i):
@@ -420,83 +422,123 @@ def inno_setup_rule17(colorer, s, i):
 
 
 def inno_setup_rule18(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#define", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#define", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule19(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#dim", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#dim", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule20(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#undef", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#undef", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule21(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#include", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#include", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule22(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#emit", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#emit", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule23(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#expr", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#expr", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule24(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#insert", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#insert", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule25(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#append", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#append", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule26(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#if", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#if", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule27(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#elif", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#elif", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule28(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#else", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#else", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule29(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#endif", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#endif", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule30(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#ifexist", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#ifexist", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule31(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#ifnexist", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#ifnexist", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule32(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#ifdef", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#ifdef", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule33(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#for", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#for", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule34(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#sub", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#sub", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule35(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#endsub", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#endsub", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule36(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#pragma", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#pragma", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule37(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="literal4", seq="#error", delegate="inno_setup::directive")
+    return colorer.match_eol_span(
+        s, i, kind="literal4", seq="#error", delegate="inno_setup::directive"
+    )
 
 
 def inno_setup_rule38(colorer, s, i):
@@ -508,11 +550,15 @@ def inno_setup_rule39(colorer, s, i):
 
 
 def inno_setup_rule40(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="inno_setup::string")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="inno_setup::string"
+    )
 
 
 def inno_setup_rule41(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="inno_setup::string")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="inno_setup::string"
+    )
 
 
 def inno_setup_rule42(colorer, s, i):
@@ -791,7 +837,9 @@ def inno_setup_rule46(colorer, s, i):
 
 
 def inno_setup_rule47(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="{", end="}", delegate="inno_setup::constant")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="{", end="}", delegate="inno_setup::constant"
+    )
 
 
 # Rules dict for inno_setup_string ruleset.

--- a/leo/modes/java.py
+++ b/leo/modes/java.py
@@ -155,7 +155,9 @@ def java_rule0(colorer, s, i):
 
 
 def java_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="java::javadoc")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="java::javadoc"
+    )
 
 
 def java_rule2(colorer, s, i):
@@ -247,7 +249,9 @@ def java_rule23(colorer, s, i):
 
 
 def java_rule24(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def java_rule25(colorer, s, i):
@@ -550,7 +554,9 @@ def java_rule33(colorer, s, i):
 
 
 def java_rule34(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True
+    )
 
 
 def java_rule35(colorer, s, i):

--- a/leo/modes/javascript.py
+++ b/leo/modes/javascript.py
@@ -166,7 +166,9 @@ def javascript_rule28(colorer, s, i):
 
 # @+node:ekr.20230419052250.30: *4* javascript_rule29
 def javascript_rule29(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 # @+node:ekr.20230419052250.31: *4* javascript_rule30

--- a/leo/modes/jsp.py
+++ b/leo/modes/jsp.py
@@ -128,12 +128,19 @@ def jsp_rule0(colorer, s, i):
 
 
 def jsp_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword1", begin="<%@", end="%>", delegate="jsp::directives")
+    return colorer.match_span(
+        s, i, kind="keyword1", begin="<%@", end="%>", delegate="jsp::directives"
+    )
 
 
 def jsp_rule2(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword1", begin="<jsp:directive>", end="</jsp:directive>", delegate="jsp::directives"
+        s,
+        i,
+        kind="keyword1",
+        begin="<jsp:directive>",
+        end="</jsp:directive>",
+        delegate="jsp::directives",
     )
 
 
@@ -143,7 +150,12 @@ def jsp_rule3(colorer, s, i):
 
 def jsp_rule4(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword1", begin="<jsp:expression>", end="</jsp:expression>", delegate="java::main"
+        s,
+        i,
+        kind="keyword1",
+        begin="<jsp:expression>",
+        end="</jsp:expression>",
+        delegate="java::main",
     )
 
 
@@ -153,7 +165,12 @@ def jsp_rule5(colorer, s, i):
 
 def jsp_rule6(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword1", begin="<jsp:declaration>", end="</jsp:declaration>", delegate="java::main"
+        s,
+        i,
+        kind="keyword1",
+        begin="<jsp:declaration>",
+        end="</jsp:declaration>",
+        delegate="java::main",
     )
 
 
@@ -163,20 +180,31 @@ def jsp_rule7(colorer, s, i):
 
 def jsp_rule8(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword1", begin="<jsp:scriptlet>", end="</jsp:scriptlet>", delegate="java::main"
+        s,
+        i,
+        kind="keyword1",
+        begin="<jsp:scriptlet>",
+        end="</jsp:scriptlet>",
+        delegate="java::main",
     )
 
 
 def jsp_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="<!--", end="-->", delegate="jsp::comment")
+    return colorer.match_span(
+        s, i, kind="comment1", begin="<!--", end="-->", delegate="jsp::comment"
+    )
 
 
 def jsp_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript"
+    )
 
 
 def jsp_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css"
+    )
 
 
 def jsp_rule12(colorer, s, i):
@@ -246,7 +274,9 @@ def jsp_rule18(colorer, s, i):
 
 
 def jsp_rule19(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="jsp::attrvalue")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="jsp::attrvalue"
+    )
 
 
 def jsp_rule20(colorer, s, i):
@@ -490,7 +520,9 @@ def jsp_rule26(colorer, s, i):
 
 
 def jsp_rule27(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="jsp::attrvalue")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="jsp::attrvalue"
+    )
 
 
 def jsp_rule28(colorer, s, i):

--- a/leo/modes/julia.py
+++ b/leo/modes/julia.py
@@ -505,11 +505,15 @@ def julia_rule4(colorer, s, i):
 
 
 def julia_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="\"", end="\"", delegate="julia::stringliteral2")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="\"", end="\"", delegate="julia::stringliteral2"
+    )
 
 
 def julia_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="I\"", end="\"", delegate="julia::stringliteral2")
+    return colorer.match_span(
+        s, i, kind="literal2", begin="I\"", end="\"", delegate="julia::stringliteral2"
+    )
 
 
 def julia_rule7(colorer, s, i):
@@ -525,11 +529,15 @@ def julia_rule9(colorer, s, i):
 
 
 def julia_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="b\"", end="\"", delegate="julia::stringliteral4")
+    return colorer.match_span(
+        s, i, kind="literal4", begin="b\"", end="\"", delegate="julia::stringliteral4"
+    )
 
 
 def julia_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal3", begin="`", end="`", delegate="julia::stringliteral3")
+    return colorer.match_span(
+        s, i, kind="literal3", begin="`", end="`", delegate="julia::stringliteral3"
+    )
 
 
 def julia_rule12(colorer, s, i):
@@ -537,7 +545,9 @@ def julia_rule12(colorer, s, i):
 
 
 def julia_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="operator", begin="{", end="}", delegate="julia::typedescription")
+    return colorer.match_span(
+        s, i, kind="operator", begin="{", end="}", delegate="julia::typedescription"
+    )
 
 
 def julia_rule14(colorer, s, i):

--- a/leo/modes/jupytext.py
+++ b/leo/modes/jupytext.py
@@ -36,7 +36,9 @@ def jupytext_comment(colorer: Any, s: str, i: int) -> int:
     n = colorer.match_eol_span(s, i, kind="comment1", seq="#")
 
     in_jupytext_tree = any(
-        z.startswith('@language jupytext') for z_p in c.p.self_and_parents() for z in g.splitLines(z_p.b)
+        z.startswith('@language jupytext')
+        for z_p in c.p.self_and_parents()
+        for z in g.splitLines(z_p.b)
     )
     is_any_jupytext_comment = i == 0 and s.startswith('# %%') and in_jupytext_tree
     if is_any_jupytext_comment:

--- a/leo/modes/kivy.py
+++ b/leo/modes/kivy.py
@@ -49,7 +49,9 @@ def kivy_rule0(colorer, s, i):
 
 
 def kivy_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="kivy::literal_one")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="kivy::literal_one"
+    )
 
 
 def kivy_rule2(colorer, s, i):

--- a/leo/modes/latex.py
+++ b/leo/modes/latex.py
@@ -365,66 +365,114 @@ def latex_rule63(colorer, s, i):
 
 
 def latex_rule64(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="\\(", end="\\)", delegate="latex::mathmode")
+    return colorer.match_span(
+        s, i, kind="markup", begin="\\(", end="\\)", delegate="latex::mathmode"
+    )
 
 
 def latex_rule65(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="\\[", end="\\]", delegate="latex::mathmode")
+    return colorer.match_span(
+        s, i, kind="markup", begin="\\[", end="\\]", delegate="latex::mathmode"
+    )
 
 
 def latex_rule66(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="\\begin{math}", end="\\end{math}", delegate="latex::mathmode")
+    return colorer.match_span(
+        s, i, kind="markup", begin="\\begin{math}", end="\\end{math}", delegate="latex::mathmode"
+    )
 
 
 def latex_rule67(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{displaymath}", end="\\end{displaymath}", delegate="latex::mathmode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{displaymath}",
+        end="\\end{displaymath}",
+        delegate="latex::mathmode",
     )
 
 
 def latex_rule68(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{equation}", end="\\end{equation}", delegate="latex::mathmode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{equation}",
+        end="\\end{equation}",
+        delegate="latex::mathmode",
     )
 
 
 def latex_rule69(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="\\ensuremath{", end="}", delegate="latex::mathmode")
+    return colorer.match_span(
+        s, i, kind="markup", begin="\\ensuremath{", end="}", delegate="latex::mathmode"
+    )
 
 
 def latex_rule70(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{eqnarray}", end="\\end{eqnarray}", delegate="latex::arraymode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{eqnarray}",
+        end="\\end{eqnarray}",
+        delegate="latex::arraymode",
     )
 
 
 def latex_rule71(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{eqnarray*}", end="\\end{eqnarray*}", delegate="latex::arraymode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{eqnarray*}",
+        end="\\end{eqnarray*}",
+        delegate="latex::arraymode",
     )
 
 
 def latex_rule72(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{tabular}", end="\\end{tabular}", delegate="latex::tabularmode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{tabular}",
+        end="\\end{tabular}",
+        delegate="latex::tabularmode",
     )
 
 
 def latex_rule73(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{tabular*}", end="\\end{tabular*}", delegate="latex::tabularmode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{tabular*}",
+        end="\\end{tabular*}",
+        delegate="latex::tabularmode",
     )
 
 
 def latex_rule74(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{tabbing}", end="\\end{tabbing}", delegate="latex::tabbingmode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{tabbing}",
+        end="\\end{tabbing}",
+        delegate="latex::tabbingmode",
     )
 
 
 def latex_rule75(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="\\begin{picture}", end="\\end{picture}", delegate="latex::picturemode"
+        s,
+        i,
+        kind="markup",
+        begin="\\begin{picture}",
+        end="\\end{picture}",
+        delegate="latex::picturemode",
     )
 
 

--- a/leo/modes/lilypond.py
+++ b/leo/modes/lilypond.py
@@ -1528,7 +1528,9 @@ def lilypond_rule341(colorer, s, i):
 
 
 def lilypond_rule342(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="\\\\AncientRemoveEmptyStaffContext\\>")
+    return colorer.match_seq_regexp(
+        s, i, kind="keyword2", regexp="\\\\AncientRemoveEmptyStaffContext\\>"
+    )
 
 
 def lilypond_rule343(colorer, s, i):

--- a/leo/modes/mail.py
+++ b/leo/modes/mail.py
@@ -84,7 +84,9 @@ def mail_rule4(colorer, s, i):
 
 
 def mail_rule5(colorer, s, i):
-    return colorer.match_seq(s, i, kind="comment2", seq="--", at_line_start=True, delegate="mail::signature")
+    return colorer.match_seq(
+        s, i, kind="comment2", seq="--", at_line_start=True, delegate="mail::signature"
+    )
 
 
 def mail_rule6(colorer, s, i):

--- a/leo/modes/makefile.py
+++ b/leo/modes/makefile.py
@@ -75,13 +75,25 @@ def makefile_rule0(colorer, s, i):
 
 def makefile_rule1(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword2", begin="$(", end=")", delegate="makefile::variable", no_line_break=True
+        s,
+        i,
+        kind="keyword2",
+        begin="$(",
+        end=")",
+        delegate="makefile::variable",
+        no_line_break=True,
     )
 
 
 def makefile_rule2(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword2", begin="${", end="}", delegate="makefile::variable", no_line_break=True
+        s,
+        i,
+        kind="keyword2",
+        begin="${",
+        end="}",
+        delegate="makefile::variable",
+        no_line_break=True,
     )
 
 
@@ -334,13 +346,25 @@ def makefile_rule9(colorer, s, i):
 
 def makefile_rule10(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword2", begin="$(", end=")", delegate="makefile::variable", no_line_break=True
+        s,
+        i,
+        kind="keyword2",
+        begin="$(",
+        end=")",
+        delegate="makefile::variable",
+        no_line_break=True,
     )
 
 
 def makefile_rule11(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword2", begin="${", end="}", delegate="makefile::variable", no_line_break=True
+        s,
+        i,
+        kind="keyword2",
+        begin="${",
+        end="}",
+        delegate="makefile::variable",
+        no_line_break=True,
     )
 
 

--- a/leo/modes/md.py
+++ b/leo/modes/md.py
@@ -195,7 +195,9 @@ def md_jupytext_comment(colorer, s, i):
 
     # Leo 6.8.3. Add special case for @language jupytext.
     in_jupytext_tree = any(
-        z.startswith('@language jupytext') for z_p in c.p.self_and_parents() for z in g.splitLines(z_p.b)
+        z.startswith('@language jupytext')
+        for z_p in c.p.self_and_parents()
+        for z in g.splitLines(z_p.b)
     )
     is_any_jupytext_comment = i == 0 and s.startswith('# %%') and in_jupytext_tree
     if is_any_jupytext_comment:
@@ -270,12 +272,20 @@ def md_rule0(colorer, s, i):
 
 def md_rule1(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script", end="</script>", at_line_start=True, delegate="html::javascript"
+        s,
+        i,
+        kind="markup",
+        begin="<script",
+        end="</script>",
+        at_line_start=True,
+        delegate="html::javascript",
     )
 
 
 def md_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="<hr\\b([^<>])*?/?>", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="markup", regexp="<hr\\b([^<>])*?/?>", at_line_start=True
+    )
 
 
 def md_rule3(colorer, s, i):
@@ -321,15 +331,21 @@ rulesDict2 = {}
 if 0:  # Rules 6 & 7 will never match?
 
     def md_rule6(colorer, s, i):
-        return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="[\\S]+", at_line_start=True)
+        return colorer.match_eol_span_regexp(
+            s, i, kind="invalid", regexp="[\\S]+", at_line_start=True
+        )
 
     def md_rule7(colorer, s, i):
-        return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="{1,3}[\\S]+", at_line_start=True)
+        return colorer.match_eol_span_regexp(
+            s, i, kind="invalid", regexp="{1,3}[\\S]+", at_line_start=True
+        )
 
 
 def md_rule8(colorer, s, i):
     # leadin: [ \t]
-    return colorer.match_eol_span_regexp(s, i, kind="", regexp="( {4}|\\t)", at_line_start=True, delegate="html::main")
+    return colorer.match_eol_span_regexp(
+        s, i, kind="", regexp="( {4}|\\t)", at_line_start=True, delegate="html::main"
+    )
 
 
 def md_rule9(colorer, s, i):
@@ -364,7 +380,12 @@ rulesDict3 = {
 def md_rule12(colorer, s, i):
     # Leadins: [ \t>]
     return colorer.match_eol_span_regexp(
-        s, i, kind="", regexp="[ \\t]*(>[ \\t]{1})+", at_line_start=True, delegate="md::markdown_blockquote"
+        s,
+        i,
+        kind="",
+        regexp="[ \\t]*(>[ \\t]{1})+",
+        at_line_start=True,
+        delegate="md::markdown_blockquote",
     )
 
 
@@ -387,7 +408,13 @@ def md_rule15(colorer, s, i):
 
 def md_rule17(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal2", begin="``` ruby", end="```", at_line_start=True, delegate="ruby::main"
+        s,
+        i,
+        kind="literal2",
+        begin="``` ruby",
+        end="```",
+        at_line_start=True,
+        delegate="ruby::main",
     )
 
 
@@ -402,7 +429,9 @@ def md_rule19(colorer, s, i):
 
 def md_rule20(colorer, s, i):
     # Leadins are [ \t]
-    return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S", at_line_start=True)
+    return colorer.match_eol_span_regexp(
+        s, i, kind="literal2", regexp="( {4,}|\\t+)\\S", at_line_start=True
+    )
 
 
 def md_rule21(colorer, s, i):
@@ -412,7 +441,9 @@ def md_rule21(colorer, s, i):
 
 def md_rule22(colorer, s, i):
     # Leadin is #
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)", at_line_start=True)
+    return colorer.match_eol_span_regexp(
+        s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)", at_line_start=True
+    )
 
 
 def md_rule23(colorer, s, i):
@@ -424,17 +455,26 @@ def md_rule23(colorer, s, i):
 
 def md_rule24(colorer, s, i):
     # Leadins are [ \t*+-]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+", at_line_start=True
+    )
 
 
 def md_rule25(colorer, s, i):
     # Leadins are [ \t0123456789]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+", at_line_start=True
+    )
 
 
 def md_rule26(colorer, s, i):
     return colorer.match_eol_span_regexp(
-        s, i, kind="label", regexp="\\[(.*?)\\]\\:", at_whitespace_end=True, delegate="md::link_label_definition"
+        s,
+        i,
+        kind="label",
+        regexp="\\[(.*?)\\]\\:",
+        at_whitespace_end=True,
+        delegate="md::link_label_definition",
     )
 
     # Invalid regex.
@@ -454,12 +494,16 @@ def md_rule26(colorer, s, i):
 
 def md_rule28(colorer, s, i):
     # Leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="literal3", begin="(\\*\\*|__)", end="$1", no_line_break=True
+    )
 
 
 def md_rule29(colorer, s, i):
     # Leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="literal4", begin="(\\*|_)", end="$1", no_line_break=True
+    )
 
 
 # Rules dict for md_markdown ruleset.
@@ -537,13 +581,25 @@ def md_rule34(colorer, s, i):
 
 def md_rule35(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword4", begin="\\[", end="\\]", delegate="md::link_inline_label_close", no_line_break=True
+        s,
+        i,
+        kind="keyword4",
+        begin="\\[",
+        end="\\]",
+        delegate="md::link_inline_label_close",
+        no_line_break=True,
     )
 
 
 def md_rule36(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword4", begin="\\(", end="\\)", delegate="md::link_inline_url_title_close", no_line_break=True
+        s,
+        i,
+        kind="keyword4",
+        begin="\\(",
+        end="\\)",
+        delegate="md::link_inline_url_title_close",
+        no_line_break=True,
     )
 
 
@@ -637,7 +693,9 @@ def md_rule48(colorer, s, i):
 
 def md_rule49(colorer, s, i):
     # leadins: [ -_*]
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*")
+    return colorer.match_eol_span_regexp(
+        s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*"
+    )
 
 
 def md_rule50(colorer, s, i):

--- a/leo/modes/moin.py
+++ b/leo/modes/moin.py
@@ -46,7 +46,9 @@ def moin_rule2(colorer, s, i):
 
 
 def moin_rule3(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="\\s+\\w[[:alnum:][:blank:]]+::", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="label", regexp="\\s+\\w[[:alnum:][:blank:]]+::", at_line_start=True
+    )
 
 
 def moin_rule4(colorer, s, i):
@@ -66,7 +68,9 @@ def moin_rule7(colorer, s, i):
 
 
 def moin_rule8(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword1", begin="(={1,5})", end="$1", at_line_start=True)
+    return colorer.match_span_regexp(
+        s, i, kind="keyword1", begin="(={1,5})", end="$1", at_line_start=True
+    )
 
 
 def moin_rule9(colorer, s, i):

--- a/leo/modes/mqsc.py
+++ b/leo/modes/mqsc.py
@@ -222,11 +222,15 @@ def mqsc_rule0(colorer, s, i):
 
 
 def mqsc_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="('", end="')", exclude_match=True, no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="('", end="')", exclude_match=True, no_line_break=True
+    )
 
 
 def mqsc_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="(", end=")", exclude_match=True, no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal2", begin="(", end=")", exclude_match=True, no_line_break=True
+    )
 
 
 def mqsc_rule3(colorer, s, i):

--- a/leo/modes/netrexx.py
+++ b/leo/modes/netrexx.py
@@ -351,7 +351,9 @@ keywordsDictDict = {
 
 
 def netrexx_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/", delegate="java::javadoc")
+    return colorer.match_span(
+        s, i, kind="comment2", begin="/**", end="*/", delegate="java::javadoc"
+    )
 
 
 def netrexx_rule1(colorer, s, i):

--- a/leo/modes/nqc.py
+++ b/leo/modes/nqc.py
@@ -256,7 +256,9 @@ def nqc_rule21(colorer, s, i):
 
 
 def nqc_rule22(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def nqc_rule23(colorer, s, i):

--- a/leo/modes/nsis2.py
+++ b/leo/modes/nsis2.py
@@ -476,15 +476,21 @@ def nsis2_rule4(colorer, s, i):
 
 
 def nsis2_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="nsis2::nsis_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="nsis2::nsis_literal"
+    )
 
 
 def nsis2_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="nsis2::nsis_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="nsis2::nsis_literal"
+    )
 
 
 def nsis2_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="`", end="`", delegate="nsis2::nsis_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="`", end="`", delegate="nsis2::nsis_literal"
+    )
 
 
 def nsis2_rule8(colorer, s, i):

--- a/leo/modes/objective_c.py
+++ b/leo/modes/objective_c.py
@@ -109,11 +109,15 @@ keywordsDictDict = {
 
 
 def objective_c_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 def objective_c_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/*!", end="*/", delegate="doxygen::doxygen"
+    )
 
 
 def objective_c_rule2(colorer, s, i):
@@ -213,7 +217,9 @@ def objective_c_rule25(colorer, s, i):
 
 
 def objective_c_rule26(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def objective_c_rule27(colorer, s, i):

--- a/leo/modes/objectrexx.py
+++ b/leo/modes/objectrexx.py
@@ -302,7 +302,9 @@ def objectrexx_rule22(colorer, s, i):
 
 
 def objectrexx_rule23(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def objectrexx_rule24(colorer, s, i):

--- a/leo/modes/omnimark.py
+++ b/leo/modes/omnimark.py
@@ -438,7 +438,9 @@ def omnimark_rule1(colorer, s, i):
 
 
 def omnimark_rule2(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="invalid", begin="\"((?!$)[^\"])*$", end="$", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="invalid", begin="\"((?!$)[^\"])*$", end="$", no_line_break=True
+    )
 
 
 def omnimark_rule3(colorer, s, i):
@@ -446,7 +448,9 @@ def omnimark_rule3(colorer, s, i):
 
 
 def omnimark_rule4(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="invalid", begin="'((?!$)[^'])*$", end="$", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="invalid", begin="'((?!$)[^'])*$", end="$", no_line_break=True
+    )
 
 
 def omnimark_rule5(colorer, s, i):

--- a/leo/modes/openscad.py
+++ b/leo/modes/openscad.py
@@ -141,7 +141,14 @@ def openscad_rule2(colorer, s, i):
 
 def openscad_rule3(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq=")", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq=")",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
@@ -161,139 +168,300 @@ def openscad_rule4(colorer, s, i):
 
 def openscad_rule5(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="}", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="}",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule6(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="{", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="{",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule7(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="]", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="]",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule8(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="[", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="[",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule9(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="=", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="=",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule10(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq=";", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq=";",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule11(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="&&", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="&&",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule12(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="||", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="||",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule13(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="!", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="!",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule14(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="<", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="<",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule15(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="<=", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="<=",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule16(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="==", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="==",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule17(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="!=", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="!=",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule18(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq=">=", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq=">=",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule19(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq=">", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq=">",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule20(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="?", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="?",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule21(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq=":", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq=":",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule22(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="+", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="+",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule23(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="-", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="-",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule24(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="*", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="*",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule25(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="/", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="/",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule26(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="%", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="%",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 
 def openscad_rule27(colorer, s, i):
     return colorer.match_seq(
-        s, i, kind="operator", seq="#", at_line_start=False, at_whitespace_end=False, at_word_start=False, delegate=""
+        s,
+        i,
+        kind="operator",
+        seq="#",
+        at_line_start=False,
+        at_whitespace_end=False,
+        at_word_start=False,
+        delegate="",
     )
 
 

--- a/leo/modes/pandoc.py
+++ b/leo/modes/pandoc.py
@@ -212,12 +212,20 @@ def pandoc_rule0(colorer, s, i):
 
 def pandoc_rule1(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script", end="</script>", at_line_start=True, delegate="html::javascript"
+        s,
+        i,
+        kind="markup",
+        begin="<script",
+        end="</script>",
+        at_line_start=True,
+        delegate="html::javascript",
     )
 
 
 def pandoc_rule2(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="<hr\\b([^<>])*?/?>", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="markup", regexp="<hr\\b([^<>])*?/?>", at_line_start=True
+    )
 
 
 def pandoc_rule3(colorer, s, i):
@@ -237,7 +245,9 @@ def pandoc_rule4(colorer, s, i):
 
 
 def pandoc_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="pandoc::inline_markup")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="pandoc::inline_markup"
+    )
 
 
 # Rules dict for pandoc_main ruleset.
@@ -285,15 +295,21 @@ rulesDict2 = {}
 if 0:  # Rules 6 & 7 will never match?
 
     def pandoc_rule6(colorer, s, i):
-        return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="[\\S]+", at_line_start=True)
+        return colorer.match_eol_span_regexp(
+            s, i, kind="invalid", regexp="[\\S]+", at_line_start=True
+        )
 
     def pandoc_rule7(colorer, s, i):
-        return colorer.match_eol_span_regexp(s, i, kind="invalid", regexp="{1,3}[\\S]+", at_line_start=True)
+        return colorer.match_eol_span_regexp(
+            s, i, kind="invalid", regexp="{1,3}[\\S]+", at_line_start=True
+        )
 
 
 def pandoc_rule8(colorer, s, i):
     # leadin: [ \t]
-    return colorer.match_eol_span_regexp(s, i, kind="", regexp="( {4}|\\t)", at_line_start=True, delegate="html::main")
+    return colorer.match_eol_span_regexp(
+        s, i, kind="", regexp="( {4}|\\t)", at_line_start=True, delegate="html::main"
+    )
 
 
 def pandoc_rule9(colorer, s, i):
@@ -332,7 +348,12 @@ rulesDict3 = {
 def pandoc_rule12(colorer, s, i):
     # Leadins: [ \t>]
     return colorer.match_eol_span_regexp(
-        s, i, kind="", regexp="[ \\t]*(>[ \\t]{1})+", at_line_start=True, delegate="pandoc::markdown_blockquote"
+        s,
+        i,
+        kind="",
+        regexp="[ \\t]*(>[ \\t]{1})+",
+        at_line_start=True,
+        delegate="pandoc::markdown_blockquote",
     )
 
 
@@ -356,7 +377,13 @@ if 0:  # Invalid regular expression.
 
 def pandoc_rule17(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal2", begin="``` ruby", end="```", at_line_start=True, delegate="ruby::main"
+        s,
+        i,
+        kind="literal2",
+        begin="``` ruby",
+        end="```",
+        at_line_start=True,
+        delegate="ruby::main",
     )
 
 
@@ -371,7 +398,9 @@ def pandoc_rule19(colorer, s, i):
 
 def pandoc_rule20(colorer, s, i):
     # Leadins are [ \t]
-    return colorer.match_eol_span_regexp(s, i, kind="literal2", regexp="( {4,}|\\t+)\\S", at_line_start=True)
+    return colorer.match_eol_span_regexp(
+        s, i, kind="literal2", regexp="( {4,}|\\t+)\\S", at_line_start=True
+    )
 
 
 def pandoc_rule21(colorer, s, i):
@@ -381,7 +410,9 @@ def pandoc_rule21(colorer, s, i):
 
 def pandoc_rule22(colorer, s, i):
     # Leadin is #
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)", at_line_start=True)
+    return colorer.match_eol_span_regexp(
+        s, i, kind="keyword1", regexp="#{1,6}[ \\t]*(.+?)", at_line_start=True
+    )
 
 
 def pandoc_rule23(colorer, s, i):
@@ -393,17 +424,26 @@ def pandoc_rule23(colorer, s, i):
 
 def pandoc_rule24(colorer, s, i):
     # Leadins are [ \t*+-]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="keyword2", regexp="[ \\t]{0,}[*+-][ \\t]+", at_line_start=True
+    )
 
 
 def pandoc_rule25(colorer, s, i):
     # Leadins are [ \t0123456789]
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="keyword2", regexp="[ \\t]{0,}\\d+\\.[ \\t]+", at_line_start=True
+    )
 
 
 def pandoc_rule26(colorer, s, i):
     return colorer.match_eol_span_regexp(
-        s, i, kind="label", regexp="\\[(.*?)\\]\\:", at_whitespace_end=True, delegate="pandoc::link_label_definition"
+        s,
+        i,
+        kind="label",
+        regexp="\\[(.*?)\\]\\:",
+        at_whitespace_end=True,
+        delegate="pandoc::link_label_definition",
     )
 
 
@@ -424,12 +464,16 @@ if 0:  # Invalid regex.
 
 def pandoc_rule28(colorer, s, i):
     # Leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal3", begin="(\\*\\*|__)", end="$1", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="literal3", begin="(\\*\\*|__)", end="$1", no_line_break=True
+    )
 
 
 def pandoc_rule29(colorer, s, i):
     # Leadins: [*_]
-    return colorer.match_span_regexp(s, i, kind="literal4", begin="(\\*|_)", end="$1", no_line_break=True)
+    return colorer.match_span_regexp(
+        s, i, kind="literal4", begin="(\\*|_)", end="$1", no_line_break=True
+    )
 
 
 # Rules dict for pandoc_markdown ruleset.
@@ -439,13 +483,25 @@ rulesDict4 = {
     "#": [
         pandoc_rule22,
     ],
-    "*": [pandoc_rule13, pandoc_rule23, pandoc_rule24, pandoc_rule28, pandoc_rule29],  # new: 23,24,28,29.
+    "*": [
+        pandoc_rule13,
+        pandoc_rule23,
+        pandoc_rule24,
+        pandoc_rule28,
+        pandoc_rule29,
+    ],  # new: 23,24,28,29.
     "\\": [
         pandoc_rule15,
         # pandoc_rule16,
         pandoc_rule26,
     ],
-    "_": [pandoc_rule14, pandoc_rule23, pandoc_rule24, pandoc_rule28, pandoc_rule29],  # new: 23,24,28,29.
+    "_": [
+        pandoc_rule14,
+        pandoc_rule23,
+        pandoc_rule24,
+        pandoc_rule28,
+        pandoc_rule29,
+    ],  # new: 23,24,28,29.
     "`": [
         pandoc_rule17,
         pandoc_rule18,
@@ -545,7 +601,13 @@ def pandoc_rule34(colorer, s, i):
 
 def pandoc_rule35(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword4", begin="\\[", end="\\]", delegate="pandoc::link_inline_label_close", no_line_break=True
+        s,
+        i,
+        kind="keyword4",
+        begin="\\[",
+        end="\\]",
+        delegate="pandoc::link_inline_label_close",
+        no_line_break=True,
     )
 
 
@@ -610,7 +672,9 @@ def pandoc_rule39(colorer, s, i):
 
 
 def pandoc_rule40(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="pandoc::inline_markup")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="pandoc::inline_markup"
+    )
 
 
 def pandoc_rule41(colorer, s, i):
@@ -655,7 +719,9 @@ def pandoc_rule48(colorer, s, i):
 
 def pandoc_rule49(colorer, s, i):
     # leadins: [ -_*]
-    return colorer.match_eol_span_regexp(s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*")
+    return colorer.match_eol_span_regexp(
+        s, i, kind="keyword1", regexp="[ ]{0,2}([ ]?[-_*][ ]?){3,}[ \\t]*"
+    )
 
 
 def pandoc_rule50(colorer, s, i):

--- a/leo/modes/perl.py
+++ b/leo/modes/perl.py
@@ -337,47 +337,69 @@ def perl_rule0(colorer, s, i):
 
 
 def perl_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=head1", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=head1", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=head2", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=head2", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=head3", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=head3", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=head4", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=head4", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=item", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=item", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=over", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=over", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule7(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=back", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=back", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=pod", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=pod", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=for", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=for", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=begin", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=begin", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="=end", end="=cut", at_line_start=True, delegate="perl::pod")
+    return colorer.match_span(
+        s, i, kind="label", begin="=end", end="=cut", at_line_start=True, delegate="perl::pod"
+    )
 
 
 def perl_rule12(colorer, s, i):
@@ -393,7 +415,9 @@ def perl_rule14(colorer, s, i):
 
 
 def perl_rule15(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="${", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="${", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule16(colorer, s, i):
@@ -409,11 +433,15 @@ def perl_rule18(colorer, s, i):
 
 
 def perl_rule19(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="@{", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="@{", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule20(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="%{", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="%{", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule21(colorer, s, i):
@@ -441,7 +469,12 @@ def perl_rule24(colorer, s, i):
 
 def perl_rule25(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="literal2", begin="<<([[:alpha:]_][[:alnum:]_]*);?\\s*", end="$1", delegate="perl::literal"
+        s,
+        i,
+        kind="literal2",
+        begin="<<([[:alpha:]_][[:alnum:]_]*);?\\s*",
+        end="$1",
+        delegate="perl::literal",
     )
 
 
@@ -454,11 +487,15 @@ def perl_rule27(colorer, s, i):
 
 
 def perl_rule28(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="tr([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1")
+    return colorer.match_seq_regexp(
+        s, i, kind="markup", regexp="tr([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1"
+    )
 
 
 def perl_rule29(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="y([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1")
+    return colorer.match_seq_regexp(
+        s, i, kind="markup", regexp="y([[:punct:]])(?:.*?[^\\\\])*?\\1(?:.*?[^\\\\])*?\\1"
+    )
 
 
 def perl_rule30(colorer, s, i):
@@ -466,7 +503,9 @@ def perl_rule30(colorer, s, i):
 
 
 def perl_rule31(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="markup", regexp="m([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*")
+    return colorer.match_seq_regexp(
+        s, i, kind="markup", regexp="m([[:punct:]])(?:.*?[^\\\\])*?\\1[sgiexom]*"
+    )
 
 
 def perl_rule32(colorer, s, i):
@@ -865,15 +904,21 @@ rulesDict2 = {}
 
 
 def perl_rule55(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="${", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="${", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule56(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="@{", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="@{", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule57(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="%{", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="%{", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule58(colorer, s, i):
@@ -1094,7 +1139,9 @@ rulesDict4 = {
 
 
 def perl_rule86(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="{", end="}", delegate="perl::variable", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="{", end="}", delegate="perl::variable", no_line_break=True
+    )
 
 
 def perl_rule87(colorer, s, i):

--- a/leo/modes/php.py
+++ b/leo/modes/php.py
@@ -2567,16 +2567,25 @@ def php_rule3(colorer, s, i):
 
 def php_rule4(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="markup", begin="<SCRIPT\\s+LANGUAGE=\"?PHP\"?>", end="</SCRIPT>", delegate="php::php"
+        s,
+        i,
+        kind="markup",
+        begin="<SCRIPT\\s+LANGUAGE=\"?PHP\"?>",
+        end="</SCRIPT>",
+        delegate="php::php",
     )
 
 
 def php_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="php::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="php::javascript"
+    )
 
 
 def php_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css"
+    )
 
 
 def php_rule7(colorer, s, i):
@@ -2627,11 +2636,15 @@ def php_rule12(colorer, s, i):
 
 
 def php_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="php::tags_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="php::tags_literal"
+    )
 
 
 def php_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="php::tags_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="php::tags_literal"
+    )
 
 
 def php_rule15(colorer, s, i):
@@ -2692,7 +2705,9 @@ def php_rule20(colorer, s, i):
 
 
 def php_rule21(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="php::php_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="php::php_literal"
+    )
 
 
 def php_rule22(colorer, s, i):
@@ -2700,7 +2715,9 @@ def php_rule22(colorer, s, i):
 
 
 def php_rule23(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="`", end="`", delegate="php::php_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="`", end="`", delegate="php::php_literal"
+    )
 
 
 def php_rule24(colorer, s, i):
@@ -3220,7 +3237,9 @@ def php_rule68(colorer, s, i):
 
 
 def php_rule69(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True
+    )
 
 
 def php_rule70(colorer, s, i):

--- a/leo/modes/phpsection.py
+++ b/leo/modes/phpsection.py
@@ -2547,7 +2547,9 @@ keywordsDictDict = {
 
 
 def phpsection_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>", delegate="phpsection::php")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<?php", end="?>", delegate="phpsection::php"
+    )
 
 
 def phpsection_rule1(colorer, s, i):
@@ -2555,7 +2557,9 @@ def phpsection_rule1(colorer, s, i):
 
 
 def phpsection_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>", delegate="phpsection::php")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<%=", end="%>", delegate="phpsection::php"
+    )
 
 
 def phpsection_rule3(colorer, s, i):
@@ -2564,16 +2568,25 @@ def phpsection_rule3(colorer, s, i):
 
 def phpsection_rule4(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="markup", begin="<SCRIPT\\s+LANGUAGE=\"?PHP\"?>", end="</SCRIPT>", delegate="phpsection::php"
+        s,
+        i,
+        kind="markup",
+        begin="<SCRIPT\\s+LANGUAGE=\"?PHP\"?>",
+        end="</SCRIPT>",
+        delegate="phpsection::php",
     )
 
 
 def phpsection_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="phpsection::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="phpsection::javascript"
+    )
 
 
 def phpsection_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css"
+    )
 
 
 def phpsection_rule7(colorer, s, i):
@@ -2612,7 +2625,9 @@ rulesDict1 = {
 
 
 def phpsection_rule10(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>", delegate="phpsection::php")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<?php", end="?>", delegate="phpsection::php"
+    )
 
 
 def phpsection_rule11(colorer, s, i):
@@ -2620,15 +2635,21 @@ def phpsection_rule11(colorer, s, i):
 
 
 def phpsection_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>", delegate="phpsection::php")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<%=", end="%>", delegate="phpsection::php"
+    )
 
 
 def phpsection_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="phpsection::tags_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="phpsection::tags_literal"
+    )
 
 
 def phpsection_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="phpsection::tags_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="phpsection::tags_literal"
+    )
 
 
 def phpsection_rule15(colorer, s, i):
@@ -2657,7 +2678,9 @@ rulesDict2 = {
 
 
 def phpsection_rule16(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<?php", end="?>", delegate="phpsection::php")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<?php", end="?>", delegate="phpsection::php"
+    )
 
 
 def phpsection_rule17(colorer, s, i):
@@ -2665,7 +2688,9 @@ def phpsection_rule17(colorer, s, i):
 
 
 def phpsection_rule18(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<%=", end="%>", delegate="phpsection::php")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<%=", end="%>", delegate="phpsection::php"
+    )
 
 
 # Rules dict for phpsection_tags_literal ruleset.
@@ -2681,7 +2706,9 @@ rulesDict3 = {
 
 
 def phpsection_rule19(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="phpsection::phpdoc")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="phpsection::phpdoc"
+    )
 
 
 def phpsection_rule20(colorer, s, i):
@@ -2689,7 +2716,9 @@ def phpsection_rule20(colorer, s, i):
 
 
 def phpsection_rule21(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="phpsection::php_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="phpsection::php_literal"
+    )
 
 
 def phpsection_rule22(colorer, s, i):
@@ -2697,7 +2726,9 @@ def phpsection_rule22(colorer, s, i):
 
 
 def phpsection_rule23(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="`", end="`", delegate="phpsection::php_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="`", end="`", delegate="phpsection::php_literal"
+    )
 
 
 def phpsection_rule24(colorer, s, i):
@@ -3217,7 +3248,9 @@ def phpsection_rule68(colorer, s, i):
 
 
 def phpsection_rule69(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="markup", begin="<", end=">", delegate="xml::tags", no_line_break=True
+    )
 
 
 def phpsection_rule70(colorer, s, i):

--- a/leo/modes/pike.py
+++ b/leo/modes/pike.py
@@ -195,12 +195,20 @@ def pike_rule3(colorer, s, i):
 
 def pike_rule4(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal1", begin="\"", end="\"", delegate="pike::string_literal", no_line_break=True
+        s,
+        i,
+        kind="literal1",
+        begin="\"",
+        end="\"",
+        delegate="pike::string_literal",
+        no_line_break=True,
     )
 
 
 def pike_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="#\"", end="\"", delegate="pike::string_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="#\"", end="\"", delegate="pike::string_literal"
+    )
 
 
 def pike_rule6(colorer, s, i):
@@ -208,7 +216,9 @@ def pike_rule6(colorer, s, i):
 
 
 def pike_rule7(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="keyword2", regexp="#.*?(?=($|/\\*|//))", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="keyword2", regexp="#.*?(?=($|/\\*|//))", at_line_start=True
+    )
 
 
 def pike_rule8(colorer, s, i):
@@ -777,7 +787,9 @@ rulesDict2 = {
 
 
 def pike_rule33(colorer, s, i):
-    return colorer.match_eol_span(s, i, kind="null", seq="@decl", delegate="pike::main", exclude_match=True)
+    return colorer.match_eol_span(
+        s, i, kind="null", seq="@decl", delegate="pike::main", exclude_match=True
+    )
 
 
 def pike_rule34(colorer, s, i):
@@ -789,7 +801,9 @@ def pike_rule35(colorer, s, i):
 
 
 def pike_rule36(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="function", regexp="@(b|i|u|tt|url|pre|ref|code|expr|image)?(\\{.*@\\})")
+    return colorer.match_seq_regexp(
+        s, i, kind="function", regexp="@(b|i|u|tt|url|pre|ref|code|expr|image)?(\\{.*@\\})"
+    )
 
 
 def pike_rule37(colorer, s, i):

--- a/leo/modes/pl1.py
+++ b/leo/modes/pl1.py
@@ -566,7 +566,9 @@ def pl1_rule2(colorer, s, i):
 
 
 def pl1_rule3(colorer, s, i):
-    return colorer.match_eol_span_regexp(s, i, kind="keyword2", regexp="\\* *process", at_line_start=True)
+    return colorer.match_eol_span_regexp(
+        s, i, kind="keyword2", regexp="\\* *process", at_line_start=True
+    )
 
 
 def pl1_rule4(colorer, s, i):
@@ -630,7 +632,9 @@ def pl1_rule18(colorer, s, i):
 
 
 def pl1_rule19(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def pl1_rule20(colorer, s, i):

--- a/leo/modes/pop11.py
+++ b/leo/modes/pop11.py
@@ -192,7 +192,9 @@ keywordsDictDict = {
 
 
 def pop11_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/", delegate="pop11::comment")
+    return colorer.match_span(
+        s, i, kind="comment1", begin="/*", end="*/", delegate="pop11::comment"
+    )
 
 
 def pop11_rule1(colorer, s, i):
@@ -200,15 +202,21 @@ def pop11_rule1(colorer, s, i):
 
 
 def pop11_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="pop11::string", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="pop11::string", no_line_break=True
+    )
 
 
 def pop11_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="pop11::string", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="pop11::string", no_line_break=True
+    )
 
 
 def pop11_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="`", end="`", delegate="pop11::string", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="`", end="`", delegate="pop11::string", no_line_break=True
+    )
 
 
 def pop11_rule5(colorer, s, i):
@@ -611,11 +619,15 @@ def pop11_rule35(colorer, s, i):
 
 
 def pop11_rule36(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="pop11::string", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="pop11::string", no_line_break=True
+    )
 
 
 def pop11_rule37(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="pop11::string", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="pop11::string", no_line_break=True
+    )
 
 
 def pop11_rule38(colorer, s, i):
@@ -623,7 +635,9 @@ def pop11_rule38(colorer, s, i):
 
 
 def pop11_rule39(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment1", begin="/*", end="*/", delegate="pop11::comment")
+    return colorer.match_span(
+        s, i, kind="comment1", begin="/*", end="*/", delegate="pop11::comment"
+    )
 
 
 def pop11_rule40(colorer, s, i):

--- a/leo/modes/postscript.py
+++ b/leo/modes/postscript.py
@@ -113,7 +113,9 @@ def postscript_rule3(colorer, s, i):
 
 
 def postscript_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="(", end=")", delegate="postscript::literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="(", end=")", delegate="postscript::literal"
+    )
 
 
 def postscript_rule5(colorer, s, i):
@@ -368,7 +370,9 @@ rulesDict1 = {
 
 
 def postscript_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="(", end=")", delegate="postscript::literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="(", end=")", delegate="postscript::literal"
+    )
 
 
 # Rules dict for postscript_literal ruleset.

--- a/leo/modes/povray.py
+++ b/leo/modes/povray.py
@@ -581,7 +581,9 @@ def povray_rule20(colorer, s, i):
 
 
 def povray_rule21(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def povray_rule22(colorer, s, i):

--- a/leo/modes/powerdynamo.py
+++ b/leo/modes/powerdynamo.py
@@ -298,125 +298,227 @@ keywordsDictDict = {
 
 def powerdynamo_rule0(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--script", end="-->", delegate="powerdynamo::powerdynamo-script"
+        s,
+        i,
+        kind="label",
+        begin="<!--script",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-script",
     )
 
 
 def powerdynamo_rule1(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--data", end="-->", delegate="powerdynamo::powerdynamo-tag-data"
+        s,
+        i,
+        kind="label",
+        begin="<!--data",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-data",
     )
 
 
 def powerdynamo_rule2(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--document", end="-->", delegate="powerdynamo::powerdynamo-tag-document"
+        s,
+        i,
+        kind="label",
+        begin="<!--document",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-document",
     )
 
 
 def powerdynamo_rule3(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--evaluate", end="-->", delegate="powerdynamo::powerdynamo-script"
+        s,
+        i,
+        kind="label",
+        begin="<!--evaluate",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-script",
     )
 
 
 def powerdynamo_rule4(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--execute", end="-->", delegate="powerdynamo::powerdynamo-script"
+        s,
+        i,
+        kind="label",
+        begin="<!--execute",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-script",
     )
 
 
 def powerdynamo_rule5(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--formatting", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--formatting",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule6(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--/formatting", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--/formatting",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule7(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--include", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--include",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule8(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--label", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--label",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule9(colorer, s, i):
-    return colorer.match_span(s, i, kind="label", begin="<!--sql", end="-->", delegate="transact-sql::main")
+    return colorer.match_span(
+        s, i, kind="label", begin="<!--sql", end="-->", delegate="transact-sql::main"
+    )
 
 
 def powerdynamo_rule10(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_error_code", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_error_code",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule11(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_error_info", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_error_info",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule12(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_state", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_state",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule13(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_on_no_error", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_on_no_error",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule14(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--/sql_on_no_error", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--/sql_on_no_error",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule15(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_on_error", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_on_error",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule16(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--/sql_on_error", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--/sql_on_error",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule17(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_on_no_rows", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_on_no_rows",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule18(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--/sql_on_no_rows", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--/sql_on_no_rows",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule19(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--sql_on_rows", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--sql_on_rows",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
 def powerdynamo_rule20(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--/sql_on_rows", end="-->", delegate="powerdynamo::powerdynamo-tag-general"
+        s,
+        i,
+        kind="label",
+        begin="<!--/sql_on_rows",
+        end="-->",
+        delegate="powerdynamo::powerdynamo-tag-general",
     )
 
 
@@ -425,11 +527,15 @@ def powerdynamo_rule21(colorer, s, i):
 
 
 def powerdynamo_rule22(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript"
+    )
 
 
 def powerdynamo_rule23(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css"
+    )
 
 
 def powerdynamo_rule24(colorer, s, i):
@@ -484,16 +590,25 @@ rulesDict1 = {
 
 def powerdynamo_rule27(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--script", end="--?>", delegate="powerdynamo::powerdynamo-script"
+        s,
+        i,
+        kind="label",
+        begin="<!--script",
+        end="--?>",
+        delegate="powerdynamo::powerdynamo-script",
     )
 
 
 def powerdynamo_rule28(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::tags_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::tags_literal"
+    )
 
 
 def powerdynamo_rule29(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::tags_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::tags_literal"
+    )
 
 
 def powerdynamo_rule30(colorer, s, i):
@@ -521,7 +636,12 @@ rulesDict2 = {
 
 def powerdynamo_rule31(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="label", begin="<!--script", end="?-->", delegate="powerdynamo::powerdynamo-script"
+        s,
+        i,
+        kind="label",
+        begin="<!--script",
+        end="?-->",
+        delegate="powerdynamo::powerdynamo-script",
     )
 
 
@@ -540,11 +660,15 @@ def powerdynamo_rule32(colorer, s, i):
 
 
 def powerdynamo_rule33(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule34(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule35(colorer, s, i):
@@ -944,11 +1068,15 @@ rulesDict4 = {
 
 
 def powerdynamo_rule64(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule65(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule66(colorer, s, i):
@@ -1161,11 +1289,15 @@ rulesDict5 = {
 
 
 def powerdynamo_rule67(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule68(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule69(colorer, s, i):
@@ -1378,11 +1510,15 @@ rulesDict6 = {
 
 
 def powerdynamo_rule70(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule71(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="'", end="'", delegate="powerdynamo::powerdynamo_literal"
+    )
 
 
 def powerdynamo_rule72(colorer, s, i):

--- a/leo/modes/prolog.py
+++ b/leo/modes/prolog.py
@@ -146,7 +146,9 @@ def prolog_rule3(colorer, s, i):
 
 
 def prolog_rule4(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="[", end="]", delegate="prolog::list", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal2", begin="[", end="]", delegate="prolog::list", no_line_break=True
+    )
 
 
 def prolog_rule5(colorer, s, i):
@@ -600,7 +602,9 @@ rulesDict1 = {
 
 
 def prolog_rule45(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal2", begin="[", end="]", delegate="prolog::list", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal2", begin="[", end="]", delegate="prolog::list", no_line_break=True
+    )
 
 
 # Rules dict for prolog_list ruleset.

--- a/leo/modes/pseudoplain.py
+++ b/leo/modes/pseudoplain.py
@@ -43,7 +43,9 @@ keywordsDictDict = {
 
 
 def pseudoplain_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="operator", begin="[[", end="]]", delegate="pseudoplain::interior")
+    return colorer.match_span(
+        s, i, kind="operator", begin="[[", end="]]", delegate="pseudoplain::interior"
+    )
 
 
 # Rules dict for pseudoplain_main ruleset.

--- a/leo/modes/psp.py
+++ b/leo/modes/psp.py
@@ -67,7 +67,9 @@ keywordsDictDict = {
 
 
 def psp_rule0(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal4", begin="<%@", end="%>", delegate="psp::directive")
+    return colorer.match_span(
+        s, i, kind="literal4", begin="<%@", end="%>", delegate="psp::directive"
+    )
 
 
 def psp_rule1(colorer, s, i):
@@ -80,18 +82,30 @@ def psp_rule2(colorer, s, i):
 
 def psp_rule3(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"jscript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"jscript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def psp_rule4(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="<script language=\"javascript\">", end="</script>", delegate="javascript::main"
+        s,
+        i,
+        kind="markup",
+        begin="<script language=\"javascript\">",
+        end="</script>",
+        delegate="javascript::main",
     )
 
 
 def psp_rule5(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<script>", end="</script>", delegate="javascript::main"
+    )
 
 
 def psp_rule6(colorer, s, i):
@@ -103,7 +117,9 @@ def psp_rule7(colorer, s, i):
 
 
 def psp_rule8(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE>", end="</STYLE>", delegate="css::main"
+    )
 
 
 def psp_rule9(colorer, s, i):

--- a/leo/modes/python.py
+++ b/leo/modes/python.py
@@ -337,7 +337,9 @@ def python_comment(colorer, s, i):
 
     # Leo 6.8.3. Add special case for @language jupytext.
     in_jupytext_tree = any(
-        z.startswith('@language jupytext') for z_p in c.p.self_and_parents() for z in g.splitLines(z_p.b)
+        z.startswith('@language jupytext')
+        for z_p in c.p.self_and_parents()
+        for z in g.splitLines(z_p.b)
     )
     is_any_jupytext_comment = i == 0 and s.startswith('# %%') and in_jupytext_tree
     if is_any_jupytext_comment:

--- a/leo/modes/rest.py
+++ b/leo/modes/rest.py
@@ -157,7 +157,9 @@ def rest_rule1(colorer, s, i):
 
 # @+node:ekr.20250109073551.12: *3* function: rest_rule11 .. |...|
 def rest_rule11(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp=r"\.\.\s\|[^|]+\|", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="literal3", regexp=r"\.\.\s\|[^|]+\|", at_line_start=True
+    )
 
 
 # @+node:ekr.20250109073551.13: *3* function: rest_rule12 |...|
@@ -167,7 +169,9 @@ def rest_rule12(colorer, s, i):
 
 # @+node:ekr.20250109073551.14: *3* function: rest_rule13 .. word::
 def rest_rule13(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=r"\.\.\s[A-z][A-z0-9-_]+::", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="literal2", regexp=r"\.\.\s[A-z][A-z0-9-_]+::", at_line_start=True
+    )
 
 
 # @+node:ekr.20250109073551.17: *3* function: rest_rule16 ..

--- a/leo/modes/rest_comments.py
+++ b/leo/modes/rest_comments.py
@@ -150,7 +150,9 @@ def rest_comments_rule1(colorer, s, i):
 
 # @+node:ekr.20250115040652.20: *3* function: rest_comments_rule11 .. |...|
 def rest_comments_rule11(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp=r"\.\.\s\|[^|]+\|", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="literal3", regexp=r"\.\.\s\|[^|]+\|", at_line_start=True
+    )
 
 
 # @+node:ekr.20250115040652.21: *3* function: rest_comments_rule12 |...|
@@ -160,7 +162,9 @@ def rest_comments_rule12(colorer, s, i):
 
 # @+node:ekr.20250115040652.22: *3* function: rest_comments_rule13 .. word::
 def rest_comments_rule13(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal2", regexp=r"\.\.\s[A-z][A-z0-9-_]+::", at_line_start=True)
+    return colorer.match_seq_regexp(
+        s, i, kind="literal2", regexp=r"\.\.\s[A-z][A-z0-9-_]+::", at_line_start=True
+    )
 
 
 # @+node:ekr.20250115040652.23: *3* function: rest_comments_rule16 ..

--- a/leo/modes/rib.py
+++ b/leo/modes/rib.py
@@ -253,7 +253,9 @@ def rib_rule5(colorer, s, i):
 
 
 def rib_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="rib::literals", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="rib::literals", no_line_break=True
+    )
 
 
 def rib_rule7(colorer, s, i):

--- a/leo/modes/rpmspec.py
+++ b/leo/modes/rpmspec.py
@@ -145,7 +145,13 @@ def rpmspec_rule4(colorer, s, i):
 
 def rpmspec_rule5(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="markup", begin="%verify(", end=")", delegate="rpmspec::verify", no_line_break=True
+        s,
+        i,
+        kind="markup",
+        begin="%verify(",
+        end=")",
+        delegate="rpmspec::verify",
+        no_line_break=True,
     )
 
 

--- a/leo/modes/ruby.py
+++ b/leo/modes/ruby.py
@@ -106,7 +106,13 @@ def ruby_rule1(colorer, s, i):
 
 def ruby_rule2(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="literal1", begin="\"", end="\"", delegate="ruby::doublequoteliteral", no_line_break=True
+        s,
+        i,
+        kind="literal1",
+        begin="\"",
+        end="\"",
+        delegate="ruby::doublequoteliteral",
+        no_line_break=True,
     )
 
 
@@ -231,7 +237,9 @@ def ruby_rule32(colorer, s, i):
 
 
 def ruby_rule33(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def ruby_rule34(colorer, s, i):

--- a/leo/modes/rview.py
+++ b/leo/modes/rview.py
@@ -142,7 +142,9 @@ def rview_rule0(colorer, s, i):
 
 
 def rview_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="/**", end="*/", delegate="rview::javadoc")
+    return colorer.match_span(
+        s, i, kind="comment2", begin="/**", end="*/", delegate="rview::javadoc"
+    )
 
 
 def rview_rule2(colorer, s, i):

--- a/leo/modes/scala.py
+++ b/leo/modes/scala.py
@@ -342,7 +342,9 @@ def scala_rule2(colorer, s, i):
 
 
 def scala_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="/**", end="*/", delegate="scala::scaladoc")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="/**", end="*/", delegate="scala::scaladoc"
+    )
 
 
 def scala_rule4(colorer, s, i):
@@ -374,12 +376,17 @@ def scala_rule9(colorer, s, i):
 
 
 def scala_rule10(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="label", regexp="'[0-9a-zA-Z><=+]([0-9a-zA-Z><=+]|_[0-9a-zA-Z><=+])*")
+    return colorer.match_seq_regexp(
+        s, i, kind="label", regexp="'[0-9a-zA-Z><=+]([0-9a-zA-Z><=+]|_[0-9a-zA-Z><=+])*"
+    )
 
 
 def scala_rule11(colorer, s, i):
     return colorer.match_seq_regexp(
-        s, i, kind="literal3", regexp="\\[[^\\[\\]]*(\\[[^\\[\\]]*(\\[[^\\[\\]]*\\][^\\[\\]]*)*\\][^\\[\\]]*)*\\]"
+        s,
+        i,
+        kind="literal3",
+        regexp="\\[[^\\[\\]]*(\\[[^\\[\\]]*(\\[[^\\[\\]]*\\][^\\[\\]]*)*\\][^\\[\\]]*)*\\]",
     )
 
 
@@ -512,7 +519,9 @@ def scala_rule43(colorer, s, i):
 
 
 def scala_rule44(colorer, s, i):
-    return colorer.match_span(s, i, kind="", begin="case", end="=>", delegate="scala::pattern", no_line_break=True)
+    return colorer.match_span(
+        s, i, kind="", begin="case", end="=>", delegate="scala::pattern", no_line_break=True
+    )
 
 
 def scala_rule45(colorer, s, i):
@@ -838,7 +847,9 @@ def scala_rule48(colorer, s, i):
 
 
 def scala_rule49(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<pre>", end="</pre>", delegate="scala::scaladoc_pre")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<pre>", end="</pre>", delegate="scala::scaladoc_pre"
+    )
 
 
 def scala_rule50(colorer, s, i):
@@ -1107,7 +1118,9 @@ def scala_rule60(colorer, s, i):
 
 
 def scala_rule61(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp=">\\s*\\)", delegate="scala::main")
+    return colorer.match_seq_regexp(
+        s, i, kind="literal3", regexp=">\\s*\\)", delegate="scala::main"
+    )
 
 
 def scala_rule62(colorer, s, i):
@@ -1141,11 +1154,15 @@ def scala_rule63(colorer, s, i):
 
 
 def scala_rule64(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="<!--", delegate="scala::xml_comment")
+    return colorer.match_seq_regexp(
+        s, i, kind="comment2", regexp="<!--", delegate="scala::xml_comment"
+    )
 
 
 def scala_rule65(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="literal3", regexp="<\\/?\\w*", delegate="scala::xml_tag")
+    return colorer.match_seq_regexp(
+        s, i, kind="literal3", regexp="<\\/?\\w*", delegate="scala::xml_tag"
+    )
 
 
 # Rules dict for scala_xml_text ruleset.
@@ -1167,7 +1184,9 @@ def scala_rule66(colorer, s, i):
 
 
 def scala_rule67(colorer, s, i):
-    return colorer.match_seq_regexp(s, i, kind="comment2", regexp="-->\\s*;", delegate="scala::main")
+    return colorer.match_seq_regexp(
+        s, i, kind="comment2", regexp="-->\\s*;", delegate="scala::main"
+    )
 
 
 def scala_rule68(colorer, s, i):

--- a/leo/modes/sgml.py
+++ b/leo/modes/sgml.py
@@ -38,11 +38,15 @@ def sgml_rule0(colorer, s, i):
 
 
 def sgml_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="<!ENTITY", end=">", delegate="xml::entity-tags")
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="<!ENTITY", end=">", delegate="xml::entity-tags"
+    )
 
 
 def sgml_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="<![CDATA[", end="]]>", delegate="xml::cdata")
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="<![CDATA[", end="]]>", delegate="xml::cdata"
+    )
 
 
 def sgml_rule3(colorer, s, i):

--- a/leo/modes/shell.py
+++ b/leo/modes/shell.py
@@ -143,7 +143,9 @@ def shell_rule14(colorer, s, i):
 
 
 def shell_rule15(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="shell::literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="shell::literal"
+    )
 
 
 def shell_rule16(colorer, s, i):

--- a/leo/modes/shellscript.py
+++ b/leo/modes/shellscript.py
@@ -127,23 +127,33 @@ def shellscript_rule10(colorer, s, i):
 
 
 def shellscript_rule11(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$((", end="))", delegate="shellscript::exec")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="$((", end="))", delegate="shellscript::exec"
+    )
 
 
 def shellscript_rule12(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$(", end=")", delegate="shellscript::exec")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="$(", end=")", delegate="shellscript::exec"
+    )
 
 
 def shellscript_rule13(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="$[", end="]", delegate="shellscript::exec")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="$[", end="]", delegate="shellscript::exec"
+    )
 
 
 def shellscript_rule14(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword3", begin="`", end="`", delegate="shellscript::exec")
+    return colorer.match_span(
+        s, i, kind="keyword3", begin="`", end="`", delegate="shellscript::exec"
+    )
 
 
 def shellscript_rule15(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="shellscript::literal")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="shellscript::literal"
+    )
 
 
 def shellscript_rule16(colorer, s, i):

--- a/leo/modes/splus.py
+++ b/leo/modes/splus.py
@@ -144,7 +144,9 @@ def splus_rule21(colorer, s, i):
 
 
 def splus_rule22(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def splus_rule23(colorer, s, i):

--- a/leo/modes/tex.py
+++ b/leo/modes/tex.py
@@ -103,13 +103,24 @@ def tex_rule6(colorer, s, i):
 
 def tex_rule7(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword1", begin="\\begin{verbatim}", end="\\end{verbatim}", delegate="tex::verbatim"
+        s,
+        i,
+        kind="keyword1",
+        begin="\\begin{verbatim}",
+        end="\\end{verbatim}",
+        delegate="tex::verbatim",
     )
 
 
 def tex_rule8(colorer, s, i):
     return colorer.match_span(
-        s, i, kind="keyword1", begin="\\verb|", end="|", delegate="tex::verbatim", no_line_break=True
+        s,
+        i,
+        kind="keyword1",
+        begin="\\verb|",
+        end="|",
+        delegate="tex::verbatim",
+        no_line_break=True,
     )
 
 

--- a/leo/modes/tpl.py
+++ b/leo/modes/tpl.py
@@ -73,11 +73,15 @@ def tpl_rule0(colorer, s, i):
 
 
 def tpl_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="html::javascript"
+    )
 
 
 def tpl_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="html::css"
+    )
 
 
 def tpl_rule3(colorer, s, i):

--- a/leo/modes/typescript.py
+++ b/leo/modes/typescript.py
@@ -313,7 +313,9 @@ def typescript_rule28(colorer, s, i):
 
 
 def typescript_rule29(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def typescript_rule30(colorer, s, i):

--- a/leo/modes/uscript.py
+++ b/leo/modes/uscript.py
@@ -220,7 +220,9 @@ def uscript_rule23(colorer, s, i):
 
 
 def uscript_rule24(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_whitespace_end=True, exclude_match=True
+    )
 
 
 def uscript_rule25(colorer, s, i):

--- a/leo/modes/vbscript.py
+++ b/leo/modes/vbscript.py
@@ -418,7 +418,9 @@ def vbscript_rule19(colorer, s, i):
 
 
 def vbscript_rule20(colorer, s, i):
-    return colorer.match_mark_previous(s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True)
+    return colorer.match_mark_previous(
+        s, i, kind="label", pattern=":", at_line_start=True, exclude_match=True
+    )
 
 
 def vbscript_rule21(colorer, s, i):

--- a/leo/modes/velocity.py
+++ b/leo/modes/velocity.py
@@ -140,11 +140,15 @@ def velocity_rule0(colorer, s, i):
 
 
 def velocity_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="velocity::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="velocity::javascript"
+    )
 
 
 def velocity_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="velocity::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="velocity::css"
+    )
 
 
 def velocity_rule3(colorer, s, i):

--- a/leo/modes/xml.py
+++ b/leo/modes/xml.py
@@ -109,11 +109,15 @@ def xml_rule0(colorer, s, i):
 
 
 def xml_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="<!ENTITY", end=">", delegate="xml::entity-tags")
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="<!ENTITY", end=">", delegate="xml::entity-tags"
+    )
 
 
 def xml_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="<![CDATA[", end="]]>", delegate="xml::cdata")
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="<![CDATA[", end="]]>", delegate="xml::cdata"
+    )
 
 
 def xml_rule3(colorer, s, i):

--- a/leo/modes/xsl.py
+++ b/leo/modes/xsl.py
@@ -239,15 +239,21 @@ def xsl_rule0(colorer, s, i):
 
 
 def xsl_rule1(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword2", begin="<(?=xsl:)", end=">", delegate="xsl::xsltags")
+    return colorer.match_span_regexp(
+        s, i, kind="keyword2", begin="<(?=xsl:)", end=">", delegate="xsl::xsltags"
+    )
 
 
 def xsl_rule2(colorer, s, i):
-    return colorer.match_span_regexp(s, i, kind="keyword2", begin="<(?=/xsl:)", end=">", delegate="xsl::xsltags")
+    return colorer.match_span_regexp(
+        s, i, kind="keyword2", begin="<(?=/xsl:)", end=">", delegate="xsl::xsltags"
+    )
 
 
 def xsl_rule3(colorer, s, i):
-    return colorer.match_span(s, i, kind="keyword2", begin="<![CDATA[", end="]]>", delegate="xml::cdata")
+    return colorer.match_span(
+        s, i, kind="keyword2", begin="<![CDATA[", end="]]>", delegate="xml::cdata"
+    )
 
 
 def xsl_rule4(colorer, s, i):
@@ -577,115 +583,210 @@ def xsl_rule19(colorer, s, i):
 
 def xsl_rule20(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="count[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="count[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule21(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="count[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="count[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule22(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="from[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="from[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule23(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="from[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="from[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule24(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-adjacent[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-adjacent[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule25(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-adjacent[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-adjacent[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule26(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-by[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-by[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule27(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-by[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-by[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule28(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-ending-with[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-ending-with[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule29(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-ending-with[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-ending-with[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule30(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-starting-with[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-starting-with[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule31(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="group-starting-with[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="group-starting-with[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule32(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="match[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="match[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule33(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="match[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="match[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule34(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="select[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="select[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule35(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="select[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="select[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule36(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="test[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="test[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule37(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="test[[:space:]]*=[[:space:]]*'", end="'", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="test[[:space:]]*=[[:space:]]*'",
+        end="'",
+        delegate="xsl::xpath",
     )
 
 
 def xsl_rule38(colorer, s, i):
     return colorer.match_span_regexp(
-        s, i, kind="keyword2", begin="use[[:space:]]*=[[:space:]]*\"", end="\"", delegate="xsl::xpath"
+        s,
+        i,
+        kind="keyword2",
+        begin="use[[:space:]]*=[[:space:]]*\"",
+        end="\"",
+        delegate="xsl::xpath",
     )
 
 
@@ -954,7 +1055,9 @@ def xsl_rule45(colorer, s, i):
 
 
 def xsl_rule46(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="(:", end=":)", delegate="xsl::xpathcomment2")
+    return colorer.match_span(
+        s, i, kind="comment2", begin="(:", end=":)", delegate="xsl::xpathcomment2"
+    )
 
 
 def xsl_rule47(colorer, s, i):
@@ -1288,7 +1391,9 @@ rulesDict6 = {
 
 
 def xsl_rule66(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment3", begin="(:", end=":)", delegate="xsl::xpathcomment3")
+    return colorer.match_span(
+        s, i, kind="comment3", begin="(:", end=":)", delegate="xsl::xpathcomment3"
+    )
 
 
 # Rules dict for xsl_xpathcomment2 ruleset.
@@ -1302,7 +1407,9 @@ rulesDict7 = {
 
 
 def xsl_rule67(colorer, s, i):
-    return colorer.match_span(s, i, kind="comment2", begin="(:", end=":)", delegate="xsl::xpathcomment2")
+    return colorer.match_span(
+        s, i, kind="comment2", begin="(:", end=":)", delegate="xsl::xpathcomment2"
+    )
 
 
 # Rules dict for xsl_xpathcomment3 ruleset.

--- a/leo/modes/zpt.py
+++ b/leo/modes/zpt.py
@@ -159,11 +159,15 @@ def zpt_rule0(colorer, s, i):
 
 
 def zpt_rule1(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="zpt::javascript")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<SCRIPT", end="</SCRIPT>", delegate="zpt::javascript"
+    )
 
 
 def zpt_rule2(colorer, s, i):
-    return colorer.match_span(s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="zpt::css")
+    return colorer.match_span(
+        s, i, kind="markup", begin="<STYLE", end="</STYLE>", delegate="zpt::css"
+    )
 
 
 def zpt_rule3(colorer, s, i):
@@ -196,7 +200,9 @@ rulesDict1 = {
 
 
 def zpt_rule6(colorer, s, i):
-    return colorer.match_span(s, i, kind="literal1", begin="\"", end="\"", delegate="zpt::attribute")
+    return colorer.match_span(
+        s, i, kind="literal1", begin="\"", end="\"", delegate="zpt::attribute"
+    )
 
 
 def zpt_rule7(colorer, s, i):

--- a/leo/plugins/FileActions.py
+++ b/leo/plugins/FileActions.py
@@ -144,7 +144,12 @@ def applyFileAction(p, filename, c):
             g.redirectStdout()
             g.redirectStderr()
         try:
-            namespace = {'c': c, 'g': g, 'filename': filename, 'shellScriptInWindow': shellScriptInWindow}
+            namespace = {
+                'c': c,
+                'g': g,
+                'filename': filename,
+                'shellScriptInWindow': shellScriptInWindow,
+            }
             # exec script in namespace
             exec(script, namespace)
         except Exception:

--- a/leo/plugins/active_path.py
+++ b/leo/plugins/active_path.py
@@ -142,10 +142,14 @@ def attachToCommander(t, k):
     }
 
     if c.config.getData('active_path_ignore'):
-        c.__active_path['ignore'] = [re.compile(i, re.IGNORECASE) for i in c.config.getData('active_path_ignore')]
+        c.__active_path['ignore'] = [
+            re.compile(i, re.IGNORECASE) for i in c.config.getData('active_path_ignore')
+        ]
 
     if c.config.getData('active_path_autoload'):
-        c.__active_path['autoload'] = [re.compile(i, re.IGNORECASE) for i in c.config.getData('active_path_autoload')]
+        c.__active_path['autoload'] = [
+            re.compile(i, re.IGNORECASE) for i in c.config.getData('active_path_autoload')
+        ]
 
     if c.config.getBool('active-path-load-docstring'):
         c.__active_path['load_docstring'] = True
@@ -373,7 +377,9 @@ def createFile(c, parent, d):
 
     d = os.path.basename(d)
     atType = c.config.getString('active-path-attype') or 'auto'
-    ok = g.app.gui.runAskYesNoDialog(c, 'Create / load file?', 'Create file @' + atType + ' ' + d + '?')
+    ok = g.app.gui.runAskYesNoDialog(
+        c, 'Create / load file?', 'Create file @' + atType + ' ' + d + '?'
+    )
     if ok == 'no':
         return False
     parent.h = '@' + atType + ' ' + d
@@ -414,7 +420,9 @@ def openFile(c, parent, d, autoload=False):
             return
 
         if oversize:
-            if not query(c, "File size greater than %d bytes, continue?" % c.__active_path['max_size']):
+            if not query(
+                c, "File size greater than %d bytes, continue?" % c.__active_path['max_size']
+            ):
                 return
 
     if autoload and oversize:
@@ -484,7 +492,11 @@ def openDir(c, parent, d):
                 entry = entry[len(directive[0]) :].strip()
         # find existing inc/exc nodes to remove
         # using p.h allows for example exc=/ to remove all directories
-        if not checkIncExc(p.h, inc, exc, regEx) or (excdirs and entry in dirs) or (excfiles and entry in files):
+        if (
+            not checkIncExc(p.h, inc, exc, regEx)
+            or (excdirs and entry in dirs)
+            or (excfiles and entry in files)
+        ):
             toRemove.add(p.h)  # must not strip '/', so nodes can be removed
         else:
             oldlist.add(entry)
@@ -500,7 +512,10 @@ def openDir(c, parent, d):
         if d2 in oldlist:
             oldlist.discard(d2)
         else:
-            if checkIncExc(d2, [i.strip('/') for i in inc], [e.strip('/') for e in exc], regEx) and not excdirs:
+            if (
+                checkIncExc(d2, [i.strip('/') for i in inc], [e.strip('/') for e in exc], regEx)
+                and not excdirs
+            ):
                 newlist.append('/' + d2 + '/')
 
     # files trimmed by toRemove, retains original functionality of plugin
@@ -528,7 +543,11 @@ def openDir(c, parent, d):
             p.b = '@path ' + name.strip('/')
         elif c.__active_path['do_autoload'] and inReList(name, c.__active_path['autoload']):
             openFile(c, p, os.path.join(d, p.h), autoload=True)
-        elif c.__active_path['do_autoload'] and c.__active_path['load_docstring'] and name.lower().endswith(".py"):
+        elif (
+            c.__active_path['do_autoload']
+            and c.__active_path['load_docstring']
+            and name.lower().endswith(".py")
+        ):
             # do_autoload suppresses doc string loading because turning
             # autoload off is supposed to address situations where autoloading
             # causes problems, so don't still do some form of autoloading

--- a/leo/plugins/anki.py
+++ b/leo/plugins/anki.py
@@ -60,7 +60,9 @@ def _request(action, **params):
 
 def _invoke(action, **params):
     requestJson = json.dumps(_request(action, **params)).encode('utf-8')
-    response = json.load(urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson)))
+    response = json.load(
+        urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson))
+    )
     if len(response) != 2:
         raise TypeError('response has an unexpected number of fields')
     if 'error' not in response:
@@ -74,9 +76,7 @@ def _invoke(action, **params):
 
 def anki_warn(deck, front, back):
     # AnkiConnect will anyway throw an error, warn user now?
-    useful_msg = (
-        'No %s specified for this card. Please create a child node to @anki called @anki %s and populate with a %s name'
-    )
+    useful_msg = 'No %s specified for this card. Please create a child node to @anki called @anki %s and populate with a %s name'
     if deck is None:
         g.es(useful_msg % ("deck", "deck", "deck"))
         return
@@ -91,7 +91,10 @@ def anki_warn(deck, front, back):
 def anki_deck_check(deck):
     result = _invoke('deckNames')
     if deck not in result:
-        g.es('Specified deck is %s. But it is present in your list of desks. Creating now...' % (deck))
+        g.es(
+            'Specified deck is %s. But it is present in your list of desks. Creating now...'
+            % (deck)
+        )
         result = _invoke('createDeck', deck=deck)
         g.es('Created %s with id %s' % (deck, str(result)))
 

--- a/leo/plugins/anki.py
+++ b/leo/plugins/anki.py
@@ -60,9 +60,7 @@ def _request(action, **params):
 
 def _invoke(action, **params):
     requestJson = json.dumps(_request(action, **params)).encode('utf-8')
-    response = json.load(
-        urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson))
-    )
+    response = json.load(urllib.request.urlopen(urllib.request.Request('http://localhost:8765', requestJson)))
     if len(response) != 2:
         raise TypeError('response has an unexpected number of fields')
     if 'error' not in response:
@@ -76,7 +74,10 @@ def _invoke(action, **params):
 
 def anki_warn(deck, front, back):
     # AnkiConnect will anyway throw an error, warn user now?
-    useful_msg = 'No %s specified for this card. Please create a child node to @anki called @anki %s and populate with a %s name'
+    useful_msg = (
+        'No %s specified for this card. '
+        'Please create a child node to @anki called @anki %s and populate with a %s name'
+    )  # fmt: skip
     if deck is None:
         g.es(useful_msg % ("deck", "deck", "deck"))
         return
@@ -91,10 +92,7 @@ def anki_warn(deck, front, back):
 def anki_deck_check(deck):
     result = _invoke('deckNames')
     if deck not in result:
-        g.es(
-            'Specified deck is %s. But it is present in your list of desks. Creating now...'
-            % (deck)
-        )
+        g.es('Specified deck is %s. But it is present in your list of desks. Creating now...' % (deck))
         result = _invoke('createDeck', deck=deck)
         g.es('Created %s with id %s' % (deck, str(result)))
 

--- a/leo/plugins/attrib_edit.py
+++ b/leo/plugins/attrib_edit.py
@@ -200,10 +200,19 @@ class AttributeGetterUA(AttributeGetter):
                             type_ = self.typeMap[ek]
                             for ekt in d[k][ek]:
                                 ans.append(
-                                    (self, ekt, d[k][ek][ekt], tuple(path + ['_edit', ek, ekt]), type_, k != '_edit')
+                                    (
+                                        self,
+                                        ekt,
+                                        d[k][ek][ekt],
+                                        tuple(path + ['_edit', ek, ekt]),
+                                        type_,
+                                        k != '_edit',
+                                    )
                                 )
                         else:
-                            ans.append((self, ek, d[k][ek], tuple(path + ['_edit', ek]), str, k != '_edit'))
+                            ans.append(
+                                (self, ek, d[k][ek], tuple(path + ['_edit', ek]), str, k != '_edit')
+                            )
 
     # @+node:tbrown.20091103080354.1410: *3* getAttribs
     def getAttribs(self, v):
@@ -709,7 +718,10 @@ class attrib_edit_Controller:
                 g.es("For '%s' attributes:\n  %s" % (getter.name(), getter.helpCreate()))
 
         if len(ans) > 1:
-            g.error('Eror: more than one attribute type (%s) active' % ', '.join([i.name() for i in ans]))
+            g.error(
+                'Eror: more than one attribute type (%s) active'
+                % ', '.join([i.name() for i in ans])
+            )
         elif ans:
             ans[0].createAttrib(self.c.currentPosition().v, gui_parent=self.parent)
             self.updateEditorInt()
@@ -730,7 +742,12 @@ class attrib_edit_Controller:
         dat.sort(key=lambda x: x[0])
 
         res: QWidget
-        res = ListDialog(self.parent, "Enter attribute path", "Enter path to attribute (space separated words)", dat)
+        res = ListDialog(
+            self.parent,
+            "Enter attribute path",
+            "Enter path to attribute (space separated words)",
+            dat,
+        )
         res.exec()
         if res.result() == DialogCode.Rejected:
             return
@@ -763,7 +780,12 @@ class attrib_edit_Controller:
     def manageModes(self):
         modes = [[i[0].name(), i[1]] for i in self.getsetters]
 
-        res = ListDialog(self.parent, "Enter attribute path", "Enter path to attribute (space separated words)", modes)
+        res = ListDialog(
+            self.parent,
+            "Enter attribute path",
+            "Enter path to attribute (space separated words)",
+            modes,
+        )
 
         res.exec()
         if res.result() == DialogCode.Rejected:

--- a/leo/plugins/backlink.py
+++ b/leo/plugins/backlink.py
@@ -152,7 +152,9 @@ class backlinkController:
                     del v.u['_bklnk']['id']
 
                 if 'links' in v.u['_bklnk']:
-                    v.u['_bklnk']['links'] = [i for i in v.u['_bklnk']['links'] if i[1] not in update]
+                    v.u['_bklnk']['links'] = [
+                        i for i in v.u['_bklnk']['links'] if i[1] not in update
+                    ]
                     v.u['_bklnk']['links'].extend(
                         [(i[0], update[i[1]]) for i in v.u['_bklnk']['links'] if i[1] in update]
                     )
@@ -415,7 +417,10 @@ class backlinkController:
 
         c = self.c
         url = g.app.gui.runAskOkCancelStringDialog(
-            c, "Link to URL/UNL", "Enter URL / UNL to link to from this node", default=g.app.gui.getTextFromClipboard()
+            c,
+            "Link to URL/UNL",
+            "Enter URL / UNL to link to from this node",
+            default=g.app.gui.getTextFromClipboard(),
         )
         if url is None or not url.strip():
             return
@@ -469,7 +474,9 @@ class backlinkController:
                     if link[0] == 'S':
                         lt = ('from', 'to')
                     # use g.es rather than showMessage here
-                    g.error('backlink: link %s %s %s ??? lost' % (lt[0], self.vnode[vnode].h, lt[1]))
+                    g.error(
+                        'backlink: link %s %s %s ??? lost' % (lt[0], self.vnode[vnode].h, lt[1])
+                    )
                     continue
 
                 # check other end has link

--- a/leo/plugins/bibtex.py
+++ b/leo/plugins/bibtex.py
@@ -222,7 +222,9 @@ def writeTreeAsBibTex(c, fn, root):
     for p in root.subtree():
         h = p.h
         if h.lower() == '@string':
-            strings.extend([('@string{%s}\n\n' % z.rstrip()) for z in g.splitLines(p.b) if z.strip()])
+            strings.extend(
+                [('@string{%s}\n\n' % z.rstrip()) for z in g.splitLines(p.b) if z.strip()]
+            )
         else:
             i = h.find(' ')
             kind, rest = h[:i].lower(), h[i + 1 :].rstrip()

--- a/leo/plugins/bigdash.py
+++ b/leo/plugins/bigdash.py
@@ -368,7 +368,11 @@ class GlobalSearch:
         if qs == "stats":
             s = self.fts.statistics()
             docs = s['documents']
-            tgt.web.setHtml("<p>Indexed documents:</p><ul>" + "".join("<li>%s</li>" % doc for doc in docs) + "</ul>")
+            tgt.web.setHtml(
+                "<p>Indexed documents:</p><ul>"
+                + "".join("<li>%s</li>" % doc for doc in docs)
+                + "</ul>"
+            )
 
     # @+node:ekr.20140919160020.17921: *3* matchlines
     def matchlines(self, b, miter):

--- a/leo/plugins/bookmarks.py
+++ b/leo/plugins/bookmarks.py
@@ -383,7 +383,11 @@ def cmd_bookmark(event, child=False, organizer=False, container=None):
     bp = bc.vnode2position(container)
     nd = bp.insertAsNthChild(0)
     # pylint: disable=consider-using-ternary
-    nd.h = c.frame.body.wrapper.hasSelection() and c.frame.body.wrapper.getSelectedText() or bm.fix_text(c.p.h)
+    nd.h = (
+        c.frame.body.wrapper.hasSelection()
+        and c.frame.body.wrapper.getSelectedText()
+        or bm.fix_text(c.p.h)
+    )
     if not organizer:
         nd.b = new_url
     else:
@@ -470,7 +474,9 @@ def cmd_mark_as_target(event):
     c = event.get('c')
     g._bookmarks_target = c.p.get_UNL()
     g._bookmarks_target_v = c.p.v
-    g.es("Node noted - now use\nbookmarks-use-other-outline\nin the outline you want to\nstore bookmarks in this node")
+    g.es(
+        "Node noted - now use\nbookmarks-use-other-outline\nin the outline you want to\nstore bookmarks in this node"
+    )
 
 
 # @+node:ekr.20190619132530.1: ** bookmarks-use-other-outline
@@ -638,7 +644,9 @@ class BookMarkDisplay:
         KeyboardModifier.AltModifier: 'Alt',
         KeyboardModifier.AltModifier | KeyboardModifier.ControlModifier: 'AltControl',
         (
-            KeyboardModifier.AltModifier | KeyboardModifier.ControlModifier | KeyboardModifier.ShiftModifier
+            KeyboardModifier.AltModifier
+            | KeyboardModifier.ControlModifier
+            | KeyboardModifier.ShiftModifier
         ): 'AltControlShift',
         KeyboardModifier.AltModifier | KeyboardModifier.ShiftModifier: 'AltShift',
         KeyboardModifier.ControlModifier: 'Control',
@@ -794,7 +802,10 @@ class BookMarkDisplay:
             ("Re-name", self.rename_bookmark),
             ("Edit in tree", self.edit_bookmark),
             ("Delete", self.delete_bookmark),
-            ("Add this node as child bookmark", lambda e: cmd_bookmark_child(event={'c': bm.v.context})),
+            (
+                "Add this node as child bookmark",
+                lambda e: cmd_bookmark_child(event={'c': bm.v.context}),
+            ),
             ("Add bookmark folder", lambda e: cmd_bookmark_organizer(event={'c': bm.v.context})),
         ]
         for action in actions:
@@ -1043,7 +1054,14 @@ class BookMarkDisplay:
 
         if self.levels:  # drop excess levels
             if (
-                (not self.second and current_url and current_url.strip() and self.levels == 1 or up or self.upwards)
+                (
+                    not self.second
+                    and current_url
+                    and current_url.strip()
+                    and self.levels == 1
+                    or up
+                    or self.upwards
+                )
                 and current_level < self.w.layout().count()
                 and self.levels < self.w.layout().count()
             ):
@@ -1202,7 +1220,10 @@ class BookMarkDisplayProvider:
                             if factory and hasattr(factory, 'setTabForCommander'):
                                 factory.setTabForCommander(c)
 
-                        g.es("NOTE: bookmarks for this outline\nare in a different outline:\n  '%s'" % file_)
+                        g.es(
+                            "NOTE: bookmarks for this outline\nare in a different outline:\n  '%s'"
+                            % file_
+                        )
                     other_p = g.findAnyUnl(UNL, other_c)
                     if other_p:
                         v = other_p.v

--- a/leo/plugins/bzr_qcommands.py
+++ b/leo/plugins/bzr_qcommands.py
@@ -34,7 +34,10 @@ def bzr_qcommands(c, p, menu):
     def bzr_stat(c=c, p=p):
         path = c.getPath(p)
         cmd = subprocess.Popen(
-            ['bzr', 'stat', path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ['bzr', 'stat', path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         stdout_bytes, stderr_bytes = cmd.communicate()
         stdout = g.toUnicode(stdout_bytes)

--- a/leo/plugins/chapter_hoist.py
+++ b/leo/plugins/chapter_hoist.py
@@ -55,7 +55,10 @@ class chapterHoist:
             c.hoist()
 
         b = sc.createIconButton(
-            args=None, text='save-hoist', command=saveHoistCallback, statusLine='Create hoist button current node'
+            args=None,
+            text='save-hoist',
+            command=saveHoistCallback,
+            statusLine='Create hoist button current node',
         )
 
         return b
@@ -69,7 +72,9 @@ class chapterHoist:
         # Fix #426 with a kludge that satisfies k.registerCommand.
         dehoistCallback.__name__ = 'wrapper: dehoist'
 
-        b = sc.createIconButton(args=None, text='dehoist', command=dehoistCallback, statusLine='Dehoist')
+        b = sc.createIconButton(
+            args=None, text='dehoist', command=dehoistCallback, statusLine='Dehoist'
+        )
 
         return b
 
@@ -87,7 +92,9 @@ class chapterHoist:
             c.hoist()
             return 'break'
 
-        sc.createIconButton(args=None, text=buttonText, command=hoistButtonCallback, statusLine=statusLine)
+        sc.createIconButton(
+            args=None, text=buttonText, command=hoistButtonCallback, statusLine=statusLine
+        )
 
     # @-others
 

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -585,7 +585,9 @@ class LeoTreeLine(npyscreen.TreeLine):
         # pylint: disable=no-member
 
         def put(char: str) -> None:
-            self.parent.curses_pad.addch(self.rely, self.relx + self.left_margin, ord(char), curses.A_NORMAL)
+            self.parent.curses_pad.addch(
+                self.rely, self.relx + self.left_margin, ord(char), curses.A_NORMAL
+            )
             self.left_margin += 1
 
         self.left_margin = left_margin

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -127,7 +127,10 @@ class LeoBodyTextfield(npyscreen.Textfield):
         c = parent_w.leo_c
         p = c.p
         if trace:
-            g.trace('LeoBodyTextfield. row: %s len(p.b): %4s ch_i: %s' % (parent_w.cursor_line, len(p.b), ch_i))
+            g.trace(
+                'LeoBodyTextfield. row: %s len(p.b): %4s ch_i: %s'
+                % (parent_w.cursor_line, len(p.b), ch_i)
+            )
         try:
             # Careful: chr can fail.
             ch = g.toUnicode(chr(ch_i))
@@ -1041,7 +1044,9 @@ class StringFindTabManager:
             if val:
                 w.toggle()
 
-            def check_box_callback(n: int, setting_name: str = setting_name, w: Wrapper = w) -> None:
+            def check_box_callback(
+                n: int, setting_name: str = setting_name, w: Wrapper = w
+            ) -> None:
                 val = w.isChecked()
                 assert hasattr(find, setting_name), setting_name
                 setattr(find, setting_name, val)
@@ -1163,7 +1168,11 @@ class KeyEvent:
 
     # @+node:edward.20170428174322.3: *4* KeyEvent.__repr__
     def __repr__(self) -> str:
-        return 'KeyEvent: stroke: %s, char: %s, w: %s' % (repr(self.stroke), repr(self.char), repr(self.w))
+        return 'KeyEvent: stroke: %s, char: %s, w: %s' % (
+            repr(self.stroke),
+            repr(self.char),
+            repr(self.w),
+        )
 
     # @+node:edward.20170428174322.4: *4* KeyEvent.get & __getitem__
     def get(self, attr: str) -> Value:
@@ -1268,7 +1277,14 @@ class KeyHandler:
         # Switch the Shift modifier to handle the cap-lock key.
         if isinstance(ch, int):
             g.trace('can not happen: ch: %r binding: %r' % (ch, binding))
-        elif ch and len(ch) == 1 and binding and len(binding) == 1 and ch.isalpha() and binding.isalpha():
+        elif (
+            ch
+            and len(ch) == 1
+            and binding
+            and len(binding) == 1
+            and ch.isalpha()
+            and binding.isalpha()
+        ):
             if ch != binding:
                 if trace:
                     g.trace('caps-lock')
@@ -1725,7 +1741,9 @@ class LeoCursesGui(leoGui.LeoGui):
                 g.pr(s.rstrip())
 
     # @+node:ekr.20171126182120.2: *5* CGui.runAboutLeoDialog
-    def runAboutLeoDialog(self, c: Cmdr, version: str, theCopyright: str, url: str, email: str) -> None:
+    def runAboutLeoDialog(
+        self, c: Cmdr, version: str, theCopyright: str, url: str, email: str
+    ) -> None:
         """Create and run Leo's About Leo dialog."""
         if not g.unitTesting:
             message = '%s\n%s\n%s\n%s' % (version, theCopyright, url, email)
@@ -1904,7 +1922,11 @@ class LeoCursesGui(leoGui.LeoGui):
     def dump_keys(self) -> None:
         """Show all defined curses.KEY_ constants."""
         if 0:
-            aList = ['%3s %s' % (getattr(curses, z), z) for z in dir(curses) if isinstance(getattr(curses, z), int)]
+            aList = [
+                '%3s %s' % (getattr(curses, z), z)
+                for z in dir(curses)
+                if isinstance(getattr(curses, z), int)
+            ]
             g.trace()
             g.printList(sorted(aList))
 
@@ -1940,7 +1962,9 @@ class LeoCursesGui(leoGui.LeoGui):
         self.set_focus(c, c.frame.miniBufferWidget)
 
     # @+node:ekr.20170502101347.1: *5* CGui.get_focus
-    def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> Optional[Wrapper]:
+    def get_focus(
+        self, c: Cmdr = None, raw: bool = False, at_idle: bool = False
+    ) -> Optional[Wrapper]:
         """
         Return the Leo wrapper for the npyscreen widget that is being edited.
         """
@@ -2535,6 +2559,9 @@ class CoreLog(leoFrame.LeoLog):
 
     # @+node:ekr.20170419143731.15: *4* CLog.put
     # Signature is different.
+
+    # fmt: off
+
     def put(self, s: str, color: str = None, tabName: str = 'Log', from_redirect: bool = False) -> None:  # type:ignore
         """All output to the log stream eventually comes here."""
         c, w = self.c, self.widget
@@ -2550,6 +2577,8 @@ class CoreLog(leoFrame.LeoLog):
         w.cursor_line += len(lines)
         w.start_display_at += len(lines)
         w.update()
+
+    # fmt: on
 
     # @+node:ekr.20170419143731.16: *4* CLog.putnl
     def putnl(self, tabName: str = 'Log') -> None:
@@ -2751,7 +2780,9 @@ class CoreTree(leoFrame.LeoTree):
         return HeadWrapper(c=self.c, name='head', p=p)
 
     # @+node:ekr.20170511095353.1: *5* CTree.editLabel (cursesGui2) (not used)
-    def editLabel(self, p: Position, selectAll: bool = False, selection: tuple = None) -> tuple[None, None]:
+    def editLabel(
+        self, p: Position, selectAll: bool = False, selection: tuple = None
+    ) -> tuple[None, None]:
         """Start editing p's headline."""
         return None, None
 
@@ -3229,7 +3260,10 @@ class LeoForm(npyscreen.Form):
     def display(self, *args: Args, **kwargs: KWargs) -> None:
         changed = any(z.c.isChanged() for z in g.app.windowList)
         c = g.app.log.c
-        self.name = 'Welcome to Leo: %s%s' % ('(changed) ' if changed else '', c.fileName() if c else '')
+        self.name = 'Welcome to Leo: %s%s' % (
+            '(changed) ' if changed else '',
+            c.fileName() if c else '',
+        )
         super().display(*args, **kwargs)
 
 
@@ -3512,7 +3546,9 @@ class LeoMLTree(npyscreen.MLTree):
         trace = False and not g.unitTesting
         assert self.values, g.callers()
         try:
-            active_line: "LeoTreeLine" = self._my_widgets[(self.cursor_line - self.start_display_at)]
+            active_line: "LeoTreeLine" = self._my_widgets[
+                (self.cursor_line - self.start_display_at)
+            ]
             assert isinstance(active_line, LeoTreeLine)
             if trace:
                 g.trace('LeoMLTree.active_line: %r' % active_line)
@@ -3941,7 +3977,10 @@ class LeoMLTree(npyscreen.MLTree):
         )  # fmt: skip
         reasons = (reason for (reason, cond) in table if cond)
         if trace:
-            g.trace('line: %2s %-20s %s' % (self.cursor_line, ','.join(reasons), self.values[self.cursor_line].content))
+            g.trace(
+                'line: %2s %-20s %s'
+                % (self.cursor_line, ','.join(reasons), self.values[self.cursor_line].content)
+            )
         return reasons
 
     # @+node:ekr.20170513122427.1: *5* LeoMLTree._redraw & helpers
@@ -4100,7 +4139,9 @@ class LeoValues(npyscreen.TreeData):
         """Ctor for LeoValues class."""
         super().__init__()  # Init the base class.
         self.c: Cmdr = c  # The commander of this outline.
-        self.data_cache: dict[int, LeoTreeData] = {}  # Keys are ints, values are LeoTreeData objects.
+        self.data_cache: dict[
+            int, LeoTreeData
+        ] = {}  # Keys are ints, values are LeoTreeData objects.
         self.last_generation = -1  # The last value of c.frame.tree.generation.
         self.last_len = 0  # The last computed value of the number of visible nodes.
         self.n_refreshes = 0  # Number of calls to refresh_cache.

--- a/leo/plugins/datenodes.py
+++ b/leo/plugins/datenodes.py
@@ -186,7 +186,9 @@ class DateNodes:
         month_fmt = self.settings["month_node_month_headline"]
         omit_saturdays = self.settings["month_node_omit_saturdays"]
         omit_sundays = self.settings["month_node_omit_sundays"]
-        month_node = self._insert_month_node(c.p, today, day_fmt, month_fmt, omit_saturdays, omit_sundays)
+        month_node = self._insert_month_node(
+            c.p, today, day_fmt, month_fmt, omit_saturdays, omit_sundays
+        )
         c.selectPosition(month_node)
         c.redraw()
 
@@ -199,7 +201,9 @@ class DateNodes:
         year_fmt = self.settings["year_node_year_headline"]
         omit_saturdays = self.settings["year_node_omit_saturdays"]
         omit_sundays = self.settings["year_node_omit_sundays"]
-        year_node = self._insert_year_node(c.p, today, day_fmt, month_fmt, year_fmt, omit_saturdays, omit_sundays)
+        year_node = self._insert_year_node(
+            c.p, today, day_fmt, month_fmt, year_fmt, omit_saturdays, omit_sundays
+        )
         c.selectPosition(year_node)
         c.redraw()
 

--- a/leo/plugins/dragdropgoodies.py
+++ b/leo/plugins/dragdropgoodies.py
@@ -20,7 +20,9 @@ g.assertUi('qt')  # May raise g.UiTypeException, caught by the plugins manager.
 def init():
     ok = g.app.gui.guiName() == "qt"
     if ok:
-        if 0:  # Use this if you want to create the commander class before the frame is fully created.
+        if (
+            0
+        ):  # Use this if you want to create the commander class before the frame is fully created.
             g.registerHandler('before-create-leo-frame', onCreate)
         else:  # Use this if you want to create the commander class after the frame is fully created.
             g.registerHandler('after-create-leo-frame', onCreate)

--- a/leo/plugins/editpane/csvedit.py
+++ b/leo/plugins/editpane/csvedit.py
@@ -437,7 +437,11 @@ class LEP_CSVEdit(QtWidgets.QWidget):
             buttons.addWidget(QtWidgets.QLabel(what + ": "))
             for name, tip, fallback in list_:
                 button = QtWidgets.QPushButton()
-                button.setIcon(QtGui.QIcon.fromTheme(name, QtWidgets.QApplication.style().standardIcon(fallback)))
+                button.setIcon(
+                    QtGui.QIcon.fromTheme(
+                        name, QtWidgets.QApplication.style().standardIcon(fallback)
+                    )
+                )
                 button.setToolTip(tip % what)
                 button.clicked.connect(lambda checked, name=name: function(name))
                 buttons.addWidget(button)

--- a/leo/plugins/editpane/editpane.py
+++ b/leo/plugins/editpane/editpane.py
@@ -110,7 +110,9 @@ class LeoEditPane(QtWidgets.QWidget):
         self._register_handlers()
 
     # @+node:tbrown.20171028115438.6: *3* _add_checkbox
-    def _add_checkbox(self, text, state_changed, tooltip, checked=True, enabled=True, button_label=True):
+    def _add_checkbox(
+        self, text, state_changed, tooltip, checked=True, enabled=True, button_label=True
+    ):
         """
         _add_checkbox - helper to add a checkbox
 
@@ -246,10 +248,18 @@ class LeoEditPane(QtWidgets.QWidget):
         self.control = self._add_frame()
         # checkboxes
         txt = ",\ncheck to do this always"
-        self.cb_track = self._add_checkbox("Track", self.change_track, "Track the node selected in the tree" + txt)
-        self.cb_goto = self._add_checkbox("Goto", self.change_goto, "Make the tree go to this node" + txt)
-        self.cb_update = self._add_checkbox("Update", self.change_update, "Update view to match changed node" + txt)
-        self.cb_recurse = self._add_checkbox("Recurse", self.change_recurse, "Recursive view" + txt, checked=recurse)
+        self.cb_track = self._add_checkbox(
+            "Track", self.change_track, "Track the node selected in the tree" + txt
+        )
+        self.cb_goto = self._add_checkbox(
+            "Goto", self.change_goto, "Make the tree go to this node" + txt
+        )
+        self.cb_update = self._add_checkbox(
+            "Update", self.change_update, "Update view to match changed node" + txt
+        )
+        self.cb_recurse = self._add_checkbox(
+            "Recurse", self.change_recurse, "Recursive view" + txt, checked=recurse
+        )
         # mode menu
         btn = self.btn_mode = QtWidgets.QPushButton("Mode", self)
         self.control.layout().addWidget(btn)
@@ -292,7 +302,9 @@ class LeoEditPane(QtWidgets.QWidget):
         self.line_edit.setText("test")
 
         # toggle control visibility
-        self.toggle_ctrl.clicked.connect(lambda checked: self.control.setVisible(not self.control.isVisible()))
+        self.toggle_ctrl.clicked.connect(
+            lambda checked: self.control.setVisible(not self.control.isVisible())
+        )
 
     # @+node:tbrown.20171028115438.14: *3* header_visible
     @property
@@ -376,7 +388,11 @@ class LeoEditPane(QtWidgets.QWidget):
     def load_modules(self):
         """load_modules - load modules to find widgets"""
         module_dir = os.path.dirname(__file__)
-        names = [os.path.splitext(i) for i in os.listdir(module_dir) if os.path.isfile(os.path.join(module_dir, i))]
+        names = [
+            os.path.splitext(i)
+            for i in os.listdir(module_dir)
+            if os.path.isfile(os.path.join(module_dir, i))
+        ]
         # FIXME: sort 'plain' to start of list for devel.
         names.sort(key=lambda x: (not x[0].startswith('plain'), x[0]))
         modules = []

--- a/leo/plugins/expfolder.py
+++ b/leo/plugins/expfolder.py
@@ -57,7 +57,9 @@ def on_icondclick(tag, keywords):
     h = p.h
     if g.match_word(h, 0, "@expfolder"):
         if p.hasChildren():
-            result = g.app.gui.runAskYesNoDialog(c, "Reread?", "Reread contents of folder " + h[11:] + "?")
+            result = g.app.gui.runAskYesNoDialog(
+                c, "Reread?", "Reread contents of folder " + h[11:] + "?"
+            )
             if result == "no":
                 return
             kids = []

--- a/leo/plugins/free_layout.py
+++ b/leo/plugins/free_layout.py
@@ -266,7 +266,10 @@ class FreeLayoutController:
             else:
                 c.free_layout.original_layout = name
             if layout:
-                g.es("NOTE: embedded layout in @settings/@data free-layout-layout overrides saved layout " + name)
+                g.es(
+                    "NOTE: embedded layout in @settings/@data free-layout-layout overrides saved layout "
+                    + name
+                )
             else:
                 layout = d.get(name)
         # EKR: Create commands that will load each layout.

--- a/leo/plugins/freewin.py
+++ b/leo/plugins/freewin.py
@@ -1106,7 +1106,9 @@ class ZEditorWin(QtWidgets.QMainWindow):
         # Insert stylesheet if our rendering view is a web browser widget
         if self.render_pane_type == BROWSER_VIEW:
             if self.rst_stylesheet:
-                style_insert = f"<style type='text/css'>\n{self.rst_stylesheet}\n</style>\n</head>\n"
+                style_insert = (
+                    f"<style type='text/css'>\n{self.rst_stylesheet}\n</style>\n</head>\n"
+                )
                 _html = _html.replace('</head>', style_insert, 1)
         return _html
 

--- a/leo/plugins/graphcanvas.py
+++ b/leo/plugins/graphcanvas.py
@@ -298,7 +298,9 @@ class GetImage:
     @staticmethod
     def _no_image():
         """return QGraphicsPixmapItem with "No Image" image loaded"""
-        testpath = g.os_path_abspath(g.os_path_join(g.app.loadDir, '../plugins/GraphCanvas/no_image.png'))
+        testpath = g.os_path_abspath(
+            g.os_path_join(g.app.loadDir, '../plugins/GraphCanvas/no_image.png')
+        )
         return QtWidgets.QGraphicsPixmapItem(QtGui.QPixmap(testpath))
 
 
@@ -401,7 +403,12 @@ class nodeRect(nodeBase):
     def do_update(self):
         self.text.setPlainText(self.get_text())
 
-        self.bg.setRect(-2, +2, self.text.document().size().width() + 4, self.text.document().size().height() - 2)
+        self.bg.setRect(
+            -2,
+            +2,
+            self.text.document().size().width() + 4,
+            self.text.document().size().height() - 2,
+        )
 
 
 nodeBase.node_types[nodeRect.__name__] = nodeRect
@@ -454,7 +461,12 @@ class nodeEllipse(nodeRect):
     def do_update(self):
         marginX = self.text.document().size().width() / 2
         # marginY = self.text.document().size().height()/2
-        self.bg.setRect(-marginX, 0, self.text.document().size().width() * 2, self.text.document().size().height())
+        self.bg.setRect(
+            -marginX,
+            0,
+            self.text.document().size().width() * 2,
+            self.text.document().size().height(),
+        )
 
 
 nodeBase.node_types[nodeEllipse.__name__] = nodeEllipse
@@ -516,7 +528,12 @@ class nodeComment(nodeRect):
     def do_update(self):
         self._set_text(self.text)
 
-        self.bg.setRect(-2, +2, self.text.document().size().width() + 4, self.text.document().size().height() - 2)
+        self.bg.setRect(
+            -2,
+            +2,
+            self.text.document().size().width() + 4,
+            self.text.document().size().height() - 2,
+        )
 
         self.setToolTip(self.node.h)
 
@@ -791,7 +808,9 @@ class graphcanvasController:
                     self.nodeItem[i].do_update()
         if pydot:
             x, y, width, height = map(float, G.get_bb().strip('"').split(','))
-            self.ui.canvasView.setSceneRect(self.ui.canvas.sceneRect().adjusted(x, y, width, height))
+            self.ui.canvasView.setSceneRect(
+                self.ui.canvas.sceneRect().adjusted(x, y, width, height)
+            )
         self.do_update(adjust=False)
         self.center_graph()
         # self.ui.canvasView.centerOn(self.ui.canvas.sceneRect().center())
@@ -1211,7 +1230,10 @@ class graphcanvasController:
                 # self.loadLinked('all')
                 self.loadGraph('recur', create=False)
             elif self.lastNodeItem and '_bklnk' in self.lastNodeItem.node.u:
-                x, y = self.lastNodeItem.node.u['_bklnk']['x'], self.lastNodeItem.node.u['_bklnk']['y']
+                x, y = (
+                    self.lastNodeItem.node.u['_bklnk']['x'],
+                    self.lastNodeItem.node.u['_bklnk']['y'],
+                )
                 self.ui.canvasView.centerOn(x, y)
 
         if c.p.v in self.nodeItem and self.ui.UI.chkTrack.isChecked():

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -199,7 +199,9 @@ class Importer:
         return ok
 
     # @+node:ekr.20230529075138.39: *5* 1B: i.regularize_whitespace
-    def regularize_whitespace(self, lines: list[str]) -> list[str]:  # pragma: no cover (missing test)
+    def regularize_whitespace(
+        self, lines: list[str]
+    ) -> list[str]:  # pragma: no cover (missing test)
         """
         Importer.regularize_whitespace.
 
@@ -227,7 +229,9 @@ class Importer:
                     count += 1
                 result.append(s)
         if count and not g.unitTesting:
-            print(f"{self.root.h}:\nchanged leading {kind2} to {kind} in {count} line{g.plural(count)}")
+            print(
+                f"{self.root.h}:\nchanged leading {kind2} to {kind} in {count} line{g.plural(count)}"
+            )
         return result
 
     # @+node:ekr.20230529075138.38: *5* 1C: i.preprocess_lines
@@ -400,7 +404,9 @@ class Importer:
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
                     # Don't generate small blocks.
                     if min_size == 0 or end - prev_i > min_size:
-                        block = Block(kind, name, start=prev_i, start_body=i, end=end, lines=self.lines)
+                        block = Block(
+                            kind, name, start=prev_i, start_body=i, end=end, lines=self.lines
+                        )
                         results.append(block)
                         i = prev_i = end
                     else:
@@ -448,7 +454,9 @@ class Importer:
         return f"{block.kind} {name_s}"
 
     # @+node:ekr.20230920165923.1: *5* 2D: i.generate_all_bodies & helpers
-    def generate_all_bodies(self, parent: Position, outer_block: Block, result_blocks: list[Block]) -> None:
+    def generate_all_bodies(
+        self, parent: Position, outer_block: Block, result_blocks: list[Block]
+    ) -> None:
         """Carefully generate bodies from the given blocks."""
         c = self.c
         at = c.atFileCommands

--- a/leo/plugins/importers/c.py
+++ b/leo/plugins/importers/c.py
@@ -80,7 +80,9 @@ class C_Importer(Importer):
                     ):
                         end = self.find_end_of_block(i, i2)
                         assert i1 + 1 <= end <= i2, (i1, end, i2)
-                        block = Block(kind, name, start=prev_i, start_body=i + 1, end=end, lines=self.lines)
+                        block = Block(
+                            kind, name, start=prev_i, start_body=i + 1, end=end, lines=self.lines
+                        )
                         results.append(block)
                         i = prev_i = end
                         break
@@ -95,7 +97,9 @@ class C_Importer(Importer):
                     ):
                         end = self.find_end_of_block(i + 1, i2)
                         assert i1 + 1 <= end <= i2, (i1, end, i2)
-                        block = Block('func', name, start=prev_i, start_body=i + 1, end=end, lines=self.lines)
+                        block = Block(
+                            'func', name, start=prev_i, start_body=i + 1, end=end, lines=self.lines
+                        )
                         results.append(block)
                         i = prev_i = end
                         break

--- a/leo/plugins/importers/leo_rst.py
+++ b/leo/plugins/importers/leo_rst.py
@@ -111,7 +111,12 @@ class Rst_Importer(Importer):
             return False
         line0 = lines[i]
         line1 = lines[i + 1]
-        return not line0.isspace() and len(line1) >= 4 and self.is_underline(line1) and not self.is_underline(line0)
+        return (
+            not line0.isspace()
+            and len(line1) >= 4
+            and self.is_underline(line1)
+            and not self.is_underline(line0)
+        )
 
     # @+node:ekr.20230529072922.5: *4* rst_i.is_underline
     def is_underline(self, line: str, extra: str = None) -> bool:

--- a/leo/plugins/importers/python.py
+++ b/leo/plugins/importers/python.py
@@ -141,7 +141,9 @@ class Python_Importer(Importer):
                     ):
                         i = end
                     else:
-                        block = Block(kind, name, start=prev_i, start_body=i, end=end, lines=self.lines)
+                        block = Block(
+                            kind, name, start=prev_i, start_body=i, end=end, lines=self.lines
+                        )
                         if trace:
                             g.printObj(block, tag=f"{g.my_name()}")
                         results.append(block)
@@ -339,7 +341,9 @@ class Python_Importer(Importer):
             at_others_indent = 4  # Default
 
         # Add the indentation of the @others statement in class body.
-        docstring_lines = [f"{' ' * at_others_indent}{z}" if z.strip() else '\n' for z in g.splitLines(docstring)]
+        docstring_lines = [
+            f"{' ' * at_others_indent}{z}" if z.strip() else '\n' for z in g.splitLines(docstring)
+        ]
         class_p.b = ''.join(class_lines[:n] + docstring_lines + class_lines[n:])
 
     # @+node:ekr.20230825111112.1: *4* python_i.move_class_docstrings

--- a/leo/plugins/importers/rust.py
+++ b/leo/plugins/importers/rust.py
@@ -370,7 +370,9 @@ class Rust_Importer(Importer):
                     assert i1 + 1 <= end <= i2, (i1, end, i2)
                     # Don't generate small blocks.
                     if min_size == 0 or end - prev_i > min_size:
-                        block = Block(kind, name, start=prev_i, start_body=i, end=end, lines=self.lines)
+                        block = Block(
+                            kind, name, start=prev_i, start_body=i, end=end, lines=self.lines
+                        )
                         results.append(block)
                         i = prev_i = end
                     else:

--- a/leo/plugins/importers/xml.py
+++ b/leo/plugins/importers/xml.py
@@ -124,7 +124,11 @@ class Xml_Importer(Importer):
             m3 = self.tag_name_pat.match(m.group(3))
             tag_name2 = m2 and m2.group(1) or ''
             tag_name3 = m3 and m3.group(1) or ''
-            same_element = tag_name2 == tag_name3 and not m.group(2).startswith('</') and m.group(3).startswith('</')
+            same_element = (
+                tag_name2 == tag_name3
+                and not m.group(2).startswith('</')
+                and m.group(3).startswith('</')
+            )
             lws = g.get_leading_ws(m.group(1))
             sep = '' if same_element else '\n' + lws
             return m.group(1) + m.group(2).rstrip() + sep + m.group(3)

--- a/leo/plugins/indented_languages.py
+++ b/leo/plugins/indented_languages.py
@@ -274,7 +274,9 @@ class Indented_Importer:
                 if 0:
                     print('')
                     print(f"{tag} Remove")
-                    print(f"matching: {{ line: {match_line:3} column: {match_column:2} {guide_lines[match_line]!r}")
+                    print(
+                        f"matching: {{ line: {match_line:3} column: {match_column:2} {guide_lines[match_line]!r}"
+                    )
                     print(f"    this: }} line: {line_number:3} column: {column_number:2} {line!r}")
 
                 # Replace the previous line in result_lines, *not* lines.

--- a/leo/plugins/initinclass.py
+++ b/leo/plugins/initinclass.py
@@ -37,7 +37,9 @@ def InitInClass(tag, keywords):
             if '__init__' in p.headString():
                 cull.append(p.copy())
                 old = parent.bodyString().strip().split('\n')
-                new = '\n'.join(['    ' + i if i.strip() else '' for i in p.bodyString().strip().split('\n')])
+                new = '\n'.join(
+                    ['    ' + i if i.strip() else '' for i in p.bodyString().strip().split('\n')]
+                )
                 new = '\n%s\n' % new
 
                 # insert before @others

--- a/leo/plugins/leoOPML.py
+++ b/leo/plugins/leoOPML.py
@@ -578,7 +578,10 @@ class PutToOPML:
     # @+node:ekr.20141020112451.18339: *3* putXMLLine
     def putXMLLine(self):
         """Put the **properly encoded** <?xml> element."""
-        self.put('%s"%s"%s\n' % (g.app.prolog_prefix_string, self.leo_file_encoding, g.app.prolog_postfix_string))
+        self.put(
+            '%s"%s"%s\n'
+            % (g.app.prolog_prefix_string, self.leo_file_encoding, g.app.prolog_postfix_string)
+        )
 
     # @-others
 
@@ -640,7 +643,9 @@ class SaxContentHandler(xml.sax.saxutils.XMLGenerator):
     def printStartElement(self, name, attrs):
         indent = '\t' * self.level or ''
         if attrs.getLength() > 0:
-            print('%s<%s %s>' % (indent, self.clean(name).strip(), self.attrsToString(attrs, sep=' ')))
+            print(
+                '%s<%s %s>' % (indent, self.clean(name).strip(), self.attrsToString(attrs, sep=' '))
+            )
         else:
             print('%s<%s>' % (indent, self.clean(name).strip()))
         if name.lower() in [

--- a/leo/plugins/leo_babel/babel_api.py
+++ b/leo/plugins/leo_babel/babel_api.py
@@ -74,7 +74,9 @@ class BabelGlobals(object):
 
         if leoG.app.gui.guiName() == "qt":
             self.babelMenu = babel_lib.MenuPopUp(self)
-        self.pathBabelKill = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'babel_kill.py')
+        self.pathBabelKill = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), 'babel_kill.py'
+        )
         self.babel_api = sys.modules[__name__]
 
     # @-others
@@ -135,14 +137,22 @@ class BabelCmdr(object):
         self.babel_color_stderr = _getColor(cmdr, 'Leo-Babel-stderr', default='#ff3300')
         self.babel_color_information = _getColor(cmdr, 'Leo-Babel-completion')
         if self.babel_color_information is None:
-            self.babel_color_information = _getColor(cmdr, 'Leo-Babel-information', default='#3333ff')
-        self.babel_node_creation = cmdr.config.getBool('Leo-Babel-Node-Creation-Default', default=None)
+            self.babel_color_information = _getColor(
+                cmdr, 'Leo-Babel-information', default='#3333ff'
+            )
+        self.babel_node_creation = cmdr.config.getBool(
+            'Leo-Babel-Node-Creation-Default', default=None
+        )
         if self.babel_node_creation is None:
             self.babel_node_creation = cmdr.config.getBool('Leo-Babel-Node-Creation', default=True)
-        self.babel_interpreter_python = _getString(cmdr, 'Leo-Babel-Python', default='/usr/bin/python3')
+        self.babel_interpreter_python = _getString(
+            cmdr, 'Leo-Babel-Python', default='/usr/bin/python3'
+        )
         self.babel_interpreter_shell = _getString(cmdr, 'Leo-Babel-Shell', default='/usr/bin/bash')
         self.babel_sudo = cmdr.config.getBool('Leo-Babel-Sudo', default=False)
-        self.babel_prefix_information = _getString(cmdr, 'Leo-Babel-Prefix-Information', default="- ")
+        self.babel_prefix_information = _getString(
+            cmdr, 'Leo-Babel-Prefix-Information', default="- "
+        )
         self.babel_prefix_stdout = _getString(cmdr, 'Leo-Babel-Prefix-stdout', default="| ")
         self.babel_prefix_stderr = _getString(cmdr, 'Leo-Babel-Prefix-stderr', default="* ")
         self.babel_tab_babel = cmdr.config.getBool('Leo-Babel-Tab-Babel', default=True)

--- a/leo/plugins/leo_babel/babel_kill.py
+++ b/leo/plugins/leo_babel/babel_kill.py
@@ -18,14 +18,18 @@ try:
 except ImportError as err:
     # pylint: disable=no-member
     signal.signal(signal.SIGHUP, signal.SIG_IGN)
-    errMsg = 'Python Package required by Leo-Babel is missing.\nImporting Python module {0} failed.'.format(err.name)
+    errMsg = 'Python Package required by Leo-Babel is missing.\nImporting Python module {0} failed.'.format(
+        err.name
+    )
     QtWidgets.QMessageBox.critical(None, 'Missing Python Package', errMsg)
     exit(1)
 
 
 pidTarg = int(sys.argv[1])
 msg = 'Kill Leo-Babel process {0}?'.format(pidTarg)
-reply = QtWidgets.QMessageBox.question(None, msg, msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No)
+reply = QtWidgets.QMessageBox.question(
+    None, msg, msg, QtWidgets.QMessageBox.Yes, QtWidgets.QMessageBox.No
+)
 if reply == QtWidgets.QMessageBox.Yes:
     # pylint: disable=no-member
     os.kill(pidTarg, signal.SIGHUP)

--- a/leo/plugins/leo_babel/babel_lib.py
+++ b/leo/plugins/leo_babel/babel_lib.py
@@ -229,7 +229,9 @@ def _descendHdl(cmdrUnl, unlList):
 
     if unlList is None:
         return listRoots(cmdrUnl)
-    soFarList = [[(childVnode, idx)] for idx, childVnode in enumerate(cmdrUnl.hiddenRootNode.children)]
+    soFarList = [
+        [(childVnode, idx)] for idx, childVnode in enumerate(cmdrUnl.hiddenRootNode.children)
+    ]
     lastUnlIdx = len(unlList) - 1
     for idx1, hdl in enumerate(unlList):
         if idx1 == lastUnlIdx:
@@ -243,7 +245,9 @@ def _descendHdl(cmdrUnl, unlList):
             ]
         if not soFarList:
             return list()
-    return [leoNodes.position(stk[-1][0], childIndex=stk[-1][1], stack=stk[:-1]) for stk in soFarList]
+    return [
+        leoNodes.position(stk[-1][0], childIndex=stk[-1][1], stack=stk[:-1]) for stk in soFarList
+    ]
 
 
 # @+node:bob.20170726143458.9: ** class MenuPopUp(QtWidgets.QMenu)
@@ -267,7 +271,9 @@ class MenuPopUp(QtWidgets.QMenu):
 
         super(MenuPopUp, self).__init__(parent=parent)
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
-        self.setWindowTitle('LeoPopUp')  # I configure i3 to run all windows named LeoPopUp as floating
+        self.setWindowTitle(
+            'LeoPopUp'
+        )  # I configure i3 to run all windows named LeoPopUp as floating
         self.hovered.connect(self._actionHovered)
 
         actTDL = QtWidgets.QAction('Leo-Babel Menu', self)
@@ -330,7 +336,9 @@ def babelMenu(event):
     cmdr = event.get('c')
     babelG = leoG.user_dict['leo_babel']
     babelG.cmdr = cmdr
-    babelG.babelMenu.exec_(QtWidgets.QApplication.desktop().screen().rect().center() - babelG.babelMenu.rect().center())
+    babelG.babelMenu.exec_(
+        QtWidgets.QApplication.desktop().screen().rect().center() - babelG.babelMenu.rect().center()
+    )
 
 
 # @+node:bob.20170726143458.16: ** babelExec(event)
@@ -455,7 +463,9 @@ def babelExec(event):
             babelCmdr.babelExecCnt += 1
             raise babelG.babel_api.BABEL_LANGUAGE('Unknown language "{0}"'.format(langx))
 
-        script = f'#! {interpreter}\n' + getScript(cmdrScr, scriptRoot, useSelectedText=False, language=langx)
+        script = f'#! {interpreter}\n' + getScript(
+            cmdrScr, scriptRoot, useSelectedText=False, language=langx
+        )
 
         cmdrScr.setCurrentDirectoryFromContext(scriptRoot)
         cwd = leoG.os_path_abspath(os.getcwd())
@@ -614,10 +624,13 @@ def babelExec(event):
             else:
                 s = p.b
             s = extractExecutableString(c, p, s, language)
-            script = composeScript(c, p, s, forcePythonSentinels=forcePythonSentinels, sentinels=sentinels)
+            script = composeScript(
+                c, p, s, forcePythonSentinels=forcePythonSentinels, sentinels=sentinels
+            )
         except Exception:
             leoG.es_print(
-                "unexpected exception in Leo-Babel getScript()", tabName='Babel' if babelCmdr.babel_tab_babel else 'Log'
+                "unexpected exception in Leo-Babel getScript()",
+                tabName='Babel' if babelCmdr.babel_tab_babel else 'Log',
             )
             raise
         return script
@@ -642,7 +655,9 @@ def babelExec(event):
                 for lineX in lix.decode('utf-8').split('\n'):
                     if lineX:
                         leoG.es(
-                            linePrefix + lineX, color=color, tabName='Babel' if babelCmdr.babel_tab_babel else 'Log'
+                            linePrefix + lineX,
+                            color=color,
+                            tabName='Babel' if babelCmdr.babel_tab_babel else 'Log',
                         )
             else:
                 break
@@ -712,7 +727,9 @@ def babelExec(event):
                     tabName='Babel' if babelCmdr.babel_tab_babel else 'Log',
                 )
                 if babel_node_creation:
-                    makeBabelNodes(cmdrRes, resultsRoot, reo, ree, babelCmdr.termMsg, babelCmdr.etMsg)
+                    makeBabelNodes(
+                        cmdrRes, resultsRoot, reo, ree, babelCmdr.termMsg, babelCmdr.etMsg
+                    )
                 reo.close()
                 ree.close()
                 babelCmdr.babelExecCnt += 1
@@ -730,7 +747,10 @@ def babelExec(event):
                 minutes, secs = divmod(et, 60)
                 hours, minutes = divmod(minutes, 60)
                 babelCmdr.etMsg = '{hr:02d}:{mi:02d}:{se:02d} Elapsed Time. {end} End Time'.format(
-                    hr=hours, mi=minutes, se=secs, end=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                    hr=hours,
+                    mi=minutes,
+                    se=secs,
+                    end=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
                 )
 
     # @+node:bob.20170726143458.21: *3* makeBabelNodes(cmdrRes, resultsRoot, reo, ree, termMsg, etMsg)
@@ -804,7 +824,9 @@ def babelExec(event):
             posX = babelRoot.getNthChild({'script': 0, 'results': 1}[scrOrRes])
             if not posX:
                 childOrd = {'script': 'First', 'results': 'Second'}[scrOrRes]
-                raise babelG.babel_api.BABEL_ROOT(f'{childOrd} child of current node must be the {scrOrRes} root.')
+                raise babelG.babel_api.BABEL_ROOT(
+                    f'{childOrd} child of current node must be the {scrOrRes} root.'
+                )
         elif isinstance(posX, type('abc')):
             pathname, nodePart = unlSplit(posX)
             if pathname is None:
@@ -819,7 +841,9 @@ def babelExec(event):
             else:
                 posX = posList[0]
                 if len(posList) > 1:
-                    warning = f'{scrOrRes.capitalize()} Root UNL satisfies {len(posList)} positions.'
+                    warning = (
+                        f'{scrOrRes.capitalize()} Root UNL satisfies {len(posList)} positions.'
+                    )
                     leoG.warning(warning)
         posX = posX.copy()
         return leoCmdrX, posX

--- a/leo/plugins/leo_babel/tests/lib_test.py
+++ b/leo/plugins/leo_babel/tests/lib_test.py
@@ -161,7 +161,9 @@ class TestCmdr:
         self.colorStdout = _getColor(cmdrT, 'Leo-Babel-stdout', default='#00ff00')
         self.colorStderr = _getColor(cmdrT, 'Leo-Babel-stderr', default='#A020F0')
         self.colorCompletion = _getColor(cmdrT, 'Leo-Babel-completion', default='#FFD700')
-        self.nodeCreationDefault = cmdrT.config.getBool('Leo-Babel-Node-Creation-Default', default=True)
+        self.nodeCreationDefault = cmdrT.config.getBool(
+            'Leo-Babel-Node-Creation-Default', default=True
+        )
         self.interpreterPython = _getString(cmdrT, 'Leo-Babel-Python', default='python3')
         self.interpreterShell = _getString(cmdrT, 'Leo-Babel-Shell', default='bash')
 
@@ -170,7 +172,9 @@ class TestCmdr:
         self.testCnt = 0
         self.babelExecCnt = 0
 
-        fdR.write('||* Tests *|| {0}\n'.format(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%s')))
+        fdR.write(
+            '||* Tests *|| {0}\n'.format(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%s'))
+        )
 
     # @-others
 

--- a/leo/plugins/leo_babel/tests/tests.py
+++ b/leo/plugins/leo_babel/tests/tests.py
@@ -53,9 +53,15 @@ def cmdLineHandler():
     @param return:  Instance of class argparse.Namespace containing all the parsed command line arguments.
     """
 
-    parser = argparse.ArgumentParser(description="Run Leo-Babel Tests", usage='%(prog)s [options] tests results')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s Revision {0}'.format(version))
-    parser.add_argument('fpnTests', help='Pathname of a Leo-Editor file containing tests. Required argument.')
+    parser = argparse.ArgumentParser(
+        description="Run Leo-Babel Tests", usage='%(prog)s [options] tests results'
+    )
+    parser.add_argument(
+        '-v', '--version', action='version', version='%(prog)s Revision {0}'.format(version)
+    )
+    parser.add_argument(
+        'fpnTests', help='Pathname of a Leo-Editor file containing tests. Required argument.'
+    )
     parser.add_argument(
         'fpnResults',
         help='Pathname of a Leo-Editor file to contain the test results. '
@@ -79,7 +85,9 @@ def main():
     args = cmdLineHandler()
     # 2024/04/09: This statement is almost certainly wrong.
     # leoG.IdleTime = idle_time.IdleTime
-    bridge = leoBridge.controller(gui='nullGui', silent=True, verbose=False, loadPlugins=True, readSettings=True)
+    bridge = leoBridge.controller(
+        gui='nullGui', silent=True, verbose=False, loadPlugins=True, readSettings=True
+    )
     cmdrT = bridge.openLeoFile(args.fpnTests)
     if os.path.exists(args.fpnResults):
         os.remove(args.fpnResults)

--- a/leo/plugins/leo_cloud.py
+++ b/leo/plugins/leo_cloud.py
@@ -508,7 +508,9 @@ class LeoCloud:
                 read = True
             elif read_on_load == 'ask':
                 try:
-                    last_read = datetime.strptime(lc_v.u['_leo_cloud']['last_read'], "%Y-%m-%dT%H:%M:%S.%f")
+                    last_read = datetime.strptime(
+                        lc_v.u['_leo_cloud']['last_read'], "%Y-%m-%dT%H:%M:%S.%f"
+                    )
                 except KeyError:
                     last_read = None
                 message = "Read cloud data '%s', overwriting local nodes?" % kwargs['ID']
@@ -521,14 +523,18 @@ class LeoCloud:
                         int(delta.seconds / 60) % 60,
                         delta.seconds % 60,
                     )
-                read = g.app.gui.runAskYesNoCancelDialog(self.c, "Read cloud data?", message=message)
+                read = g.app.gui.runAskYesNoCancelDialog(
+                    self.c, "Read cloud data?", message=message
+                )
                 read = str(read).lower() == 'yes'
             if read:
                 self.read_current(p=self.c.vnode2position(lc_v))
             elif read_on_load == 'background':
                 # second time round, with from_background data, this will
                 # have been changed to 'ask' (above), so no infinite loop
-                background.append((lc_v, kwargs, self.recursive_hash(lc_v, [], include_current=False)))
+                background.append(
+                    (lc_v, kwargs, self.recursive_hash(lc_v, [], include_current=False))
+                )
             elif read_on_load == 'no':
                 g.es("NOTE: not reading '%s' from cloud" % kwargs['ID'])
             elif read_on_load != 'ask':
@@ -538,7 +544,8 @@ class LeoCloud:
                 self.c,
                 "Unloaded cloud data",
                 message="There is unloaded (possibly stale) cloud data, use\nread_on_load: yes|no|ask\n"
-                "in @leo_cloud nodes to avoid this message.\nUnloaded data:\n%s" % ', '.join(skipped),
+                "in @leo_cloud nodes to avoid this message.\nUnloaded data:\n%s"
+                % ', '.join(skipped),
             )
 
         if background:
@@ -603,7 +610,9 @@ class LeoCloud:
         childs: list = []
         hashes: list = [LeoCloud.recursive_hash(child, childs) for child in nd.children]
         if include_current:
-            hashes.extend([nd.h + nd.b.rstrip('\n') + json.dumps(LeoCloud._ua_clean(nd.u), sort_keys=True)])
+            hashes.extend(
+                [nd.h + nd.b.rstrip('\n') + json.dumps(LeoCloud._ua_clean(nd.u), sort_keys=True)]
+            )
         whole_hash = sha1(''.join(hashes).encode('utf-8')).hexdigest()
         tree.append([whole_hash, childs])
         return whole_hash
@@ -642,7 +651,8 @@ class LeoCloud:
                 self.c,
                 "Unsaved cloud data",
                 message="There is unsaved cloud data, use\nwrite_on_save: yes|no|ask\n"
-                "in @leo_cloud nodes to avoid this message.\nUnsaved data:\n%s" % ', '.join(skipped),
+                "in @leo_cloud nodes to avoid this message.\nUnsaved data:\n%s"
+                % ', '.join(skipped),
             )
         if unchanged:
             g.es("Unchanged cloud data: %s" % ', '.join(unchanged))

--- a/leo/plugins/leo_interface.py
+++ b/leo/plugins/leo_interface.py
@@ -254,7 +254,9 @@ class leo_node(LeoNode, node_with_parent):
 
     # @+node:ekr.20101110092416.5755: *3* gen_t_elements
     def gen_t_elements(self, file):
-        self.mark_with_attributes(file, "t", (("tx", "T" + repr(self.nr)),), self.gen_t_elements1, newline=False)
+        self.mark_with_attributes(
+            file, "t", (("tx", "T" + repr(self.nr)),), self.gen_t_elements1, newline=False
+        )
         for child in self.children:
             child.gen_t_elements(file)
 
@@ -271,7 +273,9 @@ class leo_node(LeoNode, node_with_parent):
             # Also number all nodes for easier error hunting.
             vnode_stack.append(self)
             if self in allvnodes:
-                print("Fix this; This is an endless recursive call in leo_interface.leo_node.gen_v_elements")
+                print(
+                    "Fix this; This is an endless recursive call in leo_interface.leo_node.gen_v_elements"
+                )
                 x = vnode_stack[:]
                 x.reverse()
                 for i in x:

--- a/leo/plugins/leo_pdf.py
+++ b/leo/plugins/leo_pdf.py
@@ -189,13 +189,26 @@ def getStyleSheet():
         return None
     stylesheet = StyleSheet1()
     stylesheet.add(
-        ParagraphStyle(name='Normal', fontName='Times-Roman', fontSize=10, leading=12, spaceBefore=4, spaceAfter=4)
+        ParagraphStyle(
+            name='Normal',
+            fontName='Times-Roman',
+            fontSize=10,
+            leading=12,
+            spaceBefore=4,
+            spaceAfter=4,
+        )
     )
-    stylesheet.add(ParagraphStyle(name='DocInfo', parent=stylesheet['Normal'], leading=12, spaceBefore=0, spaceAfter=0))
+    stylesheet.add(
+        ParagraphStyle(
+            name='DocInfo', parent=stylesheet['Normal'], leading=12, spaceBefore=0, spaceAfter=0
+        )
+    )
     stylesheet.add(ParagraphStyle(name='Comment', fontName='Times-Italic'))
     stylesheet.add(ParagraphStyle(name='Indent1', leftIndent=36, firstLineIndent=0))
     stylesheet.add(ParagraphStyle(name='BodyText', parent=stylesheet['Normal'], spaceBefore=6))
-    stylesheet.add(ParagraphStyle(name='Italic', parent=stylesheet['BodyText'], fontName='Times-Italic'))
+    stylesheet.add(
+        ParagraphStyle(name='Italic', parent=stylesheet['BodyText'], fontName='Times-Italic')
+    )
     stylesheet.add(
         ParagraphStyle(
             name='Heading1',
@@ -357,12 +370,21 @@ def getStyleSheet():
     )
     stylesheet.add(
         ParagraphStyle(
-            name='FunctionHeader', parent=stylesheet['Normal'], fontName='Courier-Bold', fontSize=8, leading=8.8
+            name='FunctionHeader',
+            parent=stylesheet['Normal'],
+            fontName='Courier-Bold',
+            fontSize=8,
+            leading=8.8,
         )
     )
     stylesheet.add(
         ParagraphStyle(
-            name='DocString', parent=stylesheet['Normal'], fontName='Courier', fontSize=8, leftIndent=18, leading=8.8
+            name='DocString',
+            parent=stylesheet['Normal'],
+            fontName='Courier',
+            fontSize=8,
+            leftIndent=18,
+            leading=8.8,
         )
     )
     stylesheet.add(
@@ -377,12 +399,18 @@ def getStyleSheet():
     )
     stylesheet.add(
         ParagraphStyle(
-            name='URL', parent=stylesheet['Normal'], fontName='Courier', textColor=colors.navy, alignment=TA_CENTER
+            name='URL',
+            parent=stylesheet['Normal'],
+            fontName='Courier',
+            textColor=colors.navy,
+            alignment=TA_CENTER,
         ),
         alias='u',
     )
     stylesheet.add(ParagraphStyle(name='Centred', parent=stylesheet['Normal'], alignment=TA_CENTER))
-    stylesheet.add(ParagraphStyle(name='Caption', parent=stylesheet['Centred'], fontName='Times-Italic'))
+    stylesheet.add(
+        ParagraphStyle(name='Caption', parent=stylesheet['Centred'], fontName='Times-Italic')
+    )
     return stylesheet
 
 
@@ -441,7 +469,9 @@ class Bunch:
 
     def toString(self):
         tag = self.__dict__.get('tag')
-        entries = ["%s: %s" % (key, str(self.__dict__.get(key))) for key in self.ivars() if key != 'tag']
+        entries = [
+            "%s: %s" % (key, str(self.__dict__.get(key))) for key in self.ivars() if key != 'tag'
+        ]
         if tag:
             return "Bunch(tag=%s)...\n%s\n" % (tag, '\n'.join(entries))
         return "Bunch...\n%s\n" % '\n'.join(entries)
@@ -491,7 +521,11 @@ if docutils:
                 (
                     'Format for footnote references: one of "superscript" or "brackets".  Default is "brackets".',
                     ['--footnote-references'],
-                    {'choices': ['superscript', 'brackets'], 'default': 'brackets', 'metavar': '<FORMAT>'},
+                    {
+                        'choices': ['superscript', 'brackets'],
+                        'default': 'brackets',
+                        'metavar': '<FORMAT>',
+                    },
                 ),
             ),
         )
@@ -786,7 +820,9 @@ if docutils:  # NOQA
             else:
                 # if node.has_key('id'):
                 if 'id' in node:
-                    self.body.append(self.starttag({}, 'setLink', '', destination=node['id'], caller=caller))
+                    self.body.append(
+                        self.starttag({}, 'setLink', '', destination=node['id'], caller=caller)
+                    )
                     markup.append('</setLink>')
                 # if node.has_key('refid'):
                 if 'refid' in node:
@@ -816,7 +852,9 @@ if docutils:  # NOQA
                 self.body.append(
                     "%s%s"
                     % (
-                        self.starttag(node, 'setLink', suffix='', destination=href, caller='visit_targtet'),
+                        self.starttag(
+                            node, 'setLink', suffix='', destination=href, caller='visit_targtet'
+                        ),
                         '</setLink>',
                     )
                 )
@@ -848,10 +886,14 @@ if docutils:  # NOQA
                 self.dumpNode(node, tag='node')
             # Bug fix: 8/21/05: changed 'id' to 'ids'.
             if node.parent.hasattr('ids'):
-                self.body.append(self.starttag({}, 'setLink', '', destination=node.parent['ids'], caller=caller))
+                self.body.append(
+                    self.starttag({}, 'setLink', '', destination=node.parent['ids'], caller=caller)
+                )
                 markup.append('</setLink>')
             if node.hasattr('refid'):
-                self.body.append(self.starttag({}, 'setLink', '', destination=node['refid'], caller=caller))
+                self.body.append(
+                    self.starttag({}, 'setLink', '', destination=node['refid'], caller=caller)
+                )
                 markup.append('</setLink>')
 
             self.push(kind='title', markup=markup, start=start, style=style)
@@ -1533,7 +1575,11 @@ if docutils:  # NOQA
         def visit_topic(self, node):
             if node.hasattr('id'):
                 self.push(kind='topic-id', markup='</setLink>')
-                self.body.append(self.starttag({}, 'setLink', suffix='', destination=node['id'], caller='visit_topic'))
+                self.body.append(
+                    self.starttag(
+                        {}, 'setLink', suffix='', destination=node['id'], caller='visit_topic'
+                    )
+                )
 
         def depart_topic(self, node):
             if node.hasattr('id'):
@@ -1564,7 +1610,9 @@ if docutils:  # NOQA
         # @+node:ekr.20090704103932.5292: *5*  literal_blocks...
         def visit_literal_block(self, node):
             if reportlab:
-                self.story.append(reportlab.platypus.Preformatted(node.astext(), self.styleSheet.get('Code')))
+                self.story.append(
+                    reportlab.platypus.Preformatted(node.astext(), self.styleSheet.get('Code'))
+                )
 
             raise docutils.nodes.SkipNode
 
@@ -1615,7 +1663,9 @@ if docutils:  # NOQA
 
         # @+node:ekr.20090704103932.5299: *4* unimplemented_visit
         def unimplemented_visit(self, node):
-            raise NotImplementedError('visiting unimplemented node type: %s' % node.__class__.__name__)
+            raise NotImplementedError(
+                'visiting unimplemented node type: %s' % node.__class__.__name__
+            )
 
         # @+node:ekr.20090704103932.5300: *4* visit_raw
         def visit_raw(self, node):

--- a/leo/plugins/leo_to_html.py
+++ b/leo/plugins/leo_to_html.py
@@ -190,7 +190,9 @@ def createExportMenus(tag, keywords):
         ('Save Node as HTML', 'export-html-node'),
         ('Save Outline as HTML', 'export-html'),
     ):
-        c.frame.menu.insert('Export Files', 3, label=item, command=lambda c=c, cmd=cmd: c.doCommandByName(cmd))
+        c.frame.menu.insert(
+            'Export Files', 3, label=item, command=lambda c=c, cmd=cmd: c.doCommandByName(cmd)
+        )
 
 
 # @+node:bob.20080107154757: ** class pluginController
@@ -418,7 +420,9 @@ class Leo_to_HTML:
         if not self.include_body:
             return
 
-        self.xhtml.append(self.openBodyString + '<pre>' + safe(pp.b) + '</pre>' + self.closeBodyString)
+        self.xhtml.append(
+            self.openBodyString + '<pre>' + safe(pp.b) + '</pre>' + self.closeBodyString
+        )
 
     # @+node:bob.20080107175336: *4* showSubtree
     def showSubtree(self, p):

--- a/leo/plugins/leo_to_html_outline_viewer.py
+++ b/leo/plugins/leo_to_html_outline_viewer.py
@@ -57,7 +57,9 @@ def createExportMenu(tag, keywords):
         'Export Files',
         2,
         label='Export HTML Outline Viewer',
-        command=lambda c=c, cmd='export-html-outline-viewer': c.doCommandByName('export-html-outline-viewer'),
+        command=lambda c=c, cmd='export-html-outline-viewer': c.doCommandByName(
+            'export-html-outline-viewer'
+        ),
     )
 
 

--- a/leo/plugins/leo_to_rtf.py
+++ b/leo/plugins/leo_to_rtf.py
@@ -40,7 +40,9 @@ def createExportMenu(tag, keywords):
         return
 
     # Insert leoToRTF in #3 position of the File > Export menu.
-    c.frame.menu.insert('Export Files', 3, label='Outline to Microsoft RTF', command=lambda c=c: export_rtf(c))
+    c.frame.menu.insert(
+        'Export Files', 3, label='Outline to Microsoft RTF', command=lambda c=c: export_rtf(c)
+    )
 
 
 # @+node:danr7.20060902083957.3: ** export_rtf
@@ -63,7 +65,9 @@ def export_rtf(c):
     else:
         return
     # Write RTF header information
-    f.write("{\\rtf1\\ansi\\ansicpg1252\\deff0\\deflang1033{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}\n\n")
+    f.write(
+        "{\\rtf1\\ansi\\ansicpg1252\\deff0\\deflang1033{\\fonttbl{\\f0\\fswiss\\fcharset0 Arial;}}\n\n"
+    )
     # Write RTF list table that provides numbered list formatting
     # @+<< listtable >>
     # @+node:danr7.20060902085826: *3* << listtable >>
@@ -83,13 +87,17 @@ def export_rtf(c):
         "{\\listlevel\\levelnfc4\\levelnfcn4\\leveljc0\\leveljcn0\\levelfollow0\\levelstartat1\\levelspace360\\levelindent0"
     )  # NOQA
     f.write("{\\leveltext\\leveltemplateid67698713\\'02\\'01.;} {\\levelnumbers\\'01;}")
-    f.write("\\chbrdr\\brdrnone\\brdrcf1 \\chshdng0\\chcfpat1\\chcbpat1 \\fi-360\\li1440\\jclisttab\\tx1440 }")  # NOQA
+    f.write(
+        "\\chbrdr\\brdrnone\\brdrcf1 \\chshdng0\\chcfpat1\\chcbpat1 \\fi-360\\li1440\\jclisttab\\tx1440 }"
+    )  # NOQA
 
     f.write(
         "{\\listlevel\\levelnfc2\\levelnfcn2\\leveljc2\\leveljcn2\\levelfollow0\\levelstartat1\\levelspace360\\levelindent0"
     )  # NOQA
     f.write("{\\leveltext\\leveltemplateid67698715\\'02\\'02.;} {\\levelnumbers\\'01;}")
-    f.write("\\chbrdr\\brdrnone\\brdrcf1 \\chshdng0\\chcfpat1\\chcbpat1\\fi-180\\li2160\\jclisttab\\tx2160 }")
+    f.write(
+        "\\chbrdr\\brdrnone\\brdrcf1 \\chshdng0\\chcfpat1\\chcbpat1\\fi-180\\li2160\\jclisttab\\tx2160 }"
+    )
 
     f.write("{\\listlevel\\levelnfc0\\levelnfcn0\\leveljc0\\leveljcn0\\levelfollow0\\levelstartat1")
     f.write("\\levelspace360\\levelindent0{\\leveltext\\leveltemplateid67698703\\'02\\'03.;}")
@@ -130,16 +138,22 @@ def export_rtf(c):
         "{\\listlevel\\levelnfc2\\levelnfcn2\\leveljc2\\leveljcn2\\levelfollow0\\levelstartat1\\levelspace360\\levelindent0"
     )  # NOQA
     f.write("{\\leveltext\\leveltemplateid67698715\\'02\\'08.;}{\\levelnumbers\\'01;}")
-    f.write("\\chbrdr\\brdrnone\\brdrcf1 \\chshdng0\\chcfpat1\\chcbpat1 \\fi-180\\li6480\\jclisttab\\tx6480 }")
+    f.write(
+        "\\chbrdr\\brdrnone\\brdrcf1 \\chshdng0\\chcfpat1\\chcbpat1 \\fi-180\\li6480\\jclisttab\\tx6480 }"
+    )
 
     f.write("{\\listname ;}\\listid127936308}}\n\n")
 
-    f.write("{\\*\\listoverridetable{\\listoverride\\listid127936308\\listoverridecount0\\ls1}}\n\n")
+    f.write(
+        "{\\*\\listoverridetable{\\listoverride\\listid127936308\\listoverridecount0\\ls1}}\n\n"
+    )
     # @-<< listtable >>
     # Write text formatting foundation
     f.write("\\viewkind4\\uc1\\pard\\f0\\fs20\n\n")
     # Create generic level header
-    levelHeader = "\\pard \\ql \\fi-360\\ri0\\widctlpar\\jclisttab\\faauto\\ls1\\adjustright\\rin0\\itap0"
+    levelHeader = (
+        "\\pard \\ql \\fi-360\\ri0\\widctlpar\\jclisttab\\faauto\\ls1\\adjustright\\rin0\\itap0"
+    )
     myLevel = -1
     for p in c.all_positions():
         curLevel = p.level() + 1  # Store current level so method doesn't have to be called again
@@ -151,7 +165,16 @@ def export_rtf(c):
             levelIndent = str(720 * curLevel)
             # Output the generic RTF level info
             f.write(levelHeader)
-            f.write("\\li" + levelIndent + "\\tx" + levelIndent + "\\ilvl" + str(curLevel - 1) + "\\lin" + levelIndent)
+            f.write(
+                "\\li"
+                + levelIndent
+                + "\\tx"
+                + levelIndent
+                + "\\ilvl"
+                + str(curLevel - 1)
+                + "\\lin"
+                + levelIndent
+            )
             f.write("{")
         myLevel = curLevel
         myHeadline = p.h

--- a/leo/plugins/leoscreen.py
+++ b/leo/plugins/leoscreen.py
@@ -393,7 +393,9 @@ class leoscreen_Controller:
     def get_prefix(self):
         """get the prefix for insertions from get_line"""
 
-        x = g.app.gui.runAskOkCancelStringDialog(self.c, 'Prefix for text loading', 'Prefix for text loading')
+        x = g.app.gui.runAskOkCancelStringDialog(
+            self.c, 'Prefix for text loading', 'Prefix for text loading'
+        )
 
         if x is not None:
             self.get_line_prefix = x
@@ -407,7 +409,9 @@ class leoscreen_Controller:
         out = out_bytes.decode('utf-8')
 
         screens = [
-            [('CURRENT: ' if i == self.use_screen else '') + i, False, i] for i in out.split('\n') if i.startswith('\t')
+            [('CURRENT: ' if i == self.use_screen else '') + i, False, i]
+            for i in out.split('\n')
+            if i.startswith('\t')
         ]  # type:ignore
 
         ld = ListDialog(None, 'Pick screen', 'Pick screen', screens)

--- a/leo/plugins/md_docer.py
+++ b/leo/plugins/md_docer.py
@@ -147,7 +147,9 @@ def sync_transformations(event):
             h = v.h
             if h.startswith('@transformer '):
                 name = h.partition(' ')[2].strip()
-                trscripts[name] = g.getScript(c, p.copy(), useSentinels=False, forcePythonSentinels=True)
+                trscripts[name] = g.getScript(
+                    c, p.copy(), useSentinels=False, forcePythonSentinels=True
+                )
                 p.moveToNodeAfterTree()
             elif h.startswith('@transform-node '):
                 name = h.partition(' ')[2].strip()

--- a/leo/plugins/mod_http.py
+++ b/leo/plugins/mod_http.py
@@ -281,7 +281,10 @@ def init():
         try:
             Server(config.http_ip, config.http_port, RequestHandler)
         except socket.error as e:
-            g.es("mod_http server initialization failed (%s:%s): %s" % (config.http_ip, config.http_port, e))
+            g.es(
+                "mod_http server initialization failed (%s:%s): %s"
+                % (config.http_ip, config.http_port, e)
+            )
             return False
         asyncore.read = a_read
         g.registerHandler("idle", plugin_wrapper)

--- a/leo/plugins/mod_leo2ascd.py
+++ b/leo/plugins/mod_leo2ascd.py
@@ -98,7 +98,9 @@ def GetAscFilename(c, p):
             ascFileName = containsAscFileDirective.group(1)
             if ascFileName is not None:
                 base = os.path.split(c.mFileName)[0]  # linux or windows
-                if ((base[0] == "/") and (ascFileName[0] != "/")) or ((base[1] == ":") and (ascFileName[1] != ":")):
+                if ((base[0] == "/") and (ascFileName[0] != "/")) or (
+                    (base[1] == ":") and (ascFileName[1] != ":")
+                ):
                     # no full pathname specified
                     ascFileName = os.path.join(base, ascFileName)
                 Conf.GetCurrentOptions(c, p)
@@ -113,7 +115,10 @@ def SectionUnderline(h, level, v):
         g.es("Section level is less than 1:\n  %s" % v.headString())
         level = 1
     elif level > asciiDocSectionLevels - 1:
-        g.es("Section level is more than maximum Section Levels: %d\n  %s" % (asciiDocSectionLevels, v.headString()))
+        g.es(
+            "Section level is more than maximum Section Levels: %d\n  %s"
+            % (asciiDocSectionLevels, v.headString())
+        )
         level = asciiDocSectionLevels - 1
     str = Conf.current["headingUnderlines"][level]
     return str * max(len(h), 1)

--- a/leo/plugins/mod_scripting.py
+++ b/leo/plugins/mod_scripting.py
@@ -170,7 +170,9 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+others
 # @+node:ekr.20180328085010.1: ** Top level (mod_scripting)
 # @+node:tbrown.20140819100840.37719: *3* mod_scripting.build_rclick_tree
-def build_rclick_tree(command_p: Position, rclicks: RClicks = None, top_level: bool = False) -> list:
+def build_rclick_tree(
+    command_p: Position, rclicks: RClicks = None, top_level: bool = False
+) -> list:
     """
     Return a list of top level RClicks for the button at command_p, which can be
     used later to add the rclick menus.
@@ -240,7 +242,10 @@ def init() -> bool:
     ok = bool(g.app.gui) and g.app.gui.guiName() in ('qt', 'nullGui')
     if ok:
         sc = 'ScriptingControllerClass'
-        if not hasattr(g.app.gui, sc) or getattr(g.app.gui, sc) is leoGui.NullScriptingControllerClass:
+        if (
+            not hasattr(g.app.gui, sc)
+            or getattr(g.app.gui, sc) is leoGui.NullScriptingControllerClass
+        ):
             setattr(g.app.gui, sc, ScriptingController)
         # Note: call onCreate _after_ reading the .leo file.
         # That is, the 'after-create-leo-frame' hook is too early!
@@ -355,7 +360,9 @@ class ScriptingController:
         getBool = c.config.getBool
         self.scanned = False
         kind = c.config.getString('debugger-kind') or 'idle'
-        self.buttonsDict: dict[QtWidgets.QButton, str] = {}  # Keys are buttons, values are button names (strings).
+        self.buttonsDict: dict[
+            QtWidgets.QButton, str
+        ] = {}  # Keys are buttons, values are button names (strings).
         self.debuggerKind = kind.lower()
         # True: adds a button for every @button node.
         self.atButtonNodes = getBool('scripting-at-button-nodes')
@@ -443,8 +450,12 @@ class ScriptingController:
                     elif self.debuggerKind == 'winpdb':
                         # pylint: disable=line-too-long
                         f.write('import rpdb2\n')
-                        f.write('if rpdb2.g_debugger is not None: # don\'t hang if the debugger isn\'t running.\n')
-                        f.write('  rpdb2.start_embedded_debugger(pwd="",fAllowUnencrypted=True) # Hard breakpoint.\n')
+                        f.write(
+                            'if rpdb2.g_debugger is not None: # don\'t hang if the debugger isn\'t running.\n'
+                        )
+                        f.write(
+                            '  rpdb2.start_embedded_debugger(pwd="",fAllowUnencrypted=True) # Hard breakpoint.\n'
+                        )
                     # f.write('# Remove all previous variables.\n')
                     f.write('# Predefine c, g and p.\n')
                     f.write('from leo.core import leoGlobals as g\n')
@@ -575,7 +586,12 @@ class ScriptingController:
         # At last we can define the command and use the shortcut.
         # registerAllCommands recomputes the shortcut.
         self.registerAllCommands(
-            args=self.getArgs(p), func=cb, h=h, pane='button', source_c=p.v.context, tag='local @button'
+            args=self.getArgs(p),
+            func=cb,
+            h=h,
+            pane='button',
+            source_c=p.v.context,
+            tag='local @button',
         )
         return b
 
@@ -616,9 +632,13 @@ class ScriptingController:
         if statusLine:
             self.createBalloon(b, statusLine)
         if command:
-            self.registerAllCommands(args=args, func=command, h=text, pane='button', source_c=c, tag='icon button')
+            self.registerAllCommands(
+                args=args, func=command, h=text, pane='button', source_c=c, tag='icon button'
+            )
 
-        def deleteButtonCallback(event: Event = None, self: Any = self, b: QtWidgets.QButton = b) -> None:
+        def deleteButtonCallback(
+            event: Event = None, self: Any = self, b: QtWidgets.QButton = b
+        ) -> None:
             self.deleteButton(b, event=event)
 
         # Register the delete-x-button command.
@@ -773,7 +793,9 @@ class ScriptingController:
         )
         self.handleRclicks(rclicks)
         # At last we can define the command.
-        self.registerAllCommands(args=args, func=cb, h=p.h, pane='button', source_c=p.v.context, tag='@button')
+        self.registerAllCommands(
+            args=args, func=cb, h=p.h, pane='button', source_c=p.v.context, tag='@button'
+        )
 
     # @+node:ekr.20080312071248.2: *4* sc.createCommonCommands
     def createCommonCommands(self) -> None:
@@ -908,7 +930,12 @@ class ScriptingController:
 
         if p.b.strip():
             self.registerAllCommands(
-                args=args, func=atCommandCallback, h=p.h, pane='all', source_c=p.v.context, tag='local @rclick'
+                args=args,
+                func=atCommandCallback,
+                h=p.h,
+                pane='all',
+                source_c=p.v.context,
+                tag='local @rclick',
             )
         g.app.config.atLocalCommandsList.append(p.copy())
 
@@ -1151,7 +1178,9 @@ class ScriptingController:
                 commandName2 = commandName[len(prefix) :].strip()
                 # Create a *second* func, to avoid collision in c.commandsDict.
 
-                def registerAllCommandsCallback(event: Event = None, func: Callable = func) -> Callable:
+                def registerAllCommandsCallback(
+                    event: Event = None, func: Callable = func
+                ) -> Callable:
                     return func()
 
                 # Fix bug 1251252: https://bugs.launchpad.net/leo-editor/+bug/1251252

--- a/leo/plugins/multifile.py
+++ b/leo/plugins/multifile.py
@@ -94,7 +94,9 @@ def addMenu(tag, keywords):
         return
     haveseen[c] = None
     menu = c.frame.menu.getMenu('Edit')
-    c.add_command(menu, label="Insert Directory String", command=lambda c=c: insertDirectoryString(c))
+    c.add_command(
+        menu, label="Insert Directory String", command=lambda c=c: insertDirectoryString(c)
+    )
 
 
 # @+node:mork.20041019091524: *3* insertDirectoryString

--- a/leo/plugins/nested_splitter.py
+++ b/leo/plugins/nested_splitter.py
@@ -92,7 +92,9 @@ class NestedSplitterChoice(QtWidgets.QWidget):
         button = QtWidgets.QPushButton("Action", self)  # EKR: 2011/03/15
         self.layout().addWidget(button)
         button.setContextMenuPolicy(ContextMenuPolicy.CustomContextMenu)
-        button.customContextMenuRequested.connect(lambda pnt: self.parent().choice_menu(self, button.mapToParent(pnt)))
+        button.customContextMenuRequested.connect(
+            lambda pnt: self.parent().choice_menu(self, button.mapToParent(pnt))
+        )
         button.clicked.connect(lambda: self.parent().choice_menu(self, button.pos()))
 
     # @-others
@@ -260,7 +262,9 @@ class NestedSplitterHandle(QtWidgets.QSplitterHandle):
                     def swap_mark_callback(i=i, index=index, splitter=splitter):
                         splitter.swap_with_marked(index, i)
 
-                    self.add_item(swap_mark_callback, menu, f"Swap {count[i]:d} {lr[i]} With Marked")
+                    self.add_item(
+                        swap_mark_callback, menu, f"Swap {count[i]:d} {lr[i]} With Marked"
+                    )
         # Add.
         for i in 0, 1:
             if (
@@ -301,7 +305,11 @@ class NestedSplitterHandle(QtWidgets.QSplitterHandle):
                 self.add_item(lambda: splitter.open_window(), submenu, "Empty")
             # adapted from choice_menu()
             if splitter.root.marked and splitter.top().max_count() > 1:
-                self.add_item(lambda: splitter.open_window(action="_move_marked_there"), submenu, "Move marked there")
+                self.add_item(
+                    lambda: splitter.open_window(action="_move_marked_there"),
+                    submenu,
+                    "Move marked there",
+                )
             for provider in splitter.root.providers:
                 if hasattr(provider, 'ns_provides'):
                     for title, id_ in provider.ns_provides():
@@ -522,7 +530,8 @@ class NestedSplitter(QtWidgets.QSplitter):
             """Recursively look for this widget"""
             for n, i in enumerate(layout['content']):
                 if i == id_ or (
-                    isinstance(i, QtWidgets.QWidget) and (i.objectName() == id_ or i.__class__.__name__ == id_)
+                    isinstance(i, QtWidgets.QWidget)
+                    and (i.objectName() == id_ or i.__class__.__name__ == id_)
                 ):
                     return layout, n
                 if not isinstance(i, QtWidgets.QWidget):
@@ -577,7 +586,11 @@ class NestedSplitter(QtWidgets.QSplitter):
         """build menu on Action button"""
         menu = QtWidgets.QMenu(self.top())  # #1995
         index = self.indexOf(button)
-        if self.root.marked and not self.invalid_swap(button, self.root.marked[3]) and self.top().max_count() > 2:
+        if (
+            self.root.marked
+            and not self.invalid_swap(button, self.root.marked[3])
+            and self.top().max_count() > 2
+        ):
             act = QAction("Move marked here", self)
             act.triggered.connect(lambda checked: self.replace_widget(button, self.root.marked[3]))
             menu.addAction(act)
@@ -1118,7 +1131,9 @@ class NestedSplitter(QtWidgets.QSplitter):
         if self.count() == len(layout['sizes']):
             self.setSizes(layout['sizes'])
         else:
-            print(f"Wrong pane count at level {level:d}, count:{self.count():d}, sizes:{len(layout['sizes']):d}")
+            print(
+                f"Wrong pane count at level {level:d}, count:{self.count():d}, sizes:{len(layout['sizes']):d}"
+            )
             self.equalize_sizes()
 
     # @+node:tbrown.20110628083641.21156: *3* ns.prune_empty

--- a/leo/plugins/nodediff.py
+++ b/leo/plugins/nodediff.py
@@ -260,7 +260,10 @@ class NodeDiffController:
         """
         ns = self.get_subtree()
         if ns is None:
-            g.es('nodediff.py: Make sure that the selected node has exactly two children.', color='red')
+            g.es(
+                'nodediff.py: Make sure that the selected node has exactly two children.',
+                color='red',
+            )
             return
         self.run_appropriate_diff(ns)
 

--- a/leo/plugins/nodewatch.py
+++ b/leo/plugins/nodewatch.py
@@ -161,8 +161,12 @@ class LeoNodewatchWidget(QtWidgets.QWidget):  # type:ignore
         self.c = c
         self.initUI()
         self.registerCallbacks()
-        autoexecute_nodewatch_nodes = c.config.getBool('nodewatch-autoexecute-scripts', default=False)
-        if autoexecute_nodewatch_nodes and c.config.isLocalSetting('nodewatch_autoexecute_scripts', 'bool'):
+        autoexecute_nodewatch_nodes = c.config.getBool(
+            'nodewatch-autoexecute-scripts', default=False
+        )
+        if autoexecute_nodewatch_nodes and c.config.isLocalSetting(
+            'nodewatch_autoexecute_scripts', 'bool'
+        ):
             g.issueSecurityWarning('@bool nodewatch_autoexecute_scripts')
             autoexecute_nodewatch_nodes = False
         if autoexecute_nodewatch_nodes:

--- a/leo/plugins/obsolete/gtkDialogs.py
+++ b/leo/plugins/obsolete/gtkDialogs.py
@@ -162,7 +162,9 @@ def runOpenFileDialog(title=None, filetypes=None, defaultextension=None, multipl
     ok, data = callGtkDialogs(data)
 
     if not ok:
-        return oldopen(title=title, filetypes=filetypes, defaultextension=defaultextension, multiple=multiple)
+        return oldopen(
+            title=title, filetypes=filetypes, defaultextension=defaultextension, multiple=multiple
+        )
 
     if data is None:
         return ''

--- a/leo/plugins/obsolete/ironPythonGui.py
+++ b/leo/plugins/obsolete/ironPythonGui.py
@@ -125,7 +125,12 @@ class ironPythonGui(leoGui.leoGui):
         if g.app.unitTesting:
             return
 
-        message = "%s\n\n%s\n\n%s\n\n%s" % (version.strip(), copyright.strip(), url.strip(), email.strip())
+        message = "%s\n\n%s\n\n%s\n\n%s" % (
+            version.strip(),
+            copyright.strip(),
+            url.strip(),
+            email.strip(),
+        )
 
         wx.MessageBox(message, "About Leo", wx.Center, self.root)
 
@@ -180,7 +185,9 @@ class ironPythonGui(leoGui.leoGui):
         return g.choose(answer == wx.YES, "yes", "no")
 
     # @+node:ekr.20081121105001.103: *4* runAskYesNoCancelDialog
-    def runAskYesNoCancelDialog(self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"):
+    def runAskYesNoCancelDialog(
+        self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"
+    ):
         """Create and run a wxPython askYesNoCancel dialog ."""
 
         if g.app.unitTesting:
@@ -696,7 +703,16 @@ class ironPythonGui(leoGui.leoGui):
             return font
         except:
             g.es("exception setting font from " + repr(family_name))
-            g.es("family,size,slant,weight:" + repr(family) + ':' + repr(size) + ':' + repr(slant) + ':' + repr(weight))
+            g.es(
+                "family,size,slant,weight:"
+                + repr(family)
+                + ':'
+                + repr(size)
+                + ':'
+                + repr(slant)
+                + ':'
+                + repr(weight)
+            )
             g.es_exception()
             return g.app.config.defaultFont
 

--- a/leo/plugins/obsolete/rst3.py
+++ b/leo/plugins/obsolete/rst3.py
@@ -192,7 +192,9 @@ def onCreate(tag, keywords):
 
 
 # @+node:ekr.20050806101253: *3* code_block
-def code_block(name, arguments, options, content, lineno, content_offset, block_text, state, state_machine):
+def code_block(
+    name, arguments, options, content, lineno, content_offset, block_text, state, state_machine
+):
     '''Implement the code-block directive for docutils.'''
 
     try:
@@ -549,7 +551,15 @@ class link_htmlparserClass(linkAnchorParserClass):
                         http_node_ref = mod_http.node_reference(href_node)
                         line, column = self.getpos()
                         if bwm_file:
-                            print >> bwm_file, "link(2):", line, column, href, href_file, http_node_ref
+                            (
+                                print >> bwm_file,
+                                "link(2):",
+                                line,
+                                column,
+                                href,
+                                href_file,
+                                http_node_ref,
+                            )
                         self.replacements.append((line, column, href, href_file, http_node_ref))
 
     # @+node:ekr.20050805162550.56: *4* get_replacements
@@ -765,7 +775,10 @@ class rstClass(object):
     def getOption(self, name):
         bwm = False
         if bwm:
-            g.trace("bwm: getOption self:%s, name:%s, value:%s" % (self, name, self.optionsDict.get(name)))
+            g.trace(
+                "bwm: getOption self:%s, name:%s, value:%s"
+                % (self, name, self.optionsDict.get(name))
+            )
 
         return self.optionsDict.get(name)
 
@@ -1117,7 +1130,9 @@ class rstClass(object):
             h = p.h.strip()
             if g.match_word(h, 0, "@rst"):
                 self.outputFileName = h[4:].strip()
-                if (self.outputFileName and self.outputFileName[0] != '-') or (toString and not self.outputFileName):
+                if (self.outputFileName and self.outputFileName[0] != '-') or (
+                    toString and not self.outputFileName
+                ):
                     found = True
                     self.toplevel = p.level()  # Define toplevel separately for each rst file.
                     if toString:
@@ -1396,13 +1411,18 @@ class rstClass(object):
             lines = self.handleDocOnlyMode(p, lines)
         else:
             lines = self.handleSpecialDocParts(lines, '@rst-options', retainContents=False)
-            lines = self.handleSpecialDocParts(lines, '@rst-markup', retainContents=self.getOption('generate_rst'))
+            lines = self.handleSpecialDocParts(
+                lines, '@rst-markup', retainContents=self.getOption('generate_rst')
+            )
             if self.getOption('show_doc_parts_in_rst_mode') is True:
                 pass  # original behaviour, treat as plain text
             elif self.getOption('show_doc_parts_in_rst_mode'):
                 # use value as class for content
                 lines = self.handleSpecialDocParts(
-                    lines, None, retainContents=True, asClass=self.getOption('show_doc_parts_in_rst_mode')
+                    lines,
+                    None,
+                    retainContents=True,
+                    asClass=self.getOption('show_doc_parts_in_rst_mode'),
                 )
             else:  # option evaluates to false, cut them out
                 lines = self.handleSpecialDocParts(lines, None, retainContents=False)
@@ -1940,13 +1960,17 @@ class rstClass(object):
                     marker = marker_parts[1]
                     replacement = "%s#%s" % (http_node_ref, marker)
                     try:
-                        attr[line + 2] = attr[line + 2].replace('href="%s"' % href, 'href="%s"' % replacement)
+                        attr[line + 2] = attr[line + 2].replace(
+                            'href="%s"' % href, 'href="%s"' % replacement
+                        )
                     except Exception:
                         g.es("Skipped ", attr[line + 2])
                 else:
                     # filename = marker_parts [0]
                     try:
-                        attr[line + 2] = attr[line + 2].replace('href="%s"' % href, 'href="%s"' % http_node_ref)
+                        attr[line + 2] = attr[line + 2].replace(
+                            'href="%s"' % href, 'href="%s"' % http_node_ref
+                        )
                     except Exception:
                         g.es("Skipped", attr[line + 2])
         # g.trace('after %s\n\n\n',attr)

--- a/leo/plugins/obsolete/swing_gui.py
+++ b/leo/plugins/obsolete/swing_gui.py
@@ -73,7 +73,9 @@ class leoSwingDialog:
         self.modal = None
 
         self.buttonsFrame = None  # Frame to hold typical dialog buttons.
-        self.defaultButtonCommand = None  # Command to call when user closes the window by clicking the close box.
+        self.defaultButtonCommand = (
+            None  # Command to call when user closes the window by clicking the close box.
+        )
         self.frame = None  # The outermost frame.
         self.root = None  # g.app.root
         self.showFlag = show
@@ -264,7 +266,9 @@ class swingAboutLeo(leoSwingDialog):
 
         frame.pack(padx=6, pady=4)
 
-        self.text = w = g.app.gui.plainTextWidget(frame, height=height, width=width, bd=0, bg=frame.cget("background"))
+        self.text = w = g.app.gui.plainTextWidget(
+            frame, height=height, width=width, bd=0, bg=frame.cget("background")
+        )
         w.pack(pady=10)
 
         try:
@@ -705,10 +709,21 @@ class swingAskYesNoCancel(leoSwingDialog):
 
     # @+others
     # @+node:ekr.20081121105001.639: *4* askYesNoCancel.__init__
-    def __init__(self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes", resizeable=False):
+    def __init__(
+        self,
+        c,
+        title,
+        message=None,
+        yesMessage="Yes",
+        noMessage="No",
+        defaultButton="Yes",
+        resizeable=False,
+    ):
         """Create a dialog having three buttons."""
 
-        leoSwingDialog.__init__(self, c, title, resizeable, canClose=False)  # Initialize the base class.
+        leoSwingDialog.__init__(
+            self, c, title, resizeable, canClose=False
+        )  # Initialize the base class.
 
         if g.app.unitTesting:
             return
@@ -1360,7 +1375,13 @@ class leoSwingFrame(leoFrame.leoFrame):
     def destroyAllPanels(self):
         """Destroy all panels attached to this frame."""
 
-        panels = (self.comparePanel, self.colorPanel, self.findPanel, self.fontPanel, self.prefsPanel)
+        panels = (
+            self.comparePanel,
+            self.colorPanel,
+            self.findPanel,
+            self.fontPanel,
+            self.prefsPanel,
+        )
 
         for panel in panels:
             if panel:
@@ -1408,7 +1429,12 @@ class leoSwingFrame(leoFrame.leoFrame):
 
             bg = self.statusFrame.cget("background")
             self.textWidget = w = g.app.gui.bodyTextWidget(
-                self.statusFrame, height=1, state="disabled", bg=bg, relief="groove", name='status-line'
+                self.statusFrame,
+                height=1,
+                state="disabled",
+                bg=bg,
+                relief="groove",
+                name='status-line',
             )
             self.textWidget.pack(side="left", expand=1, fill="x")
             w.bind("<Button-1>", self.onActivate)
@@ -2317,7 +2343,9 @@ class leoSwingFrame(leoFrame.leoFrame):
             # @+node:ekr.20081121105001.743: *8* << create the scale widget >>
             top = Tk.Toplevel()
             top.title("Download progress")
-            self.scale = scale = Tk.Scale(top, state="normal", orient="horizontal", from_=0, to=total)
+            self.scale = scale = Tk.Scale(
+                top, state="normal", orient="horizontal", from_=0, to=total
+            )
             scale.pack()
             top.lift()
             # @-<< create the scale widget >>
@@ -2828,7 +2856,11 @@ class leoSwingMenu(leoMenu.leoMenu):
             weight = config.get(c, "jyshell_text_font_weight", "weight")
             slant = None
             font = config.getFontFromParams(
-                c, "jyshell_text_font_family", "jyshell_text_font_size", None, "jyshell_text_font_weight"
+                c,
+                "jyshell_text_font_family",
+                "jyshell_text_font_size",
+                None,
+                "jyshell_text_font_weight",
             )
 
             use_bgimage = g.app.config.getBool(c, "jyshell_background_image")
@@ -3419,7 +3451,13 @@ class leoSwingLog(leoFrame.leoLog):
         self.logNumber += 1
 
         log = g.app.gui.plainTextWidget(
-            parentFrame, name="log-%d" % self.logNumber, setgrid=0, wrap=self.wrap, bd=2, bg="white", relief="flat"
+            parentFrame,
+            name="log-%d" % self.logNumber,
+            setgrid=0,
+            wrap=self.wrap,
+            bd=2,
+            bg="white",
+            relief="flat",
         )
 
         return log
@@ -4796,29 +4834,47 @@ class leoSwingTree(leoFrame.leoTree):
         self.expanded_click_area = c.config.getBool('expanded_click_area')
         self.gc_before_redraw = c.config.getBool('gc_before_redraw')
 
-        self.headline_text_editing_foreground_color = c.config.getColor('headline_text_editing_foreground_color')
-        self.headline_text_editing_background_color = c.config.getColor('headline_text_editing_background_color')
+        self.headline_text_editing_foreground_color = c.config.getColor(
+            'headline_text_editing_foreground_color'
+        )
+        self.headline_text_editing_background_color = c.config.getColor(
+            'headline_text_editing_background_color'
+        )
         self.headline_text_editing_selection_foreground_color = c.config.getColor(
             'headline_text_editing_selection_foreground_color'
         )
         self.headline_text_editing_selection_background_color = c.config.getColor(
             'headline_text_editing_selection_background_color'
         )
-        self.headline_text_selected_foreground_color = c.config.getColor("headline_text_selected_foreground_color")
-        self.headline_text_selected_background_color = c.config.getColor("headline_text_selected_background_color")
+        self.headline_text_selected_foreground_color = c.config.getColor(
+            "headline_text_selected_foreground_color"
+        )
+        self.headline_text_selected_background_color = c.config.getColor(
+            "headline_text_selected_background_color"
+        )
         self.headline_text_editing_selection_foreground_color = c.config.getColor(
             "headline_text_editing_selection_foreground_color"
         )
         self.headline_text_editing_selection_background_color = c.config.getColor(
             "headline_text_editing_selection_background_color"
         )
-        self.headline_text_unselected_foreground_color = c.config.getColor('headline_text_unselected_foreground_color')
-        self.headline_text_unselected_background_color = c.config.getColor('headline_text_unselected_background_color')
+        self.headline_text_unselected_foreground_color = c.config.getColor(
+            'headline_text_unselected_foreground_color'
+        )
+        self.headline_text_unselected_background_color = c.config.getColor(
+            'headline_text_unselected_background_color'
+        )
 
         self.idle_redraw = c.config.getBool('idle_redraw')
-        self.initialClickExpandsOrContractsNode = c.config.getBool('initialClickExpandsOrContractsNode')
-        self.look_for_control_drag_on_mouse_down = c.config.getBool('look_for_control_drag_on_mouse_down')
-        self.select_all_text_when_editing_headlines = c.config.getBool('select_all_text_when_editing_headlines')
+        self.initialClickExpandsOrContractsNode = c.config.getBool(
+            'initialClickExpandsOrContractsNode'
+        )
+        self.look_for_control_drag_on_mouse_down = c.config.getBool(
+            'look_for_control_drag_on_mouse_down'
+        )
+        self.select_all_text_when_editing_headlines = c.config.getBool(
+            'select_all_text_when_editing_headlines'
+        )
 
         self.stayInTree = c.config.getBool('stayInTreeAfterSelect')
         self.trace = c.config.getBool('trace_tree')
@@ -5027,7 +5083,9 @@ class leoSwingTree(leoFrame.leoTree):
             theId = self.freeLines.pop(0)
             canvas.coords(theId, x1, y1, x2, y2)
         else:
-            theId = canvas.create_line(x1, y1, x2, y2, tag="lines", fill="gray50")  # stipple="gray25")
+            theId = canvas.create_line(
+                x1, y1, x2, y2, tag="lines", fill="gray50"
+            )  # stipple="gray25")
             if self.trace_alloc:
                 g.trace("%3d %s" % (theId, p and p.h), align=-20)
 
@@ -5053,7 +5111,13 @@ class leoSwingTree(leoFrame.leoTree):
             # Tags are not valid in Tk.Text widgets.
             self.textNumber += 1
             w = g.app.gui.plainTextWidget(
-                canvas, name='head-%d' % self.textNumber, state="normal", font=self.font, bd=0, relief="flat", height=1
+                canvas,
+                name='head-%d' % self.textNumber,
+                state="normal",
+                font=self.font,
+                bd=0,
+                relief="flat",
+                height=1,
             )
             ### w.bindtags(self.textBindings) # Set the bindings for this widget.
 
@@ -5663,10 +5727,16 @@ class leoSwingTree(leoFrame.leoTree):
         self.drag_p = None  # Disable drags across redraws.
         self.dragging = False
         if trace:
-            g.trace('redrawCount', self.redrawCount, g.callers())  # 'len(c.hoistStack)',len(c.hoistStack))
+            g.trace(
+                'redrawCount', self.redrawCount, g.callers()
+            )  # 'len(c.hoistStack)',len(c.hoistStack))
             if 0:
                 delta = g.app.positions - self.prevPositions
-                g.trace("**** gen: %-3d positions: %5d +%4d" % (self.generation, g.app.positions, delta), g.callers())
+                g.trace(
+                    "**** gen: %-3d positions: %5d +%4d"
+                    % (self.generation, g.app.positions, delta),
+                    g.callers(),
+                )
 
         self.prevPositions = g.app.positions
         if self.trace_gc:
@@ -5706,7 +5776,18 @@ class leoSwingTree(leoFrame.leoTree):
         c = self.c
         yfirst = ylast = y
         h1 = None
-        data = g.doHook("draw-sub-outline", tree=tree, c=c, p=p, v=p, x=x, y=y, h=h, level=level, hoistFlag=hoistFlag)
+        data = g.doHook(
+            "draw-sub-outline",
+            tree=tree,
+            c=c,
+            p=p,
+            v=p,
+            x=x,
+            y=y,
+            h=h,
+            level=level,
+            hoistFlag=hoistFlag,
+        )
         if data is not None:
             return data
 
@@ -6895,7 +6976,12 @@ class leoSwingTree(leoFrame.leoTree):
 
         try:  # Use system defaults for selection foreground/background
             w.configure(
-                state="normal", highlightthickness=1, fg=fg, bg=bg, selectforeground=selfg, selectbackground=selbg
+                state="normal",
+                highlightthickness=1,
+                fg=fg,
+                bg=bg,
+                selectforeground=selfg,
+                selectbackground=selbg,
             )
         except:
             g.es_exception()
@@ -7069,9 +7155,13 @@ class swingGui(leoGui.leoGui):
         d = leoSwingDialog.swingAskYesNo(c, title, message)
         return d.run(modal=True)
 
-    def runAskYesNoCancelDialog(self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"):
+    def runAskYesNoCancelDialog(
+        self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"
+    ):
         """Create and run an askYesNoCancel dialog ."""
-        d = leoSwingDialog.swingAskYesNoCancel(c, title, message, yesMessage, noMessage, defaultButton)
+        d = leoSwingDialog.swingAskYesNoCancel(
+            c, title, message, yesMessage, noMessage, defaultButton
+        )
         return d.run(modal=True)
 
     # @+node:ekr.20081121105001.1039: *4* swingGui.createSpellTab
@@ -7093,17 +7183,25 @@ class swingGui(leoGui.leoGui):
         if multiple:
             # askopenfilenames requires Python 2.3 and Tk 8.4.
             version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
-            if g.CheckVersion(version, "2.3") and g.CheckVersion(self.root.getvar("tk_patchLevel"), "8.4"):
-                files = swingFileDialog.askopenfilenames(title=title, filetypes=filetypes, initialdir=initialdir)
+            if g.CheckVersion(version, "2.3") and g.CheckVersion(
+                self.root.getvar("tk_patchLevel"), "8.4"
+            ):
+                files = swingFileDialog.askopenfilenames(
+                    title=title, filetypes=filetypes, initialdir=initialdir
+                )
                 # g.trace(files)
                 return list(files)
             else:
                 # Get one file and return it as a list.
-                theFile = swingFileDialog.askopenfilename(title=title, filetypes=filetypes, initialdir=initialdir)
+                theFile = swingFileDialog.askopenfilename(
+                    title=title, filetypes=filetypes, initialdir=initialdir
+                )
                 return [theFile]
         else:
             # Return a single file name as a string.
-            return swingFileDialog.askopenfilename(title=title, filetypes=filetypes, initialdir=initialdir)
+            return swingFileDialog.askopenfilename(
+                title=title, filetypes=filetypes, initialdir=initialdir
+            )
 
     # @+node:ekr.20081121105001.1042: *5* runSaveFileDialog
     def runSaveFileDialog(self, initialfile, title, filetypes, defaultextension):
@@ -7304,7 +7402,8 @@ class swingGui(leoGui.leoGui):
             self.set_focus_count += 1
             # Do not call trace here: that might affect focus!
             print(
-                'gui.set_focus: %4d %10s %s' % (self.set_focus_count, c and c.shortFileName(), c and c.widget_name(w)),
+                'gui.set_focus: %4d %10s %s'
+                % (self.set_focus_count, c and c.shortFileName(), c and c.widget_name(w)),
                 g.callers(5),
             )
 
@@ -7481,12 +7580,16 @@ class swingGui(leoGui.leoGui):
                 b.pack_forget()
             c.bodyWantsFocus()
 
-        def executeScriptCallback(event=None, b=b, c=c, buttonText=buttonText, p=p and p.copy(), script=script):
+        def executeScriptCallback(
+            event=None, b=b, c=c, buttonText=buttonText, p=p and p.copy(), script=script
+        ):
             if c.disableCommandsMessage:
                 g.es(c.disableCommandsMessage, color='blue')
             else:
                 g.app.scriptDict = {}
-                c.executeScript(p=p, script=script, define_g=define_g, define_name=define_name, silent=silent)
+                c.executeScript(
+                    p=p, script=script, define_g=define_g, define_name=define_name, silent=silent
+                )
                 # Remove the button if the script asks to be removed.
                 if g.app.scriptDict.get('removeMe'):
                     g.es("Removing '%s' button at its request" % buttonText)
@@ -7514,7 +7617,9 @@ class swingGui(leoGui.leoGui):
         buttonCommandName = 'press-%s-button' % buttonCommandName.lower()
 
         # This will use any shortcut defined in an @shortcuts node.
-        k.registerCommand(buttonCommandName, None, executeScriptCallback, pane='button', verbose=False)
+        k.registerCommand(
+            buttonCommandName, None, executeScriptCallback, pane='button', verbose=False
+        )
         # @-<< create press-buttonText-button command >>
 
     # @+node:ekr.20081121105001.1073: *3* class leoKeyEvent (swingGui)
@@ -7541,7 +7646,10 @@ class swingGui(leoGui.leoGui):
             self.widget = self.w
 
         def __repr__(self):
-            return 'swingGui.leoKeyEvent: char: %s, keysym: %s' % (repr(self.char), repr(self.keysym))
+            return 'swingGui.leoKeyEvent: char: %s, keysym: %s' % (
+                repr(self.char),
+                repr(self.keysym),
+            )
 
     # @-others
 

--- a/leo/plugins/obsolete/tkGui.py
+++ b/leo/plugins/obsolete/tkGui.py
@@ -263,7 +263,9 @@ class tkinterGui(leoGui.leoGui):
         d = tkinterAskYesNo(c, title, message)
         return d.run(modal=True)
 
-    def runAskYesNoCancelDialog(self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"):
+    def runAskYesNoCancelDialog(
+        self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"
+    ):
         """Create and run an askYesNoCancel dialog ."""
         d = tkinterAskYesNoCancel(c, title, message, yesMessage, noMessage, defaultButton)
         return d.run(modal=True)
@@ -306,17 +308,25 @@ class tkinterGui(leoGui.leoGui):
         if multiple:
             # askopenfilenames requires Python 2.3 and Tk 8.4.
             version = '.'.join([str(sys.version_info[i]) for i in (0, 1, 2)])
-            if g.CheckVersion(version, "2.3") and g.CheckVersion(self.root.getvar("tk_patchLevel"), "8.4"):
-                files = tkFileDialog.askopenfilenames(title=title, filetypes=filetypes, initialdir=initialdir)
+            if g.CheckVersion(version, "2.3") and g.CheckVersion(
+                self.root.getvar("tk_patchLevel"), "8.4"
+            ):
+                files = tkFileDialog.askopenfilenames(
+                    title=title, filetypes=filetypes, initialdir=initialdir
+                )
                 # g.trace(files)
                 return list(files)
             else:
                 # Get one file and return it as a list.
-                theFile = tkFileDialog.askopenfilename(title=title, filetypes=filetypes, initialdir=initialdir)
+                theFile = tkFileDialog.askopenfilename(
+                    title=title, filetypes=filetypes, initialdir=initialdir
+                )
                 return [theFile]
         else:
             # Return a single file name as a string.
-            return tkFileDialog.askopenfilename(title=title, filetypes=filetypes, initialdir=initialdir)
+            return tkFileDialog.askopenfilename(
+                title=title, filetypes=filetypes, initialdir=initialdir
+            )
 
     # @+node:ekr.20081121110412.370: *5* runSaveFileDialog
     def runSaveFileDialog(self, initialfile, title, filetypes, defaultextension):
@@ -517,7 +527,8 @@ class tkinterGui(leoGui.leoGui):
             self.set_focus_count += 1
             # Do not call trace here: that might affect focus!
             g.pr(
-                'gui.set_focus: %4d %10s %s' % (self.set_focus_count, c and c.shortFileName(), c and c.widget_name(w)),
+                'gui.set_focus: %4d %10s %s'
+                % (self.set_focus_count, c and c.shortFileName(), c and c.widget_name(w)),
                 g.callers(5),
             )
 
@@ -754,7 +765,12 @@ class tkinterGui(leoGui.leoGui):
             else:
                 g.app.scriptDict = {}
                 c.executeScript(
-                    args=args, p=p, script=script, define_g=define_g, define_name=define_name, silent=silent
+                    args=args,
+                    p=p,
+                    script=script,
+                    define_g=define_g,
+                    define_name=define_name,
+                    silent=silent,
                 )
                 # Remove the button if the script asks to be removed.
                 if g.app.scriptDict.get('removeMe'):
@@ -783,7 +799,9 @@ class tkinterGui(leoGui.leoGui):
         buttonCommandName = 'press-%s-button' % buttonCommandName.lower()
 
         # This will use any shortcut defined in an @shortcuts node.
-        k.registerCommand(buttonCommandName, None, executeScriptCallback, pane='button', verbose=False)
+        k.registerCommand(
+            buttonCommandName, None, executeScriptCallback, pane='button', verbose=False
+        )
         # @-<< create press-buttonText-button command >>
 
     # @+node:ekr.20081121110412.401: *4* killPopupMenu
@@ -951,9 +969,9 @@ class TkPropertiesDialog:
         buttons.extend(("OK", "Cancel"))
 
         for name in buttons:
-            Tk.Button(box, text=name, width=6, command=lambda self=self, name=name: self.onButton(name)).pack(
-                side="left", padx=5
-            )
+            Tk.Button(
+                box, text=name, width=6, command=lambda self=self, name=name: self.onButton(name)
+            ).pack(side="left", padx=5)
 
         # @-<< Create the buttons >>
 
@@ -994,7 +1012,9 @@ class TkPropertiesDialog:
             if section not in data:
                 data[section] = {}
             s = entry.get()
-            s = g.toEncodedString(s, "ascii", reportErrors=True)  # Config params had better be ascii.
+            s = g.toEncodedString(
+                s, "ascii", reportErrors=True
+            )  # Config params had better be ascii.
             data[section][option] = s
 
         return data
@@ -1043,7 +1063,9 @@ class leoTkinterDialog:
         self.modal = None
 
         self.buttonsFrame = None  # Frame to hold typical dialog buttons.
-        self.defaultButtonCommand = None  # Command to call when user closes the window by clicking the close box.
+        self.defaultButtonCommand = (
+            None  # Command to call when user closes the window by clicking the close box.
+        )
         self.frame = None  # The outermost frame.
         self.root = None  # g.app.root
         self.showFlag = show
@@ -1293,9 +1315,9 @@ class leoTkinterPropertiesDialog:
         buttons.extend(("OK", "Cancel"))
 
         for name in buttons:
-            Tk.Button(box, text=name, width=6, command=lambda self=self, name=name: self.onButton(name)).pack(
-                side="left", padx=5
-            )
+            Tk.Button(
+                box, text=name, width=6, command=lambda self=self, name=name: self.onButton(name)
+            ).pack(side="left", padx=5)
 
         # @-<< Create the buttons >>
 
@@ -1336,7 +1358,9 @@ class leoTkinterPropertiesDialog:
             if section not in data:
                 data[section] = {}
             s = entry.get()
-            s = g.toEncodedString(s, "ascii", reportErrors=True)  # Config params had better be ascii.
+            s = g.toEncodedString(
+                s, "ascii", reportErrors=True
+            )  # Config params had better be ascii.
             data[section][option] = s
 
         return data
@@ -1552,8 +1576,20 @@ class leoTkinterComparePanel(leoCompare.leoCompare, leoTkinterDialog):
         # @+<< create the browser rows >>
         # @+node:ekr.20081121110412.15: *6* << create the browser rows >>
         for row, text, text2, command, var in (
-            (row1, "Compare path 1:", "Ignore first line", self.onBrowse1, self.ignoreFirstLine1Var),
-            (row2, "Compare path 2:", "Ignore first line", self.onBrowse2, self.ignoreFirstLine2Var),
+            (
+                row1,
+                "Compare path 1:",
+                "Ignore first line",
+                self.onBrowse1,
+                self.ignoreFirstLine1Var,
+            ),
+            (
+                row2,
+                "Compare path 2:",
+                "Ignore first line",
+                self.onBrowse2,
+                self.ignoreFirstLine2Var,
+            ),
             (row3, "Output file:", "Use output file", self.onBrowse3, self.useOutputFileVar),
         ):
             lab = Tk.Label(row, anchor="e", text=text, width=13)
@@ -1571,13 +1607,17 @@ class leoTkinterComparePanel(leoCompare.leoCompare, leoTkinterDialog):
         # @-<< create the browser rows >>
         # @+<< create the extension row >>
         # @+node:ekr.20081121110412.16: *6* << create the extension row >>
-        b = Tk.Checkbutton(row4, anchor="w", var=self.limitToExtensionVar, text="Limit directory compares to type:")
+        b = Tk.Checkbutton(
+            row4, anchor="w", var=self.limitToExtensionVar, text="Limit directory compares to type:"
+        )
         b.pack(side="left", padx=4)
 
         self.extensionEntry = e = Tk.Entry(row4, width=6)
         e.pack(side="left", padx=2)
 
-        b = Tk.Checkbutton(row4, anchor="w", var=self.appendOutputVar, text="Append output to output file")
+        b = Tk.Checkbutton(
+            row4, anchor="w", var=self.appendOutputVar, text="Append output to output file"
+        )
         b.pack(side="left", padx=4)
         # @-<< create the extension row >>
         # @+<< create the whitespace options frame >>
@@ -1803,7 +1843,9 @@ class tkinterAboutLeo(leoTkinterDialog):
     def __init__(self, c, version, theCopyright, url, email):
         """Create a Tkinter About Leo dialog."""
 
-        leoTkinterDialog.__init__(self, c, "About Leo", resizeable=True)  # Initialize the base class.
+        leoTkinterDialog.__init__(
+            self, c, "About Leo", resizeable=True
+        )  # Initialize the base class.
 
         if g.app.unitTesting:
             return
@@ -1844,7 +1886,9 @@ class tkinterAboutLeo(leoTkinterDialog):
 
         frame.pack(padx=6, pady=4)
 
-        self.text = w = g.app.gui.plainTextWidget(frame, height=height, width=width, bd=0, bg=frame.cget("background"))
+        self.text = w = g.app.gui.plainTextWidget(
+            frame, height=height, width=width, bd=0, bg=frame.cget("background")
+        )
         w.pack(pady=10)
 
         try:
@@ -2281,10 +2325,21 @@ class tkinterAskYesNoCancel(leoTkinterDialog):
 
     # @+others
     # @+node:ekr.20081121110412.69: *4* askYesNoCancel.__init__
-    def __init__(self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes", resizeable=False):
+    def __init__(
+        self,
+        c,
+        title,
+        message=None,
+        yesMessage="Yes",
+        noMessage="No",
+        defaultButton="Yes",
+        resizeable=False,
+    ):
         """Create a dialog having three buttons."""
 
-        leoTkinterDialog.__init__(self, c, title, resizeable, canClose=False)  # Initialize the base class.
+        leoTkinterDialog.__init__(
+            self, c, title, resizeable, canClose=False
+        )  # Initialize the base class.
 
         if g.app.unitTesting:
             return
@@ -2696,7 +2751,13 @@ class tkFindTab(leoFind.findTab):
         for i in range(numberOfColumns):
             for var, name, val in radioLists[i]:
                 box = underlinedTkButton(
-                    "radio", columns[i], anchor="w", text=name, variable=var, value=val, background=bg
+                    "radio",
+                    columns[i],
+                    anchor="w",
+                    text=name,
+                    variable=var,
+                    value=val,
+                    background=bg,
                 )
                 box.button.pack(fill="x")
                 c.bind(box.button, "<Button-1>", self.resetWrap)
@@ -2705,7 +2766,9 @@ class tkFindTab(leoFind.findTab):
                 box.bindHotKey(ftxt)
                 box.bindHotKey(ctxt)
             for name, var in checkLists[i]:
-                box = underlinedTkButton("check", columns[i], anchor="w", text=name, variable=var, background=bg)
+                box = underlinedTkButton(
+                    "check", columns[i], anchor="w", text=name, variable=var, background=bg
+                )
                 box.button.pack(fill="x")
                 c.bind(box.button, "<Button-1>", self.resetWrap)
                 box.bindHotKey(ftxt)
@@ -2821,7 +2884,10 @@ class tkFindTab(leoFind.findTab):
         # @+<< set radio buttons from ivars >>
         # @+node:ekr.20081121110412.100: *6* << set radio buttons from ivars >>
         found = False
-        for var, setting in (("pattern_match", "pattern-search"), ("script_search", "script-search")):
+        for var, setting in (
+            ("pattern_match", "pattern-search"),
+            ("script_search", "script-search"),
+        ):
             val = self.svarDict[var].get()
             if val:
                 self.svarDict["radio-find-type"].set(setting)
@@ -3308,7 +3374,9 @@ class leoTkinterBody(leoFrame.leoBody):
         wrap = g.choose(wrap, "word", "none")
 
         # Setgrid=1 cause severe problems with the font panel.
-        body = w = leoTkTextWidget(parentFrame, name='body-pane', bd=2, bg="white", relief="flat", setgrid=0, wrap=wrap)
+        body = w = leoTkTextWidget(
+            parentFrame, name='body-pane', bd=2, bg="white", relief="flat", setgrid=0, wrap=wrap
+        )
 
         bodyBar = Tk.Scrollbar(parentFrame, name='bodyBar')
 
@@ -3815,7 +3883,9 @@ class leoTkinterFrame(leoFrame.leoFrame):
 
     def createLeoSplitters(self, parentFrame):
         # Splitter 1 is the main splitter.
-        f1, bar1, split1Pane1, split1Pane2 = self.createLeoTkSplitter(parentFrame, self.splitVerticalFlag, 'splitter1')
+        f1, bar1, split1Pane1, split1Pane2 = self.createLeoTkSplitter(
+            parentFrame, self.splitVerticalFlag, 'splitter1'
+        )
 
         self.f1, self.bar1 = f1, bar1
         self.split1Pane1, self.split1Pane2 = split1Pane1, split1Pane2
@@ -4014,7 +4084,13 @@ class leoTkinterFrame(leoFrame.leoFrame):
     def destroyAllPanels(self):
         """Destroy all panels attached to this frame."""
 
-        panels = (self.comparePanel, self.colorPanel, self.findPanel, self.fontPanel, self.prefsPanel)
+        panels = (
+            self.comparePanel,
+            self.colorPanel,
+            self.findPanel,
+            self.fontPanel,
+            self.prefsPanel,
+        )
 
         for panel in panels:
             if panel:
@@ -4070,7 +4146,12 @@ class leoTkinterFrame(leoFrame.leoFrame):
 
             bg = self.statusFrame.cget("background")
             self.textWidget = w = g.app.gui.bodyTextWidget(
-                self.statusFrame, height=1, state="disabled", bg=bg, relief="groove", name='status-line'
+                self.statusFrame,
+                height=1,
+                state="disabled",
+                bg=bg,
+                relief="groove",
+                name='status-line',
             )
             self.textWidget.pack(side="left", expand=1, fill="x")
             c.bind(w, "<Button-1>", self.onActivate)
@@ -4447,7 +4528,9 @@ class leoTkinterFrame(leoFrame.leoFrame):
         lab = Tk.Label(f, text='mini-buffer', justify='left', anchor='nw', foreground='blue')
         lab.pack(side='left')
 
-        label = g.app.gui.plainTextWidget(f, height=1, relief='groove', background='lightgrey', name='minibuffer')
+        label = g.app.gui.plainTextWidget(
+            f, height=1, relief='groove', background='lightgrey', name='minibuffer'
+        )
         label.pack(side='left', fill='x', expand=1, padx=2, pady=1)
 
         frame.minibufferVisible = c.showMinibuffer
@@ -5107,7 +5190,9 @@ class leoTkinterFrame(leoFrame.leoFrame):
             # @+node:ekr.20081121110412.242: *8* << create the scale widget >>
             top = Tk.Toplevel()
             top.title("Download progress")
-            self.scale = scale = Tk.Scale(top, state="normal", orient="horizontal", from_=0, to=total)
+            self.scale = scale = Tk.Scale(
+                top, state="normal", orient="horizontal", from_=0, to=total
+            )
             scale.pack()
             top.lift()
             # @-<< create the scale widget >>
@@ -5262,7 +5347,13 @@ class leoTkinterLog(leoFrame.leoLog):
     def createTextWidget(self, parentFrame):
         self.logNumber += 1
         log = g.app.gui.plainTextWidget(
-            parentFrame, name="log-%d" % self.logNumber, setgrid=0, wrap=self.wrap, bd=2, bg="white", relief="flat"
+            parentFrame,
+            name="log-%d" % self.logNumber,
+            setgrid=0,
+            wrap=self.wrap,
+            bd=2,
+            bg="white",
+            relief="flat",
         )
 
         logBar = Tk.Scrollbar(parentFrame, name="logBar")
@@ -6704,29 +6795,47 @@ class leoTkinterTree(leoFrame.leoTree):
         self.expanded_click_area = c.config.getBool('expanded_click_area')
         self.gc_before_redraw = c.config.getBool('gc_before_redraw')
 
-        self.headline_text_editing_foreground_color = c.config.getColor('headline_text_editing_foreground_color')
-        self.headline_text_editing_background_color = c.config.getColor('headline_text_editing_background_color')
+        self.headline_text_editing_foreground_color = c.config.getColor(
+            'headline_text_editing_foreground_color'
+        )
+        self.headline_text_editing_background_color = c.config.getColor(
+            'headline_text_editing_background_color'
+        )
         self.headline_text_editing_selection_foreground_color = c.config.getColor(
             'headline_text_editing_selection_foreground_color'
         )
         self.headline_text_editing_selection_background_color = c.config.getColor(
             'headline_text_editing_selection_background_color'
         )
-        self.headline_text_selected_foreground_color = c.config.getColor("headline_text_selected_foreground_color")
-        self.headline_text_selected_background_color = c.config.getColor("headline_text_selected_background_color")
+        self.headline_text_selected_foreground_color = c.config.getColor(
+            "headline_text_selected_foreground_color"
+        )
+        self.headline_text_selected_background_color = c.config.getColor(
+            "headline_text_selected_background_color"
+        )
         self.headline_text_editing_selection_foreground_color = c.config.getColor(
             "headline_text_editing_selection_foreground_color"
         )
         self.headline_text_editing_selection_background_color = c.config.getColor(
             "headline_text_editing_selection_background_color"
         )
-        self.headline_text_unselected_foreground_color = c.config.getColor('headline_text_unselected_foreground_color')
-        self.headline_text_unselected_background_color = c.config.getColor('headline_text_unselected_background_color')
+        self.headline_text_unselected_foreground_color = c.config.getColor(
+            'headline_text_unselected_foreground_color'
+        )
+        self.headline_text_unselected_background_color = c.config.getColor(
+            'headline_text_unselected_background_color'
+        )
 
         self.idle_redraw = c.config.getBool('idle_redraw')
-        self.initialClickExpandsOrContractsNode = c.config.getBool('initialClickExpandsOrContractsNode')
-        self.look_for_control_drag_on_mouse_down = c.config.getBool('look_for_control_drag_on_mouse_down')
-        self.select_all_text_when_editing_headlines = c.config.getBool('select_all_text_when_editing_headlines')
+        self.initialClickExpandsOrContractsNode = c.config.getBool(
+            'initialClickExpandsOrContractsNode'
+        )
+        self.look_for_control_drag_on_mouse_down = c.config.getBool(
+            'look_for_control_drag_on_mouse_down'
+        )
+        self.select_all_text_when_editing_headlines = c.config.getBool(
+            'select_all_text_when_editing_headlines'
+        )
 
         self.stayInTree = c.config.getBool('stayInTreeAfterSelect')
         self.trace = c.config.getBool('trace_tree')
@@ -7015,7 +7124,9 @@ class leoTkinterTree(leoFrame.leoTree):
             del d[theId]
             canvas.coords(theId, x1, y1, x2, y2)
         else:
-            theId = canvas.create_line(x1, y1, x2, y2, tag="lines", fill="gray50")  # stipple="gray25")
+            theId = canvas.create_line(
+                x1, y1, x2, y2, tag="lines", fill="gray50"
+            )  # stipple="gray25")
             if self.trace_alloc:
                 g.trace("%3d %s" % (theId, p and p.h), align=-20)
 
@@ -7045,7 +7156,13 @@ class leoTkinterTree(leoFrame.leoTree):
             # Tags are not valid in Tk.Text widgets.
             self.textNumber += 1
             w = g.app.gui.plainTextWidget(
-                canvas, name='head-%d' % self.textNumber, state="normal", font=self.font, bd=0, relief="flat", height=1
+                canvas,
+                name='head-%d' % self.textNumber,
+                state="normal",
+                font=self.font,
+                bd=0,
+                relief="flat",
+                height=1,
             )
             w.bindtags(self.textBindings)  # Set the bindings for this widget.
 
@@ -7695,7 +7812,9 @@ class leoTkinterTree(leoFrame.leoTree):
                     image = None
 
             if image:
-                theId = self.canvas.create_image(x + xoffset + w2, y + yoffset, anchor="nw", image=image)
+                theId = self.canvas.create_image(
+                    x + xoffset + w2, y + yoffset, anchor="nw", image=image
+                )
 
                 tag = 'userIcon-%s' % theId
                 self.canvas.itemconfigure(theId, tag=(tag, 'userIcon'))  # BJ
@@ -7754,7 +7873,11 @@ class leoTkinterTree(leoFrame.leoTree):
             # 'len(c.hoistStack)',len(c.hoistStack))
             if 0:
                 delta = g.app.positions - self.prevPositions
-                g.trace("**** gen: %-3d positions: %5d +%4d" % (self.generation, g.app.positions, delta), g.callers())
+                g.trace(
+                    "**** gen: %-3d positions: %5d +%4d"
+                    % (self.generation, g.app.positions, delta),
+                    g.callers(),
+                )
 
         self.prevPositions = g.app.positions
         if self.trace_gc:
@@ -7794,7 +7917,18 @@ class leoTkinterTree(leoFrame.leoTree):
         c = self.c
         yfirst = ylast = y
         h1 = None
-        data = g.doHook("draw-sub-outline", tree=tree, c=c, p=p, v=p, x=x, y=y, h=h, level=level, hoistFlag=hoistFlag)
+        data = g.doHook(
+            "draw-sub-outline",
+            tree=tree,
+            c=c,
+            p=p,
+            v=p,
+            x=x,
+            y=y,
+            h=h,
+            level=level,
+            hoistFlag=hoistFlag,
+        )
         if data is not None:
             return data
 
@@ -7935,7 +8069,10 @@ class leoTkinterTree(leoFrame.leoTree):
                     self.prevMoveToFrac = frac0
                     self.canvas.yview("moveto", frac0)
                     if trace:
-                        g.trace("frac0 %1.2f h1 %3d htot %3d wtot %3d" % (frac0, h1, htot, wtot), g.callers())
+                        g.trace(
+                            "frac0 %1.2f h1 %3d htot %3d wtot %3d" % (frac0, h1, htot, wtot),
+                            g.callers(),
+                        )
             else:
                 last = c.lastVisible()
                 nextToLast = last.visBack(c)
@@ -7971,14 +8108,20 @@ class leoTkinterTree(leoFrame.leoTree):
                         self.prevMoveToFrac = frac
                         self.canvas.yview("moveto", frac)
                         if trace:
-                            g.trace("frac  %1.2f h1 %3d h2 %3d lo %1.2f hi %1.2f" % (frac, h1, h2, lo, hi), g.callers())
+                            g.trace(
+                                "frac  %1.2f h1 %3d h2 %3d lo %1.2f hi %1.2f"
+                                % (frac, h1, h2, lo, hi),
+                                g.callers(),
+                            )
                 elif frac2 + (hi - lo) >= hi:  # frac2 is for scrolling up.
                     if self.prevMoveToFrac != frac2:
                         self.prevMoveToFrac = frac2
                         self.canvas.yview("moveto", frac2)
                         if trace:
                             g.trace(
-                                "frac2 %1.2f h1 %3d h2 %3d lo %1.2f hi %1.2f" % (frac2, h1, h2, lo, hi), g.callers()
+                                "frac2 %1.2f h1 %3d h2 %3d lo %1.2f hi %1.2f"
+                                % (frac2, h1, h2, lo, hi),
+                                g.callers(),
                             )
 
             if self.allocateOnlyVisibleNodes:
@@ -9076,7 +9219,12 @@ class leoTkinterTree(leoFrame.leoTree):
 
         try:  # Use system defaults for selection foreground/background
             w.configure(
-                state="normal", highlightthickness=1, fg=fg, bg=bg, selectforeground=selfg, selectbackground=selbg
+                state="normal",
+                highlightthickness=1,
+                fg=fg,
+                bg=bg,
+                selectforeground=selfg,
+                selectbackground=selbg,
             )
         except:
             g.es_exception()
@@ -9354,7 +9502,9 @@ class leoTkTextWidget(Tk.Text):
                 sel = Tk.Text.tag_ranges(w, "sel")
                 i, j = sel
                 # This is required for the unit test.
-                anchor = g.choose(hasattr(w, 'leo_text_anchor') and w.leo_text_anchor, w.leo_text_anchor, i)
+                anchor = g.choose(
+                    hasattr(w, 'leo_text_anchor') and w.leo_text_anchor, w.leo_text_anchor, i
+                )
                 extend = True
                 anchor, ins = ins, anchor
                 newIns = ins

--- a/leo/plugins/obsolete/wxGui.py
+++ b/leo/plugins/obsolete/wxGui.py
@@ -338,7 +338,10 @@ class wxFindPanel(wx.Panel):
 
         # Label.
         findSizer.Add(
-            wx.StaticText(self, -1, "Find:", wx.Point(-1, 10), wx.Size(50, 25), 0, ""), 0, wx.BORDER | wx.TOP, 15
+            wx.StaticText(self, -1, "Find:", wx.Point(-1, 10), wx.Size(50, 25), 0, ""),
+            0,
+            wx.BORDER | wx.TOP,
+            15,
         )  # Vertical offset.
 
         findSizer.Add(10, 0)  # Width.
@@ -370,7 +373,10 @@ class wxFindPanel(wx.Panel):
 
         # Label.
         changeSizer.Add(
-            wx.StaticText(self, -1, "Change:", wx.Point(-1, 10), wx.Size(50, 25), 0, ""), 0, wx.BORDER | wx.TOP, 15
+            wx.StaticText(self, -1, "Change:", wx.Point(-1, 10), wx.Size(50, 25), 0, ""),
+            0,
+            wx.BORDER | wx.TOP,
+            15,
         )  # Vertical offset.
 
         changeSizer.Add(10, 0)  # Width.
@@ -410,7 +416,9 @@ class wxFindPanel(wx.Panel):
 
         for var, label, style in table:
             id = wx.NewId()
-            box = wx.RadioButton(self, id, label, wx.DefaultPosition, (100, 25), style, wx.DefaultValidator, "group1")
+            box = wx.RadioButton(
+                self, id, label, wx.DefaultPosition, (100, 25), style, wx.DefaultValidator, "group1"
+            )
 
             if style == wx.RB_GROUP:
                 box.SetValue(True)  # The default entry.
@@ -422,7 +430,9 @@ class wxFindPanel(wx.Panel):
 
         for var, label in table:
             id = wx.NewId()
-            box = wx.CheckBox(self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, "")
+            box = wx.CheckBox(
+                self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, ""
+            )
 
             col1Sizer.Add(box, 0, wx.BORDER | wx.LEFT, 60)
             self.frame.dict[var] = box, id
@@ -441,7 +451,9 @@ class wxFindPanel(wx.Panel):
 
         for var, label in table:
             id = wx.NewId()
-            box = wx.CheckBox(self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, "")
+            box = wx.CheckBox(
+                self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, ""
+            )
 
             col2Sizer.Add(box, 0, wx.BORDER | wx.LEFT, 20)
             self.frame.dict[var] = box, id
@@ -460,7 +472,9 @@ class wxFindPanel(wx.Panel):
 
         for label, var, group in table:
             id = wx.NewId()
-            box = wx.RadioButton(self, id, label, wx.DefaultPosition, (100, 25), group, wx.DefaultValidator, "group2")
+            box = wx.RadioButton(
+                self, id, label, wx.DefaultPosition, (100, 25), group, wx.DefaultValidator, "group2"
+            )
 
             col3Sizer.Add(box, 0, wx.BORDER | wx.LEFT, 20)
 
@@ -480,7 +494,9 @@ class wxFindPanel(wx.Panel):
 
         for var, label in table:
             id = wx.NewId()
-            box = wx.CheckBox(self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, "")
+            box = wx.CheckBox(
+                self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, ""
+            )
 
             col4Sizer.Add(box, 0, wx.BORDER | wx.LEFT, 20)
             self.frame.dict[var] = box, id
@@ -514,9 +530,13 @@ class wxFindPanel(wx.Panel):
         for var, label, isButton in table:
             id = wx.NewId()
             if isButton:
-                widget = button = wx.Button(self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, "")
+                widget = button = wx.Button(
+                    self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, ""
+                )
             else:
-                widget = box = wx.CheckBox(self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, "")
+                widget = box = wx.CheckBox(
+                    self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, ""
+                )
 
                 self.frame.dict[var] = box, id
 
@@ -539,7 +559,9 @@ class wxFindPanel(wx.Panel):
 
         for var, label in table:
             id = wx.NewId()
-            button = wx.Button(self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, "")
+            button = wx.Button(
+                self, id, label, wx.DefaultPosition, (100, 25), 0, wx.DefaultValidator, ""
+            )
 
             row2Sizer.Add(button)
             row2Sizer.Add(
@@ -1211,7 +1233,9 @@ class headlineWidget(baseTextWidget):
         self.tree = treeCtrl
 
         # Init the base class.
-        baseTextWidget.__init__(self, c, baseClassName='headlineWidget', name='headline', widget=self)
+        baseTextWidget.__init__(
+            self, c, baseClassName='headlineWidget', name='headline', widget=self
+        )
 
         self.init(id)
 
@@ -1315,7 +1339,9 @@ class plainTextWidget(baseTextWidget):
 
         # Init the base class.
         name = keys.get('name') or '<unknown plainTextWidget>'
-        baseTextWidget.__init__(self, c, baseClassName=self.baseClassName, name=name, widget=self.widget)
+        baseTextWidget.__init__(
+            self, c, baseClassName=self.baseClassName, name=name, widget=self.widget
+        )
 
         wx.EVT_CHAR(w.widget, self.onChar)
 
@@ -1409,7 +1435,9 @@ class richTextWidget(baseTextWidget):
 
         wx.EVT_CHAR(w.widget, self.onChar)
 
-        baseTextWidget.__init__(self, c, baseClassName=self.baseClassName, name=name, widget=self.widget)
+        baseTextWidget.__init__(
+            self, c, baseClassName=self.baseClassName, name=name, widget=self.widget
+        )
 
         self.defaultFont = font = wx.Font(
             pointSize=10,
@@ -1571,8 +1599,12 @@ class stcWidget(baseTextWidget):
             w.SetMarginWidth(2, 12)
 
             # and now set up the fold markers
-            w.MarkerDefine(stc.STC_MARKNUM_FOLDEREND, stc.STC_MARK_BOXPLUSCONNECTED, "white", "black")
-            w.MarkerDefine(stc.STC_MARKNUM_FOLDEROPENMID, stc.STC_MARK_BOXMINUSCONNECTED, "white", "black")
+            w.MarkerDefine(
+                stc.STC_MARKNUM_FOLDEREND, stc.STC_MARK_BOXPLUSCONNECTED, "white", "black"
+            )
+            w.MarkerDefine(
+                stc.STC_MARKNUM_FOLDEROPENMID, stc.STC_MARK_BOXMINUSCONNECTED, "white", "black"
+            )
             w.MarkerDefine(stc.STC_MARKNUM_FOLDERMIDTAIL, stc.STC_MARK_TCORNER, "white", "black")
             w.MarkerDefine(stc.STC_MARKNUM_FOLDERTAIL, stc.STC_MARK_LCORNER, "white", "black")
             w.MarkerDefine(stc.STC_MARKNUM_FOLDERSUB, stc.STC_MARK_VLINE, "white", "black")
@@ -1581,7 +1613,9 @@ class stcWidget(baseTextWidget):
 
         # Global default style
         if wx.Platform == '__WXMSW__':
-            w.StyleSetSpec(stc.STC_STYLE_DEFAULT, 'fore:#000000,back:#FFFFFF,face:Courier New,size:9')
+            w.StyleSetSpec(
+                stc.STC_STYLE_DEFAULT, 'fore:#000000,back:#FFFFFF,face:Courier New,size:9'
+            )
         elif wx.Platform == '__WXMAC__':
             # TODO: if this looks fine on Linux too, remove the Mac-specific case
             # and use this whenever OS != MSW.
@@ -1679,7 +1713,10 @@ class stcWidget(baseTextWidget):
         lineNum = 0
         while lineNum < lineCount:
             level = self.GetFoldLevel(lineNum)
-            if level & stc.STC_FOLDLEVELHEADERFLAG and (level & stc.STC_FOLDLEVELNUMBERMASK) == stc.STC_FOLDLEVELBASE:
+            if (
+                level & stc.STC_FOLDLEVELHEADERFLAG
+                and (level & stc.STC_FOLDLEVELNUMBERMASK) == stc.STC_FOLDLEVELBASE
+            ):
                 if expanding:
                     self.SetFoldExpanded(lineNum, True)
                     lineNum = self.Expand(lineNum, True)
@@ -2087,8 +2124,20 @@ class wxComparePanel(leoCompare.leoCompare):  # ,leoWxDialog):
         # @+<< create the browser rows >>
         # @+node:ekr.20090126093408.115: *6* << create the browser rows >>
         for row, text, text2, command, var in (
-            (row1, "Compare path 1:", "Ignore first line", self.onBrowse1, self.ignoreFirstLine1Var),
-            (row2, "Compare path 2:", "Ignore first line", self.onBrowse2, self.ignoreFirstLine2Var),
+            (
+                row1,
+                "Compare path 1:",
+                "Ignore first line",
+                self.onBrowse1,
+                self.ignoreFirstLine1Var,
+            ),
+            (
+                row2,
+                "Compare path 2:",
+                "Ignore first line",
+                self.onBrowse2,
+                self.ignoreFirstLine2Var,
+            ),
             (row3, "Output file:", "Use output file", self.onBrowse3, self.useOutputFileVar),
         ):
             lab = Tk.Label(row, anchor="e", text=text, width=13)
@@ -2106,13 +2155,17 @@ class wxComparePanel(leoCompare.leoCompare):  # ,leoWxDialog):
         # @-<< create the browser rows >>
         # @+<< create the extension row >>
         # @+node:ekr.20090126093408.116: *6* << create the extension row >>
-        b = Tk.Checkbutton(row4, anchor="w", var=self.limitToExtensionVar, text="Limit directory compares to type:")
+        b = Tk.Checkbutton(
+            row4, anchor="w", var=self.limitToExtensionVar, text="Limit directory compares to type:"
+        )
         b.pack(side="left", padx=4)
 
         self.extensionEntry = e = Tk.Entry(row4, width=6)
         e.pack(side="left", padx=2)
 
-        b = Tk.Checkbutton(row4, anchor="w", var=self.appendOutputVar, text="Append output to output file")
+        b = Tk.Checkbutton(
+            row4, anchor="w", var=self.appendOutputVar, text="Append output to output file"
+        )
         b.pack(side="left", padx=4)
         # @-<< create the extension row >>
         # @+<< create the whitespace options frame >>
@@ -2502,7 +2555,9 @@ class wxLeoBody(leoFrame.leoBody):
         self.frame.lockout += 1
         try:
             # Call the base class method.
-            leoFrame.leoBody.onBodyChanged(self, undoType, oldSel=oldSel, oldText=oldText, oldYview=oldYview)
+            leoFrame.leoBody.onBodyChanged(
+                self, undoType, oldSel=oldSel, oldText=oldText, oldYview=oldYview
+            )
         finally:
             self.frame.lockout -= 1
 
@@ -2576,8 +2631,12 @@ class wxLeoFrame(leoFrame.leoFrame):
 
         # Create the splitters.
         style = wx.CLIP_CHILDREN | wx.SP_LIVE_UPDATE | wx.SP_3D
-        self.splitter1 = splitter1 = wx.SplitterWindow(top, -1, style=style)  # Contains body & splitter2
-        self.splitter2 = splitter2 = wx.SplitterWindow(splitter1, -1, style=style)  # Contains tree and log.
+        self.splitter1 = splitter1 = wx.SplitterWindow(
+            top, -1, style=style
+        )  # Contains body & splitter2
+        self.splitter2 = splitter2 = wx.SplitterWindow(
+            splitter1, -1, style=style
+        )  # Contains tree and log.
 
         # Create the tree.
         self.tree = wxLeoTree(frame, parentFrame=splitter2)
@@ -2626,7 +2685,13 @@ class wxLeoFrame(leoFrame.leoFrame):
         g.app.windowList.append(self)
         self.tree.redraw()
 
-        self.setFocus(g.choose(c.config.getBool('outline_pane_has_initial_focus'), self.tree.treeWidget, self.bodyCtrl))
+        self.setFocus(
+            g.choose(
+                c.config.getBool('outline_pane_has_initial_focus'),
+                self.tree.treeWidget,
+                self.bodyCtrl,
+            )
+        )
 
     # @+node:ekr.20090126093408.211: *6* setWindowIcon
     def setWindowIcon(self):
@@ -3100,7 +3165,9 @@ class wxLeoFrame(leoFrame.leoFrame):
             # @+node:ekr.20090126093408.246: *8* << create the scale widget >>
             top = Tk.Toplevel()
             top.title("Download progress")
-            self.scale = scale = Tk.Scale(top, state="normal", orient="horizontal", from_=0, to=total)
+            self.scale = scale = Tk.Scale(
+                top, state="normal", orient="horizontal", from_=0, to=total
+            )
             scale.pack()
             top.lift()
             # @-<< create the scale widget >>
@@ -3554,7 +3621,9 @@ class wxLeoMenu(leoMenu.leoMenu):
             # Munge accel to make it invalid.
             d = {'BackSpace': 'BkSpc', 'Return': 'Rtn', 'Tab': 'TabChr'}
             accel = d.get(accel, accel)
-            accel = accel.replace('Alt+', 'Alt-').replace('Ctrl+', 'Ctrl-').replace('Shift+', 'Shift-')
+            accel = (
+                accel.replace('Alt+', 'Alt-').replace('Ctrl+', 'Ctrl-').replace('Shift+', 'Shift-')
+            )
 
             # *** Accelerators are NOT SHOWN when the user opens the menu with the mouse!
             label = label + '\t' + accel
@@ -4690,7 +4759,12 @@ class wxGui(leoGui.leoGui):
         if g.app.unitTesting:
             return
 
-        message = "%s\n\n%s\n\n%s\n\n%s" % (version.strip(), copyright.strip(), url.strip(), email.strip())
+        message = "%s\n\n%s\n\n%s\n\n%s" % (
+            version.strip(),
+            copyright.strip(),
+            url.strip(),
+            email.strip(),
+        )
 
         wx.MessageBox(message, "About Leo", wx.Center, self.root)
 
@@ -4745,7 +4819,9 @@ class wxGui(leoGui.leoGui):
         return g.choose(answer == wx.YES, "yes", "no")
 
     # @+node:ekr.20090126093408.146: *4* runAskYesNoCancelDialog
-    def runAskYesNoCancelDialog(self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"):
+    def runAskYesNoCancelDialog(
+        self, c, title, message=None, yesMessage="Yes", noMessage="No", defaultButton="Yes"
+    ):
         """Create and run a wxPython askYesNoCancel dialog ."""
 
         if g.app.unitTesting:
@@ -4862,7 +4938,11 @@ class wxGui(leoGui.leoGui):
             self.w = self.widget
 
         def __repr__(self):
-            return 'leoKeyEvent char: %s keysym: %s widget: %s' % (repr(self.char), self.keysym, self.widget)
+            return 'leoKeyEvent char: %s keysym: %s widget: %s' % (
+                repr(self.char),
+                self.keysym,
+                self.widget,
+            )
 
     # @+node:ekr.20090126093408.155: *4* wxKeyDict
     wxKeyDict = {
@@ -5155,7 +5235,10 @@ class wxGui(leoGui.leoGui):
             if hasattr(event, 'c'):
                 return event.c.frame.body.bodyCtrl
             else:
-                g.trace('wx gui: k.generalModeHandler event: no event widget: event = %s' % (event), g.callers())
+                g.trace(
+                    'wx gui: k.generalModeHandler event: no event widget: event = %s' % (event),
+                    g.callers(),
+                )
                 return None
         elif hasattr(event, 'GetEventObject'):  # A wx Event.
             # Return the wrapper class
@@ -5297,7 +5380,16 @@ class wxGui(leoGui.leoGui):
             return font
         except:
             g.es("exception setting font from " + repr(family_name))
-            g.es("family,size,slant,weight:" + repr(family) + ':' + repr(size) + ':' + (slant) + ':' + repr(weight))
+            g.es(
+                "family,size,slant,weight:"
+                + repr(family)
+                + ':'
+                + repr(size)
+                + ':'
+                + (slant)
+                + ':'
+                + repr(weight)
+            )
             g.es_exception()
             return g.app.config.defaultFont
 

--- a/leo/plugins/paste_as_headlines.py
+++ b/leo/plugins/paste_as_headlines.py
@@ -44,7 +44,9 @@ def createPasteAsHeadlinesMenu(tag, keywords):
     index_label = index_label.replace("&", "")
 
     # Add 'Word Count...' to the bottom of the Edit menu.
-    c.frame.menu.insert('Edit', 6, label=index_label, underline=amp_index, command=lambda c=c: paste_as_headlines(c))
+    c.frame.menu.insert(
+        'Edit', 6, label=index_label, underline=amp_index, command=lambda c=c: paste_as_headlines(c)
+    )
 
 
 # @+node:danr7.20060912105041.6: ** paste_as_headlines

--- a/leo/plugins/pygeotag/pygeotag.py
+++ b/leo/plugins/pygeotag/pygeotag.py
@@ -171,7 +171,11 @@ class GeoTagRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header('Content-type', 'text/html')
             self.end_headers()
-            self.wfile.write(open(os.path.join(self.owner.basedir, self.staticMap[path[0]])).read().encode('utf-8'))
+            self.wfile.write(
+                open(os.path.join(self.owner.basedir, self.staticMap[path[0]]))
+                .read()
+                .encode('utf-8')
+            )
             return
 
         if self.path.startswith("/sendPos?"):

--- a/leo/plugins/qt_events.py
+++ b/leo/plugins/qt_events.py
@@ -535,12 +535,22 @@ class LeoQtEventFilter(QtCore.QObject):
             if self.tag in exclude_names:
                 return
             if eventType == val:
-                tag = obj.objectName() if hasattr(obj, 'objectName') else f"id: {id(obj)}, {obj.__class__.__name__}"
+                tag = (
+                    obj.objectName()
+                    if hasattr(obj, 'objectName')
+                    else f"id: {id(obj)}, {obj.__class__.__name__}"
+                )
                 if traceKey:
-                    g.trace(f"{kind:>25} {self.tag:25} in-state: {repr(c.k and c.k.inState()):5} obj: {tag}")
+                    g.trace(
+                        f"{kind:>25} {self.tag:25} in-state: {repr(c.k and c.k.inState()):5} obj: {tag}"
+                    )
                 return
         if eventType not in ignore:
-            tag = obj.objectName() if hasattr(obj, 'objectName') else f"id: {id(obj)}, {obj.__class__.__name__}"
+            tag = (
+                obj.objectName()
+                if hasattr(obj, 'objectName')
+                else f"id: {id(obj)}, {obj.__class__.__name__}"
+            )
             g.trace(f"{eventType:>25} {self.tag:25} {tag}")
 
     # @+node:ekr.20131121050226.16331: *4* filter.traceWidget

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -27,7 +27,13 @@ from leo.core.leoQt import QAction, Qsci
 from leo.core.leoQt import AlignLeft
 from leo.core.leoQt import ContextMenuPolicy, DropAction, FocusReason, KeyboardModifier
 from leo.core.leoQt import MoveOperation, Orientation, MouseButton
-from leo.core.leoQt import Policy, ScrollBarPolicy, SelectionBehavior, SelectionMode, SizeAdjustPolicy
+from leo.core.leoQt import (
+    Policy,
+    ScrollBarPolicy,
+    SelectionBehavior,
+    SelectionMode,
+    SizeAdjustPolicy,
+)
 from leo.core.leoQt import Shadow, Shape, Style
 from leo.core.leoQt import TextInteractionFlag, ToolBarArea, Type, Weight, WindowState, WrapMode
 from leo.plugins import qt_events
@@ -359,7 +365,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
         return row
 
     # @+node:ekr.20131118152731.16851: *5* dw.create_find_checkboxes
-    def create_find_checkboxes(self, grid: QGridLayout, parent: QWidget, max_row2: int, row: int) -> int:
+    def create_find_checkboxes(
+        self, grid: QGridLayout, parent: QWidget, max_row2: int, row: int
+    ) -> int:
         """Create check boxes and radio buttons."""
         c, dw = self.leo_c, self
         fc = c.findCommands
@@ -428,13 +436,17 @@ class DynamicWindow(QtWidgets.QMainWindow):
     def create_help_row(self, grid: QGridLayout, parent: QWidget, row: int) -> int:
         # Help row.
         if False:
-            w = self.createLabel(parent, 'findHelp', 'For help: <alt-x>help-for-find-commands<return>')
+            w = self.createLabel(
+                parent, 'findHelp', 'For help: <alt-x>help-for-find-commands<return>'
+            )
             grid.addWidget(w, row, 0, 1, 3)
             row += 1
         return row
 
     # @+node:ekr.20131118152731.16852: *5* dw.create_find_buttons
-    def create_find_buttons(self, grid: QGridLayout, parent: QWidget, max_row2: int, row: int) -> int:
+    def create_find_buttons(
+        self, grid: QGridLayout, parent: QWidget, max_row2: int, row: int
+    ) -> int:
         """
         Per #1342, this method now creates labels, not real buttons.
         """
@@ -563,7 +575,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
                 # #2094: Use code similar to the end of LeoQtEventFilter.eventFilter.
                 #        The ctor converts <Alt-X> to <Alt-x> !!
                 #        That is, we must use the stroke, not the binding.
-                key_event = leoGui.LeoKeyEvent(c=self.c, char=ch, event=event, binding=binding, w=self.w)
+                key_event = leoGui.LeoKeyEvent(
+                    c=self.c, char=ch, event=event, binding=binding, w=self.w
+                )
                 if key_event.stroke:
                     cmd_name = self.d.get(key_event.stroke)
                     if cmd_name:
@@ -639,14 +653,18 @@ class DynamicWindow(QtWidgets.QMainWindow):
         return w
 
     # @+node:ekr.20110605121601.18157: *4* dw.createHLayout & createVLayout
-    def createHLayout(self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0) -> QBoxLayout:
+    def createHLayout(
+        self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0
+    ) -> QBoxLayout:
         hLayout = QtWidgets.QHBoxLayout(parent)
         hLayout.setSpacing(spacing)
         hLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
         self.setName(hLayout, name)
         return hLayout
 
-    def createVLayout(self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0) -> QBoxLayout:
+    def createVLayout(
+        self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0
+    ) -> QBoxLayout:
         vLayout = QtWidgets.QVBoxLayout(parent)
         vLayout.setSpacing(spacing)
         vLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
@@ -668,7 +686,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
         return w
 
     # @+node:ekr.20110605121601.18160: *4* dw.createRadioButton
-    def createRadioButton(self, parent: QWidget, name: str, label: str) -> QWidget:  # QtWidgets.QRadioButton:
+    def createRadioButton(
+        self, parent: QWidget, name: str, label: str
+    ) -> QWidget:  # QtWidgets.QRadioButton:
         w = QtWidgets.QRadioButton(parent)
         self.setName(w, name)
         w.setText(self.tr(label))
@@ -909,7 +929,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
         #
         # Create the log frame.
         logFrame = self.createFrame(parent, 'logFrame', vPolicy=Policy.Minimum)
-        innerFrame = self.createFrame(logFrame, 'logInnerFrame', hPolicy=Policy.Preferred, vPolicy=Policy.Expanding)
+        innerFrame = self.createFrame(
+            logFrame, 'logInnerFrame', hPolicy=Policy.Preferred, vPolicy=Policy.Expanding
+        )
         tabWidget = self.createTabWidget(innerFrame, 'logTabWidget')
         #
         # Pack.
@@ -984,7 +1006,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
     def createMiniBuffer(self, parent: QWidget) -> QWidget:
         """Create the widgets for Leo's minibuffer area."""
         # Create widgets.
-        frame = self.createFrame(parent, 'minibufferFrame', hPolicy=Policy.MinimumExpanding, vPolicy=Policy.Fixed)
+        frame = self.createFrame(
+            parent, 'minibufferFrame', hPolicy=Policy.MinimumExpanding, vPolicy=Policy.Fixed
+        )
         frame.setMinimumSize(QtCore.QSize(100, 0))
         label = self.createLabel(frame, 'minibufferLabel', 'Minibuffer:')
 
@@ -1139,7 +1163,9 @@ class DynamicWindow(QtWidgets.QMainWindow):
             super().setGeometry(rect)
 
     # @+node:ekr.20110605121601.18170: *4* dw.set_widget_size_policy
-    def set_widget_size_policy(self, widget: QWidget, kind1: Policy = None, kind2: Policy = None) -> None:
+    def set_widget_size_policy(
+        self, widget: QWidget, kind1: Policy = None, kind2: Policy = None
+    ) -> None:
         if kind1 is None:
             kind1 = Policy.Ignored
         if kind2 is None:
@@ -1347,7 +1373,9 @@ class FindTabManager:
                 setattr(find, setting_name, val)
                 w.toggle()
 
-            def radio_button_callback(n: int, ivar: str = ivar, setting_name: str = setting_name, w: str = w) -> None:
+            def radio_button_callback(
+                n: int, ivar: str = ivar, setting_name: str = setting_name, w: str = w
+            ) -> None:
                 val = w.isChecked()
                 if ivar:
                     assert hasattr(find, ivar), ivar
@@ -2313,7 +2341,9 @@ class LeoQtLog(leoFrame.LeoLog):
         self.logCtrl: QWidget = None  # A union.
         self.logDict: dict[str, QWidget] = {}  # Keys are tab names.
         self.logWidget: LeoLog = None  # Set in finishCreate.
-        self.menu: qt_text.LeoQTextBrowser = None  # A Qt menu that pops up on right clicks in the hull or in tabs.
+        self.menu: qt_text.LeoQTextBrowser = (
+            None  # A Qt menu that pops up on right clicks in the hull or in tabs.
+        )
         self.tabWidget: QTabWidget = c.frame.top.tabWidget  # A QTabWidget that holds all the tabs.
         tw = self.tabWidget
 
@@ -2847,7 +2877,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         action.leo_command_name = commandName or ''
         if command:
 
-            def qt_add_command_callback(checked: int, label: str = label, command: Callable = command) -> None:
+            def qt_add_command_callback(
+                checked: int, label: str = label, command: Callable = command
+            ) -> None:
                 return command()
 
             action.triggered.connect(qt_add_command_callback)
@@ -2901,7 +2933,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
             action = menu.addAction(label)
             if command:
 
-                def insert_callback(checked: str, label: str = label, command: Callable = command) -> None:
+                def insert_callback(
+                    checked: str, label: str = label, command: Callable = command
+                ) -> None:
                     command()
 
                 action.triggered.connect(insert_callback)
@@ -2931,7 +2965,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         return menu
 
     # @+node:ekr.20110605121601.18353: *5* LeoQtMenu.new_menu
-    def new_menu(self, parent: QWidget, tearoff: int = 0, label: str = '') -> QtMenuWrapper:  # label is for debugging.
+    def new_menu(
+        self, parent: QWidget, tearoff: int = 0, label: str = ''
+    ) -> QtMenuWrapper:  # label is for debugging.
         """Wrapper for the Tkinter new_menu menu method."""
         c, leoFrame = self.c, self.frame
         # Parent can be None, in which case it will be added to the menuBar.
@@ -2957,7 +2993,9 @@ class LeoQtMenu(leoMenu.LeoMenu):
         self.createMenusFromTables()  # This is LeoMenu.createMenusFromTables.
 
     # @+node:ekr.20110605121601.18357: *5* LeoQtMenu.createOpenWithMenu
-    def createOpenWithMenu(self, parent: QWidget, label: str, index: int, amp_index: int) -> QtMenuWrapper:
+    def createOpenWithMenu(
+        self, parent: QWidget, label: str, index: int, amp_index: int
+    ) -> QtMenuWrapper:
         """
         Create the File:Open With submenu.
 
@@ -3246,7 +3284,11 @@ class LeoQTreeWidget(QtWidgets.QTreeWidget):
                     z.setDirty()
             c.setChanged()
             u.afterMoveNode(p1, 'Drag', undoData)
-            if not as_child or p2.isExpanded() or c.config.getBool("drag-alt-drag-expands") is not False:
+            if (
+                not as_child
+                or p2.isExpanded()
+                or c.config.getBool("drag-alt-drag-expands") is not False
+            ):
                 c.redraw(p1)
             else:
                 c.redraw(p2)
@@ -4055,7 +4097,9 @@ class QtIconBarClass:
             else:  # recurse submenu
                 sub_menu = QtWidgets.QMenu(action_container)
                 act.setMenu(sub_menu)
-                self.add_rclick_menu(sub_menu, rc.children, controller, top_level=False, button=button)
+                self.add_rclick_menu(
+                    sub_menu, rc.children, controller, top_level=False, button=button
+                )
             if top_level:
                 # insert act before Remove Button
                 action_container.insertAction(action_container.actions()[top_offset], act)
@@ -4065,7 +4109,9 @@ class QtIconBarClass:
             act = QAction('---', action_container)
             act.setSeparator(True)
             action_container.insertAction(action_container.actions()[top_offset], act)
-            action_container.setText(action_container.text() + (c.config.getString('mod-scripting-subtext') or ''))
+            action_container.setText(
+                action_container.text() + (c.config.getString('mod-scripting-subtext') or '')
+            )
 
     # @-others
 
@@ -4236,9 +4282,13 @@ class QtStatusLineClass:
             # put(msg, status) where status is None, 'info', or 'fail'.
             # Just as a quick hack to avoid dealing with propagating those changes
             # back upstream, infer status like this:
-            if fg == c.config.getColor('find-found-fg') and bg == c.config.getColor('find-found-bg'):
+            if fg == c.config.getColor('find-found-fg') and bg == c.config.getColor(
+                'find-found-bg'
+            ):
                 status = 'info'
-            elif fg == c.config.getColor('find-not-found-fg') and bg == c.config.getColor('find-not-found-bg'):
+            elif fg == c.config.getColor('find-not-found-fg') and bg == c.config.getColor(
+                'find-not-found-bg'
+            ):
                 status = 'fail'
             else:
                 status = None
@@ -4784,7 +4834,11 @@ def showQtWidgets(event: LeoKeyEvent) -> None:
             children = [z for z in w.children() if any(z2 in z.__class__.__name__ for z2 in wanted)]
         else:  # Specifiy unwanted classes...
             ignore = ('action', 'animation', 'menu')
-            children = [z for z in w.children() if not any(z2 in z.__class__.__name__.lower() for z2 in ignore)]
+            children = [
+                z
+                for z in w.children()
+                if not any(z2 in z.__class__.__name__.lower() for z2 in ignore)
+            ]
         if children:
             for i, child in enumerate(children):
                 dump(child, level + 1)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -198,7 +198,12 @@ class LeoQtGui(leoGui.LeoGui):
         ]
         # @-<< define specialChars >>
         # Put up the splash screen()
-        if g.app.use_splash_screen and not g.app.batchMode and not g.app.silentMode and not g.unitTesting:
+        if (
+            g.app.use_splash_screen
+            and not g.app.batchMode
+            and not g.app.silentMode
+            and not g.unitTesting
+        ):
             self.splashScreen = self.createSplashScreen()
         # qtFrame.finishCreate does all the other work.
         self.frameFactory = qt_frame.TabbedFrameFactory()
@@ -358,7 +363,9 @@ class LeoQtGui(leoGui.LeoGui):
         """Create a new Leo frame."""
         return qt_frame.LeoQtFrame(c, title, gui=self)
 
-    def createSpellTab(self, c: Cmdr, spellHandler: Callable, tabName: str) -> qt_frame.LeoQtSpellTab:
+    def createSpellTab(
+        self, c: Cmdr, spellHandler: Callable, tabName: str
+    ) -> qt_frame.LeoQtSpellTab:
         if g.unitTesting:
             return None
         return qt_frame.LeoQtSpellTab(c, spellHandler, tabName)
@@ -572,7 +579,9 @@ class LeoQtGui(leoGui.LeoGui):
         dialog.setTextValue(default)
         if wide:
             # pylint: disable=unsubscriptable-object
-            dialog.resize(int(g.windows()[0].get_window_info()[0] * 0.9), 100)  # g.windows is a list.
+            dialog.resize(
+                int(g.windows()[0].get_window_info()[0] * 0.9), 100
+            )  # g.windows is a list.
         if cancelButtonText:
             dialog.setCancelButtonText(cancelButtonText)
         if okButtonText:
@@ -651,7 +660,9 @@ class LeoQtGui(leoGui.LeoGui):
             yes_to_all = dialog.addButton(yesToAllMessage, ButtonRole.YesRole)
             yes_to_all.setObjectName('yes-to-all')
 
-        dialog.setDefaultButton(yes if defaultButton == 'Yes' else no if defaultButton == 'No' else cancel)
+        dialog.setDefaultButton(
+            yes if defaultButton == 'Yes' else no if defaultButton == 'No' else cancel
+        )
 
         # Run the dialog, saving and restoring focus.
         try:
@@ -776,11 +787,15 @@ class LeoQtGui(leoGui.LeoGui):
         if c:
             try:
                 c.in_qt_dialog = True
-                dialog_val = dialog.getOpenFileName(parent=None, caption=title, directory=startpath, filter=filter_)
+                dialog_val = dialog.getOpenFileName(
+                    parent=None, caption=title, directory=startpath, filter=filter_
+                )
             finally:
                 c.in_qt_dialog = False
         else:
-            dialog_val = dialog.getOpenFileName(parent=None, caption=title, directory=startpath, filter=filter_)
+            dialog_val = dialog.getOpenFileName(
+                parent=None, caption=title, directory=startpath, filter=filter_
+            )
         # This is a *PyQt* change, not a Qt change.
         val, junk_selected_filter = dialog_val
         s = g.os_path_normslashes(val)
@@ -818,12 +833,16 @@ class LeoQtGui(leoGui.LeoGui):
         if c:
             try:
                 c.in_qt_dialog = True
-                dialog_val = dialog.getOpenFileNames(parent=None, caption=title, directory=startpath, filter=filter_)
+                dialog_val = dialog.getOpenFileNames(
+                    parent=None, caption=title, directory=startpath, filter=filter_
+                )
             finally:
                 c.in_qt_dialog = False
 
         else:
-            dialog_val = dialog.getOpenFileNames(parent=None, caption=title, directory=startpath, filter=filter_)
+            dialog_val = dialog.getOpenFileNames(
+                parent=None, caption=title, directory=startpath, filter=filter_
+            )
         # This is a *PyQt* change, not a Qt change.
         val, _ = dialog_val  # type:ignore
         files = [g.os_path_normslashes(s) for s in val]
@@ -903,7 +922,15 @@ class LeoQtGui(leoGui.LeoGui):
             return None
 
         def send() -> Any:
-            return g.doHook('scrolledMessage', short_title=short_title, title=title, label=label, msg=msg, c=c, **keys)
+            return g.doHook(
+                'scrolledMessage',
+                short_title=short_title,
+                title=title,
+                label=label,
+                msg=msg,
+                c=c,
+                **keys,
+            )
 
         if not c or not c.exists:
             # @+<< no c error>>
@@ -1330,7 +1357,9 @@ class LeoQtGui(leoGui.LeoGui):
         # @-<< create the button b >>
         # @+<< define the callbacks for b >>
         # @+node:ekr.20110605121601.18530: *4* << define the callbacks for b >>
-        def deleteButtonCallback(event: LeoKeyEvent = None, b: QPushButton = b, c: Cmdr = c) -> None:
+        def deleteButtonCallback(
+            event: LeoKeyEvent = None, b: QPushButton = b, c: Cmdr = c
+        ) -> None:
             if b:
                 b.pack_forget()
             c.bodyWantsFocus()
@@ -1348,7 +1377,12 @@ class LeoQtGui(leoGui.LeoGui):
             else:
                 g.app.scriptDict = {'script_gnx': p.gnx}
                 c.executeScript(
-                    args=args, p=p, script=script, define_g=define_g, define_name=define_name, silent=silent
+                    args=args,
+                    p=p,
+                    script=script,
+                    define_g=define_g,
+                    define_name=define_name,
+                    silent=silent,
                 )
                 # Remove the button if the script asks to be removed.
                 if g.app.scriptDict.get('removeMe'):
@@ -1731,7 +1765,9 @@ class LeoQtGui(leoGui.LeoGui):
         return w
 
     # @+node:ekr.20190819091851.1: *4* LeoQtGui.createGrid
-    def createGrid(self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0) -> QGridLayout:
+    def createGrid(
+        self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0
+    ) -> QGridLayout:
         w = QtWidgets.QGridLayout(parent)
         w.setContentsMargins(QtCore.QMargins(margin, margin, margin, margin))
         w.setSpacing(spacing)
@@ -1739,14 +1775,18 @@ class LeoQtGui(leoGui.LeoGui):
         return w
 
     # @+node:ekr.20190819093830.1: *4* LeoQtGui.createHLayout & createVLayout
-    def createHLayout(self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0) -> QHBoxLayout:
+    def createHLayout(
+        self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0
+    ) -> QHBoxLayout:
         hLayout = QtWidgets.QHBoxLayout(parent)
         hLayout.setObjectName(name)
         hLayout.setSpacing(spacing)
         hLayout.setContentsMargins(QtCore.QMargins(0, 0, 0, 0))
         return hLayout
 
-    def createVLayout(self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0) -> QVBoxLayout:
+    def createVLayout(
+        self, parent: QWidget, name: str, margin: int = 0, spacing: int = 0
+    ) -> QVBoxLayout:
         vLayout = QtWidgets.QVBoxLayout(parent)
         vLayout.setObjectName(name)
         vLayout.setSpacing(spacing)
@@ -2247,7 +2287,9 @@ class StyleSheetManager:
         To avoid false mismatches, this should approximate what Qt does.
         To avoid false matches, this should not munge too much.
         """
-        s = ''.join([s.lstrip().replace('  ', ' ').replace(' \n', '\n') for s in g.splitLines(stylesheet)])
+        s = ''.join(
+            [s.lstrip().replace('  ', ' ').replace(' \n', '\n') for s in g.splitLines(stylesheet)]
+        )
         return s.rstrip()  # Don't care about ending newline.
 
     # @+node:tom.20220310224019.1: *4* ssm.rescale_sizes

--- a/leo/plugins/qt_layout.py
+++ b/leo/plugins/qt_layout.py
@@ -459,7 +459,10 @@ VERTICAL_THIRDS_LAYOUT = {
             (VR3_OBJ_NAME, 'main_splitter'),
         )
     ),
-    'ORIENTATIONS': {'secondary_splitter': Orientation.Vertical, 'main_splitter': Orientation.Horizontal},
+    'ORIENTATIONS': {
+        'secondary_splitter': Orientation.Vertical,
+        'main_splitter': Orientation.Horizontal,
+    },
     'name': 'vertical-thirds',
 }
 

--- a/leo/plugins/qt_main.py
+++ b/leo/plugins/qt_main.py
@@ -13,7 +13,9 @@ class Ui_MainWindow(object):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(691, 635)
         MainWindow.setDockNestingEnabled(False)
-        MainWindow.setDockOptions(QtGui.QMainWindow.AllowTabbedDocks | QtGui.QMainWindow.AnimatedDocks)
+        MainWindow.setDockOptions(
+            QtGui.QMainWindow.AllowTabbedDocks | QtGui.QMainWindow.AnimatedDocks
+        )
         self.centralwidget = QtGui.QWidget(MainWindow)
         self.centralwidget.setObjectName("centralwidget")
         self.verticalLayout = QtGui.QVBoxLayout(self.centralwidget)
@@ -212,10 +214,14 @@ class Ui_MainWindow(object):
         self.leo_spell_btn_Hide.setCheckable(False)
         self.leo_spell_btn_Hide.setObjectName("leo_spell_btn_Hide")
         self.gridLayout_6.addWidget(self.leo_spell_btn_Hide, 4, 1, 1, 1)
-        spacerItem = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        spacerItem = QtGui.QSpacerItem(
+            20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding
+        )
         self.gridLayout_6.addItem(spacerItem, 5, 0, 1, 1)
         self.leo_spell_listBox = QtGui.QListWidget(self.leo_spell_panel)
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Expanding)
+        sizePolicy = QtGui.QSizePolicy(
+            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Expanding
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.leo_spell_listBox.sizePolicy().hasHeightForWidth())
@@ -224,7 +230,9 @@ class Ui_MainWindow(object):
         self.leo_spell_listBox.setMaximumSize(QtCore.QSize(150, 150))
         self.leo_spell_listBox.setObjectName("leo_spell_listBox")
         self.gridLayout_6.addWidget(self.leo_spell_listBox, 1, 0, 1, 2)
-        spacerItem1 = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        spacerItem1 = QtGui.QSpacerItem(
+            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum
+        )
         self.gridLayout_6.addItem(spacerItem1, 2, 2, 1, 1)
         self.leo_spell_label = QtGui.QLabel(self.leo_spell_panel)
         self.leo_spell_label.setObjectName("leo_spell_label")
@@ -327,7 +335,9 @@ class Ui_MainWindow(object):
         MainWindow.setCentralWidget(self.centralwidget)
         self.menubar = QtGui.QMenuBar(MainWindow)
         self.menubar.setGeometry(QtCore.QRect(0, 0, 691, 19))
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Minimum)
+        sizePolicy = QtGui.QSizePolicy(
+            QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.Minimum
+        )
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(self.menubar.sizePolicy().hasHeightForWidth())
@@ -347,17 +357,29 @@ class Ui_MainWindow(object):
         self.retranslateUi(MainWindow)
         self.tabWidget.setCurrentIndex(3)
         self.stackedWidget.setCurrentIndex(1)
-        QtCore.QObject.connect(self.leo_spell_btn_Add, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Add)
         QtCore.QObject.connect(
-            self.leo_spell_btn_Change, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Change
+            self.leo_spell_btn_Add, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Add
         )
-        QtCore.QObject.connect(self.leo_spell_btn_Find, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Find)
         QtCore.QObject.connect(
-            self.leo_spell_btn_FindChange, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_FindChange
+            self.leo_spell_btn_Change,
+            QtCore.SIGNAL("clicked()"),
+            MainWindow.do_leo_spell_btn_Change,
         )
-        QtCore.QObject.connect(self.leo_spell_btn_Hide, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Hide)
         QtCore.QObject.connect(
-            self.leo_spell_btn_Ignore, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Ignore
+            self.leo_spell_btn_Find, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Find
+        )
+        QtCore.QObject.connect(
+            self.leo_spell_btn_FindChange,
+            QtCore.SIGNAL("clicked()"),
+            MainWindow.do_leo_spell_btn_FindChange,
+        )
+        QtCore.QObject.connect(
+            self.leo_spell_btn_Hide, QtCore.SIGNAL("clicked()"), MainWindow.do_leo_spell_btn_Hide
+        )
+        QtCore.QObject.connect(
+            self.leo_spell_btn_Ignore,
+            QtCore.SIGNAL("clicked()"),
+            MainWindow.do_leo_spell_btn_Ignore,
         )
         QtCore.QObject.connect(
             self.leo_spell_listBox,
@@ -375,55 +397,91 @@ class Ui_MainWindow(object):
         )
         self.tabWidget.setTabText(
             self.tabWidget.indexOf(self.tab),
-            QtGui.QApplication.translate("MainWindow", "Tab 1", None, QtGui.QApplication.UnicodeUTF8),
+            QtGui.QApplication.translate(
+                "MainWindow", "Tab 1", None, QtGui.QApplication.UnicodeUTF8
+            ),
         )
         self.checkBoxWholeWord.setText(
-            QtGui.QApplication.translate("MainWindow", "Whole Word", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Whole Word", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxEntireOutline.setText(
-            QtGui.QApplication.translate("MainWindow", "Entire Outline", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Entire Outline", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxIgnoreCase.setText(
-            QtGui.QApplication.translate("MainWindow", "Ignore Case", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Ignore Case", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxSuboutlineOnly.setText(
-            QtGui.QApplication.translate("MainWindow", "Suboutline Only", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Suboutline Only", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxWrapAround.setText(
-            QtGui.QApplication.translate("MainWindow", "Wrap Around", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Wrap Around", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxNodeOnly.setText(
-            QtGui.QApplication.translate("MainWindow", "Node Only", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Node Only", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxReverse.setText(
-            QtGui.QApplication.translate("MainWindow", "Reverse", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Reverse", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxSearchHeadline.setText(
-            QtGui.QApplication.translate("MainWindow", "Search Headline", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Search Headline", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxRexexp.setText(
-            QtGui.QApplication.translate("MainWindow", "Regexp", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Regexp", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxSearchBody.setText(
-            QtGui.QApplication.translate("MainWindow", "Search Body", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Search Body", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxMarkFinds.setText(
-            QtGui.QApplication.translate("MainWindow", "Mark Finds", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Mark Finds", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.checkBoxMarkChanges.setText(
-            QtGui.QApplication.translate("MainWindow", "Mark Changes", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Mark Changes", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
-        self.label_2.setText(QtGui.QApplication.translate("MainWindow", "Find:", None, QtGui.QApplication.UnicodeUTF8))
+        self.label_2.setText(
+            QtGui.QApplication.translate(
+                "MainWindow", "Find:", None, QtGui.QApplication.UnicodeUTF8
+            )
+        )
         self.label_3.setText(
-            QtGui.QApplication.translate("MainWindow", "Change:", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Change:", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.tabWidget.setTabText(
             self.tabWidget.indexOf(self.tab_2),
-            QtGui.QApplication.translate("MainWindow", "Tab 2", None, QtGui.QApplication.UnicodeUTF8),
+            QtGui.QApplication.translate(
+                "MainWindow", "Tab 2", None, QtGui.QApplication.UnicodeUTF8
+            ),
         )
         self.tabWidget.setTabText(
             self.tabWidget.indexOf(self.tab_3),
-            QtGui.QApplication.translate("MainWindow", "Page", None, QtGui.QApplication.UnicodeUTF8),
+            QtGui.QApplication.translate(
+                "MainWindow", "Page", None, QtGui.QApplication.UnicodeUTF8
+            ),
         )
         self.leo_spell_btn_Add.setText(
             QtGui.QApplication.translate("MainWindow", "Add", None, QtGui.QApplication.UnicodeUTF8)
@@ -432,26 +490,38 @@ class Ui_MainWindow(object):
             QtGui.QApplication.translate("MainWindow", "Find", None, QtGui.QApplication.UnicodeUTF8)
         )
         self.leo_spell_btn_Change.setText(
-            QtGui.QApplication.translate("MainWindow", "Change", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Change", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.leo_spell_btn_FindChange.setText(
-            QtGui.QApplication.translate("MainWindow", "Change, Find", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Change, Find", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.leo_spell_btn_Ignore.setText(
-            QtGui.QApplication.translate("MainWindow", "Ignore", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Ignore", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.leo_spell_btn_Hide.setText(
             QtGui.QApplication.translate("MainWindow", "Hide", None, QtGui.QApplication.UnicodeUTF8)
         )
         self.leo_spell_label.setText(
-            QtGui.QApplication.translate("MainWindow", "Suggestions for:", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Suggestions for:", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.tabWidget.setTabText(
             self.tabWidget.indexOf(self.leo_spell_tab),
-            QtGui.QApplication.translate("MainWindow", "Spell", None, QtGui.QApplication.UnicodeUTF8),
+            QtGui.QApplication.translate(
+                "MainWindow", "Spell", None, QtGui.QApplication.UnicodeUTF8
+            ),
         )
         self.label.setText(
-            QtGui.QApplication.translate("MainWindow", "Minibuffer", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "Minibuffer", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
         self.actionOpen.setText(
             QtGui.QApplication.translate("MainWindow", "Open", None, QtGui.QApplication.UnicodeUTF8)
@@ -460,7 +530,9 @@ class Ui_MainWindow(object):
             QtGui.QApplication.translate("MainWindow", "Save", None, QtGui.QApplication.UnicodeUTF8)
         )
         self.actionIPython.setText(
-            QtGui.QApplication.translate("MainWindow", "IPython", None, QtGui.QApplication.UnicodeUTF8)
+            QtGui.QApplication.translate(
+                "MainWindow", "IPython", None, QtGui.QApplication.UnicodeUTF8
+            )
         )
 
 

--- a/leo/plugins/qt_quicksearch.py
+++ b/leo/plugins/qt_quicksearch.py
@@ -30,4 +30,6 @@ class Ui_LeoQuickSearchWidget:
         QtCore.QMetaObject.connectSlotsByName(LeoQuickSearchWidget)
 
     def retranslateUi(self, LeoQuickSearchWidget):
-        LeoQuickSearchWidget.setWindowTitle(QtWidgets.QApplication.translate("LeoQuickSearchWidget", "Form", None))
+        LeoQuickSearchWidget.setWindowTitle(
+            QtWidgets.QApplication.translate("LeoQuickSearchWidget", "Form", None)
+        )

--- a/leo/plugins/qt_quicksearch_sub.py
+++ b/leo/plugins/qt_quicksearch_sub.py
@@ -50,5 +50,9 @@ class Ui_LeoQuickSearchWidget:
         LeoQuickSearchWidget.setTabOrder(self.showParents, self.listWidget)
 
     def retranslateUi(self, LeoQuickSearchWidget):
-        self.showParents.setText(QtWidgets.QApplication.translate("LeoQuickSearchWidget", "Show Parents", None))
-        LeoQuickSearchWidget.setWindowTitle(QtWidgets.QApplication.translate("LeoQuickSearchWidget", "Form", None))
+        self.showParents.setText(
+            QtWidgets.QApplication.translate("LeoQuickSearchWidget", "Show Parents", None)
+        )
+        LeoQuickSearchWidget.setWindowTitle(
+            QtWidgets.QApplication.translate("LeoQuickSearchWidget", "Form", None)
+        )

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -228,7 +228,14 @@ class QTextMixin:
         i, j = p.v.selectionStart, p.v.selectionLength
         oldSel = (i, i + j)
         c.undoer.doTyping(
-            p, 'Typing', oldText, newText, oldSel=oldSel, oldYview=None, newInsert=newInsert, newSel=newSel
+            p,
+            'Typing',
+            oldText,
+            newText,
+            oldSel=oldSel,
+            oldYview=None,
+            newInsert=newInsert,
+            newSel=newSel,
         )
 
     # @+node:ekr.20140901122110.18734: *3* QTextMixin.Generic high-level interface
@@ -393,7 +400,9 @@ class QLineEditWrapper(QTextMixin):
 
     # @+node:ekr.20110605121601.18118: *3* qlew.Widget-specific overrides
     # @+node:ekr.20220911105050.1: *4* qlew: do-nothings
-    def flashCharacter(self, i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75) -> None:
+    def flashCharacter(
+        self, i: int, bg: str = 'white', fg: str = 'red', flashes: int = 3, delay: int = 75
+    ) -> None:
         pass
 
     def getXScrollPosition(self) -> int:
@@ -476,7 +485,9 @@ class QLineEditWrapper(QTextMixin):
         w.setCursorPosition(i)
 
     # @+node:ekr.20110605121601.18130: *4* qlew.setSelectionRange
-    def setSelectionRange(self, i: int, j: int, insert: Optional[int] = None, s: str = None) -> None:
+    def setSelectionRange(
+        self, i: int, j: int, insert: Optional[int] = None, s: str = None
+    ) -> None:
         """QHeadlineWrapper."""
         if not self.check():
             return
@@ -752,7 +763,9 @@ if QtWidgets:
                 # These offset are reasonable. Perhaps they should depend on font size.
                 x_offset, y_offset = 10, 60
                 # Compute the new geometry, setting the size by hand.
-                geom2_topLeft = QtCore.QPoint(geom.x() + delta_x + x_offset, geom.y() + delta_y + y_offset)
+                geom2_topLeft = QtCore.QPoint(
+                    geom.x() + delta_x + x_offset, geom.y() + delta_y + y_offset
+                )
                 geom2_size = QtCore.QSize(400, 100)
                 geom2 = QtCore.QRect(geom2_topLeft, geom2_size)
                 # These tests fail once offsets are added.
@@ -932,7 +945,9 @@ if QtWidgets:
             # @+<< Recalculate Color >>
             # @+node:tom.20210909124441.1: *5* << Recalculate Color >>
             config_setting = c.config.getString('line-highlight-color') or ''
-            config_setting = config_setting.replace("'", '').replace('"', '').lower().replace('none', '')
+            config_setting = (
+                config_setting.replace("'", '').replace('"', '').lower().replace('none', '')
+            )
 
             last_color_setting = params['last_color_setting']
             config_setting_changed = config_setting != last_color_setting
@@ -1071,7 +1086,9 @@ if QtWidgets:
                     self.leo_cursor_width = width
                     w.setCursorWidth(width)
 
-            if w == getattr(c.frame.body, 'widget', None) and c.config.getBool('show-rmargin-guide'):
+            if w == getattr(c.frame.body, 'widget', None) and c.config.getBool(
+                'show-rmargin-guide'
+            ):
                 # @+<< paint margin guides >>
                 # @+node:tom.20220423204906.1: *4* << paint margin guides  >>
                 # based on https://stackoverflow.com/questions/30371613
@@ -1166,7 +1183,9 @@ class NumberBar(QtWidgets.QFrame):
         self.fm = self.fontMetrics()  # A QFontMetrics
         self.image = QtGui.QImage(
             g.app.gui.getImageImage(
-                g.finalize_join(g.app.loadDir, '..', 'Icons', 'Tango', '16x16', 'actions', 'stop.png')
+                g.finalize_join(
+                    g.app.loadDir, '..', 'Icons', 'Tango', '16x16', 'actions', 'stop.png'
+                )
             )
         )
         self.highest_line = 0  # The highest line that is currently visible.

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -85,7 +85,9 @@ class LeoQtTree(leoFrame.LeoTree):
             w.setDragDropMode(w.InternalMove)
             if 1:  # Does not work
 
-                def dropMimeData(self, data: str, action: str, row: str, col: str, parent: str) -> None:
+                def dropMimeData(
+                    self, data: str, action: str, row: str, col: str, parent: str
+                ) -> None:
                     g.trace()
 
                 # w.dropMimeData = dropMimeData
@@ -135,11 +137,15 @@ class LeoQtTree(leoFrame.LeoTree):
         c = self.c
         self.auto_edit = c.config.getBool('single-click-auto-edits-headline', False)
         self.enable_drag_messages = c.config.getBool("enable-drag-messages")
-        self.select_all_text_when_editing_headlines = c.config.getBool('select_all_text_when_editing_headlines')
+        self.select_all_text_when_editing_headlines = c.config.getBool(
+            'select_all_text_when_editing_headlines'
+        )
         self.stayInTree = c.config.getBool('stayInTreeAfterSelect')
         self.use_chapters = c.config.getBool('use-chapters')
         self.use_declutter = c.config.getBool('tree-declutter', default=False)
-        self.use_mouse_expand_gestures = c.config.getBool('use-mouse-expand-gestures', default=False)
+        self.use_mouse_expand_gestures = c.config.getBool(
+            'use-mouse-expand-gestures', default=False
+        )
 
     # @+node:ekr.20110605121601.17868: *3* qtree.Debugging & tracing
     def error(self, s: str) -> None:
@@ -242,7 +248,10 @@ class LeoQtTree(leoFrame.LeoTree):
                 try:
                     s = pattern.sub(arg, text)
                 except re.error as e:
-                    g.app.log(f'Error in declutter: {e!r}"\n  REPLACE:{arg!r}\n  HEADLINE:{text!r}', color='error')
+                    g.app.log(
+                        f'Error in declutter: {e!r}"\n  REPLACE:{arg!r}\n  HEADLINE:{text!r}',
+                        color='error',
+                    )
             elif cmd == 'REPLACE-HEAD':
                 s = text[: m.start()].rstrip()
             elif cmd == 'REPLACE-TAIL':
@@ -347,7 +356,9 @@ class LeoQtTree(leoFrame.LeoTree):
             return modifier, param
 
         # @+node:vitalije.20200327163522.1: *7* apply_declutter_rules
-        def apply_declutter_rules(cmds: list[tuple[Callable, str]], pattern: str) -> list[tuple[Value, str]]:
+        def apply_declutter_rules(
+            cmds: list[tuple[Callable, str]], pattern: str
+        ) -> list[tuple[Value, str]]:
             """
             Applies all commands for the matched rule. Returns the list
             of the applied operations paired with their single parameter.

--- a/leo/plugins/quickMove.py
+++ b/leo/plugins/quickMove.py
@@ -453,7 +453,9 @@ class quickMove:
         cnt = 0
         for mover, button in qm.buttons:
             if (
-                mover.target == v and (not type_ or mover.type_ == type_) and (not first or mover.which == first)
+                mover.target == v
+                and (not type_ or mover.type_ == type_)
+                and (not first or mover.which == first)
             ):  # TNB untested .first -> .which
                 cnt += 1
                 v.u['quickMove']['buttons'].append({'first': mover.which, 'type': mover.type_})
@@ -513,7 +515,11 @@ class quickMove:
                 def cb(c2=c2, cut=cut):
                     self.to_other(c2, cut=cut)
 
-                def wrap(checked, cb=cb, name=txt.strip('.') + ' top of ' + g.os_path_basename(c2.fileName())):
+                def wrap(
+                    checked,
+                    cb=cb,
+                    name=txt.strip('.') + ' top of ' + g.os_path_basename(c2.fileName()),
+                ):
                     self.do_wrap(cb, name)
 
                 a.triggered.connect(wrap)
@@ -537,7 +543,9 @@ class quickMove:
             def cb(c2=c2):
                 self.bookmark_other(c2)
 
-            def wrap(checked, cb=cb, name="Bookmark to top of " + g.os_path_basename(c2.fileName())):
+            def wrap(
+                checked, cb=cb, name="Bookmark to top of " + g.os_path_basename(c2.fileName())
+            ):
                 self.do_wrap(cb, name)
 
             a.triggered.connect(wrap)
@@ -641,7 +649,9 @@ class quickMove:
         # need to set 'parent' key in v.u['quickMove'] list item to gnx of parent
 
         parents = [
-            [i[0].targetHeadString, False, i[0]] for i in self.buttons if i[0] is not qmb and not i[0].has_parent
+            [i[0].targetHeadString, False, i[0]]
+            for i in self.buttons
+            if i[0] is not qmb and not i[0].has_parent
         ]
 
         if not parents:
@@ -673,7 +683,9 @@ class quickMove:
                 {'type': qmb.type_, 'first': qmb.which, 'parent': parent.gnx}
             )  # TNB untested .first -> .which
 
-        self.addButton(qmb.which, qmb.type_, v=qmb.target, parent=parent.gnx)  # TNB untested .first -> .which
+        self.addButton(
+            qmb.which, qmb.type_, v=qmb.target, parent=parent.gnx
+        )  # TNB untested .first -> .which
         self.buttons = [i for i in self.buttons if i[0] is not qmb]
         print(b)
         b.button.parent().layout().removeWidget(b.button)
@@ -847,7 +859,9 @@ class quickMove:
 
             # other lines are just ignored
 
-        g.app.db['_quickmove']['global_targets'] = [{'name': name2, 'unl': unl2} for name2, unl2 in new]
+        g.app.db['_quickmove']['global_targets'] = [
+            {'name': name2, 'unl': unl2} for name2, unl2 in new
+        ]
         # make sure g.app.db knows it's been changed
         g.app.db['_quickmove'] = g.app.db['_quickmove']
 
@@ -994,9 +1008,9 @@ class quickMoveButton:
         for z in p2.parents():
             if z == p:
                 return False
-        return c.checkMoveWithParentWithWarning(p, p2, warningFlag=False) and c.checkMoveWithParentWithWarning(
-            p2, p, warningFlag=False
-        )
+        return c.checkMoveWithParentWithWarning(
+            p, p2, warningFlag=False
+        ) and c.checkMoveWithParentWithWarning(p2, p, warningFlag=False)
 
     # @+node:tbrown.20100114111020.15726: *3* computeUNL
     def computeUNL(self, p):

--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -201,7 +201,11 @@ def install_qt_quicksearch_tab(c: Cmdr) -> None:
     def activate_input(idx: int, c: Cmdr = c) -> None:
         wdg = c.frame.nav
         tab_widget = wdg.parent().parent()
-        if tab_widget and hasattr(tab_widget, 'currentWidget') and tab_widget.currentWidget() == wdg:
+        if (
+            tab_widget
+            and hasattr(tab_widget, 'currentWidget')
+            and tab_widget.currentWidget() == wdg
+        ):
             wdg.ui.lineEdit.selectAll()
             wdg.ui.lineEdit.setFocus()
 

--- a/leo/plugins/richtext.py
+++ b/leo/plugins/richtext.py
@@ -112,14 +112,18 @@ class CKEEditor(QtWidgets.QWidget):  # type:ignore
         template_path = g.os_path_join(g.computeLeoDir(), 'plugins', 'cke_template.html')
         self.template = open(template_path).read()
         path = g.os_path_join(g.computeLeoDir(), 'external', 'ckeditor')
-        self.template = self.template.replace('[CKEDITOR]', QtCore.QUrl.fromLocalFile(path).toString())
+        self.template = self.template.replace(
+            '[CKEDITOR]', QtCore.QUrl.fromLocalFile(path).toString()
+        )
         # make widget containing QWebView
         self.setLayout(QtWidgets.QVBoxLayout())
         self.layout().setSpacing(0)
         self.layout().setContentsMargins(0, 0, 0, 0)
         # enable inspector, if this really is QtWebKit
         if real_webkit:
-            QtWebKit.QWebSettings.globalSettings().setAttribute(QtWebKit.QWebSettings.DeveloperExtrasEnabled, True)
+            QtWebKit.QWebSettings.globalSettings().setAttribute(
+                QtWebKit.QWebSettings.DeveloperExtrasEnabled, True
+            )
         self.webview = QtWebKitWidgets.QWebView()
         self.layout().addWidget(self.webview)
         g.registerHandler('select3', self.select_node)

--- a/leo/plugins/rpcalc.py
+++ b/leo/plugins/rpcalc.py
@@ -222,7 +222,10 @@ def onCreate(tag: str, keys: Any) -> None:
     if c:
         sc = scriptingController(c)
         sc.createIconButton(
-            args=None, text='RPCalc', command=lambda: c.doCommandByName('rpcalc-toggle'), statusLine=None
+            args=None,
+            text='RPCalc',
+            command=lambda: c.doCommandByName('rpcalc-toggle'),
+            statusLine=None,
         )
 
 
@@ -305,7 +308,11 @@ class AltBaseDialog(QWidget):  # type: ignore
         self.baseBoxes[self.dlgRef.calc.base].setHighlight(False)
         self.baseBoxes[base].setHighlight(True)
         self.buttons.button(base).setChecked(True)
-        if endEntryMode and self.dlgRef.calc.base != base and self.dlgRef.calc.flag == Mode.entryMode:
+        if (
+            endEntryMode
+            and self.dlgRef.calc.base != base
+            and self.dlgRef.calc.flag == Mode.entryMode
+        ):
             self.dlgRef.calc.flag = Mode.saveMode
         self.dlgRef.calc.base = base
 
@@ -757,7 +764,9 @@ class CalcCore:
                 if self.base == 16 and 'A' <= cmdStr <= 'F':
                     return self.numEntry(cmdStr)
                 if cmdStr in '+-*/':
-                    eqn = '{0} {1} {2}'.format(self.formatNum(self.stack[1]), cmdStr, self.formatNum(self.stack[0]))
+                    eqn = '{0} {1} {2}'.format(
+                        self.formatNum(self.stack[1]), cmdStr, self.formatNum(self.stack[0])
+                    )
                     if cmdStr == '+':
                         self.stack.replaceXY(self.stack[1] + self.stack[0])
                     elif cmdStr == '-':
@@ -816,10 +825,14 @@ class CalcCore:
                 eqn = '{0}^2'.format(self.formatNum(self.stack[0]))
                 self.stack[0] = self.stack[0] * self.stack[0]
             elif cmdStr == 'Y^X':  # x power of y
-                eqn = '({0})^{1}'.format(self.formatNum(self.stack[1]), self.formatNum(self.stack[0]))
+                eqn = '({0})^{1}'.format(
+                    self.formatNum(self.stack[1]), self.formatNum(self.stack[0])
+                )
                 self.stack.replaceXY(self.stack[1] ** self.stack[0])
             elif cmdStr == 'XRTY':  # x root of y
-                eqn = '({0})^(1/{1})'.format(self.formatNum(self.stack[1]), self.formatNum(self.stack[0]))
+                eqn = '({0})^(1/{1})'.format(
+                    self.formatNum(self.stack[1]), self.formatNum(self.stack[0])
+                )
                 self.stack.replaceXY(self.stack[1] ** (1 / self.stack[0]))
             elif cmdStr == 'RCIP':  # 1/x
                 eqn = '1 / ({0})'.format(self.formatNum(self.stack[0]))
@@ -857,7 +870,9 @@ class CalcCore:
             if eqn:
                 self.history.append((eqn, self.stack[0]))
                 self.histChg += 1
-                maxLen = self.option.intData('MaxHistLength', CalcCore.minMaxHist, CalcCore.maxMaxHist)
+                maxLen = self.option.intData(
+                    'MaxHistLength', CalcCore.minMaxHist, CalcCore.maxMaxHist
+                )
                 while len(self.history) > maxLen:
                     del self.history[0]
             return True
@@ -1055,7 +1070,10 @@ class CalcDlg(QWidget):  # type: ignore
         ySize = self.calc.option.intData('MainDlgYSize', 0, 10000)
         if xSize and ySize:
             self.resize(xSize, ySize)
-        self.move(self.calc.option.intData('MainDlgXPos', 0, 10000), self.calc.option.intData('MainDlgYPos', 0, 10000))
+        self.move(
+            self.calc.option.intData('MainDlgXPos', 0, 10000),
+            self.calc.option.intData('MainDlgYPos', 0, 10000),
+        )
 
         self.updateEntryLabel('rpCalc Version {0}'.format(__version__))
         QTimer.singleShot(5000, self.updateEntryLabel)
@@ -1088,10 +1106,20 @@ class CalcDlg(QWidget):  # type: ignore
         OptionDlgBool(self.optDlg, 'ViewRegisters', 'View Registers on LCD')
         OptionDlgBool(self.optDlg, 'HideLcdHighlight', 'Hide LCD highlight')
         self.optDlg.startNewColumn()
-        OptionDlgRadio(self.optDlg, 'AngleUnit', 'Angular Units', [('deg', 'Degrees'), ('rad', 'Radians')])
+        OptionDlgRadio(
+            self.optDlg, 'AngleUnit', 'Angular Units', [('deg', 'Degrees'), ('rad', 'Radians')]
+        )
         self.optDlg.startGroupBox('Alternate Bases')
         OptionDlgInt(
-            self.optDlg, 'AltBaseBits', 'Size limit', CalcCore.minNumBits, CalcCore.maxNumBits, True, 4, False, ' bits'
+            self.optDlg,
+            'AltBaseBits',
+            'Size limit',
+            CalcCore.minNumBits,
+            CalcCore.maxNumBits,
+            True,
+            4,
+            False,
+            ' bits',
         )
         OptionDlgBool(self.optDlg, 'UseTwosComplement', 'Use two\'s complement\nnegative numbers')
         self.optDlg.startGroupBox(
@@ -1101,7 +1129,13 @@ class CalcDlg(QWidget):  # type: ignore
         OptionDlgPush(self.optDlg, 'View Other Bases', self.viewAltBases)
         OptionDlgPush(self.optDlg, 'View Help file', self.help)
         OptionDlgInt(
-            self.optDlg, 'MaxHistLength', 'Saved history steps', CalcCore.minMaxHist, CalcCore.maxMaxHist, True, 10
+            self.optDlg,
+            'MaxHistLength',
+            'Saved history steps',
+            CalcCore.minMaxHist,
+            CalcCore.maxMaxHist,
+            True,
+            10,
         )
         if self.optDlg.exec() == QDialog.DialogCode.Accepted:
             self.calc.option.writeChanges()
@@ -1124,7 +1158,11 @@ class CalcDlg(QWidget):  # type: ignore
     # @+node:tom.20230424130102.54: *3* setLcdHighlight
     def setLcdHighlight(self):
         """Set lcd highlight based on option."""
-        opt = self.calc.option.boolData('HideLcdHighlight') and SegmentStyle.Flat or SegmentStyle.Filled
+        opt = (
+            self.calc.option.boolData('HideLcdHighlight')
+            and SegmentStyle.Flat
+            or SegmentStyle.Filled
+        )
         self.lcd.setSegmentStyle(opt)
         for lcd in self.extraLcds:
             lcd.setSegmentStyle(opt)
@@ -1221,7 +1259,9 @@ class CalcDlg(QWidget):  # type: ignore
     def about(self):
         """About this program."""
         QMessageBox.about(
-            self, 'rpCalc', 'rpCalc for the Leo Editor, Version {0}\n by {1}'.format(__version__, __author__)
+            self,
+            'rpCalc',
+            'rpCalc for the Leo Editor, Version {0}\n by {1}'.format(__version__, __author__),
         )
 
     # @+node:tom.20230429090628.1: *3* license
@@ -1249,7 +1289,9 @@ class CalcDlg(QWidget):  # type: ignore
     def updateLcd(self):
         """Sets display back to CalcCore string."""
         numDigits = int(self.calc.option.numData('NumDecimalPlaces', 0, 9)) + 9
-        if self.calc.option.boolData('ThousandsSeparator') or self.calc.option.boolData('UseEngNotation'):
+        if self.calc.option.boolData('ThousandsSeparator') or self.calc.option.boolData(
+            'UseEngNotation'
+        ):
             numDigits += 2
         self.lcd.setDisplay(self.calc.xStr, numDigits)
         if self.calc.option.boolData('ViewRegisters'):
@@ -1579,7 +1621,9 @@ class HistViewWidget(ExtraViewWidget):
         """Update with current data."""
         if not self.calcRef.histChg:
             return
-        maxLen = self.calcRef.option.intData('MaxHistLength', self.calcRef.minMaxHist, self.calcRef.maxMaxHist)
+        maxLen = self.calcRef.option.intData(
+            'MaxHistLength', self.calcRef.minMaxHist, self.calcRef.maxMaxHist
+        )
         for eqn, value in self.calcRef.history[-self.calcRef.histChg :]:
             item = QTreeWidgetItem(self, [eqn, self.calcRef.formatNum(value)])
             if self.topLevelItemCount() > maxLen:
@@ -1684,7 +1728,9 @@ class ExtraDisplay(QWidget):  # type: ignore
         ySize = option.intData('ExtraViewYSize', 0, 10000)
         if xSize and ySize:
             self.resize(xSize, ySize)
-        self.move(option.intData('ExtraViewXPos', 0, 10000), option.intData('ExtraViewYPos', 0, 10000))
+        self.move(
+            option.intData('ExtraViewXPos', 0, 10000), option.intData('ExtraViewYPos', 0, 10000)
+        )
 
     # @+node:tom.20230424130102.111: *4* tabUpdate
     def tabUpdate(self, index):
@@ -2098,10 +2144,14 @@ class Option:
                 with open(self.path, 'r', encoding='utf-8') as f:
                     fileList = f.readlines()
                 for key in self.chgList[:]:
-                    hitList = [line for line in fileList if line.strip().split(None, 1)[:1] == [key]]
+                    hitList = [
+                        line for line in fileList if line.strip().split(None, 1)[:1] == [key]
+                    ]
                     if not hitList:
                         hitList = [
-                            line for line in fileList if line.replace('#', ' ', 1).strip().split(None, 1)[:1] == [key]
+                            line
+                            for line in fileList
+                            if line.replace('#', ' ', 1).strip().split(None, 1)[:1] == [key]
                         ]
                     if hitList:
                         fileList[fileList.index(hitList[-1])] = '{0}{1}\n'.format(
@@ -2109,7 +2159,9 @@ class Option:
                         )
                         self.chgList.remove(key)
                 for key in self.chgList:
-                    fileList.append('{0}{1}\n'.format(key.ljust(self.keySpaces), self.userDict[key]))
+                    fileList.append(
+                        '{0}{1}\n'.format(key.ljust(self.keySpaces), self.userDict[key])
+                    )
                 with open(self.path, 'w', encoding='utf-8') as f:
                     f.writelines([line for line in fileList])
                 return True
@@ -2130,7 +2182,9 @@ class OptionDlg(QDialog):  # type: ignore
     # @+node:tom.20230424130102.158: *4* __init__
     def __init__(self, option, parent=None):
         QDialog.__init__(self, parent)
-        self.setWindowFlags(DialogCode.Accepted | WindowType.WindowTitleHint | WindowType.WindowSystemMenuHint)
+        self.setWindowFlags(
+            DialogCode.Accepted | WindowType.WindowTitleHint | WindowType.WindowSystemMenuHint
+        )
         self.option = option
 
         topLayout = QVBoxLayout(self)

--- a/leo/plugins/run_nodes.py
+++ b/leo/plugins/run_nodes.py
@@ -305,7 +305,11 @@ def OpenProcess(p):
             arg = h[4:].strip()
             args.append(arg)
         else:
-            if not g.match_word(h, 0, "@run") and not g.match_word(h, 0, "@in") and not g.match_word(h, 0, "@input"):
+            if (
+                not g.match_word(h, 0, "@run")
+                and not g.match_word(h, 0, "@in")
+                and not g.match_word(h, 0, "@input")
+            ):
                 args.append(child.b.strip())
     # @-<< append arguments from child nodes to command >>
 

--- a/leo/plugins/screenshots.py
+++ b/leo/plugins/screenshots.py
@@ -444,7 +444,9 @@ def screenshot_helper(window_id):
     screen = app.primaryScreen()
     if screen is not None:
         # Save to the home directory.
-        file_name = os.path.normpath(os.path.expanduser(f"~/.leo/screenshot-{screenshot_number}.png"))
+        file_name = os.path.normpath(
+            os.path.expanduser(f"~/.leo/screenshot-{screenshot_number}.png")
+        )
         pixmap = screen.grabWindow(window_id)
         pixmap.save(file_name, 'png')
         print(f"Screenshot saved in {file_name}")
@@ -1985,7 +1987,9 @@ class ScreenShotController:
         if not sc.match(p, '@slideshow'):
             return g.error('not a @slideshow node: %s', p.h)
         if n1 != (n2 - n3):
-            return g.error('%s wink slides\n%s @slide nodes\n%s @no_screenshot nodes' % (n1, n2, n3))
+            return g.error(
+                '%s wink slides\n%s @slide nodes\n%s @no_screenshot nodes' % (n1, n2, n3)
+            )
         return True
 
     # @+node:ekr.20101113193341.5454: *5* check_dir

--- a/leo/plugins/script_io_to_body.py
+++ b/leo/plugins/script_io_to_body.py
@@ -54,14 +54,23 @@ def newPutNl(self, s, *args, **keys):
 
 # @+node:ekr.20071212091008.1: ** newExecuteScript & helpers
 def newExecuteScript(
-    self, event=None, p=None, script=None, useSelectedText=True, define_g=True, define_name='__main__', silent=False
+    self,
+    event=None,
+    p=None,
+    script=None,
+    useSelectedText=True,
+    define_g=True,
+    define_name='__main__',
+    silent=False,
 ):
     c = self
     log = c.frame.log
     redirect(c)
 
     # Use silent to suppress 'end of script message'
-    c.script_io_to_body_oldexec(event, p, script, useSelectedText, define_g, define_name, silent=True)
+    c.script_io_to_body_oldexec(
+        event, p, script, useSelectedText, define_g, define_name, silent=True
+    )
     undirect(c)
 
     # Now issue the 'end of script' message'

--- a/leo/plugins/settings_finder.py
+++ b/leo/plugins/settings_finder.py
@@ -90,7 +90,9 @@ class SettingsFinder:
         settings_menu = menu.getMenu('Settings')
         menu.add_separator(settings_menu)
         menu.createNewMenu('Edit Settings', 'Settings')
-        finder_menu = self._outline_data_to_python(self.c.config.getOutlineData("settings-finder-menu"))
+        finder_menu = self._outline_data_to_python(
+            self.c.config.getOutlineData("settings-finder-menu")
+        )
         aList = []
         self.tree_to_menulist(aList, finder_menu)
         # #1144: Case must match.
@@ -161,7 +163,11 @@ class SettingsFinder:
                 "behavior in more places, which may or may not be what you prefer."
             ).format(specific=setting, general=value.val)
             which = g.app.gui.runAskYesNoCancelDialog(
-                self.c, "Which setting?", message=msg, yesMessage='Edit Specific', noMessage='Edit General'
+                self.c,
+                "Which setting?",
+                message=msg,
+                yesMessage='Edit Specific',
+                noMessage='Edit General',
             )
             if which != 'no':
                 break

--- a/leo/plugins/sftp.py
+++ b/leo/plugins/sftp.py
@@ -261,7 +261,8 @@ class SFTPController:
         cached_hostkey = self.get_hostkey(host)
         if cached_hostkey is None:
             store = self.confirm_hostkey(
-                'Unknown host: %s' % host, 'Add the server key for host \'%s\' to the trusted host list?' % host
+                'Unknown host: %s' % host,
+                'Add the server key for host \'%s\' to the trusted host list?' % host,
             )
             if store:
                 self.set_hostkey(host, hostkey)

--- a/leo/plugins/stickynotes.py
+++ b/leo/plugins/stickynotes.py
@@ -363,10 +363,16 @@ class TextEditSearch(QtWidgets.QWidget):  # type:ignore
         self.textedit = QtWidgets.QTextEdit(*args, **kwargs)
         # need to call focusin/out set on parent by FocusingPlaintextEdit / mknote
         self.textedit.focusInEvent = self._call_old_first(self.textedit.focusInEvent, self.focusin)
-        self.textedit.focusOutEvent = self._call_old_first(self.textedit.focusOutEvent, self.focusout)
+        self.textedit.focusOutEvent = self._call_old_first(
+            self.textedit.focusOutEvent, self.focusout
+        )
         self.searchbox = QLineEdit()
-        self.searchbox.focusInEvent = self._call_old_first(self.searchbox.focusInEvent, self.focusin)
-        self.searchbox.focusOutEvent = self._call_old_first(self.searchbox.focusOutEvent, self.focusout)
+        self.searchbox.focusInEvent = self._call_old_first(
+            self.searchbox.focusInEvent, self.focusin
+        )
+        self.searchbox.focusOutEvent = self._call_old_first(
+            self.searchbox.focusOutEvent, self.focusout
+        )
 
         # invoke find when return pressed
         self.searchbox.returnPressed.connect(self.search)
@@ -807,7 +813,9 @@ class Tabula(QtWidgets.QMainWindow):  # type:ignore
         self.update_notes()
 
         # n.parent() because the wrapper QMdiSubWindow holds the geom relative to parent
-        geoms = dict((gnx, n.parent().saveGeometry()) for (gnx, n) in self.notes.items() if n.isVisible())
+        geoms = dict(
+            (gnx, n.parent().saveGeometry()) for (gnx, n) in self.notes.items() if n.isVisible()
+        )
 
         geoms['mainwindow'] = self.saveState()
 

--- a/leo/plugins/stickynotes_plus.py
+++ b/leo/plugins/stickynotes_plus.py
@@ -186,7 +186,9 @@ class notetextedit(QTextEdit):
         document = self.document()
         document.setDefaultFont(font)
         self.font = font
-        document.setDefaultStyleSheet("pre{margin-top:0px; margin-bottom:0px} li{margin-top:0px; margin-bottom:0px}")
+        document.setDefaultStyleSheet(
+            "pre{margin-top:0px; margin-bottom:0px} li{margin-top:0px; margin-bottom:0px}"
+        )
         QTimer.singleShot(0, get_markdown)
 
     # @+node:ekr.20100103100944.5398: *3* focusOutEvent
@@ -511,7 +513,9 @@ class notetextedit(QTextEdit):
         references = ''
         i = 1
         doc = ''
-        block = self.document().begin()  # block is like a para; text fragment is sequence of same char format
+        block = (
+            self.document().begin()
+        )  # block is like a para; text fragment is sequence of same char format
         while block.isValid():
             if block.blockFormat().nonBreakableLines():
                 doc += '    ' + block.text() + '\n'

--- a/leo/plugins/systray.py
+++ b/leo/plugins/systray.py
@@ -17,7 +17,9 @@ def init():
     ok = g.app.gui.guiName() == "qt"
 
     if ok:
-        if 0:  # Use this if you want to create the commander class before the frame is fully created.
+        if (
+            0
+        ):  # Use this if you want to create the commander class before the frame is fully created.
             g.registerHandler('before-create-leo-frame', onCreate)
         else:  # Use this if you want to create the commander class after the frame is fully created.
             g.registerHandler('after-create-leo-frame', onCreate)

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -186,13 +186,21 @@ if g.app.gui.guiName() == "qt":
                 lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), field='nextworktime')
             )
 
-            u.dueDateToggle.stateChanged.connect(lambda v: o.set_due_date(val=u.dueDateEdit.date(), mode='check'))
-            u.dueTimeToggle.stateChanged.connect(lambda v: o.set_due_time(val=u.dueTimeEdit.time(), mode='check'))
+            u.dueDateToggle.stateChanged.connect(
+                lambda v: o.set_due_date(val=u.dueDateEdit.date(), mode='check')
+            )
+            u.dueTimeToggle.stateChanged.connect(
+                lambda v: o.set_due_time(val=u.dueTimeEdit.time(), mode='check')
+            )
             u.nxtwkDateToggle.stateChanged.connect(
-                lambda v: o.set_due_date(val=u.nxtwkDateEdit.date(), mode='check', field='nextworkdate')
+                lambda v: o.set_due_date(
+                    val=u.nxtwkDateEdit.date(), mode='check', field='nextworkdate'
+                )
             )
             u.nxtwkTimeToggle.stateChanged.connect(
-                lambda v: o.set_due_time(val=u.nxtwkTimeEdit.time(), mode='check', field='nextworktime')
+                lambda v: o.set_due_time(
+                    val=u.nxtwkTimeEdit.time(), mode='check', field='nextworktime'
+                )
             )
 
             for but in [
@@ -235,7 +243,9 @@ if g.app.gui.guiName() == "qt":
                     '+7 +0 +1 +2 +3 +4 +5 +6 +10 +14 +21 +28 +42 +60 +90 +120 +150 >7 <7 <14 >14 <28 >28'
                 ).split()
             self.date_offset_default = int(offsets[0].strip('>').replace('<', '-'))
-            offsets = sorted(set(offsets), key=lambda x: (x[0], int(x[1:].strip('>').replace('<', '-'))))
+            offsets = sorted(
+                set(offsets), key=lambda x: (x[0], int(x[1:].strip('>').replace('<', '-')))
+            )
             u.dueDateOffset.addItems(offsets)
             u.dueDateOffset.setCurrentIndex(self.date_offset_default)
 
@@ -244,7 +254,9 @@ if g.app.gui.guiName() == "qt":
             u.nxtwkDateOffset.addItems(offsets)
             u.nxtwkDateOffset.setCurrentIndex(self.date_offset_default)
 
-            self.UI.nxtwkDateOffset.activated.connect(lambda v: o.set_date_offset(field='nextworkdate'))
+            self.UI.nxtwkDateOffset.activated.connect(
+                lambda v: o.set_date_offset(field='nextworkdate')
+            )
 
             self.setDueDate = self.make_func(
                 self.UI.dueDateEdit,
@@ -254,7 +266,10 @@ if g.app.gui.guiName() == "qt":
             )
 
             self.setDueTime = self.make_func(
-                self.UI.dueTimeEdit, self.UI.dueTimeToggle, 'setTime', datetime.datetime.now().time()
+                self.UI.dueTimeEdit,
+                self.UI.dueTimeToggle,
+                'setTime',
+                datetime.datetime.now().time(),
             )
 
             self.setNextWorkDate = self.make_func(
@@ -265,7 +280,10 @@ if g.app.gui.guiName() == "qt":
             )
 
             self.setNextWorkTime = self.make_func(
-                self.UI.nxtwkTimeEdit, self.UI.nxtwkTimeToggle, 'setTime', datetime.datetime.now().time()
+                self.UI.nxtwkTimeEdit,
+                self.UI.nxtwkTimeToggle,
+                'setTime',
+                datetime.datetime.now().time(),
             )
 
             self.UI.butDetails.clicked.connect(
@@ -277,8 +295,12 @@ if g.app.gui.guiName() == "qt":
 
             self.UI.butNext.clicked.connect(lambda checked: self.owner.c.selectVisNext())
             self.UI.butNextTodo.clicked.connect(lambda checked: self.owner.find_todo())
-            self.UI.butApplyDueOffset.clicked.connect(lambda checked: o.set_date_offset(field='duedate'))
-            self.UI.butApplyOffset.clicked.connect(lambda checked: o.set_date_offset(field='nextworkdate'))
+            self.UI.butApplyDueOffset.clicked.connect(
+                lambda checked: o.set_date_offset(field='duedate')
+            )
+            self.UI.butApplyOffset.clicked.connect(
+                lambda checked: o.set_date_offset(field='nextworkdate')
+            )
 
             n = g.app.config.getInt("todo-calendar-n")
             cols = g.app.config.getInt("todo-calendar-cols")
@@ -534,7 +556,8 @@ class todoController:
             if isinstance(prog, int):
                 f = prog / 100.0
                 a = taskmenu.addAction(
-                    "(%s+%s=%s %s)" % (rnd(f * time_), rnd((1.0 - f) * time_), rnd(time_), self.time_name)
+                    "(%s+%s=%s %s)"
+                    % (rnd(f * time_), rnd((1.0 - f) * time_), rnd(time_), self.time_name)
                 )
             else:
                 a = taskmenu.addAction("(%s %s)" % (rnd(time_), self.time_name))
@@ -630,7 +653,12 @@ class todoController:
                     use = prog // 10 * 10
                     use = 'prg%03d.png' % use  # type:ignore
                     com.appendImageDictToList(
-                        icons, g.os_path_join('cleo', use), 2, on='vnode', cleoIcon='1', where=self.prog_location
+                        icons,
+                        g.os_path_join('cleo', use),
+                        2,
+                        on='vnode',
+                        cleoIcon='1',
+                        where=self.prog_location,
                     )
             elif which == 'duedate':
                 duedate = self.getat(p.v, 'duedate')
@@ -645,7 +673,12 @@ class todoController:
                         icon = "date_future.png"
                     # Append the icon to the icons list.
                     com.appendImageDictToList(
-                        icons, g.os_path_join('cleo', icon), 2, on='vnode', cleoIcon='1', where=self.prog_location
+                        icons,
+                        g.os_path_join('cleo', icon),
+                        2,
+                        on='vnode',
+                        cleoIcon='1',
+                        where=self.prog_location,
                     )
         # Set the p.v.u for the icons.
         com.setIconList(p, icons)
@@ -710,7 +743,9 @@ class todoController:
     def setat(self, node: VNode, attrib: Any, val: Any) -> None:
         "new attribute setter"
 
-        if attrib in self._datetime_fields and isinstance(val, (datetime.date, datetime.time, datetime.datetime)):
+        if attrib in self._datetime_fields and isinstance(
+            val, (datetime.date, datetime.time, datetime.datetime)
+        ):
             val = val.isoformat()
 
         if 'annotate' in node.u and 'src_unl' in node.u['annotate']:
@@ -746,14 +781,19 @@ class todoController:
             if not hasattr(node, 'unknownAttributes'):  # node has no unknownAttributes
                 node.unknownAttributes = {}
                 node.unknownAttributes["annotate"] = {}
-            elif "annotate" not in node.unknownAttributes or not isinstance(node.unknownAttributes["annotate"], dict):
+            elif "annotate" not in node.unknownAttributes or not isinstance(
+                node.unknownAttributes["annotate"], dict
+            ):
                 node.unknownAttributes["annotate"] = {}
             # node.unknownAttributes["annotate"]['created'] = datetime.datetime.now()
             node.unknownAttributes["annotate"][attrib] = val
             return
 
         # dictionary exists
-        if attrib not in node.unknownAttributes["annotate"] or node.unknownAttributes["annotate"][attrib] != val:
+        if (
+            attrib not in node.unknownAttributes["annotate"]
+            or node.unknownAttributes["annotate"][attrib] != val
+        ):
             self.c.setChanged()
             node.setDirty()
 
@@ -1082,7 +1122,9 @@ class todoController:
             self.setat(p.v, 'duedate', '')
 
     # @+node:tbrown.20130207103126.28498: *4* todoController.needs_doing
-    def needs_doing(self, v: VNode = None, pri: Any = None, due: Any = None) -> bool:  # Hard to annotate.
+    def needs_doing(
+        self, v: VNode = None, pri: Any = None, due: Any = None
+    ) -> bool:  # Hard to annotate.
         """needs_doing - Return true if the node is a todo node that needs doing
 
         :Parameters:
@@ -1147,7 +1189,9 @@ class todoController:
         return pa if pa != 24 else 0
 
     # @+node:tbrown.20110213153425.16373: *4* todoController.duekey
-    def duekey(self, v: VNode, field: str = 'due') -> tuple[bool, datetime.date, datetime.time, int]:
+    def duekey(
+        self, v: VNode, field: str = 'due'
+    ) -> tuple[bool, datetime.date, datetime.time, int]:
         """key function for sorting by due date/time"""
         # pylint: disable=boolean-datetime
         priority = self.getat(v, 'priority')
@@ -1192,7 +1236,9 @@ class todoController:
         dat: dict = {}
         for end in 'from', 'to':
             if Qt:
-                x0, ok = QtWidgets.QInputDialog.getText(None, 'Reclassify priority', '%s priorities (1-9,19)' % end)
+                x0, ok = QtWidgets.QInputDialog.getText(
+                    None, 'Reclassify priority', '%s priorities (1-9,19)' % end
+                )
                 if not ok:
                     x0 = None
                 else:
@@ -1268,7 +1314,12 @@ class todoController:
             if item[0] in self.priorities:
                 g.es(
                     '%s\t%d\t%s\t(%s)'
-                    % (self.priorities[item[0]]['short'], item[1], self.priorities[item[0]]['long'], item[0])
+                    % (
+                        self.priorities[item[0]]['short'],
+                        item[1],
+                        self.priorities[item[0]]['long'],
+                        item[0],
+                    )
                 )
 
     # @+node:tbrown.20150605111428.1: *3* todoController.updateStyle

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -316,7 +316,9 @@ def init() -> bool:
 
 
 # @+node:ekr.20240727091022.1: *3* vr function: getVR
-def getVr(*, c: Any = None, event: Any = None, parent: QtWidgets.QWidget = None) -> Optional[QtWidgets.QWidget]:
+def getVr(
+    *, c: Any = None, event: Any = None, parent: QtWidgets.QWidget = None
+) -> Optional[QtWidgets.QWidget]:
     """Return the ViewRenderedController instance or None."""
     if g.app.gui.guiName() != 'qt':
         return None
@@ -673,7 +675,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.locked = False
         self.pdf_qwv = None  # The singleton qwv instance, with support for pdf.
         self.qwv = None  # The singleton qwv instance.
-        self.scrollbar_pos_dict: dict[VNode, Position] = {}  # Keys are vnodes, values are positions.
+        self.scrollbar_pos_dict: dict[
+            VNode, Position
+        ] = {}  # Keys are vnodes, values are positions.
         # User settings.
         self.reloadSettings()
         self.node_changed = True
@@ -1468,7 +1472,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         with open("temp.plantuml", "w") as f:
             f.write(s)
         pth_plantuml_jar = "~/.leo"
-        os.system("cat temp.plantuml | java -jar %s/plantuml.jar -pipe > %s" % (pth_plantuml_jar, path))
+        os.system(
+            "cat temp.plantuml | java -jar %s/plantuml.jar -pipe > %s" % (pth_plantuml_jar, path)
+        )
         template = self.image_template % (path)
         template = textwrap.dedent(template).strip()
         self.show()
@@ -1519,9 +1525,9 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
             elif child.h == '@jinja inputs':
                 for template_var_node in child.children():
                     # pylint: disable=line-too-long
-                    template_data[template_var_node.h.replace('@jinja variable', '').strip()] = untangle(
-                        c, template_var_node
-                    ).strip()
+                    template_data[template_var_node.h.replace('@jinja variable', '').strip()] = (
+                        untangle(c, template_var_node).strip()
+                    )
 
         if not template_path:
             g.es(

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -1574,7 +1574,9 @@ def init() -> bool:
         return False
     if not QtWidgets or not g.app.gui.guiName().startswith('qt'):
         if (
-            not g.unitTesting and not g.app.batchMode and g.app.gui.guiName() in ('browser', 'curses')  # EKR.
+            not g.unitTesting
+            and not g.app.batchMode
+            and g.app.gui.guiName() in ('browser', 'curses')  # EKR.
         ):
             g.es_print('viewrendered3 requires Qt')
         return False
@@ -2505,10 +2507,14 @@ class ViewRenderedController3(QtWidgets.QWidget):
             self.asciidoctor = find_exe(self.prefer_external) or None
 
         self.asciidoc_show_proc_fail_msgs = True
-        self.asciidoctor_suppress_footer = c.config.getBool('vr3-asciidoctor-nofooter', default=False)
+        self.asciidoctor_suppress_footer = c.config.getBool(
+            'vr3-asciidoctor-nofooter', default=False
+        )
         self.asciidoctor_icons = c.config.getString('vr3-asciidoctor-icons') or ''
         self.asciidoctor_imagesdir = c.config.getString('vr3-asciidoctor-imagesdir') or ''
-        self.asciidoctor_diagram = asciidoc_has_diagram and c.config.getBool('vr3-asciidoctor-diagram', default=False)
+        self.asciidoctor_diagram = asciidoc_has_diagram and c.config.getBool(
+            'vr3-asciidoctor-diagram', default=False
+        )
         # @-<< configure asciidoc >>
 
         self.external_editor = c.config.getString('vr3-ext-editor') or ''
@@ -2874,7 +2880,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
         if use_default:
             leo_theme_path = g.app.loadManager.computeThemeFilePath()
             leo_theme_name = g.os_path_basename(leo_theme_path)
-            use_dark_theme = self.use_dark_theme or 'dark' in leo_theme_name or leo_theme_name == LEO_THEME_NAME
+            use_dark_theme = (
+                self.use_dark_theme or 'dark' in leo_theme_name or leo_theme_name == LEO_THEME_NAME
+            )
             if use_dark_theme:
                 stylesheet = RST_DEFAULT_DARK_STYLESHEET
             else:
@@ -3386,7 +3394,12 @@ class ViewRenderedController3(QtWidgets.QWidget):
             elif self.gnx != p.v.gnx and not self.lock_to_tree:
                 _must_update = True
                 self.cancel_scroll()
-            elif doc.isModified() or len(p.b) != self.length or self.last_text != p.b or self.last_headline != p.h:
+            elif (
+                doc.isModified()
+                or len(p.b) != self.length
+                or self.last_text != p.b
+                or self.last_headline != p.h
+            ):
                 if self.get_kind(p) in ('html', 'pyplot'):
                     _must_update = False  # Only update explicitly.
                 else:
@@ -4317,7 +4330,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
                 execution_result, err_result = self.exec_code(code, environment)
             # Otherwise check VR3_CONFIG_FILE to see if we know how to run this language
             elif self.controlling_code_lang in exepaths:
-                execution_result, err_result = self.ext_execute_code(self.controlling_code_lang, code)
+                execution_result, err_result = self.ext_execute_code(
+                    self.controlling_code_lang, code
+                )
             else:
                 err_result = f"Can't execute {self.controlling_code_lang} today."
 
@@ -4656,7 +4671,13 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # @+<< fill_chunks >>
             # @+node:TomP.20200112103729.5: *7* << fill_chunks >>
             _cleanline = line.strip()
-            _starts_with_at = not _got_language and line and line[0] == '@' and _cleanline != '@' and _cleanline != '@c'
+            _starts_with_at = (
+                not _got_language
+                and line
+                and line[0] == '@'
+                and _cleanline != '@'
+                and _cleanline != '@c'
+            )
 
             if i == 0 and not _got_language:
                 # Set up the first chunk (unless the first line changes the language)
@@ -5644,7 +5665,10 @@ class StateMachine:
         (State.FENCED_MATH, Marker.MARKER_NONE): (Action.add_line, State.FENCED_MATH),
         (State.FENCED_MATH, Marker.MD_FENCE_MARKER): (Action.add_math_block_end, State.BASE),
         # ========== ASCIIDOC-specific states =================
-        (State.BASE, Marker.ASCDOC_CODE_LANG_MARKER): (Action.no_action, State.ASCDOC_READY_FOR_FENCE),
+        (State.BASE, Marker.ASCDOC_CODE_LANG_MARKER): (
+            Action.no_action,
+            State.ASCDOC_READY_FOR_FENCE,
+        ),
         (State.ASCDOC_READY_FOR_FENCE, Marker.ASCDOC_CODE_MARKER):
         # Start a new code chunk
         (Action.new_chunk, State.FENCED_CODE),

--- a/leo/plugins/vim.py
+++ b/leo/plugins/vim.py
@@ -327,7 +327,12 @@ class VimCommander:
     def should_open_old_file(self, path, root):
         """Return True if we should open the old temp file."""
         v = root.v
-        return path and g.os_path_exists(path) and hasattr(v.b, '_vim_old_body') and v.b == v._vim_old_body
+        return (
+            path
+            and g.os_path_exists(path)
+            and hasattr(v.b, '_vim_old_body')
+            and v.b == v._vim_old_body
+        )
 
     # @+node:ekr.20150326175258.1: *3* vim.write_root (not used)
     def write_root(self, root):

--- a/leo/plugins/wikiview.py
+++ b/leo/plugins/wikiview.py
@@ -200,7 +200,8 @@ class WikiView:
                 # move right to find left end of range
                 cursor.setPosition(end)
                 while (
-                    cursor.movePosition(MoveOperation.NextCharacter) and cursor.charFormat().fontPointSize() == self.pts
+                    cursor.movePosition(MoveOperation.NextCharacter)
+                    and cursor.charFormat().fontPointSize() == self.pts
                 ):
                     pass
                 # select range and restore normal size

--- a/leo/plugins/word_export.py
+++ b/leo/plugins/word_export.py
@@ -76,7 +76,9 @@ def doPara(word, text, style=None):
 
 
 # @+node:EKR.20040517075715.18: ** writeNodeAndTree
-def writeNodeAndTree(c, word, header_style, level, maxlevel=3, usesections=1, sectionhead="", vnode=None):
+def writeNodeAndTree(
+    c, word, header_style, level, maxlevel=3, usesections=1, sectionhead="", vnode=None
+):
     """Write a node and its children to Word"""
     if vnode is None:
         vnode = c.currentVnode()

--- a/leo/plugins/xemacs.py
+++ b/leo/plugins/xemacs.py
@@ -79,7 +79,12 @@ def open_in_emacs_helper(c, p):
     efc = g.app.externalFilesController
     path = efc and efc.find_path_for_node(p)
     emacs_cmd = c.config.getString('xemacs-exe') or _emacs_cmd
-    if not path or not g.os_path_exists(path) or not hasattr(v, 'OpenWithOldBody') or v.b != v.OpenWithOldBody:
+    if (
+        not path
+        or not g.os_path_exists(path)
+        or not hasattr(v, 'OpenWithOldBody')
+        or v.b != v.OpenWithOldBody
+    ):
         # Open a new temp file.
         if path:
             # Don't do this: it prevents efc from reopening paths.

--- a/leo/plugins/xml_edit.py
+++ b/leo/plugins/xml_edit.py
@@ -334,7 +334,10 @@ def xml2leo(event, from_string=None):
 
     nd.b = '<?xml version="%s"?>\n' % (xml_.docinfo.xml_version or '1.0')
     if xml_.docinfo.encoding:
-        nd.b = '<?xml version="%s" encoding="%s"?>\n' % (xml_.docinfo.xml_version or '1.0', xml_.docinfo.encoding)
+        nd.b = '<?xml version="%s" encoding="%s"?>\n' % (
+            xml_.docinfo.xml_version or '1.0',
+            xml_.docinfo.encoding,
+        )
     if NSMAP:
         for k in sorted(NSMAP):
             if k:

--- a/leo/plugins/xsltWithNodes.py
+++ b/leo/plugins/xsltWithNodes.py
@@ -246,7 +246,9 @@ def addMenu(tag, keywords):
 
     c.add_command(xmen, label="Set Stylesheet Node", command=lambda c=c: setStyleNode(c))
     c.add_command(xmen, label="Jump To Style Node", command=lambda c=c: jumpToStyleNode(c))
-    c.add_command(xmen, label="Process Node with Stylesheet Node", command=lambda c=c: processDocumentNode(c))
+    c.add_command(
+        xmen, label="Process Node with Stylesheet Node", command=lambda c=c: processDocumentNode(c)
+    )
     xmen.add_separator(xmen)
     c.add_command(xmen, label="Create Stylesheet Node", command=lambda c=c: addXSLTNode(c))
 
@@ -257,7 +259,9 @@ def addMenu(tag, keywords):
     xsltkeys = list(xslt.keys())
     xsltkeys.sort()
     for z in xsltkeys:
-        c.add_command(menu2, label=z, command=lambda c=c, element=xslt[z]: addXSLTElement(c, element))
+        c.add_command(
+            menu2, label=z, command=lambda c=c, element=xslt[z]: addXSLTElement(c, element)
+        )
 
     # men.add_cascade(menu = xmen, label = "XSLT-Node Commands")
     menu3 = mc.createNewMenu('XSLT-Node Commands', 'XSLT')

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -26,7 +26,7 @@ os.chdir(leo_editor_dir)
 # Define components of a single command.
 arg_list = (
     f"--config {leo_editor_dir}{os.sep}pyproject.toml",
-    '--config line-length=120',
+    # '--config line-length=120',
     # '--verbose',
 )
 args = ' '.join(arg_list)

--- a/leo/scripts/check_leo.py
+++ b/leo/scripts/check_leo.py
@@ -359,11 +359,17 @@ class CheckLeo:
             f"in {t3 - t1:.2f} sec."
         )
         if report_times:
-            print(f"Setup: {t2 - t1:.2f} sec.\n Scan: {t3 - t2:.2f} sec.\nTotal: {t3 - t1:.2f} sec.")
+            print(
+                f"Setup: {t2 - t1:.2f} sec.\n Scan: {t3 - t2:.2f} sec.\nTotal: {t3 - t1:.2f} sec."
+            )
         if report_all_args:
             report_set(all_args, 'function/method args')
         if report_unusual_attrs:
-            unusual_attrs = [z for z in all_attrs if not z.startswith(('"', "'")) and any(z2 in z for z2 in '()[]{}')]
+            unusual_attrs = [
+                z
+                for z in all_attrs
+                if not z.startswith(('"', "'")) and any(z2 in z for z2 in '()[]{}')
+            ]
             print(f"{len(unusual_attrs)} Unusual attrs..")
             for z in sorted(list(unusual_attrs)):
                 print(f"  {z}")

--- a/leo/scripts/remove_duplicate_pictures.py
+++ b/leo/scripts/remove_duplicate_pictures.py
@@ -94,7 +94,9 @@ gWindow = None
 def get_args():
     # Automatically implements the --help option.
     description = "usage: python -m remove_duplicate_pictures [options]"
-    parser = argparse.ArgumentParser(description=description, formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=description, formatter_class=argparse.RawTextHelpFormatter
+    )
     # Add args.
     add = parser.add_argument
     add(
@@ -165,7 +167,9 @@ def main():
 class RemoveDuplicates:
     dup_list: list[str] = []
     filename_dict: dict[str, Any] = {}  # Keys are filenames, values are hashes.
-    hash_dict: dict[Any, list[Any]] = defaultdict(list)  # Keys are hashes, values are lists of filenames.
+    hash_dict: dict[Any, list[Any]] = defaultdict(
+        list
+    )  # Keys are hashes, values are lists of filenames.
     hash_size = 8
     window_height = 900
 
@@ -226,7 +230,9 @@ class RemoveDuplicates:
         pixmap = QtGui.QPixmap(filename)
         try:
             TransformationMode = QtCore.Qt.TransformationMode
-            image = pixmap.scaledToHeight(self.window_height, TransformationMode.SmoothTransformation)
+            image = pixmap.scaledToHeight(
+                self.window_height, TransformationMode.SmoothTransformation
+            )
             picture.setPixmap(image)
             picture.adjustSize()
             return frame

--- a/leo/scripts/win/elevate.py
+++ b/leo/scripts/win/elevate.py
@@ -20,14 +20,18 @@ def elevate(params):
     hwnd = 0  # parent window
     lpOperation = 'runas'  # force elevated UAC prompt
     lpFile = sys.executable  # path to python
-    lpFile = lpFile.replace('pythonw.exe', 'python.exe')  # force console python, only way to see messages
+    lpFile = lpFile.replace(
+        'pythonw.exe', 'python.exe'
+    )  # force console python, only way to see messages
     lpParameters = params  # arguments to pass to python
     lpDirectory = tempfile.gettempdir()  # working dir
     nShowCmd = 1  # window visibility, must be 1 for Leo.
 
     print(lpFile, lpParameters)
     # g.es(lpFile, lpParameters)
-    retcode = ctypes.windll.shell32.ShellExecuteW(hwnd, lpOperation, lpFile, lpParameters, lpDirectory, nShowCmd)
+    retcode = ctypes.windll.shell32.ShellExecuteW(
+        hwnd, lpOperation, lpFile, lpParameters, lpDirectory, nShowCmd
+    )
     msg = 'Exit code: {0} - {1}'.format(retcode, ctypes.FormatError(retcode))
     print(msg)
     # g.es(msg)

--- a/leo/unittests/commands/test_convertCommands.py
+++ b/leo/unittests/commands/test_convertCommands.py
@@ -322,7 +322,9 @@ class TestPythonToTypeRust(LeoUnitTest):
             ),
             # Test 2
             (
-                ('if TYPE_CHECKING:  # pragma: no cover\n    from leo.core.leoCommands import Commands as Cmdr\n'),
+                (
+                    'if TYPE_CHECKING:  # pragma: no cover\n    from leo.core.leoCommands import Commands as Cmdr\n'
+                ),
                 (
                     'if TYPE_CHECKING { // # pragma: no cover\n'
                     '    from leo.core.leoCommands import Commands as Cmdr\n'

--- a/leo/unittests/commands/test_outlineCommands.py
+++ b/leo/unittests/commands/test_outlineCommands.py
@@ -34,7 +34,9 @@ class TestOutlineCommands(LeoUnitTest):
         # @+node:ekr.20230724130959.5: *4* function: test_tree (test_paste_as_template)
         def test_tree(pasted_flag: bool, tag: str) -> None:
             """Test the tree."""
-            tag_s = f"kind: {test_kind} is_json? {int(is_json)} pasted? {int(pasted_flag)} {target_p.h}"
+            tag_s = (
+                f"kind: {test_kind} is_json? {int(is_json)} pasted? {int(pasted_flag)} {target_p.h}"
+            )
             try:
                 # Test clone status and gnx. Set seen.
                 seen = set()
@@ -214,7 +216,9 @@ class TestOutlineCommands(LeoUnitTest):
 
         # All nodes except cc and its children itself are valid targets.
         valid_target_headlines = list(
-            sorted(z.h for z in c.all_unique_positions() if z.h not in ('cc', 'cc:child1', 'cc:child2'))
+            sorted(
+                z.h for z in c.all_unique_positions() if z.h not in ('cc', 'cc:child1', 'cc:child2')
+            )
         )
         # g.printObj(valid_target_headlines, tag='valid_target_headlines')
         for target_headline in valid_target_headlines:

--- a/leo/unittests/core/test_leoApp.py
+++ b/leo/unittests/core/test_leoApp.py
@@ -21,7 +21,9 @@ class TestApp(LeoUnitTest):
             assert hasattr(g.app, ivar), 'missing g.app directory: %s' % ivar
             val = getattr(g.app, ivar)
             assert val is not None, 'null g.app directory: %s' % ivar
-            assert g.os_path_exists(g.os_path_abspath(val)), 'non-existent g.app directory: %s' % ivar
+            assert g.os_path_exists(g.os_path_abspath(val)), (
+                'non-existent g.app directory: %s' % ivar
+            )
         assert hasattr(g.app, 'homeDir')  # May well be None.
 
     # @+node:ekr.20210901140645.12: *3* TestApp.test_official_g_app_ivars

--- a/leo/unittests/core/test_leoAst.py
+++ b/leo/unittests/core/test_leoAst.py
@@ -453,7 +453,9 @@ class TestTOG(BaseTest):
     # @+node:ekr.20210320095504.8: *5* test_line_337
     def test_line_337(self):
         if py_version >= (3, 8):  # Requires neither line_no nor col_offset fields.
-            contents = '''def f(a, b:1, c:2, d, e:3=4, f=5, *g:6, h:7, i=8, j:9=10, **k:11) -> 12: pass'''
+            contents = (
+                '''def f(a, b:1, c:2, d, e:3=4, f=5, *g:6, h:7, i=8, j:9=10, **k:11) -> 12: pass'''
+            )
         else:
             contents = '''def f(a, b, d=4, *arg, **keys): pass'''  # pragma: no cover
         contents, tokens, tree = self.make_data(contents)
@@ -1919,7 +1921,9 @@ class TestTokens(BaseTest):
                         children_s = ', '.join(z.__class__.__name__ for z in children)
                     else:
                         children_s = 'None'
-                    print(f"\n    node: {node.__class__.__name__}\n  parent: {parent_s}\nchildren: {children_s}")
+                    print(
+                        f"\n    node: {node.__class__.__name__}\n  parent: {parent_s}\nchildren: {children_s}"
+                    )
             # Print the resulting tokens.
             g.printObj(tokens, tag='Tokens')
 

--- a/leo/unittests/core/test_leoCommands.py
+++ b/leo/unittests/core/test_leoCommands.py
@@ -327,7 +327,9 @@ class TestCommands(LeoUnitTest):
     # @+node:ekr.20210906075242.9: *3* TestCommands.test_c_hiddenRootNode_fileIndex
     def test_c_hiddenRootNode_fileIndex(self):
         c = self.c
-        assert c.hiddenRootNode.fileIndex.startswith('hidden-root-vnode-gnx'), c.hiddenRootNode.fileIndex
+        assert c.hiddenRootNode.fileIndex.startswith('hidden-root-vnode-gnx'), (
+            c.hiddenRootNode.fileIndex
+        )
 
     # @+node:ekr.20210906075242.10: *3* TestCommands.test_c_hoist_chapter_node
     def test_c_hoist_chapter_node(self):

--- a/leo/unittests/core/test_leoFind.py
+++ b/leo/unittests/core/test_leoFind.py
@@ -483,19 +483,27 @@ class TestFind(LeoUnitTest):
             whole_word=False,
         )
         # Test 1: Match in body.
-        n = x.batch_change(root=c.rootPosition(), replacements=((r'^def\b', 'DEF'),), settings=settings)
+        n = x.batch_change(
+            root=c.rootPosition(), replacements=((r'^def\b', 'DEF'),), settings=settings
+        )
         assert n > 3, n  # Test 1.
         # Test 2: Match in headline.
-        n = x.batch_change(root=c.rootPosition(), replacements=((r'^Node\b', 'DEF'),), settings=settings)
+        n = x.batch_change(
+            root=c.rootPosition(), replacements=((r'^Node\b', 'DEF'),), settings=settings
+        )
         self.assertEqual(n, 2)
         # Test 3: node-only.
         settings['node_only'] = True
-        n = x.batch_change(root=c.rootPosition(), replacements=((r'^DEF\b', 'def'),), settings=settings)
+        n = x.batch_change(
+            root=c.rootPosition(), replacements=((r'^DEF\b', 'def'),), settings=settings
+        )
         self.assertEqual(n, 1)
         # Test 4: suboutline-only.
         settings['node_only'] = False
         settings['suboutline_only'] = True
-        n = x.batch_change(root=c.rootPosition(), replacements=((r'^def\b', 'DEF'),), settings=settings)
+        n = x.batch_change(
+            root=c.rootPosition(), replacements=((r'^def\b', 'DEF'),), settings=settings
+        )
         self.assertEqual(n, 1)
 
     # @+node:ekr.20210219175850.1: *4* testFind.test_batch_change_word
@@ -735,7 +743,18 @@ class TestFind(LeoUnitTest):
                     '\n     got i: %s'
                     '\nexpected j: %s'
                     '\n     got j: %s'
-                    % (table_name, test_n, pattern, s, expected, got, expected_i, got_i, expected_j, got_j)
+                    % (
+                        table_name,
+                        test_n,
+                        pattern,
+                        s,
+                        expected,
+                        got,
+                        expected_i,
+                        got_i,
+                        expected_j,
+                        got_j,
+                    )
                 )
 
         plain_table = (
@@ -781,7 +800,18 @@ class TestFind(LeoUnitTest):
                     '\n     got i: %s'
                     '\nexpected j: %s'
                     '\n     got j: %s'
-                    % (table_name, test_n, pattern, s, expected, got, expected_i, got_i, expected_j, got_j)
+                    % (
+                        table_name,
+                        test_n,
+                        pattern,
+                        s,
+                        expected,
+                        got,
+                        expected_i,
+                        got_i,
+                        expected_j,
+                        got_j,
+                    )
                 )
 
         plain_table = (
@@ -812,14 +842,19 @@ class TestFind(LeoUnitTest):
             for pattern, s, expected in table:
                 flags = re.IGNORECASE if nocase else 0
                 x.re_obj = re.compile(pattern, flags)
-                pos, new_pos = x._inner_search_regex(s, 0, len(s), pattern, backwards=back, nocase=nocase)
+                pos, new_pos = x._inner_search_regex(
+                    s, 0, len(s), pattern, backwards=back, nocase=nocase
+                )
                 got = s[pos:new_pos]
-                assert expected == got, '\n   table: %s\n pattern: %r\n       s: %r\nexpected: %r\n     got: %r' % (
-                    table_name,
-                    pattern,
-                    s,
-                    expected,
-                    got,
+                assert expected == got, (
+                    '\n   table: %s\n pattern: %r\n       s: %r\nexpected: %r\n     got: %r'
+                    % (
+                        table_name,
+                        pattern,
+                        s,
+                        expected,
+                        got,
+                    )
                 )
 
         plain_table = (

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -80,7 +80,11 @@ class TestLeoImport(BaseTestImporter):
         x.parse_body(target)
 
         expected_results = (
-            (0, 'def spam', 'import os\n\ndef spam():\n    """A docstring"""\n    print(\'a string\')\n\n'),
+            (
+                0,
+                'def spam',
+                'import os\n\ndef spam():\n    """A docstring"""\n    print(\'a string\')\n\n',
+            ),
             (0, 'def eggs', 'def eggs():\n    pass\n\n'),
             (0, 'class NewClass', 'class NewClass\n    def f1(self):\n        pass\n'),
         )

--- a/leo/unittests/core/test_leoQt6.py
+++ b/leo/unittests/core/test_leoQt6.py
@@ -28,7 +28,11 @@ class TestQt6(BaseTestImporter):
         if 1:  # A real unit test.
             # Optional modules.
             exceptions = ('Qsci', 'QtSvg', 'QWebEngineSettings', 'WebEngineAttribute', 'uic')
-            fails = [attr for attr in attrs if attr not in exceptions and getattr(Qt6, attr, None) is None]
+            fails = [
+                attr
+                for attr in attrs
+                if attr not in exceptions and getattr(Qt6, attr, None) is None
+            ]
             self.assertFalse(fails, msg=','.join(fails))
 
         else:  # Inspection.

--- a/leo/unittests/core/test_leoShadow.py
+++ b/leo/unittests/core/test_leoShadow.py
@@ -1056,7 +1056,9 @@ class TestAtShadow(LeoUnitTest):
         x = c.shadowController
         filename = 'xyzzy'
         path = x.dirName(filename)
-        expected = g.os_path_dirname(g.os_path_abspath(g.os_path_join(g.os_path_dirname(c.fileName()), filename)))
+        expected = g.os_path_dirname(
+            g.os_path_abspath(g.os_path_join(g.os_path_dirname(c.fileName()), filename))
+        )
         self.assertEqual(path, expected)
 
     # @+node:ekr.20210902210552.7: *4* TestAtShadow.test_x_findAtLeoLine
@@ -1172,7 +1174,9 @@ class TestAtShadow(LeoUnitTest):
         prefix = c.config.getString('shadow_prefix') or ''
         filename = 'xyzzy'
         path = x.shadowPathName(filename)
-        expected = g.os_path_abspath(g.os_path_join(g.os_path_dirname(c.fileName()), subdir, prefix + filename))
+        expected = g.os_path_abspath(
+            g.os_path_join(g.os_path_dirname(c.fileName()), subdir, prefix + filename)
+        )
         self.assertEqual(path, expected)
 
     # @+node:ekr.20250710065413.1: *3* TestAtShadow.readOneAtCleanNode

--- a/leo/unittests/py3_test_grammar.py
+++ b/leo/unittests/py3_test_grammar.py
@@ -42,7 +42,12 @@ class TokenTests(unittest.TestCase):
             self.assert_(0o37777777777 > 0)
             self.assert_(0xFFFFFFFF > 0)
             self.assert_(0b1111111111111111111111111111111 > 0)
-            for s in ('2147483648', '0o40000000000', '0x100000000', '0b10000000000000000000000000000000'):
+            for s in (
+                '2147483648',
+                '0o40000000000',
+                '0x100000000',
+                '0b10000000000000000000000000000000',
+            ):
                 try:
                     x = eval(s)
                 except OverflowError:
@@ -440,7 +445,10 @@ class GrammarTests(unittest.TestCase):
         def f(a, b: 1, c: 2, d, e: 3 = 4, f=5, *g: 6, h: 7, i=8, j: 9 = 10, **k: 11) -> 12:
             pass
 
-        self.assertEquals(f.__annotations__, {'b': 1, 'c': 2, 'e': 3, 'g': 6, 'h': 7, 'j': 9, 'k': 11, 'return': 12})
+        self.assertEquals(
+            f.__annotations__,
+            {'b': 1, 'c': 2, 'e': 3, 'g': 6, 'h': 7, 'j': 9, 'k': 11, 'return': 12},
+        )
 
         # Check for SF Bug #1697248 - mixing decorators and a return annotation
         def null(x):
@@ -1099,7 +1107,13 @@ class GrammarTests(unittest.TestCase):
         ]
 
         self.assertEqual(
-            x, [('Boeing', 'Airliner'), ('Boeing', 'Engine'), ('Ford', 'Engine'), ('Macdonalds', 'Cheeseburger')]
+            x,
+            [
+                ('Boeing', 'Airliner'),
+                ('Boeing', 'Engine'),
+                ('Ford', 'Engine'),
+                ('Macdonalds', 'Cheeseburger'),
+            ],
         )
 
     def testGenexps(self):
@@ -1120,22 +1134,35 @@ class GrammarTests(unittest.TestCase):
         except TypeError:
             pass
 
-        self.assertEqual(list((x, y) for x in 'abcd' for y in 'abcd'), [(x, y) for x in 'abcd' for y in 'abcd'])
-        self.assertEqual(list((x, y) for x in 'ab' for y in 'xy'), [(x, y) for x in 'ab' for y in 'xy'])
+        self.assertEqual(
+            list((x, y) for x in 'abcd' for y in 'abcd'), [(x, y) for x in 'abcd' for y in 'abcd']
+        )
+        self.assertEqual(
+            list((x, y) for x in 'ab' for y in 'xy'), [(x, y) for x in 'ab' for y in 'xy']
+        )
 
         a = [x for x in range(10)]
         b = (x for x in (y for y in a))
         self.assertEqual(sum(b), sum([x for x in range(10)]))
 
         self.assertEqual(sum(x**2 for x in range(10)), sum([x**2 for x in range(10)]))
-        self.assertEqual(sum(x * x for x in range(10) if x % 2), sum([x * x for x in range(10) if x % 2]))
-        self.assertEqual(sum(x for x in (y for y in range(10))), sum([x for x in range(10)]))
-        self.assertEqual(sum(x for x in (y for y in (z for z in range(10)))), sum([x for x in range(10)]))
-        self.assertEqual(sum(x for x in [y for y in (z for z in range(10))]), sum([x for x in range(10)]))
         self.assertEqual(
-            sum(x for x in (y for y in (z for z in range(10) if True)) if True), sum([x for x in range(10)])
+            sum(x * x for x in range(10) if x % 2), sum([x * x for x in range(10) if x % 2])
         )
-        self.assertEqual(sum(x for x in (y for y in (z for z in range(10) if True) if False) if True), 0)
+        self.assertEqual(sum(x for x in (y for y in range(10))), sum([x for x in range(10)]))
+        self.assertEqual(
+            sum(x for x in (y for y in (z for z in range(10)))), sum([x for x in range(10)])
+        )
+        self.assertEqual(
+            sum(x for x in [y for y in (z for z in range(10))]), sum([x for x in range(10)])
+        )
+        self.assertEqual(
+            sum(x for x in (y for y in (z for z in range(10) if True)) if True),
+            sum([x for x in range(10)]),
+        )
+        self.assertEqual(
+            sum(x for x in (y for y in (z for z in range(10) if True) if False) if True), 0
+        )
         check_syntax_error(self, "foo(x for x in range(10), 100)")
         check_syntax_error(self, "foo(100, x for x in range(10))")
 
@@ -1195,7 +1222,12 @@ class GrammarTests(unittest.TestCase):
         # self.assertEqual([ x() for x in lambda: True, lambda: False if x() ], [True])
         self.assertEqual([x() for x in (lambda: True, lambda: False) if x()], [True])
         self.assertEqual(
-            [x(False) for x in (lambda x: False if x else True, lambda x: True if x else False) if x(False)], [True]
+            [
+                x(False)
+                for x in (lambda x: False if x else True, lambda x: True if x else False)
+                if x(False)
+            ],
+            [True],
         )
         self.assertEqual((5 if 1 else _checkeval("check 1", 0)), 5)
         self.assertEqual((_checkeval("check 2", 0) if 0 else 5), 5)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -358,9 +358,10 @@ Issues = "https://github.com/leo-editor/leo-editor/issues"
 "What People Are Saying about Leo" = "http://leo-editor.github.io/leo-editor/testimonials.html"
 #@-<< urls >>
 
-# @int black-line-length  overrides the default value of 120.
+# @int black-line-length  overrides this default value.
+# black's default value is 100.
 [tool.ruff]
-line-length = 120
+line-length = 100
 
 # @string black-toml gives the path to a pyproject.toml or ruff.toml file.
 [tool.ruff.format]


### PR DESCRIPTION
This PR replaces PR #4512.

`ruff format`'s default (100) seems perfect for Leo.

- [x] `leoSettings.leo`: Improve comment about line length.
- [x] `pyproject.toml`: Use `line-length = 100`.
- [x] `scripts/beautify_all_leo.py`: Don't override line length!
- [x] `plugins/cursesGui2.py.put`: Use `fmt: off` to work around weird mypy suppression failure.
- [x] Reformat all files.
- [x] Correct any infelicities in the `leo/core` and `leo/commands` directories.