### PR TITLE
Quick perf pass on core: ~3x faster cold open via leoBridge

### DIFF
--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -15,6 +15,7 @@ import io
 import json
 import os
 import pickle
+import re
 import shutil
 import sqlite3
 import tempfile
@@ -171,6 +172,9 @@ class FastRead:
     # @+node:ekr.20180602062323.7: *3* fast.readWithElementTree & helpers
     # #1510: https://en.wikipedia.org/wiki/Valid_characters_in_XML.
     translate_dict = {z: None for z in range(20) if chr(z) not in '\t\r\n'}
+    # Match any control char that must be stripped per #1510. Used as a cheap
+    # pre-check so we skip `str.translate` (~100 ms/MB) on clean files.
+    bad_xml_chars_re = re.compile('[' + ''.join(chr(z) for z in translate_dict) + ']')
 
     bad_path_dict: dict[str, bool] = {}
 
@@ -180,8 +184,9 @@ class FastRead:
         s_or_b: str | bytes,
     ) -> tuple[VNode, Value]:
         contents = g.toUnicode(s_or_b)
-        table = contents.maketrans(self.translate_dict)  # type:ignore #1510.
-        contents = contents.translate(table)  # #1036, #1046.
+        if self.bad_xml_chars_re.search(contents):  # #1036, #1046, #1510.
+            table = contents.maketrans(self.translate_dict)  # type:ignore
+            contents = contents.translate(table)
         try:
             xroot = ElementTree.fromstring(contents)
         except Exception:

--- a/leo/core/leoFileCommands.py
+++ b/leo/core/leoFileCommands.py
@@ -170,22 +170,16 @@ class FastRead:
         return hidden_v
 
     # @+node:ekr.20180602062323.7: *3* fast.readWithElementTree & helpers
+    # PR #4615: Don't use str.translate unless there are bad characters.
     # #1510: https://en.wikipedia.org/wiki/Valid_characters_in_XML.
     translate_dict = {z: None for z in range(20) if chr(z) not in '\t\r\n'}
-    # Match any control char that must be stripped per #1510. Used as a cheap
-    # pre-check so we skip `str.translate` (~100 ms/MB) on clean files.
     bad_xml_chars_re = re.compile('[' + ''.join(chr(z) for z in translate_dict) + ']')
-
     bad_path_dict: dict[str, bool] = {}
 
-    def readWithElementTree(
-        self,
-        path: str,
-        s_or_b: str | bytes,
-    ) -> tuple[VNode, Value]:
+    def readWithElementTree(self, path: str, s_or_b: str | bytes) -> tuple[VNode, Value]:
         contents = g.toUnicode(s_or_b)
         if self.bad_xml_chars_re.search(contents):  # #1036, #1046, #1510.
-            table = contents.maketrans(self.translate_dict)  # type:ignore
+            table = contents.maketrans(self.translate_dict)
             contents = contents.translate(table)
         try:
             xroot = ElementTree.fromstring(contents)

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:  # pragma: no cover
     File_List = Optional[list[str]]
 # @-<< leoMarkup imports & annotations >>
 
+
 # External tool discovery is deferred: `shutil.which` walks every entry on
 # PATH, and these lookups previously fired on every Leo file open via
 # `Commands.__init__`. Resolve lazily, cache the result.

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -5,6 +5,7 @@
 # @+<< leoMarkup imports & annotations >>
 # @+node:ekr.20190515070742.3: ** << leoMarkup imports & annotations >>
 from __future__ import annotations
+import functools
 import io
 from shutil import which
 import os
@@ -24,22 +25,27 @@ if TYPE_CHECKING:  # pragma: no cover
     File_List = Optional[list[str]]
 # @-<< leoMarkup imports & annotations >>
 
-# Try RVM Ruby asciidoctor first, then fallback to system asciidoctor
-try:
-    import subprocess
+# External tool discovery is deferred: `shutil.which` walks every entry on
+# PATH, and these lookups previously fired on every Leo file open via
+# `Commands.__init__`. Resolve lazily, cache the result.
+@functools.cache
+def _asciidoctor_exec() -> Optional[str]:
+    return which('asciidoctor')
 
-    rvm_gemdir = subprocess.check_output(['rvm', 'gemdir'], text=True).strip()
-    rvm_asciidoctor = os.path.join(rvm_gemdir, 'bin', 'asciidoctor')
-    if os.path.exists(rvm_asciidoctor):
-        asciidoctor_exec = rvm_asciidoctor
-    else:
-        asciidoctor_exec = which('asciidoctor')
-except Exception:
-    asciidoctor_exec = which('asciidoctor')
 
-asciidoc3_exec = which('asciidoc3')
-pandoc_exec = which('pandoc')
-sphinx_build = which('sphinx-build')
+@functools.cache
+def _asciidoc3_exec() -> Optional[str]:
+    return which('asciidoc3')
+
+
+@functools.cache
+def _pandoc_exec() -> Optional[str]:
+    return which('pandoc')
+
+
+@functools.cache
+def _sphinx_build() -> Optional[str]:
+    return which('sphinx-build')
 
 
 # @+others
