### PR TITLE
Ensure blank lines between imported markdown sections

### DIFF
--- a/leo/plugins/importers/markdown.py
+++ b/leo/plugins/importers/markdown.py
@@ -135,6 +135,12 @@ class Markdown_Importer(Importer):
         assert 0 <= level < len(self.stack), (level, len(self.stack))
         return self.stack[level]
 
+    # @+node:ekr.20260305084156.1: *3* md_i.postprocess
+    def postprocess(self, parent: Position) -> None:
+        """
+        MarkDown_Importer.postprocess. Don't do anything!
+        """
+
     # @-others
 
 

--- a/leo/plugins/writers/markdown.py
+++ b/leo/plugins/writers/markdown.py
@@ -19,11 +19,9 @@ class MarkdownWriter(basewriter.BaseWriter):
         """Write all the *descendants* of an @auto-markdown node."""
         self.root = root
         self.write_root(root)
-        total = sum(1 for _ in root.subtree())
         count = 0
         for p in root.subtree():
             count += 1
-            lastFlag = count == total  # Last node should not output extra newline
             if g.app.force_at_auto_sentinels:  # pragma: no cover
                 self.put_node_sentinel(p, '<!--', delim2='-->')
             if self.placeholder_regex.match(p.h):
@@ -31,15 +29,10 @@ class MarkdownWriter(basewriter.BaseWriter):
                 pass
             else:
                 self.write_headline(p)
-                # Ensure that every section ends with exactly two newlines.
-                if p.b.rstrip():
-                    s = p.b.rstrip() + ('\n' if lastFlag else '\n\n')
-                    lines = s.splitlines(False)
-                    for s in lines:
-                        if not g.isDirective(s):
-                            self.put(s)
-                elif not lastFlag:  # #3719.
-                    self.put('\n')
+                lines = p.b.splitlines(False)
+                for s in lines:
+                    if not g.isDirective(s):
+                        self.put(s)
         root.setVisited()
 
     # @+node:ekr.20141110223158.20: *3* mdw.write_headline

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -2031,6 +2031,34 @@ class TestMarkdown(BaseTestImporter):
         )
         self.new_run_test(s, expected_results)
 
+    # @+node:ekr.20260306105013.1: *3* TestMarkdown.test_markdown_importer_blank lines
+    def test_markdown_importer_blank_lines(self):
+        # Must be in standard form, with a space after '#'.
+        s = """
+            # Chapter 1: one
+
+            This is the first chapter
+
+            ## 1.1 Something
+
+            This is something
+
+            # Chapter 2: two
+
+            Welcome to chapter 2
+        """
+        expected_results = (
+            (
+                0,
+                '',  # Ignore the first headline.
+                '@language md\n@tabwidth -4\n',
+            ),
+            (1, 'Chapter 1: one', '\nThis is the first chapter\n\n'),
+            (2, '1.1 Something', '\nThis is something\n\n'),
+            (1, 'Chapter 2: two', '\nWelcome to chapter 2\n'),
+        )
+        self.new_run_test(s, expected_results)  # check=False)
+
     # @+node:ekr.20210904065459.112: *3* TestMarkdown.test_markdown_importer_implicit_section
     def test_markdown_importer_implicit_section(self):
         s = """


### PR DESCRIPTION
- [x] Add do-nothing md_i.postprocess.
- [x] Add  corresponding unit test.