### PR TITLE
PR: Generalize g.stat and related functions

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2694,7 +2694,7 @@ def printStats(event: LeoKeyEvent = None, name: str = None) -> None:
 
 
 # @+node:ekr.20031218072017.3136: *4* g.stat
-def stat(name: str = None) -> None:
+def stat(name: str = None, *, obj: Any = None) -> None:
     """Increments the statistic for name in g.app.statsDict
     The caller's name is used by default.
     """
@@ -2704,7 +2704,12 @@ def stat(name: str = None) -> None:
             name = repr(name)
     else:
         name = g._callerName(n=2)  # Get caller name 2 levels back.
-    d[name] = 1 + d.get(name, 0)
+    if obj is None:
+        d[name] = 1 + d.get(name, 0)
+    else:
+        aSet = d.get(name, set())
+        aSet.add(obj)
+        d[name] = aSet
 
 
 # @+node:ekr.20031218072017.3137: *3* g.Timing

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2667,18 +2667,7 @@ def clearStats() -> None:
 @command('show-stats')
 def printStats(event: LeoKeyEvent = None, name: str = None) -> None:
     """
-    Print all gathered statistics.
-
-    Here is the recommended code to gather stats for one method/function:
-
-        if not g.app.statsLockout:
-            g.app.statsLockout = True
-            try:
-                d = g.app.statsDict
-                key = 'g.isUnicode:' + g.callers()
-                d [key] = d.get(key, 0) + 1
-            finally:
-                g.app.statsLockout = False
+    Print all gathered statistics counts first, followed by other stats.
     """
     print('g.app.statsDict...')
     d = g.app.statsDict
@@ -2709,8 +2698,17 @@ def printStats(event: LeoKeyEvent = None, name: str = None) -> None:
 
 # @+node:ekr.20031218072017.3136: *4* g.stat
 def stat(*, name: str = None, obj: Any = None) -> None:
-    """Increments the statistic for name in g.app.statsDict
-    The caller's name is used by default.
+    """
+    Add another stat to g.app.statsDict.
+    g.printStats() prints all such stats.
+
+    When `name` is None, use the caller's name.
+    When `obj` is None, increment the count associated with name.
+    Othewise, add obj to a set associated with name.
+
+    Example:
+        g.stat(obj=w.__class__.__name__)
+        g.printStats() will show the *distinct* classes that `w` may have.
     """
     d = g.app.statsDict
     if name:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2689,7 +2689,7 @@ def printStats(event: LeoKeyEvent = None) -> None:
                 print(f"    {z.strip()}")
 
 
-# @+node:ekr.20031218072017.3136: *4* g.stat
+# @+node:ekr.20031218072017.3136: *4* g.stat & g.statObj
 _int_stat_prefix = 'stat_count: '
 
 
@@ -2713,6 +2713,17 @@ def stat(obj: Any = None) -> None:
         aSet = d.get(name, set())
         aSet.add(obj)
         d[name] = aSet
+
+
+def statObj(obj: Any) -> None:
+    """
+    Add obj to a set associated with name *without* updating count stats.
+    """
+    d = g.app.statsDict
+    name = g._callerName(n=2)  # Get caller name 2 levels back.
+    aSet = d.get(name, set())
+    aSet.add(obj)
+    d[name] = aSet
 
 
 # @+node:ekr.20031218072017.3137: *3* g.Timing

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2669,28 +2669,30 @@ def printStats(event: LeoKeyEvent = None) -> None:
     """
     Print all stats created by g.stat(), counts first.
     """
-    d = g.app.statsDict
-    int_key = 'stat_count:'  # Must match the key in g.stat.
 
     # Print the signon.
+    d = g.app.statsDict
     print('g.app.statsDict...')
 
     # Print the int stats: calls to g.stat()
     for key in sorted(d.keys()):
-        if key.startswith(int_key):
-            key_s = key[len(int_key) :].strip()
+        if key.startswith(_int_stat_prefix):
+            key_s = key[len(_int_stat_prefix) :].strip()
             print(f"  {d.get(key):4}: {key_s}")
 
     # Print the other stats: calls to g.stat(whatever)
     for key in sorted(d.keys()):
-        if not key.startswith(int_key):
-            inner_keys = [z if isinstance(z, str) else repr(z) for z in d.get(key)]
+        if not key.startswith(_int_stat_prefix):
+            inner_keys = (z if isinstance(z, str) else repr(z) for z in d.get(key))
             print(f"{key}:")
             for z in sorted(inner_keys):
                 print(f"    {z.strip()}")
 
 
 # @+node:ekr.20031218072017.3136: *4* g.stat
+_int_stat_prefix = 'stat_count: '
+
+
 def stat(obj: Any = None) -> None:
     """
     Add another count stat to g.app.statsDict.
@@ -2703,7 +2705,7 @@ def stat(obj: Any = None) -> None:
     name = g._callerName(n=2)  # Get caller name 2 levels back.
 
     # Always add the count stat.
