### PR TITLE
PR fixes #4577

### DIFF
--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -69,20 +69,15 @@ class SessionManager:
         """
         if not unls:
             return
-        trace = 'startup' in g.app.debug
         unls = [z.strip() for z in unls or [] if z.strip()]
         for unl in unls:
             if not g.isValidUnl(unl):
-                if trace:
-                    g.trace(f"Ignoring invalid session {'unl'}: {unl!r}")
                 continue
             fn = g.getUNLFilePart(unl)
             exists = fn and g.os_path_exists(fn)
             if not exists:
-                if trace:
-                    g.trace(f"Ignoring invalid session {'unl'}: {unl!r}")
                 continue
-            if trace:
+            if 'startup' in g.app.debug:
                 g.trace('loading session file:', fn)
             # This selects the proper position.
             g.openWithFileName(fn, gui=g.app.gui, old_c=c)

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -42,7 +42,14 @@ class SessionManager:
             outlines = [i.c for i in g.app.windowList]
         for c in outlines:
             if c.fileName():
-                result.append(c.p.get_full_gnx_UNL())
+                unl = c.p.get_full_gnx_UNL()
+                if not g.isValidUnl(unl):
+                    continue
+                fn = g.getUNLFilePart(unl)
+                exists = fn and g.os_path_exists(fn)
+                if not exists:
+                    continue
+                result.append(unl)
         return result
 
     # @+node:ekr.20120420054855.14416: *3* SessionManager.get_session_path

--- a/leo/core/leoSessions.py
+++ b/leo/core/leoSessions.py
@@ -69,17 +69,20 @@ class SessionManager:
         """
         if not unls:
             return
+        trace = 'startup' in g.app.debug
         unls = [z.strip() for z in unls or [] if z.strip()]
         for unl in unls:
             if not g.isValidUnl(unl):
-                g.trace(f"Ignoring invalid session {'unl'}: {unl!r}")
+                if trace:
+                    g.trace(f"Ignoring invalid session {'unl'}: {unl!r}")
                 continue
             fn = g.getUNLFilePart(unl)
             exists = fn and g.os_path_exists(fn)
             if not exists:
-                g.trace(f"Ignoring invalid session {'unl'}: {unl!r}")
+                if trace:
+                    g.trace(f"Ignoring invalid session {'unl'}: {unl!r}")
                 continue
-            if 'startup' in g.app.debug:
+            if trace:
                 g.trace('loading session file:', fn)
             # This selects the proper position.
             g.openWithFileName(fn, gui=g.app.gui, old_c=c)

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2827,6 +2827,7 @@ class TopFrame:
 
     def __init__(self, c: Cmdr) -> None:
         self.c = c
+        self.leo_master = g.NullObject()  # #4577.
 
     def select(self, *args: Args, **kwargs: KWargs) -> None:
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -332,11 +332,11 @@ dependencies = [
   "PyQt6>= 6.6",
   "PyQt6-QScintilla",
   "PyQt6-WebEngine",
-  "Send2Trash; platform_system == 'Windows'",      # picture_viewer plugin.
+  "Send2Trash; platform_system == 'Windows'",  # For picture_viewer plugin.
   
   # cursesGui2 plugin.
   # The windows-curses package has been updated for Python 3.13.
-  # "windows-curses[curses]; platform_system == 'Windows'; python_version < '3.14'",
+  "windows-curses[curses]; platform_system == 'Windows'; python_version <= '3.14'",
 ]
 
 #@-<< pyproject.toml: dependencies >>

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,11 +55,11 @@ websockets      # For leoserver.
 PyQt6>= 6.6
 PyQt6-QScintilla
 PyQt6-WebEngine
-Send2Trash; platform_system=="Windows"      # picture_viewer plugin.
+Send2Trash; platform_system=="Windows"  # For picture_viewer plugin.
 
 # cursesGui2 plugin.
-# The windows-curses package has been updated for Python 3.13.
-# windows-curses[curses]; platform_system=="Windows" ; python_version < "3.14"
+# The windows-curses package has been updated for Python 3.14.
+windows-curses[curses]; platform_system=="Windows" ; python_version <= "3.14"
 # @-<< requirements.txt: dependencies >>
 
 # @@language python


### PR DESCRIPTION
See #4577.

- [x] Curate sessions in `SessionManager.get_session`.
- [x] Remove traces to `SessionManager.load_session`.
- [x] Add `self.leo_master = g.NullObject()` to `TopFrame` class to avoid crash.
- [x] Add `windows-curses[curses]; platform_system=="Windows" ; python_version <= "3.14"` to both requirements lists.