### PR TITLE
Fix string concatenation in abbreviation toggle message

### DIFF
--- a/leo/commands/abbrevCommands.py
+++ b/leo/commands/abbrevCommands.py
@@ -815,7 +815,7 @@ class AbbrevCommandsClass(BaseEditCommandsClass):
         k.abbrevOn = not k.abbrevOn
         k.keyboardQuit()
         if not g.unitTesting and not g.app.batchMode:
-            g.es('Abbreviations are ' + 'on' if k.abbrevOn else 'off')
+            g.es('Abbreviations are ' + ('on' if k.abbrevOn else 'off'))
 
     # @-others
 


### PR DESCRIPTION
Quick fix for the toggle-abbrev-mode command's output message which was inconsistent.