-    key = f"stat_count: {name}"
+    key = f"{_int_stat_prefix}{name}"
     d[key] = 1 + d.get(key, 0)
 
     # Add the other stat if obj is given.

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2719,24 +2719,15 @@ def stat(*, name: str = None, obj: Any = None) -> None:
             name = repr(name)
     else:
         name = g._callerName(n=2)  # Get caller name 2 levels back.
-    try:
-        if obj is None:
-            key = f"stat_count: {name}"
-            d[key] = 1 + d.get(key, 0)
-        else:
-            key = name
-            aSet = d.get(key, set())
-            aSet.add(obj)
-            d[key] = aSet
-    except TypeError:
-        breakpoint()  ###
 
-    # if obj is None:
-    #     d[name] = 1 + d.get(name, 0)
-    # else:
-    #     aSet = d.get(name, set())
-    #     aSet.add(obj)
-    #     d[name] = aSet
+    if obj is None:
+        key = f"stat_count: {name}"
+        d[key] = 1 + d.get(key, 0)
+    else:
+        key = name
+        aSet = d.get(key, set())
+        aSet.add(obj)
+        d[key] = aSet
 
 
 # @+node:ekr.20031218072017.3137: *3* g.Timing

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2680,21 +2680,35 @@ def printStats(event: LeoKeyEvent = None, name: str = None) -> None:
             finally:
                 g.app.statsLockout = False
     """
+    print('g.app.statsDict...')
+    d = g.app.statsDict
+    if not d:
+        return
     if name:
         if not isinstance(name, str):
             name = repr(name)
     else:
         # Get caller name 2 levels back.
         name = g._callerName(n=2)
-    # Print the stats, organized by number of calls.
-    d = g.app.statsDict
-    print('g.app.statsDict...')
-    for key in reversed(sorted(d)):
-        print(f"{key:7} {d.get(key)}")
+
+    # Sort the stats into int stats and non-int stats.
+    tag = 'stat_count:'
+    keys = sorted(list(d.keys()))
+    counts = [z for z in keys if z.startswith(tag)]
+    non_counts = [z for z in keys if not z.startswith(tag)]
+    # Print the int stats: calls to g.stat()
+    for key in counts:
+        key_s = key[len(tag) :].strip()
+        print(f"  {d.get(key):4}: {key_s}")
+    # Print the other stats: calls to g.stat(obj=whatever)
+    for key in non_counts:
+        print(f"{key}:")
+        for z in sorted(list(d.get(key))):
+            print(f"    {z}")
 
 
 # @+node:ekr.20031218072017.3136: *4* g.stat
-def stat(name: str = None, *, obj: Any = None) -> None:
+def stat(*, name: str = None, obj: Any = None) -> None:
     """Increments the statistic for name in g.app.statsDict
     The caller's name is used by default.
     """
@@ -2704,12 +2718,24 @@ def stat(name: str = None, *, obj: Any = None) -> None:
             name = repr(name)
     else:
         name = g._callerName(n=2)  # Get caller name 2 levels back.
-    if obj is None:
-        d[name] = 1 + d.get(name, 0)
-    else:
-        aSet = d.get(name, set())
-        aSet.add(obj)
-        d[name] = aSet
+    try:
+        if obj is None:
+            key = f"stat_count: {name}"
+            d[key] = 1 + d.get(key, 0)
+        else:
+            key = name
+            aSet = d.get(key, set())
+            aSet.add(obj)
+            d[key] = aSet
+    except TypeError:
+        breakpoint()  ###
+
+    # if obj is None:
+    #     d[name] = 1 + d.get(name, 0)
+    # else:
+    #     aSet = d.get(name, set())
+    #     aSet.add(obj)
+    #     d[name] = aSet
 
 
 # @+node:ekr.20031218072017.3137: *3* g.Timing

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2707,8 +2707,11 @@ def stat(*, name: str = None, obj: Any = None) -> None:
     Othewise, add obj to a set associated with name.
 
     Example:
-        g.stat(obj=w.__class__.__name__)
-        g.printStats() will show the *distinct* classes that `w` may have.
+
+    To see all the *distinct* values that a kwarg `w` might have,
+    add `g.stat(obj=w.__class__.__name__)` to the method.
+
+    Later, execute `g.printStats()`.
     """
     d = g.app.statsDict
     if name:

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2665,56 +2665,42 @@ def clearStats() -> None:
 
 # @+node:ekr.20031218072017.3135: *4* g.printStats
 @command('show-stats')
-def printStats(event: LeoKeyEvent = None, name: str = None) -> None:
+def printStats(event: LeoKeyEvent = None) -> None:
     """
-    Print all gathered statistics counts first, followed by other stats.
+    Print all stats created by g.stat(), counts first.
     """
-    print('g.app.statsDict...')
     d = g.app.statsDict
-    if not d:
-        return
-    if name:
-        if not isinstance(name, str):
-            name = repr(name)
-    else:
-        # Get caller name 2 levels back.
-        name = g._callerName(n=2)
+    int_key = 'stat_count:'  # Must match the key in g.stat.
 
