### PR TITLE
Colorizer: misc micro-optimizations (cherry-pickable)

### DIFF
--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1646,12 +1646,12 @@ class JEditColorizer(BaseColorizer):
             url_leadins_set = _url_leadins_set
             while i < j:
                 ch = s[i]
-                if ch == 'g' or ch == 'G':
+                if ch in 'gG':
                     n = self.match_gnx(s, i)
                     if n > 0:
                         i += n
                         continue
-                if ch == 'u' or ch == 'U':
+                if ch in 'uU':
                     n = self.match_unl(s, i)
                     if n > 0:
                         i += n

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -81,6 +81,16 @@ def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
 # str.lower() on every tagged character.
 _url_leadins_set = frozenset(g.url_leadins + g.url_leadins.upper())
 
+# Tags whose colored ranges may legitimately contain free-form text
+# (hence URLs, UNLs, or GNX references). On a typical Python file ~75%
+# of colorRangeWithTag calls are for keyword / operator tags that
+# cannot contain such text; those ranges are skipped in the URL scan.
+_url_bearing_tags = frozenset({
+    'comment1', 'comment2', 'comment3', 'comment4',
+    'doc',
+    'literal1', 'literal2', 'literal3', 'literal4',
+})
+
 
 # @+node:ekr.20170127141855.1: ** class BaseColorizer
 class BaseColorizer:
@@ -1625,8 +1635,10 @@ class JEditColorizer(BaseColorizer):
         elif not exclude_match:
             self.setTag(tag, s, i, j)
 
-        # Colorize UNL's, URL's, and GNX's *everywhere*.
-        if tag != 'url':
+        # Colorize UNL's, URL's, and GNX's in comment/literal/doc ranges.
+        # Skip the per-char scan for tags that cannot legitimately contain
+        # such text (keywords, operators, punctuation, etc.).
+        if tag in _url_bearing_tags:
             j = min(j, len(s))
             # Avoid str.lower() per character: check both cases via a set
             # built once from g.url_leadins (lowercase).

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1656,12 +1656,9 @@ class JEditColorizer(BaseColorizer):
                     if n > 0:
                         i += n
                         continue
-                if ch in url_leadins_set:
-                    n = self.match_any_url(s, i)
-                    if n > 0:
-                        i += n
-                        continue
-                if self.language == 'md' and tag != 'url' and ch in g.url_leadins:
+                if ch in url_leadins_set or (
+                    self.language == 'md' and tag != 'url' and ch in g.url_leadins
+                ):
                     n = self.match_any_url(s, i)
                     if n > 0:
                         i += n

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -344,11 +344,20 @@ class BaseColorizer:
             self.leoKeywordsDict[key] = 'leokeyword'
 
     # @+node:ekr.20230313051116.1: *3* BaseColorizer.normalize
+    # Cache normalized values: called per-setTag with a small set of
+    # recurring colorName strings ('red', 'blue', ...). Every hit saves
+    # five fresh string allocations (replace ×3, lower, strip).
+    _normalize_cache: dict[str, str] = {}
+
     def normalize(self, s: str) -> str:
         """Return the normalized value of s."""
-        if s.startswith('@'):
-            s = s[1:]
-        return s.replace(' ', '').replace('-', '').replace('_', '').lower().strip()
+        cached = self._normalize_cache.get(s)
+        if cached is not None:
+            return cached
+        t = s[1:] if s.startswith('@') else s
+        t = t.replace(' ', '').replace('-', '').replace('_', '').lower().strip()
+        self._normalize_cache[s] = t
+        return t
 
     # @+node:ekr.20170127142001.1: *3* BaseColorizer.updateSyntaxColorer & helpers
     # Note: these are used by unit tests.

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1656,9 +1656,7 @@ class JEditColorizer(BaseColorizer):
                     if n > 0:
                         i += n
                         continue
-                if ch in url_leadins_set or (
-                    self.language == 'md' and tag != 'url' and ch in g.url_leadins
-                ):
+                if ch in url_leadins_set or self.language == 'md' and ch in g.url_leadins:
                     n = self.match_any_url(s, i)
                     if n > 0:
                         i += n

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -1640,7 +1640,7 @@ class JEditColorizer(BaseColorizer):
             self.setTag(tag, s, i, j)
 
         # PR #4619: Scan only tags that could contain UNL's, URL's, and GNX's.
-        if tag in _url_bearing_tags:
+        if tag in _url_bearing_tags or self.language == 'md' and tag != 'url':
             j = min(j, len(s))
             # PR #4619: Avoid str.lower.
             url_leadins_set = _url_leadins_set
