### PR TITLE
Remove ivars unnecessarily injected into gui classes

### DIFF
--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -301,7 +301,7 @@ class LeoGui:
         raise NotImplementedError
 
     # @+node:ekr.20061109212618.1: *3* LeoGui: Must be defined only in base class
-    # @+node:ekr.20110605121601.18847: *4* LeoGui.create_key_event (LeoGui)
+    # @+node:ekr.20110605121601.18847: *4* LeoGui.create_key_event
     def create_key_event(
         self,
         c: Cmdr,
@@ -331,7 +331,7 @@ class LeoGui:
         self.script = script
         self.scriptFileName = scriptFileName
 
-    # @+node:ekr.20110605121601.18845: *4* LeoGui.event_generate (LeoGui)
+    # @+node:ekr.20110605121601.18845: *4* LeoGui.event_generate
     def event_generate(self, c: Cmdr, char: str, shortcut: str, w: Wrapper) -> None:
         event = self.create_key_event(c, binding=shortcut, char=char, w=w)
         c.k.masterKeyHandler(event)

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -1097,23 +1097,11 @@ class LeoQtGui(leoGui.LeoGui):
                 factory.setTabForCommander(c)
                 c.bodyWantsFocusNow()
 
-    # @+node:ekr.20190601054958.1: *4* LeoQtGui.get_focus (no longer used)
+    # @+node:ekr.20190601054958.1: *4* LeoQtGui.get_focus
     def get_focus(self, c: Cmdr = None, raw: bool = False, at_idle: bool = False) -> QWidget:
         """Returns the widget that has focus."""
-        trace = 'focus' in g.app.debug
-        trace_idle = False
-        trace = trace and (trace_idle or not at_idle)
-        app = QtWidgets.QApplication
-        w = app.focusWidget()
-        if w and not raw and isinstance(w, qt_text.LeoQTextBrowser):
-            has_w = getattr(w, 'leo_wrapper', None)
-            if has_w:
-                if trace:
-                    g.trace(w)
-            elif c:
-                # Kludge: DynamicWindow creates the body pane
-                # with wrapper = None, so return the LeoQtBody.
-                w = c.frame.body
+        trace = 'focus' in g.app.debug and not at_idle
+        w = QtWidgets.QApplication.focusWidget()
         if trace:
             name = w.objectName() if hasattr(w, 'objectName') else w.__class__.__name__
             g.trace('(LeoQtGui)', name)

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -627,9 +627,6 @@ if QtWidgets:
 
                 # Inject leo_c into this class, a QtWidgets.QTextBrowser
                 self.leo_c = c
-
-                # A weird hack.
-                self.leo_geom_set = False  # When true, self.geom returns global coords!
                 self.itemClicked.connect(self.select_callback)
 
             # @+node:ekr.20110605121601.18011: *5* lqlw.closeEvent
@@ -734,7 +731,7 @@ if QtWidgets:
                 w.setInsertPoint(i)
                 c.k.autoCompleter.compute_completion_list()
 
-            # @+node:ekr.20110605121601.18015: *5* lqlw.set_position (to be changed more??)
+            # @+node:ekr.20110605121601.18015: *5* lqlw.set_position
             def set_position(self, c: Cmdr) -> None:
                 """Set the position of the QListWidget."""
 
@@ -748,11 +745,6 @@ if QtWidgets:
                 r = w.cursorRect()
                 geom = self.geometry()  # In viewport coordinates.
                 gr_topLeft = to_global(w, r.topLeft())
-                # As a workaround to the Qt setGeometry bug,
-                # The window is destroyed instead of being hidden.
-                if self.leo_geom_set:
-                    g.trace('Error: leo_geom_set')
-                    return
                 gg_topLeft = to_global(vp, geom.topLeft())
                 delta_x = gr_topLeft.x() - gg_topLeft.x()
                 delta_y = gr_topLeft.y() - gg_topLeft.y()
@@ -764,21 +756,7 @@ if QtWidgets:
                 )
                 geom2_size = QtCore.QSize(400, 100)
                 geom2 = QtCore.QRect(geom2_topLeft, geom2_size)
-                # These tests fail once offsets are added.
-                if x_offset == 0 and y_offset == 0:
-                    if self.leo_geom_set:
-                        if geom2.topLeft() != to_global(w, r.topLeft()):
-                            g.trace(
-                                f"Error: geom.topLeft: {geom2.topLeft()}, geom2.topLeft: {to_global(w, r.topLeft())}"
-                            )
-                    else:
-                        if to_global(vp, geom2.topLeft()) != to_global(w, r.topLeft()):
-                            g.trace(
-                                f"Error 2: geom.topLeft: {to_global(vp, geom2.topLeft())}, "
-                                f"geom2.topLeft: {to_global(w, r.topLeft())}"
-                            )
                 self.setGeometry(geom2)
