### PR TITLE
(Defensive) Fix potential bug: Improved .leojs file format support for AbbrevCommandsClass 'reload-settings'.

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -1281,9 +1281,13 @@ class FileCommands:
         oldGnxDict = self.gnxDict
         self.gnxDict = {}  # Fix #943
         try:
-            # This encoding must match the encoding used in outline_to_clipboard_string.
-            s_bytes = g.toEncodedString(s, self.leo_file_encoding, reportErrors=True)
-            v = FastRead(c, {}).readFileFromClipboard(s_bytes)
+            if s.lstrip().startswith("{"):
+                # Maybe JSON
+                v = FastRead(c, {}).readFileFromJsonClipboard(s)
+            else:
+                # This encoding must match the encoding used in outline_to_clipboard_string.
+                s_bytes = g.toEncodedString(s, self.leo_file_encoding, reportErrors=True)
+                v = FastRead(c, {}).readFileFromClipboard(s_bytes)
             if not v:
                 g.es("the clipboard is not valid ", color="blue")
                 return None


### PR DESCRIPTION
Improved .leojs file format (json) support. 

Fixed a potential error message in the log pane, that should not have happenned unless the settings were set to have clipboard in json, AND reloading settings with abbreviations turned on.