### PR TITLE
PR: yet more minor code cleanups

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -1009,7 +1009,7 @@ def writeFileFromNode(self: Self, event: LeoKeyEvent = None) -> None:
                 f.flush()
                 g.blue('wrote:', fileName)
         except IOError:
-            g.error('can not write %s', fileName)
+            g.error(f"can not write {fileName}")
 
 
 # @+node:tom.20230201124905.1: *3* c_file.writeFileFromSubtree
@@ -1051,7 +1051,7 @@ def writeFileFromSubtree(self: Self, event: LeoKeyEvent = None) -> None:
                 f.flush()
                 g.blue('wrote:', fileName)
         except IOError:
-            g.error('can not write %s', fileName)
+            g.error(f"can not write {fileName}")
 
 
 # @+node:ekr.20031218072017.2079: ** Recent Files

--- a/leo/commands/editCommands.py
+++ b/leo/commands/editCommands.py
@@ -1610,8 +1610,7 @@ class EditCommandsClass(BaseEditCommandsClass):
         s = w.getAllText()
         i = w.getInsertPoint()
         row, col = g.convertPythonIndexToRowCol(s, i)
-        percent = int((i * 100) / len(s))
-        k.setLabelGrey(f"char: {s[i]!r} row: {row} col: {col} ({percent}% of {len(s)})")
+        k.setLabelGrey(f"char: {s[i]!r} row: {row} col: {col} of {len(s)}")
 
     # @+node:ekr.20150514063305.248: *4* ec.viewLossage
     @cmd('view-lossage')

--- a/leo/core/leoApp.py
+++ b/leo/core/leoApp.py
@@ -2320,7 +2320,6 @@ class LoadManager:
             print(d)
             for key in sorted(list(d.keys())):
                 val = d.get(key)
-                # print('%20s %s' % (key,val.dump()))
                 print(f"{key:35} {[z.stroke for z in val]}")
             if d:
                 print('')

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -1484,8 +1484,11 @@ class AtFile:
             return
         ok = at.promptForDangerousWrite(
             fileName=None,
-            message=(f"{g.tr('path changed for %s' % (p.h))}\n{g.tr('write this file anyway?')}"),
-        )
+            message=(
+                f"{g.tr('path changed for %s' % (p.h))}\n"
+                f"{g.tr('write this file anyway?')}"
+            ),
+        )  # fmt: skip
         if not ok:
             raise IOError
         at.setPathUa(p, newPath)  # Remember that we have changed paths.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -673,7 +673,6 @@ class AtFile:
         junk, ext = g.os_path_splitext(fn)
         # Remember the full fileName.
         at.rememberReadPath(fn, p)
-        # if not g.unitTesting: g.es("reading: @asis %s" % (g.shortFileName(fn)))
         s, e = g.readFileIntoString(fn, kind='@edit')
         if s is None:
             return
@@ -840,7 +839,6 @@ class AtFile:
         junk, ext = g.os_path_splitext(fn)
         # Fix bug 889175: Remember the full fileName.
         at.rememberReadPath(fn, p)
-        # if not g.unitTesting: g.es("reading: @edit %s" % (g.shortFileName(fn)))
         s, e = g.readFileIntoString(fn, kind='@edit')
         if s is None:
             return

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1254,7 +1254,6 @@ class JEditColorizer(BaseColorizer):
         # But it is needed for forth.py.
         for ch in (' ', '\t'):
             if ch in chars:
-                # g.es_print('removing %s from word_chars' % (repr(ch)))
                 chars.remove(ch)
         # Convert chars to a dict for faster access.
         self.word_chars: dict[str, str] = {}
@@ -3155,7 +3154,6 @@ if QtGui:
             # Init pygments style.
             try:
                 self.setStyle(style_name)
-                # print('using %r pygments style in %r' % (style_name, c.shortFileName()))
             except Exception:
                 print(f'pygments {style_name!r} style not found. Using "default" style')
                 self.setStyle('default')
@@ -3716,9 +3714,8 @@ class QScintillaColorizer(BaseColorizer):
                 except Exception:
                     g.trace('bad color', color)
             else:
-                pass
                 # Not an error. Not all lexers have all styles.
-                # g.trace('bad style: %s.%s' % (lexer.__class__.__name__, style))
+                pass
 
     # @+node:ekr.20170128031840.1: *3* qsc.init
     def init(self) -> None:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3660,8 +3660,6 @@ class Commands:
         except Exception:
             g.es_exception()
             g.es(f"Failed to write script to {path}")
-            # g.es("Check your configuration of script_file_path, currently %s" %
-            # c.config.getString('script-file-path'))
             path = None
         return path
 
