### PR TITLE
Tkinter is not on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -324,7 +324,6 @@ dependencies = [
   "pyenchant",       # The spell tab.
  
   "sphinx",
-  "tk",              # tkinter, for emergency dialogs.
   "urllib3",
   "websockets",      # For leoserver.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,6 @@ matplotlib      # VR3 plugin.
 numpy           # VR3 plugin.
 pyenchant       # The spell tab.
 sphinx          # For documentation.
-tk              # tkinter, for emergency dialogs.
 urllib3
 websockets      # For leoserver.
 


### PR DESCRIPTION
Needs to be installed as a system package.

Tk package on PyPI does not install Python-Tkinter.

Closes #4546