### PR TITLE
PR: Fix copy paste

### DIFF
--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -129,11 +129,14 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Restart Leo with subprocess.run.
-    g.cls()
-    print('')
+    if verbose:
+        print('')
+    else:
+        g.cls()
     print('Restarting Leo...')
     if verbose:
         print(f"os.chdir({g.app.initial_cwd})")
+
     os.chdir(g.app.initial_cwd)
     if 1:  # #3916.
         if g.isWindows:

--- a/leo/commands/commanderFileCommands.py
+++ b/leo/commands/commanderFileCommands.py
@@ -89,6 +89,7 @@ def reloadSettings(self: Self, event: LeoKeyEvent = None) -> None:
 @g.commander_command('restart-leo')
 def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     """Restart Leo, reloading all presently open outlines."""
+    verbose = False
     c = self
     # Write .leoRecentFiles.txt.
     g.app.recentFilesManager.writeRecentFilesFile(c)
@@ -128,9 +129,11 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
     sys.stdout.flush()
     sys.stderr.flush()
     # Restart Leo with subprocess.run.
+    g.cls()
     print('')
     print('Restarting Leo...')
-    print(f"os.chdir({g.app.initial_cwd})")
+    if verbose:
+        print(f"os.chdir({g.app.initial_cwd})")
     os.chdir(g.app.initial_cwd)
     if 1:  # #3916.
         if g.isWindows:
@@ -148,7 +151,8 @@ def restartLeo(self: Self, event: LeoKeyEvent = None) -> None:
         launchLeo_s = rf'{leo_editor_dir}{os.sep}launchLeo.py'
         args = [sys.executable, launchLeo_s] + restart_paths + ['--no-splash']
     args_s = 'subprocess.run([\n  ' + ',\n  '.join(args) + '\n])'
-    print(args_s)
+    if verbose:
+        print(args_s)
     print('')
     subprocess.run(args)  # pylint: disable=subprocess-run-check
 

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -485,6 +485,8 @@ class LeoFrame:
         # f = self
         w = event and event.widget
         # wname = c.widget_name(w)
+        ### g.trace(event)  ###
+        ### g.trace(repr(w))  ###
         if not w or not g.isTextWrapper(w):
             return
         # Set the clipboard text.

--- a/leo/core/leoFrame.py
+++ b/leo/core/leoFrame.py
@@ -485,8 +485,6 @@ class LeoFrame:
         # f = self
         w = event and event.widget
         # wname = c.widget_name(w)
-        ### g.trace(event)  ###
-        ### g.trace(repr(w))  ###
         if not w or not g.isTextWrapper(w):
             return
         # Set the clipboard text.

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -385,10 +385,13 @@ class LeoKeyEvent:
 
     # @+node:ekr.20140907103315.18774: *3* LeoKeyEvent.__repr__
     def __repr__(self) -> str:
-        d = {'c': self.c.shortFileName()}
-        for ivar in ('char', 'event', 'stroke', 'w'):
-            d[ivar] = getattr(self, ivar)
-        return f"LeoKeyEvent:\n{g.objToString(d)}"
+        result = [
+            'LeoKeyEvent:',
+            f"  {'c':>6}: {self.c.shortFileName()}",
+        ]
+        for ivar in ('char', 'event', 'stroke', 'w', 'widget'):
+            result.append(f"  {ivar:>6}: {getattr(self, ivar)}")
+        return '\n'.join(result)
 
     # @+node:ekr.20150511181702.1: *3* LeoKeyEvent.get & __getitem__
     def get(self, attr: str) -> Value:

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -361,6 +361,8 @@ class LeoKeyEvent:
         y_root: int = None,
     ) -> None:
         """Ctor for LeoKeyEvent class."""
+        if False and not g.unitTesting:  ###
+            g.trace('(LeoKeyEvent): w:', w.__class__.__name__, g.callers(2))
         stroke: Any
         if g.isStroke(binding):
             g.trace('***** (LeoKeyEvent) oops: already a stroke', binding, g.callers())

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -361,8 +361,6 @@ class LeoKeyEvent:
         y_root: int = None,
     ) -> None:
         """Ctor for LeoKeyEvent class."""
-        if False and not g.unitTesting:  ###
-            g.trace('(LeoKeyEvent): w:', w.__class__.__name__, g.callers(2))
         stroke: Any
         if g.isStroke(binding):
             g.trace('***** (LeoKeyEvent) oops: already a stroke', binding, g.callers())

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2685,6 +2685,7 @@ class LeoQtLog(leoFrame.LeoLog):
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
         """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)
+        ### g.trace(tabName, i)  ###
         if i is None:
             self.createTab(tabName, wrap=wrap)
             self.finishCreateTab(tabName)
@@ -2702,12 +2703,15 @@ class LeoQtLog(leoFrame.LeoLog):
             self.tabName: str = None
             return
         # #1161.
+        g.trace(tabName)  ###
         if tabName == 'Log':
             widget = self.contentsDict.get('Log')
             if widget:
                 wrapper = getattr(widget, 'leo_log_wrapper', None)
+                g.trace(wrapper.__class__.__name__)  ###
                 if wrapper and isinstance(wrapper, qt_text.QTextEditWrapper):
                     self.qtLogCtrl = wrapper
+                    self.logCtrl = wrapper  # Required!
             if not wrapper:
                 g.trace('NO LOG WRAPPER')
         if tabName == 'Find':

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2611,6 +2611,7 @@ class LeoQtLog(leoFrame.LeoLog):
             self.logDict[tabName] = widget
             if tabName == 'Log':
                 self.qtLogCtrl = contents
+                self.logCtrl = contents  # PR #4601: Set the base-class ivar.
                 widget.setObjectName('log-widget')
             # Set binding on all log pane widgets.
             g.app.gui.setFilter(c, widget, self, tag='log')
@@ -2685,8 +2686,8 @@ class LeoQtLog(leoFrame.LeoLog):
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
         """Create the tab if necessary and make it active."""
         i = self.findTabIndex(tabName)
-        ### g.trace(tabName, i)  ###
         if i is None:
+            # This does happen, but not often.
             self.createTab(tabName, wrap=wrap)
             self.finishCreateTab(tabName)
         self.finishSelectTab(tabName)
@@ -2703,12 +2704,10 @@ class LeoQtLog(leoFrame.LeoLog):
             self.tabName: str = None
             return
         # #1161.
-        g.trace(tabName)  ###
         if tabName == 'Log':
             widget = self.contentsDict.get('Log')
             if widget:
                 wrapper = getattr(widget, 'leo_log_wrapper', None)
-                g.trace(wrapper.__class__.__name__)  ###
                 if wrapper and isinstance(wrapper, qt_text.QTextEditWrapper):
                     self.qtLogCtrl = wrapper
                     self.logCtrl = wrapper  # Required!


### PR DESCRIPTION
Fixes PR #4576. `git-bisect` found the culprit: rev cf2d872.

- [x] Set `self.qtLogCtrl` in `LeoQtLog.createTab` and `LeoQtLog.selectTab`.

**Other changes**

- [x] Merge PR #4600.
- [x] Improve `LeoKeyEvent.__repr__`.

**Discussion**

This bug arose from renaming the ivars of the `LeoQtLog` class, and particularly the `qtLogCtrl` ivar. This renaming was a breakthrough, not a mistake. The renaming helped mypy annotate wrappers more concretely.

From the first, I was aware that this renaming could be dangerous&mdash;the distinction between free and bound variables is crucial in mathematical logic. I simply missed a few places where I had to copy (bound) values from the subclass to the base class.