@@ -4733,9 +4731,7 @@ class Commands:
         if c.expansionLevel != old_expansion_level:
             c.redraw()
         # It's always useful to announce the level.
-        # c.k.setLabelBlue('level: %s' % (max_level+1))
-        # g.es('level', max_level + 1)
-        c.frame.putStatusLine(f"level: {max_level + 1}")  # bg='red', fg='red')
+        c.frame.putStatusLine(f"level: {max_level + 1}")
 
     # @+node:ekr.20141028061518.23: *4* c.Focus
     # @+node:ekr.20080514131122.9: *5* c.get/request/set_focus

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -6078,7 +6078,6 @@ def es(*args: Args, **kwargs: KWargs) -> None:
     newline = d.get('newline')
     s = g.translateArgs(args, d)
     # Do not call g.es, g.es_print, g.pr or g.trace here!
-    # sys.__stdout__.write('\n===== g.es: %r\n' % s)
     if app.batchMode:
         if app.log:
             app.log.put(s)

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -511,8 +511,7 @@ class BindingInfo:
                         val = val.__name__
                     s = f"{ivar}: {val!r}"
                     result.append(s)
-        # Clearer w/o f-string.
-        return "<%s>" % ' '.join(result).strip()
+        return "<{' '.join(result).strip()}>"
 
     # @+node:ekr.20120129040823.10226: *4* BindingInfo.isModeBinding
     def isModeBinding(self) -> bool:

--- a/leo/core/leoKeys.py
+++ b/leo/core/leoKeys.py
@@ -2936,12 +2936,7 @@ class KeyHandlerClass:
         key: str
         dataList: list[tuple[str, str]]
         for commandName in sorted(c.commandsDict):
-            dataList = inverseBindingDict.get(
-                commandName,
-                [
-                    ('', ''),
-                ],
-            )
+            dataList = inverseBindingDict.get(commandName, [('', '')])
             for pane, key in dataList:
                 key = k.prettyPrintKey(key)
                 binding = pane + key

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -84,8 +84,7 @@ def adoc_command(event: LeoKeyEvent = None, verbose: bool = True) -> File_List:
         import os
         paths = c.markupCommands.adoc_command(event=g.Bunch(p=p))
         paths = [z.replace('/', os.path.sep) for z in paths]
-        input_paths = ' '.join(paths)
-        g.execute_shell_commands(['asciidoctor %s' % input_paths])
+        g.execute_shell_commands([f"asciidoctor {' '.join(paths)}"])
 
     """
     # @-<< adoc command docstring >>
@@ -146,8 +145,7 @@ def pandoc_command(event: LeoKeyEvent, verbose: bool = True) -> File_List:
         import os
         paths = c.markupCommands.pandoc_command(event=g.Bunch(p=p))
         paths = [z.replace('/', os.path.sep) for z in paths]
-        input_paths = ' '.join(paths)
-        g.execute_shell_commands(['asciidoctor %s' % input_paths])
+        g.execute_shell_commands([f"asciidoctor {' '.join(paths)}"])
 
     """
     # @-<< pandoc command docstring >>
@@ -211,8 +209,7 @@ def sphinx_command(event: LeoKeyEvent, verbose: bool = True) -> File_List:
         import os
         paths = c.markupCommands.sphinx_command(event=g.Bunch(p=p))
         paths = [z.replace('/', os.path.sep) for z in paths]