@@ -368,7 +374,8 @@ class MarkupCommands:
         """
         Process the input file given by i_path with asciidoctor or asciidoc3.
         """
-        # global asciidoctor_exec, asciidoc3_exec
+        asciidoctor_exec = _asciidoctor_exec()
+        asciidoc3_exec = _asciidoc3_exec()
         assert asciidoctor_exec or asciidoc3_exec, g.callers()
         # Call the external program to write the output file.
         # The -e option deletes css.
@@ -381,8 +388,7 @@ class MarkupCommands:
         """
         Process the input file given by i_path with pandoc.
         """
-        # global pandoc_exec
-        assert pandoc_exec, g.callers()
+        assert _pandoc_exec(), g.callers()
         # Call pandoc to write the output file.
         # --quiet does no harm.
         command = f"pandoc {i_path} -t html5 -o {o_path}"
@@ -546,8 +552,7 @@ class MarkupCommands:
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
-        # global asciidoctor_exec, asciidoc3_exec
-        if asciidoctor_exec or asciidoc3_exec:
+        if _asciidoctor_exec() or _asciidoc3_exec():
             return self.command_helper(event, kind='adoc', preview=preview, verbose=verbose)
         name = 'adoc-with-preview' if preview else 'adoc'
         g.es_print(f"{name} requires either asciidoctor or asciidoc3")
@@ -559,8 +564,7 @@ class MarkupCommands:
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
-        # global pandoc_exec
-        if pandoc_exec:
+        if _pandoc_exec():
             return self.command_helper(event, kind='pandoc', preview=preview, verbose=verbose)
         name = 'pandoc-with-preview' if preview else 'pandoc'
         g.es_print(f"{name} requires pandoc")
@@ -572,8 +576,7 @@ class MarkupCommands:
         preview: bool = False,
         verbose: bool = True,
     ) -> File_List:
-        # global sphinx_build
-        if sphinx_build:
+        if _sphinx_build():
             return self.command_helper(event, kind='sphinx', preview=preview, verbose=verbose)
         name = 'sphinx-with-preview' if preview else 'sphinx'
         g.es_print(f"{name} requires sphinx")

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -26,9 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
 # @-<< leoMarkup imports & annotations >>
 
 
-# External tool discovery is deferred: `shutil.which` walks every entry on
-# PATH, and these lookups previously fired on every Leo file open via
-# `Commands.__init__`. Resolve lazily, cache the result.
+# PR #4615: Defer calls to `which` until needed.
 @functools.cache
 def _asciidoctor_exec() -> Optional[str]:
     return which('asciidoctor')

--- a/leo/core/leoMarkup.py
+++ b/leo/core/leoMarkup.py
@@ -2,8 +2,8 @@
 # @+node:ekr.20190515070742.1: * @file leoMarkup.py
 """Supports @adoc, @pandoc and @sphinx nodes and related commands."""
 
-# @+<< leoMarkup imports & annotations >>
-# @+node:ekr.20190515070742.3: ** << leoMarkup imports & annotations >>
+# @+<< leoMarkup: imports & annotations >>
+# @+node:ekr.20190515070742.3: ** << leoMarkup: imports & annotations >>
 from __future__ import annotations
 import functools
 import io
@@ -23,7 +23,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from leo.core.leoNodes import Position
 
     File_List = Optional[list[str]]
-# @-<< leoMarkup imports & annotations >>
+# @-<< leoMarkup: imports & annotations >>
+# @+<< leoMarkup: cached functions >>
+# @+node:ekr.20260421071144.1: ** << leoMarkup: cached functions >>
 
 
 # PR #4615: Defer calls to `which` until needed.
@@ -45,6 +47,9 @@ def _pandoc_exec() -> Optional[str]:
 @functools.cache
 def _sphinx_build() -> Optional[str]:
     return which('sphinx-build')
+
+
+# @-<< leoMarkup: cached functions >>
 
 
 # @+others

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -272,6 +272,8 @@ class Importer:
         lines.
         """
         string_delims = self.string_list
+        # Tuple form so str.startswith can test all delimiters in one C call.
+        string_delims_tuple = tuple(string_delims)
         line_comment, start_comment, end_comment = g.set_delims_from_language(self.language)
         target = ''  # The string ending a multi-line comment or string.
         escape = '\\'
@@ -292,21 +294,21 @@ class Importer:
                 elif target:
                     result_line.append(' ')
                     # Clear the target, but skip any remaining characters of the target.
-                    if g.match(line, i, target):
+                    if line.startswith(target, i):
                         skip_count = max(0, (len(target) - 1))
                         target = ''
                 elif line_comment and line.startswith(line_comment, i):
                     # Skip the rest of the line. It can't contain significant characters.
                     break
-                elif any(g.match(line, i, z) for z in string_delims):
+                elif line.startswith(string_delims_tuple, i):
                     # Allow multi-character string delimiters.
                     result_line.append(' ')
                     for z in string_delims:
-                        if g.match(line, i, z):
+                        if line.startswith(z, i):
                             target = z
                             skip_count = max(0, (len(z) - 1))
                             break
-                elif start_comment and g.match(line, i, start_comment):
+                elif start_comment and line.startswith(start_comment, i):
                     result_line.append(' ')
                     target = end_comment
                     skip_count = max(0, len(start_comment) - 1)

--- a/leo/plugins/importers/base_importer.py
+++ b/leo/plugins/importers/base_importer.py
@@ -272,8 +272,7 @@ class Importer:
         lines.
         """
         string_delims = self.string_list
