### PR TITLE
PR fixes #4570: Add setting to bypass file-update dialogs.

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -377,7 +377,7 @@ def refreshFromDisk(
     p: Position = None,  # For compatibility with existing scripts.
     *,
     event: LeoKeyEvent = None,  # Required for all commands.
-    silent: bool = True,
+    silent: bool = True,  # No longer used.
 ) -> None:
     """
     Refresh an @<file> node from disk.
@@ -418,10 +418,6 @@ def refreshFromDisk(
         c.selectPosition(update_p)
     else:
         update_p = p  # #4495: Do *not* change the position!
-
-    # #4495: Report the updated file.
-    if not silent and not g.unitTesting:
-        g.es_print(f"update: {update_p.h}", color='blue')
 
     # Create the 'Recovered Nodes' tree.
     at.changed_roots = []

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -632,11 +632,12 @@
 <v t="ekr.20170706103843.1"><vh>Checking files</vh>
 <v t="ekr.20150403055250.1"><vh>@bool check-for-changed-external-files = True</vh></v>
 <v t="ekr.20090514111518.8379"><vh>@bool check-python-code-on-write = True</vh></v>
+<v t="ekr.20260326111743.1"><vh>@bool raise-file-update-dialogs = False</vh></v>
 <v t="ekr.20221128115636.1"><vh>@bool run-flake8-on-write = False</vh></v>
 <v t="ekr.20161021095001.1"><vh>@bool run-pyflakes-on-write = False</vh></v>
 <v t="ekr.20240924055407.1"><vh>@bool run-pylint-on-write = False</vh></v>
-<v t="ekr.20150321090958.1"><vh>@bool verbose-check-outline = False</vh></v>
 <v t="ekr.20150710084507.1"><vh>@bool syntax-error-popup = False</vh></v>
+<v t="ekr.20150321090958.1"><vh>@bool verbose-check-outline = False</vh></v>
 </v>
 <v t="ekr.20041119034357.12"><vh>External files</vh>
 <v t="ekr.20041119034357.14"><vh>@bool at-root-bodies-start-in-doc-mode = True</vh></v>
@@ -11896,6 +11897,10 @@ If not given, Leo's beautifier uses Leo's pyproject.toml file.
 </t>
 <t tx="ekr.20260111055136.1"># If given, this setting overrides any value in pyproject.toml or ruff.toml
 # Leo uses pyproject.toml to give line length.</t>
+<t tx="ekr.20260326111743.1">New in Leo 6.8.8:
+
+True (Legacy):       Raise a dialog when any file changes externally.
+False (Recommended): Print a log message when any file changes externally.</t>
 <t tx="felix.20220506230435.1">True: (Legacy) The goto-first-visible-node and goto-first-visible-node commands collapse all nodes that are not ancestors of the target node that is selected.
 
 False: (Recommended) The commands act as simple navigation commands, and do not change the outline state.</t>

--- a/leo/core/leoAtFile.py
+++ b/leo/core/leoAtFile.py
@@ -781,8 +781,6 @@ class AtFile:
             return
         if new_private_lines == old_private_lines:
             return
-        if not g.unitTesting:
-            g.es_print("updating:", root.h)
         root.clearVisitedInTree()
         gnx2vnode = at.fileCommands.gnxDict
         contents = ''.join(new_private_lines)
@@ -910,8 +908,6 @@ class AtFile:
             return
         if new_private_lines == old_private_lines:
             return
-        if not g.unitTesting:
-            g.es_print('updating:', fileName)
         root.clearVisitedInTree()
         gnx2vnode = at.fileCommands.gnxDict
         new_contents = '@language python\n' + ''.join(new_private_lines)

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -220,16 +220,17 @@ class ExternalFilesController:
                     if p2.v.isDirty():
                         to_do_set.add(p2.v)
                 p.v.setAllAncestorAtFileNodesDirty(to_do_set=to_do_set)
+        if not changed:
+            return
         # #4570: Write all update messages here, and only here.
-        if changed and not g.unitTesting:
+        if g.unitTesting:
             changed_roots: set[str] = set()
             for p2 in c.all_positions():
                 if p2.isAnyAtFileNode() and p2.isDirty():
                     changed_roots.add(p2.h)
             for s in sorted(list(changed_roots)):
                 g.es_print('update:', s, color='blue')
-        if changed:
-            c.redraw()
+        c.redraw()
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -223,7 +223,7 @@ class ExternalFilesController:
         if not changed:
             return
         # #4570: Write all update messages here, and only here.
-        if g.unitTesting:
+        if not g.unitTesting:
             changed_roots: set[str] = set()
             for p2 in c.all_positions():
                 if p2.isAnyAtFileNode() and p2.isDirty():

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -184,6 +184,7 @@ class ExternalFilesController:
 
         # #1100: always scan the entire file for @<file> nodes.
         # #1134: Nested @<file> nodes are no longer valid, but this will do no harm.
+        changed = False
         state = 'no'
         for p in c.all_unique_positions():
             if not p.isAnyAtFileNode():
@@ -206,6 +207,7 @@ class ExternalFilesController:
             if state in ('yes', 'no'):
                 state = self.ask(c, path, p=p)
             if state in ('yes', 'yes-all'):
+                changed = True
                 c.refreshFromDisk(p, silent=False)
                 # #4565: set all clones in p's subtree dirty.
                 for p2 in p.subtree():
@@ -218,7 +220,15 @@ class ExternalFilesController:
                     if p2.v.isDirty():
                         to_do_set.add(p2.v)
                 p.v.setAllAncestorAtFileNodesDirty(to_do_set=to_do_set)
-                c.redraw()
+        # #4570: Write all update messages here, and only here.
+        if changed and not g.unitTesting:
+            changed_roots: set[str] = set()
+            for p2 in c.all_positions():
+                if p2.isAnyAtFileNode() and p2.isDirty():
+                    changed_roots.add(p2.h)
+            for s in sorted(list(changed_roots)):
+                g.es_print('update:', s, color='blue')
+        c.redraw()
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:
@@ -539,10 +549,13 @@ class ExternalFilesController:
 
         Return one of ('yes', 'no', 'yes-all', 'no-all')
         """
-        if g.unitTesting or g.app.restarting:
+        if g.unitTesting or g.app.restarting or c not in g.app.commanders():
             return ''
-        if c not in g.app.commanders():
-            return ''
+
+        # #4570: Don't raise dialogs unless the user setting is True.
+        if not c.config.getBool('raise-file-update-dialogs', default=False):
+            return 'yes'
+
         is_leo = path.endswith(('.leo', '.db'))
         is_external_file = not is_leo
 

--- a/leo/core/leoExternalFiles.py
+++ b/leo/core/leoExternalFiles.py
@@ -228,7 +228,8 @@ class ExternalFilesController:
                     changed_roots.add(p2.h)
             for s in sorted(list(changed_roots)):
                 g.es_print('update:', s, color='blue')
-        c.redraw()
+        if changed:
+            c.redraw()
 
     # @+node:ekr.20201207055713.1: *5* efc.idle_check_leo_file
     def idle_check_leo_file(self, c: Cmdr) -> None:


### PR DESCRIPTION
See #4570.

- [x] `efc.ask` does nothing unless a new setting is True.
- [x] Only `efc.idle_check_commander logs 'update' messages.
    The tricky part: print log messages only once!
- [x] Add `@bool raise-file-update-dialogs = False` to LeoSettings.leo.
