### PR TITLE
PR: Restore args to run_test_leo.py

### DIFF
--- a/leo/core/leoGlobals.py
+++ b/leo/core/leoGlobals.py
@@ -1608,7 +1608,12 @@ class OptionsUtils:
         """
         # Abbreviations (-whatever) must appear before full options (--whatever).
         option_pattern = re.compile(r'\s*(-\w)?,?\s*(--[\w-]+=?)')
-        valid = ['-?']
+        valid = [
+            '-?',
+            # For `python -m unittest`
+            '-v',
+            '--verbose',
+        ]
         for line in g.splitLines(self.usage):
             if m := option_pattern.match(line):
                 if m.group(1):

--- a/leo/scripts/run_test_leo.py
+++ b/leo/scripts/run_test_leo.py
@@ -28,6 +28,6 @@ args = ' '.join(sys.argv[1:])
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
-command = rf'{python} -m unittest'
+command = rf'{python} -m unittest {args}'
 subprocess.Popen(command, shell=True).communicate()
 # @-leo

--- a/leo/unittests/core/test_leoApp.py
+++ b/leo/unittests/core/test_leoApp.py
@@ -137,6 +137,7 @@ class TestApp(LeoUnitTest):
             '--trace-setting=whatever',
             '--trace=coloring',
             '-v',
+            '--verbose',
             '--version',
             '--window-size=100x200',
             '--window-spot=50x60',

--- a/leo/unittests/core/test_leoGlobals.py
+++ b/leo/unittests/core/test_leoGlobals.py
@@ -669,7 +669,7 @@ class TestGlobals(LeoUnitTest):
         x = g.OptionsUtils(usage, obsolete_options)
 
         # Test x.compute_valid_options.
-        expected_valid_options = [
+        expected_valid_options = list(sorted(set([
             '--black-sentinels',
             '--diff',
             '--fail-fast',
@@ -677,7 +677,10 @@ class TestGlobals(LeoUnitTest):
             '-?',
             '-b',
             '-h',
-        ]
+            # For `python -m unittest`.
+            '-v',
+            '--verbose',
+        ])))  # fmt: skip
         self.assertEqual(x.compute_valid_options(), expected_valid_options)
 
         # Test x.option_error and x.check_options.


### PR DESCRIPTION

- [x] Fix reversion in `run_test_leo.py`.
- [x] Fix one unit test (and supporting code) to all `-v` and `--version` to appear on the command-line for  `run_test_leo.py`.
    Fixing this unit test was a bit of a nightmare, but all my local tests pass.