### PR TITLE
PR fixes #4591: after-build quirps

### DIFF
--- a/leo/core/leoNodes.py
+++ b/leo/core/leoNodes.py
@@ -2143,8 +2143,6 @@ class VNode:
     ]  # fmt: skip
     # @+<< VNode constants >>
     # @+node:ekr.20031218072017.951: *3* << VNode constants >>
-    # fmt: off
-
     # Define the meaning of status bits in new vnodes.
 
     # Unused bits.
@@ -2155,18 +2153,16 @@ class VNode:
     # 0x010
 
     # Archived bits...
-    expandedBit = 0x04  # True: VNode is expanded.
-    markedBit   = 0x08  # True: VNode is marked
-    selectedBit = 0x20  # True: VNode is current vnode.
+    expandedBit = 0x04  # fmt: skip  # True: VNode is expanded.
+    markedBit   = 0x08  # fmt: skip  # True: VNode is marked.
+    selectedBit = 0x20  # fmt: skip  # VNode is current vnode.
 
     # Not archived...
-    richTextBit = 0x080  # Determines whether we use <bt> or <btr> tags.
-    visitedBit  = 0x100
-    dirtyBit    = 0x200
-    writeBit    = 0x400
-    orphanBit   = 0x800  # True: error in @<file> tree prevented it from being written.
-
-    # fmt: on
+    richTextBit = 0x080  # fmt: skip  # Do we use <bt> or <btr> tags?.
+    visitedBit  = 0x100  # fmt: skip
+    dirtyBit    = 0x200  # fmt: skip
+    writeBit    = 0x400  # fmt: skip
+    orphanBit   = 0x800  # fmt: skip  # True: error in @<file> tree.
 
     # @-<< VNode constants >>
     # @+others

--- a/leo/plugins/gitarchive.py
+++ b/leo/plugins/gitarchive.py
@@ -2,7 +2,6 @@
 # @+node:ekr.20110125103904.12504: * @file ../plugins/gitarchive.py
 """Store snapshots of outline in git."""
 
-import codecs
 import hashlib
 import os
 import shutil
@@ -34,7 +33,8 @@ def git_dump_f(event):
             gnx = p.gnx
             hl.append('<a href="%s">%s%s</a><br/>' % (gnx, '-' * p.level(), p.h))
             fname = gnx
-            codecs.open(fname, 'w', encoding='utf-8').write(p.b)
+            with open(fname, 'w', encoding='utf-8') as f:
+                f.write(p.b)
             print("wrote", fname)
 
     flatroot = g.finalize('~/.leo/dump')
@@ -58,7 +58,8 @@ def git_dump_f(event):
     if pth and bname:
         dbdirname = bname + "_" + hashlib.md5(c.mFileName).hexdigest()
     titlename = dbdirname + '.html'
-    codecs.open(titlename, 'w', encoding='utf-8').write(html)
+    with open(titlename, 'w', encoding='utf-8') as f:
+        f.write(html)
     g.es("committing to " + flatroot)
     os.system('git add *')
     out = os.popen('git commit -m "%s"' % comment).read()

--- a/leo/plugins/leo_babel/babel_lib.py
+++ b/leo/plugins/leo_babel/babel_lib.py
@@ -514,19 +514,15 @@ def babelExec(event):
 
         babelCmdr.reo = reo  # Kludge to allow itf() to determine which output it polls
         itOut = leoG.IdleTime(
-            lambda ito,
-            prefix=babelCmdr.babel_prefix_stdout,
-            color=babelCmdr.babel_color_stdout,
-            fdr=reo,
-            babelCmdr=babelCmdr: itf(prefix, color, fdr, babelCmdr),
+            lambda ito, prefix=babelCmdr.babel_prefix_stdout, color=babelCmdr.babel_color_stdout, fdr=reo, babelCmdr=babelCmdr: (
+                itf(prefix, color, fdr, babelCmdr)
+            ),
             delay=babelCmdr.babel_polling_delay,
         )
         itErr = leoG.IdleTime(
-            lambda ito,
-            prefix=babelCmdr.babel_prefix_stderr,
-            color=babelCmdr.babel_color_stderr,
-            fdr=ree,
-            babelCmdr=babelCmdr: itf(prefix, color, fdr, babelCmdr),
+            lambda ito, prefix=babelCmdr.babel_prefix_stderr, color=babelCmdr.babel_color_stderr, fdr=ree, babelCmdr=babelCmdr: (
+                itf(prefix, color, fdr, babelCmdr)
+            ),
             delay=babelCmdr.babel_polling_delay,
         )
         if (not itOut) or (not itErr):

--- a/leo/plugins/todo.py
+++ b/leo/plugins/todo.py
@@ -1234,6 +1234,7 @@ class todoController:
         g.es('\n Current distribution:')
         self.showDist()
         dat: dict = {}
+        x0: Any
         for end in 'from', 'to':
             if Qt:
                 x0, ok = QtWidgets.QInputDialog.getText(

--- a/leo/plugins/viewrendered.py
+++ b/leo/plugins/viewrendered.py
@@ -675,10 +675,7 @@ class ViewRenderedController(QtWidgets.QWidget):  # type:ignore
         self.locked = False
         self.pdf_qwv = None  # The singleton qwv instance, with support for pdf.
         self.qwv = None  # The singleton qwv instance.
-        self.scrollbar_pos_dict: dict[
-            VNode, Position
-        ] = {}  # Keys are vnodes, values are positions.
-        # User settings.
+        self.scrollbar_pos_dict: dict[VNode, int] = {}
         self.reloadSettings()
         self.node_changed = True
         # Init.

--- a/leo/scripts/mypy_leo.py
+++ b/leo/scripts/mypy_leo.py
@@ -27,7 +27,7 @@ args = ' '.join(sys.argv[1:])
 isWindows = sys.platform.startswith('win')
 python = 'py' if isWindows else 'python'
 
-if 0:  # Quick.
+if 1:  # Quick.
     command = rf'{python} -m mypy leo'
 else:  # Safe.
     command = rf'{python} -m mypy --no-incremental leo'


### PR DESCRIPTION
See #4591.

- [x] `leoNodes.py`: use per-line `# fmt: skip` suppressions. This is a workaround to new `ruff format` behavior.
- [x] `plugins/leo_babel/babel_lib.py`: Reformat two lambdas.
- [x] `plugins/gitarchive.py`: Fix two pylint complaints:
    `gitarchive.py:37:12: W4902: Using deprecated method open() (deprecated-method)`
    `gitarchive.py:61:4:  W4902: Using deprecated method open() (deprecated-method)`
- [x] `viewrendered.py`: fix erroneous annotation.
- [x] `todo.py`: Suppress a mypy complaint.
- [x] Re-enable mypy caching.
 