### PR TITLE
PR fixes #4565: update @clean files

### DIFF
--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -13,7 +13,7 @@ from leo.core import leoGlobals as g
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
-    from leo.core.leoNodes import Position
+    from leo.core.leoNodes import Position, VNode
 
     Value = Any
     Widget = Any  # 'Any' is the correct annotation for base class widgets.
@@ -209,9 +209,11 @@ class ExternalFilesController:
                 c.refreshFromDisk(p, silent=False)
                 # #4565: set all ancestor file nodes dirty and redraw.
                 p.v.setDirty()
+                to_do: set[VNode] = set()
                 for p2 in c.all_positions():
                     if p2.isDirty():
-                        p2.v.setAllAncestorAtFileNodesDirty()
+                        to_do.add(p2.v)
+                p.v.setAllAncestorAtFileNodesDirty(to_do=to_do)
                 c.redraw()
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -203,13 +203,16 @@ class ExternalFilesController:
             if p.isAtJupytextNode():
                 g.app.jupytextManager.update(c, p, path)
                 continue
-            g.trace(path)  ###
             if state in ('yes', 'no'):
                 state = self.ask(c, path, p=p)
             if state in ('yes', 'yes-all'):
                 c.refreshFromDisk(p, silent=False)
-                p.setDirty()  # #4565.
-                c.redraw()  # #4565.
+                # #4565: set all ancestor file nodes dirty and redraw.
+                p.v.setDirty()
+                for p2 in c.all_positions():
+                    if p2.isDirty():
+                        p2.v.setAllAncestorAtFileNodesDirty()
+                c.redraw()
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -207,6 +207,10 @@ class ExternalFilesController:
                 state = self.ask(c, path, p=p)
             if state in ('yes', 'yes-all'):
                 c.refreshFromDisk(p, silent=False)
+                # #4565: set all clones in p's subtree dirty.
+                for p2 in p.subtree():
+                    if p2.v.isCloned():
+                        p2.v.setDirty()
                 # #4565: set all ancestor file nodes dirty and redraw.
                 p.v.setDirty()
                 to_do_set: set[VNode] = set()

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -203,10 +203,13 @@ class ExternalFilesController:
             if p.isAtJupytextNode():
                 g.app.jupytextManager.update(c, p, path)
                 continue
+            g.trace(path)  ###
             if state in ('yes', 'no'):
                 state = self.ask(c, path, p=p)
             if state in ('yes', 'yes-all'):
                 c.refreshFromDisk(p, silent=False)
+                p.setDirty()  # #4565.
+                c.redraw()  # #4565.
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -209,11 +209,11 @@ class ExternalFilesController:
                 c.refreshFromDisk(p, silent=False)
                 # #4565: set all ancestor file nodes dirty and redraw.
                 p.v.setDirty()
-                to_do: set[VNode] = set()
+                to_do_set: set[VNode] = set()
                 for p2 in c.all_positions():
                     if p2.isDirty():
-                        to_do.add(p2.v)
-                p.v.setAllAncestorAtFileNodesDirty(to_do=to_do)
+                        to_do_set.add(p2.v)
+                p.v.setAllAncestorAtFileNodesDirty(to_do_set=to_do_set)
                 c.redraw()
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -215,7 +215,7 @@ class ExternalFilesController:
                 p.v.setDirty()
                 to_do_set: set[VNode] = set()
                 for p2 in c.all_positions():
-                    if p2.isDirty():
+                    if p2.v.isDirty():
                         to_do_set.add(p2.v)
                 p.v.setAllAncestorAtFileNodesDirty(to_do_set=to_do_set)
                 c.redraw()

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2735,19 +2735,27 @@ class VNode:
         Modified by EKR.
         """
         v = self
-        ### g.trace(v)  ###
+        to_do: list[VNode] = [v]
+        for v2 in v.parents:
+            to_do.append(v2)
         result: set[VNode] = set()
+        seen: set[VNode] = set()
 
-        def find_all_ancestor_at_file_nodes(v: VNode) -> None:
-            ### g.trace(v.h)
-            if v.isAnyAtFileNode():
-                result.add(v)
-            for parent_v in v.parents:
-                find_all_ancestor_at_file_nodes(parent_v)
+        def find_all_ancestor_at_file_nodes() -> None:
+            while to_do:
+                v2 = to_do.pop()
+                seen.add(v2)
+                if v2.isAnyAtFileNode():
+                    result.add(v2)
+                for parent_v in v2.parents:
+                    if parent_v not in seen:
+                        to_do.append(parent_v)
 
-        find_all_ancestor_at_file_nodes(v)
-        for v in list(result):
-            v.setDirty()
+        find_all_ancestor_at_file_nodes()
+        if not g.unitTesting:  ###
+            g.printObj([z.h for z in list(result)], tag=v.h)
+        for v2 in list(result):
+            v2.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2741,9 +2741,9 @@ class VNode:
         # #4565: Rewrite using a loop.
         while to_do:
             v2 = to_do.pop()
+            seen.add(v2)
             if v2.isAnyAtFileNode():
                 result.add(v2)
-                seen.add(v2)
             else:
                 for parent_v in v2.parents:
                     if parent_v not in seen:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2732,19 +2732,16 @@ class VNode:
         """
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 
-        rewritten by EKR.
+        #4565: Add the optional initial to_do set.
         """
         v = self
         result: set[VNode] = set()
         seen: set[VNode] = set([v.context.hiddenRootNode])
-        # to_do: list[VNode] = [v] + [z for z in v.parents]
         to_do_list: list[VNode] = list(to_do) if to_do else [v] + v.parents
         if to_do:
             for v2 in to_do:
                 to_do_list.extend(v2.parents)
         to_do_list = list(set(to_do_list))
-
-        # #4565: Rewrite using a loop.
         while to_do_list:
             v2 = to_do_list.pop()
             seen.add(v2)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2735,24 +2735,24 @@ class VNode:
         #4565: Rewritten by EKR to use the to_do_set kwarg.
         """
         v = self
