### PR TITLE
Remove @bool write-black-sentinels and related ivar

### DIFF
--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -489,9 +489,8 @@
 <v t="ekr.20180525053145.1"><vh>@bool use-jedi = False</vh></v>
 <v t="ekr.20110510071925.14589"><vh>@bool use-qcompleter = True</vh></v>
 </v>
-<v t="ekr.20260111055007.1"><vh>Beautifying files and writing black-compatible sentinels</vh>
+<v t="ekr.20260111055007.1"><vh>Beautifying files</vh>
 <v t="ekr.20240926065158.1"><vh>@bool beautify-python-code-on-write = False</vh></v>
-<v t="ekr.20260109162430.1"><vh>@bool write-black-sentinels = False</vh></v>
 <v t="ekr.20260111055136.1"><vh>@int black-line-length = None</vh></v>
 <v t="ekr.20260111055045.1"><vh>@string black-toml = None</vh></v>
 </v>
@@ -11891,9 +11890,6 @@ rest_comments_literal1_font_weight = normal
 <t tx="ekr.20250502045601.1">Percentage zoom.</t>
 <t tx="ekr.20250715195720.1">True: Leo will create an "update review tree" when any @file node changes externally.</t>
 <t tx="ekr.20250730050535.1">True: report changed files when saving a .leo file.</t>
-<t tx="ekr.20260109162430.1"># New in Leo 6.8.8. This setting replaces the --black-sentinels command-line argument.
-# This setting is **strongly recommended** so that you can use ruff format to beautify your code.
-</t>
 <t tx="ekr.20260111055007.1"># These settings control ruff format, which is compatible with black.</t>
 <t tx="ekr.20260111055045.1">If given, this argument should be a full, absolute path to pyproject.toml or ruff.toml.
 If not given, Leo's beautifier uses Leo's pyproject.toml file.

--- a/leo/core/LeoPyRef.leo
+++ b/leo/core/LeoPyRef.leo
@@ -18,9 +18,8 @@
 <v t="ekr.20150425145248.1"><vh>@data history-list</vh></v>
 <v t="ekr.20240107154430.1"><vh>@int max-find-long-lines-length = 100</vh></v>
 <v t="ekr.20140916101314.19538"><vh>@string target_language = python</vh></v>
-<v t="ekr.20260111055821.1"><vh>Beautifying files and writing black-compatible sentinels</vh>
+<v t="ekr.20260111055821.1"><vh>Beautifying files</vh>
 <v t="ekr.20260111055821.2"><vh>@bool beautify-python-code-on-write = True</vh></v>
-<v t="ekr.20260111055821.3"><vh>@bool write-black-sentinels = True</vh></v>
 <v t="ekr.20260111055821.4"><vh>@int black-line-length = 100</vh></v>
 <v t="ekr.20260111055821.5"><vh>@string black-toml = None</vh></v>
 </v>
@@ -1951,7 +1950,7 @@ assert core_p and command_p and globals_p
     # 'toString', 'toUnicode', 'trace', 'translateString',
     # 'underline', 'undoHelper', 'unl', 'values', 'visit',
     # 'warn', 'warning', 'word',</t>
-<t tx="ekr.20220823195205.1" _mod_time="4741da5a5b1af6c1882e">"""
+<t tx="ekr.20220823195205.1" _mod_time="4741da5f236354a72b2e">"""
 Stand alone GUI free index builder for Leo's full text search system::
 
   python leoftsindex.py &lt;file1&gt; &lt;file2&gt; &lt;file3&gt;...
@@ -2198,7 +2197,7 @@ print('done')</t>
 <t tx="ekr.20240107154430.1"></t>
 <t tx="ekr.20240204082420.1"></t>
 <t tx="ekr.20240204082924.1"></t>
-<t tx="ekr.20240206161713.1" _mod_time="4741da5a5b1b109fac2e">@language ini
+<t tx="ekr.20240206161713.1" _mod_time="4741da5f23637719e82e">@language ini
 
 [bdist_wheel]
 
@@ -2716,9 +2715,6 @@ if new_b != proj_p.b:
 <t tx="ekr.20260111055821.1"># These settings control ruff format, which is compatible with black.</t>
 <t tx="ekr.20260111055821.2"># True: beautify all @&lt;file&gt; nodes in the outline using Leo's token-based beautifier.
 # True can result in much slower writes.</t>