-        # Tuple form so str.startswith can test all delimiters in one C call.
-        string_delims_tuple = tuple(string_delims)
+        string_delims_tuple = tuple(string_delims)  # PR #4615: create tuple for s.startswith.
         line_comment, start_comment, end_comment = g.set_delims_from_language(self.language)
         target = ''  # The string ending a multi-line comment or string.
         escape = '\\'


### PR DESCRIPTION
## Caveat

This is a quick exploratory pass done with Claude Code — ~1 hour of profiling and patching, not a deep study. Each commit is small and narrowly scoped so you can cherry-pick or reject them individually. All three are measured wins on cold open via `leoBridge`, but wider testing (GUI paths, other `.leo` files, Windows) would be worth doing before merge.

## Measurements

Profiled `leoBridge.controller().openLeoFile('leo/doc/LeoDocs.leo')` (1.6 MB) on Linux / Python 3.12:

| stage | total cold open | delta |
|---|---|---|
| baseline (devel @ 18084b174) | 1784 ms | — |
| + 8114aa7f4 (leoMarkup lazy) | 808 ms | −55% |
| + e002125bf (XML translate skip) | 620 ms | −23% |
| + d66032336 (importer startswith) | 544 ms | −12% |
| **all three** | **544 ms** | **−69%** |

`cProfile` was used to attribute time; numbers are `time.perf_counter()` wall-clock, nullGui, `loadPlugins=False`, `readSettings=False`.

## Commits

### 8114aa7f4 — `leoMarkup: defer external tool discovery to first use`

`leoMarkup.py` ran four `shutil.which()` calls and spawned `rvm gemdir` at **module import time**. Because `Commands.__init__` imports `leoMarkup`, this fired on every `.leo` file open (twice — settings + file), spending ~800 ms walking PATH and fork/exec'ing a Ruby tool most users don't have.

- Wrapped each lookup in `functools.cache`d helpers; resolution now happens only when an `@adoc`/`@pandoc`/`@sphinx` command is actually invoked.
- Dropped the RVM probe entirely — nothing in-repo depends on it, and the `try: subprocess.check_output(['rvm', 'gemdir'])` fails for any user without Ruby Version Manager, wasting a fork.

Plugin copies (`viewrendered.py`, `viewrendered3.py`) have their own eager `which()` calls at import time but those modules only load when a plugin is activated, so they're not on the core hot path. Left untouched.

### e002125bf — `leoFileCommands: skip XML control-char strip on clean files`

`readWithElementTree` unconditionally ran `str.translate` over the entire `.leo` file contents to strip XML-invalid control chars (issue #1510), costing ~100 ms per MB of file. Virtually no real `.leo` file contains those chars.

- Added a compiled regex pre-check (`bad_xml_chars_re`) that scans for any affected code point. On LeoDocs.leo the check runs in ~3 ms vs ~115 ms for `translate`.
- Behavior is unchanged: when bad chars are present the same `translate` still runs.

### d66032336 — `base_importer: use str.startswith instead of g.match in inner loop`

`delete_comments_and_strings` runs for every line of every `@file` body on load. It called `g.match(line, i, pattern)` inside a per-character loop. `g.match` is a pure-Python wrapper around `str.find`; `str.startswith(pattern, i)` does the same work in C and accepts a **tuple** of alternatives, so `any(g.match(line, i, z) for z in string_delims)` collapses to one native call.

- Replaced four `g.match` call sites.
- Removed ~160k Python-level calls per LeoDocs load.
- Verified behavior equivalence: `string_list` entries are always non-empty (or the whole list is empty, e.g. rust), and the other call sites (`target`, `start_comment`) are already truthiness-guarded — so the `str.startswith('')=True` edge case cannot be hit.

## What I did not touch (but noticed)

- `leoCommands.initObjects` still runs two subcommander wire-ups per open (settings + file). Possibly skippable on the settings pass but a bigger refactor.
- `c.getPathFromNode` is called ~10k times during a full-tree walk; memoization per-VNode for the duration of a load would help but needs care around edits.
- `viewrendered*.py` have the same eager `which()` pattern as pre-fix `leoMarkup.py`.

## Test plan

- [x] Manual: open LeoDocs.leo, leoSettings.leo, and a project `.leo` in the GUI; verify no behavior change.
- [ ] `@adoc` / `@pandoc` / `@sphinx` commands still work when those tools are installed (I can't easily verify — no asciidoctor/pandoc on this machine).
- [x] CI test suite.
- [ ] A `.leo` file actually containing stripped control chars exercises the `bad_xml_chars_re` branch in `readWithElementTree`.