### PR TITLE
PR fixes #4559: consistent formatting options

### DIFF
--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -20,7 +20,7 @@ import sys
 print(os.path.basename(__file__))
 
 # cd to leo-editor
-leo_editor_dir = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
+leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
 os.chdir(leo_editor_dir)
 
 # Define components of a single command.

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -20,18 +20,20 @@ import sys
 print(os.path.basename(__file__))
 
 # cd to leo-editor
-leo_editor_dir = os.path.abspath(os.path.join(__file__, '..', '..', '..'))
+leo_editor_dir = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
 os.chdir(leo_editor_dir)
 
 # Define components of a single command.
-arg_list = (
-    f"--config {leo_editor_dir}{os.sep}pyproject.toml",
-    # '--config line-length=120',
-    # '--verbose',
+toml_file = f"{leo_editor_dir}{os.sep}pyproject.toml"
+assert os.path.exists(toml_file), toml_file
+args = " ".join(
+    (
+        f"--config {toml_file}",
+        # '--verbose',
+    )
 )
-args = ' '.join(arg_list)
-isWindows = sys.platform.startswith('win')
-python = 'py' if isWindows else 'python'
+isWindows = sys.platform.startswith("win")
+python = "py" if isWindows else "python"
 targets = (
     f"leo{os.sep}commands",
     f"leo{os.sep}core",
@@ -43,6 +45,7 @@ targets = (
 )
 # Use -m so that __name__ == '__main__'.
 command = f"{python} -m ruff format {args} {' '.join(targets)}"
+# command = f"{python} -m black {args} {' '.join(targets)}"
 # print('command:', command)
 subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -32,8 +32,8 @@ args = " ".join(
         # '--verbose',
     )
 )
-isWindows = sys.platform.startswith("win")
-python = "py" if isWindows else "python"
+isWindows = sys.platform.startswith('win')
+python = 'py' if isWindows else 'python'
 targets = (
     f"leo{os.sep}commands",
     f"leo{os.sep}core",

--- a/leo/scripts/beautify_all_leo.py
+++ b/leo/scripts/beautify_all_leo.py
@@ -45,7 +45,5 @@ targets = (
 )
 # Use -m so that __name__ == '__main__'.
 command = f"{python} -m ruff format {args} {' '.join(targets)}"
-# command = f"{python} -m black {args} {' '.join(targets)}"
-# print('command:', command)
 subprocess.Popen(command, shell=True).communicate()
 # @-leo


### PR DESCRIPTION
See #4559.

I've hit a wall:

- We *must* use `ruff format` because it supports more options than black.
- Alas, `ruff format` seems (at present) *only* to work with `pyproject.toml`.

As a result, there appears to be *no way* to hard-code formatting values into `scripts/beautify_all_leo.py.

- [x] Make sure pyproject exists.