### PR TITLE
PR: Put java interfaces into separate blocks.

### DIFF
--- a/leo/plugins/importers/java.py
+++ b/leo/plugins/importers/java.py
@@ -26,6 +26,7 @@ class Java_Importer(Importer):
     # @+node:ekr.20260412045240.1: *3* << Java_Importer: block_patterns >>
     block_patterns: tuple = (
 
+        ('interface', re.compile(r'^\s*interface\s+(\w+.*?)\s*((implements|throws).*?)?{')),
         ('', re.compile(r'^\s*(.*?\bclass\s+\w+)')),
         ('', re.compile(r'^\s*(\w+.*?)\(.*?\)\s*((implements|throws).*?)?{')),
 

--- a/leo/unittests/plugins/test_importers.py
+++ b/leo/unittests/plugins/test_importers.py
@@ -1689,12 +1689,16 @@ class TestJava(BaseTestImporter):
         expected_results = (
             (
                 0, '',  # Ignore the first headline.
+                '@others\n'
+                '@language java\n'
+                '@tabwidth -4\n'
+            ),
+            (
+                1, 'interface Bicycle',
                 'interface Bicycle {\n'
                 '    void changeCadence(int newValue);\n'
                 '    void changeGear(int newValue);\n'
                 '}\n'
-                '@language java\n'
-                '@tabwidth -4\n'
             ),
         )  # fmt: skip
         self.new_run_test(s, expected_results)
@@ -1711,12 +1715,16 @@ class TestJava(BaseTestImporter):
         expected_results = (
             (
                 0, '',  # Ignore the first headline.
+                '@others\n'
+                '@language java\n'
+                '@tabwidth -4\n'
+            ),
+            (
+                1, 'interface Bicycle',
                 'interface Bicycle {\n'
                 'void changeCadence(int newValue);\n'
                 'void changeGear(int newValue);\n'
                 '}\n'
-                '@language java\n'
-                '@tabwidth -4\n'
             ),
         )  # fmt: skip
         self.new_run_test(s, expected_results)


### PR DESCRIPTION
PR #4587 mistakenly removed support for `interface` blocks. This PR corrects that mistake.

- [x] Add block pattern for interface.
- [x] Change two unit tests accordingly.