-        result: set[VNode] = set()
+        # Init seen and to_do_list.
         seen: set[VNode] = set([v.context.hiddenRootNode])
         to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v] + v.parents
         if to_do_set:
             for v2 in to_do_set:
                 to_do_list.extend(v2.parents)
         to_do_list = list(set(to_do_list))
+
+        # The main loop.
         while to_do_list:
             v2 = to_do_list.pop()
             seen.add(v2)
             if v2.isAnyAtFileNode():
-                result.add(v2)
+                v2.setDirty()
             else:
                 for parent_v in v2.parents:
                     if parent_v not in seen:
                         to_do_list.append(parent_v)
-        for v2 in result:
-            v2.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2750,11 +2750,11 @@ class VNode:
             seen.add(v2)
             if v2.isAnyAtFileNode():
                 v2.setDirty()
-            # Scan all parents of v2, even if v2 is an @<file> node.
-            # Doing so maintains compatibility with legacy code.
-            for parent_v in v2.parents:
-                if parent_v not in seen:
-                    to_do_list.append(parent_v)
+            else:
+                # Nested @<file> nodes are no longer valid.
+                for parent_v in v2.parents:
+                    if parent_v not in seen:
+                        to_do_list.append(parent_v)
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2735,26 +2735,20 @@ class VNode:
         Modified by EKR.
         """
         v = self
-        to_do: list[VNode] = [v]
-        for v2 in v.parents:
-            to_do.append(v2)
         result: set[VNode] = set()
         seen: set[VNode] = set()
-
-        def find_all_ancestor_at_file_nodes() -> None:
-            while to_do:
-                v2 = to_do.pop()
+        to_do: list[VNode] = [v] + [z for z in v.parents]
+        # #4565: Rewrite using a loop.
+        while to_do:
+            v2 = to_do.pop()
+            if v2.isAnyAtFileNode():
+                result.add(v2)
                 seen.add(v2)
-                if v2.isAnyAtFileNode():
-                    result.add(v2)
+            else:
                 for parent_v in v2.parents:
                     if parent_v not in seen:
                         to_do.append(parent_v)
-
-        find_all_ancestor_at_file_nodes()
-        if not g.unitTesting:  ###
-            g.printObj([z.h for z in list(result)], tag=v.h)
-        for v2 in list(result):
+        for v2 in result:
             v2.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2735,6 +2735,7 @@ class VNode:
         #4565: Rewritten by EKR to use the to_do_set kwarg.
         """
         v = self
+
         # Init seen and to_do_list.
         seen: set[VNode] = set([v.context.hiddenRootNode])
         to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v]
@@ -2749,7 +2750,7 @@ class VNode:
             seen.add(v2)
             if v2.isAnyAtFileNode():
                 v2.setDirty()
-            # Scan all parents of v2, even if v2 is and @<file> node.
+            # Scan all parents of v2, even if v2 is an @<file> node.
             # Doing so maintains compatibility with legacy code.
             for parent_v in v2.parents:
                 if parent_v not in seen:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2736,7 +2736,7 @@ class VNode:
         """
         v = self
         result: set[VNode] = set()
-        seen: set[VNode] = set()
+        seen: set[VNode] = set([v.context.hiddenRootNode])
         to_do: list[VNode] = [v] + [z for z in v.parents]
         # #4565: Rewrite using a loop.
         while to_do:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2749,10 +2749,11 @@ class VNode:
             seen.add(v2)
             if v2.isAnyAtFileNode():
                 v2.setDirty()
-            else:
-                for parent_v in v2.parents:
-                    if parent_v not in seen:
-                        to_do_list.append(parent_v)
+            # Scan all parents of v2, even if v2 is and @<file> node.
+            # Doing so maintains compatibility with legacy code.
+            for parent_v in v2.parents:
+                if parent_v not in seen:
+                    to_do_list.append(parent_v)
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2728,7 +2728,7 @@ class VNode:
             pass
 
     # @+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self, *, to_do: set[VNode] = None) -> None:
+    def setAllAncestorAtFileNodesDirty(self, *, to_do_set: set[VNode] = None) -> None:
         """
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 
@@ -2737,9 +2737,9 @@ class VNode:
         v = self
         result: set[VNode] = set()
         seen: set[VNode] = set([v.context.hiddenRootNode])