-<t tx="ekr.20260111055821.3"># New in Leo 6.8.8. This setting replaces the --black-sentinels command-line argument.
-# This setting is **strongly recommended** so that you can use ruff format to beautify your code.
-</t>
 <t tx="ekr.20260111055821.4"># This setting overrides any value in pyproject.toml or ruff.toml
 # Leo uses 120 for its own files.</t>
 <t tx="ekr.20260111055821.5"># If given, this argument should be a full, absolute path to pyproject.toml or ruff.toml.

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -2574,12 +2574,12 @@ class AtFile:
 
         This method outputs all sentinels.
         """
-        at, c = self, self.c
+        at = self
         if at.sentinels or g.app.force_at_auto_sentinels:
             at.putIndent(at.indent)
             at.os(at.startSentinelComment)
-            # Blacken python sentinels if --black-sentinels is in effect.
-            if c.write_black_sentinels and self.language == 'python':
+            # Blacken python sentinels.
+            if self.language == 'python':
                 at.os(' ')
             # Apply the cweb hack to s:
             #   If the opening comment delim ends in '@',

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -674,8 +674,6 @@ class Commands:
         c.target_language = getString('target-language') or 'python'
         c.verbose_check_outline = getBool('verbose-check-outline', default=False)
         c.vim_mode = getBool('vim-mode', default=False)
-        # New in Leo 6.8.8.
-        c.write_black_sentinels = getBool('write-black-sentinels', default=False)
         c.write_script_file = getBool('write-script-file')
 
     # @+node:ekr.20090213065933.7: *4* c.setWindowPosition

--- a/leo/core/leoTest2.py
+++ b/leo/core/leoTest2.py
@@ -131,9 +131,6 @@ class LeoUnitTest(unittest.TestCase):
         fileName = g.os_path_finalize_join(g.app.loadDir, 'LeoPyRef.leo')
         self.c = c = leoCommands.Commands(fileName=fileName, gui=g.app.gui)
 
-        # Default.
-        c.write_black_sentinels = False
-
         # Init the 'root' and '@settings' nodes.
         self.root_p = c.rootPosition()
         self.root_p.h = 'root'

--- a/leo/doc/LeoDocs.leo
+++ b/leo/doc/LeoDocs.leo
@@ -33350,6 +33350,7 @@ Leo is an [IDE, outliner and PIM](https://leo-editor.github.io/leo-editor/prefac
 .. _`PR #4498`: https://github.com/leo-editor/leo-editor/pull/4498
 .. _`PR #4502`: https://github.com/leo-editor/leo-editor/pull/4502
 .. _`PR #4503`: https://github.com/leo-editor/leo-editor/pull/4503
+.. _`PR #4551`: https://github.com/leo-editor/leo-editor/pull/4551.
 
 - `PR #4464`_ and `PR #0000`_: Fix abbreviation bugs.
 - `PR #4467`_: Remove support for leoflexx and --gui=browser.
@@ -33359,14 +33360,13 @@ Leo is an [IDE, outliner and PIM](https://leo-editor.github.io/leo-editor/prefac
 - `PR #4490`_, Add support for ruff format and retire Leo's legacy beautier.
   This PR summarizes several other PRs relating to this project.
 - `PR #4498`_: Fix bug: the external files controller leaves ``c.p`` unchanged.
-- `PR #4487`_: Reformat Leo using ruff format.
+- `PR #4487`_ and `PR #4551`_: Reformat Leo using ruff format.
 - `PR #4503`_ and `PR #4506`_: Add ``gdc.summary_diff_two_revs`` script helper.
 
 **Add settings for ruff format**
 
 The defaults are shown below:
 
-- Add ``@bool write-black-sentinels = False``
 - Add ``@int black-line-length = None``
 - Add ``@string black-toml = None``
 

--- a/leo/unittests/core/test_leoAtFile.py
+++ b/leo/unittests/core/test_leoAtFile.py
@@ -277,23 +277,18 @@ class TestAtFile(LeoUnitTest):
             @ A single-line doc part.
             #AT-all
         ''').replace('AT', '@')
+        test_s = contents.replace('#@', '# @')
+        expected = expected_contents.replace('#@', '# @')
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = expected_contents.replace('#@', '# @') if blacken else expected_contents
-
-            root.b = test_s
-            at.initWriteIvars(root)
-            at.putBody(root)
-            results = ''.join(at.outputList)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        root.b = test_s
+        at.initWriteIvars(root)
+        at.putBody(root)
+        results = ''.join(at.outputList)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20211102111413.1: *3* TestAtFile.test_putBody_at_all_after_at_doc
     def test_putBody_at_all_after_at_doc(self):
@@ -310,7 +305,6 @@ class TestAtFile(LeoUnitTest):
 
         # Only @c or @code end an @doc part.
         # Therefore, the @all line is part of the @doc part.
-
         expected_contents = self.prep(
             '''
             #AT+doc
@@ -318,23 +312,18 @@ class TestAtFile(LeoUnitTest):
             # ATall
         '''
         ).replace('AT', '@')
+        test_s = contents.replace('#@', '# @')
+        expected = expected_contents.replace('#@', '# @')
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = expected_contents.replace('#@', '# @') if blacken else expected_contents
-
-            root.b = test_s
-            at.initWriteIvars(root)
-            at.putBody(root)
-            results = ''.join(at.outputList)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        root.b = test_s
+        at.initWriteIvars(root)
+        at.putBody(root)
+        results = ''.join(at.outputList)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20211102150707.1: *3* TestAtFile.test_putBody_at_others
     def test_putBody_at_others(self):
@@ -355,29 +344,18 @@ class TestAtFile(LeoUnitTest):
             #AT-others
         '''
         ).replace('AT', '@')
+        test_s = contents.replace('#@', '# @')
+        expected = expected_contents.replace('#@', '# @')
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = expected_contents.replace('#@', '# @') if blacken else expected_contents
-
-            root.b = test_s
-            at.initWriteIvars(root)
-            at.putBody(root)
-            results = ''.join(at.outputList)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
-
-        # root.b = contents
-        # at.initWriteIvars(root)
-        # at.putBody(root)
-        # result = ''.join(at.outputList)
-        # self.assertEqual(result, expected)
+        root.b = test_s
+        at.initWriteIvars(root)
+        at.putBody(root)
+        results = ''.join(at.outputList)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20211102102024.1: *3* TestAtFile.test_putBody_unterminated_at_doc_part
     def test_putBody_unterminated_at_doc_part(self):
@@ -674,23 +652,17 @@ class TestFastAtRead(LeoUnitTest):
         )
         expected_contents = expected_contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         # @-<< define expected_contents >>
+        test_s = contents.replace('#@', '# @')
+        expected = expected_contents.replace('#@', '# @')
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = expected_contents.replace('#@', '# @') if blacken else expected_contents
-
-            x.read_into_root(contents, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
-
-            self.assertEqual(root.b, expected_body, msg='mismatch in body')
+        x.read_into_root(contents, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
+        self.assertEqual(root.b, expected_body, msg='mismatch in body')
 
     # @+node:ekr.20211103093332.1: *3* TestFastAtRead.test_at_all
     def test_at_all(self):
@@ -731,20 +703,15 @@ class TestFastAtRead(LeoUnitTest):
         )
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         # @-<< define contents >>
-
-        blacken = False  # #4323: Ignore the @language directive in .txt files.
-        c.write_black_sentinels = blacken
-        test_s = contents.replace('#@', '# @') if blacken else contents
+        test_s = contents.replace('#@', '# @')
         expected = test_s.replace("# @others doesn't", "#@others doesn't")
 
         x.read_into_root(contents, path='test', root=root)
         results = c.atFileCommands.atFileToString(root, sentinels=True)
-
         if results != expected:
             g.printObj(g.splitLines(test_s), tag='test_s')
             g.printObj(g.splitLines(results), tag='results')
             g.printObj(g.splitLines(expected), tag='expected')
-
         self.assertEqual(results, expected)
 
     # @+node:ekr.20211101085019.1: *3* TestFastAtRead.test_at_comment (and @first)
@@ -793,20 +760,14 @@ class TestFastAtRead(LeoUnitTest):
         )
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         # @-<< define contents >>
-
-        blacken = False  # #4323: Ignore the @language directive in .txt files.
-        c.write_black_sentinels = blacken
-        test_s = contents
-        expected = test_s
+        test_s = expected = contents
 
         x.read_into_root(contents, path='test', root=root)
         results = c.atFileCommands.atFileToString(root, sentinels=True)
-
         if results != expected:
             g.printObj(g.splitLines(test_s), tag='test_s')
             g.printObj(g.splitLines(results), tag='results')
             g.printObj(g.splitLines(expected), tag='expected')
-
         self.assertEqual(results, expected)
 
         child1 = root.firstChild()
@@ -866,20 +827,15 @@ class TestFastAtRead(LeoUnitTest):
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
 
         # @-<< define contents >>
-
-        blacken = False  # #4323: Ignore the @language directive in .txt files.
-        c.write_black_sentinels = blacken
-        test_s = contents.replace('#@', '# @').replace('!!@', '!! @') if blacken else contents
+        test_s = contents.replace('#@', '# @').replace('!!@', '!! @')
         expected = test_s
 
         x.read_into_root(contents, path='test', root=root)
         results = c.atFileCommands.atFileToString(root, sentinels=True)
-
         if results != expected:
             g.printObj(g.splitLines(test_s), tag='test_s')
             g.printObj(g.splitLines(results), tag='results')
             g.printObj(g.splitLines(expected), tag='expected')
-
         self.assertEqual(results, expected)
 
         child1 = root.firstChild()
@@ -935,23 +891,17 @@ class TestFastAtRead(LeoUnitTest):
         '''
         ).replace('AT', '@')
         # @-<< define expected_body >>
+        test_s = contents.replace('#@', '# @')
+        expected = test_s
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = test_s
-
-            x.read_into_root(contents, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
-
-            self.assertEqual(root.b, expected_body)
+        x.read_into_root(contents, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
+        self.assertEqual(root.b, expected_body)
 
     # @+node:ekr.20211103092228.1: *3* TestFastAtRead.test_at_others
     def test_at_others(self):
@@ -983,21 +933,15 @@ class TestFastAtRead(LeoUnitTest):
             .replace('LB', '<<')
         )
         # @-<< define contents >>
-
-        blacken = False  # #4323: Ignore the @language directive in .txt files.
-
-        c.write_black_sentinels = blacken
-        test_s = contents.replace('#@', '# @') if blacken else contents
+        test_s = contents.replace('#@', '# @')
         expected = test_s
 
         x.read_into_root(contents, path='test', root=root)
         results = c.atFileCommands.atFileToString(root, sentinels=True)
-
         if results != expected:
             g.printObj(g.splitLines(test_s), tag='test_s')
             g.printObj(g.splitLines(results), tag='results')
             g.printObj(g.splitLines(expected), tag='expected')
-
         self.assertEqual(results, expected)
 
     # @+node:ekr.20211031093209.1: *3* TestFastAtRead.test_at_section_delim
@@ -1046,32 +990,27 @@ class TestFastAtRead(LeoUnitTest):
             .replace('{h}', root.h)
         )
         # @-<< define contents >>
+        test_s = contents.replace('#@', '# @')
+        expected = test_s
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = test_s
+        x.read_into_root(contents, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
-            x.read_into_root(contents, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
-
-            child1 = root.firstChild()
-            child2 = child1.next()
-            child3 = child2.next()
-            table = (
-                (child1, '<!< test >!>'),
-                (child2, 'spam'),
-                (child3, 'eggs'),
-            )
-            for child, h in table:
-                self.assertEqual(child.h, h)
+        child1 = root.firstChild()
+        child2 = child1.next()
+        child3 = child2.next()
+        table = (
+            (child1, '<!< test >!>'),
+            (child2, 'spam'),
+            (child3, 'eggs'),
+        )
+        for child, h in table:
+            self.assertEqual(child.h, h)
 
     # @+node:ekr.20211101155930.1: *3* TestFastAtRead.test_clones
     def test_clones(self):
@@ -1108,39 +1047,36 @@ class TestFastAtRead(LeoUnitTest):
             .replace('LB', '<<')
         )
         # @-<< define contents >>
+        test_s = contents.replace('#@', '# @')
+        expected = test_s
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = test_s
+        x.read_into_root(contents, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
 
-            x.read_into_root(contents, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
 
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
-            self.assertEqual(results, expected)
-
-            child1 = root.firstChild()
-            child2 = child1.next()
-            grand_child1 = child1.firstChild()
-            grand_child2 = child2.firstChild()
-            table = (
-                (child1, 'cloned node'),
-                (child2, 'cloned node'),
-                (grand_child1, 'child'),
-                (grand_child2, 'child'),
-            )
-            for child, h in table:
-                self.assertEqual(child.h, h)
-            self.assertTrue(child1.isCloned())
-            self.assertTrue(child2.isCloned())
-            self.assertEqual(child1.v, child2.v)
-            self.assertFalse(grand_child1.isCloned())
-            self.assertFalse(grand_child2.isCloned())
+        child1 = root.firstChild()
+        child2 = child1.next()
+        grand_child1 = child1.firstChild()
+        grand_child2 = child2.firstChild()
+        table = (
+            (child1, 'cloned node'),
+            (child2, 'cloned node'),
+            (grand_child1, 'child'),
+            (grand_child2, 'child'),
+        )
+        for child, h in table:
+            self.assertEqual(child.h, h)
+        self.assertTrue(child1.isCloned())
+        self.assertTrue(child2.isCloned())
+        self.assertEqual(child1.v, child2.v)
+        self.assertFalse(grand_child1.isCloned())
+        self.assertFalse(grand_child2.isCloned())
 
     # @+node:ekr.20211103080718.1: *3* TestFastAtRead.test_cweb
     # @@language python
@@ -1194,21 +1130,16 @@ class TestFastAtRead(LeoUnitTest):
         )
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         # @-<< define contents >>
+        test_s = contents.replace('#@', '# @')
+        expected = test_s
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = test_s
-
-            x.read_into_root(contents, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        x.read_into_root(contents, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20211101152817.1: *3* TestFastAtRead.test_doc_parts
     def test_doc_parts(self):
@@ -1248,20 +1179,16 @@ class TestFastAtRead(LeoUnitTest):
         )
         contents = contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         # @-<< define contents >>
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = test_s
+        test_s = contents.replace('#@', '# @')
+        expected = test_s
 
-            x.read_into_root(test_s, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        x.read_into_root(test_s, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20231207083858.1: *3* TestFastAtRead.test_doc_parts_html
     def test_doc_parts_html(self):
@@ -1342,23 +1269,16 @@ class TestFastAtRead(LeoUnitTest):
         )
         expected_contents = expected_contents.replace('{root.gnx}', root.gnx).replace('{h}', root.h)
         # @-<< define expected_contents >>
+        test_s = contents
+        expected = expected_contents
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-
-            # --black-sentinels applies only to python files.
-            test_s = contents
-            expected = expected_contents
-
-            x.read_into_root(test_s, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        x.read_into_root(test_s, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20211101154632.1: *3* TestFastAtRead.test_html_doc_part
     def test_html_doc_part(self):
@@ -1415,26 +1335,19 @@ class TestFastAtRead(LeoUnitTest):
             .replace('{h}', root.h)
         )
         # @-<< define expected >>
-
-        blacken = False  # #4323: Ignore the @language directive in .txt files.
-        c.write_black_sentinels = blacken
-        test_s = contents.replace('#@', '# @') if blacken else contents
-        expected = expected.replace('#@', '# @') if blacken else expected
+        test_s = contents.replace('#@', '# @')
+        expected = expected.replace('#@', '# @')
 
         x.read_into_root(contents, path='test', root=root)
         results = c.atFileCommands.atFileToString(root, sentinels=True)
-
         if results != expected:
             g.printObj(g.splitLines(test_s), tag='test_s')
             g.printObj(g.splitLines(results), tag='results')
             g.printObj(g.splitLines(expected), tag='expected')
-
         self.assertEqual(results, expected)
 
         x.read_into_root(contents, path='test', root=root)
         s = c.atFileCommands.atFileToString(root, sentinels=True)
-        # g.printObj(g.splitLines(s), tag='s')
-
         self.assertEqual(s, expected)
 
     # @+node:ekr.20231203092436.1: *3* TestFastAtRead.test_minimal_cweb
@@ -1475,21 +1388,15 @@ class TestFastAtRead(LeoUnitTest):
             .replace('{h}', root.h)
         )
         # @-<< define contents >>
+        expected = test_s = contents.replace('#@', '# @')
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = contents.replace('#@', '# @') if blacken else contents
-            expected = test_s
-
-            x.read_into_root(contents, path='test', root=root)
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        x.read_into_root(contents, path='test', root=root)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20211101180354.1: *3* TestFastAtRead.test_verbatim
     def test_verbatim(self):
@@ -1524,33 +1431,24 @@ class TestFastAtRead(LeoUnitTest):
         '''
         ).replace('AT', '@')
         # @-<< define expected_body >>
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = expected = contents
+        test_s = expected = contents
+        expected = test_s.replace('#@', '# @')
+        # Protect the @verbatim line.
+        expected = expected.replace('# @+node (verbatim)', '#@+node (verbatim)')
 
-            if blacken:
-                # All true sentinels should be blackened.
-                expected = test_s.replace('#@', '# @')
-                # Protect the @verbatim line.
-                expected = expected.replace('# @+node (verbatim)', '#@+node (verbatim)')
+        x.read_into_root(test_s, path='test', root=root)
+        if root.b != expected_body:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(root.b), tag='root.b')
+            g.printObj(g.splitLines(expected_body), tag='expected_body')
+        self.assertEqual(root.b, expected_body)
 
-            x.read_into_root(test_s, path='test', root=root)
-
-            if root.b != expected_body:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(root.b), tag='root.b')
-                g.printObj(g.splitLines(expected_body), tag='expected_body')
-
-            self.assertEqual(root.b, expected_body)
-
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @+node:ekr.20231207080536.1: *3* TestFastAtRead.test_verbatim_html
     def test_verbatim_html(self):
@@ -1589,33 +1487,24 @@ class TestFastAtRead(LeoUnitTest):
         ).replace('AT', '@')
         # @-<< define expected_body >>
 
-        for blacken in (True, False):
-            c.write_black_sentinels = blacken
-            test_s = expected = contents
+        test_s = contents
+        expected = test_s.replace('#@', '# @')
+        # Protect the @verbatim line.
+        expected = expected.replace('<!-- @+node (verbatim)', '<!--@+node (verbatim)')
 
-            if blacken:
-                # All true sentinels should be blackened.
-                expected = test_s.replace('#@', '# @')
-                # Protect the @verbatim line.
-                expected = expected.replace('<!-- @+node (verbatim)', '<!--@+node (verbatim)')
+        x.read_into_root(test_s, path='test', root=root)
+        if root.b != expected_body:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(root.b), tag='root.b')
+            g.printObj(g.splitLines(expected_body), tag='expected_body')
+        self.assertEqual(root.b, expected_body)
 
-            x.read_into_root(test_s, path='test', root=root)
-
-            if root.b != expected_body:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(root.b), tag='root.b')
-                g.printObj(g.splitLines(expected_body), tag='expected_body')
-
-            self.assertEqual(root.b, expected_body)
-
-            results = c.atFileCommands.atFileToString(root, sentinels=True)
-
-            if results != expected:
-                g.printObj(g.splitLines(test_s), tag='test_s')
-                g.printObj(g.splitLines(results), tag='results')
-                g.printObj(g.splitLines(expected), tag='expected')
-
-            self.assertEqual(results, expected)
+        results = c.atFileCommands.atFileToString(root, sentinels=True)
+        if results != expected:
+            g.printObj(g.splitLines(test_s), tag='test_s')
+            g.printObj(g.splitLines(results), tag='results')
+            g.printObj(g.splitLines(expected), tag='expected')
+        self.assertEqual(results, expected)
 
     # @-others
 


### PR DESCRIPTION
See #4545.

*Important*: This PR changes only how Leo *writes* sentinel comments. Leo will always be able to *read* legacy sentinels.

- [x] Remove all mention of `@bool write-black-sentinels` in Leo's core.
- [x] Update unit tests.
- [x] Remove `@bool write-black-sentinels` from `leoSettings.leo` and `LeoPyRef.leo`.
- [x] Update documentation in `LeoDocs.leo`.