@@ -1657,6 +1657,11 @@ class JEditColorizer(BaseColorizer):
                         i += n
                         continue
                 if ch in url_leadins_set:
+                    n = self.match_any_url(s, i)
+                    if n > 0:
+                        i += n
+                        continue
+                if self.language == 'md' and tag != 'url' and ch in g.url_leadins:
                     n = self.match_any_url(s, i)
                     if n > 0:
                         i += n

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -76,6 +76,12 @@ def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
     print('\n'.join(colorizer.last_trace))
 
 
+# Module-level: URL lead-in characters as a set covering both cases, so
+# jedit.colorRangeWithTag's per-character scan does not have to call
+# str.lower() on every tagged character.
+_url_leadins_set = frozenset(g.url_leadins + g.url_leadins.upper())
+
+
 # @+node:ekr.20170127141855.1: ** class BaseColorizer
 class BaseColorizer:
     """
@@ -1622,19 +1628,22 @@ class JEditColorizer(BaseColorizer):
         # Colorize UNL's, URL's, and GNX's *everywhere*.
         if tag != 'url':
             j = min(j, len(s))
+            # Avoid str.lower() per character: check both cases via a set
+            # built once from g.url_leadins (lowercase).
+            url_leadins_set = _url_leadins_set
             while i < j:
-                ch = s[i].lower()
-                if ch == 'g':
+                ch = s[i]
+                if ch == 'g' or ch == 'G':
                     n = self.match_gnx(s, i)
                     if n > 0:
                         i += n
                         continue
-                if ch == 'u':
+                if ch == 'u' or ch == 'U':
                     n = self.match_unl(s, i)
                     if n > 0:
                         i += n
                         continue
-                if ch in g.url_leadins:
+                if ch in url_leadins_set:
                     n = self.match_any_url(s, i)
                     if n > 0:
                         i += n

--- a/leo/core/leoColorizer.py
+++ b/leo/core/leoColorizer.py
@@ -76,20 +76,23 @@ def dump_colorizer_last_colorizer_traces(event: LeoKeyEvent) -> None:
     print('\n'.join(colorizer.last_trace))
 
 
-# Module-level: URL lead-in characters as a set covering both cases, so
-# jedit.colorRangeWithTag's per-character scan does not have to call
-# str.lower() on every tagged character.
+# PR #4619: Avoid str.lower in jedit.colorRangeWithTag.
 _url_leadins_set = frozenset(g.url_leadins + g.url_leadins.upper())
 
-# Tags whose colored ranges may legitimately contain free-form text
-# (hence URLs, UNLs, or GNX references). On a typical Python file ~75%
-# of colorRangeWithTag calls are for keyword / operator tags that
-# cannot contain such text; those ranges are skipped in the URL scan.
-_url_bearing_tags = frozenset({
-    'comment1', 'comment2', 'comment3', 'comment4',
-    'doc',
-    'literal1', 'literal2', 'literal3', 'literal4',
-})
+# PR #4619: Tags whose colored ranges could contain URLs, UNLs, or GNX references.
+_url_bearing_tags = frozenset(
+    {
+        'comment1',
+        'comment2',
+        'comment3',
+        'comment4',
+        'doc',
+        'literal1',
+        'literal2',
+        'literal3',
+        'literal4',
+    }
+)
 
 
 # @+node:ekr.20170127141855.1: ** class BaseColorizer
@@ -360,9 +363,7 @@ class BaseColorizer:
             self.leoKeywordsDict[key] = 'leokeyword'
 
     # @+node:ekr.20230313051116.1: *3* BaseColorizer.normalize
-    # Cache normalized values: called per-setTag with a small set of
-    # recurring colorName strings ('red', 'blue', ...). Every hit saves
-    # five fresh string allocations (replace ×3, lower, strip).
+    # PR #4619: avoid str.lower, str.strip in jedit.setTag.
     _normalize_cache: dict[str, str] = {}
 
     def normalize(self, s: str) -> str:
@@ -1638,13 +1639,10 @@ class JEditColorizer(BaseColorizer):
         elif not exclude_match:
             self.setTag(tag, s, i, j)
 
-        # Colorize UNL's, URL's, and GNX's in comment/literal/doc ranges.
-        # Skip the per-char scan for tags that cannot legitimately contain
-        # such text (keywords, operators, punctuation, etc.).
+        # PR #4619: Scan only tags that could contain UNL's, URL's, and GNX's.
         if tag in _url_bearing_tags:
             j = min(j, len(s))
-            # Avoid str.lower() per character: check both cases via a set
-            # built once from g.url_leadins (lowercase).
+            # PR #4619: Avoid str.lower.
             url_leadins_set = _url_leadins_set
             while i < j:
                 ch = s[i]


### PR DESCRIPTION
## Caveat

A grab-bag of small colorizer wins found while profiling. Each commit is independent and cherry-pickable; skip any that don't appeal. Every commit: 38/38 `test_leoColorizer.py` tests pass, and the message includes isolated before/after numbers.

All measurements: `JEditColorizer.mainLoop` driven headlessly over `leo/core/leoGlobals.py` (~278 KB, 8716 lines) on Python 3.12 / Linux. Baseline = `devel` @ 18084b174.

## Summary

| | colorRangeWithTag cumtime | mainLoop wall |
|---|---|---|
| devel baseline | 813 ms | 1555 ms |
| + 1042da5be (normalize cache) | 810 ms | 1538 ms |
| + 61830b7bf (drop per-char lower) | 770 ms | 1448 ms |
| + aee3ca675 (URL scan whitelist) | 727 ms | 1422 ms |

cProfile numbers are the honest measurement of *which* function got cheaper. Wall time on this file is still dominated by the jupytext bug addressed in #4617; the numbers above are measured without that fix so each commit's impact is visible in isolation. With #4617 landed, the proportional wins below are larger because colorize time is smaller overall.

## Commits

### 1042da5be — `colorizer: cache BaseColorizer.normalize output`

`setTag` calls `self.normalize(colorName)` ~14 600× per colorize pass. Each call allocates five fresh strings (`replace` ×3, `lower`, `strip`) for a small, recurring set of colorName values. A dict cache keyed on the raw string removes this work entirely.

- Before: `normalize` at ~29 ms cumtime / 17 ms tottime.
- After: `normalize` not in cProfile top-25.

Zero behavior change.

### 61830b7bf — `colorizer: skip per-char str.lower in URL/UNL/GNX scan`

After every `setTag`, `colorRangeWithTag` scans the colored range character by character for URL/UNL/GNX lead-ins. The old code called `ch.lower()` on every character to compare against the lowercase-only `g.url_leadins` string (`'fghmnptw'`) — ~148 000 `.lower()` calls per colorize pass.

Build a module-level `frozenset` containing both cases of `g.url_leadins` once at import time; test `ch in set` directly. `g` / `G` / `u` / `U` are compared explicitly.

- `colorRangeWithTag` cumtime: 813 → 770 ms (−5%).
- `str.lower` drops out of the top hits.

Zero behavior change.

### aee3ca675 — `colorizer: restrict URL/UNL/GNX scan to comment and literal ranges`

The per-char URL/UNL/GNX scan above ran for *every* colored range, regardless of whether the tag could plausibly contain free-form text. On leoGlobals.py, a call-tag breakdown of the 14 596 ranges:

    4222  operator    \\
    4186  keyword1     \\
    1649  keyword2      > 10 979 (75%) cannot contain URLs.
     922  keyword3     /
      29  url         /  (already a no-op: matched URLs.)

    1721  literal1    \\
    1408  comment1     > 3 572 still scanned.
     443  literal2    /

Gate the scan on a `_url_bearing_tags` frozenset of comment/literal/doc tags.

- `colorRangeWithTag` cumtime: 770 → 727 ms (−5.5%).

**Behavior change:** if any third-party mode file emits a URL-like run under an 'operator' or 'keyword*' tag, it will no longer be auto-recolored as a clickable URL. None of Leo's bundled mode files do this as far as I can see; flagging in case. Cherry-pick this one only if you're comfortable with that trade.

## Tried but dropped

I also evaluated replacing the Python `while j < n and s[j] in self.word_chars:` loop in `match_keywords` with a compiled regex. Microbenchmark on 21 500 word-pick positions:

| | time |
|---|---|
| dict `in` loop | 4.0 ms |
| `re.compile(r'\\w+').match(s, i)` | 5.1 ms |

The regex is *slower* here because words are short and CPython's dict membership is extremely fast; the regex match-object allocation dominates. No commit for this.

## Test plan

- [x] `leo/unittests/core/test_leoColorizer.py` — 38 passed after each commit.
- [x] Manual: confirm URLs/UNLs/GNXs in comments and string literals are still clickable (should be unchanged).
- [x] Manual: confirm no mode file puts URL-like text under 'operator' / 'keyword*' (for commit 3).