### PR TITLE
PR fixes #4574: preserve indentation when adding comments

### DIFF
--- a/leo/commands/commanderEditCommands.py
+++ b/leo/commands/commanderEditCommands.py
@@ -27,38 +27,15 @@ if TYPE_CHECKING:  # pragma: no cover
 # @+node:ekr.20171123135625.34: ** c_ec.addComments
 @g.commander_command('add-comments')
 def addComments(self: Self, event: LeoKeyEvent = None) -> None:
-    # @+<< addComments docstring >>
-    # @+node:ekr.20171123135625.35: *3* << addComments docstring >>
-    # @@pagewidth 50
-    """
-    Converts all selected lines to comment lines using
-    the comment delimiters given by the applicable @language directive.
-
-    Inserts single-line comments if possible; inserts
-    block comments for languages like html that lack
-    single-line comments.
-
-    @bool indent_added_comments
-
-    If True (the default), inserts opening comment
-    delimiters just before the first non-whitespace
-    character of each line. Otherwise, inserts opening
-    comment delimiters at the start of each line.
-
-    *See also*: delete-comments.
-    """
-    # @-<< addComments docstring >>
+    """Undoably add comments to the selected text."""
     c, p, u, w = self, self.p, self.undoer, self.frame.body.wrapper
-    #
     # "Before" snapshot.
     bunch = u.beforeChangeBody(p)
-    #
     # Make sure there is a selection.
     head, lines, tail, oldSel, oldYview = self.getBodyLines()
     if not lines:
         g.warning('no text selected')
         return
-    #
     # The default language in effect at p.
     language = c.frame.body.colorizer.scanLanguageDirectives(p)
     if c.hasAmbiguousLanguage(p):
@@ -70,35 +47,26 @@ def addComments(self: Self, event: LeoKeyEvent = None) -> None:
         openDelim, closeDelim = d1 + ' ', ''
     else:
         openDelim, closeDelim = d2 + ' ', ' ' + d3
-    #
     # Calculate the result.
-    indent = c.config.getBool('indent-added-comments', default=True)
     result = []
+    i: int = None
     for line in lines:
         if line.strip():
-            i = g.skip_ws(line, 0)
-            if indent:
-                s = line[i:].replace('\n', '')
-                result.append(line[0:i] + openDelim + s + closeDelim + '\n')
-            else:
-                s = line.replace('\n', '')
-                result.append(openDelim + s + closeDelim + '\n')
+            if i is None:
+                i = g.skip_ws(line, 0)
+            s = line[i:].replace('\n', '')
+            result.append(line[0:i] + openDelim + s + closeDelim + '\n')
         else:
             result.append(line)
-    #
     # Set p.b and w's text first.
     middle = ''.join(result)
     p.b = head + middle + tail  # Sets dirty and changed bits.
     w.setAllText(head + middle + tail)
-    #
-    # Calculate the proper selection range (i, j, ins).
+    # Set the selection range and scroll position.
     i = len(head)
     j = max(i, len(head) + len(middle) - 1)
-    #
-    # Set the selection range and scroll position.
     w.setSelectionRange(i, j, insert=j)
     w.setYScrollPosition(oldYview)
-    #
     # "after" snapshot.
     u.afterChangeBody(p, 'Add Comments', bunch)
 

--- a/leo/config/leoSettings.leo
+++ b/leo/config/leoSettings.leo
@@ -510,7 +510,6 @@
 <v t="ekr.20210506073820.1"><vh>@bool allow-text-zoom = True</vh></v>
 <v t="ekr.20241012050620.1"><vh>@bool diff-leo-files = True</vh></v>
 <v t="ekr.20131112150804.18737"><vh>@bool force-execute-entire-body = False</vh></v>
-<v t="ekr.20111115083813.12518"><vh>@bool indent-added-comments = True</vh></v>
 <v t="ekr.20150227102835.1"><vh>@bool make-node-conflicts-node = True</vh></v>
 <v t="ekr.20220624062948.1"><vh>@bool redirect-execute-script-output-to-log_pane = False</vh></v>
 <v t="ekr.20230804112912.1"><vh>@bool search-links-backwards=True</vh></v>
@@ -5204,7 +5203,6 @@ True (Recommended):
     The contract-or-goto-parent (Alt-RtArrow) contracts all
     children of the to-be-selected parent.
 </t>
-<t tx="ekr.20111115083813.12518"></t>
 <t tx="ekr.20120205022040.15410">These are needed to handle shortcuts for the find panel!</t>
 <t tx="ekr.20120305084218.11271"># Unbound F-Keys cause problems on Ubuntu
 help            = F1

--- a/leo/unittests/core/test_leoUndo.py
+++ b/leo/unittests/core/test_leoUndo.py
@@ -50,24 +50,20 @@ class TestUndo(LeoUnitTest):
             @language python
 
             def addCommentTest():
-
                 if 1:
                     a = 2
                     b = 3
-
                 pass
-        """
+            """
         )
         after = self.prep(
             """
             @language python
 
             def addCommentTest():
-
                 # if 1:
-                    # a = 2
-                    # b = 3
-
+                #     a = 2
+                #     b = 3
                 pass
         """
         )


### PR DESCRIPTION
See #4574

- [x] Revise `c_ec.addComments`.
- [x] Revise unit test.
- [x] Remove `@bool indent-added-comments`.