### PR TITLE
fix: Change Iconbar button hover text color to orange in SwotMoknokai…

### DIFF
--- a/leo/themes/SwotMoknokai.leo
+++ b/leo/themes/SwotMoknokai.leo
@@ -774,7 +774,7 @@ QTextEdit:focus#log-widget,LeoQTreeWidget:focus#treeWidget, QTextEdit:focus#rich
   margin-right: 5px;
 }
 QPushButton:hover {
-  color: @button-hover-fg;
+  color: @solarized-orange;
   background: @bg-gradient-hover;
 }
 </t>


### PR DESCRIPTION
**Description:** This PR updates the stylesheet for the `SwotMoknokai` theme to fix a visibility issue on the Iconbar.

**Changes:**

- Modified the `QPushButton:hover` CSS rule in the `@data qt-gui-plugin-style-sheet` node.
  
- Changed the `color` property from `@button-hover-fg` (which was set to a dark color) to `@solarized-orange`.
  

**Reasoning:** The previous dark font on a dark background made it nearly impossible to see the button labels when moving the mouse over them. Using the established orange accent color from the Solarized palette ensures a consistent and accessible UI.

ref: https://github.com/leo-editor/leo-editor/issues/4556