### PR TITLE
PR fixes #4602: simplify isTextWidget logic

### DIFF
--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -116,8 +116,8 @@ class StringTextWrapper(QTextMixin):
         self.s = ''
 
     # @+node:ekr.20260415161250.1: *3* StringTextWrapper.__repr__
-    def __repr__(self):
-        return f"<StringTextWrapper: @ {id(self)}"
+    def __repr__(self) -> str:
+        return f"<StringTextWrapper: @ {id(self)}>"
 
     # @+node:ekr.20140903172510.18579: *3* StringTextWrapper.setFocus
     def setFocus(self) -> None:

--- a/leo/core/leoAPI.py
+++ b/leo/core/leoAPI.py
@@ -104,6 +104,8 @@ class StringTextWrapper(QTextMixin):
     A class that represents Leo's body pane as a Python string.
     """
 
+    # @+others
+    # @+node:ekr.20260415161218.1: *3* StringTextWrapper.__init__
     def __init__(self, c: Cmdr, name: str) -> None:
         super().__init__(c)
         self.c = c
@@ -113,7 +115,10 @@ class StringTextWrapper(QTextMixin):
         self.sel = 0, 0
         self.s = ''
 
-    # @+others
+    # @+node:ekr.20260415161250.1: *3* StringTextWrapper.__repr__
+    def __repr__(self):
+        return f"<StringTextWrapper: @ {id(self)}"
+
     # @+node:ekr.20140903172510.18579: *3* StringTextWrapper.setFocus
     def setFocus(self) -> None:
         pass

--- a/leo/core/leoCommands.py
+++ b/leo/core/leoCommands.py
@@ -3438,10 +3438,7 @@ class Commands:
             g.trace('stroke', stroke, 'plain:', k.isPlainKey(stroke), 'widget', name)
         if not stroke:
             return
-        #
-        # Part 1: Very late special cases.
-        #
-        # #1448
+        # #1448: Very late special cases.
         if stroke.isNumPadKey() and k.state.kind == 'getArg':
             stroke.removeNumPadModifier()
             k.getArg(event, stroke=stroke)
@@ -3452,9 +3449,6 @@ class Commands:
             if w and g.app.gui.widget_name(w).lower().startswith('canvas'):
                 c.onCanvasKey(event)
             return
-        #
-        # Part 2: Filter out keys that should never be inserted by default.
-        #
         # Ignore unbound F-keys.
         if stroke.isFKey():
             return
@@ -3477,9 +3471,6 @@ class Commands:
         # Never insert escape or insert characters.
         if 'Escape' in stroke.s or 'Insert' in stroke.s:
             return
-        #
-        # Part 3: Handle the event depending on the pane and state.
-        #
         # Handle events in the body pane.
         if name.startswith('body'):
             action = k.unboundKeyAction
@@ -3487,12 +3478,10 @@ class Commands:
                 c.editCommands.selfInsertCommand(event, action=action)
                 c.frame.updateStatusLine()
             return
-        #
         # Handle events in headlines.
         if name.startswith('head'):
             c.frame.tree.onHeadlineKey(event)
             return
-        #
         # Handle events in the background tree (not headlines).
         if name.startswith('canvas'):
             if event.char:
@@ -3501,16 +3490,13 @@ class Commands:
             elif not stroke:
                 c.onCanvasKey(event)
             return
-        #
         # Ignore all events outside the log pane.
         if not name.startswith('log'):
             return
-        #
         # Make sure we can insert into w.
         log_w = event.widget
-        if not hasattr(log_w, 'supportsHighLevelInterface'):
+        if not g.app.gui.isTextWidget(log_w):
             return
-        #
         # Send the event to the text widget, not the LeoLog instance.
         i = log_w.getInsertPoint()
         s = stroke.toGuiChar()

--- a/leo/core/leoGui.py
+++ b/leo/core/leoGui.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from typing import Any, Optional, TYPE_CHECKING
 from leo.core import leoGlobals as g
 from leo.core import leoFrame
+from leo.core.leoAPI import StringTextWrapper
 
 if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
@@ -588,7 +589,7 @@ class NullGui(LeoGui):
 
     def isTextWrapper(self, w: Widget) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
-        return w and getattr(w, 'supportsHighLevelInterface', None)
+        return isinstance(w, StringTextWrapper)
 
     # @+node:ekr.20070301172456: *3* NullGui.panels
     def createComparePanel(self, c: Cmdr) -> None:

--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -112,7 +112,7 @@ class textGui(leoGui.LeoGui):
     def set_focus(self, c, w):
         pass
 
-    # @+node:ekr.20150107090324.13: *3* isTextWidget
+    # @+node:ekr.20150107090324.13: *3* isTextWidget (cursesGui.py)
     def isTextWidget(self, w):
         """Return True if w is a Text widget suitable for text-oriented commands."""
         return w and isinstance(w, StringTextWrapper)

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -4201,13 +4201,7 @@ class TextMixin:
     def __init__(self, c: Cmdr = None) -> None:
         """Ctor for TextMixin class"""
         self.c = c
-        # self.changingText = False  # A lockout for onTextChanged.
         self.enabled = True
-        self.supportsHighLevelInterface = True  # Flag for k.masterKeyHandler and isTextWrapper.
-        # self.tags = {}
-        # self.configDict = {}  # Keys are tags, values are colors (names or values).
-        # self.configUnderlineDict = {}  # Keys are tags, values are True
-        # self.virtualInsertPoint = None
         if c:
             self.injectIvars(c)
 

--- a/leo/plugins/cursesGui2.py
+++ b/leo/plugins/cursesGui2.py
@@ -2169,7 +2169,7 @@ class LeoCursesGui(leoGui.LeoGui):
     # @+node:ekr.20170504052119.1: *4* CGui.isTextWrapper
     def isTextWrapper(self, w: Any) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
-        return bool(w and getattr(w, 'supportsHighLevelInterface', None))
+        return isinstance(w, StringTextWrapper)
 
     # @+node:ekr.20170612063102.1: *4* CGui.put_help
     def put_help(self, c: Cmdr, s: str, short_title: str) -> None:

--- a/leo/plugins/qt_gui.py
+++ b/leo/plugins/qt_gui.py
@@ -26,6 +26,7 @@ from leo.core.leoQt import Shadow, Shape, StandardButton, Weight, WindowType
 from leo.plugins import qt_events
 from leo.plugins import qt_frame
 from leo.plugins import qt_idle_time
+from leo.plugins.qt_text import QTextMixin
 
 # This defines the commands defined by @g.command.
 from leo.plugins import qt_commands
@@ -41,7 +42,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoCommands import Commands as Cmdr
     from leo.core.leoGui import LeoKeyEvent
     from leo.core.leoNodes import Position
-    from leo.plugins.qt_text import QTextMixin
 
     Args = Any
     KWargs = Any
@@ -1698,11 +1698,7 @@ class LeoQtGui(leoGui.LeoGui):
 
     def isTextWrapper(self, w: Any) -> bool:
         """Return True if w is a Text widget suitable for text-oriented commands."""
-        if w is None:
-            return False
-        if isinstance(w, (g.NullObject, g.TracingNullObject)):
-            return True
-        return bool(getattr(w, 'supportsHighLevelInterface', None))
+        return isinstance(w, (g.NullObject, g.TracingNullObject, QTextMixin))
 
     # @+node:ekr.20110605121601.18527: *4* LeoQtGui.widget_name
     def widget_name(self, w: QWidget) -> str:

--- a/leo/plugins/qt_text.py
+++ b/leo/plugins/qt_text.py
@@ -162,7 +162,6 @@ class QTextMixin:
         self.enabled = True
         self.name: str = None  # Set in subclasses.
         # A flag for k.masterKeyHandler and isTextWrapper.
-        self.supportsHighLevelInterface = True
         self.tags: dict[str, str] = {}
         self.permanent = True  # False if selecting the minibuffer will make the widget go away.
         self.useScintilla = False  # This is used!

--- a/leo/unittests/plugins/test_gui.py
+++ b/leo/unittests/plugins/test_gui.py
@@ -311,6 +311,9 @@ class TestQtGui(LeoUnitTest):
         )
         for obj, class_ in table:
             assert isinstance(obj, class_), (repr(obj), repr(class_))
+            if issubclass(obj.__class__, QTextMixin):
+                # Every subclass of QTextMix is an instance of QTextMixin.
+                assert isinstance(obj, QTextMixin)
 
         # Test the class hierarchy of text-related classes.
         assert issubclass(LeoQTextBrowser, QtWidgets.QTextBrowser)
@@ -322,6 +325,7 @@ class TestQtGui(LeoUnitTest):
             QMinibufferWrapper,
             QTextEditWrapper,
             QScintillaWrapper,
+            QTextMixin,  # Every class is a subclass of itself.
         ):
             assert issubclass(class_, QTextMixin), repr(class_)
 


### PR DESCRIPTION
See #4602. This PR is a milestone:

- Fundamental `isinstance` tests replace ad-hoc tests of `x.supportsHighLevelInterface`.
  These tests reside in the `x.isTextWidget` and `x.isTextWrapper` methods of each gui class.
- Leo's code now mirrors mypy annotations.

**Remove all `supportsHighLevelInterface` ivars**

- [x] `c.insertCharFromEvent`: call `g.app.gui.isTextWidget` instead of testing `supportsHighLevelInterface` ivar.
- [x] `LeoQtGui.isTextWrapper`: Test  isinstance(w, QTextMixin) instead of `supportsHighLevelInterface`.
- [x] `NullGui` and `CursesGui2`: Test `isinstance(w, StringTextWrapper) instead of `supportsHighLevelInterface`.
- [x] `class QTextMixin`: remove  `supportsHighLevelInterface` ivar.

**Testing**

- [x] Test with `--gui=console`.
- [x] Improve `TestQtGui.test_annotations`.
    The new tests show that `isinstance` is the proper test in `LeoQtGui.sTextWrapper`.

**Other changes**

- [x] `cursesGui.py`: Add disambiguating headline.
- [x] Add `StringTextWrapper.__repr__`