### PR TITLE
PR Fixes #4522: contract-parent

### DIFF
--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -556,7 +556,7 @@ def expandAllHeadlines(self: Cmdr, event: LeoKeyEvent = None) -> None:
     while p:
         c.expandSubtree(p)
         p.moveToNext()
-    c.redraw_after_expand(p0)  # Keep focus on original position
+    c.redraw(p0)  # Keep focus on original position
     c.expansionLevel = 0  # Reset expansion level.
 
 
@@ -653,7 +653,7 @@ def expandNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
     p = c.p
     c.endEditing()
     p.expand()
-    c.redraw_after_expand(p)
+    c.redraw(p)
     c.selectPosition(p)
 
 
@@ -683,7 +683,7 @@ def expandNodeOrGoToFirstChild(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c.endEditing()
     if p.hasChildren():
         if p.isExpanded():
-            c.redraw_after_expand(p.firstChild())
+            c.redraw(p.firstChild())
         else:
             c.expandNode()
 

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -497,9 +497,9 @@ def contractNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
     c = self
     p = c.p
     c.endEditing()
-    p.contract()
-    c.redraw_after_contract(p)
     c.selectPosition(p)
+    p.contract()
+    c.redraw()
 
 
 # @+node:ekr.20040930064232: *3* c_oc.contractNodeOrGoToParent
@@ -539,8 +539,9 @@ def contractParent(self: Cmdr, event: LeoKeyEvent = None) -> None:
     parent = p.parent()
     if not parent:
         return
+    c.selectPosition(parent)
     parent.contract()
-    c.redraw_after_contract(p=parent)
+    c.redraw()
 
 
 # @+node:ekr.20031218072017.2903: *3* c_oc.expandAllHeadlines

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -433,12 +433,6 @@ class TreeAPI:
 
     # Hints for optimization. The proper default is c.redraw()
 
-    def redraw_after_contract(self, p: Position) -> None:
-        pass
-
-    def redraw_after_expand(self, p: Position) -> None:
-        pass
-
     def redraw_after_head_changed(self) -> None:
         pass
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4552,7 +4552,7 @@ class Commands:
         """
         c = self
         if not c.requestLaterRedraw and 'drawing' in g.app.debug:
-            g.trace('set c.requestLaterRedraw', c.shortFileName(), g.callers(1))
+            g.trace(f"set c.requestLaterRedraw: {c.shortFileName():>20} {g.callers(1)}")
         c.requestLaterRedraw = True
 
     # @+node:ekr.20080514131122.17: *5* c.widget_name

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4694,7 +4694,6 @@ class Commands:
     def expandToLevel(self, level: int) -> None:
         c = self
         n = c.p.level()
-        old_expansion_level = c.expansionLevel
         max_level = 0
         for p in c.p.self_and_subtree(copy=False):
             if p.level() - n + 1 < level:
@@ -4704,8 +4703,7 @@ class Commands:
                 p.contract()
         c.expansionNode = c.p.copy()
         c.expansionLevel = max_level + 1
-        if c.expansionLevel != old_expansion_level:
-            c.redraw()
+        c.redraw()
         # It's always useful to announce the level.
         c.frame.putStatusLine(f"level: {max_level + 1}")
 

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4551,9 +4551,9 @@ class Commands:
         c.outerUpdate will call c.redraw() only if no other code calls c.redraw().
         """
         c = self
+        if not c.requestLaterRedraw and 'drawing' in g.app.debug:
+            g.trace('set c.requestLaterRedraw', c.shortFileName(), g.callers(1))
         c.requestLaterRedraw = True
-        if 'drawing' in g.app.debug:
-            g.trace(g.callers(1))
 
     # @+node:ekr.20080514131122.17: *5* c.widget_name
     def widget_name(self, widget: Widget) -> str:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4511,12 +4511,13 @@ class Commands:
         # Clear the redraw request, again.
         c.requestLaterRedraw = False
 
-    # Compatibility with old scripts
+    # Compatibility with old scripts.
+    # Do *not* delete redraw_after_select or redraw_after_head_changed.
 
     force_redraw = redraw
-    redraw_now = redraw
     redraw_after_contract = redraw
     redraw_after_expand = redraw
+    redraw_now = redraw
 
     # @+node:ekr.20090110073010.2: *6* c.redraw_after_head_changed
     def redraw_after_head_changed(self) -> None:
@@ -4552,8 +4553,7 @@ class Commands:
         c = self
         c.requestLaterRedraw = True
         if 'drawing' in g.app.debug:
-            # g.trace('\n' + g.callers(8))
-            g.trace(g.callers())
+            g.trace(g.callers(1))
 
     # @+node:ekr.20080514131122.17: *5* c.widget_name
     def widget_name(self, widget: Widget) -> str:

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4516,19 +4516,6 @@ class Commands:
     force_redraw = redraw
     redraw_now = redraw
 
-    # @+node:ekr.20090110131802.2: *6* c.redraw_after_contract
-    def redraw_after_contract(self, p: Position = None) -> None:
-        c = self
-        if c.enableRedrawFlag:
-            if p:
-                c.setCurrentPosition(p)
-            else:
-                p = c.currentPosition()
-            c.frame.tree.redraw_after_contract(p)
-            c.treeFocusHelper()
-        else:
-            c.requestLaterRedraw = True
-
     # @+node:ekr.20090112065525.1: *6* c.redraw_after_expand
     def redraw_after_expand(self, p: Position) -> None:
         c = self

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -4515,19 +4515,8 @@ class Commands:
 
     force_redraw = redraw
     redraw_now = redraw
-
-    # @+node:ekr.20090112065525.1: *6* c.redraw_after_expand
-    def redraw_after_expand(self, p: Position) -> None:
-        c = self
-        if c.enableRedrawFlag:
-            if p:
-                c.setCurrentPosition(p)
-            else:
-                p = c.currentPosition()
-            c.frame.tree.redraw_after_expand(p)
-            c.treeFocusHelper()
-        else:
-            c.requestLaterRedraw = True
+    redraw_after_contract = redraw
+    redraw_after_expand = redraw
 
     # @+node:ekr.20090110073010.2: *6* c.redraw_after_head_changed
     def redraw_after_head_changed(self) -> None:

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -1177,10 +1177,7 @@ class LeoTree:
         if g.app.killed or self.tree_select_lockout:  # Essential.
             return
         if trace:
-            print(f"----- {tag}: {p.h}")
-            # print(f"{tag:>30}: {c.frame.body.wrapper} {p.h}")
-            # Format matches traces in retired leoflexx.py
-            # print(f"{tag:30}: {len(p.b):4} {p.gnx} {p.h}")
+            print(tag, p.h)
         try:
             self.tree_select_lockout = True
             self.prev_v = c.p.v

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -997,12 +997,6 @@ class LeoTree:
 
     # Hints for optimization. The proper default is c.redraw()
 
-    def redraw_after_contract(self, p: Position) -> None:
-        self.c.redraw()
-
-    def redraw_after_expand(self, p: Position) -> None:
-        self.c.redraw()
-
     def redraw_after_head_changed(self) -> None:
         self.c.redraw()
 
@@ -1855,19 +1849,11 @@ class NullTree(LeoTree):
     def redraw(self, p: Position = None) -> None:
         self.redrawCount += 1
 
+    redraw_after_contract = redraw
+    redraw_after_expand = redraw
+    redraw_after_head_changed = redraw
+    redraw_after_select = redraw
     redraw_now = redraw
-
-    def redraw_after_contract(self, p: Position) -> None:
-        self.redraw()
-
-    def redraw_after_expand(self, p: Position) -> None:
-        self.redraw()
-
-    def redraw_after_head_changed(self) -> None:
-        self.redraw()
-
-    def redraw_after_select(self, p: Position = None) -> None:
-        self.redraw()
 
     def scrollTo(self, p: Position) -> None:
         pass

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2647,12 +2647,6 @@ class CoreTree(leoFrame.LeoTree):
     repaint = redraw
 
     # @+node:ekr.20170511100356.1: *5* CTree.redraw_after...
-    def redraw_after_contract(self, p: Position = None) -> None:
-        self.redraw(p)
-
-    def redraw_after_expand(self, p: Position = None) -> None:
-        self.redraw(p)
-
     def redraw_after_head_changed(self) -> None:
         self.redraw()
 

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2618,11 +2618,7 @@ class CoreTree(leoFrame.LeoTree):
         self.redrawCount = 0  # For unit tests.
         self.widget: Wrapper = None  # A LeoMLTree set by CGui.createCursesTree.
         # self.setConfigIvars()
-        # Status flags, for busy()
-        self.contracting = False
-        self.expanding = False
-        self.redrawing = False
-        self.selecting = False
+        self.redrawing = False  # Lockout..
 
     # @+node:ekr.20170511094217.1: *4* CTree.Drawing
     # @+node:ekr.20170511094217.3: *5* CTree.redraw
@@ -2636,7 +2632,7 @@ class CoreTree(leoFrame.LeoTree):
             return  # There is no need. At present, the tests hang.
         if trace:
             g.trace(g.callers())
-        if self.widget and not self.busy():
+        if self.widget and not self.redrawing:
             self.redrawCount += 1  # To keep a unit test happy.
             self.widget.update()
 
@@ -2652,14 +2648,8 @@ class CoreTree(leoFrame.LeoTree):
 
     def redraw_after_select(self, p: Position = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
-        # Prevent the selecting lockout from disabling the redraw.
-        oldSelecting = self.selecting
-        self.selecting = False
-        try:
-            if not self.busy():
-                self.redraw(p=p)
-        finally:
-            self.selecting = oldSelecting
+        if not self.redrawing:
+            self.redraw(p=p)
 
     # @+node:ekr.20170511104032.1: *4* CTree.error
     def error(self, s: str) -> None:
@@ -2667,17 +2657,6 @@ class CoreTree(leoFrame.LeoTree):
             g.trace('LeoQtTree Error: %s' % (s), g.callers())
 
     # @+node:ekr.20170511104533.1: *4* CTree.Event handlers
-    # @+node:ekr.20170511104533.10: *5* CTree.busy
-    def busy(self) -> str:
-        """Return True (actually, a debugging string)
-        if any lockout is set."""
-        trace = False
-        table = ('contracting', 'expanding', 'redrawing', 'selecting')
-        kinds = ','.join([z for z in table if getattr(self, z)])
-        if kinds and trace:
-            g.trace(kinds)
-        return kinds  # Return the string for debugging
-
     # @+node:ekr.20170511104533.12: *5* CTree.onHeadChanged (cursesGui2)
     # Tricky code: do not change without careful thought and testing.
 

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2660,7 +2660,6 @@ class CoreTree(leoFrame.LeoTree):
                 self.redraw(p=p)
         finally:
             self.selecting = oldSelecting
-        # Do *not* call redraw_after_select here!
 
     # @+node:ekr.20170511104032.1: *4* CTree.error
     def error(self, s: str) -> None:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -519,7 +519,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 p.moveToNext()
         if trace:
             t2 = time.process_time()
-            g.trace(f"{t2 - t1:5.2f} sec.", g.callers(6))
+            g.trace(f"{t2 - t1:5.2f} sec.", g.callers(3))
 
     # @+node:ekr.20110605121601.17877: *5* qtree.drawTree
     def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -685,6 +685,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17895: *4* qtree.onItemCollapsed
     def onItemCollapsed(self, item: QTreeWidgetItem) -> None:
+        """Handle Qt tree-collapsed events."""
         if self.busy:
             return
         if 'drawing' in g.app.debug:
@@ -725,7 +726,7 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17898: *4* qtree.onItemExpanded
     def onItemExpanded(self, item: QTreeWidgetItem) -> None:
-        """Handle and tree-expansion event."""
+        """Handle Qt tree-expansion events."""
         if self.busy:  # Required
             return
         if 'drawing' in g.app.debug:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -683,6 +683,8 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17895: *4* qtree.onItemCollapsed
     def onItemCollapsed(self, item: QTreeWidgetItem) -> None:
+        if 'drawing' in g.app.debug:
+            g.trace(g.callers(1))
         if self.busy:
             return
         c = self.c
@@ -722,6 +724,8 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17898: *4* qtree.onItemExpanded
     def onItemExpanded(self, item: QTreeWidgetItem) -> None:
         """Handle and tree-expansion event."""
+        if 'drawing' in g.app.debug:
+            g.trace(g.callers(1))
         if self.busy:  # Required
             return
         c = self.c
@@ -733,7 +737,6 @@ class LeoQtTree(leoFrame.LeoTree):
         # Only methods that actually generate events should set lockouts.
         if not p.isExpanded():
             p.expand()
-            c.redraw_after_expand(p)
         self.select(p)
         c.outerUpdate()
 

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -519,7 +519,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 p.moveToNext()
         if trace:
             t2 = time.process_time()
-            g.trace(f"{t2 - t1:5.2f} sec.")
+            g.trace(f"{t2 - t1:5.2f} sec.", g.callers(6))
 
     # @+node:ekr.20110605121601.17877: *5* qtree.drawTree
     def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:
@@ -686,9 +686,9 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17895: *4* qtree.onItemCollapsed
     def onItemCollapsed(self, item: QTreeWidgetItem) -> None:
         if self.busy:
-            if 'drawing' in g.app.debug:
-                g.trace('busy!', g.callers(1))
             return
+        if 'drawing' in g.app.debug:
+            g.trace(g.callers(1))
         c = self.c
         p = self.item2position(item)
         if not p:
@@ -696,10 +696,10 @@ class LeoQtTree(leoFrame.LeoTree):
             return
         # Do **not** set lockouts here.
         # Only methods that actually generate events should set lockouts.
+        self.select(p)
         if p.isExpanded():
             p.contract()
-        self.select(p)
-        c.outerUpdate()
+        c.redraw()
 
     # @+node:ekr.20110605121601.17897: *4* qtree.onItemDoubleClicked
     def onItemDoubleClicked(self, item: QTreeWidgetItem, col: int) -> None:  # col not used.
@@ -727,9 +727,9 @@ class LeoQtTree(leoFrame.LeoTree):
     def onItemExpanded(self, item: QTreeWidgetItem) -> None:
         """Handle and tree-expansion event."""
         if self.busy:  # Required
-            if 'drawing' in g.app.debug:
-                g.trace('busy!', g.callers(1))
             return
+        if 'drawing' in g.app.debug:
+            g.trace(g.callers(1))
         c = self.c
         p = self.item2position(item)
         if not p:
@@ -737,10 +737,10 @@ class LeoQtTree(leoFrame.LeoTree):
             return
         # Do **not** set lockouts here.
         # Only methods that actually generate events should set lockouts.
+        self.select(p)
         if not p.isExpanded():
             p.expand()
-        self.select(p)
-        c.outerUpdate()
+        c.redraw()
 
     # @+node:ekr.20110605121601.17899: *4* qtree.onTreeSelect
     def onTreeSelect(self) -> None:

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -519,7 +519,7 @@ class LeoQtTree(leoFrame.LeoTree):
                 p.moveToNext()
         if trace:
             t2 = time.process_time()
-            g.trace(f"{t2 - t1:5.2f} sec.", g.callers(5))
+            g.trace(f"{t2 - t1:5.2f} sec.")
 
     # @+node:ekr.20110605121601.17877: *5* qtree.drawTree
     def drawTree(self, p: Position, parent_item: QTreeWidgetItem = None) -> None:
@@ -557,6 +557,8 @@ class LeoQtTree(leoFrame.LeoTree):
     def redraw_after_select(self, p: Position = None) -> None:
         """Redraw the entire tree when an invisible node is selected."""
         if self.busy:
+            if 'drawing' in g.app.debug:
+                g.trace('busy!', g.callers(1))
             return
         self.full_redraw(p)
         # c.redraw_after_select calls tree.select indirectly.
@@ -683,9 +685,9 @@ class LeoQtTree(leoFrame.LeoTree):
 
     # @+node:ekr.20110605121601.17895: *4* qtree.onItemCollapsed
     def onItemCollapsed(self, item: QTreeWidgetItem) -> None:
-        if 'drawing' in g.app.debug:
-            g.trace(g.callers(1))
         if self.busy:
+            if 'drawing' in g.app.debug:
+                g.trace('busy!', g.callers(1))
             return
         c = self.c
         p = self.item2position(item)
@@ -724,9 +726,9 @@ class LeoQtTree(leoFrame.LeoTree):
     # @+node:ekr.20110605121601.17898: *4* qtree.onItemExpanded
     def onItemExpanded(self, item: QTreeWidgetItem) -> None:
         """Handle and tree-expansion event."""
-        if 'drawing' in g.app.debug:
-            g.trace(g.callers(1))
         if self.busy:  # Required
+            if 'drawing' in g.app.debug:
+                g.trace('busy!', g.callers(1))
             return
         c = self.c
         p = self.item2position(item)

--- a/leo/plugins/qt_tree.py
+++ b/leo/plugins/qt_tree.py
@@ -538,21 +538,6 @@ class LeoQtTree(leoFrame.LeoTree):
         self.vnode2itemsDict = {}
         self.editWidgetsDict = {}
 
-    # @+node:ekr.20110605121601.17880: *4* qtree.redraw_after_contract
-    def redraw_after_contract(self, p: Position) -> None:
-        if self.busy:
-            return
-        self.update_expansion(p)
-
-    # @+node:ekr.20110605121601.17881: *4* qtree.redraw_after_expand
-    def redraw_after_expand(self, p: Position) -> None:
-        if 0:  # Does not work. Newly visible nodes do not show children correctly.
-            c = self.c
-            c.selectPosition(p)
-            self.update_expansion(p)
-        else:
-            self.full_redraw(p)  # Don't try to shortcut this!
-
     # @+node:ekr.20110605121601.17882: *4* qtree.redraw_after_head_changed
     def redraw_after_head_changed(self) -> None:
         """Redraw all Qt outline items cloned to c.p."""
@@ -583,30 +568,6 @@ class LeoQtTree(leoFrame.LeoTree):
         w = self.treeWidget
         w.repaint()
         w.resizeColumnToContents(0)  # 2009/12/22
-
-    # @+node:ekr.20180817043619.1: *4* qtree.update_expansion
-    def update_expansion(self, p: Position) -> None:
-        """Update expansion bits for p, including all clones."""
-        c = self.c
-        w = self.treeWidget
-        expand = c.shouldBeExpanded(p)
-        if 'drawing' in g.app.debug:
-            g.trace('expand' if expand else 'contract')
-        item = self.position2itemDict.get(p.key())
-        if p:
-            try:
-                # These generate events, which would trigger a full redraw.
-                self.busy = True
-                if expand:
-                    w.expandItem(item)
-                else:
-                    w.collapseItem(item)
-            finally:
-                self.busy = False
-            w.repaint()
-        else:
-            g.trace('NO P')
-            c.redraw()
 
     # @+node:ekr.20110605121601.17885: *3* qtree.Event handlers
     # @+node:ekr.20110605121601.17887: *4*  qtree.Click Box
@@ -733,7 +694,6 @@ class LeoQtTree(leoFrame.LeoTree):
         # Only methods that actually generate events should set lockouts.
         if p.isExpanded():
             p.contract()
-            c.redraw_after_contract(p)
         self.select(p)
         c.outerUpdate()
 

--- a/leo/unittests/core/test_leoserver.py
+++ b/leo/unittests/core/test_leoserver.py
@@ -198,8 +198,8 @@ class TestLeoServer(LeoUnitTest):
         for action, package in table:
             self._request(action, package)
 
-    # @+node:felix.20210621233316.104: *3* TestLeoServer.test_find_commands
-    def test_find_commands(self):
+    # @+node:felix.20210621233316.104: *3* TestLeoServer.slow_test_find_commands
+    def slow_test_find_commands(self):
         tag = 'test_find_commands'
         test_dot_leo = g.finalize_join(g.app.loadDir, '..', 'test', 'test.leo')
         assert os.path.exists(test_dot_leo), repr(test_dot_leo)


### PR DESCRIPTION
See #4522.

**Discussion**

*Warning*: All changes to drawing code have the potential to corrupt data. This probably happened once to me while working on this PR. Careful testing and analysis are required.

Only the changes to `leo/commands/commanderOutlineCommands.py` are likely to affect LeoJS directly. 

**Straightforward changes to Leo's core and Qt gui code**

- [x] Call `c.redraw` instead of `c.redraw_after_contract`.
- [x] Retire `c.redraw_after_contract`, and `c.redraw_after_expand`, making them synonyms for `c.redraw`.
- [x] Retire `qtree.redraw_after_contract`, `qtree.redraw_after_expand` and `qtree.update_expansion`.
   No script should ever calls these methods.
- [x] `c.redraw`: Add comment that `redraw_after_select` and `redraw_after_head_changed` must remain as they are.
   Making them synonyms for `c.redraw` would break the Qt gui!
- [x] `c.expandToLevel` always calls `c.redraw`. This might be an ancient bug.
- [x] Don't execute one slow unit test by default. This takes about 10 seconds on my machine!

**Potentially dangerous changes to `leo/plugins/qt_tree.py`**

- [x] `qtree.onItemCollapsed` and `qtree.onItemExpanded`: always call `c.redraw` instead of `c.outerUpdate`.
  The danger: too many redraws. Tests with `--trace=drawing` show that all is well.

**Straightforward changes to the `CTree` class in `leo/plugins/cursesGui2.py`**

I have tested these changes by hand using `--gui=console`.

- [x] Retire `CTree.redraw_after_contract` and `CTree.redraw_after_expand`.
- [x] Replace `CTree.busy()` by a single test on `CTree.redrawing`, removing three unnecessary lockouts.
- [x] Simplify `CTree.redraw_after_select`.