### PR TITLE
Title: Core: Improve AsciiDoc path detection and @ignore-node level logic (#4424)

### DIFF
--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -442,9 +442,14 @@ class MarkupCommands:
                 p.moveToNodeAfterTree()
                 continue
             is_section_def = h.startswith('<<') and h.endswith('>>')
-            if g.match_word(h, 0, '@ignore-node') or is_section_def:
+            if g.match_word(h, 0, '@ignore-node'):
                 p.moveToThreadNext()
                 continue
+
+            if is_section_def:
+                p.moveToNodeAfterTree()
+                continue
+
             if not g.match_word(h, 0, '@no-head'):
                 self.write_headline(p)
             self.write_body(p)
@@ -531,7 +536,7 @@ class MarkupCommands:
             if g.match_word(current.h.rstrip(), 0, '@ignore-node'):
                 effective_level -= 1
             current = current.parent()
-            return effective_level
+        return effective_level
     # @+node:ekr.20191006155051.1: *3* markup.commands
     def adoc_command(
         self,

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -441,7 +441,8 @@ class MarkupCommands:
             if g.match_word(h, 0, '@ignore-tree'):
                 p.moveToNodeAfterTree()
                 continue
-            if g.match_word(h, 0, '@ignore-node'):
+            is_section_def = h.startswith('<<') and h.endswith('>>')
+            if g.match_word(h, 0, '@ignore-node') or is_section_def:
                 p.moveToThreadNext()
                 continue
             if not g.match_word(h, 0, '@no-head'):
@@ -468,7 +469,8 @@ class MarkupCommands:
         """Write p.b"""
         # We no longer add newlines to the start of nodes because
         # we write a blank line after all sections.
-        s = self.remove_directives(p.b)
+        script = g.getScript(self.c, p, useSentinels=False)
+        s = self.remove_directives(script)
         self.output_file.write(g.ensureTrailingNewlines(s, 2))
 
     # @+node:ekr.20190515070742.47: *4* markup.write_headline

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -24,7 +24,18 @@ if TYPE_CHECKING:  # pragma: no cover
     File_List = Optional[list[str]]
 # @-<< leoMarkup imports & annotations >>
 
-asciidoctor_exec = which('asciidoctor')
+# Try RVM Ruby asciidoctor first, then fallback to system asciidoctor
+try:
+    import subprocess
+    rvm_gemdir = subprocess.check_output(['rvm', 'gemdir'], text=True).strip()
+    rvm_asciidoctor = os.path.join(rvm_gemdir, 'bin', 'asciidoctor')
+    if os.path.exists(rvm_asciidoctor):
+        asciidoctor_exec = rvm_asciidoctor
+    else:
+        asciidoctor_exec = which('asciidoctor')
+except Exception as e:
+    asciidoctor_exec = which('asciidoctor')
+    print("e:", e)
 asciidoc3_exec = which('asciidoc3')
 pandoc_exec = which('pandoc')
 sphinx_build = which('sphinx-build')
@@ -360,7 +371,7 @@ class MarkupCommands:
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         # Call the external program to write the output file.
         # The -e option deletes css.
-        prog = 'asciidoctor' if asciidoctor_exec else 'asciidoc3'
+        prog = asciidoctor_exec if asciidoctor_exec else asciidoc3_exec
         command = f"{prog} {i_path} -o {o_path} -b html5"
         g.execute_shell_commands(command)
 
@@ -465,7 +476,8 @@ class MarkupCommands:
         """Generate an AsciiDoctor section"""
         if not p.h.strip():
             return
-        level = max(0, self.level_offset + p.level() - self.root_level)
+        effective_level = self.compute_effective_level(p)
+        level = max(0, self.level_offset + effective_level - self.root_level)
         if self.kind == 'sphinx':
             # For now, assume rST markup!
             # Hard coded characters. Never use '#' underlining.
@@ -499,6 +511,17 @@ class MarkupCommands:
             result.append(s)
         return ''.join(result)
 
+    # @+node:swot.20260218221512.1: *4* compute_effective_level
+    def compute_effective_level(self, p: Position) -> int:
+        """Compute the effective level of a node, accounting for @ignore-node ancestors."""
+        effective_level = p.level()
+        # Walk up the tree and subtract levels for @ignore-node ancestors
+        current = p.parent()
+        while current and current.level() >= self.root_level:
+            if g.match_word(current.h.rstrip(), 0, '@ignore-node'):
+                effective_level -= 1
+            current = current.parent()
+            return effective_level
     # @+node:ekr.20191006155051.1: *3* markup.commands
     def adoc_command(
         self,

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -448,7 +448,15 @@ class MarkupCommands:
             if not g.match_word(h, 0, '@no-head'):
                 self.write_headline(p)
             self.write_body(p)
-            p.moveToThreadNext()
+            # --- solve @others rendered below again ---
+            # check current node whether including @others or not
+            if re.search(r'^[ \t]*@others\b', p.b, re.MULTILINE):
+                # including @others: g.getScript has got all the subnodes
+                # then skip all subnodes for not to be rendered
+                p.moveToNodeAfterTree()
+            else:
+                # not including @others: mote to next node
+                p.moveToThreadNext()
 
     # @+node:ekr.20190515114836.1: *4* markup.compute_level_offset
     adoc_title_pat = re.compile(r'^= ')


### PR DESCRIPTION
### Overview

This PR addresses the core logic modifications outlined in #4424 (Items 1 and 2). It improves the reliability of the AsciiDoc environment setup and fixes structural issues in the generated document hierarchy.

### Key Changes

#### 1. Improved Asciidoctor Path Detection (RVM Support)

Updated the global initialization in `leoMarkup.py` to better handle Ruby environments:

* **Priority Detection:** The logic now prioritizes the `asciidoctor` executable within RVM-managed Ruby environments.
* **Robust Fallback:** It gracefully falls back to the system-wide `asciidoctor` if the RVM path is not found or inaccessible.

#### 2. @ignore-node Level Logic Fix

Refactored `compute_effective_level` and `write_headline` to ensure document structural integrity:

* **Level Normalization:** Correctly calculates the effective heading level for children of `@ignore-node` ancestors.
* **Edge Case Handling:** Now properly handles `@ignore-node` headlines that may contain trailing spaces.
* **Deep Nesting:** Ensures that nodes nested under multiple `@ignore-node` levels still render at the correct hierarchical depth in the final AsciiDoc output.

### Note on Scope

As discussed in #4293, this PR **does not** include the implementation for `asciidoctor-diagram` support (Item 3 of #4424). I have focused this PR strictly on the path detection and node leveling fixes to maintain stability.

### Related Issues

* Partially addresses #4424
* Contextually relates to #4293

---

Added again：

"Hi Edward,

I've been using the @adoc feature extensively and found that I missed the ability to use Leo's literate programming structures within my documentation code blocks.

I have implemented a fix that allows g.getScript to handle the body expansion. I also added a check during the tree traversal to prevent sub-nodes (used as code sections) from being rendered twice—once in the code block and once as a heading.

I've tested this with various nesting levels, and the indentation remains consistent. I hope you find this a useful addition to Leo's markup capabilities!"

https://github.com/leo-editor/leo-editor/issues/4538