-        input_paths = ' '.join(paths)
-        g.execute_shell_commands(['asciidoctor %s' % input_paths])
+        g.execute_shell_commands([f"asciidoctor {' '.join(paths)}"])
 
     """
     # @-<< sphinx command docstring >>

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -1349,7 +1349,7 @@ class Position:
             g.trace('child', child)
             g.trace('** callers:', g.callers())
             if g.unitTesting:
-                assert False, 'children[%s] != p.v'  # noqa
+                assert False, f"children[{n}] != p.v"
         else:
             g.trace(
                 f"**can not happen: bad child index: {n}, len(children): {len(parent_v.children)}"
@@ -1358,7 +1358,7 @@ class Position:
             g.trace('parent_v', parent_v, 'child', child)
             g.trace('** callers:', g.callers())
             if g.unitTesting:
-                assert False, f"bad child index: {n}"  # noqa
+                assert False, f"bad child index: {n}"
 
     # @+node:ekr.20080416161551.199: *3* p.moveToX
     # @+at These routines change self to a new position "in place".

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2227,10 +2227,8 @@ class VNode:
 
     def dump(self, label: str = "") -> None:  # pragma: no cover
         v = self
-        # s = '-' * 10
         print('')
         print(f"dump of vnode: {label} {v}")
-        # print('gnx: %s' % v.gnx)
         print(f"len(parents): {len(v.parents)} len(children): {len(v.children)}")
         if v.parents:
             print(f"parents: {g.listToString(v.parents)}")

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -363,7 +363,6 @@ class LeoPluginsController:
             if c:
                 # Make sure c exists and has a frame.
                 if not c.exists or not hasattr(c, 'frame'):
-                    # g.pr('skipping tag %s: c does not exist or does not have a frame.' % tag)
                     return None
         # Calls to registerHandler from inside the handler belong to moduleName.
         self.loadingModuleNameStack.append(moduleName)
@@ -585,8 +584,6 @@ class LeoPluginsController:
                 report(f"plugin {moduleName} does not support {g.app.gui.guiName()} gui")
             except ImportError:
                 report(f"error importing plugin: {moduleName}")
-            # except ModuleNotFoundError:
-            # report('module not found: %s' % moduleName)
             except SyntaxError:
                 report(f"syntax error importing plugin: {moduleName}")
             except Exception:

--- a/leo/core/leoPlugins.py
+++ b/leo/core/leoPlugins.py
@@ -211,13 +211,13 @@ class BaseLeoPlugin:
                 self.setMenuItem('Cmds', 'Ciao baby', self.ciao)
 
             def hello(self, event: LeoKeyEvent) -> None:
-                g.pr("hello from node %s" % self.c.p.h)
+                g.pr(f"hello from node {self.c.p.h}")
 
             def hola(self, event: LeoKeyEvent) -> None:
-                g.pr("hola from node %s" % self.c.p.h)
+                g.pr(f"hola from node {self.c.p.h}")
 
             def ciao(self, event: LeoKeyEvent) -> None:
-                g.pr("ciao baby (%s)" % self.c.p.h)
+                g.pr(f"ciao baby {self.c.p.h}")
 
         leoPlugins.registerHandler("after-create-leo-frame", Hello)
 

--- a/leo/core/leoShadow.py
+++ b/leo/core/leoShadow.py
@@ -446,12 +446,7 @@ class ShadowController:
             if written:
                 x.message(f"updated private {shadow_fn} from public {fn}")
         else:
-            pass
-            # Don't write *anything*.
-            # if 0: # This causes considerable problems.
-            # # Create the public file from the private shadow file.
-            # x.copy_file_removing_sentinels(shadow_fn,fn)
-            # x.message("created public %s from private %s " % (fn, shadow_fn))
+            pass  # Don't write *anything*.
 
     # @+node:ekr.20080708094444.89: *3* x.Utils...
     # @+node:ekr.20080708094444.85: *4* x.error & message & verbatim_error

--- a/leo/core/leoUndo.py
+++ b/leo/core/leoUndo.py
@@ -172,7 +172,6 @@ class Undoer:
                     return
                 i -= 1
             # This work regardless of how many items appear after bead n.
-            # g.trace('Cutting undo stack to %d entries' % (n))
             u.beads = u.beads[-n:]
             u.bead = n - 1
         if 'undo' in g.app.debug and 'verbose' in g.app.debug:  # pragma: no cover

--- a/leo/core/leoVim.py
+++ b/leo/core/leoVim.py
@@ -1647,8 +1647,6 @@ class VimCommands:
         if self.n1_seen:
             self.ignore()
             self.quit()
-            # self.beep('%sv not valid' % self.n1)
-            # self.done()
         elif self.is_text_wrapper(self.w):
             # Enter visual mode.
             self.vis_mode_w = w = self.w
@@ -2590,9 +2588,6 @@ class VimCommands:
         self.set_border()
         if k.state.kind:
             pass
-        # elif self.state == 'visual':
-        # s = '%8s:' % self.state.capitalize()
-        # k.setLabelBlue(s)
         else:
             if self.visual_line_flag:
                 state_s = 'Visual Line'
@@ -2600,7 +2595,6 @@ class VimCommands:
                 state_s = self.state.capitalize()
             command_s = self.show_command()
             dot_s = self.show_dot()
-            # if self.in_motion: state_s = state_s + '(in_motion)'
             if 1:  # Don't show the dot:
                 s = f"{state_s:8}: {command_s}"
             else:


### PR DESCRIPTION
- [x] Remove magic commas to compress tuples.
- [x] Remove old comments containing '%' as a string op.
- [x] Fix a minor bug in `p.badUnlink`.
- [x] Simplify the report in the `line-number` command.