### PR TITLE
PR: tweaks after changing black-line-length to 100

### DIFF
--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1611,10 +1611,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         i = w.getInsertPoint()
         row, col = g.convertPythonIndexToRowCol(s, i)
         percent = int((i * 100) / len(s))
-        k.setLabelGrey(
-            'char: %s row: %d col: %d pos: %d (%d%% of %d)'
-            % (repr(s[i]), row, col, i, percent, len(s))
-        )  # fmt: skip
+        k.setLabelGrey(f"char: {s[i]!r} row: {row} col: {col} ({percent}% of {len(s)})")
 
     # @+node:ekr.20150514063305.248: *4* ec.viewLossage
     @cmd('view-lossage')

--- a/leo/core/leoserver.py
+++ b/leo/core/leoserver.py
@@ -680,7 +680,7 @@ class QuickSearchController:
         c = self.c
         changed: list[tuple[Position, Match_Iter]] = [
             (p.copy(), None) for p in c.all_unique_positions() if p.isDirty()
-        ]  # fmt: skip
+        ]
         self.clear()
         self.addHeadlineMatches(changed)
 


### PR DESCRIPTION
- [x] Remove one unnecessary `#fmt skip` statement.
- [x] Convert one message using an f-string.