### PR TITLE
PR fixes #4540: import python files containing tabs

### DIFF
--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2181,7 +2181,8 @@ class TabImporter:
         elif lws > level:
             # Create a new parent.
             level = lws
-            parent = parent.insertAsLastChild() if parent else root.insertAsLastChild()
+            parent = parent or root  # #4562
+            parent.insertAsLastChild()
             parent.h = h
             stack.append((level, parent))
         else:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2164,11 +2164,11 @@ class TabImporter:
         if stack:
             level, parent = stack[-1]
         else:
-            level, parent = 0, root  # #4540: create a default parent.
+            level, parent = 0, None
         lws = len(self.lws(s))
         h = s.strip()
         if lws == level:
-            if separate:
+            if separate or not parent:
                 # Replace the top of the stack with a new entry.
                 if stack:
                     stack.pop()
@@ -2181,7 +2181,7 @@ class TabImporter:
         elif lws > level:
             # Create a new parent.
             level = lws
-            parent = parent.insertAsLastChild()
+            parent = parent.insertAsLastChild() if parent else root.insertAsLastChild()
             parent.h = h
             stack.append((level, parent))
         else:

--- a/leo/core/leoImport.py
+++ b/leo/core/leoImport.py
@@ -2164,11 +2164,11 @@ class TabImporter:
         if stack:
             level, parent = stack[-1]
         else:
-            level, parent = 0, None
+            level, parent = 0, root  # #4540: create a default parent.
         lws = len(self.lws(s))
         h = s.strip()
         if lws == level:
-            if separate or not parent:
+            if separate:
                 # Replace the top of the stack with a new entry.
                 if stack:
                     stack.pop()

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -180,6 +180,56 @@ class TestLeoImport(BaseTestImporter):
             u.undo()
             self.assertEqual(c.lastTopLevel(), root)
 
+    # @+node:ekr.20260322090512.1: *3* TestLeoImport.test_tabbed_python_importer
+    def test_tabbed_python_importer(self):
+        # See #4542
+        c = self.c
+        u = c.undoer
+        x = c.importCommands
+        target = c.p.insertAfter()
+        c.selectPosition(target)
+        target.h = 'target'
+
+        body_1 = self.prep(
+            '''
+            import os
+
+            def spam():
+            \t"""A docstring"""
+            \tprint('a string')
+
+
+            class NewClass:
+            \tdef f1(self):
+            \t\tpass
+        '''
+        )
+        target.b = body_1
+        x.parse_body(target)
+
+        expected_results = (
+            (
+                0,
+                'def spam',
+                'import os\n\ndef spam():\n\t"""A docstring"""\n\tprint(\'a string\')\n\n',
+            ),
+            (
+                0,
+                'class NewClass',
+                'class NewClass\n\tdef f1(self):\n\t\tpass\n',
+            ),
+        )
+        # Don't call run_test.
+        self.check_outline(target, expected_results)
+
+        # Test undo
+        u.undo()
+        self.assertEqual(target.b, body_1, msg='undo test')
+        self.assertFalse(target.hasChildren(), msg='undo test')
+        # Test redo
+        u.redo()
+        self.check_outline(target, expected_results)
+
     # @-others
 
 

--- a/leo/unittests/core/test_leoImport.py
+++ b/leo/unittests/core/test_leoImport.py
@@ -192,16 +192,14 @@ class TestLeoImport(BaseTestImporter):
 
         body_1 = self.prep(
             '''
-            import os
+            #!/usr/bin/python3
+            # -*- coding: utf-8 -*-
 
-            def spam():
-            \t"""A docstring"""
-            \tprint('a string')
-
-
-            class NewClass:
-            \tdef f1(self):
-            \t\tpass
+            def someFunction ():
+            \tif (someLongCondition) or \\
+            \t\t\t(anotherLongCondition):
+            \t\treturn
+            \tpass
         '''
         )
         target.b = body_1
@@ -209,16 +207,17 @@ class TestLeoImport(BaseTestImporter):
 
         expected_results = (
             (
-                0,
-                'def spam',
-                'import os\n\ndef spam():\n\t"""A docstring"""\n\tprint(\'a string\')\n\n',
+                0,  'def someFunction',  # Ignored
+                '#!/usr/bin/python3\n'
+                '# -*- coding: utf-8 -*-\n'
+                '\n'
+                'def someFunction ():\n'
+                '\tif (someLongCondition) or \\\n'
+                '\t\t\t(anotherLongCondition):\n'
+                '\t\treturn\n'
+                '\tpass\n'
             ),
-            (
-                0,
-                'class NewClass',
-                'class NewClass\n\tdef f1(self):\n\t\tpass\n',
-            ),
-        )
+        )  # fmt: skip
         # Don't call run_test.
         self.check_outline(target, expected_results)
 


### PR DESCRIPTION
See #4540.

- [x] Use `root` as the default `parent`.
- [x] Create a new unit test