### PR TITLE
PR: Remove duplicate goto commands from commanderEditCommands.py

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -646,21 +646,6 @@ def findMatchingBracket(self: Self, event: LeoKeyEvent = None) -> None:
         g.MatchBrackets(c, p, language).run()
 
 
-# @+node:ekr.20110402084740.14490: ** c_ec.goToNext/PrevHistory
-@g.commander_command('goto-next-history-node')
-def goToNextHistory(self: Self, event: LeoKeyEvent = None) -> None:
-    """Go to the next node in the history list."""
-    c = self
-    c.nodeHistory.goNext()
-
-
-@g.commander_command('goto-prev-history-node')
-def goToPrevHistory(self: Self, event: LeoKeyEvent = None) -> None:
-    """Go to the previous node in the history list."""
-    c = self
-    c.nodeHistory.goPrev()
-
-
 # @+node:ekr.20171123135625.30: ** c_ec.alwaysIndentBody (always-indent-region)
 @g.commander_command('always-indent-region')
 def alwaysIndentBody(self: Self, event: LeoKeyEvent = None) -> None:

--- a/leo/commands/commanderOutlineCommands.py
+++ b/leo/commands/commanderOutlineCommands.py
@@ -763,6 +763,7 @@ def findNextClone(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1628: *3* c_oc.goNextVisitedNode
 @g.commander_command('go-forward')
+@g.commander_command('goto-next-history-node')
 def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
     """Select the next visited node."""
     c = self
@@ -771,6 +772,7 @@ def goNextVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
 
 # @+node:ekr.20031218072017.1627: *3* c_oc.goPrevVisitedNode
 @g.commander_command('go-back')
+@g.commander_command('goto-prev-history-node')
 def goPrevVisitedNode(self: Cmdr, event: LeoKeyEvent = None) -> None:
     """Select the previously visited node."""
     c = self


### PR DESCRIPTION
See #4525.

- [x]  Remove duplicate goto commands from `commanderEditCommands.py`, retaining the spelling of all commands.