### PR TITLE
Fix quicksearch.py body matches for Python 3.14

### DIFF
--- a/leo/plugins/quicksearch.py
+++ b/leo/plugins/quicksearch.py
@@ -572,7 +572,7 @@ class QuickSearchController:
         if not pat.startswith('r:'):
             hpat = fnmatch.translate('*' + pat + '*').replace(r"\Z(?ms)", "")
             bpat = fnmatch.translate(pat).rstrip('$').replace(r"\Z(?ms)", "")
-            bpat = bpat.replace(r'\Z', '')
+            bpat = bpat.replace(r'\Z', '').replace(r'\z', '')
             flags = re.IGNORECASE
         else:
             hpat = pat[2:]


### PR DESCRIPTION
The quicksearch.py (Nav pane) plugin stopped producing matches for node body text after upgrade to python 3.14.

This is a result of a few behavior changes:

Python 3.14 now recognizes `/z` as a synonym for `/Z` in regexes (https://docs.python.org/3/whatsnew/3.14.html#re)

The `fnmatch.translate` function in Python 3.14 now returns strings that use the new `/z` (https://docs.python.org/3.14/library/fnmatch.html#fnmatch.translate).  The code in quicksearch.py's `doSearch` didn't account for the lowercase variant.

Simple fix, just replace both variants with empty strings.