### PR TITLE
PR fixes #4605: Improve docstring for LeoQtLog.selectTab

### DIFF
--- a/leo/plugins/cursesGui.py
+++ b/leo/plugins/cursesGui.py
@@ -101,7 +101,7 @@ class textGui(leoGui.LeoGui):
     def destroySelf(self):
         self.killed = True
 
-    # @+node:ekr.20150107090324.12: *3* finishCreate
+    # @+node:ekr.20150107090324.12: *3* finishCreate (cursesGui.py)
     def finishCreate(self):
         pass
 
@@ -500,7 +500,7 @@ class textLog(leoFrame.LeoLog):
     def setFontFromConfig(self):
         pass  # N/A
 
-    # @+node:ekr.20150107090324.68: *3* finishCreate
+    # @+node:ekr.20150107090324.68: *3* finishCreate (cursesGui.py)
     def finishCreate(self):
         pass
 

--- a/leo/plugins/qt_frame.py
+++ b/leo/plugins/qt_frame.py
@@ -2684,7 +2684,14 @@ class LeoQtLog(leoFrame.LeoLog):
 
     # @+node:ekr.20110605121601.18331: *4* LeoQtLog.selectTab & helpers
     def selectTab(self, tabName: str, wrap: str = 'none') -> None:
-        """Create the tab if necessary and make it active."""
+        """
+        Create the tab if necessary and make it active.
+
+        Any plugin or script can call this method to create a new tab.
+        There is no need to call c.frame.log.createTab first.
+
+        As a result, this code can *not* be moved to the startup logic.
+        """
         i = self.findTabIndex(tabName)
         if i is None:
             # This does happen, but not often.


### PR DESCRIPTION
See #4605.

- [x] Update the docstring for `LeoQtLog.selectTab`.
    Nothing more can (or should) be done.
- [x] Add disambiguating headlines for cursesGui.py