### PR TITLE
Ensured proper tree re-rendering on separator drag.

### DIFF
--- a/leo/plugins/html_outline_viewer.html
+++ b/leo/plugins/html_outline_viewer.html
@@ -2374,7 +2374,6 @@
                     OUTLINE_FIND_CONTAINER.style.width = (minWidth - 3) + 'px';
                 }
                 CONFIG_BTN.style.inset = `auto auto 7px ${newWidth - 33}px`;
-                renderTree(); // Need to re-render tree
             } else {
                 let clientY = e.clientY;
                 if (e.touches) {
@@ -2389,6 +2388,7 @@
                 CONFIG_BTN.style.inset = `${newHeight - 33}px 7px auto auto`;
             }
             positionCrossDragger();
+            renderTree();
             updateCollapseAllPosition();
         }, 33);
 
@@ -2476,9 +2476,9 @@
                     OUTLINE_PANE.style.flex = `0 0 ${relativeX - 3}px`;
                     FIND_PANE.style.flex = '1 1 auto'; // Let it take the remaining space
                 }
-                renderTree(); // Need to re-render tree
             }
             positionCrossDragger();
+            renderTree();
             updateCollapseAllPosition();
         }, 33);
 
@@ -2551,7 +2551,7 @@
                 }
             }
             positionCrossDragger();
-            renderTree(); // Render afterward as it would be in each branch of the if/else
+            renderTree();
             updateCollapseAllPosition();
         }, 33);
 

--- a/leo/plugins/html_outline_viewer.html
+++ b/leo/plugins/html_outline_viewer.html
@@ -2153,7 +2153,7 @@
                 BODY_PANE.style.whiteSpace = "pre-wrap"; // Wrap text
             }
             let text = data[node.gnx].bodyString || "";
-            
+
             // Escape HTML entities first to preserve literal characters
             text = text.replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')
@@ -2374,6 +2374,7 @@
                     OUTLINE_FIND_CONTAINER.style.width = (minWidth - 3) + 'px';
                 }
                 CONFIG_BTN.style.inset = `auto auto 7px ${newWidth - 33}px`;
+                renderTree(); // Need to re-render tree
             } else {
                 let clientY = e.clientY;
                 if (e.touches) {
@@ -2385,7 +2386,6 @@
                 } else {
                     OUTLINE_FIND_CONTAINER.style.height = (minWidth - 3) + 'px';
                 }
-                renderTree(); // Resizing vertically, so need to re-render tree
                 CONFIG_BTN.style.inset = `${newHeight - 33}px 7px auto auto`;
             }
             positionCrossDragger();
@@ -2464,7 +2464,6 @@
                     OUTLINE_PANE.style.flex = `0 0 ${relativeY - 8}px`;
                     FIND_PANE.style.flex = '1 1 auto'; // Let it take the remaining space
                 }
-                renderTree(); // Resizing vertically, so need to re-render tree
             } else {
                 let clientX = e.clientX;
                 if (e.touches) {
@@ -2477,6 +2476,7 @@
                     OUTLINE_PANE.style.flex = `0 0 ${relativeX - 3}px`;
                     FIND_PANE.style.flex = '1 1 auto'; // Let it take the remaining space
                 }
+                renderTree(); // Need to re-render tree
             }
             positionCrossDragger();
             updateCollapseAllPosition();
@@ -2551,7 +2551,6 @@
                 }
             }
             positionCrossDragger();
-
             renderTree(); // Render afterward as it would be in each branch of the if/else
             updateCollapseAllPosition();
         }, 33);


### PR DESCRIPTION
As I'm putting the finishing touches on Leo-Web which re-uses this html_outline_viewer, I've stumbled upon another small correction in the mouse-drag behavior of the separators. 