-        to_do_list: list[VNode] = list(to_do) if to_do else [v] + v.parents
-        if to_do:
-            for v2 in to_do:
+        to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v] + v.parents
+        if to_do_set:
+            for v2 in to_do_set:
                 to_do_list.extend(v2.parents)
         to_do_list = list(set(to_do_list))
         while to_do_list:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2737,7 +2737,7 @@ class VNode:
         v = self
         # Init seen and to_do_list.
         seen: set[VNode] = set([v.context.hiddenRootNode])
-        to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v] + v.parents
+        to_do_list: list[VNode] = list(to_do_set) if to_do_set else [v]
         if to_do_set:
             for v2 in to_do_set:
                 to_do_list.extend(v2.parents)

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2734,16 +2734,19 @@ class VNode:
 
         Modified by EKR.
         """
+        v = self
+        ### g.trace(v)  ###
         result: set[VNode] = set()
 
         def find_all_ancestor_at_file_nodes(v: VNode) -> None:
+            ### g.trace(v.h)
             if v.isAnyAtFileNode():
                 result.add(v)
             for parent_v in v.parents:
                 find_all_ancestor_at_file_nodes(parent_v)
 
+        find_all_ancestor_at_file_nodes(v)
         for v in list(result):
-            g.trace(v)
             v.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2734,21 +2734,17 @@ class VNode:
 
         Modified by EKR.
         """
-        v = self
-        seen: set[VNode] = set([v.context.hiddenRootNode])
+        result: set[VNode] = set()
 
-        def v_and_parents(v: VNode) -> Generator:
-            if v in seen:
-                return
-            seen.add(v)
-            yield v
+        def find_all_ancestor_at_file_nodes(v: VNode) -> None:
+            if v.isAnyAtFileNode():
+                result.add(v)
             for parent_v in v.parents:
-                if parent_v not in seen:
-                    yield from v_and_parents(parent_v)
+                find_all_ancestor_at_file_nodes(parent_v)
 
-        for v2 in v_and_parents(v):
-            if v2.isAnyAtFileNode():
-                v2.setDirty()
+        for v in list(result):
+            g.trace(v)
+            v.setDirty()
 
     # @+node:ekr.20040315032144: *4* v.setBodyString & v.setHeadString
     def setBodyString(self, s: object) -> None:

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2732,7 +2732,7 @@ class VNode:
         """
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 
-        #4565: Add the optional initial to_do set.
+        #4565: Rewritten by EKR to use the to_do_set kwarg.
         """
         v = self
         result: set[VNode] = set()

--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2728,26 +2728,32 @@ class VNode:
             pass
 
     # @+node:ekr.20191213161023.1: *4* v.setAllAncestorAtFileNodesDirty
-    def setAllAncestorAtFileNodesDirty(self) -> None:
+    def setAllAncestorAtFileNodesDirty(self, *, to_do: set[VNode] = None) -> None:
         """
         Original idea by Виталије Милошевић (Vitalije Milosevic).
 
-        Modified by EKR.
+        rewritten by EKR.
         """
         v = self
         result: set[VNode] = set()
         seen: set[VNode] = set([v.context.hiddenRootNode])
-        to_do: list[VNode] = [v] + [z for z in v.parents]
+        # to_do: list[VNode] = [v] + [z for z in v.parents]
+        to_do_list: list[VNode] = list(to_do) if to_do else [v] + v.parents
+        if to_do:
+            for v2 in to_do:
+                to_do_list.extend(v2.parents)
+        to_do_list = list(set(to_do_list))
+
         # #4565: Rewrite using a loop.
-        while to_do:
-            v2 = to_do.pop()
+        while to_do_list:
+            v2 = to_do_list.pop()
             seen.add(v2)
             if v2.isAnyAtFileNode():
                 result.add(v2)
             else:
                 for parent_v in v2.parents:
                     if parent_v not in seen:
-                        to_do.append(parent_v)
+                        to_do_list.append(parent_v)
         for v2 in result:
             v2.setDirty()
 


### PR DESCRIPTION
See #4565.

- [x] Update dirty bits in `efc.idle_check_commander`.
- [x] `efc.idle_check_commander` calls `v.setAllAncestorAtFileNodesDirty` once with the computed `to_do_set` kwarg.
- [x] Rewrite `v.setAllAncestorAtFileNodesDirty`, adding the `to_do_set` kwarg.

Note: The new version of `v.setAllAncestorAtFileNodesDirty` scans for nested `@<file>` nodes to maintain compatibility with legacy code. This is a dubious choice, but it seems best.