-    # Sort the stats into int stats and non-int stats.
-    tag = 'stat_count:'
-    keys = sorted(list(d.keys()))
-    counts = [z for z in keys if z.startswith(tag)]
-    non_counts = [z for z in keys if not z.startswith(tag)]
+    # Print the signon.
+    print('g.app.statsDict...')
+
     # Print the int stats: calls to g.stat()
-    for key in counts:
-        key_s = key[len(tag) :].strip()
-        print(f"  {d.get(key):4}: {key_s}")
-    # Print the other stats: calls to g.stat(obj=whatever)
-    for key in non_counts:
-        print(f"{key}:")
-        for z in sorted([repr(z) if not isinstance(z, str) else z for z in list(d.get(key))]):
-            print(f"    {z.strip()}")
+    for key in sorted(d.keys()):
+        if key.startswith(int_key):
+            key_s = key[len(int_key) :].strip()
+            print(f"  {d.get(key):4}: {key_s}")
+
+    # Print the other stats: calls to g.stat(whatever)
+    for key in sorted(d.keys()):
+        if not key.startswith(int_key):
+            inner_keys = [z if isinstance(z, str) else repr(z) for z in d.get(key)]
+            print(f"{key}:")
+            for z in sorted(inner_keys):
+                print(f"    {z.strip()}")
 
 
 # @+node:ekr.20031218072017.3136: *4* g.stat
-def stat(*, name: str = None, obj: Any = None) -> None:
+def stat(obj: Any = None) -> None:
     """
-    Add another stat to g.app.statsDict.
+    Add another count stat to g.app.statsDict.
     g.printStats() prints all such stats.
-
-    When `name` is None, use the caller's name.
-
-    Always add a count statistic for `name`.
 
     When `obj` is given, add obj to a set associated with name.
     Example: `g.stat(obj=w.__class__.__name__)`.
     """
     d = g.app.statsDict
-    if name:
-        if not isinstance(name, str):
-            name = repr(name)
-    else:
-        name = g._callerName(n=2)  # Get caller name 2 levels back.
+    name = g._callerName(n=2)  # Get caller name 2 levels back.
 
     # Always add the count stat.
     key = f"stat_count: {name}"

--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -2692,8 +2692,8 @@ def printStats(event: LeoKeyEvent = None, name: str = None) -> None:
     # Print the other stats: calls to g.stat(obj=whatever)
     for key in non_counts:
         print(f"{key}:")
-        for z in sorted(list(d.get(key))):
-            print(f"    {z}")
+        for z in sorted([repr(z) if not isinstance(z, str) else z for z in list(d.get(key))]):
+            print(f"    {z.strip()}")
 
 
 # @+node:ekr.20031218072017.3136: *4* g.stat
@@ -2703,15 +2703,11 @@ def stat(*, name: str = None, obj: Any = None) -> None:
     g.printStats() prints all such stats.
 
     When `name` is None, use the caller's name.
-    When `obj` is None, increment the count associated with name.
-    Othewise, add obj to a set associated with name.
 
-    Example:
+    Always add a count statistic for `name`.
 
-    To see all the *distinct* values that a kwarg `w` might have,
-    add `g.stat(obj=w.__class__.__name__)` to the method.
-
-    Later, execute `g.printStats()`.
+    When `obj` is given, add obj to a set associated with name.
+    Example: `g.stat(obj=w.__class__.__name__)`.
     """
     d = g.app.statsDict
     if name:
@@ -2720,14 +2716,15 @@ def stat(*, name: str = None, obj: Any = None) -> None:
     else:
         name = g._callerName(n=2)  # Get caller name 2 levels back.
 
-    if obj is None:
-        key = f"stat_count: {name}"
-        d[key] = 1 + d.get(key, 0)
-    else:
-        key = name
-        aSet = d.get(key, set())
+    # Always add the count stat.
+    key = f"stat_count: {name}"
+    d[key] = 1 + d.get(key, 0)
+
+    # Add the other stat if obj is given.
+    if obj is not None:
+        aSet = d.get(name, set())
         aSet.add(obj)
-        d[key] = aSet
+        d[name] = aSet
 
 
 # @+node:ekr.20031218072017.3137: *3* g.Timing


### PR DESCRIPTION
This PR will remain a draft until Leo 6.8.8 is released. It is a work in progress and is really part of PR #4576.

The `g.stat` function maintains `g.app.statsDict`, annotated as `dict[str, Any]`.
At present, `g.stats` inserts only ints, that is counts of how many times a function/method is executed.

This PR allows these legacy statistics, but adds the capability to list the set of other objects.
My tests call `g.stat(obj=w.__class__.__name__)` to show all the object types that an argument `w` has during execution.
These show `w`'s actual types when `w` is annotated as `Any`.

- [x] Remove `name` arg from `g.stat` and `g.printStats`.
- [x] Add a new `obj` arg to `g.stat`.
    Update the count statistic regardless of the `obj` kwarg.
- [x] All intermixed calls to `g.stat()` and `g.stat(obj=whatever)`.
- [x] `g.printStats` prints int stats followed non-int stats.

Imo, this PR is a significant addition to Leo's debugging capabilities.