-                self.leo_geom_set = True
 
             # @+node:ekr.20110605121601.18016: *5* lqlw.show_completions
             def show_completions(self, aList: list[str]) -> None:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -571,18 +571,13 @@ if QtWidgets:
         # @+node:ekr.20110605121601.18006: *3*  lqtb.ctor
         def __init__(self, parent: QWidget, c: Cmdr, wrapper: BaseTextAPI) -> None:
             """
-            ctor for LeoQTextBrowser class.
+            ctor for LeoQTextBrowser class, a subclass of QtWidgets.QTextBrowser.
 
             wrapper is a LeoQtBody or LeoQtLog.
             """
-            for attr in (
-                'leo_c',
-                'leo_wrapper',
-            ):
-                assert not hasattr(QtWidgets.QTextBrowser, attr), attr
+            assert not hasattr(QtWidgets.QTextBrowser, 'leo_c')
             self.leo_c = c
             self.leo_s = ''  # The cached text.
-            self.leo_wrapper = wrapper
             self.htmlFlag = True
             super().__init__(parent)
             self.setCursorWidth(c.config.getInt('qt-cursor-width') or 1)
@@ -629,10 +624,10 @@ if QtWidgets:
                 """ctor for LeoQListWidget class"""
                 super().__init__()
                 self.setWindowFlags(WindowType.Popup | self.windowFlags())
-                # Inject the ivars
-                # A LeoQTextBrowser, a subclass of QtWidgets.QTextBrowser.
-                self.leo_w = c.frame.body.wrapper.widget
+
+                # Inject leo_c into this class, a QtWidgets.QTextBrowser
                 self.leo_c = c
+
                 # A weird hack.
                 self.leo_geom_set = False  # When true, self.geom returns global coords!
                 self.itemClicked.connect(self.select_callback)
@@ -739,7 +734,7 @@ if QtWidgets:
                 w.setInsertPoint(i)
                 c.k.autoCompleter.compute_completion_list()
 
-            # @+node:ekr.20110605121601.18015: *5* lqlw.set_position
+            # @+node:ekr.20110605121601.18015: *5* lqlw.set_position (to be changed more??)
             def set_position(self, c: Cmdr) -> None:
                 """Set the position of the QListWidget."""
 
@@ -747,7 +742,8 @@ if QtWidgets:
                     """Convert pt from obj's local coordinates to global coordinates."""
                     return obj.mapToGlobal(pt)
 
-                w = self.leo_w
+                c = self.leo_c
+                w = c.frame.body.wrapper.widget
                 vp = self.viewport()
                 r = w.cursorRect()
                 geom = self.geometry()  # In viewport coordinates.

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -1674,10 +1674,8 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         text_name = 'body-text-renderer'
         w.setObjectName(text_name)
         w.setReadOnly(True)
-        # Create the standard Leo bindings.
-        wrapper_name = 'rendering-pane-wrapper'
-        wrapper = qt_text.QTextEditWrapper(w, wrapper_name, c)
-        w.leo_wrapper = wrapper
+        # Create the standard Leo bindings in a wrapper widget.
+        wrapper = qt_text.QTextEditWrapper(w, 'rendering-pane-wrapper', c)
         c.k.completeAllBindingsForWidget(wrapper)
         w.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
 

--- a/leo/plugins/viewrendered3.py
+++ b/leo/plugins/viewrendered3.py
@@ -3357,11 +3357,9 @@ class ViewRenderedController3(QtWidgets.QWidget):
             # Do not do this! It interferes with themes.
             # self.setBackgroundColor(self.background_color, text_name, w)
             w.setReadOnly(True)
-            # Create the standard Leo bindings.
-            wrapper_name = 'rendering-pane-wrapper'
-            wrapper = qt_text.QTextEditWrapper(w, wrapper_name, c)
-            w.leo_wrapper = wrapper
-            c.k.completeAllBindingsForWidget(wrapper)
+            # Create the standard Leo bindings in a wrapper widget.
+            wrapper_widget = qt_text.QTextEditWrapper(w, 'rendering-pane-wrapper', c)
+            c.k.completeAllBindingsForWidget(wrapper_widget)
             w.setWordWrapMode(WrapMode.WrapAtWordBoundaryOrAnywhere)
 
     # @+node:TomP.20191215195433.52: *4* vr3.setBackgroundColor


### PR DESCRIPTION
This PR contains preliminary work for the more ambitious #4572.

The `leo_c` ivar *does* need to be injected into Qt classes:
it would be unwise to inject an ivar named `c` into Qt Widgets.

Injecting the `leo_w` and `leo_wrapper` ivars into Qt widgets is unnecessary and confusing.

- [x] Remove all `leo_wrapper` ivars from all Qt gui classes, including VR and VR3 plugins.
- [x] Remove `leo_w` ivar from all Qt gui classes.
- [x] Remove `leo_geom_set` ivar and simplify `lqlw.set_position`.
- [x] For clarity, in the VR and VR3 plugins, rename the `wrapper` local var to `wrapper_widget`.
- [x] Remove two redundant headline annotations.